### PR TITLE
Share more of the TYP_MASK handling and support rewriting TYP_MASK operands in rationalization

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3185,6 +3185,10 @@ public:
     GenTree* gtNewSimdAbsNode(
         var_types type, GenTree* op1, CorInfoType simdBaseJitType, unsigned simdSize);
 
+#if defined(TARGET_ARM64)
+    GenTree* gtNewSimdAllTrueMaskNode(CorInfoType simdBaseJitType, unsigned simdSize);
+#endif
+
     GenTree* gtNewSimdBinOpNode(genTreeOps  op,
                                 var_types   type,
                                 GenTree*    op1,
@@ -3223,6 +3227,8 @@ public:
                                  CorInfoType simdBaseJitType,
                                  unsigned    simdSize);
 
+    GenTree* gtNewSimdCvtMaskToVectorNode(var_types type, GenTree* op1, CorInfoType simdBaseJitType, unsigned simdSize);
+
     GenTree* gtNewSimdCvtNode(var_types   type,
                               GenTree*    op1,
                               CorInfoType simdTargetBaseJitType,
@@ -3234,6 +3240,8 @@ public:
                                     CorInfoType simdTargetBaseJitType,
                                     CorInfoType simdSourceBaseJitType,
                                     unsigned    simdSize);
+
+    GenTree* gtNewSimdCvtVectorToMaskNode(var_types type, GenTree* op1, CorInfoType simdBaseJitType, unsigned simdSize);
 
     GenTree* gtNewSimdCreateBroadcastNode(
         var_types type, GenTree* op1, CorInfoType simdBaseJitType, unsigned simdSize);
@@ -3515,12 +3523,6 @@ public:
     GenTree* gtNewRuntimeLookup(CORINFO_GENERIC_HANDLE hnd, CorInfoGenericHandleType hndTyp, GenTree* lookupTree);
 
     GenTreeIndir* gtNewMethodTableLookup(GenTree* obj);
-
-#if defined(TARGET_ARM64)
-    GenTree* gtNewSimdConvertVectorToMaskNode(var_types type, GenTree* node, CorInfoType simdBaseJitType, unsigned simdSize);
-    GenTree* gtNewSimdConvertMaskToVectorNode(GenTreeHWIntrinsic* node, var_types type);
-    GenTree* gtNewSimdAllTrueMaskNode(CorInfoType simdBaseJitType, unsigned simdSize);
-#endif
 
     //------------------------------------------------------------------------
     // Other GenTree functions

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -21530,6 +21530,35 @@ GenTree* Compiler::gtNewSimdCeilNode(var_types type, GenTree* op1, CorInfoType s
     return gtNewSimdHWIntrinsicNode(type, op1, intrinsic, simdBaseJitType, simdSize);
 }
 
