### PR TITLE
[release/6.0-staging] Merge #75473

### DIFF
--- a/eng/pipelines/common/build-coreclr-and-libraries-job.yml
+++ b/eng/pipelines/common/build-coreclr-and-libraries-job.yml
@@ -7,7 +7,6 @@ parameters:
   container: ''
   testGroup: ''
   crossBuild: false
-  crossrootfsDir: ''
   timeoutInMinutes: ''
   signBinaries: false
   stagedBuild: false
@@ -27,7 +26,6 @@ jobs:
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
     timeoutInminutes: ${{ parameters.timeoutInMinutes }}
     signBinaries: ${{ parameters.signBinaries }}
     stagedBuild: ${{ parameters.stagedBuild }}
@@ -46,7 +44,6 @@ jobs:
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
     timeoutInminutes: ${{ parameters.timeoutInMinutes }}
     variables: ${{ parameters.variables }}
     pool: ${{ parameters.pool }}

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -7,7 +7,6 @@ parameters:
   osSubgroup: ''
   container: ''
   crossBuild: false
-  crossrootfsDir: ''
   variables: []
   targetRid: ''
   timeoutInMinutes: ''

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -37,9 +37,7 @@ jobs:
       archType: arm
       targetRid: linux-arm
       platform: Linux_arm
