### PR TITLE
[workload] Remove name versioning from coreclr runtime packs since they are never referenced by name

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -147,9 +147,9 @@
       "abstract": true,
       "description": "Windows Runtime Packs",
       "packs": [
-        "Microsoft.NETCore.App.Runtime.${NetVersion}.win-x64",
-        "Microsoft.NETCore.App.Runtime.${NetVersion}.win-x86",
-        "Microsoft.NETCore.App.Runtime.${NetVersion}.win-arm64"
+        "Microsoft.NETCore.App.Runtime.win-x64",
+        "Microsoft.NETCore.App.Runtime.win-x86",
+        "Microsoft.NETCore.App.Runtime.win-arm64"
       ]
     },
     "microsoft-net-runtime-mono-tooling": {
@@ -315,19 +315,13 @@
           "any": "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
       }
     },
-    "Microsoft.NETCore.App.Runtime.${NetVersion}.osx-arm64": {
+    "Microsoft.NETCore.App.Runtime.osx-arm64": {
       "kind": "framework",
       "version": "${PackageVersion}",
-      "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.osx-arm64"
-      }
     },
-    "Microsoft.NETCore.App.Runtime.${NetVersion}.osx-x64": {
+    "Microsoft.NETCore.App.Runtime.osx-x64": {
       "kind": "framework",
       "version": "${PackageVersion}",
-      "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.osx-x64"
-      }
     },
     "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.ios-arm64" : {
       "kind": "framework",

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -115,8 +115,8 @@
       "packs": [
         "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.osx-arm64",
         "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.osx-x64",
-        "Microsoft.NETCore.App.Runtime.osx-arm64",
-        "Microsoft.NETCore.App.Runtime.osx-x64"
+        "Microsoft.NETCore.App.Runtime.${NetVersion}.osx-arm64",
+        "Microsoft.NETCore.App.Runtime.${NetVersion}.osx-x64"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
       "platforms": [ "osx-arm64", "osx-x64" ]
@@ -147,9 +147,9 @@
       "abstract": true,
       "description": "Windows Runtime Packs",
       "packs": [
-        "Microsoft.NETCore.App.Runtime.win-x64",
-        "Microsoft.NETCore.App.Runtime.win-x86",
-        "Microsoft.NETCore.App.Runtime.win-arm64"
+        "Microsoft.NETCore.App.Runtime.${NetVersion}.win-x64",
+        "Microsoft.NETCore.App.Runtime.${NetVersion}.win-x86",
+        "Microsoft.NETCore.App.Runtime.${NetVersion}.win-arm64"
       ]
     },
     "microsoft-net-runtime-mono-tooling": {
@@ -315,13 +315,19 @@
           "any": "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
       }
     },
-    "Microsoft.NETCore.App.Runtime.osx-arm64": {
+    "Microsoft.NETCore.App.Runtime.${NetVersion}.osx-arm64": {
       "kind": "framework",
       "version": "${PackageVersion}",
+      "alias-to": {
+          "any": "Microsoft.NETCore.App.Runtime.osx-arm64"
+      }
     },
-    "Microsoft.NETCore.App.Runtime.osx-x64": {
+    "Microsoft.NETCore.App.Runtime.${NetVersion}.osx-x64": {
       "kind": "framework",
       "version": "${PackageVersion}",
+      "alias-to": {
+          "any": "Microsoft.NETCore.App.Runtime.osx-x64"
+      }
     },
     "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.ios-arm64" : {
       "kind": "framework",
@@ -478,17 +484,26 @@
           "any": "Microsoft.NETCore.App.Runtime.Mono.wasi-wasm"
       }
     },
-    "Microsoft.NETCore.App.Runtime.win-x64" : {
+    "Microsoft.NETCore.App.Runtime.${NetVersion}.win-x64" : {
       "kind": "framework",
-      "version": "${PackageVersion}"
+      "version": "${PackageVersion}",
+      "alias-to": {
+          "any": "Microsoft.NETCore.App.Runtime.win-x64"
+      }
     },
-    "Microsoft.NETCore.App.Runtime.win-x86" : {
+    "Microsoft.NETCore.App.Runtime.${NetVersion}.win-x86" : {
       "kind": "framework",
-      "version": "${PackageVersion}"
+      "version": "${PackageVersion}",
+      "alias-to": {
+          "any": "Microsoft.NETCore.App.Runtime.win-x86"
+      }
     },
-    "Microsoft.NETCore.App.Runtime.win-arm64" : {
+    "Microsoft.NETCore.App.Runtime.${NetVersion}.win-arm64" : {
       "kind": "framework",
-      "version": "${PackageVersion}"
+      "version": "${PackageVersion}",
+      "alias-to": {
+          "any": "Microsoft.NETCore.App.Runtime.win-arm64"
+      }
     }
   }
 }

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net8.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net8.Manifest/WorkloadManifest.json.in
@@ -131,16 +131,6 @@
       "extends": [ "microsoft-net-runtime-mono-tooling-net8" ],
       "platforms": [ "win-x64", "win-arm64", "osx-arm64", "osx-x64" ]
     },
-    "runtimes-windows-net8": {
-      "abstract": true,
-      "description": "Windows Runtime Packs for net8.0",
-      "packs": [
-        "Microsoft.NETCore.App.Runtime.net8.win-x64",
-        "Microsoft.NETCore.App.Runtime.net8.win-x86",
-        "Microsoft.NETCore.App.Runtime.net8.win-arm",
-        "Microsoft.NETCore.App.Runtime.net8.win-arm64"
-      ]
-    },
     "microsoft-net-runtime-mono-tooling-net8": {
       "abstract": true,
       "description": "Shared native build tooling for Mono runtime",
@@ -436,33 +426,5 @@
         "any": "Microsoft.NETCore.App.Runtime.Mono.wasi-wasm"
       }
     },
-    "Microsoft.NETCore.App.Runtime.net8.win-x64" : {
-      "kind": "framework",
-      "version": "${PackageVersionNet8}",
-      "alias-to": {
-        "any": "Microsoft.NETCore.App.Runtime.win-x64"
-      }
-    },
-    "Microsoft.NETCore.App.Runtime.net8.win-x86" : {
-      "kind": "framework",
-      "version": "${PackageVersionNet8}",
-      "alias-to": {
-        "any": "Microsoft.NETCore.App.Runtime.win-x86"
-      }
-    },
-    "Microsoft.NETCore.App.Runtime.net8.win-arm" : {
-      "kind": "framework",
-      "version": "${PackageVersionNet8}",
-      "alias-to": {
-        "any": "Microsoft.NETCore.App.Runtime.win-arm"
-      }
-    },
-    "Microsoft.NETCore.App.Runtime.net8.win-arm64" : {
-      "kind": "framework",
-      "version": "${PackageVersionNet8}",
-      "alias-to": {
-        "any": "Microsoft.NETCore.App.Runtime.win-arm64"
-      }
-    }
   }
 }


### PR DESCRIPTION
While fixing the [failure here](https://dev.azure.com/dnceng/internal/_build/results?buildId=2471138&view=logs&j=7bf215f5-1c95-5bbd-4005-575fc2c46c79&t=88f8f928-3551-5dff-d5e2-be29d98ae725&l=71) I noticed we still had a reference to packs that don't exist in the current net8 build.  I've removed the reference, It shouldn't be required and it will break insertion into VS as is.