+//------------------------------------------------------------------------
+// gtNewSimdCvtMaskToVectorNode: Convert a HW instrinsic mask node to a vector
+//
+// Arguments:
+//    type            -- The type of the node to convert to
+//    op1             -- The node to convert
+//    simdBaseJitType -- the base jit type of the converted node
+//    simdSize        -- the simd size of the converted node
+//
+// Return Value:
+//    The node converted to the given type
+//
+GenTree* Compiler::gtNewSimdCvtMaskToVectorNode(var_types   type,
+                                                GenTree*    op1,
+                                                CorInfoType simdBaseJitType,
+                                                unsigned    simdSize)
+{
+    assert(varTypeIsMask(op1));
+    assert(varTypeIsSIMD(type));
+
+#if defined(TARGET_XARCH)
+    return gtNewSimdHWIntrinsicNode(type, op1, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
+#elif defined(TARGET_ARM64)
+    return gtNewSimdHWIntrinsicNode(type, op1, NI_Sve_ConvertMaskToVector, simdBaseJitType, simdSize);
+#else
+#error Unsupported platform
+#endif // !TARGET_XARCH && !TARGET_ARM64
+}
+
 GenTree* Compiler::gtNewSimdCvtNode(var_types   type,
                                     GenTree*    op1,
                                     CorInfoType simdTargetBaseJitType,
@@ -21890,6 +21919,37 @@ GenTree* Compiler::gtNewSimdCvtNativeNode(var_types   type,
 
     assert(hwIntrinsicID != NI_Illegal);
     return gtNewSimdHWIntrinsicNode(type, op1, hwIntrinsicID, simdSourceBaseJitType, simdSize);
+}
+
+//------------------------------------------------------------------------
+// gtNewSimdCvtVectorToMaskNode: Convert a HW instrinsic vector node to a mask
+//
+// Arguments:
+//    type            -- The type of the mask to produce.
+//    op1             -- The node to convert
+//    simdBaseJitType -- the base jit type of the converted node
+//    simdSize        -- the simd size of the converted node
+//
+// Return Value:
+//    The node converted to the a mask type
+//
+GenTree* Compiler::gtNewSimdCvtVectorToMaskNode(var_types   type,
+                                                GenTree*    op1,
+                                                CorInfoType simdBaseJitType,
+                                                unsigned    simdSize)
+{
+    assert(varTypeIsMask(type));
+    assert(varTypeIsSIMD(op1));
+
+#if defined(TARGET_XARCH)
+    return gtNewSimdHWIntrinsicNode(TYP_MASK, op1, NI_EVEX_ConvertVectorToMask, simdBaseJitType, simdSize);
+#elif defined(TARGET_ARM64)
+    // We use cmpne which requires an embedded mask.
+    GenTree* trueMask = gtNewSimdAllTrueMaskNode(simdBaseJitType, simdSize);
+    return gtNewSimdHWIntrinsicNode(TYP_MASK, trueMask, op1, NI_Sve_ConvertVectorToMask, simdBaseJitType, simdSize);
+#else
+#error Unsupported platform
+#endif // !TARGET_XARCH && !TARGET_ARM64
 }
 
 GenTree* Compiler::gtNewSimdCmpOpNode(
@@ -22569,19 +22629,15 @@ GenTree* Compiler::gtNewSimdCmpOpNode(
 
     assert(intrinsic != NI_Illegal);
 
-#if defined(TARGET_XARCH)
     if (needsConvertMaskToVector)
     {
         GenTree* retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, intrinsic, simdBaseJitType, simdSize);
-        return gtNewSimdHWIntrinsicNode(type, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
+        return gtNewSimdCvtMaskToVectorNode(type, retNode, simdBaseJitType, simdSize);
     }
     else
     {
         return gtNewSimdHWIntrinsicNode(type, op1, op2, intrinsic, simdBaseJitType, simdSize);
     }
-#else
-    return gtNewSimdHWIntrinsicNode(type, op1, op2, intrinsic, simdBaseJitType, simdSize);
-#endif
 }
 
 GenTree* Compiler::gtNewSimdCmpOpAllNode(
@@ -27158,6 +27214,20 @@ bool GenTreeHWIntrinsic::OperIsCreateScalarUnsafe() const
 }
 
 //------------------------------------------------------------------------
+// OperIsBitwiseHWIntrinsic: Is the operation a bitwise logic operation.
+//
+// Arguments:
+//    oper -- The operation to check
+//
+// Return Value:
+//    Whether oper is a bitwise logic intrinsic node.
+//
+bool GenTreeHWIntrinsic::OperIsBitwiseHWIntrinsic(genTreeOps oper)
+{
+    return (oper == GT_AND) || (oper == GT_AND_NOT) || (oper == GT_OR) || (oper == GT_XOR);
+}
+
+//------------------------------------------------------------------------
 // OperIsBitwiseHWIntrinsic: Is this HWIntrinsic a bitwise logic intrinsic node.
 //
 // Return Value:
@@ -27165,8 +27235,8 @@ bool GenTreeHWIntrinsic::OperIsCreateScalarUnsafe() const
 //
 bool GenTreeHWIntrinsic::OperIsBitwiseHWIntrinsic() const
 {
-    genTreeOps Oper = HWOperGet();
-    return Oper == GT_AND || Oper == GT_OR || Oper == GT_XOR || Oper == GT_AND_NOT;
+    genTreeOps oper = HWOperGet();
+    return OperIsBitwiseHWIntrinsic(oper);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6505,6 +6505,8 @@ struct GenTreeHWIntrinsic : public GenTreeJitIntrinsic
     }
 #endif
 
+    static bool OperIsBitwiseHWIntrinsic(genTreeOps oper);
+
     bool OperIsMemoryLoad(GenTree** pAddr = nullptr) const;
     bool OperIsMemoryStore(GenTree** pAddr = nullptr) const;
     bool OperIsMemoryLoadOrStore() const;

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1657,15 +1657,14 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
             // HWInstrinsic requires a mask for op2
             if (!varTypeIsMask(op2))
             {
-                retNode->AsHWIntrinsic()->Op(2) =
-                    gtNewSimdConvertVectorToMaskNode(retType, op2, simdBaseJitType, simdSize);
+                retNode->AsHWIntrinsic()->Op(2) = gtNewSimdCvtVectorToMaskNode(retType, op2, simdBaseJitType, simdSize);
             }
         }
 
         if (!varTypeIsMask(op1))
         {
             // Op1 input is a vector. HWInstrinsic requires a mask.
-            retNode->AsHWIntrinsic()->Op(1) = gtNewSimdConvertVectorToMaskNode(retType, op1, simdBaseJitType, simdSize);
+            retNode->AsHWIntrinsic()->Op(1) = gtNewSimdCvtVectorToMaskNode(retType, op1, simdBaseJitType, simdSize);
         }
 
         if (HWIntrinsicInfo::IsMultiReg(intrinsic))
@@ -1682,7 +1681,13 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
         // HWInstrinsic returns a mask, but all returns must be vectors, so convert mask to vector.
         assert(HWIntrinsicInfo::ReturnsPerElementMask(intrinsic));
         assert(nodeRetType == TYP_MASK);
-        retNode = gtNewSimdConvertMaskToVectorNode(retNode->AsHWIntrinsic(), retType);
+
+        GenTreeHWIntrinsic* op = retNode->AsHWIntrinsic();
+
+        CorInfoType simdBaseJitType = op->GetSimdBaseJitType();
+        unsigned    simdSize        = op->GetSimdSize();
+
+        retNode = gtNewSimdCvtMaskToVectorNode(retType, op, simdBaseJitType, simdSize);
     }
 #endif // defined(TARGET_ARM64)
 

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1657,7 +1657,8 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
             // HWInstrinsic requires a mask for op2
             if (!varTypeIsMask(op2))
             {
-                retNode->AsHWIntrinsic()->Op(2) = gtNewSimdCvtVectorToMaskNode(TYP_MASK, op2, simdBaseJitType, simdSize);
+                retNode->AsHWIntrinsic()->Op(2) =
+                    gtNewSimdCvtVectorToMaskNode(TYP_MASK, op2, simdBaseJitType, simdSize);
             }
         }
 

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1657,14 +1657,14 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
             // HWInstrinsic requires a mask for op2
             if (!varTypeIsMask(op2))
             {
-                retNode->AsHWIntrinsic()->Op(2) = gtNewSimdCvtVectorToMaskNode(retType, op2, simdBaseJitType, simdSize);
+                retNode->AsHWIntrinsic()->Op(2) = gtNewSimdCvtVectorToMaskNode(TYP_MASK, op2, simdBaseJitType, simdSize);
             }
         }
 
         if (!varTypeIsMask(op1))
         {
             // Op1 input is a vector. HWInstrinsic requires a mask.
-            retNode->AsHWIntrinsic()->Op(1) = gtNewSimdCvtVectorToMaskNode(retType, op1, simdBaseJitType, simdSize);
+            retNode->AsHWIntrinsic()->Op(1) = gtNewSimdCvtVectorToMaskNode(TYP_MASK, op1, simdBaseJitType, simdSize);
         }
 
         if (HWIntrinsicInfo::IsMultiReg(intrinsic))

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -2582,7 +2582,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             // HWInstrinsic requires a mask for op2
             if (!varTypeIsMask(op2))
             {
-                op2 = gtNewSimdCvtVectorToMaskNode(retType, op2, simdBaseJitType, simdSize);
+                op2 = gtNewSimdCvtVectorToMaskNode(TYP_MASK, op2, simdBaseJitType, simdSize);
             }
 
             retNode = gtNewSimdHWIntrinsicNode(retType, op1, op2, intrinsic, simdBaseJitType, simdSize);

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -2582,7 +2582,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             // HWInstrinsic requires a mask for op2
             if (!varTypeIsMask(op2))
             {
-                op2 = gtNewSimdConvertVectorToMaskNode(retType, op2, simdBaseJitType, simdSize);
+                op2 = gtNewSimdCvtVectorToMaskNode(retType, op2, simdBaseJitType, simdSize);
             }
 
             retNode = gtNewSimdHWIntrinsicNode(retType, op1, op2, intrinsic, simdBaseJitType, simdSize);
