### PR TITLE
update parsing for manually configured proxy on Windows

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpWindowsProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpWindowsProxy.cs
@@ -73,8 +73,8 @@ namespace System.Net.Http
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(proxyHelper, $"ManualSettingsUsed, {proxyHelper.Proxy}");
 
-                _secureProxy = MultiProxy.Parse(_failedProxies, proxyHelper.Proxy, true);
-                _insecureProxy = MultiProxy.Parse(_failedProxies, proxyHelper.Proxy, false);
+                _secureProxy = MultiProxy.ParseManualSettings(_failedProxies, proxyHelper.Proxy, true);
+                _insecureProxy = MultiProxy.ParseManualSettings(_failedProxies, proxyHelper.Proxy, false);
 
                 if (!string.IsNullOrWhiteSpace(proxyHelper.ProxyBypass))
                 {


### PR DESCRIPTION
Fixes #38670
Fixes #91045

The current behavior was intruded by  https://github.com/dotnet/corefx/pull/40082 to support multiple proxies. 
The logic for parsing PAC files was also applied to the manual proxy setting. 
But as the issues above noticed that does not quite reflect reality. 
The existing code assumes that ion the proxy location starts with `http://` it would apply only to HTTP (and not HTTPS traffic. In reality one can put `http://x.y.x/` string to the proxy location and all browsers would apply it to both http & https. 
If the string is prefixed with `http=` it is also respected e.g.  `http=http://x.y.x/` would apply only for HTTP and not HTTPS traffic. 

To limit regressions I split the logic and tests and I left PAC processing ASIS and I made small change to relax the restrictions if it comes from the manual settings location. 