### PR TITLE
Add JsonSchemaExporter.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -186,6 +186,8 @@
     <NUnitVersion>3.12.0</NUnitVersion>
     <NUnit3TestAdapterVersion>4.5.0</NUnit3TestAdapterVersion>
     <CoverletCollectorVersion>6.0.0</CoverletCollectorVersion>
+    <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
+    <JsonSchemaNetVersion>7.0.2</JsonSchemaNetVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -888,6 +888,28 @@ namespace System.Text.Json.Nodes
         public abstract bool TryGetValue<T>([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? value);
     }
 }
+namespace System.Text.Json.Schema
+{
+    public static partial class JsonSchemaExporter
+    {
+        public static System.Text.Json.Nodes.JsonNode GetJsonSchemaAsNode(this System.Text.Json.JsonSerializerOptions options, System.Type type, System.Text.Json.Schema.JsonSchemaExporterOptions? exporterOptions = null) { throw null; }
+        public static System.Text.Json.Nodes.JsonNode GetJsonSchemaAsNode(this System.Text.Json.Serialization.Metadata.JsonTypeInfo typeInfo, System.Text.Json.Schema.JsonSchemaExporterOptions? exporterOptions = null) { throw null; }
+    }
+    public readonly partial struct JsonSchemaExporterContext
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public System.Text.Json.Serialization.Metadata.JsonPropertyInfo? PropertyInfo { get { throw null; } }
+        public System.ReadOnlySpan<string> Path { get { throw null; } }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo TypeInfo { get { throw null; } }
+    }
+    public sealed partial class JsonSchemaExporterOptions
+    {
+        public JsonSchemaExporterOptions() { }
+        public static System.Text.Json.Schema.JsonSchemaExporterOptions Default { get { throw null; } }
+        public System.Action<JsonSchemaExporterContext, System.Text.Json.Nodes.JsonObject>? OnSchemaNodeGenerated { get; init; }
+    }
+}
 namespace System.Text.Json.Serialization
 {
     public partial interface IJsonOnDeserialized

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -907,7 +907,8 @@ namespace System.Text.Json.Schema
     {
         public JsonSchemaExporterOptions() { }
         public static System.Text.Json.Schema.JsonSchemaExporterOptions Default { get { throw null; } }
-        public System.Func<JsonSchemaExporterContext, System.Text.Json.Nodes.JsonNode, System.Text.Json.Nodes.JsonNode>? TransformSchemaNode { get; init; }
+        public System.Func<JsonSchemaExporterContext, System.Text.Json.Nodes.JsonNode, System.Text.Json.Nodes.JsonNode>? TransformSchemaNode { get { throw null; } init { } }
+        public bool TreatNullObliviousAsNonNullable { get { throw null; } init { } }
     }
 }
 namespace System.Text.Json.Serialization

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -907,7 +907,7 @@ namespace System.Text.Json.Schema
     {
         public JsonSchemaExporterOptions() { }
         public static System.Text.Json.Schema.JsonSchemaExporterOptions Default { get { throw null; } }
-        public System.Action<JsonSchemaExporterContext, System.Text.Json.Nodes.JsonObject>? OnSchemaNodeGenerated { get; init; }
+        public System.Func<JsonSchemaExporterContext, System.Text.Json.Nodes.JsonNode, System.Text.Json.Nodes.JsonNode>? TransformSchemaNode { get; init; }
     }
 }
 namespace System.Text.Json.Serialization

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -752,4 +752,10 @@
   <data name="NullabilityInfoContext_NotSupported" xml:space="preserve">
     <value>NullabilityInfoContext is not supported in the current application because 'System.Reflection.NullabilityInfoContext.IsSupported' is set to false. Set the MSBuild Property 'NullabilityInfoContextSupport' to true in order to enable it.</value>
   </data>
+  <data name="JsonSchemaExporter_ReferenceHandlerPreserve_NotSupported" xml:space="preserve">
+    <value>JSON schema generation is not supported for contracts using ReferenceHandler.Preserve.</value>
+  </data>
+  <data name="JsonSchemaExporter_DepthTooLarge" xml:space="preserve">
+    <value>The depth of the generated JSON schema exceeds the JsonSerializerOptions.MaxDepth setting.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -100,6 +100,11 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Reader\Utf8JsonReader.cs" />
     <Compile Include="System\Text\Json\Reader\Utf8JsonReader.MultiSegment.cs" />
     <Compile Include="System\Text\Json\Reader\Utf8JsonReader.TryGet.cs" />
+    <Compile Include="System\Text\Json\Schema\JsonSchema.cs" />
+    <Compile Include="System\Text\Json\Schema\JsonSchemaExporter.cs" />
+    <Compile Include="System\Text\Json\Schema\JsonSchemaExporterOptions.cs" />
+    <Compile Include="System\Text\Json\Schema\JsonSchemaExporterContext.cs" />
+    <Compile Include="System\Text\Json\Schema\JsonSchemaType.cs" />
     <Compile Include="System\Text\Json\Serialization\Arguments.cs" />
     <Compile Include="System\Text\Json\Serialization\ArgumentState.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonObjectCreationHandlingAttribute.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -1,0 +1,225 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+