@@ -2601,48 +2601,6 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
     assert(!isScalar || isValidScalarIntrinsic);
 
     return retNode;
-}
-
-//------------------------------------------------------------------------
-// gtNewSimdConvertMaskToVectorNode: Convert a HW instrinsic vector node to a mask
-//
-// Arguments:
-//    node            -- The node to convert
-//    simdBaseJitType -- the base jit type of the converted node
-//    simdSize        -- the simd size of the converted node
-//
-// Return Value:
-//    The node converted to the a mask type
-//
-GenTree* Compiler::gtNewSimdConvertVectorToMaskNode(var_types   type,
-                                                    GenTree*    node,
-                                                    CorInfoType simdBaseJitType,
-                                                    unsigned    simdSize)
-{
-    assert(varTypeIsSIMD(node));
-
-    // ConvertVectorToMask uses cmpne which requires an embedded mask.
-    GenTree* trueMask = gtNewSimdAllTrueMaskNode(simdBaseJitType, simdSize);
-    return gtNewSimdHWIntrinsicNode(TYP_MASK, trueMask, node, NI_Sve_ConvertVectorToMask, simdBaseJitType, simdSize);
-}
-
-//------------------------------------------------------------------------
-// gtNewSimdConvertMaskToVectorNode: Convert a HW instrinsic mask node to a vector
-//
-// Arguments:
-//    node          -- The node to convert
-//    type          -- The type of the node to convert to
-//
-// Return Value:
-//    The node converted to the given type
-//
-GenTree* Compiler::gtNewSimdConvertMaskToVectorNode(GenTreeHWIntrinsic* node, var_types type)
-{
-    assert(varTypeIsMask(node));
-    assert(varTypeIsSIMD(type));
-
-    return gtNewSimdHWIntrinsicNode(type, node, NI_Sve_ConvertMaskToVector, node->GetSimdBaseJitType(),
-                                    node->GetSimdSize());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -2043,8 +2043,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                 if (!varTypeIsMask(op1))
                 {
-                    op1 =
-                        gtNewSimdHWIntrinsicNode(TYP_MASK, op1, NI_EVEX_ConvertVectorToMask, simdBaseJitType, simdSize);
+                    op1 = gtNewSimdCvtVectorToMaskNode(TYP_MASK, op1, simdBaseJitType, simdSize);
                 }
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, NI_EVEX_MoveMask, simdBaseJitType, simdSize);
             }
