### PR TITLE
Disable newly added System.Resources.Extensions tests with native AOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -506,6 +506,8 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Mail\tests\Functional\System.Net.Mail.Functional.Tests.csproj"
                       Condition="'$(TargetOS)' == 'windows'"/>
 
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.Extensions\tests\CompatTests\System.Resources.Extensions.Compat.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.Extensions\tests\BinaryFormatTests\System.Resources.Extensions.BinaryFormat.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.CodeDom\tests\System.CodeDom.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.Annotations\tests\System.ComponentModel.Annotations.Tests.csproj" />


### PR DESCRIPTION
Native AOT outerloop testing is on the floor due to build breaks:

Build break 1:

```
The published project has a runtimeconfig.template.json that is not supported by PublishAot. Move the configuration to the project file using RuntimeHostConfigurationOption.
```

Build break 2 (this is a warning, but WarnAsError makes this more severe):

```
AOT analysis error IL3054: FluentAssertions.Equivalency.EquivalencyAssertionOptions`1<IEnumerable`1<IEnumerable`1<IEnumerable`1<IEnumerable`1<Int32[,,]>>>>>: Generic expansion to 'FluentAssertions.Equivalency.EquivalencyAssertionOptions`1<IEnumerable`1<IEnumerable`1<IEnumerable`1<IEnumerable`1<IEnumerable`1<Int32[,,]>>>>>>' was aborted due to generic recursion. An exception will be thrown at runtime if this codepath is ever reached. Generic recursion also negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'FluentAssertions.Equivalency.EquivalencyAssertionOptions`1', 'FluentAssertions.Equivalency.NestedExclusionOptionBuilder`2'
```

Cc @dotnet/ilc-contrib 