-      container:
-        image: ubuntu-16.04-cross-20210719121212-8a8d3be
-        registry: mcr
+      container: Linux_arm
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -48,7 +46,6 @@ jobs:
           platforms: ${{ parameters.platforms }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux arm64
@@ -63,9 +60,7 @@ jobs:
       archType: arm64
       targetRid: linux-arm64
       platform: Linux_arm64
-      container:
-        image: ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
-        registry: mcr
+      container: Linux_arm64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -74,7 +69,6 @@ jobs:
           platforms: ${{ parameters.platforms }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl x64
@@ -90,9 +84,7 @@ jobs:
       archType: x64
       targetRid: linux-musl-x64
       platform: Linux_musl_x64
-      container:
-        image: alpine-3.13-WithNode-20210910135845-c401c85
-        registry: mcr
+      container: Linux_musl_x64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -115,9 +107,7 @@ jobs:
       archType: arm
       targetRid: linux-musl-arm
       platform: Linux_musl_arm
-      container:
-        image: ubuntu-16.04-cross-arm-alpine-20210719121212-044d5b9
-        registry: mcr
+      container: Linux_musl_arm
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -126,7 +116,6 @@ jobs:
           platforms: ${{ parameters.platforms }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm64
@@ -142,9 +131,7 @@ jobs:
       archType: arm64
       targetRid: linux-musl-arm64
       platform: Linux_musl_arm64
-      container:
-        image: ubuntu-16.04-cross-arm64-alpine-20210719121212-b2c2436
-        registry: mcr
+      container: Linux_musl_arm64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -153,7 +140,6 @@ jobs:
           platforms: ${{ parameters.platforms }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x64
@@ -168,9 +154,7 @@ jobs:
       archType: x64
       targetRid: linux-x64
       platform: Linux_x64
-      container:
-        image: centos-7-20210714125435-9b5bbc2
-        registry: mcr
+      container: Linux_x64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -192,9 +176,7 @@ jobs:
       archType: x64
       targetRid: linux-x64
       platform: Linux_x64
-      container:
-        image: centos-7-source-build-20210714125450-5d87b80
-        registry: mcr
+      container: SourceBuild_Linux_x64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -217,9 +199,7 @@ jobs:
       archType: s390x
       targetRid: linux-s390x
       platform: Linux_s390x
-      container:
-        image: ubuntu-18.04-cross-s390x-20201102145728-d6e0352
-        registry: mcr
+      container: Linux_s390x
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -228,7 +208,6 @@ jobs:
           platforms: ${{ parameters.platforms }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/s390x'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # WebAssembly
@@ -244,9 +223,7 @@ jobs:
       archType: wasm
       targetRid: browser-wasm
       platform: Browser_wasm
-      container:
-        image: ubuntu-18.04-webassembly-20210531091624-f5c7a43
-        registry: mcr
+      container: Browser_wasm
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -287,15 +264,12 @@ jobs:
       archType: x64
       targetRid: freebsd-x64
       platform: FreeBSD_x64
-      container:
-        image: ubuntu-18.04-cross-freebsd-11-20200407092345-a84b0d2
-        registry: mcr
+      container: FreeBSD_x64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/x64'
         ${{ if eq(parameters.passPlatforms, true) }}:
           platforms: ${{ parameters.platforms }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -312,9 +286,7 @@ jobs:
       archType: x64
       targetRid: android-x64
       platform: Android_x64
-      container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
-        registry: mcr
+      container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -336,9 +308,7 @@ jobs:
       archType: x86
       targetRid: android-x86
       platform: Android_x86
-      container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
-        registry: mcr
+      container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -360,9 +330,7 @@ jobs:
       archType: arm
       targetRid: android-arm
       platform: Android_arm
-      container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
-        registry: mcr
+      container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -384,9 +352,7 @@ jobs:
       archType: arm64
       targetRid: android-arm64
       platform: Android_arm64
-      container:
-        image: ubuntu-18.04-android-20200422191843-e2c3f83
-        registry: mcr
+      container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
         stagedBuild: ${{ parameters.stagedBuild }}

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -1,0 +1,79 @@
+parameters:
+  - name: stages
+    type: stageList
+
+resources:
+  containers:
+    - container: Linux_arm
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-20220907130538-70ed2e8
+      env:
+        ROOTFS_DIR: /crossrootfs/arm
+
+    - container: Linux_armv6
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-armv6-raspbian-10-20211208135931-e6e3ac4
+      env:
+        ROOTFS_DIR: /crossrootfs/armv6
+
+    - container: Linux_arm64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-20220907130538-70ed2e8
+      env:
+        ROOTFS_DIR: /crossrootfs/arm64
+
+    - container: Linux_musl_x64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20210910135845-c401c85
+
+    - container: Linux_musl_arm
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20220915134743-78f7860
+      env:
+        ROOTFS_DIR: /crossrootfs/arm
+
+    - container: Linux_musl_arm64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm64-alpine-20220915142421-44c622d
+      env:
+        ROOTFS_DIR: /crossrootfs/arm64
+    # This container contains all required toolsets to build for Android and for Linux with bionic libc.
+
+    - container: Linux_bionic
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-android-20200422191843-e2c3f83
+
+    - container: Linux_x64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2
+
+    - container: Linux_x86
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-x86-linux-20211022152824-f853169
+      env:
+        ROOTFS_DIR: /crossrootfs/x86
+
+    - container: SourceBuild_Linux_x64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-source-build-20210714125450-5d87b80
+
+    - container: Linux_s390x
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-s390x-20201102145728-d6e0352
+      env:
+        ROOTFS_DIR: /crossrootfs/s390x
+
+    - container: Linux_ppc64le
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-ppc64le-20220531132048-b9de666
+      env:
+        ROOTFS_DIR: /crossrootfs/ppc64le
+
+    - container: Browser_wasm
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-webassembly-20210531091624-f5c7a43
+
+    - container: FreeBSD_x64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-12-20210917001307-f13d79e
+      env:
+        ROOTFS_DIR: /crossrootfs/x64
+
+    - container: Tizen_armel
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-armel-tizen-20210719212651-8b02f56
+      env:
+        ROOTFS_DIR: /crossrootfs/armel
+
+    - container: debpkg
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-debpkg-20220504035737-cfdd435
+
+    - container: rpmpkg
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-8-rpmpkg-20210714125410-daa5116
+
+stages: ${{ parameters.stages }}

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -15,7 +15,7 @@ resources:
         ROOTFS_DIR: /crossrootfs/armv6
 
     - container: Linux_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-20220907130538-70ed2e8
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
       env:
         ROOTFS_DIR: /crossrootfs/arm64
 
@@ -28,7 +28,7 @@ resources:
         ROOTFS_DIR: /crossrootfs/arm
 
     - container: Linux_musl_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm64-alpine-20220915142421-44c622d
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-20210719121212-b2c2436
       env:
         ROOTFS_DIR: /crossrootfs/arm64
     # This container contains all required toolsets to build for Android and for Linux with bionic libc.

--- a/eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
@@ -5,7 +5,6 @@ parameters:
   osSubgroup: ''
   container: ''
   testGroup: ''
-  crossrootfsDir: ''
   liveLibrariesBuildConfig: ''
   helixQueues: ''
   stagedBuild: false
@@ -23,8 +22,8 @@ parameters:
   enableMicrobuild: ''
   gatherAssetManifests: false
   shouldContinueOnError: false
-  
-  
+
+
 steps:
   - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci -excludemonofailures os ${{ parameters.osGroup }} ${{ parameters.archType }} /p:RuntimeVariant=${{ parameters.runtimeVariant }} $(buildConfigUpper)
     displayName: Build Tests
@@ -68,4 +67,4 @@ steps:
 
         helixProjectArguments: '$(Build.SourcesDirectory)/src/tests/Common/helixpublishwitharcade.proj'
 
-        scenarios: normal 
+        scenarios: normal

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -6,7 +6,6 @@ parameters:
   container: ''
   testGroup: ''
   crossBuild: false
-  crossrootfsDir: ''
   readyToRun: false
   liveLibrariesBuildConfig: ''
   crossgen2: false
@@ -40,7 +39,6 @@ jobs:
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
     stagedBuild: ${{ parameters.stagedBuild }}
     liveLibrariesBuildConfig: ${{ parameters.liveLibrariesBuildConfig }}
     helixType: 'build/tests/'

--- a/eng/pipelines/common/templates/runtimes/wasm-runtime-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/wasm-runtime-and-send-to-helix.yml
@@ -6,7 +6,6 @@ parameters:
   container: ''
   testGroup: ''
   crossBuild: false
-  crossrootfsDir: ''
   readyToRun: false
   liveLibrariesBuildConfig: ''
   crossgen2: false

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -7,7 +7,6 @@ parameters:
   helixType: '(unspecified)'
   container: ''
   crossBuild: false
-  crossrootfsDir: ''
   stagedBuild: false
   strategy: ''
   pool: ''

--- a/eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
@@ -1,0 +1,10 @@
+parameters:
+  - name: jobs
+    type: jobList
+
+extends:
+  template: pipeline-with-resources.yml
+  parameters:
+    stages:
+      - stage: Build
+        jobs: ${{ parameters.jobs }}

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -90,11 +90,6 @@ jobs:
         - name: setScriptToEchoAndFailOnNonZero
           value: 'set -xe'
 
-      - ${{ if ne(parameters.jobParameters.crossrootfsDir, '') }}:
-        # This is only required for cross builds.
-        - name: ROOTFS_DIR
-          value: ${{ parameters.jobParameters.crossrootfsDir }}
-
       - name: runtimeFlavorName
         ${{ if eq(parameters.jobParameters.runtimeFlavor, 'mono') }}:
           value: Mono
@@ -113,8 +108,10 @@ jobs:
     ${{ if ne(parameters.container, '') }}:
       ${{ if eq(parameters.container.registry, 'mcr') }}:
         container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container.image) }}
-      ${{ if ne(parameters.container.registry, 'mcr') }}:
+      ${{ if and(ne(parameters.container.image, ''), ne(parameters.container.registry, 'mcr')) }}:
         container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
+      ${{ if eq(parameters.container.image, '') }}:
+        container: ${{ parameters.container }}
 
     ${{ if eq(parameters.jobParameters.pool, '') }}:
       pool:

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -24,129 +24,132 @@ trigger:
     - eng/pipelines/libraries/*
     - eng/pipelines/runtime.yml
 
-jobs:
-
-#
-# Debug builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template: /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: debug
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_musl_arm64
-    - Linux_musl_x64
-    - Linux_x64
-    - OSX_arm64
-    - OSX_x64
-    - windows_arm
-    - windows_arm64
-    jobParameters:
-      testGroup: outerloop
+    jobs:
 
-#
-# Checked builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: checked
-    platformGroup: all
-    platforms:
-    # It is too early to include OSX_arm64 in platform group all
-    # Adding it here will enable it also
-    - OSX_arm64
-    jobParameters:
-      testGroup: outerloop
+    #
+    # Debug builds
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: debug
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_musl_arm64
+        - Linux_musl_x64
+        - Linux_x64
+        - OSX_arm64
+        - OSX_x64
+        - windows_arm
+        - windows_arm64
+        jobParameters:
+          testGroup: outerloop
 
-#
-# Release builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: release
-    platforms:
-    - Linux_arm
-    - Linux_musl_arm64
-    - Linux_x64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x86
-    jobParameters:
-      testGroup: outerloop
+    #
+    # Checked builds
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: checked
+        platformGroup: all
+        platforms:
+        # It is too early to include OSX_arm64 in platform group all
+        # Adding it here will enable it also
+        - OSX_arm64
+        jobParameters:
+          testGroup: outerloop
 
-#
-# Release library builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platformGroup: all
-    platforms:
-    # It is too early to include OSX_arm64 in platform group all
-    # Adding it here will enable it also
-    - OSX_arm64
-    jobParameters:
-      isOfficialBuild: false
-      liveRuntimeBuildConfig: checked
+    #
+    # Release builds
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: release
+        platforms:
+        - Linux_arm
+        - Linux_musl_arm64
+        - Linux_x64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x86
+        jobParameters:
+          testGroup: outerloop
 
-#
-# Checked test builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    testGroup: outerloop
-    jobParameters:
-      liveLibrariesBuildConfig: Release
+    #
+    # Release library builds
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/build-job.yml
+        buildConfig: Release
+        platformGroup: all
+        platforms:
+        # It is too early to include OSX_arm64 in platform group all
+        # Adding it here will enable it also
+        - OSX_arm64
+        jobParameters:
+          isOfficialBuild: false
+          liveRuntimeBuildConfig: checked
 
-#
-# Checked JIT test runs
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platformGroup: all
-    platforms:
-    # It is too early to include OSX_arm64 in platform group all
-    # Adding it here will enable it to also run this test
-    - OSX_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    #
+    # Checked test builds
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        testGroup: outerloop
+        jobParameters:
+          liveLibrariesBuildConfig: Release
 
-#
-# Checked R2R test runs
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm64
-    - Linux_musl_x64
-    - Linux_musl_arm64
-    - Linux_x64
-    - OSX_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      readyToRun: true
-      crossgen2: true
-      displayNameArgs: R2R_CG2
-      liveLibrariesBuildConfig: Release
+    #
+    # Checked JIT test runs
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platformGroup: all
+        platforms:
+        # It is too early to include OSX_arm64 in platform group all
+        # Adding it here will enable it to also run this test
+        - OSX_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+
+    #
+    # Checked R2R test runs
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm64
+        - Linux_musl_x64
+        - Linux_musl_arm64
+        - Linux_x64
+        - OSX_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          readyToRun: true
+          crossgen2: true
+          displayNameArgs: R2R_CG2
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/clrinterpreter.yml
+++ b/eng/pipelines/coreclr/clrinterpreter.yml
@@ -8,46 +8,49 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template: /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: clrinterpreter
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: clrinterpreter
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: clrinterpreter
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: clrinterpreter
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: clrinterpreter
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: clrinterpreter
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -8,53 +8,56 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template: /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x86
-    - windows_x64
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: innerloop
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x86
+        - windows_x64
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: innerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x86
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      testGroup: innerloop
-      readyToRun: true
-      crossgen2: true
-      compositeBuildMode: true
-      displayNameArgs: Composite
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x86
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          testGroup: innerloop
+          readyToRun: true
+          crossgen2: true
+          compositeBuildMode: true
+          displayNameArgs: Composite
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -8,49 +8,52 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gcstress-extra
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gcstress-extra
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x64
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gcstress-extra
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      testGroup: gcstress-extra
-      readyToRun: true
-      crossgen2: true
-      compositeBuildMode: true
-      displayNameArgs: Composite
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gcstress-extra
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          testGroup: gcstress-extra
+          readyToRun: true
+          crossgen2: true
+          compositeBuildMode: true
+          displayNameArgs: Composite
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -8,213 +8,216 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_x86
-    - windows_x64
-    jobParameters:
-      testGroup: outerloop
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x64
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x86
-    - windows_x64
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      isOfficialBuild: false
-      liveRuntimeBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - OSX_arm64
+        - windows_x86
+        - windows_x64
+        jobParameters:
+          testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/build-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x86
+        - windows_x64
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          isOfficialBuild: false
+          liveRuntimeBuildConfig: Release
 
-# Test most platforms in composite mode as the expected mainline shipping mode
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      testGroup: outerloop
-      readyToRun: true
-      crossgen2: true
-      compositeBuildMode: true
-      displayNameArgs: Composite
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
 
-# Limited outerloop testing in non-composite mode
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: checked
-    platforms:
-    - OSX_x64
-    jobParameters:
-      testGroup: outerloop
-      readyToRun: true
-      crossgen2: true
-      displayNameArgs: R2R_CG2
-      liveLibrariesBuildConfig: Release
+    # Test most platforms in composite mode as the expected mainline shipping mode
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          testGroup: outerloop
+          readyToRun: true
+          crossgen2: true
+          compositeBuildMode: true
+          displayNameArgs: Composite
+          liveLibrariesBuildConfig: Release
 
-# Build Crossgen2 baselines
-# These are the various crossgen2 targets that are supported, and cover all major
-# significantly different code generators
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_x86
-    - windows_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    # Limited outerloop testing in non-composite mode
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: checked
+        platforms:
+        - OSX_x64
+        jobParameters:
+          testGroup: outerloop
+          readyToRun: true
+          crossgen2: true
+          displayNameArgs: R2R_CG2
+          liveLibrariesBuildConfig: Release
 
-# test crossgen target Windows X86
-# This job verifies that 32-bit and 64 bit crossgen2 produces the same binaries,
-# and that cross-os targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_x64
-    - windows_x86
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: windows
-      targetarch: x86
+    # Build Crossgen2 baselines
+    # These are the various crossgen2 targets that are supported, and cover all major
+    # significantly different code generators
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - OSX_arm64
+        - windows_x86
+        - windows_x64
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
 
-# test target Linux X64
-# verify that cross OS targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: Linux
-      targetarch: x64
+    # test crossgen target Windows X86
+    # This job verifies that 32-bit and 64 bit crossgen2 produces the same binaries,
+    # and that cross-os targetting works
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_x64
+        - windows_x86
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          targetos: windows
+          targetarch: x86
 
-# test target Windows X64
-# verify that cross OS targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_x64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: windows
-      targetarch: x64
+    # test target Linux X64
+    # verify that cross OS targetting works
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+        buildConfig: Release
+        platforms:
+        - windows_x64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          targetos: Linux
+          targetarch: x64
 
-# test target Linux arm
-# verify that cross architecture targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: Linux
-      targetarch: arm
+    # test target Windows X64
+    # verify that cross OS targetting works
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_x64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          targetos: windows
+          targetarch: x64
 
-# test target Linux arm64
-# verify that cross architecture targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: Linux
-      targetarch: arm64
+    # test target Linux arm
+    # verify that cross architecture targetting works
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          targetos: Linux
+          targetarch: arm
 
-# test target osx-arm64
-# verify that cross architecture targetting works
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
-    buildConfig: Release
-    platforms:
-    - OSX_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      targetos: OSX
-      targetarch: arm64
+    # test target Linux arm64
+    # verify that cross architecture targetting works
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          targetos: Linux
+          targetarch: arm64
+
+    # test target osx-arm64
+    # verify that cross architecture targetting works
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+        buildConfig: Release
+        platforms:
+        - OSX_arm64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          targetos: OSX
+          targetarch: arm64

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -8,48 +8,51 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: innerloop
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x64
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: innerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      testGroup: innerloop
-      readyToRun: true
-      crossgen2: true
-      displayNameArgs: R2R_CG2
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          testGroup: innerloop
+          readyToRun: true
+          crossgen2: true
+          displayNameArgs: R2R_CG2
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/gc-longrunning.yml
+++ b/eng/pipelines/coreclr/gc-longrunning.yml
@@ -8,43 +8,46 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: release
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - windows_x64
-    - windows_arm64
-    - OSX_x64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gc-longrunning
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: release
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gc-longrunning
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: release
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - windows_x64
+        - windows_arm64
+        - OSX_x64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gc-longrunning
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    - windows_x64
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: gc-longrunning
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: release
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gc-longrunning
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: release
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        - windows_x64
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: gc-longrunning
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/gc-simulator.yml
+++ b/eng/pipelines/coreclr/gc-simulator.yml
@@ -8,45 +8,48 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: release
-    platforms:
-    # disable Linux x64 for now untill OOMs are resolved.
-    # - Linux_x64
-    - Linux_arm64
-    - windows_x64
-    - windows_arm64
-    - OSX_x64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gc-simulator
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: release
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gc-simulator
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: release
+        platforms:
+        # disable Linux x64 for now untill OOMs are resolved.
+        # - Linux_x64
+        - Linux_arm64
+        - windows_x64
+        - windows_arm64
+        - OSX_x64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gc-simulator
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    platforms:
-    # disable Linux x64 for now untill OOMs are resolved.
-    # - Linux_x64
-    - Linux_arm64
-    - windows_x64
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: gc-simulator
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: release
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gc-simulator
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: release
+        platforms:
+        # disable Linux x64 for now untill OOMs are resolved.
+        # - Linux_x64
+        - Linux_arm64
+        - windows_x64
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: gc-simulator
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/gc-standalone.yml
+++ b/eng/pipelines/coreclr/gc-standalone.yml
@@ -8,58 +8,61 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm64
-    - windows_arm64
-    - windows_x64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gc-standalone
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gc-standalone
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm64
+        - windows_arm64
+        - windows_x64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gc-standalone
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm64
-    - Linux_x64
-    - windows_arm64
-    - windows_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: gc-standalone
-      displayNameArgs: GCStandAlone
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gc-standalone
+          liveLibrariesBuildConfig: Release
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm64
-    - Linux_x64
-    - windows_arm64
-    - windows_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: gc-standalone-server
-      displayNameArgs: GCStandAloneServer
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm64
+        - Linux_x64
+        - windows_arm64
+        - windows_x64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: gc-standalone
+          displayNameArgs: GCStandAlone
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm64
+        - Linux_x64
+        - windows_arm64
+        - windows_x64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: gc-standalone-server
+          displayNameArgs: GCStandAloneServer
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/gcstress-extra.yml
+++ b/eng/pipelines/coreclr/gcstress-extra.yml
@@ -8,42 +8,45 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platformGroup: gcstress
-    platforms:
-    # It is too early to include OSX_arm64 in platform group gcstress
-    # Adding it here will enable it also
-    - OSX_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gcstress-extra
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gcstress-extra
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platformGroup: gcstress
+        platforms:
+        # It is too early to include OSX_arm64 in platform group gcstress
+        # Adding it here will enable it also
+        - OSX_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gcstress-extra
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platformGroup: gcstress
-    platforms:
-    # It is too early to include OSX_arm64 in platform group gcstress
-    # Adding it here will enable it also
-    - OSX_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: gcstress-extra
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gcstress-extra
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platformGroup: gcstress
+        platforms:
+        # It is too early to include OSX_arm64 in platform group gcstress
+        # Adding it here will enable it also
+        - OSX_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: gcstress-extra
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
@@ -8,42 +8,45 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platformGroup: gcstress
-    platforms:
-    # It is too early to include OSX_arm64 in platform group gcstress
-    # Adding it here will enable it also
-    - OSX_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gcstress0x3-gcstress0xc
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: gcstress0x3-gcstress0xc
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platformGroup: gcstress
+        platforms:
+        # It is too early to include OSX_arm64 in platform group gcstress
+        # Adding it here will enable it also
+        - OSX_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gcstress0x3-gcstress0xc
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platformGroup: gcstress
-    platforms:
-    # It is too early to include OSX_arm64 in platform group gcstress
-    # Adding it here will enable it also
-    - OSX_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: gcstress0x3-gcstress0xc
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: gcstress0x3-gcstress0xc
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platformGroup: gcstress
+        platforms:
+        # It is too early to include OSX_arm64 in platform group gcstress
+        # Adding it here will enable it also
+        - OSX_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: gcstress0x3-gcstress0xc
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/ilasm.yml
+++ b/eng/pipelines/coreclr/ilasm.yml
@@ -17,50 +17,53 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: ilasm
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: ilasm
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: ilasm
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: ilasm
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: ilasm
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: ilasm
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jit-experimental.yml
+++ b/eng/pipelines/coreclr/jit-experimental.yml
@@ -8,38 +8,41 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - windows_x64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jit-experimental
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jit-experimental
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - windows_x64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jit-experimental
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - windows_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: jit-experimental
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jit-experimental
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - windows_x64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jit-experimental
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jitrollingbuild.yml
+++ b/eng/pipelines/coreclr/jitrollingbuild.yml
@@ -12,21 +12,24 @@ trigger:
 # and should not be triggerable from a PR. 
 pr: none
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-jit-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    # Currently, Linux arm/arm64 machines don't have the Python 'pip3' tool, nor the azure-storage-blob package that
-    # is required to do the JIT upload to Azure Storage. Thus, these platforms are disabled. If we can figure out how
-    # to get Python properly configured, then re-enable them.
-    # - Linux_arm
-    # - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
+    jobs:
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-jit-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        # Currently, Linux arm/arm64 machines don't have the Python 'pip3' tool, nor the azure-storage-blob package that
+        # is required to do the JIT upload to Azure Storage. Thus, these platforms are disabled. If we can figure out how
+        # to get Python properly configured, then re-enable them.
+        # - Linux_arm
+        # - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64

--- a/eng/pipelines/coreclr/jitstress-isas-arm.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-arm.yml
@@ -8,40 +8,43 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm64
-    - OSX_arm64
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstress-isas-arm
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstress-isas-arm
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm64
+        - OSX_arm64
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress-isas-arm
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm64
-    - OSX_arm64
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: jitstress-isas-arm
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress-isas-arm
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm64
+        - OSX_arm64
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jitstress-isas-arm
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jitstress-isas-x86.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-x86.yml
@@ -8,42 +8,45 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - OSX_x64
-    - windows_x64
-    - windows_x86
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstress-isas-x86
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstress-isas-x86
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - OSX_x64
+        - windows_x64
+        - windows_x86
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress-isas-x86
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - OSX_x64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: jitstress-isas-x86
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress-isas-x86
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - OSX_x64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jitstress-isas-x86
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -8,50 +8,53 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstress
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstress
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: jitstress
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jitstress
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -8,50 +8,53 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstress2-jitstressregs
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: checked
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress2-jitstressregs
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: jitstress2-jitstressregs
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: checked
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jitstress2-jitstressregs
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jitstressregs-x86.yml
+++ b/eng/pipelines/coreclr/jitstressregs-x86.yml
@@ -8,40 +8,43 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstressregs-x86
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstressregs-x86
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstressregs-x86
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: jitstressregs-x86
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstressregs-x86
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jitstressregs-x86
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstressregs.yml
@@ -8,50 +8,53 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstressregs
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: jitstressregs
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstressregs
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: jitstressregs
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstressregs
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jitstressregs
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/libraries-gcstress-extra.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress-extra.yml
@@ -9,37 +9,40 @@ trigger: none
 #     - main
 #   always: true
 
-jobs:
-
-#
-# Build CoreCLR checked and libraries Release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platformGroup: gcstress
-    jobParameters:
-      # libraries test build platforms
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
+    jobs:
 
-#
-# Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platformGroup: gcstress
-    helixQueueGroup: libraries
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
-      timeoutInMinutes: 600
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: Release
-      dependsOnTestArchitecture: x64
-      coreclrTestGroup: gcstress-extra
+    #
+    # Build CoreCLR checked and libraries Release
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platformGroup: gcstress
+        jobParameters:
+          # libraries test build platforms
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
+
+    #
+    # Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platformGroup: gcstress
+        helixQueueGroup: libraries
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
+          timeoutInMinutes: 600
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: Release
+          dependsOnTestArchitecture: x64
+          coreclrTestGroup: gcstress-extra

--- a/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
@@ -9,37 +9,40 @@ trigger: none
 #     - main
 #   always: true
 
-jobs:
-
-#
-# Build CoreCLR checked and libraries Release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platformGroup: gcstress
-    jobParameters:
-      # libraries test build platforms
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
+    jobs:
 
-#
-# Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platformGroup: gcstress
-    helixQueueGroup: libraries
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
-      timeoutInMinutes: 600
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: Release
-      dependsOnTestArchitecture: x64
-      coreclrTestGroup: gcstress0x3-gcstress0xc
+    #
+    # Build CoreCLR checked and libraries Release
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platformGroup: gcstress
+        jobParameters:
+          # libraries test build platforms
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
+
+    #
+    # Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platformGroup: gcstress
+        helixQueueGroup: libraries
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
+          timeoutInMinutes: 600
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: Release
+          dependsOnTestArchitecture: x64
+          coreclrTestGroup: gcstress0x3-gcstress0xc

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -8,49 +8,52 @@ schedules:
     - main
   always: true
 
-jobs:
-
-#
-# Build CoreCLR checked and libraries Release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm
-    - Linux_arm64
-    - windows_x86
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      # libraries test build platforms
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
+    jobs:
 
-#
-# Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: libraries
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
-      timeoutInMinutes: 300
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: Release
-      dependsOnTestArchitecture: x64
-      coreclrTestGroup: jitstress
+    #
+    # Build CoreCLR checked and libraries Release
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm
+        - Linux_arm64
+        - windows_x86
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          # libraries test build platforms
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
+
+    #
+    # Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: libraries
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
+          timeoutInMinutes: 300
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: Release
+          dependsOnTestArchitecture: x64
+          coreclrTestGroup: jitstress

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
@@ -8,49 +8,52 @@ schedules:
     - main
   always: true
 
-jobs:
-
-#
-# Build CoreCLR checked and libraries Release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm
-    - Linux_arm64
-    - windows_x86
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      # libraries test build platforms
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
+    jobs:
 
-#
-# Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: libraries
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
-      timeoutInMinutes: 300
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: Release
-      dependsOnTestArchitecture: x64
-      coreclrTestGroup: jitstress2-jitstressregs
+    #
+    # Build CoreCLR checked and libraries Release
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm
+        - Linux_arm64
+        - windows_x86
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          # libraries test build platforms
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
+
+    #
+    # Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: libraries
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
+          timeoutInMinutes: 300
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: Release
+          dependsOnTestArchitecture: x64
+          coreclrTestGroup: jitstress2-jitstressregs

--- a/eng/pipelines/coreclr/libraries-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstressregs.yml
@@ -8,49 +8,52 @@ schedules:
     - main
   always: true
 
-jobs:
-
-#
-# Build CoreCLR checked and libraries Release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm
-    - Linux_arm64
-    - windows_x86
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      # libraries test build platforms
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
+    jobs:
 
-#
-# Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: libraries
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
-      timeoutInMinutes: 300
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: Release
-      dependsOnTestArchitecture: x64
-      coreclrTestGroup: jitstressregs
+    #
+    # Build CoreCLR checked and libraries Release
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm
+        - Linux_arm64
+        - windows_x86
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          # libraries test build platforms
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
+
+    #
+    # Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: libraries
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
+          timeoutInMinutes: 300
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: Release
+          dependsOnTestArchitecture: x64
+          coreclrTestGroup: jitstressregs

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -8,48 +8,51 @@ schedules:
     - main
   always: true
 
-jobs:
-
-#
-# Build CoreCLR checked and libraries Release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm
-    - Linux_arm64
-    - windows_x86
-    - windows_x64
-    - windows_arm64
-    jobParameters:
-      # libraries test build platforms
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
+    jobs:
 
-#
-# Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: libraries
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      timeoutInMinutes: 150
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: Release
-      dependsOnTestArchitecture: x64
-      coreclrTestGroup: pgo
+    #
+    # Build CoreCLR checked and libraries Release
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm
+        - Linux_arm64
+        - windows_x86
+        - windows_x64
+        - windows_arm64
+        jobParameters:
+          # libraries test build platforms
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
+
+    #
+    # Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: libraries
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          timeoutInMinutes: 150
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: Release
+          dependsOnTestArchitecture: x64
+          coreclrTestGroup: pgo

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -30,462 +30,465 @@ schedules:
     - main
   always: true
 
-jobs:
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-  
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+      
+      # build mono
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+          runtimeFlavor: mono
+          buildConfig: release
+          platforms:
+          - Linux_x64
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
+      # build coreclr and libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_x64
+          jobParameters:
+            testGroup: perf
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Browser Wasm Artifacts
-              artifactName: BrowserWasm
-              archiveType: zip
-              archiveExtension: .zip
+      # build mono on wasm
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Browser_wasm
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: wasm
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: Browser Wasm Artifacts
+                  artifactName: BrowserWasm
+                  archiveType: zip
+                  archiveExtension: .zip
 
-  #run mono wasm microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'javascriptcore'
+      #run mono wasm microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+          buildConfig: release
+          runtimeFlavor: wasm
+          platforms:
+          - Linux_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: wasm
+            codeGenType: 'wasm'
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
+            javascriptEngine: 'javascriptcore'
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        testgroup: perf
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        projectfile: microbenchmarks.proj
-        runkind: micro
-        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptengine: 'javascriptcore'
+      #run mono wasm aot microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+          buildconfig: release
+          runtimeflavor: wasm
+          platforms:
+          - linux_x64
+          jobparameters:
+            testgroup: perf
+            livelibrariesbuildconfig: Release
+            runtimetype: wasm
+            codegentype: 'aot'
+            projectfile: microbenchmarks.proj
+            runkind: micro
+            runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
+            javascriptengine: 'javascriptcore'
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
+      # build coreclr and libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_x64
+          - windows_x64
+          - windows_x86
+          - Linux_musl_x64
+          jobParameters:
+            testGroup: perf
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Browser Wasm Artifacts
-              artifactName: BrowserWasm
-              archiveType: zip
-              archiveExtension: .zip
+      # build mono on wasm
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Browser_wasm
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: wasm
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: Browser Wasm Artifacts
+                  artifactName: BrowserWasm
+                  archiveType: zip
+                  archiveExtension: .zip
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AOT
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: AOT Mono Artifacts
-              artifactName: LinuxMonoAOTx64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+      # build mono for AOT
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Linux_x64
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: AOT
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: AOT Mono Artifacts
+                  artifactName: LinuxMonoAOTx64
+                  archiveExtension: '.tar.gz'
+                  archiveType: tar
+                  tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Android Mono Artifacts
-              artifactName: AndroidMonoarm64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
-    
-  # build mono iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: iOSMono
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: iOS Mono Artifacts
-              artifactName: iOSMonoarm64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+      # build mono Android scenarios
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Android_arm64
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: AndroidMono
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: Android Mono Artifacts
+                  artifactName: AndroidMonoarm64
+                  archiveExtension: '.tar.gz'
+                  archiveType: tar
+                  tarCompression: gz
+        
+      # build mono iOS scenarios
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - iOS_arm64
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: iOSMono
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: iOS Mono Artifacts
+                  artifactName: iOSMonoarm64
+                  archiveExtension: '.tar.gz'
+                  archiveType: tar
+                  tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
+      # build mono
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+          runtimeFlavor: mono
+          buildConfig: release
+          platforms:
+          - Linux_x64
 
-  # run mono android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
+      # run mono android scenarios
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+            - Windows_x64
+          jobParameters:
+            testGroup: perf
+            runtimeType: AndroidMono
+            projectFile: android_scenarios.proj
+            runKind: android_scenarios
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+            logicalmachine: 'perfpixel4a'
 
-  # run mono iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: False
+      # run mono iOS scenarios
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+            - Windows_x64
+          jobParameters:
+            testGroup: perf
+            runtimeType: iOSMono
+            projectFile: ios_scenarios.proj
+            runKind: ios_scenarios
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+            logicalmachine: 'perfpixel4a'
+            iosLlvmBuild: False
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: True
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+            - Windows_x64
+          jobParameters:
+            testGroup: perf
+            runtimeType: iOSMono
+            projectFile: ios_scenarios.proj
+            runKind: ios_scenarios
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+            logicalmachine: 'perfpixel4a'
+            iosLlvmBuild: True
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+      # run mono microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Linux_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: mono
+            projectFile: microbenchmarks.proj
+            runKind: micro_mono
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+      # run mono interpreter perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Linux_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: mono
+            codeGenType: 'Interpreter'
+            projectFile: microbenchmarks.proj
+            runKind: micro_mono
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
 
-  # run mono wasm interpreter (default) microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+      # run mono wasm interpreter (default) microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+          buildConfig: release
+          runtimeFlavor: wasm
+          platforms:
+          - Linux_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: wasm
+            codeGenType: 'wasm'
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
+            javascriptEngine: 'v8'
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        testgroup: perf
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        projectfile: microbenchmarks.proj
-        runkind: micro
-        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+      #run mono wasm aot microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+          buildconfig: release
+          runtimeflavor: wasm
+          platforms:
+          - linux_x64
+          jobparameters:
+            testgroup: perf
+            livelibrariesbuildconfig: Release
+            runtimetype: wasm
+            codegentype: 'aot'
+            projectfile: microbenchmarks.proj
+            runkind: micro
+            runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
+            javascriptEngine: 'v8'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+      # run mono aot microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+          buildConfig: release
+          runtimeFlavor: aot
+          platforms:
+          - Linux_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: mono
+            codeGenType: 'AOT'
+            projectFile: microbenchmarks.proj
+            runKind: micro_mono
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+      # run coreclr perftiger microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - Linux_x64
+          - windows_x64
+          - windows_x86
+          - Linux_musl_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
 
-# run coreclr perftiger microbenchmarks pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoPgo
+    # run coreclr perftiger microbenchmarks pgo perf jobs
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
+            pgoRunType: -NoPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -DynamicPgo
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
+            pgoRunType: -DynamicPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -FullPgo
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
+            pgoRunType: -FullPgo
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+      # run coreclr perfowl microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - Linux_x64
+          - windows_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger_crossgen'
+      # run coreclr crossgen perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - Linux_x64
+          - windows_x64
+          - windows_x86
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: crossgen_perf.proj
+            runKind: crossgen_scenarios
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+            logicalmachine: 'perftiger_crossgen'
 
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: blazor_perf.proj
-        runKind: blazor_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        additionalSetupParameters: '--latestdotnet'
-        logicalmachine: 'perftiger'
+      # run mono wasm blazor perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: wasm
+          platforms:
+          - Linux_x64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: wasm
+            projectFile: blazor_perf.proj
+            runKind: blazor_scenarios
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+            additionalSetupParameters: '--latestdotnet'
+            logicalmachine: 'perftiger'
 

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -11,205 +11,208 @@ schedules:
     - main
   always: true
 
-jobs:
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-  
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_arm64
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+      
+      # build mono
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+          runtimeFlavor: mono
+          buildConfig: release
+          platforms:
+          - Linux_arm64
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_arm64
-      jobParameters:
-        testGroup: perf
+      # build coreclr and libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_arm64
+          jobParameters:
+            testGroup: perf
 
-  # run arm64 interpreter jobs for mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_arm64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfa64'
+      # run arm64 interpreter jobs for mono
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Linux_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: mono
+            codeGenType: 'Interpreter'
+            projectFile: microbenchmarks.proj
+            runKind: micro_mono
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfa64'
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Browser Wasm Artifacts
-              artifactName: BrowserWasm
-              archiveType: zip
-              archiveExtension: .zip
+      # build mono on wasm
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Browser_wasm
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: wasm
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: Browser Wasm Artifacts
+                  artifactName: BrowserWasm
+                  archiveType: zip
+                  archiveExtension: .zip
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_arm64
-      - windows_arm64
-      jobParameters:
-        testGroup: perf
+      # build coreclr and libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_arm64
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Browser Wasm Artifacts
-              artifactName: BrowserWasm
-              archiveType: zip
-              archiveExtension: .zip
+      # build mono on wasm
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Browser_wasm
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: wasm
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: Browser Wasm Artifacts
+                  artifactName: BrowserWasm
+                  archiveType: zip
+                  archiveExtension: .zip
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AOT
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: AOT Mono Artifacts
-              artifactName: LinuxMonoAOTarm64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Linux_arm64
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: AOT
+            isOfficialBuild: false
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                  includeRootFolder: true
+                  displayName: AOT Mono Artifacts
+                  artifactName: LinuxMonoAOTarm64
+                  archiveExtension: '.tar.gz'
+                  archiveType: tar
+                  tarCompression: gz
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - Linux_arm64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+      # run mono aot microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+          buildConfig: release
+          runtimeFlavor: aot
+          platforms:
+          - Linux_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: mono
+            codeGenType: 'AOT'
+            projectFile: microbenchmarks.proj
+            runKind: micro_mono
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perftiger'
 
-# run coreclr Linux arm64 microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_arm64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfa64'
+    # run coreclr Linux arm64 microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - Linux_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfa64'
 
-# run coreclr Windows arm64 microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_arm64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfsurf' 
+    # run coreclr Windows arm64 microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfsurf' 
 
-# Uncomment once we fix https://github.com/dotnet/performance/issues/1950
-# # run coreclr linux crossgen perf job
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#     buildConfig: release
-#     runtimeFlavor: coreclr
-#     platforms:
-#     - Linux_arm64
-#     jobParameters:
-#       testGroup: perf
-#       liveLibrariesBuildConfig: Release
-#       projectFile: crossgen_perf.proj
-#       runKind: crossgen_scenarios
-#       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-#       logicalmachine: 'perfa64'
+    # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
+    # # run coreclr linux crossgen perf job
+    # - template: /eng/pipelines/common/platform-matrix.yml
+    #   parameters:
+    #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #     buildConfig: release
+    #     runtimeFlavor: coreclr
+    #     platforms:
+    #     - Linux_arm64
+    #     jobParameters:
+    #       testGroup: perf
+    #       liveLibrariesBuildConfig: Release
+    #       projectFile: crossgen_perf.proj
+    #       runKind: crossgen_scenarios
+    #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+    #       logicalmachine: 'perfa64'
 
-# # run coreclr windows crossgen perf job
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#     buildConfig: release
-#     runtimeFlavor: coreclr
-#     platforms:
-#     - windows_arm64
-#     jobParameters:
-#       testGroup: perf
-#       liveLibrariesBuildConfig: Release
-#       projectFile: crossgen_perf.proj
-#       runKind: crossgen_scenarios
-#       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-#       logicalmachine: 'perfsurf'
+    # # run coreclr windows crossgen perf job
+    # - template: /eng/pipelines/common/platform-matrix.yml
+    #   parameters:
+    #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #     buildConfig: release
+    #     runtimeFlavor: coreclr
+    #     platforms:
+    #     - windows_arm64
+    #     jobParameters:
+    #       testGroup: perf
+    #       liveLibrariesBuildConfig: Release
+    #       projectFile: crossgen_perf.proj
+    #       runKind: crossgen_scenarios
+    #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+    #       logicalmachine: 'perfsurf'

--- a/eng/pipelines/coreclr/pgo.yml
+++ b/eng/pipelines/coreclr/pgo.yml
@@ -8,50 +8,53 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_arm
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: pgo
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: pgo
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - OSX_arm64
+        - windows_arm
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: pgo
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_arm
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: pgo
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: pgo
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - OSX_arm64
+        - windows_arm
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: pgo
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/r2r-extra.yml
+++ b/eng/pipelines/coreclr/r2r-extra.yml
@@ -8,44 +8,47 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platformGroup: gcstress
-    platforms:
-    # It is too early to include OSX_arm64 in platform group gcstress
-    # Adding it here will enable it also
-    - OSX_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: r2r-extra
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: r2r-extra
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platformGroup: gcstress
+        platforms:
+        # It is too early to include OSX_arm64 in platform group gcstress
+        # Adding it here will enable it also
+        - OSX_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: r2r-extra
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platformGroup: gcstress # r2r-extra testGroup runs gcstress0xf scenario
-    platforms:
-    # It is too early to include OSX_arm64 in platform group gcstress
-    # Adding it here will enable it also
-    - OSX_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: r2r-extra
-      readyToRun: true
-      displayNameArgs: R2R
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: r2r-extra
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platformGroup: gcstress # r2r-extra testGroup runs gcstress0xf scenario
+        platforms:
+        # It is too early to include OSX_arm64 in platform group gcstress
+        # Adding it here will enable it also
+        - OSX_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: r2r-extra
+          readyToRun: true
+          displayNameArgs: R2R
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -8,52 +8,55 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_arm
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - OSX_arm64
+        - windows_arm
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - OSX_arm64
-    - windows_arm
-    - windows_arm64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      readyToRun: true
-      displayNameArgs: R2R
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - OSX_arm64
+        - windows_arm
+        - windows_arm64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          readyToRun: true
+          displayNameArgs: R2R
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -8,67 +8,70 @@ schedules:
     - main
   always: true
 
-jobs:
-
-#
-# Release CoreCLR and Library builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: release
-    platformGroup: all
-    platforms:
-    # It is too early to include OSX_arm64 in platform group all
-    # Adding it here will enable it also
-    - OSX_arm64
-    jobParameters:
-      isOfficialBuild: false
+    jobs:
 
-#
-# Release test builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: release
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    #
+    # Release CoreCLR and Library builds
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: release
+        platformGroup: all
+        platforms:
+        # It is too early to include OSX_arm64 in platform group all
+        # Adding it here will enable it also
+        - OSX_arm64
+        jobParameters:
+          isOfficialBuild: false
 
-#
-# Release test runs
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    platformGroup: all
-    platforms:
-    # It is too early to include OSX_arm64 in platform group all
-    # Adding it here will enable it also
-    - OSX_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    #
+    # Release test builds
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: release
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
 
-#
-# Release R2R test runs
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    platformGroup: all
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      readyToRun: true
-      displayNameArgs: R2R
+    #
+    # Release test runs
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: release
+        platformGroup: all
+        platforms:
+        # It is too early to include OSX_arm64 in platform group all
+        # Adding it here will enable it also
+        - OSX_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+
+    #
+    # Release R2R test runs
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: release
+        platformGroup: all
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          readyToRun: true
+          displayNameArgs: R2R
 

--- a/eng/pipelines/coreclr/runincontext.yml
+++ b/eng/pipelines/coreclr/runincontext.yml
@@ -8,42 +8,45 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      runInUnloadableContext: true
-      displayNameArgs: RunInContext
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          runInUnloadableContext: true
+          displayNameArgs: RunInContext
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/superpmi-replay.yml
+++ b/eng/pipelines/coreclr/superpmi-replay.yml
@@ -12,24 +12,27 @@ trigger:
 # and should not be triggerable from a PR. 
 pr: none
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-jit-job.yml
-    buildConfig: checked
-    platforms:
-    - windows_x64
-    - windows_x86
-    jobParameters:
-      uploadAs: 'pipelineArtifacts'
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-replay-job.yml
-    buildConfig: checked
-    platforms:
-    - windows_x64
-    - windows_x86
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-jit-job.yml
+        buildConfig: checked
+        platforms:
+        - windows_x64
+        - windows_x86
+        jobParameters:
+          uploadAs: 'pipelineArtifacts'
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-replay-job.yml
+        buildConfig: checked
+        platforms:
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -23,143 +23,146 @@ schedules:
     - main
   always: true
 
-jobs:
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      # libraries test build platforms
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
+    jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        # Linux tests are built on the OSX machines.
+        # - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
+          # libraries test build platforms
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: coreclr_tests
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+        buildConfig: checked
+        platforms:
+        # Linux tests are built on the OSX machines.
+        # - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: pmi
+          collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries_tests
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+        buildConfig: checked
+        platforms:
+        # Linux tests are built on the OSX machines.
+        # - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: pmi
+          collectionName: coreclr_tests
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen2
-      collectionName: libraries
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+        buildConfig: checked
+        platforms:
+        # Linux tests are built on the OSX machines.
+        # - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: pmi
+          collectionName: libraries_tests
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
-    # - Linux_arm
-    # - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: run
-      collectionName: benchmarks
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+        buildConfig: checked
+        platforms:
+        # Linux tests are built on the OSX machines.
+        # - OSX_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: crossgen2
+          collectionName: libraries
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+        buildConfig: checked
+        platforms:
+        # Linux tests are built on the OSX machines.
+        # - OSX_x64
+        #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
+        # - Linux_arm
+        # - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: run
+          collectionName: benchmarks

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -3,7 +3,6 @@ parameters:
   buildConfig: ''
   container: ''
   crossBuild: false
-  crossrootfsDir: ''
   osGroup: ''
   osSubgroup: ''
   pool: ''
@@ -38,7 +37,6 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     gatherAssetManifests: true
 

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -7,7 +7,6 @@ parameters:
   condition: true
   container: ''
   crossBuild: false
-  crossrootfsDir: ''
   dependOnEvaluatePaths: false
   isOfficialBuild: false
   osGroup: ''
@@ -64,7 +63,6 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     gatherAssetManifests: true
     variables:

--- a/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
@@ -7,7 +7,6 @@ parameters:
   helixQueues: ''
   runtimeVariant: ''
   crossBuild: false
-  crossrootfsDir: ''
   dependOnEvaluatePaths: false
   stagedBuild: false
   variables: {}
@@ -44,7 +43,6 @@ jobs:
     displayName: ${{ format('Test crossgen2-comparison build {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
 
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     variables:
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
@@ -7,7 +7,6 @@ parameters:
   helixQueues: ''
   runtimeVariant: ''
   crossBuild: false
-  crossrootfsDir: ''
   dependOnEvaluatePaths: false
   stagedBuild: false
   variables: {}
@@ -48,7 +47,6 @@ jobs:
     displayName: ${{ format('Test crossgen2-comparison {0}{1} {2} {3} to {4} {5}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.targetarch, parameters.targetos) }}
 
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     variables:
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/pipelines/coreclr/templates/format-job.yml
+++ b/eng/pipelines/coreclr/templates/format-job.yml
@@ -5,7 +5,6 @@ parameters:
   osSubgroup: ''
   container: ''
   crossBuild: false
-  crossrootfsDir: ''
   dependOnEvaluatePaths: false
   timeoutInMinutes: ''
   stagedBuild: false
@@ -23,7 +22,6 @@ jobs:
     osSubgroup: ${{ parameters.osSubgroup }}
     container: ${{ parameters.container }}
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
     stagedBuild: ${{ parameters.stagedBuild }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -8,7 +8,6 @@ parameters:
   container: ''
   testGroup: ''
   crossBuild: false
-  crossrootfsDir: ''
   liveLibrariesBuildConfig: ''
   stagedBuild: false
   strategy: ''
@@ -37,7 +36,6 @@ jobs:
     helixType: ${{ parameters.helixType }}
     container: ${{ parameters.container }}
     crossBuild: ${{ parameters.crossBuild }}
-    crossrootfsDir: ${{ parameters.crossrootfsDir }}
     stagedBuild: ${{ parameters.stagedBuild }}
     strategy: ${{ parameters.strategy }}
     pool: ${{ parameters.pool }}

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -28,111 +28,115 @@ pr:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
 
-jobs:
-#
-# Build with Release config and Debug runtimeConfiguration
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: release
-    platforms:
-    - windows_x86
-    - OSX_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: Runtime_Debug
-      buildArgs: -c release -runtimeConfiguration debug
-      timeoutInMinutes: 90
+    jobs:
 
-#
-# Build with Release config and runtimeConfiguration with MSBuild generator
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: release
-    platforms:
-    - windows_x86
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: MSBuild_CMake
-      buildArgs: -c Release -msbuild
-      timeoutInMinutes: 90
+    #
+    # Build with Release config and Debug runtimeConfiguration
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        platforms:
+        - windows_x86
+        - OSX_x64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: Runtime_Debug
+          buildArgs: -c release -runtimeConfiguration debug
+          timeoutInMinutes: 90
 
-#
-# Build with Debug config and Release runtimeConfiguration
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: debug
-    platforms:
-    - Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: Runtime_Release
-      buildArgs: -c debug -runtimeConfiguration release
-      timeoutInMinutes: 90
+    #
+    # Build with Release config and runtimeConfiguration with MSBuild generator
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        platforms:
+        - windows_x86
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: MSBuild_CMake
+          buildArgs: -c Release -msbuild
+          timeoutInMinutes: 90
 
-#
-# Build with RuntimeFlavor only. This excercise code paths where only RuntimeFlavor is
-# specified. Catches cases where we depend on Configuration also being specified
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: debug
-    platforms:
-    - Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: RuntimeFlavor_Mono
-      buildArgs: /p:RuntimeFlavor=Mono
-      timeoutInMinutes: 90
+    #
+    # Build with Debug config and Release runtimeConfiguration
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: debug
+        platforms:
+        - Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: Runtime_Release
+          buildArgs: -c debug -runtimeConfiguration release
+          timeoutInMinutes: 90
 
-#
-# Build Mono + Libraries. This excercises the code path where we build libraries without
-# first building CoreCLR
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: debug
-    platforms:
-    - windows_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: Mono_Libraries
-      buildArgs: -subset mono+libs /p:RuntimeFlavor=Mono
-      timeoutInMinutes: 90
+    #
+    # Build with RuntimeFlavor only. This excercise code paths where only RuntimeFlavor is
+    # specified. Catches cases where we depend on Configuration also being specified
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: debug
+        platforms:
+        - Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: RuntimeFlavor_Mono
+          buildArgs: /p:RuntimeFlavor=Mono
+          timeoutInMinutes: 90
 
-#
-# Build Libraries AllConfigurations. This exercises the code path where we build libraries for all
-# configurations on a non Windows operating system.
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: debug
-    platforms:
-    - Linux_x64
-    jobParameters:
-      nameSuffix: Libraries_AllConfigurations
-      buildArgs: -subset libs -allconfigurations
-      timeoutInMinutes: 90
+    #
+    # Build Mono + Libraries. This excercises the code path where we build libraries without
+    # first building CoreCLR
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: debug
+        platforms:
+        - windows_x64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: Mono_Libraries
+          buildArgs: -subset mono+libs /p:RuntimeFlavor=Mono
+          timeoutInMinutes: 90
 
-#
-# SourceBuild Build
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    platforms:
-    - SourceBuild_linux_x64
-    jobParameters:
-      nameSuffix: PortableSourceBuild
-      timeoutInMinutes: 95
-      condition:
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true)
+    #
+    # Build Libraries AllConfigurations. This exercises the code path where we build libraries for all
+    # configurations on a non Windows operating system.
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: debug
+        platforms:
+        - Linux_x64
+        jobParameters:
+          nameSuffix: Libraries_AllConfigurations
+          buildArgs: -subset libs -allconfigurations
+          timeoutInMinutes: 90
+
+    #
+    # SourceBuild Build
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: Release
+        platforms:
+        - SourceBuild_linux_x64
+        jobParameters:
+          nameSuffix: PortableSourceBuild
+          timeoutInMinutes: 95
+          condition:
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true)

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -5,7 +5,6 @@ parameters:
   osSubgroup: ''
   platform: ''
   crossBuild: false
-  crossrootfsDir: ''
   timeoutInMinutes: 120
   condition: true
   shouldContinueOnError: false
@@ -176,7 +175,6 @@ jobs:
           -v "$(Build.SourcesDirectory):/root/runtime"
           -w="/root/runtime"
           $(PreserveNuGetAuthDockerArgs)
-          -e ROOTFS_DIR=${{ parameters.crossrootfsDir }}
           ${{ parameters.container }}
 
     - name: BuildScript

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -4,7 +4,6 @@ parameters:
   archType: ''
   osSubgroup: ''
   crossBuild: false
-  crossrootfsDir: ''
   framework: 'net6.0'
   isSourceBuild: false
   liveRuntimeBuildConfig: ''

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -5,7 +5,6 @@ parameters:
   archType: ''
   targetRid: ''
   crossBuild: false
-  crossrootfsDir: ''
   framework: 'net6.0'
   isOfficialBuild: false
   runtimeVariant: ''
@@ -29,7 +28,6 @@ jobs:
       osSubgroup:  ${{ parameters.osSubgroup }}
       archType:  ${{ parameters.archType }}
       crossBuild: ${{ parameters.crossBuild }}
-      crossrootfsDir: ${{ parameters.crossrootfsDir }}
       framework:  ${{ parameters.framework }}
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
       runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -27,54 +27,57 @@ variables:
   - name: containerLibrariesRoot
     value: /repo/src/libraries
 
-jobs:
-- job: EnterpriseLinuxTests
-  timeoutInMinutes: 120
-  pool:
-    name: NetCore-Svc-Public
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-  steps:
-  - bash: |
-      cd $(enterpriseTestsSetup)
-      docker-compose build
-    displayName: Build test machine images
-    env:
-      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
+    - job: EnterpriseLinuxTests
+      timeoutInMinutes: 120
+      pool:
+        name: NetCore-Svc-Public
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+      steps:
+      - bash: |
+          cd $(enterpriseTestsSetup)
+          docker-compose build
+        displayName: Build test machine images
+        env:
+          DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-  - bash: |
-      cd $(enterpriseTestsSetup)
-      docker-compose up -d
-    displayName: Start test network and machines
-    env:
-      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+      - bash: |
+          cd $(enterpriseTestsSetup)
+          docker-compose up -d
+        displayName: Start test network and machines
+        env:
+          DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-  - bash: |
-      docker exec linuxclient bash /setup/test-webserver.sh
-    displayName: Test linuxclient connection to web server
+      - bash: |
+          docker exec linuxclient bash /setup/test-webserver.sh
+        displayName: Test linuxclient connection to web server
 
-  - bash: |
-      docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NoPgoOptimize=true'
-      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj'
-      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj'
-    displayName: Build product sources
+      - bash: |
+          docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NoPgoOptimize=true'
+          docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj'
+          docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj'
+        displayName: Build product sources
 
-  - bash: |
-      docker exec linuxclient bash -c 'if [ -f /erc/resolv.conf.ORI ]; then cp -f /erc/resolv.conf.ORI /etc/resolv.conf; fi'
-      docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
-      docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
-    displayName: Build and run tests
+      - bash: |
+          docker exec linuxclient bash -c 'if [ -f /erc/resolv.conf.ORI ]; then cp -f /erc/resolv.conf.ORI /etc/resolv.conf; fi'
+          docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
+          docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
+        displayName: Build and run tests
 
-  - bash: |
-      cd $(enterpriseTestsSetup)
-      docker-compose down
-    displayName: Stop test network and machines
-    env:
-      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+      - bash: |
+          cd $(enterpriseTestsSetup)
+          docker-compose down
+        displayName: Stop test network and machines
+        env:
+          DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-  - task: PublishTestResults@2
-    inputs:
-      testRunner: 'xUnit'
-      testResultsFiles: '**/testResults.xml'
-      testRunTitle: 'Enterprise Tests'
-      mergeTestResults: true
-      failTaskOnFailedTests: true
+      - task: PublishTestResults@2
+        inputs:
+          testRunner: 'xUnit'
+          testResultsFiles: '**/testResults.xml'
+          testRunTitle: 'Enterprise Tests'
+          mergeTestResults: true
+          failTaskOnFailedTests: true

--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -12,61 +12,64 @@ trigger: none
 variables:
   - template: variables.yml
 
-jobs:
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-      buildConfig: Release
-      runtimeFlavor: mono
-      platforms:
-      - windows_x86
-      - Browser_wasm
-      - ${{ if eq(variables['isFullMatrix'], true) }}:
-        - windows_x64
-        - Linux_x64
-        - Linux_arm
-        - Linux_musl_x64
-        - OSX_x64
-      jobParameters:
-        testScope: outerloop
-        nameSuffix: AllSubsets_Mono
-        buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) -testscope outerloop /p:ArchiveTests=true
-        timeoutInMinutes: 180
-        isFullMatrix: ${{ variables['isFullMatrix'] }}
-        # extra steps, run tests
-        postBuildSteps:
-          - template: /eng/pipelines/libraries/helix.yml
-            parameters:
-              scenarios:
-              - wasmtestonbrowser
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: Release
+          runtimeFlavor: mono
+          platforms:
+          - windows_x86
+          - Browser_wasm
+          - ${{ if eq(variables['isFullMatrix'], true) }}:
+            - windows_x64
+            - Linux_x64
+            - Linux_arm
+            - Linux_musl_x64
+            - OSX_x64
+          jobParameters:
+            testScope: outerloop
+            nameSuffix: AllSubsets_Mono
+            buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) -testscope outerloop /p:ArchiveTests=true
+            timeoutInMinutes: 180
+            isFullMatrix: ${{ variables['isFullMatrix'] }}
+            # extra steps, run tests
+            postBuildSteps:
+              - template: /eng/pipelines/libraries/helix.yml
+                parameters:
+                  scenarios:
+                  - wasmtestonbrowser
+                  testScope: outerloop
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+        
+      - ${{ if eq(variables['isFullMatrix'], false) }}:
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/global-build-job.yml
+            helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+            buildConfig: Debug
+            runtimeFlavor: mono
+            platforms:
+            - windows_x64
+            - Linux_x64
+            - Linux_musl_x64
+            - OSX_x64
+            jobParameters:
               testScope: outerloop
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-    
-  - ${{ if eq(variables['isFullMatrix'], false) }}:
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/common/global-build-job.yml
-        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-        buildConfig: Debug
-        runtimeFlavor: mono
-        platforms:
-        - windows_x64
-        - Linux_x64
-        - Linux_musl_x64
-        - OSX_x64
-        jobParameters:
-          testScope: outerloop
-          nameSuffix: AllSubsets_Mono
-          buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) -testscope outerloop /p:ArchiveTests=true
-          timeoutInMinutes: 180
-          isFullMatrix: ${{ variables['isFullMatrix'] }}
-          # extra steps, run tests
-          postBuildSteps:
-            - template: /eng/pipelines/libraries/helix.yml
-              parameters:
-                testScope: outerloop
-                creator: dotnet-bot
-                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+              nameSuffix: AllSubsets_Mono
+              buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) -testscope outerloop /p:ArchiveTests=true
+              timeoutInMinutes: 180
+              isFullMatrix: ${{ variables['isFullMatrix'] }}
+              # extra steps, run tests
+              postBuildSteps:
+                - template: /eng/pipelines/libraries/helix.yml
+                  parameters:
+                    testScope: outerloop
+                    creator: dotnet-bot
+                    testRunNamePrefixSuffix: Mono_$(_BuildConfig)

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -11,96 +11,99 @@ schedules:
 variables:
   - template: variables.yml
 