@@ -4141,7 +4140,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             if (!varTypeIsMask(op3))
             {
-                op3 = gtNewSimdHWIntrinsicNode(TYP_MASK, op3, NI_EVEX_ConvertVectorToMask, simdBaseJitType, simdSize);
+                op3 = gtNewSimdCvtVectorToMaskNode(TYP_MASK, op3, simdBaseJitType, simdSize);
             }
             retNode =
                 gtNewSimdHWIntrinsicNode(retType, op1, op2, op3, NI_EVEX_BlendVariableMask, simdBaseJitType, simdSize);
@@ -4157,8 +4156,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             op1 = impSIMDPopStack();
 
             retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, op3, NI_EVEX_CompareMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
 
             break;
         }
@@ -4172,9 +4170,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             op1 = impSIMDPopStack();
 
             retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareEqualMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4191,9 +4187,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode =
                 gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareGreaterThanMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4210,9 +4204,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareGreaterThanOrEqualMask,
                                                simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4229,9 +4221,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode =
                 gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareLessThanMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4248,9 +4238,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareLessThanOrEqualMask, simdBaseJitType,
                                                simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4267,9 +4255,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode =
                 gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareNotEqualMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4282,9 +4268,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareNotGreaterThanMask, simdBaseJitType,
                                                simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4297,9 +4281,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareNotGreaterThanOrEqualMask,
                                                simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4312,9 +4294,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode =
                 gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareNotLessThanMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4327,9 +4307,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode = gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareNotLessThanOrEqualMask,
                                                simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4342,9 +4320,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode =
                 gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareOrderedMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 