+namespace System.Text.Json.Schema
+{
+    internal sealed class JsonSchema
+    {
+        internal const string RefPropertyName = "$ref";
+        internal const string TypePropertyName = "type";
+        internal const string FormatPropertyName = "format";
+        internal const string PatternPropertyName = "pattern";
+        internal const string PropertiesPropertyName = "properties";
+        internal const string RequiredPropertyName = "required";
+        internal const string ItemsPropertyName = "items";
+        internal const string AdditionalPropertiesPropertyName = "additionalProperties";
+        internal const string EnumPropertyName = "enum";
+        internal const string NotPropertyName = "not";
+        internal const string AnyOfPropertyName = "anyOf";
+        internal const string ConstPropertyName = "const";
+        internal const string DefaultPropertyName = "default";
+
+        public static JsonSchema False { get; } = new() { TrueOrFalse = false };
+        public static JsonSchema True { get; } = new() { TrueOrFalse = true };
+
+        public static JsonSchema CreateFalseSchemaAsObject() => new() { Not = True };
+        public static JsonSchema CreateTrueSchemaAsObject() => new();
+
+        public bool? TrueOrFalse { get; private init; }
+        public string? Ref { get; set; }
+        public JsonSchemaType Type { get; set; } = JsonSchemaType.Any;
+        public string? Format { get; set; }
+        public string? Pattern { get; set; }
+        public JsonNode? Constant { get; set; }
+        public List<KeyValuePair<string, JsonSchema>>? Properties { get; set; }
+        public List<string>? Required { get; set; }
+        public JsonSchema? Items { get; set; }
+        public JsonSchema? AdditionalProperties { get; set; }
+        public JsonArray? Enum { get; set; }
+        public JsonSchema? Not { get; set; }
+        public List<JsonSchema>? AnyOf { get; set; }
+        public bool HasDefaultValue { get; set; }
+        public JsonNode? DefaultValue { get; set; }
+
+        public JsonSchemaExporterContext? ExporterContext { get; set; }
+
+        public void MakeNullable()
+        {
+            if (Type != JsonSchemaType.Any)
+            {
+                Type |= JsonSchemaType.Null;
+            }
+        }
+
+        public JsonNode ToJsonNode(JsonSchemaExporterOptions options)
+        {
+            if (TrueOrFalse is { } boolSchema)
+            {
+                return (JsonNode)boolSchema;
+            }
+
+            var objSchema = new JsonObject();
+
+            if (Ref != null)
+            {
+                objSchema.Add(RefPropertyName, Ref);
+            }
+
+            if (MapSchemaType(Type) is JsonNode type)
+            {
+                objSchema.Add(TypePropertyName, type);
+            }
+
+            if (Format != null)
+            {
+                objSchema.Add(FormatPropertyName, Format);
+            }
+
+            if (Pattern != null)
+            {
+                objSchema.Add(PatternPropertyName, Pattern);
+            }
+
+            if (Constant != null)
+            {
+                objSchema.Add(ConstPropertyName, Constant);
+            }
+
+            if (Properties != null)
+            {
+                var properties = new JsonObject();
+                foreach (KeyValuePair<string, JsonSchema> property in Properties)
+                {
+                    properties.Add(property.Key, property.Value.ToJsonNode(options));
+                }
+
+                objSchema.Add(PropertiesPropertyName, properties);
+            }
+
+            if (Required != null)
+            {
+                var requiredArray = new JsonArray();
+                foreach (string requiredProperty in Required)
+                {
+                    requiredArray.Add((JsonNode)requiredProperty);
+                }
+
+                objSchema.Add(RequiredPropertyName, requiredArray);
+            }
+
+            if (Items != null)
+            {
+                objSchema.Add(ItemsPropertyName, Items.ToJsonNode(options));
+            }
+
+            if (AdditionalProperties != null)
+            {
+                objSchema.Add(AdditionalPropertiesPropertyName, AdditionalProperties.ToJsonNode(options));
+            }
+
+            if (Enum != null)
+            {
+                objSchema.Add(EnumPropertyName, Enum);
+            }
+
+            if (Not != null)
+            {
+                objSchema.Add(NotPropertyName, Not.ToJsonNode(options));
+            }
+
+            if (AnyOf != null)
+            {
+                var anyOfArray = new JsonArray();
+                foreach (JsonSchema schema in AnyOf)
+                {
+                    anyOfArray.Add(schema.ToJsonNode(options));
+                }
+
+                objSchema.Add(AnyOfPropertyName, anyOfArray);
+            }
+
+            if (HasDefaultValue)
+            {
+                objSchema.Add(DefaultPropertyName, DefaultValue);
+            }
+
+            if (ExporterContext is { } context)
+            {
+                Debug.Assert(options.OnSchemaNodeGenerated != null, "context should only be populated if a callback is present.");
+                // Apply any user-defined transformations to the schema.
+                options.OnSchemaNodeGenerated(context, objSchema);
+            }
+
+            if (objSchema.Count == 0)
+            {
+                // Transform '{}' schemas to 'true'.
+                return (JsonNode)true;
+            }
+            else if (
+                objSchema.Count == 1 &&
+                objSchema.TryGetPropertyValue(NotPropertyName, out JsonNode? notValue) &&
+                notValue?.GetValueKind() is JsonValueKind.True)
+            {
+                // Transform '{ "not": true }' schemas to 'false'.
+                return (JsonNode)false;
+            }
+
+            return objSchema;
+        }
+
+        private static readonly JsonSchemaType[] s_schemaValues =
+        [
+            // NB the order of these values influences order of types in the rendered schema
+            JsonSchemaType.String,
+            JsonSchemaType.Integer,
+            JsonSchemaType.Number,
+            JsonSchemaType.Boolean,
+            JsonSchemaType.Array,
+            JsonSchemaType.Object,
+            JsonSchemaType.Null,
+        ];
+
+        public static JsonNode? MapSchemaType(JsonSchemaType schemaType)
+        {
+            if (schemaType is JsonSchemaType.Any)
+            {
+                return null;
+            }
+
+            if (ToIdentifier(schemaType) is string identifier)
+            {
+                return identifier;
+            }
+
+            var array = new JsonArray();
+            foreach (JsonSchemaType type in s_schemaValues)
+            {
+                if ((schemaType & type) != 0)
+                {
+                    array.Add((JsonNode)ToIdentifier(type)!);
+                }
+            }
+
+            return array;
+
+            static string? ToIdentifier(JsonSchemaType schemaType)
+            {
+                return schemaType switch
+                {
+                    JsonSchemaType.Null => "null",
+                    JsonSchemaType.Boolean => "boolean",
+                    JsonSchemaType.Integer => "integer",
+                    JsonSchemaType.Number => "number",
+                    JsonSchemaType.String => "string",
+                    JsonSchemaType.Array => "array",
+                    JsonSchemaType.Object => "object",
+                    _ => null,
+                };
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -243,7 +243,7 @@ namespace System.Text.Json.Schema
             }
         }
 
-        private static readonly JsonSchemaType[] s_schemaValues =
+        private static ReadOnlySpan<JsonSchemaType> s_schemaValues =>
         [
             // NB the order of these values influences order of types in the rendered schema
             JsonSchemaType.String,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -1,0 +1,506 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Schema
+{
+    /// <summary>
+    /// Functionality for exporting JSON schema from serialization contracts defined in <see cref="JsonTypeInfo"/>.
+    /// </summary>
+    public static class JsonSchemaExporter
+    {
+        /// <summary>
+        /// Gets the JSON schema for <paramref name="type"/> as a <see cref="JsonNode"/> document.
+        /// </summary>
+        /// <param name="options">The options declaring the contract for the type.</param>
+        /// <param name="type">The type for which to resolve a schema.</param>
+        /// <param name="exporterOptions">The options object governing the export operation.</param>
+        /// <returns>A JSON object containing the schema for <paramref name="type"/>.</returns>
+        public static JsonNode GetJsonSchemaAsNode(this JsonSerializerOptions options, Type type, JsonSchemaExporterOptions? exporterOptions = null)
+        {
+            if (options is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(options));
+            }
+
+            if (type is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(type));
+            }
+
+            ValidateOptions(options);
+            JsonTypeInfo typeInfo = options.GetTypeInfoInternal(type);
+            return typeInfo.GetJsonSchemaAsNode(exporterOptions);
+        }
+
+        /// <summary>
+        /// Gets the JSON schema for <paramref name="typeInfo"/> as a <see cref="JsonNode"/> document.
+        /// </summary>
+        /// <param name="typeInfo">The contract from which to resolve the JSON schema.</param>
+        /// <param name="exporterOptions">The options object governing the export operation.</param>
+        /// <returns>A JSON object containing the schema for <paramref name="typeInfo"/>.</returns>
+        public static JsonNode GetJsonSchemaAsNode(this JsonTypeInfo typeInfo, JsonSchemaExporterOptions? exporterOptions = null)
+        {
+            if (typeInfo is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(typeInfo));
+            }
+
+            ValidateOptions(typeInfo.Options);
+            exporterOptions ??= JsonSchemaExporterOptions.Default;
+
+            typeInfo.EnsureConfigured();
+            GenerationState state = new(typeInfo.Options, exporterOptions);
+            JsonSchema schema = MapJsonSchemaCore(ref state, typeInfo);
+            return schema.ToJsonNode(exporterOptions);
+        }
+
+        private static JsonSchema MapJsonSchemaCore(
+            ref GenerationState state,
+            JsonTypeInfo typeInfo,
+            JsonPropertyInfo? propertyInfo = null,
+            JsonConverter? customConverter = null,
+            JsonNumberHandling? customNumberHandling = null,
+            Type? parentPolymorphicType = null,
+            bool parentPolymorphicTypeContainsTypesWithoutDiscriminator = false,
+            bool parentPolymorphicTypeIsNonNullable = false,
+            KeyValuePair<string, JsonSchema>? typeDiscriminator = null,
+            bool cacheResult = true)
+        {
+            Debug.Assert(typeInfo.IsConfigured);
+            JsonSchema? schema;
+
+            if (cacheResult && state.TryPushType(typeInfo, propertyInfo, out string? existingJsonPointer))
+            {
+                // Schema for type has already been generated, return a reference to it.
+                schema = new JsonSchema { Ref = existingJsonPointer };
+                goto FinalizeSchema;
+            }
+
+            JsonConverter effectiveConverter = customConverter ?? typeInfo.Converter;
+            JsonNumberHandling effectiveNumberHandling = customNumberHandling ?? typeInfo.NumberHandling ?? typeInfo.Options.NumberHandling;
+            if ((schema = effectiveConverter.GetSchema(effectiveNumberHandling)) != null)
+            {
+                goto FinalizeSchema;
+            }
+
+            if (parentPolymorphicType is null && typeInfo.PolymorphismOptions is { DerivedTypes.Count: > 0 } polyOptions)
+            {
+                // This is the base type of a polymorphic type hierarchy. The schema for this type
+                // will include an "anyOf" property with the schemas for all derived types.
+
+                string typeDiscriminatorKey = polyOptions.TypeDiscriminatorPropertyName;
+                List<JsonDerivedType> derivedTypes = new(polyOptions.DerivedTypes);
+
+                if (!typeInfo.Type.IsAbstract && !IsPolymorphicTypeThatSpecifiesItselfAsDerivedType(typeInfo))
+                {
+                    // For non-abstract base types that haven't been explicitly configured,
+                    // add a trivial schema to the derived types since we should support it.
+                    derivedTypes.Add(new JsonDerivedType(typeInfo.Type));
+                }
+
+                bool containsTypesWithoutDiscriminator = derivedTypes.Exists(static derivedTypes => derivedTypes.TypeDiscriminator is null);
+
+                state.PushSchemaNode(JsonSchema.AnyOfPropertyName);
+                JsonSchemaType? commonDerivedSchemaType = null;
+                List<JsonSchema> anyOf = new(derivedTypes.Count);
+                int i = 0;
+
+                foreach (JsonDerivedType derivedType in derivedTypes)
+                {
+                    Debug.Assert(derivedType.TypeDiscriminator is null or int or string);
+
+                    KeyValuePair<string, JsonSchema>? derivedTypeDiscriminator = null;
+                    if (derivedType.TypeDiscriminator is { } discriminatorValue)
+                    {
+                        JsonNode discriminatorNode = discriminatorValue switch
+                        {
+                            string stringId => (JsonNode)stringId,
+                            _ => (JsonNode)(int)discriminatorValue,
+                        };
+
+                        JsonSchema discriminatorSchema = new() { Constant = discriminatorNode };
+                        derivedTypeDiscriminator = new(typeDiscriminatorKey, discriminatorSchema);
+                    }
+
+                    JsonTypeInfo derivedTypeInfo = typeInfo.Options.GetTypeInfoInternal(derivedType.DerivedType);
+
+                    state.PushSchemaNode(i.ToString(CultureInfo.InvariantCulture));
+                    JsonSchema derivedSchema = MapJsonSchemaCore(
+                        ref state,
+                        derivedTypeInfo,
+                        parentPolymorphicType: typeInfo.Type,
+                        typeDiscriminator: derivedTypeDiscriminator,
+                        parentPolymorphicTypeContainsTypesWithoutDiscriminator: containsTypesWithoutDiscriminator,
+                        parentPolymorphicTypeIsNonNullable: propertyInfo is { IsGetNullable: false, IsSetNullable: false },
+                        cacheResult: false);
+
+                    anyOf.Add(derivedSchema);
+                    state.PopSchemaNode();
+
+                    // Determine if all derived types have the same schema type.
+                    if (i++ == 0)
+                    {
+                        commonDerivedSchemaType = derivedSchema.Type;
+                    }
+                    else if (commonDerivedSchemaType != derivedSchema.Type)
+                    {
+                        commonDerivedSchemaType = null;
+                    }
+                }
+
+                state.PopSchemaNode();
+
+                schema = new JsonSchema { AnyOf = anyOf };
+
+                if (!containsTypesWithoutDiscriminator)
+                {
+                    // If all derived types have a discriminator, we can require it in the base schema.
+                    schema.Required = [typeDiscriminatorKey];
+                }
+
+                if (commonDerivedSchemaType is JsonSchemaType commonType)
+                {
+                    // If all derived types have the same schema type, we can simplify the schema
+                    // by moving the type keyword to the base schema and removing it from the derived schemas.
+                    foreach (JsonSchema derivedSchema in anyOf)
+                    {
+                        derivedSchema.Type = JsonSchemaType.Any;
+                    }
+
+                    schema.Type = commonType;
+                }
+
+                goto FinalizeSchema;
+            }
+
+            if (effectiveConverter.NullableElementConverter is { } elementConverter)
+            {
+                JsonTypeInfo elementTypeInfo = typeInfo.Options.GetTypeInfo(elementConverter.Type!);
+                schema = MapJsonSchemaCore(ref state, elementTypeInfo, customConverter: elementConverter, cacheResult: false);
+
+                if (schema.Enum != null)
+                {
+                    Debug.Assert(elementTypeInfo.Type.IsEnum, "The enum keyword should only be populated by schemas for enum types.");
+                    schema.Enum.Add(null); // Append null to the enum array.
+                }
+
+                goto FinalizeSchema;
+            }
+
+            switch (typeInfo.Kind)
+            {
+                case JsonTypeInfoKind.Object:
+                    List<KeyValuePair<string, JsonSchema>>? properties = null;
+                    List<string>? required = null;
+                    JsonSchema? additionalProperties = null;
+
+                    if (typeInfo.UnmappedMemberHandling is JsonUnmappedMemberHandling.Disallow)
+                    {
+                        additionalProperties = JsonSchema.False;
+                    }
+
+                    if (typeDiscriminator is { } typeDiscriminatorPair)
+                    {
+                        (properties ??= []).Add(typeDiscriminatorPair);
+                        if (parentPolymorphicTypeContainsTypesWithoutDiscriminator)
+                        {
+                            // Require the discriminator here since it's not common to all derived types.
+                            (required ??= []).Add(typeDiscriminatorPair.Key);
+                        }
+                    }
+
+                    state.PushSchemaNode(JsonSchema.PropertiesPropertyName);
+                    foreach (JsonPropertyInfo property in typeInfo.Properties)
+                    {
+                        if (property is { Get: null, Set: null } or { IsExtensionData: true })
+                        {
+                            continue; // Skip JsonIgnored properties and extension data
+                        }
+
+                        state.PushSchemaNode(property.Name);
+                        JsonSchema propertySchema = MapJsonSchemaCore(
+                            ref state,
+                            property.JsonTypeInfo,
+                            propertyInfo: property,
+                            customConverter: property.EffectiveConverter,
+                            customNumberHandling: property.EffectiveNumberHandling);
+
+                        state.PopSchemaNode();
+
+                        if (property.AssociatedParameter is { HasDefaultValue: true } parameterInfo)
+                        {
+                            propertySchema.DefaultValue = JsonSerializer.SerializeToNode(parameterInfo.DefaultValue, property.JsonTypeInfo);
+                            propertySchema.HasDefaultValue = true;
+                        }
+
+                        (properties ??= []).Add(new(property.Name, propertySchema));
+
+                        if (property is { IsRequired: true } or { AssociatedParameter.IsRequiredParameter: true })
+                        {
+                            (required ??= []).Add(property.Name);
+                        }
+                    }
+
+                    state.PopSchemaNode();
+                    schema = new()
+                    {
+                        Type = JsonSchemaType.Object,
+                        Properties = properties,
+                        Required = required,
+                        AdditionalProperties = additionalProperties,
+                    };
+
+                    break;
+
+                case JsonTypeInfoKind.Enumerable:
+                    Debug.Assert(typeInfo.ElementTypeInfo != null);
+
+
+                    if (typeDiscriminator is null)
+                    {
+                        state.PushSchemaNode(JsonSchema.ItemsPropertyName);
+                        JsonSchema items = MapJsonSchemaCore(ref state, typeInfo.ElementTypeInfo, customNumberHandling: effectiveNumberHandling);
+                        state.PopSchemaNode();
+
+                        schema = new()
+                        {
+                            Type = JsonSchemaType.Array,
+                            Items = items,
+                        };
+                    }
+                    else
+                    {
+                        // Polymorphic enumerable types are represented using a wrapping object:
+                        // { "$type" : "discriminator", "$values" : [element1, element2, ...] }
+                        // Which corresponds to the schema
+                        // { "properties" : { "$type" : { "const" : "discriminator" }, "$values" : { "type" : "array", "items" : { ... } } } }
+                        const string ValuesKeyword = JsonSerializer.ValuesPropertyName;
+
+                        state.PushSchemaNode(JsonSchema.PropertiesPropertyName);
+                        state.PushSchemaNode(ValuesKeyword);
+                        state.PushSchemaNode(JsonSchema.ItemsPropertyName);
+
+                        JsonSchema items = MapJsonSchemaCore(ref state, typeInfo.ElementTypeInfo, customNumberHandling: effectiveNumberHandling);
+
+                        state.PopSchemaNode();
+                        state.PopSchemaNode();
+                        state.PopSchemaNode();
+
+                        schema = new()
+                        {
+                            Type = JsonSchemaType.Object,
+                            Properties =
+                            [
+                                typeDiscriminator.Value,
+                                new(ValuesKeyword, new() { Type = JsonSchemaType.Array, Items = items }),
+                            ],
+                        };
+
+                        if (parentPolymorphicTypeContainsTypesWithoutDiscriminator)
+                        {
+                            // Require the discriminator here since it's not common to all derived types.
+                            schema.Required = [typeDiscriminator.Value.Key];
+                        }
+                    }
+
+                    break;
+
+                case JsonTypeInfoKind.Dictionary:
+                    Debug.Assert(typeInfo.ElementTypeInfo != null);
+
+                    List<KeyValuePair<string, JsonSchema>>? dictProps = null;
+                    List<string>? dictRequired = null;
+
+                    if (typeDiscriminator is { } dictDiscriminator)
+                    {
+                        dictProps = [dictDiscriminator];
+                        if (parentPolymorphicTypeContainsTypesWithoutDiscriminator)
+                        {
+                            // Require the discriminator here since it's not common to all derived types.
+                            dictRequired = [dictDiscriminator.Key];
+                        }
+                    }
+
+                    state.PushSchemaNode(JsonSchema.AdditionalPropertiesPropertyName);
+                    JsonSchema additionalPropertiesSchema = MapJsonSchemaCore(ref state, typeInfo.ElementTypeInfo, customNumberHandling: effectiveNumberHandling);
+                    state.PopSchemaNode();
+
+                    schema = new()
+                    {
+                        Type = JsonSchemaType.Object,
+                        Properties = dictProps,
+                        Required = dictRequired,
+                        AdditionalProperties = additionalPropertiesSchema,
+                    };
+
+                    break;
+
+                default:
+                    Debug.Assert(typeInfo.Kind is JsonTypeInfoKind.None);
+                    schema = JsonSchema.CreateTrueSchemaAsObject();
+                    break;
+            }
+
+        FinalizeSchema:
+            if (schema.Ref is null)
+            {
+                bool isNullableSchema = propertyInfo != null
+                    ? propertyInfo.IsGetNullable || propertyInfo.IsSetNullable
+                    : typeInfo.CanBeNull && !parentPolymorphicTypeIsNonNullable;
+
+                if (isNullableSchema)
+                {
+                    schema.MakeNullable();
+                }
+
+                if (cacheResult)
+                {
+                    state.PopGeneratedType();
+                }
+            }
+
+            if (state.ExporterOptions.OnSchemaNodeGenerated != null)
+            {
+                schema.ExporterContext = state.CreateContext(typeInfo, propertyInfo);
+            }
+
+            return schema;
+        }
+
+        private static void ValidateOptions(JsonSerializerOptions options)
+        {
+            if (options.ReferenceHandler == ReferenceHandler.Preserve)
+            {
+                ThrowHelper.ThrowNotSupportedException_JsonSchemaExporterDoesNotSupportReferenceHandlerPreserve();
+            }
+
+            options.MakeReadOnly();
+        }
+
+        private static bool IsPolymorphicTypeThatSpecifiesItselfAsDerivedType(JsonTypeInfo typeInfo)
+        {
+            Debug.Assert(typeInfo.PolymorphismOptions is not null);
+
+            foreach (JsonDerivedType derivedType in typeInfo.PolymorphismOptions.DerivedTypes)
+            {
+                if (derivedType.DerivedType == typeInfo.Type)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private readonly ref struct GenerationState(JsonSerializerOptions options, JsonSchemaExporterOptions exporterOptions)
+        {
+            private readonly List<string> _currentPath = [];
+            private readonly List<(JsonTypeInfo typeInfo, JsonPropertyInfo? propertyInfo, int depth)> _generationStack = [];
+
+            public int CurrentDepth => _currentPath.Count;
+            public JsonSerializerOptions Options { get; } = options;
+            public JsonSchemaExporterOptions ExporterOptions { get; } = exporterOptions;
+
+            public void PushSchemaNode(string nodeId)
+            {
+                if (CurrentDepth == Options.EffectiveMaxDepth)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_JsonSchemaExporterDepthTooLarge();
+                }
+
+                _currentPath.Add(nodeId);
+            }
+
+            public void PopSchemaNode()
+            {
+                Debug.Assert(CurrentDepth > 0);
+                _currentPath.RemoveAt(_currentPath.Count - 1);
+            }
+
+            /// <summary>
+            /// Pushes the current type/property to the generation stack or returns a JSON pointer if the type is recursive.
+            /// </summary>
+            public bool TryPushType(JsonTypeInfo typeInfo, JsonPropertyInfo? propertyInfo, [NotNullWhen(true)] out string? existingJsonPointer)
+            {
+                foreach ((JsonTypeInfo otherTypeInfo, JsonPropertyInfo? otherPropertyInfo, int depth) in _generationStack)
+                {
+                    if (typeInfo == otherTypeInfo && propertyInfo == otherPropertyInfo)
+                    {
+                        existingJsonPointer = FormatJsonPointer(_currentPath, depth);
+                        return true;
+                    }
+                }
+
+                _generationStack.Add((typeInfo, propertyInfo, CurrentDepth));
+                existingJsonPointer = null;
+                return false;
+            }
+
+            public void PopGeneratedType()
+            {
+                Debug.Assert(_generationStack.Count > 0);
+                _generationStack.RemoveAt(_generationStack.Count - 1);
+            }
+
+            public JsonSchemaExporterContext CreateContext(JsonTypeInfo typeInfo, JsonPropertyInfo? propertyInfo)
+            {
+                return new JsonSchemaExporterContext(typeInfo, propertyInfo, _currentPath.ToArray());
+            }
+
+            private static string FormatJsonPointer(List<string> currentPathList, int depth)
+            {
+                Debug.Assert(0 <= depth && depth < currentPathList.Count);
+
+                if (depth == 0)
+                {
+                    return "#";
+                }
+
+                using ValueStringBuilder sb = new(initialCapacity: depth * 10);
+                sb.Append('#');
+
+                for (int i = 0; i < depth; i++)
+                {
+                    ReadOnlySpan<char> segment = currentPathList[i].AsSpan();
+                    sb.Append('/');
+
+                    do
+                    {
+                        // Per RFC 6901 the characters '~' and '/' must be escaped.
+                        int pos = segment.IndexOfAny('~', '/');
+                        if (pos < 0)
+                        {
+                            sb.Append(segment);
+                            break;
+                        }
+
+                        sb.Append(segment.Slice(0, pos));
+
+                        if (segment[pos] == '~')
+                        {
+                            sb.Append("~0");
+                        }
+                        else
+                        {
+                            Debug.Assert(segment[pos] == '/');
+                            sb.Append("~1");
+                        }
+
+                        segment = segment.Slice(pos + 1);
+                    }
+                    while (!segment.IsEmpty);
+                }
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -349,7 +349,7 @@ namespace System.Text.Json.Schema
                 {
                     bool isNullableSchema = propertyInfo != null
                         ? propertyInfo.IsGetNullable || propertyInfo.IsSetNullable
-                        : typeInfo.CanBeNull && !parentPolymorphicTypeIsNonNullable;
+                        : typeInfo.CanBeNull && !parentPolymorphicTypeIsNonNullable && !state.ExporterOptions.TreatNullObliviousAsNonNullable;
 
                     if (isNullableSchema)
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterContext.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Schema
+{
+    /// <summary>
+    /// Defines the context for the generated JSON schema for a particular node in a type graph.
+    /// </summary>
+    public readonly struct JsonSchemaExporterContext
+    {
+        private readonly string[] _path;
+
+        internal JsonSchemaExporterContext(JsonTypeInfo typeInfo, JsonPropertyInfo? propertyInfo, string[] path)
+        {
+            TypeInfo = typeInfo;
+            PropertyInfo = propertyInfo;
+            _path = path;
+        }
+
+        /// <summary>
+        /// The <see cref="JsonTypeInfo"/> for the type being processed.
+        /// </summary>
+        public JsonTypeInfo TypeInfo { get; }
+
+        /// <summary>
+        /// The <see cref="JsonPropertyInfo"/> if the schema is being generated for a property.
+        /// </summary>
+        public JsonPropertyInfo? PropertyInfo { get; }
+
+        /// <summary>
+        /// The path to the current node in the generated JSON schema.
+        /// </summary>
+        public ReadOnlySpan<string> Path => _path;
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterOptions.cs
@@ -16,6 +16,16 @@ namespace System.Text.Json.Schema
         public static JsonSchemaExporterOptions Default { get; } = new();
 
         /// <summary>
+        /// Determines whether non-nullable schemas should be generated for null oblivious reference types.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see langword="false"/>. Due to restrictions in the run-time representation of nullable reference types
+        /// most occurences are null oblivious and are treated as nullable by the serializer. A notable exception to that rule
+        /// are nullability annotations of field, property and constructor parameters which are represented in the contract metadata.
+        /// </remarks>
+        public bool TreatNullObliviousAsNonNullable { get; init; }
+
+        /// <summary>
         /// Defines a callback that is invoked for every schema that is generated within the type graph.
         /// </summary>
         public Func<JsonSchemaExporterContext, JsonNode, JsonNode>? TransformSchemaNode { get; init; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterOptions.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+
+namespace System.Text.Json.Schema
+{
+    /// <summary>
+    /// Configures the behavior of the <see cref="JsonSchemaExporter"/> APIs.
+    /// </summary>
+    public sealed class JsonSchemaExporterOptions
+    {
+        /// <summary>
+        /// Gets the default configuration object used by <see cref="JsonSchemaExporter"/>.
+        /// </summary>
+        public static JsonSchemaExporterOptions Default { get; } = new();
+
+        /// <summary>
+        /// Defines a callback that is invoked for every schema that is generated within the type graph.
+        /// </summary>
+        public Action<JsonSchemaExporterContext, JsonObject>? OnSchemaNodeGenerated { get; init; }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporterOptions.cs
@@ -18,6 +18,6 @@ namespace System.Text.Json.Schema
         /// <summary>
         /// Defines a callback that is invoked for every schema that is generated within the type graph.
         /// </summary>
-        public Action<JsonSchemaExporterContext, JsonObject>? OnSchemaNodeGenerated { get; init; }
+        public Func<JsonSchemaExporterContext, JsonNode, JsonNode>? TransformSchemaNode { get; init; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaType.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaType.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Schema
+{
+    [Flags]
+    internal enum JsonSchemaType
+    {
+        Any = 0,
+        Null = 1,
+        Boolean = 2,
+        Integer = 4,
+        Number = 8,
+        String = 16,
+        Object = 32,
+        Array = 64,
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
@@ -3,7 +3,9 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
 using System.Text.Json.Reflection;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -72,5 +74,8 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, T? value, JsonNumberHandling handling)
             => _sourceConverter.WriteNumberWithCustomHandlingAsObject(writer, value, handling);
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling)
+            => _sourceConverter.GetSchema(numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -65,5 +67,8 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
             => Converter.ConfigureJsonTypeInfo(jsonTypeInfo, options);
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling)
+            => Converter.GetSchema(numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonArrayConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -38,5 +39,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonElement jElement = JsonElement.ParseValue(ref reader);
             return new JsonArray(jElement, options);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.Array };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -78,5 +79,7 @@ namespace System.Text.Json.Serialization.Converters
 
             return node;
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchemaAsObject();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
@@ -80,6 +80,6 @@ namespace System.Text.Json.Serialization.Converters
             return node;
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchemaAsObject();
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -64,5 +65,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonObject jObject = new JsonObject(jElement, options);
             return jObject;
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.Object };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -30,5 +31,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonValue value = new JsonValuePrimitive<JsonElement>(element, JsonMetadataServices.JsonElementConverter, options.GetNodeOptions());
             return value;
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchemaAsObject();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
@@ -32,6 +32,6 @@ namespace System.Text.Json.Serialization.Converters
             return value;
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchemaAsObject();
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -145,5 +146,7 @@ namespace System.Text.Json.Serialization.Converters
 
             return true;
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchemaAsObject();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -147,6 +147,6 @@ namespace System.Text.Json.Serialization.Converters
             return true;
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchemaAsObject();
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
@@ -3,6 +3,8 @@
 
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -35,5 +37,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             writer.WritePropertyName(value);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.Boolean };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteArrayConverter.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Schema;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ByteArrayConverter : JsonConverter<byte[]?>
@@ -26,5 +28,7 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteBase64StringValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -54,5 +56,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -60,5 +60,7 @@ namespace System.Text.Json.Serialization.Converters
 #endif
                 );
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
@@ -61,6 +61,7 @@ namespace System.Text.Json.Serialization.Converters
                 );
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String };
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) =>
+            new() { Type = JsonSchemaType.String, MinLength = 1, MaxLength = 1 };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -78,5 +78,7 @@ namespace System.Text.Json.Serialization.Converters
             Debug.Assert(formattedSuccessfully && charsWritten == FormatLength);
             writer.WritePropertyName(buffer);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String, Format = "date" };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -27,5 +28,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             writer.WritePropertyName(value);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new JsonSchema { Type = JsonSchemaType.String, Format = "date-time" };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -27,5 +28,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             writer.WritePropertyName(value);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new JsonSchema { Type = JsonSchemaType.String, Format = "date-time" };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -55,5 +56,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
@@ -69,6 +69,6 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
-                GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isFloatingPoint: true);
+                GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isIeeeFloatingPoint: true);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -65,5 +67,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+                GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isFloatingPoint: true);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -413,34 +413,27 @@ namespace System.Text.Json.Serialization.Converters
                 // This explicitly ignores the integer component in converters configured as AllowNumbers | AllowStrings
                 // which is the default for JsonStringEnumConverter. This sacrifices some precision in the schema for simplicity.
 
-                JsonArray? enumValues;
                 if (s_isFlagsEnum)
                 {
                     // Do not report enum values in case of flags.
-                    enumValues = null;
+                    return new() { Type = JsonSchemaType.String };
                 }
-                else
-                {
-                    enumValues = [];
+
+                JsonNamingPolicy? namingPolicy = _namingPolicy;
+                JsonArray enumValues = [];
 #if NET
-                    string[] names = Enum.GetNames<T>();
+                string[] names = Enum.GetNames<T>();
 #else
-                    string[] names = Enum.GetNames(Type);
+                string[] names = Enum.GetNames(Type);
 #endif
-                    JsonNamingPolicy? namingPolicy = _namingPolicy;
 
-                    for (int i = 0; i < names.Length; i++)
-                    {
-                        JsonNode name = FormatJsonName(names[i], namingPolicy);
-                        enumValues.Add(name);
-                    }
+                for (int i = 0; i < names.Length; i++)
+                {
+                    JsonNode name = FormatJsonName(names[i], namingPolicy);
+                    enumValues.Add(name);
                 }
 
-                return new()
-                {
-                    Type = JsonSchemaType.String,
-                    Enum = enumValues,
-                };
+                return new() { Enum = enumValues };
             }
 
             return new() { Type = JsonSchemaType.Integer };

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -27,5 +29,8 @@ namespace System.Text.Json.Serialization.Converters
         {
             writer.WritePropertyName(value);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            new() { Type = JsonSchemaType.String, Format = "uuid" };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/HalfConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/HalfConverter.cs
@@ -4,6 +4,8 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -142,6 +144,9 @@ namespace System.Text.Json.Serialization.Converters
                 WriteCore(writer, value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isFloatingPoint: true);
 
         private static bool TryGetFloatingPointConstant(ref Utf8JsonReader reader, out Half value)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/HalfConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/HalfConverter.cs
@@ -146,7 +146,7 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
-            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isFloatingPoint: true);
+            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isIeeeFloatingPoint: true);
 
         private static bool TryGetFloatingPointConstant(ref Utf8JsonReader reader, out Half value)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int128Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int128Converter.cs
@@ -4,6 +4,8 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -127,6 +129,9 @@ namespace System.Text.Json.Serialization.Converters
                 WriteCore(writer, value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
 
         // Int128.TryParse(ROS<byte>) is not available on .NET 7, only Int128.TryParse(ROS<char>).
         private static bool TryParse(

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -57,5 +59,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue((long)value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -57,5 +59,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue((long)value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -55,5 +57,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonDocumentConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonDocumentConverter.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Schema;
+using System.Text.Json.Nodes;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class JsonDocumentConverter : JsonConverter<JsonDocument?>
@@ -22,5 +25,7 @@ namespace System.Text.Json.Serialization.Converters
 
             value.WriteTo(writer);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonDocumentConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonDocumentConverter.cs
@@ -26,6 +26,6 @@ namespace System.Text.Json.Serialization.Converters
             value.WriteTo(writer);
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new();
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonElementConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonElementConverter.cs
@@ -18,6 +18,6 @@ namespace System.Text.Json.Serialization.Converters
             value.WriteTo(writer);
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new();
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonElementConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonElementConverter.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Schema;
+using System.Text.Json.Nodes;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class JsonElementConverter : JsonConverter<JsonElement>
@@ -14,5 +17,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             value.WriteTo(writer);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonPrimitiveConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonPrimitiveConverter.cs
@@ -33,18 +33,18 @@ namespace System.Text.Json.Serialization.Converters
             return ReadAsPropertyNameCore(ref reader, typeToConvert, options);
         }
 
-        private protected static JsonSchema GetSchemaForNumericType(JsonSchemaType schemaType, JsonNumberHandling numberHandling, bool isFloatingPoint = false)
+        private protected static JsonSchema GetSchemaForNumericType(JsonSchemaType schemaType, JsonNumberHandling numberHandling, bool isIeeeFloatingPoint = false)
         {
             Debug.Assert(schemaType is JsonSchemaType.Integer or JsonSchemaType.Number);
-            Debug.Assert(!isFloatingPoint || schemaType is JsonSchemaType.Number);
-#if NETCOREAPP
-            Debug.Assert(isFloatingPoint == (typeof(T) == typeof(double) || typeof(T) == typeof(float) || typeof(T) == typeof(Half)));
+            Debug.Assert(!isIeeeFloatingPoint || schemaType is JsonSchemaType.Number);
+#if NET
+            Debug.Assert(isIeeeFloatingPoint == (typeof(T) == typeof(double) || typeof(T) == typeof(float) || typeof(T) == typeof(Half)));
 #endif
             if ((numberHandling & (JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)) != 0)
             {
                 schemaType |= JsonSchemaType.String;
             }
-            else if (isFloatingPoint && numberHandling is JsonNumberHandling.AllowNamedFloatingPointLiterals)
+            else if (isIeeeFloatingPoint && numberHandling is JsonNumberHandling.AllowNamedFloatingPointLiterals)
             {
                 return new JsonSchema
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/MemoryByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/MemoryByteConverter.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class MemoryByteConverter : JsonConverter<Memory<byte>>
@@ -16,5 +19,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             writer.WriteBase64StringValue(value.Span);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ReadOnlyMemoryByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ReadOnlyMemoryByteConverter.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ReadOnlyMemoryByteConverter : JsonConverter<ReadOnlyMemory<byte>>
@@ -16,5 +19,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             writer.WriteBase64StringValue(value.Span);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -55,5 +57,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
@@ -70,6 +70,6 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
-            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isFloatingPoint: true);
+            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isIeeeFloatingPoint: true);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -66,5 +68,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isFloatingPoint: true);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -50,5 +52,7 @@ namespace System.Text.Json.Serialization.Converters
 
             writer.WritePropertyName(value);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeOnlyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeOnlyConverter.cs
@@ -3,6 +3,8 @@
 
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -93,5 +95,7 @@ namespace System.Text.Json.Serialization.Converters
 
             writer.WritePropertyName(output.Slice(0, bytesWritten));
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new() { Type = JsonSchemaType.String, Format = "time" };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
@@ -95,10 +95,10 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         internal override JsonSchema? GetSchema(JsonNumberHandling _) => new()
-            {
-                Type = JsonSchemaType.String,
-                // TimeSpan is represented as a string in the format "[-][d.]hh:mm:ss[.fffffff]"
-                Pattern = @"^-?(\d+\.)?\d{2}:\d{2}:\d{2}(\.\d{1,7})?$"
-            };
+        {
+            Type = JsonSchemaType.String,
+            Comment = "Represents a System.TimeSpan value.",
+            Pattern = @"^-?(\d+\.)?\d{2}:\d{2}:\d{2}(\.\d{1,7})?$"
+        };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
@@ -3,6 +3,8 @@
 
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -91,5 +93,12 @@ namespace System.Text.Json.Serialization.Converters
 
             writer.WritePropertyName(output.Slice(0, bytesWritten));
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => new()
+            {
+                Type = JsonSchemaType.String,
+                // TimeSpan is represented as a string in the format "[-][d.]hh:mm:ss[.fffffff]"
+                Pattern = @"^-?(\d+\.)?\d{2}:\d{2}:\d{2}(\.\d{1,7})?$"
+            };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt128Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt128Converter.cs
@@ -4,6 +4,8 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -126,6 +128,9 @@ namespace System.Text.Json.Serialization.Converters
                 WriteCore(writer, value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
 
         // UInt128.TryParse(ROS<byte>) is not available on .NET 7, only UInt128.TryParse(ROS<char>).
         private static bool TryParse(

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -57,5 +59,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue((long)value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -57,5 +59,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue((ulong)value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -55,5 +57,8 @@ namespace System.Text.Json.Serialization.Converters
                 writer.WriteNumberValue(value);
             }
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverter.cs
@@ -20,6 +20,7 @@ namespace System.Text.Json.Serialization.Converters
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
             throw new NotSupportedException(ErrorMessage);
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateFalseSchemaAsObject();
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) =>
+            new JsonSchema { Comment = "Unsupported .NET type", Not = JsonSchema.True };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverter.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Schema;
+using System.Text.Json.Nodes;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class UnsupportedTypeConverter<T> : JsonConverter<T>
@@ -16,5 +19,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
             throw new NotSupportedException(ErrorMessage);
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateFalseSchemaAsObject();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UriConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UriConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -50,5 +52,8 @@ namespace System.Text.Json.Serialization.Converters
 
             writer.WritePropertyName(value.OriginalString);
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) =>
+            new() { Type = JsonSchemaType.String, Format = "uri" };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -130,6 +130,7 @@ namespace System.Text.Json.Serialization.Converters
             new()
             {
                 Type = JsonSchemaType.String,
+                Comment = "Represents a version string.",
                 Pattern = @"^\d+(\.\d+){1,3}$",
             };
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -123,5 +125,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WritePropertyName(value.ToString());
 #endif
         }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) =>
+            new()
+            {
+                Type = JsonSchemaType.String,
+                Pattern = @"^\d+(\.\d+){1,3}$",
+            };
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Converters;
 using System.Text.Json.Serialization.Metadata;
 
@@ -200,6 +201,10 @@ namespace System.Text.Json.Serialization
         internal abstract void WriteAsPropertyNameCoreAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, bool isWritingExtensionDataProperty);
         internal abstract void WriteNumberWithCustomHandlingAsObject(Utf8JsonWriter writer, object? value, JsonNumberHandling handling);
 
+        /// <summary>
+        /// Gets a schema from the type being converted
+        /// </summary>
+        internal virtual JsonSchema? GetSchema(JsonNumberHandling numberHandling) => null;
 
         // Whether a type (ConverterStrategy.Object) is deserialized using a parameterized constructor.
         internal virtual bool ConstructorIsParameterized { get; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -123,9 +123,6 @@ namespace System.Text.Json.Serialization.Metadata
         internal JsonNumberHandling? NumberHandling => MatchingProperty.EffectiveNumberHandling;
         internal JsonTypeInfo JsonTypeInfo => MatchingProperty.JsonTypeInfo;
         internal bool ShouldDeserialize => !MatchingProperty.IsIgnored;
-        internal bool IsRequiredParameter =>
-            Options.RespectRequiredConstructorParameters &&
-            !HasDefaultValue &&
-            !IsMemberInitializer;
+        internal bool IsRequiredParameter => !HasDefaultValue && !IsMemberInitializer;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -448,7 +448,9 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (IsRequired)
             {
-                if (!CanDeserialize && AssociatedParameter?.IsRequiredParameter != true)
+                if (!CanDeserialize &&
+                    !(AssociatedParameter?.IsRequiredParameter is true &&
+                      Options.RespectRequiredConstructorParameters))
                 {
                     ThrowHelper.ThrowInvalidOperationException_JsonPropertyRequiredAndNotDeserializable(this);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -120,8 +120,12 @@ namespace System.Text.Json.Serialization.Metadata
             AssociatedParameter = new JsonParameterInfo<T>(parameterInfoValues, this);
             // Overwrite the nullability annotation of property setter with the parameter.
             _isSetNullable = parameterInfoValues.IsNullable;
-            // If the property has been associated with a non-optional parameter, mark it as required.
-            _isRequired |= AssociatedParameter.IsRequiredParameter;
+
+            if (Options.RespectRequiredConstructorParameters)
+            {
+                // If the property has been associated with a non-optional parameter, mark it as required.
+                _isRequired |= AssociatedParameter.IsRequiredParameter;
+            }
         }
 
         internal new JsonConverter<T> EffectiveConverter

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -360,6 +360,7 @@ namespace System.Text.Json.Serialization.Metadata
         internal bool PropertyMetadataSerializationNotSupported { get; set; }
 
         internal bool IsNullable => Converter.NullableElementConverter is not null;
+        internal bool CanBeNull => PropertyInfoForTypeInfo.PropertyTypeCanBeNull;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void ValidateCanBeUsedForPropertyMetadataSerialization()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -936,5 +936,17 @@ namespace System.Text.Json
         {
             throw new InvalidOperationException(SR.Format(SR.PipeWriter_DoesNotImplementUnflushedBytes, pipeWriter.GetType().Name));
         }
+
+        [DoesNotReturn]
+        public static void ThrowNotSupportedException_JsonSchemaExporterDoesNotSupportReferenceHandlerPreserve()
+        {
+            throw new NotSupportedException(SR.JsonSchemaExporter_ReferenceHandlerPreserve_NotSupported);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_JsonSchemaExporterDepthTooLarge()
+        {
+            throw new InvalidOperationException(SR.JsonSchemaExporter_DepthTooLarge);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -73,7 +73,7 @@ namespace System.Text.Json.Schema.Tests
             yield return new TestData<TimeSpan>(
                 Value: new(hours: 5, minutes: 13, seconds: 3),
                 AdditionalValues: [TimeSpan.MinValue, TimeSpan.MaxValue],
-                ExpectedJsonSchema: """{"type":"string", "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$"}""");
+                ExpectedJsonSchema: """{"$comment": "Represents a System.TimeSpan value.", "type":"string", "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$"}""");
 
 #if NET
             yield return new TestData<DateOnly>(new(2021, 1, 1), ExpectedJsonSchema: """{"type":"string","format": "date"}""");
@@ -81,7 +81,7 @@ namespace System.Text.Json.Schema.Tests
 #endif
             yield return new TestData<Guid>(Guid.Empty, ExpectedJsonSchema: """{"type":"string","format":"uuid"}""");
             yield return new TestData<Uri>(new("http://example.com"), """{"type":["string","null"],"format":"uri"}""");
-            yield return new TestData<Version>(new(1, 2, 3, 4), ExpectedJsonSchema: """{"type":["string","null"],"pattern":"^\\d+(\\.\\d+){1,3}$"}""");
+            yield return new TestData<Version>(new(1, 2, 3, 4), ExpectedJsonSchema: """{"$comment": "Represents a version string.", "type":["string","null"],"pattern":"^\\d+(\\.\\d+){1,3}$"}""");
             yield return new TestData<JsonDocument>(JsonDocument.Parse("""[{ "x" : 42 }]"""), ExpectedJsonSchema: "true");
             yield return new TestData<JsonElement>(JsonDocument.Parse("""[{ "x" : 42 }]""").RootElement, ExpectedJsonSchema: "true");
             yield return new TestData<JsonNode>(JsonNode.Parse("""[{ "x" : 42 }]"""), ExpectedJsonSchema: "true");

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -53,7 +53,7 @@ namespace System.Text.Json.Schema.Tests
             yield return new TestData<Half>((Half)3.141, ExpectedJsonSchema: """{"type":"number"}""");
 #endif
             yield return new TestData<string>("I am a string", ExpectedJsonSchema: """{"type":["string","null"]}""");
-            yield return new TestData<char>('c', ExpectedJsonSchema: """{"type":"string"}""");
+            yield return new TestData<char>('c', ExpectedJsonSchema: """{"type":"string", "minLength":1, "maxLength":1 }""");
             yield return new TestData<byte[]>(
                 Value: [1, 2, 3],
                 AdditionalValues: [[]],
@@ -682,12 +682,7 @@ namespace System.Text.Json.Schema.Tests
             yield return new TestData<NonAbstractClassWithSingleDerivedType>(
                 Value: new NonAbstractClassWithSingleDerivedType(),
                 AdditionalValues: [new NonAbstractClassWithSingleDerivedType.Derived()],
-                ExpectedJsonSchema: """
-                {
-                    "type": ["object","null"],
-                    "anyOf": [true, true]
-                }
-                """);
+                ExpectedJsonSchema: """{"type":["object","null"]}""");
 
             yield return new TestData<DiscriminatedUnion>(
                 Value: new DiscriminatedUnion.Left("value"),
@@ -884,12 +879,12 @@ namespace System.Text.Json.Schema.Tests
             yield return new TestData<List<bool>>([false, true, false], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"boolean"}}""");
             yield return new TestData<HashSet<string>>(["one", "two", "three"], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":["string","null"]}}""");
             yield return new TestData<Queue<double>>(new([1.1, 2.2, 3.3]), ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"number"}}""");
-            yield return new TestData<Stack<char>>(new(['x', '2', '+']), ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"string"}}""");
+            yield return new TestData<Stack<char>>(new(['x', '2', '+']), ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"string","minLength":1,"maxLength":1}}""");
             yield return new TestData<ImmutableArray<int>>([1, 2, 3], ExpectedJsonSchema: """{"type":"array","items":{"type":"integer"}}""");
             yield return new TestData<ImmutableList<string>>(["one", "two", "three"], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":["string","null"]}}""");
             yield return new TestData<ImmutableQueue<bool>>([false, false, true], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"boolean"}}""");
-            yield return new TestData<object[]>([1, "two", 3.14], ExpectedJsonSchema: """{"type":["array","null"],"items":true}""");
-            yield return new TestData<System.Collections.ArrayList>([1, "two", 3.14], ExpectedJsonSchema: """{"type":["array","null"],"items":true}""");
+            yield return new TestData<object[]>([1, "two", 3.14], ExpectedJsonSchema: """{"type":["array","null"]}""");
+            yield return new TestData<System.Collections.ArrayList>([1, "two", 3.14], ExpectedJsonSchema: """{"type":["array","null"]}""");
 
             // Dictionary types
             yield return new TestData<Dictionary<string, int>>(
@@ -929,11 +924,11 @@ namespace System.Text.Json.Schema.Tests
 
             yield return new TestData<Dictionary<string, object>>(
                 Value: new() { ["one"] = 1, ["two"] = "two", ["three"] = 3.14 },
-                ExpectedJsonSchema: """{"type":["object","null"],"additionalProperties":true}""");
+                ExpectedJsonSchema: """{"type":["object","null"]}""");
 
             yield return new TestData<Hashtable>(
                 Value: new() { ["one"] = 1, ["two"] = "two", ["three"] = 3.14 },
-                ExpectedJsonSchema: """{"type":["object","null"],"additionalProperties":true}""");
+                ExpectedJsonSchema: """{"type":["object","null"]}""");
         }
 
         public enum IntEnum { A, B, C };

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -184,7 +184,7 @@ namespace System.Text.Json.Schema.Tests
                 """);
 
             yield return new TestData<PocoWithRequiredMembers>(
-                new() { X = "str1", Y = "str2" },
+                new() { X = "str1", Y = "str2", Z = 42 },
                 ExpectedJsonSchema: """
                 {
                   "type": ["object","null"],

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -215,30 +215,56 @@ namespace System.Text.Json.Schema.Tests
                 ExpectedJsonSchema: """
                 {
                     "type": ["object","null"],
-                    "properties": { "X": { "type": ["string","integer"] } }
+                    "properties": { "X": { "type": ["string","integer"], "pattern": "^-?(?:0|[1-9]\\d*)$" } }
                 }
                 """);
 
             yield return new TestData<PocoWithCustomNumberHandlingOnProperties>(
-                Value: new() { X = 1, Y = 2, Z = 3 },
+                Value: new() {
+                    IntegerReadingFromString = 3,
+                    DoubleReadingFromString = 3.14,
+                    DecimalReadingFromString = 3.14M,
+                    IntegerWritingAsString = 3,
+                    DoubleWritingAsString = 3.14,
+                    DecimalWritingAsString = 3.14M,
+                    IntegerAllowingFloatingPointLiterals = 3,
+                    DoubleAllowingFloatingPointLiterals = 3.14,
+                    DecimalAllowingFloatingPointLiterals = 3.14M,
+                    IntegerAllowingFloatingPointLiteralsAndReadingFromString = 3,
+                    DoubleAllowingFloatingPointLiteralsAndReadingFromString = 3.14,
+                    DecimalAllowingFloatingPointLiteralsAndReadingFromString = 3.14M,
+                },
                 AdditionalValues: [
-                    new() { X = 1, Y = double.NaN, Z = 3 },
-                    new() { X = 1, Y = double.PositiveInfinity, Z = 3 },
-                    new() { X = 1, Y = double.NegativeInfinity, Z = 3 },
+                    new() { DoubleAllowingFloatingPointLiterals = double.NaN, },
+                    new() { DoubleAllowingFloatingPointLiterals = double.PositiveInfinity },
+                    new() { DoubleAllowingFloatingPointLiterals = double.NegativeInfinity },
                 ],
                 ExpectedJsonSchema: """
                 {
                   "type": ["object","null"],
                   "properties": {
-                    "X": { "type": ["string", "integer"] },
-                    "Y": {
-                      "anyOf": [
-                        { "type": "number" },
-                        { "enum": ["NaN", "Infinity", "-Infinity"]}
-                      ]
+                    "IntegerReadingFromString": { "type": ["string","integer"], "pattern": "^-?(?:0|[1-9]\\d*)$" },
+                    "DoubleReadingFromString": { "type": ["string","number"], "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$" },
+                    "DecimalReadingFromString": { "type": ["string","number"], "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$" },
+                    "IntegerWritingAsString": { "type": ["string","integer"], "pattern": "^-?(?:0|[1-9]\\d*)$" },
+                    "DoubleWritingAsString": { "type": ["string","number"], "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$" },
+                    "DecimalWritingAsString": { "type": ["string","number"], "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$" },
+                    "IntegerAllowingFloatingPointLiterals": { "type": "integer" },
+                    "DoubleAllowingFloatingPointLiterals": {
+                        "anyOf": [
+                            { "type": "number" },
+                            { "enum": ["NaN", "Infinity", "-Infinity"] }
+                        ]
                     },
-                    "Z": { "type": ["string", "integer"] },
-                    "W" : { "type": "number" }
+                    "DecimalAllowingFloatingPointLiterals": { "type": "number" },
+                    "IntegerAllowingFloatingPointLiteralsAndReadingFromString": { "type": ["string","integer"], "pattern": "^-?(?:0|[1-9]\\d*)$" },
+                    "DoubleAllowingFloatingPointLiteralsAndReadingFromString": {
+                        "anyOf": [
+                            { "type": ["string","number"], "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$" },
+                            { "enum": ["NaN", "Infinity", "-Infinity"] }
+                        ]
+                    },
+                    "DecimalAllowingFloatingPointLiteralsAndReadingFromString": { "type": ["string","number"], "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$" }
                   }
                 }
                 """);
@@ -993,16 +1019,40 @@ namespace System.Text.Json.Schema.Tests
         public class PocoWithCustomNumberHandlingOnProperties
         {
             [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
-            public int X { get; set; }
+            public int IntegerReadingFromString { get; set; }
 
-            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
-            public double Y { get; set; }
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+            public double DoubleReadingFromString { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+            public decimal DecimalReadingFromString { get; set; }
 
             [JsonNumberHandling(JsonNumberHandling.WriteAsString)]
-            public int Z { get; set; }
+            public int IntegerWritingAsString { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.WriteAsString)]
+            public double DoubleWritingAsString { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.WriteAsString)]
+            public decimal DecimalWritingAsString { get; set; }
 
             [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
-            public decimal W { get; set; }
+            public int IntegerAllowingFloatingPointLiterals { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+            public double DoubleAllowingFloatingPointLiterals { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+            public decimal DecimalAllowingFloatingPointLiterals { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals | JsonNumberHandling.AllowReadingFromString)]
+            public int IntegerAllowingFloatingPointLiteralsAndReadingFromString { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals | JsonNumberHandling.AllowReadingFromString)]
+            public double DoubleAllowingFloatingPointLiteralsAndReadingFromString { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals | JsonNumberHandling.AllowReadingFromString)]
+            public decimal DecimalAllowingFloatingPointLiteralsAndReadingFromString { get; set; }
         }
 
         public class PocoWithRecursiveMembers

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -1,0 +1,1320 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Json.Serialization.Tests;
+
+namespace System.Text.Json.Schema.Tests
+{
+    public abstract partial class JsonSchemaExporterTests : SerializerTests
+    {
+        public static IEnumerable<object[]> GetTestData() =>
+            from testCase in GetTestDataCore()
+            select new object[] { testCase };
+
+        public static IEnumerable<object[]> GetTestDataUsingAllValues() =>
+            from testCase in GetTestDataCore()
+            from expandedTestCase in testCase.GetTestDataForAllValues()
+            select new object[] { expandedTestCase };
+
+        public static IEnumerable<ITestData> GetTestDataCore()
+        {
+            // Primitives and built-in types
+            yield return new TestData<object>(
+                Value: new(),
+                AdditionalValues: [null, 42, false, 3.14, 3.14M, new int[] { 1, 2, 3 }, new SimpleRecord(1, "str", false, 3.14)],
+                ExpectedJsonSchema: "true");
+
+            yield return new TestData<bool>(true, ExpectedJsonSchema: """{"type":"boolean"}""");
+            yield return new TestData<byte>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<ushort>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<uint>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<ulong>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<sbyte>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<short>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<int>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<long>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<float>(1.2f, ExpectedJsonSchema: """{"type":"number"}""");
+            yield return new TestData<double>(3.14159d, ExpectedJsonSchema: """{"type":"number"}""");
+            yield return new TestData<decimal>(3.14159M, ExpectedJsonSchema: """{"type":"number"}""");
+#if NET
+            yield return new TestData<UInt128>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<Int128>(42, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<Half>((Half)3.141, ExpectedJsonSchema: """{"type":"number"}""");
+#endif
+            yield return new TestData<string>("I am a string", ExpectedJsonSchema: """{"type":["string","null"]}""");
+            yield return new TestData<char>('c', ExpectedJsonSchema: """{"type":"string"}""");
+            yield return new TestData<byte[]>(
+                Value: [1, 2, 3],
+                AdditionalValues: [[]],
+                ExpectedJsonSchema: """{"type":["string","null"]}""");
+
+            yield return new TestData<Memory<byte>>(new byte[] { 1, 2, 3 }, ExpectedJsonSchema: """{"type":"string"}""");
+            yield return new TestData<ReadOnlyMemory<byte>>(new byte[] { 1, 2, 3 }, ExpectedJsonSchema: """{"type":"string"}""");
+            yield return new TestData<DateTime>(
+                Value: new(2024, 06, 06, 21, 39, 42, DateTimeKind.Utc),
+                ExpectedJsonSchema: """{"type":"string","format":"date-time"}""");
+
+            yield return new TestData<DateTimeOffset>(
+                Value: new(new DateTime(2021, 1, 1), TimeSpan.Zero),
+                AdditionalValues: [DateTimeOffset.MinValue, DateTimeOffset.MaxValue],
+                ExpectedJsonSchema: """{"type":"string","format": "date-time"}""");
+
+            yield return new TestData<TimeSpan>(
+                Value: new(hours: 5, minutes: 13, seconds: 3),
+                AdditionalValues: [TimeSpan.MinValue, TimeSpan.MaxValue],
+                ExpectedJsonSchema: """{"type":"string", "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$"}""");
+
+#if NET
+            yield return new TestData<DateOnly>(new(2021, 1, 1), ExpectedJsonSchema: """{"type":"string","format": "date"}""");
+            yield return new TestData<TimeOnly>(new(hour: 22, minute: 30, second: 33, millisecond: 100), ExpectedJsonSchema: """{"type":"string","format": "time"}""");
+#endif
+            yield return new TestData<Guid>(Guid.Empty, ExpectedJsonSchema: """{"type":"string","format":"uuid"}""");
+            yield return new TestData<Uri>(new("http://example.com"), """{"type":["string","null"],"format":"uri"}""");
+            yield return new TestData<Version>(new(1, 2, 3, 4), ExpectedJsonSchema: """{"type":["string","null"],"pattern":"^\\d+(\\.\\d+){1,3}$"}""");
+            yield return new TestData<JsonDocument>(JsonDocument.Parse("""[{ "x" : 42 }]"""), ExpectedJsonSchema: "true");
+            yield return new TestData<JsonElement>(JsonDocument.Parse("""[{ "x" : 42 }]""").RootElement, ExpectedJsonSchema: "true");
+            yield return new TestData<JsonNode>(JsonNode.Parse("""[{ "x" : 42 }]"""), ExpectedJsonSchema: "true");
+            yield return new TestData<JsonValue>((JsonValue)42, ExpectedJsonSchema: "true");
+            yield return new TestData<JsonObject>(new() { ["x"] = 42 }, ExpectedJsonSchema: """{"type":["object","null"]}""");
+            yield return new TestData<JsonArray>([(JsonNode)1, (JsonNode)2, (JsonNode)3], ExpectedJsonSchema: """{"type":["array","null"]}""");
+
+            // Enum types
+            yield return new TestData<IntEnum>(IntEnum.A, ExpectedJsonSchema: """{"type":"integer"}""");
+            yield return new TestData<StringEnum>(StringEnum.A, ExpectedJsonSchema: """{"type":"string","enum":["A","B","C"]}""");
+            yield return new TestData<FlagsStringEnum>(FlagsStringEnum.A, ExpectedJsonSchema: """{"type":"string"}""");
+
+            // Nullable<T> types
+            yield return new TestData<bool?>(true, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["boolean","null"]}""");
+            yield return new TestData<int?>(42, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["integer","null"]}""");
+            yield return new TestData<double?>(3.14, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["number","null"]}""");
+            yield return new TestData<Guid?>(Guid.Empty, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["string","null"],"format":"uuid"}""");
+            yield return new TestData<JsonElement?>(JsonDocument.Parse("{}").RootElement, AdditionalValues: [null], ExpectedJsonSchema: "true");
+            yield return new TestData<IntEnum?>(IntEnum.A, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["integer","null"]}""");
+            yield return new TestData<StringEnum?>(StringEnum.A, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["string","null"],"enum":["A","B","C",null]}""");
+            yield return new TestData<SimpleRecordStruct?>(
+                new(1, "two", true, 3.14),
+                AdditionalValues: [null],
+                ExpectedJsonSchema: """
+                {
+                    "type":["object","null"],
+                    "properties": {
+                        "X": {"type":"integer"},
+                        "Y": {"type":"string"},
+                        "Z": {"type":"boolean"},
+                        "W": {"type":"number"}
+                    }
+                }
+                """);
+
+            // User-defined POCOs
+            yield return new TestData<SimplePoco>(
+                Value: new() { String = "string", StringNullable = "string", Int = 42, Double = 3.14, Boolean = true },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "String": { "type": "string" },
+                        "StringNullable": { "type": ["string", "null"] },
+                        "Int": { "type": "integer" },
+                        "Double": { "type": "number" },
+                        "Boolean": { "type": "boolean" }
+                    }
+                }
+                """);
+
+            yield return new TestData<SimpleRecord>(
+                Value: new(1, "two", true, 3.14),
+                ExpectedJsonSchema: """
+                {
+                  "type": ["object","null"],
+                  "properties": {
+                    "X": { "type": "integer" },
+                    "Y": { "type": "string" },
+                    "Z": { "type": "boolean" },
+                    "W": { "type": "number" }
+                  },
+                  "required": ["X","Y","Z","W"]
+                }
+                """);
+
+            yield return new TestData<SimpleRecordStruct>(
+                Value: new(1, "two", true, 3.14),
+                ExpectedJsonSchema: """
+                {
+                  "type": "object",
+                  "properties": {
+                    "X": { "type": "integer" },
+                    "Y": { "type": "string" },
+                    "Z": { "type": "boolean" },
+                    "W": { "type": "number" }
+                  }
+                }
+                """);
+
+            yield return new TestData<RecordWithOptionalParameters>(
+                Value: new(1, "two", true, 3.14, StringEnum.A),
+                ExpectedJsonSchema: """
+                {
+                  "type": ["object","null"],
+                  "properties": {
+                    "X1": { "type": "integer" },
+                    "X2": { "type": "string" },
+                    "X3": { "type": "boolean" },
+                    "X4": { "type": "number" },
+                    "X5": { "type": "string", "enum": ["A", "B", "C"] },
+                    "Y1": { "type": "integer", "default": 42 },
+                    "Y2": { "type": "string", "default": "str" },
+                    "Y3": { "type": "boolean", "default": true },
+                    "Y4": { "type": "number", "default": 0 },
+                    "Y5": { "type": "string", "enum": ["A", "B", "C"], "default": "A" }
+                  },
+                  "required": ["X1", "X2", "X3", "X4", "X5"]
+                }
+                """);
+
+            yield return new TestData<PocoWithRequiredMembers>(
+                new() { X = "str1", Y = "str2" },
+                ExpectedJsonSchema: """
+                {
+                  "type": ["object","null"],
+                  "properties": {
+                    "Y": { "type": "string" },
+                    "Z": { "type": "integer" },
+                    "X": { "type": "string" }
+                  },
+                  "required": [ "Y", "Z", "X" ]
+                }
+                """);
+
+            yield return new TestData<PocoWithIgnoredMembers>(new() { X = 1, Y = 2 }, ExpectedJsonSchema: """{"type":["object","null"],"properties":{"X":{"type":"integer"}}}""");
+            yield return new TestData<PocoWithCustomNaming>(
+                Value: new() { IntegerProperty = 1, StringProperty = "str" },
+                ExpectedJsonSchema: """
+                {
+                  "type": ["object","null"],
+                  "properties": {
+                    "int": { "type": "integer" },
+                    "str": { "type": ["string", "null"] }
+                  }
+                }
+                """);
+
+            yield return new TestData<PocoWithCustomNumberHandling>(
+                Value: new() { X = 1 },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": { "X": { "type": ["string","integer"] } }
+                }
+                """);
+
+            yield return new TestData<PocoWithCustomNumberHandlingOnProperties>(
+                Value: new() { X = 1, Y = 2, Z = 3 },
+                AdditionalValues: [
+                    new() { X = 1, Y = double.NaN, Z = 3 },
+                    new() { X = 1, Y = double.PositiveInfinity, Z = 3 },
+                    new() { X = 1, Y = double.NegativeInfinity, Z = 3 },
+                ],
+                ExpectedJsonSchema: """
+                {
+                  "type": ["object","null"],
+                  "properties": {
+                    "X": { "type": ["string", "integer"] },
+                    "Y": {
+                      "anyOf": [
+                        { "type": "number" },
+                        { "enum": ["NaN", "Infinity", "-Infinity"]}
+                      ]
+                    },
+                    "Z": { "type": ["string", "integer"] },
+                    "W" : { "type": "number" }
+                  }
+                }
+                """);
+
+            yield return new TestData<PocoWithRecursiveMembers>(
+                Value: new() { Value = 1, Next = new() { Value = 2, Next = new() { Value = 3 } } },
+                AdditionalValues: [new() { Value = 1, Next = null }],
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "Value": { "type": "integer" },
+                        "Next": {
+                            "type": ["object", "null"],
+                            "properties": {
+                                "Value": { "type": "integer" },
+                                "Next": { "$ref": "#/properties/Next" }
+                            }
+                        }
+                    }
+                }
+                """);
+
+            // Same as above but using an anchor-based reference scheme
+            yield return new TestData<PocoWithRecursiveMembers>(
+                Value: new() { Value = 1, Next = new() { Value = 2, Next = new() { Value = 3 } } },
+                AdditionalValues: [new() { Value = 1, Next = null }],
+                ExpectedJsonSchema: """
+                {
+                    "$anchor" : "PocoWithRecursiveMembers",
+                    "type": ["object","null"],
+                    "properties": {
+                        "Value": { "type": "integer" },
+                        "Next": {
+                            "$anchor" : "PocoWithRecursiveMembers_Next",
+                            "type": ["object", "null"],
+                            "properties": {
+                                "Value": { "type": "integer" },
+                                "Next": { "$ref": "#PocoWithRecursiveMembers_Next" }
+                            }
+                        }
+                    }
+                }
+                """,
+                Options: new JsonSchemaExporterOptions
+                {
+                    OnSchemaNodeGenerated = static (ctx, schema) =>
+                    {
+                        if (ctx.TypeInfo.Kind is JsonTypeInfoKind.None)
+                        {
+                            return;
+                        }
+
+                        string anchorName = ctx.PropertyInfo is { } property
+                            ? ctx.TypeInfo.Type.Name + "_" + property.Name
+                            : ctx.TypeInfo.Type.Name;
+
+                        if (schema.ContainsKey("$ref"))
+                        {
+                            schema["$ref"] = "#" + anchorName;
+                        }
+                        else
+                        {
+                            schema["$anchor"] = anchorName;
+                        }
+                    }
+                });
+
+            // Same as above but using an id-based reference scheme
+            yield return new TestData<PocoWithRecursiveMembers>(
+                Value: new() { Value = 1, Next = new() { Value = 2, Next = new() { Value = 3 } } },
+                AdditionalValues: [new() { Value = 1, Next = null }],
+                    ExpectedJsonSchema: """
+                    {
+                        "$id" : "https://example.com/schema/pocowithrecursivemembers.json",
+                        "type": ["object","null"],
+                        "properties": {
+                            "Value": { "type": "integer" },
+                            "Next": {
+                                "$id" : "https://example.com/schema/pocowithrecursivemembers/next.json",
+                                "type": ["object", "null"],
+                                "properties": {
+                                    "Value": { "type": "integer" },
+                                    "Next": { "$ref": "https://example.com/schema/pocowithrecursivemembers/next.json" }
+                                }
+                            }
+                        }
+                    }
+                """,
+                Options: new JsonSchemaExporterOptions
+                {
+                    OnSchemaNodeGenerated = static (ctx, schema) =>
+                    {
+                        if (ctx.TypeInfo.Kind is JsonTypeInfoKind.None)
+                        {
+                            return;
+                        }
+
+                        string idPath = ctx.PropertyInfo is { } property
+                            ? ctx.TypeInfo.Type.Name.ToLower() + "/" + property.Name.ToLower()
+                            : ctx.TypeInfo.Type.Name.ToLower();
+
+                        string idUrl = "https://example.com/schema/" + idPath + ".json";
+
+                        if (schema.ContainsKey("$ref"))
+                        {
+                            schema["$ref"] = idUrl;
+                        }
+                        else
+                        {
+                            schema["$id"] = idUrl;
+                        }
+                    }
+                });
+
+            yield return new TestData<PocoWithRecursiveCollectionElement>(
+                Value: new() { Children = [new(), new() { Children = [] }] },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "Children": {
+                            "type": "array",
+                            "items": { "$ref" : "#" }
+                        }
+                    }
+                }
+                """);
+
+            yield return new TestData<PocoWithRecursiveDictionaryValue>(
+                Value: new() { Children = new() { ["key1"] = new(), ["key2"] = new() { Children = new() { ["key3"] = new() }  } } },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "Children": {
+                            "type": "object",
+                            "additionalProperties": { "$ref" : "#" }
+                        }
+                    }
+                }
+                """);
+
+            yield return new TestData<PocoWithDescription>(
+                Value: new() { X = 42 },
+                ExpectedJsonSchema: """
+                {
+                  "description": "The type description",
+                  "type": ["object","null"],
+                  "properties": {
+                    "X": {
+                      "description": "The property description",
+                      "type": "integer"
+                    }
+                  }
+                }
+                """,
+                Options: new()
+                {
+                    OnSchemaNodeGenerated = static (ctx, schema) =>
+                    {
+                        if (schema.ContainsKey("$ref"))
+                        {
+                            return;
+                        }
+
+                        DescriptionAttribute? descriptionAttribute =
+                            GetCustomAttribute<DescriptionAttribute>(ctx.PropertyInfo?.AttributeProvider) ??
+                            GetCustomAttribute<DescriptionAttribute>(ctx.PropertyInfo?.AssociatedParameter.AttributeProvider) ??
+                            GetCustomAttribute<DescriptionAttribute>(ctx.TypeInfo.Type);
+
+                        if (descriptionAttribute != null)
+                        {
+                            schema["description"] = (JsonNode)descriptionAttribute.Description;
+                        }
+                    }
+                });
+
+            yield return new TestData<PocoWithCustomConverter>(new() { Value = 42 }, ExpectedJsonSchema: "true");
+            yield return new TestData<PocoWithCustomPropertyConverter>(new() { Value = 42 }, ExpectedJsonSchema: """{"type":["object", "null"],"properties":{"Value":true}}""");
+            yield return new TestData<PocoWithEnums>(
+                Value: new()
+                {
+                    IntEnum = IntEnum.A,
+                    StringEnum = StringEnum.B,
+                    IntEnumUsingStringConverter = IntEnum.A,
+                    NullableIntEnumUsingStringConverter = IntEnum.B,
+                    StringEnumUsingIntConverter = StringEnum.A,
+                    NullableStringEnumUsingIntConverter = StringEnum.B
+                },
+                AdditionalValues: [
+                    new()
+                    {
+                        IntEnum = (IntEnum)int.MaxValue,
+                        StringEnum = StringEnum.A,
+                        IntEnumUsingStringConverter = IntEnum.A,
+                        NullableIntEnumUsingStringConverter = null,
+                        StringEnumUsingIntConverter = (StringEnum)int.MaxValue,
+                        NullableStringEnumUsingIntConverter = null
+                    },
+                ],
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "IntEnum": { "type": "integer" },
+                        "StringEnum": { "type": "string", "enum": [ "A", "B", "C" ] },
+                        "IntEnumUsingStringConverter": { "type": "string", "enum": [ "A", "B", "C" ] },
+                        "NullableIntEnumUsingStringConverter": { "type": ["string", "null"], "enum": [ "A", "B", "C", null ] },
+                        "StringEnumUsingIntConverter": { "type": "integer" },
+                        "NullableStringEnumUsingIntConverter": { "type": [ "integer", "null" ] }
+                    }
+                }
+                """);
+
+            var recordStruct = new SimpleRecordStruct(42, "str", true, 3.14);
+            yield return new TestData<PocoWithStructFollowedByNullableStruct>(
+                Value: new() { Struct = recordStruct, NullableStruct = null },
+                AdditionalValues: [new() { Struct = recordStruct, NullableStruct = recordStruct }],
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "Struct": {
+                            "type": "object",
+                            "properties": {
+                                "X": {"type":"integer"},
+                                "Y": {"type":"string"},
+                                "Z": {"type":"boolean"},
+                                "W": {"type":"number"}
+                            }
+                        },
+                        "NullableStruct": {
+                            "type": ["object","null"],
+                            "properties": {
+                                "X": {"type":"integer"},
+                                "Y": {"type":"string"},
+                                "Z": {"type":"boolean"},
+                                "W": {"type":"number"}
+                            }
+                        }
+                    }
+                }
+                """);
+
+            yield return new TestData<PocoWithNullableStructFollowedByStruct>(
+                Value: new() { NullableStruct = null, Struct = recordStruct },
+                AdditionalValues: [new() { NullableStruct = recordStruct, Struct = recordStruct }],
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "NullableStruct": {
+                            "type": ["object","null"],
+                            "properties": {
+                                "X": {"type":"integer"},
+                                "Y": {"type":"string"},
+                                "Z": {"type":"boolean"},
+                                "W": {"type":"number"}
+                            }
+                        },
+                        "Struct": {
+                            "type": "object",
+                            "properties": {
+                                "X": {"type":"integer"},
+                                "Y": {"type":"string"},
+                                "Z": {"type":"boolean"},
+                                "W": {"type":"number"}
+                            }
+                        }
+                    }
+                }
+                """);
+
+            yield return new TestData<PocoWithExtensionDataProperty>(
+                Value: new() { Name = "name", ExtensionData = new() { ["x"] = 42 } },
+                ExpectedJsonSchema: """
+                    {
+                        "type": ["object","null"],
+                        "properties": {
+                            "Name": { "type": ["string", "null"] }
+                        }
+                    }
+                    """);
+
+            yield return new TestData<PocoDisallowingUnmappedMembers>(
+                Value: new() { Name = "name", Age = 42 },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "Name": {"type": ["string", "null"]},
+                        "Age": {"type":"integer"}
+                    },
+                    "additionalProperties": false
+                }
+                """);
+
+            yield return new TestData<PocoWithNullableAnnotationAttributes>(
+                Value: new() { MaybeNull = null!, AllowNull = null, NotNull = null, DisallowNull = null!, NotNullDisallowNull = "str" },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "MaybeNull": {"type":["string","null"]},
+                        "AllowNull": {"type":["string","null"]},
+                        "NotNull": {"type":["string","null"]},
+                        "DisallowNull": {"type":["string","null"]},
+                        "NotNullDisallowNull": {"type":"string"}
+                    }
+                }
+                """);
+
+            yield return new TestData<PocoWithNullableAnnotationAttributesOnConstructorParams>(
+                Value: new(allowNull: null, disallowNull: "str"),
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "AllowNull": {"type":["string","null"]},
+                        "DisallowNull": {"type":"string"}
+                    },
+                    "required": ["AllowNull", "DisallowNull"]
+                }
+                """);
+
+            yield return new TestData<PocoWithNullableConstructorParameter>(
+                Value: new(null),
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "Value": {"type":["string","null"]}
+                    },
+                    "required": ["Value"]
+                }
+                """);
+
+            yield return new TestData<PocoWithOptionalConstructorParams>(
+                Value: new(),
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "X1": {"type":"string", "default": "str" },
+                        "X2": {"type":"integer", "default": 42 },
+                        "X3": {"type":"boolean", "default": true },
+                        "X4": {"type":"number", "default": 0 },
+                        "X5": {"type":"string", "enum":["A","B","C"], "default": "A" },
+                        "X6": {"type":["string","null"], "default": "str" },
+                        "X7": {"type":["integer","null"], "default": 42 },
+                        "X8": {"type":["boolean","null"], "default": true },
+                        "X9": {"type":["number","null"], "default": 0 },
+                        "X10": {"type":["string","null"], "enum":["A","B","C", null], "default": "A" }
+                    }
+                }
+                """);
+
+            yield return new TestData<GenericPocoWithNullableConstructorParameter<string>>(
+                Value: new(null!),
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "Value": {"type":["string","null"]}
+                    },
+                    "required": ["Value"]
+                }
+                """);
+
+            yield return new TestData<PocoWithPolymorphism>(
+                Value: new PocoWithPolymorphism.DerivedPocoStringDiscriminator { BaseValue = 42, DerivedValue = "derived" },
+                AdditionalValues: [
+                    new PocoWithPolymorphism.DerivedPocoNoDiscriminator { BaseValue = 42, DerivedValue = "derived" },
+                    new PocoWithPolymorphism.DerivedPocoIntDiscriminator { BaseValue = 42, DerivedValue = "derived" },
+                    new PocoWithPolymorphism.DerivedCollectionNoDiscriminator { BaseValue = 42 },
+                    new PocoWithPolymorphism.DerivedCollection { BaseValue = 42 },
+                    new PocoWithPolymorphism.DerivedDictionaryNoDiscriminator { BaseValue = 42 },
+                    new PocoWithPolymorphism.DerivedDictionary { BaseValue = 42 },
+                ],
+
+                ExpectedJsonSchema: """
+                {
+                    "anyOf": [
+                        {
+                            "type": ["object","null"],
+                            "properties": {
+                                "BaseValue": {"type":"integer"},
+                                "DerivedValue": {"type":["string", "null"]}
+                            }
+                        },
+                        {
+                            "type": ["object","null"],
+                            "properties": {
+                                "$type": {"const":"derivedPoco"},
+                                "BaseValue": {"type":"integer"},
+                                "DerivedValue": {"type":["string", "null"]}
+                            },
+                            "required": ["$type"]
+                        },
+                        {
+                            "type": ["object","null"],
+                            "properties": {
+                                "$type": {"const":42},
+                                "BaseValue": {"type":"integer"},
+                                "DerivedValue": {"type":["string", "null"]}
+                            },
+                            "required": ["$type"]
+                        },
+                        {
+                            "type": ["array","null"],
+                            "items": {"type":"integer"}
+                        },
+                        {
+                            "type": ["object","null"],
+                            "properties": {
+                                "$type": {"const":"derivedCollection"},
+                                "$values": {
+                                    "type": "array",
+                                    "items": {"type":"integer"}
+                                }
+                            },
+                            "required": ["$type"]
+                        },
+                        {
+                            "type": ["object","null"],
+                            "additionalProperties":{"type": "integer"}
+                        },
+                        {
+                            "type": ["object","null"],
+                            "properties": {
+                                "$type": {"const":"derivedDictionary"}
+                            },
+                            "additionalProperties":{"type": "integer"},
+                            "required": ["$type"]
+                        }
+                    ]
+                }
+                """);
+
+            yield return new TestData<NonAbstractClassWithSingleDerivedType>(
+                Value: new NonAbstractClassWithSingleDerivedType(),
+                AdditionalValues: [new NonAbstractClassWithSingleDerivedType.Derived()],
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "anyOf": [true, true]
+                }
+                """);
+
+            yield return new TestData<DiscriminatedUnion>(
+                Value: new DiscriminatedUnion.Left("value"),
+                AdditionalValues: [new DiscriminatedUnion.Right(42)],
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "required": ["case"],
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "case": {"const":"left"},
+                                "value": {"type":"string"}
+                            },
+                            "required": ["value"]
+                        },
+                        {
+                            "properties": {
+                                "case": {"const":"right"},
+                                "value": {"type":"integer"}
+                            },
+                            "required": ["value"]
+                        }
+                    ]
+                }
+                """);
+
+            yield return new TestData<PocoCombiningPolymorphicTypeAndDerivedTypes>(
+                Value: new(),
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "PolymorphicValue": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "BaseValue": {"type":"integer"},
+                                        "DerivedValue": {"type":["string", "null"]}
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "$type": {"const":"derivedPoco"},
+                                        "BaseValue": {"type":"integer"},
+                                        "DerivedValue": {"type":["string","null"]}
+                                    },
+                                    "required": ["$type"]
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "$type": {"const":42},
+                                        "BaseValue": {"type":"integer"},
+                                        "DerivedValue": {"type":["string", "null"]}
+                                    },
+                                    "required": ["$type"]
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {"type":"integer"}
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "$type": {"const":"derivedCollection"},
+                                        "$values": {
+                                            "type": "array",
+                                            "items": {"type":"integer"}
+                                        }
+                                    },
+                                    "required": ["$type"]
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties":{"type": "integer"}
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "$type": {"const":"derivedDictionary"}
+                                    },
+                                    "additionalProperties":{"type": "integer"},
+                                    "required": ["$type"]
+                                }
+                            ]
+                        },
+                        "DiscriminatedUnion":{
+                            "type": "object",
+                            "required": ["case"],
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "case": {"const":"left"},
+                                        "value": {"type":"string"}
+                                    },
+                                    "required": ["value"]
+                                },
+                                {
+                                    "properties": {
+                                        "case": {"const":"right"},
+                                        "value": {"type":"integer"}
+                                    },
+                                    "required": ["value"]
+                                }
+                            ]
+                        },
+                        "DerivedValue1": {
+                            "type": "object",
+                            "properties": {
+                                "BaseValue": {"type":"integer"},
+                                "DerivedValue": {"type":["string", "null"]}
+                            }
+                        },
+                        "DerivedValue2": {
+                            "type": "object",
+                            "properties": {
+                                "BaseValue": {"type":"integer"},
+                                "DerivedValue": {"type":["string", "null"]}
+                            }
+                        }
+                    }
+                }
+                """);
+
+            yield return new TestData<ClassWithComponentModelAttributes>(
+                Value: new("string", -1),
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "StringValue": {"type":"string","pattern":"\\w+"},
+                        "IntValue": {"type":"integer","default":42}
+                    },
+                    "required": ["StringValue","IntValue"]
+                }
+                """,
+                Options: new()
+                {
+                    OnSchemaNodeGenerated = static (ctx, schema) =>
+                    {
+                        if (ctx.PropertyInfo is null || schema.ContainsKey("$ref"))
+                        {
+                            return;
+                        }
+
+                        DefaultValueAttribute? defaultValueAttr =
+                            GetCustomAttribute<DefaultValueAttribute>(ctx.PropertyInfo?.AttributeProvider) ??
+                            GetCustomAttribute<DefaultValueAttribute>(ctx.PropertyInfo?.AssociatedParameter?.AttributeProvider);
+
+                        if (defaultValueAttr != null)
+                        {
+                            schema["default"] = JsonSerializer.SerializeToNode(defaultValueAttr.Value, ctx.TypeInfo);
+                        }
+
+                        RegularExpressionAttribute? regexAttr =
+                            GetCustomAttribute<RegularExpressionAttribute>(ctx.PropertyInfo?.AttributeProvider) ??
+                            GetCustomAttribute<RegularExpressionAttribute>(ctx.PropertyInfo?.AssociatedParameter?.AttributeProvider);
+
+                        if (regexAttr != null)
+                        {
+                            schema["pattern"] = regexAttr.Pattern;
+                        }
+                    }
+                });
+
+            yield return new TestData<ClassWithJsonPointerEscapablePropertyNames>(
+                Value: new ClassWithJsonPointerEscapablePropertyNames { Value = new() },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "~/path/to/value": {
+                            "type": "object",
+                            "properties": {
+                                "Value" : {"type":"integer"},
+                                "Next": {
+                                    "type": ["object","null"],
+                                    "properties": {
+                                        "Value" : {"type":"integer"},
+                                        "Next": {"$ref":"#/properties/~0~1path~1to~1value/properties/Next"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+
+            // Collection types
+            yield return new TestData<int[]>([1, 2, 3], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"integer"}}""");
+            yield return new TestData<List<bool>>([false, true, false], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"boolean"}}""");
+            yield return new TestData<HashSet<string>>(["one", "two", "three"], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":["string","null"]}}""");
+            yield return new TestData<Queue<double>>(new([1.1, 2.2, 3.3]), ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"number"}}""");
+            yield return new TestData<Stack<char>>(new(['x', '2', '+']), ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"string"}}""");
+            yield return new TestData<ImmutableArray<int>>([1, 2, 3], ExpectedJsonSchema: """{"type":"array","items":{"type":"integer"}}""");
+            yield return new TestData<ImmutableList<string>>(["one", "two", "three"], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":["string","null"]}}""");
+            yield return new TestData<ImmutableQueue<bool>>([false, false, true], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"boolean"}}""");
+            yield return new TestData<object[]>([1, "two", 3.14], ExpectedJsonSchema: """{"type":["array","null"],"items":true}""");
+            yield return new TestData<System.Collections.ArrayList>([1, "two", 3.14], ExpectedJsonSchema: """{"type":["array","null"],"items":true}""");
+
+            // Dictionary types
+            yield return new TestData<Dictionary<string, int>>(
+                Value: new() { ["one"] = 1, ["two"] = 2, ["three"] = 3 },
+                ExpectedJsonSchema: """{"type":["object","null"],"additionalProperties":{"type": "integer"}}""");
+
+            yield return new TestData<StructDictionary<string, int>>(
+                Value: new([new("one", 1), new("two", 2), new("three", 3)]),
+                ExpectedJsonSchema: """{"type":"object","additionalProperties":{"type": "integer"}}""");
+
+            yield return new TestData<SortedDictionary<int, string>>(
+                Value: new() { [1] = "one", [2] = "two", [3] = "three" },
+                ExpectedJsonSchema: """{"type":["object","null"],"additionalProperties":{"type": ["string","null"]}}""");
+
+            yield return new TestData<Dictionary<string, SimplePoco>>(
+                Value: new()
+                {
+                    ["one"] = new() { String = "string", StringNullable = "string", Int = 42, Double = 3.14, Boolean = true },
+                    ["two"] = new() { String = "string", StringNullable = null, Int = 42, Double = 3.14, Boolean = true },
+                    ["three"] = new() { String = "string", StringNullable = null, Int = 42, Double = 3.14, Boolean = true },
+                },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "additionalProperties": {
+                        "type": ["object","null"],
+                        "properties": {
+                            "String": { "type": "string" },
+                            "StringNullable": { "type": ["string","null"] },
+                            "Int": { "type": "integer" },
+                            "Double": { "type": "number" },
+                            "Boolean": { "type": "boolean" }
+                        }
+                    }
+                }
+                """);
+
+            yield return new TestData<Dictionary<string, object>>(
+                Value: new() { ["one"] = 1, ["two"] = "two", ["three"] = 3.14 },
+                ExpectedJsonSchema: """{"type":["object","null"],"additionalProperties":true}""");
+
+            yield return new TestData<Hashtable>(
+                Value: new() { ["one"] = 1, ["two"] = "two", ["three"] = 3.14 },
+                ExpectedJsonSchema: """{"type":["object","null"],"additionalProperties":true}""");
+        }
+
+        public enum IntEnum { A, B, C };
+
+        [JsonConverter(typeof(JsonStringEnumConverter<StringEnum>))]
+        public enum StringEnum { A, B, C };
+
+        [Flags, JsonConverter(typeof(JsonStringEnumConverter<FlagsStringEnum>))]
+        public enum FlagsStringEnum { A = 1, B = 2, C = 4 };
+
+        public class SimplePoco
+        {
+            public string String { get; set; } = "default";
+            public string? StringNullable { get; set; }
+
+            public int Int { get; set; }
+            public double Double { get; set; }
+            public bool Boolean { get; set; }
+        }
+
+        public record SimpleRecord(int X, string Y, bool Z, double W);
+        public record struct SimpleRecordStruct(int X, string Y, bool Z, double W);
+
+        public record RecordWithOptionalParameters(
+            int X1, string X2, bool X3, double X4, StringEnum X5,
+            int Y1 = 42, string Y2 = "str", bool Y3 = true, double Y4 = 0, StringEnum Y5 = StringEnum.A);
+
+        public class PocoWithRequiredMembers
+        {
+            [JsonInclude]
+            public required string X;
+
+            public required string Y { get; set; }
+
+            [JsonRequired]
+            public int Z { get; set; }
+        }
+
+        public class PocoWithIgnoredMembers
+        {
+            public int X { get; set; }
+
+            [JsonIgnore]
+            public int Y { get; set; }
+        }
+
+        public class PocoWithCustomNaming
+        {
+            [JsonPropertyName("int")]
+            public int IntegerProperty { get; set; }
+
+            [JsonPropertyName("str")]
+            public string? StringProperty { get; set; }
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+        public class PocoWithCustomNumberHandling
+        {
+            public int X { get; set; }
+        }
+
+        public class PocoWithCustomNumberHandlingOnProperties
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+            public int X { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+            public double Y { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.WriteAsString)]
+            public int Z { get; set; }
+
+            [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+            public decimal W { get; set; }
+        }
+
+        public class PocoWithRecursiveMembers
+        {
+            public int Value { get; init; }
+            public PocoWithRecursiveMembers? Next { get; init; }
+        }
+
+        public class PocoWithRecursiveCollectionElement
+        {
+            public List<PocoWithRecursiveCollectionElement> Children { get; init; } = new();
+        }
+
+        public class PocoWithRecursiveDictionaryValue
+        {
+            public Dictionary<string, PocoWithRecursiveDictionaryValue> Children { get; init; } = new();
+        }
+
+        [Description("The type description")]
+        public class PocoWithDescription
+        {
+            [Description("The property description")]
+            public int X { get; set; }
+        }
+
+        [JsonConverter(typeof(CustomConverter))]
+        public class PocoWithCustomConverter
+        {
+            public int Value { get; set; }
+
+            public class CustomConverter : JsonConverter<PocoWithCustomConverter>
+            {
+                public override PocoWithCustomConverter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+                    new PocoWithCustomConverter { Value = reader.GetInt32() };
+
+                public override void Write(Utf8JsonWriter writer, PocoWithCustomConverter value, JsonSerializerOptions options) =>
+                    writer.WriteNumberValue(value.Value);
+            }
+        }
+
+        public class PocoWithCustomPropertyConverter
+        {
+            [JsonConverter(typeof(CustomConverter))]
+            public int Value { get; set; }
+
+            public class CustomConverter : JsonConverter<int>
+            {
+                public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                    => int.Parse(reader.GetString()!);
+
+                public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+                    => writer.WriteStringValue(value.ToString());
+            }
+        }
+
+        public class PocoWithEnums
+        {
+            public IntEnum IntEnum { get; init; }
+            public StringEnum StringEnum { get; init; }
+
+            [JsonConverter(typeof(JsonStringEnumConverter<IntEnum>))]
+            public IntEnum IntEnumUsingStringConverter { get; set; }
+
+            [JsonConverter(typeof(JsonStringEnumConverter<IntEnum>))]
+            public IntEnum? NullableIntEnumUsingStringConverter { get; set; }
+
+            [JsonConverter(typeof(JsonNumberEnumConverter<StringEnum>))]
+            public StringEnum StringEnumUsingIntConverter { get; set; }
+
+            [JsonConverter(typeof(JsonNumberEnumConverter<StringEnum>))]
+            public StringEnum? NullableStringEnumUsingIntConverter { get; set; }
+        }
+
+        public class PocoWithStructFollowedByNullableStruct
+        {
+            public SimpleRecordStruct? NullableStruct { get; set; }
+            public SimpleRecordStruct Struct { get; set; }
+        }
+
+        public class PocoWithNullableStructFollowedByStruct
+        {
+            public SimpleRecordStruct? NullableStruct { get; set; }
+            public SimpleRecordStruct Struct { get; set; }
+        }
+
+        public class PocoWithExtensionDataProperty
+        {
+            public string? Name { get; set; }
+
+            [JsonExtensionData]
+            public Dictionary<string, object>? ExtensionData { get; set; }
+        }
+
+        [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+        public class PocoDisallowingUnmappedMembers
+        {
+            public string? Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        public class PocoWithNullableAnnotationAttributes
+        {
+            [MaybeNull]
+            public string MaybeNull { get; set; }
+
+            [AllowNull]
+            public string AllowNull { get; set; }
+
+            [NotNull]
+            public string? NotNull { get; set; }
+
+            [DisallowNull]
+            public string? DisallowNull { get; set; }
+
+            [NotNull, DisallowNull]
+            public string? NotNullDisallowNull { get; set; } = "";
+        }
+
+        public class PocoWithNullableAnnotationAttributesOnConstructorParams([AllowNull] string allowNull, [DisallowNull] string? disallowNull)
+        {
+            public string AllowNull { get; } = allowNull!;
+            public string DisallowNull { get; } = disallowNull;
+        }
+
+        public class PocoWithNullableConstructorParameter(string? value)
+        {
+            public string Value { get; } = value!;
+        }
+
+        public class PocoWithOptionalConstructorParams(
+            string x1 = "str", int x2 = 42, bool x3 = true, double x4 = 0, StringEnum x5 = StringEnum.A,
+            string? x6 = "str", int? x7 = 42, bool? x8 = true, double? x9 = 0, StringEnum? x10 = StringEnum.A)
+        {
+            public string X1 { get; } = x1;
+            public int X2 { get; } = x2;
+            public bool X3 { get; } = x3;
+            public double X4 { get; } = x4;
+            public StringEnum X5 { get; } = x5;
+
+            public string? X6 { get; } = x6;
+            public int? X7 { get; } = x7;
+            public bool? X8 { get; } = x8;
+            public double? X9 { get; } = x9;
+            public StringEnum? X10 { get; } = x10;
+        }
+
+        // Regression test for https://github.com/dotnet/runtime/issues/92487
+        public class GenericPocoWithNullableConstructorParameter<T>(T value)
+        {
+            [NotNull]
+            public T Value { get; } = value!;
+        }
+
+        [JsonDerivedType(typeof(DerivedPocoNoDiscriminator))]
+        [JsonDerivedType(typeof(DerivedPocoStringDiscriminator), "derivedPoco")]
+        [JsonDerivedType(typeof(DerivedPocoIntDiscriminator), 42)]
+        [JsonDerivedType(typeof(DerivedCollectionNoDiscriminator))]
+        [JsonDerivedType(typeof(DerivedCollection), "derivedCollection")]
+        [JsonDerivedType(typeof(DerivedDictionaryNoDiscriminator))]
+        [JsonDerivedType(typeof(DerivedDictionary), "derivedDictionary")]
+        public abstract class PocoWithPolymorphism
+        {
+            public int BaseValue { get; set; }
+
+            public class DerivedPocoNoDiscriminator : PocoWithPolymorphism
+            {
+                public string? DerivedValue { get; set; }
+            }
+
+            public class DerivedPocoStringDiscriminator : PocoWithPolymorphism
+            {
+                public string? DerivedValue { get; set; }
+            }
+
+            public class DerivedPocoIntDiscriminator : PocoWithPolymorphism
+            {
+                public string? DerivedValue { get; set; }
+            }
+
+            public class DerivedCollection : PocoWithPolymorphism, IEnumerable<int>
+            {
+                public IEnumerator<int> GetEnumerator() => Enumerable.Repeat(BaseValue, 1).GetEnumerator();
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            public class DerivedCollectionNoDiscriminator : DerivedCollection;
+
+            public class DerivedDictionary : PocoWithPolymorphism, IReadOnlyDictionary<string, int>
+            {
+                public int this[string key] => key == nameof(BaseValue) ? BaseValue : throw new KeyNotFoundException();
+                public IEnumerable<string> Keys => [nameof(BaseValue)];
+                public IEnumerable<int> Values => [BaseValue];
+                public int Count => 1;
+                public bool ContainsKey(string key) => key == nameof(BaseValue);
+                public bool TryGetValue(string key, out int value) => key == nameof(BaseValue) ? (value = BaseValue) == BaseValue : (value = 0) == 0;
+                public IEnumerator<KeyValuePair<string, int>> GetEnumerator() => Enumerable.Repeat(new KeyValuePair<string, int>(nameof(BaseValue), BaseValue), 1).GetEnumerator();
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            public class DerivedDictionaryNoDiscriminator : DerivedDictionary;
+        }
+
+        [JsonDerivedType(typeof(Derived))]
+        public class NonAbstractClassWithSingleDerivedType
+        {
+            public class Derived : NonAbstractClassWithSingleDerivedType;
+        }
+
+        [JsonPolymorphic(TypeDiscriminatorPropertyName = "case")]
+        [JsonDerivedType(typeof(Left), "left")]
+        [JsonDerivedType(typeof(Right), "right")]
+        public abstract record DiscriminatedUnion
+        {
+            public record Left(string value) : DiscriminatedUnion;
+            public record Right(int value) : DiscriminatedUnion;
+        }
+
+        public class PocoCombiningPolymorphicTypeAndDerivedTypes
+        {
+            public PocoWithPolymorphism PolymorphicValue { get; set; } = new PocoWithPolymorphism.DerivedPocoNoDiscriminator { DerivedValue = "derived" };
+            public DiscriminatedUnion DiscriminatedUnion { get; set; } = new DiscriminatedUnion.Left("value");
+            public PocoWithPolymorphism.DerivedPocoNoDiscriminator DerivedValue1 { get; set; } = new() { DerivedValue = "derived" };
+            public PocoWithPolymorphism.DerivedPocoStringDiscriminator DerivedValue2 { get; set; } = new() { DerivedValue = "derived" };
+        }
+
+        public class ClassWithComponentModelAttributes
+        {
+            public ClassWithComponentModelAttributes(string stringValue, [DefaultValue(42)] int intValue)
+            {
+                StringValue = stringValue;
+                IntValue = intValue;
+            }
+
+            [RegularExpression(@"\w+")]
+            public string StringValue { get; }
+
+            public int IntValue { get; }
+        }
+
+        public class ClassWithJsonPointerEscapablePropertyNames
+        {
+            [JsonPropertyName("~/path/to/value")]
+            public PocoWithRecursiveMembers Value { get; set; }
+        }
+
+        public readonly struct StructDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> values)
+            : IReadOnlyDictionary<TKey, TValue>
+            where TKey : notnull
+        {
+            private readonly IReadOnlyDictionary<TKey, TValue> _dictionary = values.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            public TValue this[TKey key] => _dictionary[key];
+            public IEnumerable<TKey> Keys => _dictionary.Keys;
+            public IEnumerable<TValue> Values => _dictionary.Values;
+            public int Count => _dictionary.Count;
+            public bool ContainsKey(TKey key) => _dictionary.ContainsKey(key);
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _dictionary.GetEnumerator();
+#if NET
+            public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => _dictionary.TryGetValue(key, out value);
+#else
+            public bool TryGetValue(TKey key, out TValue value) => _dictionary.TryGetValue(key, out value);
+#endif
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_dictionary).GetEnumerator();
+        }
+
+        public record TestData<T>(
+            T? Value,
+            string ExpectedJsonSchema,
+            IEnumerable<T?>? AdditionalValues = null,
+            JsonSchemaExporterOptions? Options = null)
+            : ITestData
+        {
+            public Type Type => typeof(T);
+            object? ITestData.Value => Value;
+
+            IEnumerable<ITestData> ITestData.GetTestDataForAllValues()
+            {
+                yield return this;
+
+                if (default(T) is null)
+                {
+                    yield return this with { Value = default, AdditionalValues = null };
+                }
+
+                if (AdditionalValues != null)
+                {
+                    foreach (T? value in AdditionalValues)
+                    {
+                        yield return this with { Value = value, AdditionalValues = null };
+                    }
+                }
+            }
+        }
+
+        public interface ITestData
+        {
+            Type Type { get; }
+
+            object? Value { get; }
+
+            string ExpectedJsonSchema { get; }
+
+            JsonSchemaExporterOptions? Options { get; }
+
+            IEnumerable<ITestData> GetTestDataForAllValues();
+        }
+
+        private static TAttribute? GetCustomAttribute<TAttribute>(ICustomAttributeProvider? provider, bool inherit = false) where TAttribute : Attribute
+            => provider?.GetCustomAttributes(typeof(TAttribute), inherit).FirstOrDefault() as TAttribute;
+    }
+}

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -1,0 +1,165 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Json.Serialization.Tests;
+using Json.Schema;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Text.Json.Schema.Tests
+{
+    public abstract partial class JsonSchemaExporterTests : SerializerTests
+    {
+        private readonly JsonSerializerOptions _indentedOptions;
+
+        protected JsonSchemaExporterTests(JsonSerializerWrapper serializer) : base(serializer)
+        {
+            _indentedOptions = new(serializer.DefaultOptions) { WriteIndented = true };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestData))]
+        public void TestTypes_GeneratesExpectedJsonSchema(ITestData testData)
+        {
+            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(testData.Type, testData.Options);
+            AssertValidJsonSchema(testData.Type, testData.ExpectedJsonSchema, schema);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestDataUsingAllValues))]
+        public void TestTypes_SerializedValueMatchesGeneratedSchema(ITestData testData)
+        {
+            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(testData.Type, testData.Options);
+            JsonNode? instance = JsonSerializer.SerializeToNode(testData.Value, testData.Type, Serializer.DefaultOptions);
+            AssertDocumentMatchesSchema(schema, instance);
+        }
+
+        [Theory]
+        [InlineData(typeof(Type))]
+        [InlineData(typeof(MethodInfo))]
+        [InlineData(typeof(UIntPtr))]
+        [InlineData(typeof(MemberInfo))]
+        [InlineData(typeof(SerializationInfo))]
+        [InlineData(typeof(Func<int, int>))]
+        public void UnsupportedType_ReturnsExpectedSchema(Type type)
+        {
+            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(type);
+            Assert.Equal("false", schema.ToJsonString());
+        }
+
+        [Fact]
+        public void TypeWithDisallowUnmappedMembers_AdditionalPropertiesFailValidation()
+        {
+            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(typeof(PocoDisallowingUnmappedMembers));
+            JsonNode? jsonWithUnmappedProperties = JsonNode.Parse("""{ "UnmappedProperty" : {} }""");
+            AssertDoesNotMatchSchema(schema, jsonWithUnmappedProperties);
+        }
+
+        [Fact]
+        public void GetJsonSchemaAsNode_NullInputs_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((JsonSerializerOptions)null!).GetJsonSchemaAsNode(typeof(int)));
+            Assert.Throws<ArgumentNullException>(() => Serializer.DefaultOptions.GetJsonSchemaAsNode((Type)null!));
+            Assert.Throws<ArgumentNullException>(() => ((JsonTypeInfo)null!).GetJsonSchemaAsNode());
+        }
+
+        [Fact]
+        public void GetJsonSchemaAsNode_NoResolver_ThrowInvalidOperationException()
+        {
+            var options = new JsonSerializerOptions();
+            Assert.Throws<InvalidOperationException>(() => options.GetJsonSchemaAsNode(typeof(int)));
+        }
+
+        [Fact]
+        public void JsonSerializerOptions_SmallMaxDepth_ThrowsInvalidOperationException()
+        {
+            var options = new JsonSerializerOptions(Serializer.DefaultOptions) { MaxDepth = 1 };
+            var ex = Assert.Throws<InvalidOperationException>(() => options.GetJsonSchemaAsNode(typeof(PocoWithRecursiveMembers)));
+            Assert.Contains("depth", ex.Message);
+        }
+
+        [Fact]
+        public void ReferenceHandlePreserve_Enabled_ThrowsNotSupportedException()
+        {
+            var options = new JsonSerializerOptions(Serializer.DefaultOptions) { ReferenceHandler = ReferenceHandler.Preserve };
+            options.MakeReadOnly();
+
+            var ex = Assert.Throws<NotSupportedException>(() => options.GetJsonSchemaAsNode(typeof(SimplePoco)));
+            Assert.Contains("ReferenceHandler.Preserve", ex.Message);
+        }
+
+        protected void AssertValidJsonSchema(Type type, string expectedJsonSchema, JsonNode actualJsonSchema)
+        {
+            JsonNode? expectedJsonSchemaNode = JsonNode.Parse(expectedJsonSchema, documentOptions: new() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
+
+            if (!JsonNode.DeepEquals(expectedJsonSchemaNode, actualJsonSchema))
+            {
+                throw new XunitException($"""
+                Generated schema does not match the expected specification.
+                Expected:
+                {FormatJson(expectedJsonSchemaNode)}
+                Actual:
+                {FormatJson(actualJsonSchema)}
+                """);
+            }
+        }
+
+        protected void AssertDocumentMatchesSchema(JsonNode schema, JsonNode? instance)
+        {
+            EvaluationResults results = EvaluateSchemaCore(schema, instance);
+            if (!results.IsValid)
+            {
+                IEnumerable<string> errors = results.Details
+                    .Where(d => d.HasErrors)
+                    .SelectMany(d => d.Errors!.Select(error => $"Path:${d.InstanceLocation} {error.Key}:{error.Value}"));
+
+                throw new XunitException($"""
+                Instance JSON document does not match the specified schema.
+                Schema:
+                {FormatJson(schema)}
+                Instance:
+                {FormatJson(instance)}
+                Errors:
+                {string.Join(Environment.NewLine, errors)}
+                """);
+            }
+        }
+
+        protected void AssertDoesNotMatchSchema(JsonNode schema, JsonNode? instance)
+        {
+            EvaluationResults results = EvaluateSchemaCore(schema, instance);
+            if (results.IsValid)
+            {
+                throw new XunitException($"""
+                Instance JSON document matches the specified schema.
+                Schema:
+                {FormatJson(schema)}
+                Instance:
+                {FormatJson(instance)}
+                """);
+            }
+        }
+
+        private EvaluationResults EvaluateSchemaCore(JsonNode schema, JsonNode? instance)
+        {
+            JsonSchema jsonSchema = JsonSchema.FromText(schema.ToJsonString());
+            return jsonSchema.Evaluate(instance, s_evaluationOptions);
+        }
+
+        private static readonly EvaluationOptions s_evaluationOptions = new()
+        {
+            OutputFormat = OutputFormat.List,
+            RequireFormatValidation = true,
+        };
+
+        private string FormatJson(JsonNode? node) =>
+            JsonSerializer.Serialize(node, _indentedOptions);
+    }
+}

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json.Schema.Tests
         public void UnsupportedType_ReturnsExpectedSchema(Type type)
         {
             JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(type);
-            Assert.Equal("false", schema.ToJsonString());
+            Assert.Equal(""""{"$comment":"Unsupported .NET type","not":true}"""", schema.ToJsonString());
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema.Tests;
+using System.Text.Json.Serialization;
+
+namespace System.Text.Json.SourceGeneration.Tests
+{
+    public sealed partial class JsonSchemaExporterTests_SourceGen()
+        : JsonSchemaExporterTests(new StringSerializerWrapper(TestTypesContext.Default))
+    {
+        [JsonSerializable(typeof(object))]
+        [JsonSerializable(typeof(bool))]
+        [JsonSerializable(typeof(byte))]
+        [JsonSerializable(typeof(ushort))]
+        [JsonSerializable(typeof(uint))]
+        [JsonSerializable(typeof(ulong))]
+        [JsonSerializable(typeof(sbyte))]
+        [JsonSerializable(typeof(short))]
+        [JsonSerializable(typeof(int))]
+        [JsonSerializable(typeof(long))]
+        [JsonSerializable(typeof(float))]
+        [JsonSerializable(typeof(double))]
+        [JsonSerializable(typeof(decimal))]
+#if NETCOREAPP
+        [JsonSerializable(typeof(UInt128))]
+        [JsonSerializable(typeof(Int128))]
+        [JsonSerializable(typeof(Half))]
+#endif
+        [JsonSerializable(typeof(string))]
+        [JsonSerializable(typeof(char))]
+        [JsonSerializable(typeof(byte[]))]
+        [JsonSerializable(typeof(Memory<byte>))]
+        [JsonSerializable(typeof(ReadOnlyMemory<byte>))]
+        [JsonSerializable(typeof(DateTime))]
+        [JsonSerializable(typeof(DateTimeOffset))]
+        [JsonSerializable(typeof(TimeSpan))]
+#if NETCOREAPP
+        [JsonSerializable(typeof(DateOnly))]
+        [JsonSerializable(typeof(TimeOnly))]
+#endif
+        [JsonSerializable(typeof(Guid))]
+        [JsonSerializable(typeof(Uri))]
+        [JsonSerializable(typeof(Version))]
+        [JsonSerializable(typeof(JsonDocument))]
+        [JsonSerializable(typeof(JsonElement))]
+        [JsonSerializable(typeof(JsonNode))]
+        [JsonSerializable(typeof(JsonValue))]
+        [JsonSerializable(typeof(JsonObject))]
+        [JsonSerializable(typeof(JsonArray))]
+        // Unsupported types
+        [JsonSerializable(typeof(Type))]
+        [JsonSerializable(typeof(MethodInfo))]
+        [JsonSerializable(typeof(UIntPtr))]
+        [JsonSerializable(typeof(MemberInfo))]
+        [JsonSerializable(typeof(SerializationInfo))]
+        [JsonSerializable(typeof(Func<int, int>))]
+        // Enum types
+        [JsonSerializable(typeof(IntEnum))]
+        [JsonSerializable(typeof(StringEnum))]
+        [JsonSerializable(typeof(FlagsStringEnum))]
+        // Nullable<T> types
+        [JsonSerializable(typeof(bool?))]
+        [JsonSerializable(typeof(int?))]
+        [JsonSerializable(typeof(double?))]
+        [JsonSerializable(typeof(Guid?))]
+        [JsonSerializable(typeof(JsonElement?))]
+        [JsonSerializable(typeof(IntEnum?))]
+        [JsonSerializable(typeof(StringEnum?))]
+        [JsonSerializable(typeof(SimpleRecordStruct?))]
+        // User-defined POCOs
+        [JsonSerializable(typeof(SimplePoco))]
+        [JsonSerializable(typeof(SimpleRecord))]
+        [JsonSerializable(typeof(SimpleRecordStruct))]
+        [JsonSerializable(typeof(RecordWithOptionalParameters))]
+        [JsonSerializable(typeof(PocoWithRequiredMembers))]
+        [JsonSerializable(typeof(PocoWithIgnoredMembers))]
+        [JsonSerializable(typeof(PocoWithCustomNaming))]
+        [JsonSerializable(typeof(PocoWithCustomNumberHandling))]
+        [JsonSerializable(typeof(PocoWithCustomNumberHandlingOnProperties))]
+        [JsonSerializable(typeof(PocoWithRecursiveMembers))]
+        [JsonSerializable(typeof(PocoWithRecursiveCollectionElement))]
+        [JsonSerializable(typeof(PocoWithRecursiveDictionaryValue))]
+        [JsonSerializable(typeof(PocoWithDescription))]
+        [JsonSerializable(typeof(PocoWithCustomConverter))]
+        [JsonSerializable(typeof(PocoWithCustomPropertyConverter))]
+        [JsonSerializable(typeof(PocoWithEnums))]
+        [JsonSerializable(typeof(PocoWithStructFollowedByNullableStruct))]
+        [JsonSerializable(typeof(PocoWithNullableStructFollowedByStruct))]
+        [JsonSerializable(typeof(PocoWithExtensionDataProperty))]
+        [JsonSerializable(typeof(PocoDisallowingUnmappedMembers))]
+        [JsonSerializable(typeof(PocoWithNullableAnnotationAttributes))]
+        [JsonSerializable(typeof(PocoWithNullableAnnotationAttributesOnConstructorParams))]
+        [JsonSerializable(typeof(PocoWithNullableConstructorParameter))]
+        [JsonSerializable(typeof(PocoWithOptionalConstructorParams))]
+        [JsonSerializable(typeof(GenericPocoWithNullableConstructorParameter<string>))]
+        [JsonSerializable(typeof(PocoWithPolymorphism))]
+        [JsonSerializable(typeof(DiscriminatedUnion))]
+        [JsonSerializable(typeof(NonAbstractClassWithSingleDerivedType))]
+        [JsonSerializable(typeof(PocoCombiningPolymorphicTypeAndDerivedTypes))]
+        [JsonSerializable(typeof(ClassWithComponentModelAttributes))]
+        [JsonSerializable(typeof(ClassWithJsonPointerEscapablePropertyNames))]
+        // Collection types
+        [JsonSerializable(typeof(int[]))]
+        [JsonSerializable(typeof(List<bool>))]
+        [JsonSerializable(typeof(HashSet<string>))]
+        [JsonSerializable(typeof(Queue<double>))]
+        [JsonSerializable(typeof(Stack<char>))]
+        [JsonSerializable(typeof(ImmutableArray<int>))]
+        [JsonSerializable(typeof(ImmutableList<string>))]
+        [JsonSerializable(typeof(ImmutableQueue<bool>))]
+        [JsonSerializable(typeof(object[]))]
+        [JsonSerializable(typeof(System.Collections.ArrayList))]
+        [JsonSerializable(typeof(Dictionary<string, int>))]
+        [JsonSerializable(typeof(SortedDictionary<int, string>))]
+        [JsonSerializable(typeof(Dictionary<string, SimplePoco>))]
+        [JsonSerializable(typeof(Dictionary<string, object>))]
+        [JsonSerializable(typeof(Hashtable))]
+        [JsonSerializable(typeof(StructDictionary<string, int>))]
+        public partial class TestTypesContext : JsonSerializerContext;
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
@@ -83,6 +83,8 @@
     <Compile Include="..\Common\JsonCreationHandlingTests.Generic.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonCreationHandlingTests.Generic.cs" />
     <Compile Include="..\Common\JsonCreationHandlingTests.Object.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonCreationHandlingTests.Object.cs" />
     <Compile Include="..\Common\JsonNumberTestData.cs" Link="CommonTest\System\Text\Json\Tests\JsonNumberTestData" />
+    <Compile Include="..\Common\JsonSchemaExporterTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonSchemaExporterTests.cs" />
+    <Compile Include="..\Common\JsonSchemaExporterTests.TestTypes.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonSchemaExporterTests.TestTypes.cs" />
     <Compile Include="..\Common\MetadataTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\MetadataTests\MetadataTests.cs" />
     <Compile Include="..\Common\MetadataTests.JsonSerializer.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\MetadataTests\MetadataTests.JsonSerializer.cs" />
     <Compile Include="..\Common\MetadataTests.Options.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\MetadataTests\MetadataTests.Options.cs"/>
@@ -122,6 +124,7 @@
     <Compile Include="Serialization\ExtensionDataTests.cs" />
     <Compile Include="JsonSourceGenerationOptionsTests.cs" />
     <Compile Include="Serialization\JsonCreationHandlingTests.cs" />
+    <Compile Include="Serialization\JsonSchemaExporterTests.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.IgnoreCycles.cs" />
     <Compile Include="Serialization\MetadataTests.cs" />
@@ -144,6 +147,11 @@
     <ProjectReference Include="..\..\src\System.Text.Json.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsVersion)"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JsonSchema.Net" Version="$(JsonSchemaNetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonSchemaExporterTests.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization.Tests;
+
+namespace System.Text.Json.Schema.Tests
+{
+    public sealed class JsonSchemaExporterTests_Reflection() : JsonSchemaExporterTests(JsonSerializerWrapper.StringSerializer);
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -67,6 +67,8 @@
     <Compile Include="..\Common\JsonCreationHandlingTests.Object.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonCreationHandlingTests.Object.cs" />
     <Compile Include="..\Common\JsonNumberTestData.cs" Link="CommonTest\System\Text\Json\Tests\JsonNumberTestData" />
     <Compile Include="..\Common\JsonSerializerWrapper.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonSerializerWrapper.cs" />
+    <Compile Include="..\Common\JsonSchemaExporterTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonSchemaExporterTests.cs" />
+    <Compile Include="..\Common\JsonSchemaExporterTests.TestTypes.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\JsonSchemaExporterTests.TestTypes.cs" />
     <Compile Include="..\Common\JsonTestHelper.cs" Link="CommonTest\System\Text\Json\JsonTestHelper.cs" />
     <Compile Include="..\Common\MetadataTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\MetadataTests\MetadataTests.cs" />
     <Compile Include="..\Common\MetadataTests.JsonSerializer.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\MetadataTests\MetadataTests.JsonSerializer.cs" />
@@ -175,6 +177,7 @@
     <Compile Include="Serialization\CustomConverterTests\CustomConverterTests.ValueTypedMember.cs" />
     <Compile Include="Serialization\CustomConverterTests\CustomConverterTests.cs" />
     <Compile Include="Serialization\JsonCreationHandlingTests.cs" />
+    <Compile Include="Serialization\JsonSchemaExporterTests.cs" />
     <Compile Include="Serialization\MetadataTests\DefaultJsonPropertyInfo.cs" />
     <Compile Include="Serialization\Pipe.WriteTests.cs" />
     <Compile Include="Serialization\RequiredKeywordTests.cs" />
@@ -311,9 +314,14 @@
     <ProjectReference Include="..\..\gen\System.Text.Json.SourceGeneration.Roslyn4.0.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <!-- Apple mobile trimming descriptor for Mono runtime -->
     <TrimmerRootDescriptor Condition="'$(TargetsAppleMobile)' == 'true' and '$(EnableAggressiveTrimming)' == 'true' and '$(UseNativeAotRuntime)' != 'true'" Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JsonSchema.Net" Version="$(JsonSchemaNetVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix #102788. This implementation differs somewhat compared to the [stj-schema-mapper](https://github.com/eiriktsarpalis/stj-schema-mapper) prototype in a few ways:

1. Nullable-oblivious reference types are always reported as nullable (this is controlled by a flag in the prototype).
2. The `OnSchemaNodeGenerated` callback is invoked for `$ref` schemas.
3. `$ref` schemas are only being generated for recursive types.
4. `{ }` and `{"not": true }` node schemas are normalized into `true` and `false` respectively.