-jobs:
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
 
-  #
-  # CoreCLR Build
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-      buildConfig: release
-      platforms:
-      - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
-        - windows_x64
-        - windows_x86
-      - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
-        - Linux_x64
-        - Linux_musl_x64
-        - ${{ if eq(variables['isFullMatrix'], true) }}:
-          - Linux_arm
-          - Linux_arm64
-          - Linux_musl_arm64
-      - ${{ if eq(variables['includeOsxOuterloop'], true) }}:        
-        - OSX_arm64
-        - OSX_x64
-      jobParameters:
-        testGroup: innerloop
-  #
-  # Libraries Build
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/libraries/build-job.yml
-      buildConfig: Release
-      platforms:
-      - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
-        - windows_x86
-        - ${{ if eq(variables['isFullMatrix'], true) }}:
-          - windows_x64
-      - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
-        - ${{ if eq(variables['isFullMatrix'], true) }}:
-          - Linux_x64
-          - Linux_arm
-          - Linux_arm64
-          - Linux_musl_x64
-          - Linux_musl_arm64
-      - ${{ if and(eq(variables['includeOsxOuterloop'], true), eq(variables['isFullMatrix'], true)) }}:
-        - OSX_arm64
-        - OSX_x64
-      helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-      jobParameters:
-        isOfficialBuild: ${{ variables['isOfficialBuild'] }}
-        isFullMatrix: ${{ variables['isFullMatrix'] }}
-        runTests: true
-        testScope: outerloop
-        liveRuntimeBuildConfig: release
-  
-  - ${{ if eq(variables['isFullMatrix'], false) }}:
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/libraries/build-job.yml
-        buildConfig: Debug
-        platforms:
-        - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
-          - windows_x64
-        - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
-          - Linux_x64
-          - Linux_musl_x64
-        - ${{ if eq(variables['includeOsxOuterloop'], true) }}:
-          - OSX_arm64
-          - OSX_x64
-        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-        jobParameters:
-          isOfficialBuild: ${{ variables['isOfficialBuild'] }}
-          isFullMatrix: ${{ variables['isFullMatrix'] }}
-          runTests: true
-          testScope: outerloop
-          liveRuntimeBuildConfig: release
+      #
+      # CoreCLR Build
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+          buildConfig: release
+          platforms:
+          - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
+            - windows_x64
+            - windows_x86
+          - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
+            - Linux_x64
+            - Linux_musl_x64
+            - ${{ if eq(variables['isFullMatrix'], true) }}:
+              - Linux_arm
+              - Linux_arm64
+              - Linux_musl_arm64
+          - ${{ if eq(variables['includeOsxOuterloop'], true) }}:        
+            - OSX_arm64
+            - OSX_x64
+          jobParameters:
+            testGroup: innerloop
+      #
+      # Libraries Build
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/libraries/build-job.yml
+          buildConfig: Release
+          platforms:
+          - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
+            - windows_x86
+            - ${{ if eq(variables['isFullMatrix'], true) }}:
+              - windows_x64
+          - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
+            - ${{ if eq(variables['isFullMatrix'], true) }}:
+              - Linux_x64
+              - Linux_arm
+              - Linux_arm64
+              - Linux_musl_x64
+              - Linux_musl_arm64
+          - ${{ if and(eq(variables['includeOsxOuterloop'], true), eq(variables['isFullMatrix'], true)) }}:
+            - OSX_arm64
+            - OSX_x64
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          jobParameters:
+            isOfficialBuild: ${{ variables['isOfficialBuild'] }}
+            isFullMatrix: ${{ variables['isFullMatrix'] }}
+            runTests: true
+            testScope: outerloop
+            liveRuntimeBuildConfig: release
+      
+      - ${{ if eq(variables['isFullMatrix'], false) }}:
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/libraries/build-job.yml
+            buildConfig: Debug
+            platforms:
+            - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
+              - windows_x64
+            - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
+              - Linux_x64
+              - Linux_musl_x64
+            - ${{ if eq(variables['includeOsxOuterloop'], true) }}:
+              - OSX_arm64
+              - OSX_x64
+            helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+            jobParameters:
+              isOfficialBuild: ${{ variables['isOfficialBuild'] }}
+              isFullMatrix: ${{ variables['isFullMatrix'] }}
+              runTests: true
+              testScope: outerloop
+              liveRuntimeBuildConfig: release
 
