### PR TITLE
LSRA: Update paths to print kill registers in dumps

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3740,6 +3740,29 @@ bool Compiler::compPromoteFewerStructs(unsigned lclNum)
 //
 // Arguments:
 //   regs - The set of registers to display
+//   type - The type of `regs`
+//
+void Compiler::dumpRegMask(SingleTypeRegSet regs, var_types type) const
+{
+#ifdef FEATURE_MASKED_HW_INTRINSICS
+    if (varTypeIsMask(type))
+    {
+        dumpRegMask(regMaskTP(RBM_NONE, regs));
+    }
+    else
+#endif
+    {
+        assert(varTypeUsesIntReg(type) || varTypeUsesFloatReg(type));
+        dumpRegMask(regMaskTP(regs, RBM_NONE));
+    }
+}
+
+//------------------------------------------------------------------------
+// dumpRegMask: display a register mask. For well-known sets of registers, display a well-known token instead of
+// a potentially large number of registers.
+//
+// Arguments:
+//   regs - The set of registers to display
 //
 void Compiler::dumpRegMask(regMaskTP regs) const
 {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11112,6 +11112,7 @@ public:
     bool compJitHaltMethod();
 
     void dumpRegMask(regMaskTP regs) const;
+    void dumpRegMask(SingleTypeRegSet regs, var_types type) const;
 
 #endif
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1031,17 +1031,25 @@ inline regNumber genFirstRegNumFromMask(const regMaskTP& mask)
 //
 // Arguments:
 //    mask               - the register mask
+//    type               - type of the register mask
 //
 // Return Value:
 //    The number of the first register contained in the mask.
 //
-inline regNumber genFirstRegNumFromMask(SingleTypeRegSet mask)
+inline regNumber genFirstRegNumFromMask(SingleTypeRegSet mask, var_types type)
 {
     assert(mask != RBM_NONE); // Must have one bit set, so can't have a mask of zero
 
     /* Convert the mask to a register number */
 
     regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
+
+#ifdef HAS_MORE_THAN_64_REGISTERS
+    if (varTypeIsMask(type))
+    {
+        regNum = (regNumber)(64 + regNum);
+    }
+#endif
 
     return regNum;
 }
@@ -1075,13 +1083,14 @@ inline regNumber genFirstRegNumFromMaskAndToggle(regMaskTP& mask)
 //          register number and also toggle the bit in the `mask`.
 // Arguments:
 //    mask               - the register mask
+//    type               - type of the register mask
 //
 // Return Value:
 //    The number of the first register contained in the mask and updates the `mask` to toggle
 //    the bit.
 //
 
-inline regNumber genFirstRegNumFromMaskAndToggle(SingleTypeRegSet& mask)
+inline regNumber genFirstRegNumFromMaskAndToggle(SingleTypeRegSet& mask, var_types type)
 {
     assert(mask != RBM_NONE); // Must have one bit set, so can't have a mask of zero
 
@@ -1090,6 +1099,13 @@ inline regNumber genFirstRegNumFromMaskAndToggle(SingleTypeRegSet& mask)
     regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
 
     mask ^= genSingleTypeRegMask(regNum);
+
+#ifdef HAS_MORE_THAN_64_REGISTERS
+    if (varTypeIsMask(type))
+    {
+        regNum = (regNumber)(64 + regNum);
+    }
+#endif
 
     return regNum;
 }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -10409,7 +10409,17 @@ void RefPosition::dump(LinearScan* linearScan)
     printf(FMT_BB " ", this->bbNum);
 
     printf("regmask=");
-    linearScan->compiler->dumpRegMask(registerAssignment);
+    var_types type = TYP_UNKNOWN;
+    if ((refType == RefTypeBB) || (refType == RefTypeKillGCRefs))
+    {
+        // These refTypes do not have intervals
+        type = TYP_INT;
+    }
+    else
+    {
+        type = getRegisterType();
+    }
+    linearScan->compiler->dumpRegMask(registerAssignment, type);
 
     printf(" minReg=%d", minRegCandidateCount);
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11111,7 +11111,8 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
 #ifdef HAS_MORE_THAN_64_REGISTERS
                             compiler->dumpRegMask(currentRefPosition->getKillRegisterAssignment());
 #else
-                            compiler->dumpRegMask(currentRefPosition->registerAssignment, currentRefPosition->getRegisterType());
+                            compiler->dumpRegMask(currentRefPosition->registerAssignment,
+                                                  currentRefPosition->getRegisterType());
 #endif
                             printf(" ");
                             break;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1185,7 +1185,10 @@ private:
 
     void associateRefPosWithInterval(RefPosition* rp);
 
-    weight_t getWeight(RefPosition* refPos);
+    weight_t getWeight(RefPosition* refPos DEBUG_ARG(bool forDump = false));
+#ifdef DEBUG
+    weight_t getWeightForDump(RefPosition* refPos);
+#endif // DEBUG
 
     /*****************************************************************************
      * Register management

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -647,7 +647,18 @@ RefPosition* LinearScan::newRefPosition(Interval*        theInterval,
         assert(theInterval != nullptr);
         theInterval->isSingleDef = theInterval->firstRefPosition == newRP;
     }
-
+#ifdef DEBUG
+#ifdef HAS_MORE_THAN_64_REGISTERS
+    // Need to do this here do the dump can print the mask correctly.
+    // Doing in DEBUG so we do not incur of cost of this check for
+    // every RefPosition. We will set this anyway in addKillForRegs()
+    // in RELEASE.
+    if (theRefType == RefTypeKill)
+    {
+        newRP->killRegisterAssignment = mask;
+    }
+#endif // HAS_MORE_THAN_64_REGISTERS
+#endif
     DBEXEC(VERBOSE, newRP->dump(this));
     return newRP;
 }

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -284,14 +284,14 @@ const char* getRegNameFloat(regNumber reg, var_types type)
  */
 const char* dspRegRange(regMaskTP regMask, size_t& minSiz, const char* sep, regNumber regFirst, regNumber regLast)
 {
-#ifdef TARGET_XARCH
+#ifdef FEATURE_MASKED_HW_INTRINSICS
     assert(((regFirst == REG_INT_FIRST) && (regLast == REG_INT_LAST)) ||
            ((regFirst == REG_FP_FIRST) && (regLast == REG_FP_LAST)) ||
            ((regFirst == REG_MASK_FIRST) && (regLast == REG_MASK_LAST)));
 #else
     assert(((regFirst == REG_INT_FIRST) && (regLast == REG_INT_LAST)) ||
            ((regFirst == REG_FP_FIRST) && (regLast == REG_FP_LAST)));
-#endif
+#endif // FEATURE_MASKED_HW_INTRINSICS
 
     if (strlen(sep) > 0)
     {
@@ -436,10 +436,9 @@ void dspRegMask(regMaskTP regMask, size_t minSiz)
 
     sep = dspRegRange(regMask, minSiz, sep, REG_INT_FIRST, REG_INT_LAST);
     sep = dspRegRange(regMask, minSiz, sep, REG_FP_FIRST, REG_FP_LAST);
-
-#ifdef TARGET_XARCH
+#ifdef FEATURE_MASKED_HW_INTRINSICS
     sep = dspRegRange(regMask, minSiz, sep, REG_MASK_FIRST, REG_MASK_LAST);
-#endif // TARGET_XARCH
+#endif // FEATURE_MASKED_HW_INTRINSICS
 
     printf("]");
 


### PR DESCRIPTION
There were some paths that needed updates on how we print the kill register mask correctly. Also, I realized at many places `genFirstRegNumFromMask()` and `genFirstRegNumFromMaskAndToggle()` we were passing `SingleTypeRegSet` without passing the underlying register type and the `SingleTypeRegSet` was implictely getting converted to `regMaskTP`. While this is not problematic currently but will soon be once we add predicate register. I want to put this PR separately as a cleanup item.