### PR TITLE
[osx][linux] Make sure host symbols are copied to testhost & in-tree runtime pack

### DIFF
--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -27,7 +27,8 @@
   <ItemGroup>
     <HostFxrFile Include="$(DotNetHostBinDir)$(LibPrefix)hostfxr$(LibSuffix)" />
     <HostPolicyFile Include="$(DotNetHostBinDir)$(LibPrefix)hostpolicy$(LibSuffix)" />
-    <_HostSymbols Condition="'$(TargetOS)' != 'windows'" Include="$(DotNetHostBinDir)$(LibPrefix)*$(LibSuffix)$(SymbolsSuffix)" />
+    <_HostSymbols Include="$(DotNetHostBinDir)$(LibPrefix)hostfxr$(LibSuffix)$(SymbolsSuffix)" />
+    <_HostSymbols Include="$(DotNetHostBinDir)$(LibPrefix)hostpolicy$(LibSuffix)$(SymbolsSuffix)" />
     <DotnetExe Include="$(DotNetHostBinDir)dotnet$(ExeSuffix)" />
   </ItemGroup>
 

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -84,7 +84,7 @@
     <ItemGroup>
       <RuntimeFiles Include="@(HostFxrFile)" Condition="Exists('@(HostFxrFile)')" />
       <RuntimeFiles Include="@(HostPolicyFile)" Condition="Exists('@(HostPolicyFile)')" />
-      <RuntimeFiles Include="@(_HostSymbols)" IsNative="true" />
+      <RuntimeFiles Include="@(_HostSymbols)" Condition="Exists('@(_HostSymbols)')" IsNative="true" />
       <!-- CoreRun is not used for testing anymore, but we still use it for benchmarking and profiling -->
       <RuntimeFiles Include="$(CoreCLRArtifactsPath)\corerun*" />
       <RuntimeFiles Include="$(CoreCLRArtifactsPath)\PDB\corerun*" />

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <HostFxrFile Include="$(DotNetHostBinDir)$(LibPrefix)hostfxr$(LibSuffix)" />
     <HostPolicyFile Include="$(DotNetHostBinDir)$(LibPrefix)hostpolicy$(LibSuffix)" />
+    <_HostSymbols Condition="'$(TargetOS)' != 'windows'" Include="$(DotNetHostBinDir)$(LibPrefix)*$(LibSuffix)$(SymbolsSuffix)" />
     <DotnetExe Include="$(DotNetHostBinDir)dotnet$(ExeSuffix)" />
   </ItemGroup>
 
@@ -82,6 +83,7 @@
     <ItemGroup>
       <RuntimeFiles Include="@(HostFxrFile)" Condition="Exists('@(HostFxrFile)')" />
       <RuntimeFiles Include="@(HostPolicyFile)" Condition="Exists('@(HostPolicyFile)')" />
+      <RuntimeFiles Include="@(_HostSymbols)" IsNative="true" />
       <!-- CoreRun is not used for testing anymore, but we still use it for benchmarking and profiling -->
       <RuntimeFiles Include="$(CoreCLRArtifactsPath)\corerun*" />
       <RuntimeFiles Include="$(CoreCLRArtifactsPath)\PDB\corerun*" />
@@ -117,9 +119,9 @@
           AfterTargets="AfterResolveReferences"
           Condition="'$(RuntimeFlavor)' == 'Mono'">
     <ItemGroup>
-      <!-- copy the host files to make the desktop samples work -->
       <RuntimeFiles Include="@(HostFxrFile)" Condition="Exists('@(HostFxrFile)') and '$(TargetsMobile)' != 'true'"/>
       <RuntimeFiles Include="@(HostPolicyFile)" Condition="Exists('@(HostPolicyFile)') and '$(TargetsMobile)' != 'true'" />
+      <RuntimeFiles Include="@(_HostSymbols)" IsNative="true" Condition="'$(TargetsMobile)' != 'true'" />
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
       <!-- Setup runtime pack native. -->
       <ReferenceCopyLocalPaths Include="@(MonoCrossFiles)"


### PR DESCRIPTION
Fixes the glitch for linux and mac in case you want to debug the host