-  - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/libraries/build-job.yml
-        buildConfig: Release
-        platforms:
-        - windows_x86
-        - ${{ if eq(variables['isFullMatrix'], true) }}:
-          - windows_x64
-        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-        jobParameters:
-          isOfficialBuild: ${{ variables['isOfficialBuild'] }}
-          isFullMatrix: ${{ variables['isFullMatrix'] }}
-          framework: net48
-          runTests: true
-          testScope: outerloop
+      - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/libraries/build-job.yml
+            buildConfig: Release
+            platforms:
+            - windows_x86
+            - ${{ if eq(variables['isFullMatrix'], true) }}:
+              - windows_x64
+            helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+            jobParameters:
+              isOfficialBuild: ${{ variables['isOfficialBuild'] }}
+              isFullMatrix: ${{ variables['isFullMatrix'] }}
+              framework: net48
+              runTests: true
+              testScope: outerloop

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -23,104 +23,107 @@ variables:
     value: dotnet-sdk-libraries-current
 
 
-jobs:
-- job: linux
-  displayName: Docker Linux
-  timeoutInMinutes: 180
-  pool:
-    name: NetCore-Svc-Public
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
+    - job: linux
+      displayName: Docker Linux
+      timeoutInMinutes: 180
+      pool:
+        name: NetCore-Svc-Public
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
+      steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 5
 
-  - bash: |
-      $(dockerfilesFolder)/build-docker-sdk.sh -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
-      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
-    name: buildRuntime
-    displayName: Build CLR and Libraries
+      - bash: |
+          $(dockerfilesFolder)/build-docker-sdk.sh -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+          echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+        name: buildRuntime
+        displayName: Build CLR and Libraries
 