@@ -4357,9 +4333,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             retNode =
                 gtNewSimdHWIntrinsicNode(TYP_MASK, op1, op2, NI_EVEX_CompareUnorderedMask, simdBaseJitType, simdSize);
-            retNode =
-                gtNewSimdHWIntrinsicNode(retType, retNode, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
+            retNode = gtNewSimdCvtMaskToVectorNode(retType, retNode, simdBaseJitType, simdSize);
             break;
         }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10676,220 +10676,181 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
             INDEBUG(node->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
             return node;
         }
-#if defined(TARGET_ARM64)
-        case NI_Sve_ConvertMaskToVector:
-        {
-            GenTree* op1 = node->Op(1);
-
-            if (!op1->OperIsHWIntrinsic(NI_Sve_ConvertVectorToMask))
-            {
-                break;
-            }
-
-            unsigned            simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
-            GenTreeHWIntrinsic* cvtOp1           = op1->AsHWIntrinsic();
-
-            if ((genTypeSize(cvtOp1->GetSimdBaseType()) != simdBaseTypeSize))
-            {
-                // We need the operand to be the same kind of mask; otherwise
-                // the bitwise operation can differ in how it performs
-                break;
-            }
-
-            GenTree* vectorNode = op1->AsHWIntrinsic()->Op(1);
-
-            DEBUG_DESTROY_NODE(op1, node);
-            INDEBUG(vectorNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
-
-            return vectorNode;
-        }
-
-        case NI_Sve_ConvertVectorToMask:
-        {
-            GenTree* op1 = node->Op(1);
-            GenTree* op2 = node->Op(2);
-
-            if (!op1->OperIsHWIntrinsic(NI_Sve_CreateTrueMaskAll) ||
-                !op2->OperIsHWIntrinsic(NI_Sve_ConvertMaskToVector))
-            {
-                break;
-            }
-
-            unsigned simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
-
-            if (!op2->OperIsHWIntrinsic() || (genTypeSize(op2->AsHWIntrinsic()->GetSimdBaseType()) != simdBaseTypeSize))
-            {
-                // We need the operand to be the same kind of mask; otherwise
-                // the bitwise operation can differ in how it performs
-                break;
-            }
-
-            GenTree* maskNode = op2->AsHWIntrinsic()->Op(1);
-
-            DEBUG_DESTROY_NODE(op2, node);
-            INDEBUG(maskNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
-
-            return maskNode;
-        }
-#endif
-#if defined(TARGET_XARCH)
-        case NI_AVX512F_And:
-        case NI_AVX512DQ_And:
-        case NI_AVX512F_AndNot:
-        case NI_AVX512DQ_AndNot:
-        case NI_AVX512F_Or:
-        case NI_AVX512DQ_Or:
-        case NI_AVX512F_Xor:
-        case NI_AVX512DQ_Xor:
-        case NI_AVX10v1_V512_And:
-        case NI_AVX10v1_V512_AndNot:
-        case NI_AVX10v1_V512_Or:
-        case NI_AVX10v1_V512_Xor:
-        {
-            GenTree* op1 = node->Op(1);
-            GenTree* op2 = node->Op(2);
-
-            if (!op1->OperIsHWIntrinsic(NI_EVEX_ConvertMaskToVector) ||
-                !op2->OperIsHWIntrinsic(NI_EVEX_ConvertMaskToVector))
-            {
-                // We need both operands to be ConvertMaskToVector in
-                // order to optimize this to a direct mask operation
-                break;
-            }
-
-            unsigned simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
-
-            GenTreeHWIntrinsic* cvtOp1 = op1->AsHWIntrinsic();
-            GenTreeHWIntrinsic* cvtOp2 = op2->AsHWIntrinsic();
-
-            if ((genTypeSize(cvtOp1->GetSimdBaseType()) != simdBaseTypeSize) ||
-                (genTypeSize(cvtOp2->GetSimdBaseType()) != simdBaseTypeSize))
-            {
-                // We need both operands to be the same kind of mask; otherwise
-                // the bitwise operation can differ in how it performs
-                break;
-            }
-
-            var_types   simdType        = node->TypeGet();
-            CorInfoType simdBaseJitType = node->GetSimdBaseJitType();
-            unsigned    simdSize        = node->GetSimdSize();
-
-            NamedIntrinsic maskIntrinsicId = NI_Illegal;
-
-            switch (intrinsicId)
-            {
-                case NI_AVX512F_And:
-                case NI_AVX512DQ_And:
-                case NI_AVX10v1_V512_And:
-                {
-                    maskIntrinsicId = NI_EVEX_AndMask;
-                    break;
-                }
-
-                case NI_AVX512F_AndNot:
-                case NI_AVX512DQ_AndNot:
-                case NI_AVX10v1_V512_AndNot:
-                {
-                    maskIntrinsicId = NI_EVEX_AndNotMask;
-                    break;
-                }
-
-                case NI_AVX512F_Or:
-                case NI_AVX512DQ_Or:
-                case NI_AVX10v1_V512_Or:
-                {
-                    maskIntrinsicId = NI_EVEX_OrMask;
-                    break;
-                }
-
-                case NI_AVX512F_Xor:
-                case NI_AVX512DQ_Xor:
-                case NI_AVX10v1_V512_Xor:
-                {
-                    maskIntrinsicId = NI_EVEX_XorMask;
-                    break;
-                }
-
-                default:
-                {
-                    unreached();
-                }
-            }
-
-            assert(maskIntrinsicId != NI_Illegal);
-
-            node->ChangeHWIntrinsicId(maskIntrinsicId);
-            node->gtType = TYP_MASK;
-
-            node->Op(1) = cvtOp1->Op(1);
-            DEBUG_DESTROY_NODE(op1);
-
-            node->Op(2) = cvtOp2->Op(1);
-            DEBUG_DESTROY_NODE(op2);
-
-            node = gtNewSimdHWIntrinsicNode(simdType, node, NI_EVEX_ConvertMaskToVector, simdBaseJitType, simdSize);
-
-            INDEBUG(node->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
-            break;
-        }
-
-        case NI_EVEX_ConvertMaskToVector:
-        {
-            GenTree* op1 = node->Op(1);
-
-            if (!op1->OperIsHWIntrinsic(NI_EVEX_ConvertVectorToMask))
-            {
-                break;
-            }
-
-            unsigned            simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
-            GenTreeHWIntrinsic* cvtOp1           = op1->AsHWIntrinsic();
-
-            if ((genTypeSize(cvtOp1->GetSimdBaseType()) != simdBaseTypeSize))
-            {
-                // We need the operand to be the same kind of mask; otherwise
-                // the bitwise operation can differ in how it performs
-                break;
-            }
-
-            GenTree* vectorNode = op1->AsHWIntrinsic()->Op(1);
-
-            DEBUG_DESTROY_NODE(op1, node);
-            INDEBUG(vectorNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
-
-            return vectorNode;
-        }
-
-        case NI_EVEX_ConvertVectorToMask:
-        {
-            GenTree* op1 = node->Op(1);
-
-            if (!op1->OperIsHWIntrinsic(NI_EVEX_ConvertMaskToVector))
-            {
-                break;
-            }
-
-            unsigned            simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
-            GenTreeHWIntrinsic* cvtOp1           = op1->AsHWIntrinsic();
-
-            if ((genTypeSize(cvtOp1->GetSimdBaseType()) != simdBaseTypeSize))
-            {
-                // We need the operand to be the same kind of mask; otherwise
-                // the bitwise operation can differ in how it performs
-                break;
-            }
-
-            GenTree* maskNode = op1->AsHWIntrinsic()->Op(1);
-
-            DEBUG_DESTROY_NODE(op1, node);
-            INDEBUG(maskNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
-
-            return maskNode;
-        }
-#endif // TARGET_XARCH
 
         default:
         {
+            genTreeOps oper = node->HWOperGet();
+
+            if (GenTreeHWIntrinsic::OperIsBitwiseHWIntrinsic(oper))
+            {
+                GenTree* op1 = node->Op(1);
+                GenTree* op2 = node->Op(2);
+
+                if (!op1->OperIsHWIntrinsic() || !op2->OperIsHWIntrinsic())
+                {
+                    // We need both operands to be ConvertMaskToVector in
+                    // order to optimize this to a direct mask operation
+                    break;
+                }
+
+                GenTreeHWIntrinsic* cvtOp1 = op1->AsHWIntrinsic();
+                GenTreeHWIntrinsic* cvtOp2 = op2->AsHWIntrinsic();
+
+                if (!cvtOp1->OperIsConvertMaskToVector() || !cvtOp2->OperIsConvertMaskToVector())
+                {
+                    break;
+                }
+
+                unsigned simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
+
+                if ((genTypeSize(cvtOp1->GetSimdBaseType()) != simdBaseTypeSize) ||
+                    (genTypeSize(cvtOp2->GetSimdBaseType()) != simdBaseTypeSize))
+                {
+                    // We need both operands to be the same kind of mask; otherwise
+                    // the bitwise operation can differ in how it performs
+                    break;
+                }
+
+                var_types   simdType        = node->TypeGet();
+                CorInfoType simdBaseJitType = node->GetSimdBaseJitType();
+                unsigned    simdSize        = node->GetSimdSize();
+
+                NamedIntrinsic maskIntrinsicId = NI_Illegal;
+
+#if defined(TARGET_XARCH)
+                switch (oper)
+                {
+                    case GT_AND:
+                    {
+                        maskIntrinsicId = NI_EVEX_AndMask;
+                        break;
+                    }
+
+                    case GT_AND_NOT:
+                    {
+                        maskIntrinsicId = NI_EVEX_AndNotMask;
+                        break;
+                    }
+
+                    case GT_OR:
+                    {
+                        maskIntrinsicId = NI_EVEX_OrMask;
+                        break;
+                    }
+
+                    case GT_XOR:
+                    {
+                        maskIntrinsicId = NI_EVEX_XorMask;
+                        break;
+                    }
+
+                    default:
+                    {
+                        unreached();
+                    }
+                }
+#elif defined(TARGET_ARM64)
+                // TODO-ARM64-CQ: Support transforming bitwise operations on masks
+                break;
+#else
+#error Unsupported platform
+#endif // !TARGET_XARCH && !TARGET_ARM64
+
+                if (maskIntrinsicId == NI_Illegal)
+                {
+                    break;
+                }
+
+                node->ChangeHWIntrinsicId(maskIntrinsicId);
+                node->gtType = TYP_MASK;
+
+                node->Op(1) = cvtOp1->Op(1);
+                DEBUG_DESTROY_NODE(op1);
+
+                node->Op(2) = cvtOp2->Op(1);
+                DEBUG_DESTROY_NODE(op2);
+
+                node = gtNewSimdCvtMaskToVectorNode(simdType, node, simdBaseJitType, simdSize)->AsHWIntrinsic();
+
+                INDEBUG(node->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
+                return node;
+            }
+
+            if (node->OperIsConvertMaskToVector())
+            {
+                GenTree* op = node->Op(1);
+
+                if (!op->OperIsHWIntrinsic())
+                {
+                    break;
+                }
+
+                unsigned            simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
+                GenTreeHWIntrinsic* cvtOp            = op->AsHWIntrinsic();
+
+                if (!cvtOp->OperIsConvertVectorToMask())
+                {
+                    break;
+                }
+
+                if ((genTypeSize(cvtOp->GetSimdBaseType()) != simdBaseTypeSize))
+                {
+                    // We need the operand to be the same kind of mask; otherwise
+                    // the bitwise operation can differ in how it performs
+                    break;
+                }
+
+                GenTree* vectorNode = cvtOp->Op(1);
+
+                DEBUG_DESTROY_NODE(op, node);
+                INDEBUG(vectorNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
+
+                return vectorNode;
+            }
+
+            if (node->OperIsConvertVectorToMask())
+            {
+                GenTree* op = node->Op(1);
+
+#if defined(TARGET_ARM64)
+                if (!op->OperIsHWIntrinsic(NI_Sve_CreateTrueMaskAll))
+                {
+                    break;
+                }
+                op = node->Op(2);
+#endif // TARGET_ARM64
+
+                if (!op->OperIsHWIntrinsic())
+                {
+                    break;
+                }
+
+                unsigned            simdBaseTypeSize = genTypeSize(node->GetSimdBaseType());
+                GenTreeHWIntrinsic* cvtOp            = op->AsHWIntrinsic();
+
+                if (!cvtOp->OperIsConvertMaskToVector())
+                {
+                    break;
+                }
+
+                if ((genTypeSize(cvtOp->GetSimdBaseType()) != simdBaseTypeSize))
+                {
+                    // We need the operand to be the same kind of mask; otherwise
+                    // the bitwise operation can differ in how it performs
+                    break;
+                }
+
+                GenTree* maskNode = cvtOp->Op(1);
+
+#if defined(TARGET_ARM64)
+                DEBUG_DESTROY_NODE(node->Op(1));
+#endif // TARGET_ARM64
+
+                DEBUG_DESTROY_NODE(op, node);
+                INDEBUG(maskNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
+
+                return maskNode;
+            }
             break;
         }
     }
@@ -10989,6 +10950,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
 
             return andnNode;
         }
+
         default:
         {
             break;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10800,7 +10800,13 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
                     break;
                 }
 
+#if defined(TARGET_XARCH)
                 GenTree* vectorNode = cvtOp->Op(1);
+#elif defined(TARGET_ARM64)
+                GenTree* vectorNode = cvtOp->Op(2);
+#else
+#error Unsupported platform
+#endif // !TARGET_XARCH && !TARGET_ARM64
 
                 DEBUG_DESTROY_NODE(op, node);
                 INDEBUG(vectorNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -99,6 +99,8 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
             // for intrinsics that get rewritten back to user calls
             assert(!operand->OperIsFieldList());
 
+            sigTyp = comp->impNormStructType(clsHnd);
+
             if (varTypeIsMask(operand->TypeGet()))
             {
 #if defined(FEATURE_HW_INTRINSICS)
@@ -115,9 +117,7 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
                 unreached();
 #endif // FEATURE_HW_INTRINSICS
             }
-
-            sigTyp = comp->impNormStructType(clsHnd);
-            arg    = NewCallArg::Struct(operand, sigTyp, clsHnd);
+            arg = NewCallArg::Struct(operand, sigTyp, clsHnd);
         }
         else
         {

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -176,7 +176,7 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
             CorInfoType simdBaseJitType = comp->getBaseJitTypeAndSizeOfSIMDType(call->gtRetClsHnd, &simdSize);
             assert(simdSize != 0);
 
-            GenTree* cvtNode = comp->gtNewSimdCvtVectorToMaskNode(simdType, result, simdBaseJitType, simdSize);
+            GenTree* cvtNode = comp->gtNewSimdCvtVectorToMaskNode(TYP_MASK, result, simdBaseJitType, simdSize);
             BlockRange().InsertAfter(insertionPoint, LIR::Range(comp->fgSetTreeSeq(cvtNode), cvtNode));
             result = cvtNode;
 

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -105,7 +105,7 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
                 // No managed call takes TYP_MASK, so convert it back to a TYP_SIMD
 
                 unsigned    simdSize;
-                CorInfoType simdBaseJitType = comp->getBaseJitTypeAndSizeOfSIMDType(call->gtRetClsHnd, &simdSize);
+                CorInfoType simdBaseJitType = comp->getBaseJitTypeAndSizeOfSIMDType(clsHnd, &simdSize);
                 assert(simdSize != 0);
 
                 GenTree* cvtNode = comp->gtNewSimdCvtMaskToVectorNode(sigTyp, operand, simdBaseJitType, simdSize);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -12187,24 +12187,13 @@ void Compiler::fgValueNumberHWIntrinsic(GenTreeHWIntrinsic* tree)
     // Some intrinsics should always be unique
     bool makeUnique = false;
 
-#if defined(TARGET_XARCH)
-    switch (intrinsicId)
+    if (tree->OperIsConvertMaskToVector())
     {
-        case NI_EVEX_ConvertMaskToVector:
-        {
-            // We want to ensure that we get a TYP_MASK local to
-            // ensure the relevant optimizations can kick in
+        // We want to ensure that we get a TYP_MASK local to
+        // ensure the relevant optimizations can kick in
 
-            makeUnique = true;
-            break;
-        }
-
-        default:
-        {
-            break;
-        }
+        makeUnique = true;
     }
-#endif // TARGET_XARCH
 
     if (makeUnique)
     {


### PR DESCRIPTION
This resolves the issue introduced by https://github.com/dotnet/runtime/pull/102702 which was discovered in https://github.com/dotnet/runtime/pull/103094#discussion_r1634977786.

The bug was missed in the initial PR as the Arm64 handling for `mask <-> vector` conversions was a bit different from Xarch, and it wasn't expected to be able to encounter nodes in such a shape.