-  - bash: |
-      $(httpStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
-      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
-    name: buildStress
-    displayName: Build HttpStress
+      - bash: |
+          $(httpStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+          echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+        name: buildStress
+        displayName: Build HttpStress
 
-  - bash: |
-      cd '$(httpStressProject)'
-      export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0"
-      export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP 3.0
-    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+      - bash: |
+          cd '$(httpStressProject)'
+          export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0"
+          export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
+          docker-compose up --abort-on-container-exit --no-color
+        displayName: Run HttpStress - HTTP 3.0
+        condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
-  - bash: |
-      cd '$(httpStressProject)'
-      export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 2.0"
-      export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 2.0"
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP 2.0
-    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+      - bash: |
+          cd '$(httpStressProject)'
+          export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 2.0"
+          export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 2.0"
+          docker-compose up --abort-on-container-exit --no-color
+        displayName: Run HttpStress - HTTP 2.0
+        condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
-  - bash: |
-      cd '$(httpStressProject)'
-      export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 1.1"
-      export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 1.1"
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP 1.1
-    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+      - bash: |
+          cd '$(httpStressProject)'
+          export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 1.1"
+          export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 1.1"
+          docker-compose up --abort-on-container-exit --no-color
+        displayName: Run HttpStress - HTTP 1.1
+        condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
-- job: windows
-  displayName: Docker NanoServer
-  timeoutInMinutes: 150
-  pool:
-    name: NetCore-Svc-Public
-    demands: ImageOverride -equals windows.vs2019.amd64.open
+    - job: windows
+      displayName: Docker NanoServer
+      timeoutInMinutes: 150
+      pool:
+        name: NetCore-Svc-Public
+        demands: ImageOverride -equals windows.vs2019.amd64.open
 
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    lfs: false
+      steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 5
+        lfs: false
 
-  - powershell: |
-      $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
-      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
-    name: buildRuntime
-    displayName: Build CLR and Libraries
+      - powershell: |
+          $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+          echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+        name: buildRuntime
+        displayName: Build CLR and Libraries
 
-  - powershell: |
-      $(httpStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
-      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
-    name: buildStress
-    displayName: Build HttpStress
+      - powershell: |
+          $(httpStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+          echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+        name: buildStress
+        displayName: Build HttpStress
 
-    # Firewall is disabled for the test runs, since it can lead to unexpected TCP failures on CI machines, which are unrelated to the HTTP logic.
-    # See: https://github.com/dotnet/runtime/issues/50854
-  - powershell: |
-      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
-    name: disableFirewall
-    displayName: Disable Firewall
+        # Firewall is disabled for the test runs, since it can lead to unexpected TCP failures on CI machines, which are unrelated to the HTTP logic.
+        # See: https://github.com/dotnet/runtime/issues/50854
+      - powershell: |
+          Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
+        name: disableFirewall
+        displayName: Disable Firewall
 
-  - powershell: |
-      cd '$(httpStressProject)'
-      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
-      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 2.0"
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP 2.0
-    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+      - powershell: |
+          cd '$(httpStressProject)'
+          $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
+          $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 2.0"
+          docker-compose up --abort-on-container-exit --no-color
+        displayName: Run HttpStress - HTTP 2.0
+        condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
-  - powershell: |
-      cd '$(httpStressProject)'
-      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 1.1"
-      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 1.1"
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP 1.1
-    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+      - powershell: |
+          cd '$(httpStressProject)'
+          $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 1.1"
+          $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 1.1"
+          docker-compose up --abort-on-container-exit --no-color
+        displayName: Run HttpStress - HTTP 1.1
+        condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
-  - powershell: |
-      Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled True
-    name: enableFirewall
-    displayName: Enable Firewall
+      - powershell: |
+          Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled True
+        name: enableFirewall
+        displayName: Enable Firewall

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -23,55 +23,58 @@ variables:
     value: dotnet-sdk-libraries-current
 
 
-jobs:
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
 
-- job: linux
-  displayName: Docker Linux
-  timeoutInMinutes: 120
-  pool:
-    name: NetCore-Svc-Public
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+    - job: linux
+      displayName: Docker Linux
+      timeoutInMinutes: 120
+      pool:
+        name: NetCore-Svc-Public
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
+      steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 5
 
-  - bash: |
-      $(dockerfilesFolder)/build-docker-sdk.sh -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
-    displayName: Build CLR and Libraries
+      - bash: |
+          $(dockerfilesFolder)/build-docker-sdk.sh -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+        displayName: Build CLR and Libraries
 
-  - bash: |
-      $(sslStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
-    displayName: Build SslStress
+      - bash: |
+          $(sslStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+        displayName: Build SslStress
 
-  - bash: |
-      cd '$(sslStressProject)'
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run SslStress
+      - bash: |
+          cd '$(sslStressProject)'
+          docker-compose up --abort-on-container-exit --no-color
+        displayName: Run SslStress
 
-- job: windows
-  displayName: Docker NanoServer
-  timeoutInMinutes: 120
-  pool:
-    name: NetCore-Svc-Public
-    demands: ImageOverride -equals windows.vs2019.amd64.open
+    - job: windows
+      displayName: Docker NanoServer
+      timeoutInMinutes: 120
+      pool:
+        name: NetCore-Svc-Public
+        demands: ImageOverride -equals windows.vs2019.amd64.open
 
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    lfs: false
+      steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 5
+        lfs: false
 
-  - powershell: |
-      $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
-    displayName: Build CLR and Libraries
-  
-  - powershell: |
-      $(sslStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
-    displayName: Build SslStress
-  
-  - powershell: |
-      cd '$(sslStressProject)'
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run SslStress 
+      - powershell: |
+          $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+        displayName: Build CLR and Libraries
+      
+      - powershell: |
+          $(sslStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+        displayName: Build SslStress
+      
+      - powershell: |
+          cd '$(sslStressProject)'
+          docker-compose up --abort-on-container-exit --no-color
+        displayName: Run SslStress 

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -12,7 +12,6 @@ parameters:
   runtimeVariant: ''
   isOfficialBuild: false
   crossBuild: false
-  crossrootfsDir: ''
   dependsOn: []
   monoCrossAOTTargetOS: []
   dependOnEvaluatePaths: false
@@ -31,7 +30,6 @@ jobs:
     runtimeVariant: ${{ parameters.runtimeVariant }}
     crossBuild: ${{ parameters.crossBuild }}
     monoCrossAOTTargetOS: ${{ parameters.monoCrossAOTTargetOS }}
-    crossrootfsDir: ${{ parameters.crossroofsDir }}
     condition: ${{ parameters.condition }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
 

--- a/eng/pipelines/runtime-community.yml
+++ b/eng/pipelines/runtime-community.yml
@@ -12,50 +12,53 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-#
-# Evaluate paths
-#
-- ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
-  - template: /eng/pipelines/common/evaluate-default-paths.yml
-
-#
-# s390x
-# Build the whole product using Mono and run libraries tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Linux_s390x
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
-              eq(variables['isRollingBuild'], true))
+    jobs:
+    #
+    # Evaluate paths
+    #
+    - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
+      - template: /eng/pipelines/common/evaluate-default-paths.yml
+
+    #
+    # s390x
+    # Build the whole product using Mono and run libraries tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Linux_s390x
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isRollingBuild'], true))

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -43,41 +43,44 @@ pr:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
 
-jobs:
-#
-# Build Release config vertical for Windows, Linux, Linux musl and OSX
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: release
-    platforms:
-    - windows_x64
-    - OSX_x64
-    - Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      timeoutInMinutes: 120
-      nameSuffix: Runtime_Release
-      buildArgs: -s clr+libs -c $(_BuildConfig)
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
+    jobs:
+    #
+    # Build Release config vertical for Windows, Linux, Linux musl and OSX
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        platforms:
+        - windows_x64
+        - OSX_x64
+        - Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          timeoutInMinutes: 120
+          nameSuffix: Runtime_Release
+          buildArgs: -s clr+libs -c $(_BuildConfig)
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
 
-#
-# Build Release config vertical for Browser-wasm
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: release
-    platforms:
-    - Browser_wasm
-    jobParameters:
-      testGroup: innerloop
-      timeoutInMinutes: 120
-      nameSuffix: Runtime_Release
-      buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
-          parameters:
-              extraTestArgs: '/p:WasmBuildNative=false'
+    #
+    # Build Release config vertical for Browser-wasm
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        platforms:
+        - Browser_wasm
+        jobParameters:
+          testGroup: innerloop
+          timeoutInMinutes: 120
+          nameSuffix: Runtime_Release
+          buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
+              parameters:
+                  extraTestArgs: '/p:WasmBuildNative=false'

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -37,442 +37,445 @@ variables:
 - name: PostBuildSign
   value: true
 
-stages:
-- stage: Build
-  jobs:
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
 
-  #
-  # Localization build
-  #
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: runtime
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
-
-  #
-  # Source Index Build
-  #
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-    - template: /eng/common/templates/job/source-index-stage1.yml
-      parameters:
-        sourceIndexBuildCommand: build.cmd -subset libs.ref+libs.src -binarylog -os Linux -ci
-
-  #
-  # Build CoreCLR runtime packs
-  # Windows x64/x86/arm64/arm
-  # Sign diagnostic files after native build
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      platforms:
-      - windows_x64
-      - windows_x86
-      - windows_arm64
-      - windows_arm
-      jobParameters:
-        buildArgs: -s clr.runtime+clr.alljits -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
-        nameSuffix: CoreCLR
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        timeoutInMinutes: 120
-        postBuildSteps:
-        - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+      #
+      # Localization build
+      #
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        - template: /eng/common/templates/job/onelocbuild.yml
           parameters:
-            basePath: $(Build.SourcesDirectory)/artifacts/bin/coreclr
+            MirrorRepo: runtime
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
+
+      #
+      # Source Index Build
+      #
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        - template: /eng/common/templates/job/source-index-stage1.yml
+          parameters:
+            sourceIndexBuildCommand: build.cmd -subset libs.ref+libs.src -binarylog -os Linux -ci
+
+      #
+      # Build CoreCLR runtime packs
+      # Windows x64/x86/arm64/arm
+      # Sign diagnostic files after native build
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms:
+          - windows_x64
+          - windows_x86
+          - windows_arm64
+          - windows_arm
+          jobParameters:
+            buildArgs: -s clr.runtime+clr.alljits -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
+            nameSuffix: CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
-            timeoutInMinutes: 30
-        # Now that we've signed the diagnostic files, do the rest of the build.
-        - template: /eng/pipelines/common/templates/global-build-step.yml
-          parameters:
-            buildArgs: -s clr.corelib+clr.nativecorelib+clr.tools+clr.packages+clr.paltestlist+libs+host+packs -c $(_BuildConfig)
-            displayName: Build managed CoreCLR components, all libraries, hosts, and packs
-
-        # Upload the results.
-        - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-          parameters:
-            name: $(osGroup)$(osSubgroup)_$(archType)
-
-  #
-  # Build CoreCLR runtime packs
-  # Mac x64/arm64
-  # Sign and entitle createdump and corerun after native build.
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      platforms:
-      - osx_arm64
-      - osx_x64
-      jobParameters:
-        buildArgs: -s clr.runtime+clr.alljits+host.native -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
-        nameSuffix: CoreCLR
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        timeoutInMinutes: 120
-        postBuildSteps:
-          - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
+            timeoutInMinutes: 120
+            postBuildSteps:
+            - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
               parameters:
-                filesToSign:
-                - name: createdump
-                  path: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
-                  entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/createdump-entitlements.plist
-                - name: corerun
-                  path: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
-                  entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
-                - name: dotnet
-                  path: $(Build.SourcesDirectory)/artifacts/bin/$(osGroup)-$(archType).$(_BuildConfig)/corehost
-                  entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
-                - name: apphost
-                  path: $(Build.SourcesDirectory)/artifacts/bin/$(osGroup)-$(archType).$(_BuildConfig)/corehost
-                  entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+                basePath: $(Build.SourcesDirectory)/artifacts/bin/coreclr
+                isOfficialBuild: ${{ variables.isOfficialBuild }}
+                timeoutInMinutes: 30
+            # Now that we've signed the diagnostic files, do the rest of the build.
+            - template: /eng/pipelines/common/templates/global-build-step.yml
+              parameters:
+                buildArgs: -s clr.corelib+clr.nativecorelib+clr.tools+clr.packages+clr.paltestlist+libs+host+packs -c $(_BuildConfig)
+                displayName: Build managed CoreCLR components, all libraries, hosts, and packs
 
-          - task: CopyFiles@2
-            displayName: 'Copy signed createdump to sharedFramework'
-            inputs:
-              contents: createdump
-              sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
-              targetFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)/sharedFramework
-              overWrite: true
-
-          # Now that we've entitled and signed createdump, we can build the rest.
-          - template: /eng/pipelines/common/templates/global-build-step.yml
-            parameters:
-              buildArgs: -s clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs+host.tools+host.pkg+packs -c $(_BuildConfig)
-              displayName: Build managed CoreCLR and host components, all libraries, and packs
-
-          # Upload the results.
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: $(osGroup)$(osSubgroup)_$(archType)
-
-  #
-  # Build CoreCLR runtime packs
-  # Linux and Linux_musl
-  # CoreCLR runtime for CrossDac packaging
-  # Create Linux installers
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      platforms:
-      - linux_x64
-      - linux_arm
-      - linux_arm64
-      - linux_musl_x64
-      - linux_musl_arm
-      - linux_musl_arm64
-      jobParameters:
-        buildArgs: -s clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: CoreCLR
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        timeoutInMinutes: 120
-        postBuildSteps:
-          # Upload libcoreclr.so for CrossDac packaging
-          - task: CopyFiles@2
-            displayName: Gather runtime for CrossDac
-            inputs:
-              SourceFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
-              Contents: libcoreclr.so
-              TargetFolder: $(Build.SourcesDirectory)/artifacts/CoreCLRCrossDacArtifacts/$(osGroup)$(osSubgroup).$(archType).$(_BuildConfig)/$(crossDacHostArch)
-          - task: PublishBuildArtifacts@1
-            displayName: Publish runtime for CrossDac
-            inputs:
-              pathToPublish: $(Build.SourcesDirectory)/artifacts/CoreCLRCrossDacArtifacts
-              PublishLocation: Container
-              artifactName: CoreCLRCrossDacArtifacts
-
-          # Upload the results.
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: $(osGroup)$(osSubgroup)_$(archType)
-        extraVariablesTemplates:
-          - template: /eng/pipelines/coreclr/templates/crossdac-hostarch.yml
-
-  #
-  # Build Mono runtime packs
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_x64
-      - Android_x86
-      - Android_arm
-      - Android_arm64
-      - MacCatalyst_x64
-      - MacCatalyst_arm64
-      - tvOSSimulator_x64
-      - tvOSSimulator_arm64
-      - tvOS_arm64
-      - iOSSimulator_x64
-      - iOSSimulator_x86
-      - iOSSimulator_arm64
-      - iOS_arm
-      - iOS_arm64
-      - OSX_x64
-      - OSX_arm64
-      - Linux_x64
-      - Linux_arm
-      - Linux_arm64
-      - Linux_musl_x64
-      - Browser_wasm
-      # - Linux_musl_arm
-      # - Linux_musl_arm64
-      - windows_x64
-      - windows_x86
-      # - windows_arm
-      # - windows_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: Mono
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: MonoRuntimePacks
-
-  # Build Mono AOT offset headers once, for consumption elsewhere
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/generate-offsets.yml
-      buildConfig: release
-      platforms:
-      - Android_x64
-      - Browser_wasm
-      - tvOS_arm64
-      - iOS_arm64
-      - MacCatalyst_x64
-      jobParameters:
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-
-  #
-  # Build Mono release AOT cross-compilers
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
-      jobParameters:
-        buildArgs: -s mono+packs -c $(_BuildConfig)
-                   /p:MonoCrossAOTTargetOS=Android+Browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
-        nameSuffix: CrossAOT_Mono
-        runtimeVariant: crossaot
-        dependsOn:
-        - mono_android_offsets
-        - mono_browser_offsets
-        monoCrossAOTTargetOS:
-        - Android
-        - Browser
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: MonoRuntimePacks
-
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Windows_x64
-      jobParameters:
-        buildArgs: -s mono+packs -c $(_BuildConfig)
-                   /p:MonoCrossAOTTargetOS=Android+Browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
-        nameSuffix: CrossAOT_Mono
-        runtimeVariant: crossaot
-        dependsOn:
-        - mono_android_offsets
-        - mono_browser_offsets
-        monoCrossAOTTargetOS:
-        - Android
-        - Browser
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: MonoRuntimePacks
-
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - OSX_x64
-      jobParameters:
-        buildArgs: -s mono+packs -c $(_BuildConfig)
-                   /p:MonoCrossAOTTargetOS=Android+Browser+tvOS+iOS+MacCatalyst /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
-        nameSuffix: CrossAOT_Mono
-        runtimeVariant: crossaot
-        dependsOn:
-        - mono_android_offsets
-        - mono_browser_offsets
-        - mono_tvos_offsets
-        - mono_ios_offsets
-        - mono_maccatalyst_offsets
-        monoCrossAOTTargetOS:
-        - Android
-        - Browser
-        - tvOS
-        - iOS
-        - MacCatalyst
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: MonoRuntimePacks
-
-  #
-  # Build Mono LLVM runtime packs
-  #
-  - template: /eng/pipelines/common/platform-matrix-multijob.yml
-    parameters:
-      platforms:
-      - OSX_x64
-      - Linux_x64
-      # - Linux_arm
-      - Linux_arm64
-      # - Linux_musl_x64
-      # - Linux_musl_arm64
-      # - windows_x64
-      # - windows_x86
-      # - windows_arm
-      # - windows_arm64
-      jobTemplates:
-      # LLVMJIT
-      - jobTemplate: /eng/pipelines/common/global-build-job.yml
-        buildConfig: release
-        runtimeFlavor: mono
-        jobParameters:
-          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                     /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-          nameSuffix: Mono_LLVMJIT
-          runtimeVariant: LLVMJIT
-          isOfficialBuild: ${{ variables.isOfficialBuild }}
-          postBuildSteps:
+            # Upload the results.
             - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
               parameters:
-                name: MonoRuntimePacks
-      #LLVMAOT
-      - jobTemplate: /eng/pipelines/common/global-build-job.yml
-        buildConfig: release
-        runtimeFlavor: mono
-        jobParameters:
-          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-          nameSuffix: Mono_LLVMAOT
-          runtimeVariant: LLVMAOT
+                name: $(osGroup)$(osSubgroup)_$(archType)
+
+      #
+      # Build CoreCLR runtime packs
+      # Mac x64/arm64
+      # Sign and entitle createdump and corerun after native build.
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms:
+          - osx_arm64
+          - osx_x64
+          jobParameters:
+            buildArgs: -s clr.runtime+clr.alljits+host.native -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
+            nameSuffix: CoreCLR
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 120
+            postBuildSteps:
+              - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
+                  parameters:
+                    filesToSign:
+                    - name: createdump
+                      path: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
+                      entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/createdump-entitlements.plist
+                    - name: corerun
+                      path: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
+                      entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+                    - name: dotnet
+                      path: $(Build.SourcesDirectory)/artifacts/bin/$(osGroup)-$(archType).$(_BuildConfig)/corehost
+                      entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+                    - name: apphost
+                      path: $(Build.SourcesDirectory)/artifacts/bin/$(osGroup)-$(archType).$(_BuildConfig)/corehost
+                      entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+
+              - task: CopyFiles@2
+                displayName: 'Copy signed createdump to sharedFramework'
+                inputs:
+                  contents: createdump
+                  sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
+                  targetFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)/sharedFramework
+                  overWrite: true
+
+              # Now that we've entitled and signed createdump, we can build the rest.
+              - template: /eng/pipelines/common/templates/global-build-step.yml
+                parameters:
+                  buildArgs: -s clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs+host.tools+host.pkg+packs -c $(_BuildConfig)
+                  displayName: Build managed CoreCLR and host components, all libraries, and packs
+
+              # Upload the results.
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: $(osGroup)$(osSubgroup)_$(archType)
+
+      #
+      # Build CoreCLR runtime packs
+      # Linux and Linux_musl
+      # CoreCLR runtime for CrossDac packaging
+      # Create Linux installers
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms:
+          - linux_x64
+          - linux_arm
+          - linux_arm64
+          - linux_musl_x64
+          - linux_musl_arm
+          - linux_musl_arm64
+          jobParameters:
+            buildArgs: -s clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: CoreCLR
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 120
+            postBuildSteps:
+              # Upload libcoreclr.so for CrossDac packaging
+              - task: CopyFiles@2
+                displayName: Gather runtime for CrossDac
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
+                  Contents: libcoreclr.so
+                  TargetFolder: $(Build.SourcesDirectory)/artifacts/CoreCLRCrossDacArtifacts/$(osGroup)$(osSubgroup).$(archType).$(_BuildConfig)/$(crossDacHostArch)
+              - task: PublishBuildArtifacts@1
+                displayName: Publish runtime for CrossDac
+                inputs:
+                  pathToPublish: $(Build.SourcesDirectory)/artifacts/CoreCLRCrossDacArtifacts
+                  PublishLocation: Container
+                  artifactName: CoreCLRCrossDacArtifacts
+
+              # Upload the results.
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: $(osGroup)$(osSubgroup)_$(archType)
+            extraVariablesTemplates:
+              - template: /eng/pipelines/coreclr/templates/crossdac-hostarch.yml
+
+      #
+      # Build Mono runtime packs
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Android_x64
+          - Android_x86
+          - Android_arm
+          - Android_arm64
+          - MacCatalyst_x64
+          - MacCatalyst_arm64
+          - tvOSSimulator_x64
+          - tvOSSimulator_arm64
+          - tvOS_arm64
+          - iOSSimulator_x64
+          - iOSSimulator_x86
+          - iOSSimulator_arm64
+          - iOS_arm
+          - iOS_arm64
+          - OSX_x64
+          - OSX_arm64
+          - Linux_x64
+          - Linux_arm
+          - Linux_arm64
+          - Linux_musl_x64
+          - Browser_wasm
+          # - Linux_musl_arm
+          # - Linux_musl_arm64
+          - windows_x64
+          - windows_x86
+          # - windows_arm
+          # - windows_arm64
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: Mono
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: MonoRuntimePacks
+
+      # Build Mono AOT offset headers once, for consumption elsewhere
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/mono/templates/generate-offsets.yml
+          buildConfig: release
+          platforms:
+          - Android_x64
+          - Browser_wasm
+          - tvOS_arm64
+          - iOS_arm64
+          - MacCatalyst_x64
+          jobParameters:
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+
+      #
+      # Build Mono release AOT cross-compilers
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          runtimeFlavor: mono
+          buildConfig: release
+          platforms:
+          - Linux_x64
+          jobParameters:
+            buildArgs: -s mono+packs -c $(_BuildConfig)
+                       /p:MonoCrossAOTTargetOS=Android+Browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
+            nameSuffix: CrossAOT_Mono
+            runtimeVariant: crossaot
+            dependsOn:
+            - mono_android_offsets
+            - mono_browser_offsets
+            monoCrossAOTTargetOS:
+            - Android
+            - Browser
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: MonoRuntimePacks
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          runtimeFlavor: mono
+          buildConfig: release
+          platforms:
+          - Windows_x64
+          jobParameters:
+            buildArgs: -s mono+packs -c $(_BuildConfig)
+                       /p:MonoCrossAOTTargetOS=Android+Browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
+            nameSuffix: CrossAOT_Mono
+            runtimeVariant: crossaot
+            dependsOn:
+            - mono_android_offsets
+            - mono_browser_offsets
+            monoCrossAOTTargetOS:
+            - Android
+            - Browser
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: MonoRuntimePacks
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          runtimeFlavor: mono
+          buildConfig: release
+          platforms:
+          - OSX_x64
+          jobParameters:
+            buildArgs: -s mono+packs -c $(_BuildConfig)
+                       /p:MonoCrossAOTTargetOS=Android+Browser+tvOS+iOS+MacCatalyst /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
+            nameSuffix: CrossAOT_Mono
+            runtimeVariant: crossaot
+            dependsOn:
+            - mono_android_offsets
+            - mono_browser_offsets
+            - mono_tvos_offsets
+            - mono_ios_offsets
+            - mono_maccatalyst_offsets
+            monoCrossAOTTargetOS:
+            - Android
+            - Browser
+            - tvOS
+            - iOS
+            - MacCatalyst
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: MonoRuntimePacks
+
+      #
+      # Build Mono LLVM runtime packs
+      #
+      - template: /eng/pipelines/common/platform-matrix-multijob.yml
+        parameters:
+          platforms:
+          - OSX_x64
+          - Linux_x64
+          # - Linux_arm
+          - Linux_arm64
+          # - Linux_musl_x64
+          # - Linux_musl_arm64
+          # - windows_x64
+          # - windows_x86
+          # - windows_arm
+          # - windows_arm64
+          jobTemplates:
+          # LLVMJIT
+          - jobTemplate: /eng/pipelines/common/global-build-job.yml
+            buildConfig: release
+            runtimeFlavor: mono
+            jobParameters:
+              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                         /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+              nameSuffix: Mono_LLVMJIT
+              runtimeVariant: LLVMJIT
+              isOfficialBuild: ${{ variables.isOfficialBuild }}
+              postBuildSteps:
+                - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                  parameters:
+                    name: MonoRuntimePacks
+          #LLVMAOT
+          - jobTemplate: /eng/pipelines/common/global-build-job.yml
+            buildConfig: release
+            runtimeFlavor: mono
+            jobParameters:
+              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                          /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+              nameSuffix: Mono_LLVMAOT
+              runtimeVariant: LLVMAOT
+              isOfficialBuild: ${{ variables.isOfficialBuild }}
+              postBuildSteps:
+                - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                  parameters:
+                    name: MonoRuntimePacks
+
+      #
+      # Build libraries AllConfigurations for packages
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Release
+          platforms:
+          - windows_x64
+          jobParameters:
+            buildArgs: -s libs -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
+            nameSuffix: Libraries_AllConfigurations
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: Libraries_AllConfigurations
+            timeoutInMinutes: 95
+
+      #
+      # Build SourceBuild leg
+      #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     helixQueueGroup: ci
+      #     platforms:
+      #     - SourceBuild_Linux_x64
+      #     jobParameters:
+      #       nameSuffix: PortableSourceBuild
+      #       postBuildSteps:
+      #         - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+      #           parameters:
+      #             name: SourceBuildPackages
+      #       timeoutInMinutes: 95
+
+      #
+      # Build PGO Instrumented CoreCLR Release
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          helixQueueGroup: ci
+          platforms:
+          - windows_x64
+          - windows_x86
+          - Linux_x64
+          jobParameters:
+            buildArgs: -s clr.native+clr.corelib+clr.tools+clr.nativecorelib+libs+host+packs -c $(_BuildConfig) -pgoinstrument
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            nameSuffix: PGO
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+                parameters:
+                  name: PGO
+            timeoutInMinutes: 95
+
+      #
+      # Build Workloads
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/mono/templates/workloads-build.yml
+          buildConfig: release
+          platforms:
+          - windows_x64
+          jobParameters:
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 120
+            dependsOn:
+            - Build_Android_arm_release_Mono
+            - Build_Android_arm64_release_Mono
+            - Build_Android_x86_release_Mono
+            - Build_Android_x64_release_Mono
+            - Build_Browser_wasm_release_Mono
+            - Build_iOS_arm_release_Mono
+            - Build_iOS_arm64_release_Mono
+            - Build_iOSSimulator_x64_release_Mono
+            - Build_iOSSimulator_x86_release_Mono
+            - Build_iOSSimulator_arm64_release_Mono
+            - Build_MacCatalyst_arm64_release_Mono
+            - Build_MacCatalyst_x64_release_Mono
+            - Build_tvOS_arm64_release_Mono
+            - Build_tvOSSimulator_arm64_release_Mono
+            - Build_tvOSSimulator_x64_release_Mono
+            - Build_Windows_x64_release_CrossAOT_Mono
+            - Build_windows_x64_release_CoreCLR
+            - Build_windows_x86_release_CoreCLR
+            - Build_windows_arm_release_CoreCLR
+            - Build_windows_arm64_release_CoreCLR
+
+    - ${{ if eq(variables.isOfficialBuild, true) }}:
+      - template: /eng/pipelines/official/stages/publish.yml
+        parameters:
           isOfficialBuild: ${{ variables.isOfficialBuild }}
-          postBuildSteps:
-            - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-              parameters:
-                name: MonoRuntimePacks
-
-  #
-  # Build libraries AllConfigurations for packages
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: Release
-      platforms:
-      - windows_x64
-      jobParameters:
-        buildArgs: -s libs -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
-        nameSuffix: Libraries_AllConfigurations
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: Libraries_AllConfigurations
-        timeoutInMinutes: 95
-
-  #
-  # Build SourceBuild leg
-  #
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: Release
-  #     helixQueueGroup: ci
-  #     platforms:
-  #     - SourceBuild_Linux_x64
-  #     jobParameters:
-  #       nameSuffix: PortableSourceBuild
-  #       postBuildSteps:
-  #         - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #           parameters:
-  #             name: SourceBuildPackages
-  #       timeoutInMinutes: 95
-
-  #
-  # Build PGO Instrumented CoreCLR Release
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      helixQueueGroup: ci
-      platforms:
-      - windows_x64
-      - windows_x86
-      - Linux_x64
-      jobParameters:
-        buildArgs: -s clr.native+clr.corelib+clr.tools+clr.nativecorelib+libs+host+packs -c $(_BuildConfig) -pgoinstrument
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        nameSuffix: PGO
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: PGO
-        timeoutInMinutes: 95
-
-  #
-  # Build Workloads
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/workloads-build.yml
-      buildConfig: release
-      platforms:
-      - windows_x64
-      jobParameters:
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        timeoutInMinutes: 120
-        dependsOn:
-        - Build_Android_arm_release_Mono
-        - Build_Android_arm64_release_Mono
-        - Build_Android_x86_release_Mono
-        - Build_Android_x64_release_Mono
-        - Build_Browser_wasm_release_Mono
-        - Build_iOS_arm_release_Mono
-        - Build_iOS_arm64_release_Mono
-        - Build_iOSSimulator_x64_release_Mono
-        - Build_iOSSimulator_x86_release_Mono
-        - Build_iOSSimulator_arm64_release_Mono
-        - Build_MacCatalyst_arm64_release_Mono
-        - Build_MacCatalyst_x64_release_Mono
-        - Build_tvOS_arm64_release_Mono
-        - Build_tvOSSimulator_arm64_release_Mono
-        - Build_tvOSSimulator_x64_release_Mono
-        - Build_Windows_x64_release_CrossAOT_Mono
-        - Build_windows_x64_release_CoreCLR
-        - Build_windows_x86_release_CoreCLR
-        - Build_windows_arm_release_CoreCLR
-        - Build_windows_arm64_release_CoreCLR
-
-- ${{ if eq(variables.isOfficialBuild, true) }}:
-  - template: /eng/pipelines/official/stages/publish.yml
-    parameters:
-      isOfficialBuild: ${{ variables.isOfficialBuild }}

--- a/eng/pipelines/runtime-richnav.yml
+++ b/eng/pipelines/runtime-richnav.yml
@@ -24,35 +24,38 @@ pr: none
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-#
-# Evaluate paths
-#
-- ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
-  - template: /eng/pipelines/common/evaluate-default-paths.yml
-
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: debug
-    platforms:
-      - windows_x64
-    jobParameters:
-      enableRichCodeNavigation: true
-      richCodeNavigationEnvironment: "production"
-      richCodeNavigationLanguage: "csharp"
-      timeoutInMinutes: 240
-      buildArgs: -s libs.ref+libs.src -c debug -allConfigurations
+    jobs:
+    #
+    # Evaluate paths
+    #
+    - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
+      - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: debug
-    platforms:
-      - windows_x64
-    jobParameters:
-      enableRichCodeNavigation: true
-      nameSuffix: Mono
-      richCodeNavigationEnvironment: "production"
-      richCodeNavigationLanguage: "csharp,cpp"
-      buildArgs: -s mono -c debug
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: debug
+        platforms:
+          - windows_x64
+        jobParameters:
+          enableRichCodeNavigation: true
+          richCodeNavigationEnvironment: "production"
+          richCodeNavigationLanguage: "csharp"
+          timeoutInMinutes: 240
+          buildArgs: -s libs.ref+libs.src -c debug -allConfigurations
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: debug
+        platforms:
+          - windows_x64
+        jobParameters:
+          enableRichCodeNavigation: true
+          nameSuffix: Mono
+          richCodeNavigationEnvironment: "production"
+          richCodeNavigationLanguage: "csharp,cpp"
+          buildArgs: -s mono -c debug

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -47,482 +47,485 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-#
-# Evaluate paths
-#
-- ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
-  - template: /eng/pipelines/common/evaluate-default-paths.yml
-
-#
-# iOS/tvOS/Catalyst interp - requires AOT Compilation and Interp flags
-# Build the whole product using Mono and run libraries tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - iOSSimulator_x64
-    - tvOSSimulator_x64
-    # don't run tests on arm64 PRs until we can get significantly more devices
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - iOSSimulator_arm64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            interpreter: true
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+    jobs:
+    #
+    # Evaluate paths
+    #
+    - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
+      - template: /eng/pipelines/common/evaluate-default-paths.yml
+
+    #
+    # iOS/tvOS/Catalyst interp - requires AOT Compilation and Interp flags
+    # Build the whole product using Mono and run libraries tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - iOSSimulator_x64
+        - tvOSSimulator_x64
+        # don't run tests on arm64 PRs until we can get significantly more devices
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - iOSSimulator_arm64
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                interpreter: true
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
+
+    #
+    # MacCatalyst interp - requires AOT Compilation and Interp flags
+    # Build the whole product using Mono and run libraries tests
+    # The test app is built with the App Sandbox entitlement
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - MacCatalyst_x64
+        # don't run tests on arm64 PRs until we can get significantly more devices
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - MacCatalyst_arm64
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_AppSandbox
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true /p:EnableAppSandbox=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                interpreter: true
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
+
+    #
+    # MacCatalyst interp - requires AOT Compilation and Interp flags
+    # Build the whole product using Mono and run libraries tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - MacCatalyst_x64
+        # don't run tests on arm64 PRs until we can get significantly more devices
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - MacCatalyst_arm64
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                interpreter: true
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
+
+    #
+    # Build the whole product using Mono and run libraries tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Android_x86
+        - Android_x64
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Android_arm
+        - Android_arm64
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
               eq(variables['isFullMatrix'], true))
 
-#
-# MacCatalyst interp - requires AOT Compilation and Interp flags
-# Build the whole product using Mono and run libraries tests
-# The test app is built with the App Sandbox entitlement
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - MacCatalyst_x64
-    # don't run tests on arm64 PRs until we can get significantly more devices
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - MacCatalyst_arm64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_AppSandbox
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true /p:EnableAppSandbox=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            interpreter: true
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+          # don't run tests on PRs until we can get significantly more devices
+          ${{ if eq(variables['isFullMatrix'], true) }}:
+            # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
+
+    #
+    # Build the whole product using Mono and run libraries tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Windows_x64
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testScope: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+mono.mscordbi+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+          timeoutInMinutes: 120
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
               eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
 
-#
-# MacCatalyst interp - requires AOT Compilation and Interp flags
-# Build the whole product using Mono and run libraries tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - MacCatalyst_x64
-    # don't run tests on arm64 PRs until we can get significantly more devices
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - MacCatalyst_arm64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            interpreter: true
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+    #
+    # Build the whole product using Mono for Android and run runtime tests with interpreter
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Android_x64
+        variables:
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: pr/dotnet/runtime/$(Build.SourceBranch)
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: ci/dotnet/runtime/$(Build.SourceBranch)
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_RuntimeTests_Interp
+          buildArgs: -s mono+libs -c $(_BuildConfig)
+          timeoutInMinutes: 240
+          runtimeVariant: monointerpreter
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
               eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
-#
-# Build the whole product using Mono and run libraries tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Android_x86
-    - Android_x64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+    #
+    # Build the whole product using Mono and run runtime tests with the JIT.
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - iOSSimulator_x64
+        variables:
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: pr/dotnet/runtime/$(Build.SourceBranch)
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: ci/dotnet/runtime/$(Build.SourceBranch)
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_RuntimeTests
+          buildArgs: -s mono+libs -c $(_BuildConfig)
+          timeoutInMinutes: 240
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
               eq(variables['isFullMatrix'], true))
+          # Test execution is temporarily disabled because test apps no longer launch
+          # and the test suite times out after two hours, even if xharness cannot
+          # successfully launch any tests. Re-enable once these issues have been fixed.
+          #
+          # extra steps, run tests
+          # postBuildSteps:
+          #   - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+          #     parameters:
+          #       creator: dotnet-bot
+          #       testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Android_arm
-    - Android_arm64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-
-      # don't run tests on PRs until we can get significantly more devices
-      ${{ if eq(variables['isFullMatrix'], true) }}:
-        # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+    #
+    # Build the whole product using Mono for Android and run runtime tests with Android devices
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Android_arm64
+        variables:
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: pr/dotnet/runtime/$(Build.SourceBranch)
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: ci/dotnet/runtime/$(Build.SourceBranch)
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_RuntimeTests
+          buildArgs: -s mono+libs -c $(_BuildConfig)
+          timeoutInMinutes: 240
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
               eq(variables['isFullMatrix'], true))
+          # don't run tests on PRs until we can get significantly more devices
+          ${{ if eq(variables['isFullMatrix'], true) }}:
+            # extra steps, run tests
+            postBuildSteps:
+              - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
-#
-# Build the whole product using Mono and run libraries tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Windows_x64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testScope: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+mono.mscordbi+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
-      timeoutInMinutes: 120
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+    # Run disabled installer tests on Linux x64
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_x64
+        jobParameters:
+          nameSuffix: Installer_Tests
+          isOfficialBuild: ${{ variables.isOfficialBuild }}
+          buildArgs: -s clr+libs+host+packs -restore -build -test -c $(_BuildConfig) -lc Debug /p:PortableBuild=true /p:RunOnStaging=true
+          useContinueOnErrorDuringBuild: true
+          enablePublisTestResults: true
+          testResultsFormat: xunit
+          timeoutInMinutes: 90
+
+    #
+    # Build Browser_wasm, on windows, run console and browser tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+        - Browser_wasm_win
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: Browser_wasm_Windows
+          buildArgs: -subset mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=windows
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
               eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                extraHelixArguments: /p:BrowserHost=windows
+                scenarios:
+                - normal
+                - wasmtestonbrowser
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
 
-#
-# Build the whole product using Mono for Android and run runtime tests with interpreter
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Android_x64
-    variables:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: pr/dotnet/runtime/$(Build.SourceBranch)
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: ci/dotnet/runtime/$(Build.SourceBranch)
-      - name: timeoutPerTestInMinutes
-        value: 60
-      - name: timeoutPerTestCollectionInMinutes
-        value: 180
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_RuntimeTests_Interp
-      buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
-      runtimeVariant: monointerpreter
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-
-#
-# Build the whole product using Mono and run runtime tests with the JIT.
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - iOSSimulator_x64
-    variables:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: pr/dotnet/runtime/$(Build.SourceBranch)
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: ci/dotnet/runtime/$(Build.SourceBranch)
-      - name: timeoutPerTestInMinutes
-        value: 60
-      - name: timeoutPerTestCollectionInMinutes
-        value: 180
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_RuntimeTests
-      buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # Test execution is temporarily disabled because test apps no longer launch
-      # and the test suite times out after two hours, even if xharness cannot
-      # successfully launch any tests. Re-enable once these issues have been fixed.
-      #
-      # extra steps, run tests
-      # postBuildSteps:
-      #   - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
-      #     parameters:
-      #       creator: dotnet-bot
-      #       testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-
-#
-# Build the whole product using Mono for Android and run runtime tests with Android devices
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Android_arm64
-    variables:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: pr/dotnet/runtime/$(Build.SourceBranch)
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: ci/dotnet/runtime/$(Build.SourceBranch)
-      - name: timeoutPerTestInMinutes
-        value: 60
-      - name: timeoutPerTestCollectionInMinutes
-        value: 180
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_RuntimeTests
-      buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # don't run tests on PRs until we can get significantly more devices
-      ${{ if eq(variables['isFullMatrix'], true) }}:
-        # extra steps, run tests
-        postBuildSteps:
-          - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
-            parameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-
-# Run disabled installer tests on Linux x64
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_x64
-    jobParameters:
-      nameSuffix: Installer_Tests
-      isOfficialBuild: ${{ variables.isOfficialBuild }}
-      buildArgs: -s clr+libs+host+packs -restore -build -test -c $(_BuildConfig) -lc Debug /p:PortableBuild=true /p:RunOnStaging=true
-      useContinueOnErrorDuringBuild: true
-      enablePublisTestResults: true
-      testResultsFormat: xunit
-      timeoutInMinutes: 90
-
-#
-# Build Browser_wasm, on windows, run console and browser tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - Browser_wasm_win
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: Browser_wasm_Windows
-      buildArgs: -subset mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=windows
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            extraHelixArguments: /p:BrowserHost=windows
-            scenarios:
-            - normal
-            - wasmtestonbrowser
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
-              eq(variables['isFullMatrix'], true))
-
-#
-# CoreCLR Build for running Apple Silicon libraries-innerloop
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: release
-    platforms:
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - OSX_arm64
-    jobParameters:
-      testGroup: innerloop
-#
-# Libraries Build for running Apple Silicon libraries-innerloop
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platforms:
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - OSX_arm64
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      isOfficialBuild: ${{ variables['isOfficialBuild'] }}
-      isFullMatrix: ${{ variables['isFullMatrix'] }}
-      runTests: true
-      testScope: innerloop
-      liveRuntimeBuildConfig: release
+    #
+    # CoreCLR Build for running Apple Silicon libraries-innerloop
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: release
+        platforms:
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - OSX_arm64
+        jobParameters:
+          testGroup: innerloop
+    #
+    # Libraries Build for running Apple Silicon libraries-innerloop
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/build-job.yml
+        buildConfig: Release
+        platforms:
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - OSX_arm64
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        jobParameters:
+          isOfficialBuild: ${{ variables['isOfficialBuild'] }}
+          isFullMatrix: ${{ variables['isFullMatrix'] }}
+          runTests: true
+          testScope: innerloop
+          liveRuntimeBuildConfig: release

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -48,1205 +48,1208 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-
-#
-# Evaluate paths
-#
-- ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
-  - template: /eng/pipelines/common/evaluate-default-paths.yml
-
-#
-# Build CoreCLR checked
-# Only when CoreCLR is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_musl_arm
-    - Linux_musl_arm64
-    - Linux_musl_x64
-    - OSX_arm64
-    - windows_x86
-    - windows_x64
-    - windows_arm
-    - windows_arm64
-    jobParameters:
-      testGroup: innerloop
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    jobs:
 
-#
-# Build CoreCLR checked using GCC toolchain
-# Only when CoreCLR is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      compilerName: gcc
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Evaluate paths
+    #
+    - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
+      - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-#
-# Build CoreCLR OSX_x64 checked
-# Only when CoreCLR or Libraries is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_x64
-    jobParameters:
-      testGroup: innerloop
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-
-#
-# Build CoreCLR release
-# Always as they are needed by Installer and we always build and test the Installer.
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: release
-    platforms:
-    - OSX_arm64
-    - OSX_x64
-    - Linux_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_musl_x64
-    - Linux_musl_arm
-    - Linux_musl_arm64
-    - windows_x64
-    - windows_x86
-    - windows_arm
-    - windows_arm64
-    - FreeBSD_x64
-    jobParameters:
-      testGroup: innerloop
-
-#
-# Build CoreCLR Formatting Job
-# Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
-# both CI and PR builds).
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-    platforms:
-    - Linux_x64
-    - windows_x64
-    jobParameters:
-      condition: >-
-        and(
-          or(
-            eq(variables['Build.SourceBranchName'], 'main'),
-            eq(variables['System.PullRequest.TargetBranch'], 'main')),
-          or(
-            eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-            eq(variables['isFullMatrix'], true)))
-
-# Build and test clr tools
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    jobParameters:
-      testGroup: clrTools
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-
-#
-# Build CrossDacs
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: release
-    platforms:
-    - windows_x64
-    variables:
-      - name: _archParameter
-        value: -arch x64,x86,arm,arm64
-    jobParameters:
-      buildArgs: -s linuxdac+alpinedac -c Checked,$(_BuildConfig)
-      nameSuffix: CrossDac
-      isOfficialBuild: false
-      timeoutInMinutes: 60
-      postBuildSteps:
-      - publish: $(Build.SourcesDirectory)/artifacts/bin/coreclr
-        displayName: Publish CrossDacs for diagnostics
-        artifact: CoreCLRCrossDacArtifacts
-
-# Build Mono AOT offset headers once, for consumption elsewhere
-# Only when mono changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/generate-offsets.yml
-    buildConfig: release
-    platforms:
-    - Android_x64
-    - Browser_wasm
-    - tvOS_arm64
-    - iOS_arm64
-    - MacCatalyst_x64
-    jobParameters:
-      isOfficialBuild: false
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-
-# Build the whole product using Mono runtime
-# Only when libraries, mono or installer are changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    runtimeFlavor: mono
-    platforms:
-    - MacCatalyst_x64
-    - MacCatalyst_arm64
-    - tvOSSimulator_x64
-    - iOSSimulator_x86
-    - iOS_arm64
-    - Linux_arm
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - tvOS_arm64
-    - iOS_arm
-    - Linux_musl_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-
-#
-# Build the whole product using Mono and run libraries tests, multi-scenario
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Browser_wasm
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            scenarios:
-            - normal
-            - wasmtestonbrowser
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+    #
+    # Build CoreCLR checked
+    # Only when CoreCLR is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_musl_arm
+        - Linux_musl_arm64
+        - Linux_musl_x64
+        - OSX_arm64
+        - windows_x86
+        - windows_x64
+        - windows_arm
+        - windows_arm64
+        jobParameters:
+          testGroup: innerloop
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
               eq(variables['isFullMatrix'], true))
 
-#
-# Build the whole product using Mono and run libraries tests, for Wasm.Build.Tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Browser_wasm
-    variables:
-      # map dependencies variables to local variables
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-      - name: installerContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_WasmBuildTests
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            scenarios:
-            - buildwasmapps
-            condition: >-
-              or(
-              eq(variables['monoContainsChange'], true),
-              eq(variables['installerContainsChange'], true),
+    #
+    # Build CoreCLR checked using GCC toolchain
+    # Only when CoreCLR is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          compilerName: gcc
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
               eq(variables['isFullMatrix'], true))
 
-#
-# Build for Browser/wasm, with EnableAggressiveTrimming=true
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Browser_wasm
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_EAT
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=true /p:RunAOTCompilation=false
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            extraHelixArguments: /p:NeedsToBuildWasmAppsOnHelix=true
-            scenarios:
-            - normal
-            condition: >-
-              or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+    #
+    # Build CoreCLR OSX_x64 checked
+    # Only when CoreCLR or Libraries is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_x64
+        jobParameters:
+          testGroup: innerloop
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
               eq(variables['isFullMatrix'], true))
 
-#
-# Build for Browser/wasm with RunAOTCompilation=true
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Browser_wasm
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_AOT
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=true /p:RunAOTCompilation=true
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            extraHelixArguments: /p:NeedsToBuildWasmAppsOnHelix=true
-            scenarios:
-            - normal
-            condition: >-
+    #
+    # Build CoreCLR release
+    # Always as they are needed by Installer and we always build and test the Installer.
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: release
+        platforms:
+        - OSX_arm64
+        - OSX_x64
+        - Linux_x64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_musl_x64
+        - Linux_musl_arm
+        - Linux_musl_arm64
+        - windows_x64
+        - windows_x86
+        - windows_arm
+        - windows_arm64
+        - FreeBSD_x64
+        jobParameters:
+          testGroup: innerloop
+
+    #
+    # Build CoreCLR Formatting Job
+    # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
+    # both CI and PR builds).
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
+        platforms:
+        - Linux_x64
+        - windows_x64
+        jobParameters:
+          condition: >-
+            and(
               or(
-              eq(variables['librariesContainsChange'], true),
-              eq(variables['monoContainsChange'], true),
+                eq(variables['Build.SourceBranchName'], 'main'),
+                eq(variables['System.PullRequest.TargetBranch'], 'main')),
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(variables['isFullMatrix'], true)))
+
+    # Build and test clr tools
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        jobParameters:
+          testGroup: clrTools
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
               eq(variables['isFullMatrix'], true))
 
-#
-# Build the whole product using Mono and run runtime tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Browser_wasm
-    variables:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: pr/dotnet/runtime/$(Build.SourceBranch)
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: ci/dotnet/runtime/$(Build.SourceBranch)
-      - name: timeoutPerTestInMinutes
-        value: 10
-      - name: timeoutPerTestCollectionInMinutes
-        value: 200
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_RuntimeTests
-      buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/common/templates/runtimes/wasm-runtime-and-send-to-helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+    #
+    # Build CrossDacs
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        platforms:
+        - windows_x64
+        variables:
+          - name: _archParameter
+            value: -arch x64,x86,arm,arm64
+        jobParameters:
+          buildArgs: -s linuxdac+alpinedac -c Checked,$(_BuildConfig)
+          nameSuffix: CrossDac
+          isOfficialBuild: false
+          timeoutInMinutes: 60
+          postBuildSteps:
+          - publish: $(Build.SourcesDirectory)/artifacts/bin/coreclr
+            displayName: Publish CrossDacs for diagnostics
+            artifact: CoreCLRCrossDacArtifacts
 
-#
-# Build the whole product using Mono for Android and run runtime tests with Android emulator
-#
-#- template: /eng/pipelines/common/platform-matrix.yml
-#  parameters:
-#    jobTemplate: /eng/pipelines/common/global-build-job.yml
-#    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#    buildConfig: Release
-#    runtimeFlavor: mono
-#    platforms:
-#    - Android_x64
-#    variables:
-#      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-#        - name: _HelixSource
-#          value: pr/dotnet/runtime/$(Build.SourceBranch)
-#      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-#        - name: _HelixSource
-#          value: ci/dotnet/runtime/$(Build.SourceBranch)
-#      - name: timeoutPerTestInMinutes
-#        value: 60
-#      - name: timeoutPerTestCollectionInMinutes
-#        value: 180
-#    jobParameters:
-#      testGroup: innerloop
-#      nameSuffix: AllSubsets_Mono_RuntimeTests
-#      buildArgs: -s mono+libs -c $(_BuildConfig)
-#      timeoutInMinutes: 240
-#      condition: >-
-#        or(
-#          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-#          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-#          eq(variables['isFullMatrix'], true))
-#      # extra steps, run tests
-#      postBuildSteps:
-#        - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
-#          parameters:
-#            creator: dotnet-bot
-#            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+    # Build Mono AOT offset headers once, for consumption elsewhere
+    # Only when mono changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/mono/templates/generate-offsets.yml
+        buildConfig: release
+        platforms:
+        - Android_x64
+        - Browser_wasm
+        - tvOS_arm64
+        - iOS_arm64
+        - MacCatalyst_x64
+        jobParameters:
+          isOfficialBuild: false
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Build Mono and Installer on LLVMJIT mode
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - OSX_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_LLVMJIT
-      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    # Build the whole product using Mono runtime
+    # Only when libraries, mono or installer are changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        runtimeFlavor: mono
+        platforms:
+        - MacCatalyst_x64
+        - MacCatalyst_arm64
+        - tvOSSimulator_x64
+        - iOSSimulator_x86
+        - iOS_arm64
+        - Linux_arm
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    runtimeFlavor: mono
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_LLVMJIT
-      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - tvOS_arm64
+        - iOS_arm
+        - Linux_musl_x64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Build Mono and Installer on LLVMAOT mode
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_LLVMAOT
-      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build the whole product using Mono and run libraries tests, multi-scenario
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Browser_wasm
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                scenarios:
+                - normal
+                - wasmtestonbrowser
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    runtimeFlavor: mono
-    platforms:
-    - OSX_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_LLVMAOT
-      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build the whole product using Mono and run libraries tests, for Wasm.Build.Tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Browser_wasm
+        variables:
+          # map dependencies variables to local variables
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+          - name: installerContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_WasmBuildTests
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                scenarios:
+                - buildwasmapps
+                condition: >-
+                  or(
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['installerContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
 
-#
-# Build Mono debug
-# Only when libraries or mono changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-    runtimeFlavor: mono
-    buildConfig: debug
-    platforms:
-    - OSX_x64
-    - OSX_arm64
-    - Linux_x64
-    - Linux_arm64
-    # - Linux_musl_arm64
-    - windows_x64
-    - windows_x86
-    # - windows_arm
-    # - windows_arm64
-    jobParameters:
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build for Browser/wasm, with EnableAggressiveTrimming=true
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Browser_wasm
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_EAT
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=true /p:RunAOTCompilation=false
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                extraHelixArguments: /p:NeedsToBuildWasmAppsOnHelix=true
+                scenarios:
+                - normal
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
 
-#
-# Build Mono release AOT cross-compilers
-# Only when mono changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-    runtimeFlavor: mono
-    buildConfig: release
-    platforms:
-    - Linux_x64
-    # - Linux_arm64
-    # - Linux_musl_arm64
-    - Windows_x64
-    # - windows_x86
-    # - windows_arm
-    # - windows_arm64
-    jobParameters:
-      runtimeVariant: crossaot
-      dependsOn:
-      - mono_android_offsets
-      - mono_browser_offsets
-      monoCrossAOTTargetOS:
-      - Android
-      - Browser
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build for Browser/wasm with RunAOTCompilation=true
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Browser_wasm
+        variables:
+          # map dependencies variables to local variables
+          - name: librariesContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+          - name: monoContainsChange
+            value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_AOT
+          buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=true /p:RunAOTCompilation=true
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                extraHelixArguments: /p:NeedsToBuildWasmAppsOnHelix=true
+                scenarios:
+                - normal
+                condition: >-
+                  or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isFullMatrix'], true))
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-    runtimeFlavor: mono
-    buildConfig: release
-    platforms:
-    - OSX_x64
-    jobParameters:
-      runtimeVariant: crossaot
-      dependsOn:
-      - mono_android_offsets
-      - mono_browser_offsets
-      - mono_tvos_offsets
-      - mono_ios_offsets
-      - mono_maccatalyst_offsets
-      monoCrossAOTTargetOS:
-      - Android
-      - Browser
-      - tvOS
-      - iOS
-      - MacCatalyst
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build the whole product using Mono and run runtime tests
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Browser_wasm
+        variables:
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: pr/dotnet/runtime/$(Build.SourceBranch)
+          - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _HelixSource
+              value: ci/dotnet/runtime/$(Build.SourceBranch)
+          - name: timeoutPerTestInMinutes
+            value: 10
+          - name: timeoutPerTestCollectionInMinutes
+            value: 200
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_RuntimeTests
+          buildArgs: -s mono+libs -c $(_BuildConfig)
+          timeoutInMinutes: 180
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+          # extra steps, run tests
+          postBuildSteps:
+            - template: /eng/pipelines/common/templates/runtimes/wasm-runtime-and-send-to-helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
-#
-# Build Mono release
-# Only when libraries or mono changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-    runtimeFlavor: mono
-    buildConfig: release
-    platforms:
-    - Linux_x64
-    # - Linux_musl_arm64
-    - windows_x64
-    - windows_x86
-    # - windows_arm
-    # - windows_arm64
-    jobParameters:
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build the whole product using Mono for Android and run runtime tests with Android emulator
+    #
+    #- template: /eng/pipelines/common/platform-matrix.yml
+    #  parameters:
+    #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    #    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    #    buildConfig: Release
+    #    runtimeFlavor: mono
+    #    platforms:
+    #    - Android_x64
+    #    variables:
+    #      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+    #        - name: _HelixSource
+    #          value: pr/dotnet/runtime/$(Build.SourceBranch)
+    #      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+    #        - name: _HelixSource
+    #          value: ci/dotnet/runtime/$(Build.SourceBranch)
+    #      - name: timeoutPerTestInMinutes
+    #        value: 60
+    #      - name: timeoutPerTestCollectionInMinutes
+    #        value: 180
+    #    jobParameters:
+    #      testGroup: innerloop
+    #      nameSuffix: AllSubsets_Mono_RuntimeTests
+    #      buildArgs: -s mono+libs -c $(_BuildConfig)
+    #      timeoutInMinutes: 240
+    #      condition: >-
+    #        or(
+    #          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+    #          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+    #          eq(variables['isFullMatrix'], true))
+    #      # extra steps, run tests
+    #      postBuildSteps:
+    #        - template: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+    #          parameters:
+    #            creator: dotnet-bot
+    #            testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
-#
-# Build Mono release
-# Only when libraries, mono, or the runtime tests changed
-# Currently only these architectures are needed for the runtime tests.
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-    runtimeFlavor: mono
-    buildConfig: release
-    platforms:
-    - OSX_x64
-    - Linux_arm64
-    jobParameters:
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build Mono and Installer on LLVMJIT mode
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - OSX_x64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_LLVMJIT
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                     /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Build Mono release with LLVM AOT
-# Only when mono, or the runtime tests changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-    runtimeFlavor: mono
-    buildConfig: release
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    jobParameters:
-      runtimeVariant: llvmaot
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        runtimeFlavor: mono
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_LLVMJIT
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                     /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Build libraries using live CoreLib
-# These set of libraries are built always no matter what changed
-# The reason for that is because Corelib and Installer needs it and
-# These are part of the test matrix for Libraries changes.
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_arm
-    - Linux_musl_arm
-    - Linux_musl_arm64
-    - windows_arm
-    - windows_arm64
-    - windows_x86
-    jobParameters:
-      liveRuntimeBuildConfig: release
+    #
+    # Build Mono and Installer on LLVMAOT mode
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: Release
+        runtimeFlavor: mono
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_LLVMAOT
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                     /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    - Linux_arm64
-    - Linux_musl_x64
-    - Linux_x64
-    - OSX_arm64
-    - OSX_x64
-    - windows_x64
-    - FreeBSD_x64
-    jobParameters:
-      testScope: innerloop
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
-      - OSX_x64
-      liveRuntimeBuildConfig: release
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        runtimeFlavor: mono
+        platforms:
+        - OSX_x64
+        jobParameters:
+          testGroup: innerloop
+          nameSuffix: AllSubsets_Mono_LLVMAOT
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                     /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Libraries Build that only run when libraries is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    - ${{ if eq(variables['isFullMatrix'], false) }}:
-      - windows_x86
-    jobParameters:
-      liveRuntimeBuildConfig: release
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build Mono debug
+    # Only when libraries or mono changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+        runtimeFlavor: mono
+        buildConfig: debug
+        platforms:
+        - OSX_x64
+        - OSX_arm64
+        - Linux_x64
+        - Linux_arm64
+        # - Linux_musl_arm64
+        - windows_x64
+        - windows_x86
+        # - windows_arm
+        # - windows_arm64
+        jobParameters:
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Build and test libraries for .NET Framework
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    platforms:
-    - windows_x86
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - windows_x64
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      isFullMatrix: ${{ variables.isFullMatrix }}
-      framework: net48
-      buildArgs: -s libs+libs.tests -framework net48 -c $(_BuildConfig) -testscope innerloop /p:ArchiveTests=true
-      nameSuffix: Libraries_NET48
-      timeoutInMinutes: 150
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: NET48_$(_BuildConfig)
-            extraHelixArguments: /p:BuildTargetFramework=net48
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build Mono release AOT cross-compilers
+    # Only when mono changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+        runtimeFlavor: mono
+        buildConfig: release
+        platforms:
+        - Linux_x64
+        # - Linux_arm64
+        # - Linux_musl_arm64
+        - Windows_x64
+        # - windows_x86
+        # - windows_arm
+        # - windows_arm64
+        jobParameters:
+          runtimeVariant: crossaot
+          dependsOn:
+          - mono_android_offsets
+          - mono_browser_offsets
+          monoCrossAOTTargetOS:
+          - Android
+          - Browser
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Build and test libraries AllConfigurations
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    - windows_x64
-    jobParameters:
-      buildArgs: -test -s libs+libs.tests -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
-      nameSuffix: Libraries_AllConfigurations
-      timeoutInMinutes: 150
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+        runtimeFlavor: mono
+        buildConfig: release
+        platforms:
+        - OSX_x64
+        jobParameters:
+          runtimeVariant: crossaot
+          dependsOn:
+          - mono_android_offsets
+          - mono_browser_offsets
+          - mono_tvos_offsets
+          - mono_ios_offsets
+          - mono_maccatalyst_offsets
+          monoCrossAOTTargetOS:
+          - Android
+          - Browser
+          - tvOS
+          - iOS
+          - MacCatalyst
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Installer Build and Test
-# These are always built since they only take like 15 minutes
-# we expect these to be done before we finish libraries or coreclr testing.
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/installer/jobs/base-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-      - Linux_arm
-      - Linux_musl_arm
-      - Linux_musl_arm64
-      - windows_x86
-      - windows_arm
-      - windows_arm64
-    jobParameters:
-      liveRuntimeBuildConfig: release
-      liveLibrariesBuildConfig: Release
-      runOnlyIfDependenciesSucceeded: true
-      condition:
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+    #
+    # Build Mono release
+    # Only when libraries or mono changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+        runtimeFlavor: mono
+        buildConfig: release
+        platforms:
+        - Linux_x64
+        # - Linux_musl_arm64
+        - windows_x64
+        - windows_x86
+        # - windows_arm
+        # - windows_arm64
+        jobParameters:
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/installer/jobs/base-job.yml
-    buildConfig: Release
-    platforms:
-      - OSX_arm64
-      - OSX_x64
-      - Linux_x64
-      - Linux_arm64
-      - Linux_musl_x64
-      - windows_x64
-      - FreeBSD_x64
-    jobParameters:
-      liveRuntimeBuildConfig: release
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      runOnlyIfDependenciesSucceeded: true
-      condition:
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+    #
+    # Build Mono release
+    # Only when libraries, mono, or the runtime tests changed
+    # Currently only these architectures are needed for the runtime tests.
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+        runtimeFlavor: mono
+        buildConfig: release
+        platforms:
+        - OSX_x64
+        - Linux_arm64
+        jobParameters:
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# CoreCLR Test builds using live libraries release build
-# Only when CoreCLR is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: checked
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build Mono release with LLVM AOT
+    # Only when mono, or the runtime tests changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+        runtimeFlavor: mono
+        buildConfig: release
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        jobParameters:
+          runtimeVariant: llvmaot
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# CoreCLR Test executions using live libraries
-# Only when CoreCLR is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: Release
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build libraries using live CoreLib
+    # These set of libraries are built always no matter what changed
+    # The reason for that is because Corelib and Installer needs it and
+    # These are part of the test matrix for Libraries changes.
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/build-job.yml
+        buildConfig: Release
+        platforms:
+        - Linux_arm
+        - Linux_musl_arm
+        - Linux_musl_arm64
+        - windows_arm
+        - windows_arm64
+        - windows_x86
+        jobParameters:
+          liveRuntimeBuildConfig: release
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_x64
-    - Linux_x64
-    - Linux_arm64
-    - windows_x64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/build-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        - Linux_arm64
+        - Linux_musl_x64
+        - Linux_x64
+        - OSX_arm64
+        - OSX_x64
+        - windows_x64
+        - FreeBSD_x64
+        jobParameters:
+          testScope: innerloop
+          testBuildPlatforms:
+          - Linux_x64
+          - windows_x64
+          - OSX_x64
+          liveRuntimeBuildConfig: release
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Libraries Build that only run when libraries is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/build-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        - ${{ if eq(variables['isFullMatrix'], false) }}:
+          - windows_x86
+        jobParameters:
+          liveRuntimeBuildConfig: release
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Mono Test builds with CoreCLR runtime tests using live libraries debug build
-# Only when Mono is changed
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      liveRuntimeBuildConfig: release
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build and test libraries for .NET Framework
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: Release
+        platforms:
+        - windows_x86
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - windows_x64
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        jobParameters:
+          isFullMatrix: ${{ variables.isFullMatrix }}
+          framework: net48
+          buildArgs: -s libs+libs.tests -framework net48 -c $(_BuildConfig) -testscope innerloop /p:ArchiveTests=true
+          nameSuffix: Libraries_NET48
+          timeoutInMinutes: 150
+          postBuildSteps:
+            - template: /eng/pipelines/libraries/helix.yml
+              parameters:
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: NET48_$(_BuildConfig)
+                extraHelixArguments: /p:BuildTargetFramework=net48
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Mono CoreCLR runtime Test executions using live libraries in jit mode
-# Only when Mono is changed
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - OSX_x64
-    - Linux_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      liveRuntimeBuildConfig: release
-      runtimeVariant: minijit
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Build and test libraries AllConfigurations
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        - windows_x64
+        jobParameters:
+          buildArgs: -test -s libs+libs.tests -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
+          nameSuffix: Libraries_AllConfigurations
+          timeoutInMinutes: 150
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Mono CoreCLR runtime Test executions using live libraries in interpreter mode
-# Only when Mono is changed
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - OSX_x64
-    - Linux_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      liveRuntimeBuildConfig: release
-      runtimeVariant: monointerpreter
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-#
-# Mono CoreCLR runtime Test executions using live libraries and LLVM AOT
-# Only when Mono is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - Linux_x64
-    - Linux_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      liveRuntimeBuildConfig: release
-      runtimeVariant: llvmaot
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Installer Build and Test
+    # These are always built since they only take like 15 minutes
+    # we expect these to be done before we finish libraries or coreclr testing.
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/installer/jobs/base-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+          - Linux_arm
+          - Linux_musl_arm
+          - Linux_musl_arm64
+          - windows_x86
+          - windows_arm
+          - windows_arm64
+        jobParameters:
+          liveRuntimeBuildConfig: release
+          liveLibrariesBuildConfig: Release
+          runOnlyIfDependenciesSucceeded: true
+          condition:
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+              eq(variables['isRollingBuild'], true))
 
-#
-# Libraries Release Test Execution against a release mono runtime.
-# Only when libraries or mono changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    runtimeFlavor: mono
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    # - windows_x64
-    - OSX_x64
-    - Linux_arm64
-    - Linux_x64
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      isOfficialBuild: false
-      isFullMatrix: ${{ variables.isFullMatrix }}
-      runtimeDisplayName: mono
-      testScope: innerloop
-      liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/installer/jobs/base-job.yml
+        buildConfig: Release
+        platforms:
+          - OSX_arm64
+          - OSX_x64
+          - Linux_x64
+          - Linux_arm64
+          - Linux_musl_x64
+          - windows_x64
+          - FreeBSD_x64
+        jobParameters:
+          liveRuntimeBuildConfig: release
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          runOnlyIfDependenciesSucceeded: true
+          condition:
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+              eq(variables['isRollingBuild'], true))
 
-#
-# Libraries Release Test Execution against a release mono interpreter runtime.
-# Only when libraries or mono changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    runtimeFlavor: mono
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    # - windows_x64
-    #- OSX_x64
-    - Linux_x64
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      isOfficialBuild: false
-      isFullMatrix: ${{ variables.isFullMatrix }}
-      interpreter: true
-      runtimeDisplayName: mono_interpreter
-      testScope: innerloop
-      liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # CoreCLR Test builds using live libraries release build
+    # Only when CoreCLR is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Libraries Release Test Execution against a release coreclr runtime
-# Only when the PR contains a libraries change
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platforms:
-    - windows_x86
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - windows_arm64
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      isOfficialBuild: false
-      isFullMatrix: ${{ variables.isFullMatrix }}
-      testScope: innerloop
-      liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # CoreCLR Test executions using live libraries
+    # Only when CoreCLR is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_arm
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: Release
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Libraries Debug Test Execution against a release coreclr runtime
-# Only when the PR contains a libraries change
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    - windows_x64
-    - OSX_x64
-    - Linux_x64
-    - Linux_musl_x64
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - Linux_arm64
-    - ${{ if eq(variables['isFullMatrix'], false) }}:
-      - windows_x86
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      isOfficialBuild: false
-      isFullMatrix: ${{ variables.isFullMatrix }}
-      testScope: innerloop
-      liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_x64
+        - Linux_x64
+        - Linux_arm64
+        - windows_x64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Libraries Test Execution against a checked runtime
-# Only when the PR contains a coreclr change
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platforms:
-    # - windows_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
-    - Linux_arm
-    - Linux_musl_arm
-    - Linux_musl_arm64
-    - windows_x86
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    helixQueueGroup: libraries
-    jobParameters:
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-#
-# Libraries Test Execution against a checked runtime
-# Only if CoreCLR or Libraries is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    - windows_x64
-    - Linux_x64
-    - Linux_musl_x64
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    helixQueueGroup: libraries
-    jobParameters:
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Mono Test builds with CoreCLR runtime tests using live libraries debug build
+    # Only when Mono is changed
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          liveRuntimeBuildConfig: release
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    platforms:
-    - OSX_x64
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    helixQueueGroup: libraries
-    jobParameters:
-      testScope: innerloop
-      liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+    #
+    # Mono CoreCLR runtime Test executions using live libraries in jit mode
+    # Only when Mono is changed
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+        - OSX_x64
+        - Linux_arm64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          liveRuntimeBuildConfig: release
+          runtimeVariant: minijit
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    #
+    # Mono CoreCLR runtime Test executions using live libraries in interpreter mode
+    # Only when Mono is changed
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+        - OSX_x64
+        - Linux_arm64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          liveRuntimeBuildConfig: release
+          runtimeVariant: monointerpreter
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+    #
+    # Mono CoreCLR runtime Test executions using live libraries and LLVM AOT
+    # Only when Mono is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+        - Linux_x64
+        - Linux_arm64
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: innerloop
+          liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          liveRuntimeBuildConfig: release
+          runtimeVariant: llvmaot
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    #
+    # Libraries Release Test Execution against a release mono runtime.
+    # Only when libraries or mono changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        runtimeFlavor: mono
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        # - windows_x64
+        - OSX_x64
+        - Linux_arm64
+        - Linux_x64
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        jobParameters:
+          isOfficialBuild: false
+          isFullMatrix: ${{ variables.isFullMatrix }}
+          runtimeDisplayName: mono
+          testScope: innerloop
+          liveRuntimeBuildConfig: release
+          dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
+          dependsOnTestArchitecture: x64
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    #
+    # Libraries Release Test Execution against a release mono interpreter runtime.
+    # Only when libraries or mono changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        runtimeFlavor: mono
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        # - windows_x64
+        #- OSX_x64
+        - Linux_x64
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        jobParameters:
+          isOfficialBuild: false
+          isFullMatrix: ${{ variables.isFullMatrix }}
+          interpreter: true
+          runtimeDisplayName: mono_interpreter
+          testScope: innerloop
+          liveRuntimeBuildConfig: release
+          dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
+          dependsOnTestArchitecture: x64
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    #
+    # Libraries Release Test Execution against a release coreclr runtime
+    # Only when the PR contains a libraries change
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platforms:
+        - windows_x86
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - windows_arm64
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        jobParameters:
+          isOfficialBuild: false
+          isFullMatrix: ${{ variables.isFullMatrix }}
+          testScope: innerloop
+          liveRuntimeBuildConfig: release
+          dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
+          dependsOnTestArchitecture: x64
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    #
+    # Libraries Debug Test Execution against a release coreclr runtime
+    # Only when the PR contains a libraries change
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        - windows_x64
+        - OSX_x64
+        - Linux_x64
+        - Linux_musl_x64
+        - ${{ if eq(variables['isFullMatrix'], true) }}:
+          - Linux_arm64
+        - ${{ if eq(variables['isFullMatrix'], false) }}:
+          - windows_x86
+        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+        jobParameters:
+          isOfficialBuild: false
+          isFullMatrix: ${{ variables.isFullMatrix }}
+          testScope: innerloop
+          liveRuntimeBuildConfig: release
+          dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
+          dependsOnTestArchitecture: x64
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    #
+    # Libraries Test Execution against a checked runtime
+    # Only when the PR contains a coreclr change
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: Release
+        platforms:
+        # - windows_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
+        - Linux_arm
+        - Linux_musl_arm
+        - Linux_musl_arm64
+        - windows_x86
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        helixQueueGroup: libraries
+        jobParameters:
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
+          dependsOnTestArchitecture: x64
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    #
+    # Libraries Test Execution against a checked runtime
+    # Only if CoreCLR or Libraries is changed
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        - windows_x64
+        - Linux_x64
+        - Linux_musl_x64
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        helixQueueGroup: libraries
+        jobParameters:
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
+          dependsOnTestArchitecture: x64
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(variables['isFullMatrix'], true))
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+        buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        platforms:
+        - OSX_x64
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        helixQueueGroup: libraries
+        jobParameters:
+          testScope: innerloop
+          liveRuntimeBuildConfig: checked
+          dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
+          dependsOnTestArchitecture: x64
+          condition: >-
+            or(
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+              eq(variables['isFullMatrix'], true))

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -49,179 +49,182 @@ variables:
     - name: TeamName
       value: dotnet-core
 
-stages:
-- stage: Build
-  jobs:
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
 
-  #
-  # Build with Debug config and Checked runtimeConfiguration
-  #
-  - ${{ if ne(variables.isOfficialBuild, true) }}:
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/common/global-build-job.yml
-        buildConfig: Checked
-        platforms:
-        - Linux_x64
-        - windows_x64
-        jobParameters:
-          timeoutInMinutes: 100
-          testGroup: innerloop
-          buildArgs: -s clr+libs+host+packs -c debug -runtimeConfiguration Checked
-          postBuildSteps:
-            - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
-              parameters:
-                uploadRuntimeTests: true
+      #
+      # Build with Debug config and Checked runtimeConfiguration
+      #
+      - ${{ if ne(variables.isOfficialBuild, true) }}:
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/global-build-job.yml
+            buildConfig: Checked
+            platforms:
+            - Linux_x64
+            - windows_x64
+            jobParameters:
+              timeoutInMinutes: 100
+              testGroup: innerloop
+              buildArgs: -s clr+libs+host+packs -c debug -runtimeConfiguration Checked
+              postBuildSteps:
+                - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+                  parameters:
+                    uploadRuntimeTests: true
 
-  #
-  # Build with Release config and Release runtimeConfiguration
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: Release
-      platforms:
-      - Linux_x64
-      - windows_x64
-      jobParameters:
-        timeoutInMinutes: 100
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        testGroup: innerloop
-        postBuildSteps:
-          - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
-            parameters:
-              uploadLibrariesTests: ${{ eq(variables.isOfficialBuild, false) }}
-              uploadIntermediateArtifacts: false
-            ${{ if eq(variables.isOfficialBuild, false) }}:
-              buildArgs: -s clr+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true
+      #
+      # Build with Release config and Release runtimeConfiguration
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Release
+          platforms:
+          - Linux_x64
+          - windows_x64
+          jobParameters:
+            timeoutInMinutes: 100
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            testGroup: innerloop
+            postBuildSteps:
+              - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+                parameters:
+                  uploadLibrariesTests: ${{ eq(variables.isOfficialBuild, false) }}
+                  uploadIntermediateArtifacts: false
+                ${{ if eq(variables.isOfficialBuild, false) }}:
+                  buildArgs: -s clr+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true
+                ${{ if eq(variables.isOfficialBuild, true) }}:
+                  buildArgs: -s clr+libs -c $(_BuildConfig)
+
+      #
+      # Build with Release allConfigurations to produce packages
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Release
+          platforms:
+          - windows_x64
+          jobParameters:
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            testGroup: innerloop
+            nameSuffix: AllConfigurations
+            buildArgs: -s libs -c $(_BuildConfig) -allConfigurations
             ${{ if eq(variables.isOfficialBuild, true) }}:
-              buildArgs: -s clr+libs -c $(_BuildConfig)
+              postBuildSteps:
+                - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+                  parameters:
+                    uploadIntermediateArtifacts: true
+                    isOfficialBuild: true
+                    librariesBinArtifactName: libraries_bin_official_allconfigurations
 
-  #
-  # Build with Release allConfigurations to produce packages
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: Release
-      platforms:
-      - windows_x64
-      jobParameters:
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        testGroup: innerloop
-        nameSuffix: AllConfigurations
-        buildArgs: -s libs -c $(_BuildConfig) -allConfigurations
-        ${{ if eq(variables.isOfficialBuild, true) }}:
-          postBuildSteps:
-            - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
-              parameters:
-                uploadIntermediateArtifacts: true
-                isOfficialBuild: true
-                librariesBinArtifactName: libraries_bin_official_allconfigurations
+      # Installer official builds need to build installers and need the libraries all configurations build
+      - ${{ if eq(variables.isOfficialBuild, true) }}:
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/installer/jobs/base-job.yml
+            jobParameters:
+              liveRuntimeBuildConfig: Release
+              liveLibrariesBuildConfig: Release
+              isOfficialBuild: ${{ variables.isOfficialBuild }}
+              useOfficialAllConfigurations: true
+              dependsOnGlobalBuild: true
+            platforms:
+            - Linux_x64
+            - windows_x64
 
-  # Installer official builds need to build installers and need the libraries all configurations build
-  - ${{ if eq(variables.isOfficialBuild, true) }}:
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/installer/jobs/base-job.yml
-        jobParameters:
-          liveRuntimeBuildConfig: Release
-          liveLibrariesBuildConfig: Release
+      - ${{ if ne(variables.isOfficialBuild, true) }}:
+        #
+        # CoreCLR Test builds using live libraries release build
+        #
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+            buildConfig: Checked
+            platforms:
+            - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+            jobParameters:
+              testGroup: innerloop
+              liveLibrariesBuildConfig: Release
+              dependsOn:
+              - build_Linux_x64_Checked_
+              - build_Linux_x64_Release_
+
+        #
+        # CoreCLR Test executions using live libraries
+        #
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+            buildConfig: Checked
+            platforms:
+            - Linux_x64
+            helixQueueGroup: pr
+            helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+            jobParameters:
+              testGroup: innerloop
+              liveLibrariesBuildConfig: Release
+              dependsOn:
+              - coreclr_common_test_build_p0_AnyOS_AnyCPU_Checked
+
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+            buildConfig: Checked
+            platforms:
+            - windows_x64
+            helixQueueGroup: pr
+            helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+            jobParameters:
+              testGroup: innerloop
+              liveLibrariesBuildConfig: Release
+              dependsOn:
+              - coreclr_common_test_build_p0_AnyOS_AnyCPU_Checked
+              - build_windows_x64_Checked_
+              - build_windows_x64_Release_
+
+        #
+        # Libraries Release Test Execution against a release coreclr runtime
+        #
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+            buildConfig: Release
+            platforms:
+            - Linux_x64
+            helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+            jobParameters:
+              isFullMatrix: false
+              isOfficialBuild: false
+              testScope: innerloop
+              liveRuntimeBuildConfig: Release
+              dependsOnTestBuildConfiguration: Release
+              dependsOnTestArchitecture: x64
+              dependsOn:
+              - build_Linux_x64_Release_
+
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+            buildConfig: Release
+            platforms:
+            - windows_x64
+            helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+            jobParameters:
+              isFullMatrix: false
+              isOfficialBuild: false
+              testScope: innerloop
+              liveRuntimeBuildConfig: Release
+              dependsOnTestBuildConfiguration: Release
+              dependsOnTestArchitecture: x64
+              dependsOn:
+              - build_windows_x64_Release_
+
+    - ${{ if eq(variables.isOfficialBuild, true) }}:
+      - template: /eng/pipelines/official/stages/publish.yml
+        parameters:
           isOfficialBuild: ${{ variables.isOfficialBuild }}
-          useOfficialAllConfigurations: true
-          dependsOnGlobalBuild: true
-        platforms:
-        - Linux_x64
-        - windows_x64
-
-  - ${{ if ne(variables.isOfficialBuild, true) }}:
-    #
-    # CoreCLR Test builds using live libraries release build
-    #
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-        buildConfig: Checked
-        platforms:
-        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-        jobParameters:
-          testGroup: innerloop
-          liveLibrariesBuildConfig: Release
-          dependsOn:
-          - build_Linux_x64_Checked_
-          - build_Linux_x64_Release_
-
-    #
-    # CoreCLR Test executions using live libraries
-    #
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-        buildConfig: Checked
-        platforms:
-        - Linux_x64
-        helixQueueGroup: pr
-        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-        jobParameters:
-          testGroup: innerloop
-          liveLibrariesBuildConfig: Release
-          dependsOn:
-          - coreclr_common_test_build_p0_AnyOS_AnyCPU_Checked
-
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-        buildConfig: Checked
-        platforms:
-        - windows_x64
-        helixQueueGroup: pr
-        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-        jobParameters:
-          testGroup: innerloop
-          liveLibrariesBuildConfig: Release
-          dependsOn:
-          - coreclr_common_test_build_p0_AnyOS_AnyCPU_Checked
-          - build_windows_x64_Checked_
-          - build_windows_x64_Release_
-
-    #
-    # Libraries Release Test Execution against a release coreclr runtime
-    #
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-        buildConfig: Release
-        platforms:
-        - Linux_x64
-        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-        jobParameters:
-          isFullMatrix: false
-          isOfficialBuild: false
-          testScope: innerloop
-          liveRuntimeBuildConfig: Release
-          dependsOnTestBuildConfiguration: Release
-          dependsOnTestArchitecture: x64
-          dependsOn:
-          - build_Linux_x64_Release_
-
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-        buildConfig: Release
-        platforms:
-        - windows_x64
-        helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-        jobParameters:
-          isFullMatrix: false
-          isOfficialBuild: false
-          testScope: innerloop
-          liveRuntimeBuildConfig: Release
-          dependsOnTestBuildConfiguration: Release
-          dependsOnTestArchitecture: x64
-          dependsOn:
-          - build_windows_x64_Release_
-
-- ${{ if eq(variables.isOfficialBuild, true) }}:
-  - template: /eng/pipelines/official/stages/publish.yml
-    parameters:
-      isOfficialBuild: ${{ variables.isOfficialBuild }}


### PR DESCRIPTION
This introduces new templates from #75473 needed to switch over the .NET 6 servicing branch to 1ES templates. Once this is merged, #102681 (along with some pool provider updates) should be all we need to switch `release/6.0-staging` over to 1ES templates.

cc @eduardo-vp, @agocke @jkoritzinsky PTAL. Thanks!

[Official build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2470588&view=results)