### PR TITLE
[QUIC] Add platform guard to `IsSupported`

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -23,6 +23,9 @@ namespace System.Net.Quic
     public sealed partial class QuicConnection : System.IAsyncDisposable
     {
         internal QuicConnection() { }
+        [Runtime.Versioning.SupportedOSPlatformGuard("windows")]
+        [Runtime.Versioning.SupportedOSPlatformGuard("linux")]
+        [Runtime.Versioning.SupportedOSPlatformGuard("osx")]
         public static bool IsSupported { get { throw null; } }
         public System.Net.IPEndPoint LocalEndPoint { get { throw null; } }
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
@@ -73,6 +76,9 @@ namespace System.Net.Quic
     public sealed partial class QuicListener : System.IAsyncDisposable
     {
         internal QuicListener() { }
+        [Runtime.Versioning.SupportedOSPlatformGuard("windows")]
+        [Runtime.Versioning.SupportedOSPlatformGuard("linux")]
+        [Runtime.Versioning.SupportedOSPlatformGuard("osx")]
         public static bool IsSupported { get { throw null; } }
         public System.Net.IPEndPoint LocalEndPoint { get { throw null; } }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicConnection> AcceptConnectionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.Unsupported.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.Unsupported.cs
@@ -1,9 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.Quic;
 
 public sealed partial class QuicConnection
 {
+    [SupportedOSPlatformGuard("windows")]
+    [SupportedOSPlatformGuard("linux")]
+    [SupportedOSPlatformGuard("osx")]
     public static bool IsSupported => false;
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Channels;
@@ -44,6 +45,9 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// The current implementation depends on <see href="https://github.com/microsoft/msquic">MsQuic</see> native library, this property checks its presence (Linux machines).
     /// It also checks whether TLS 1.3, requirement for QUIC protocol, is available and enabled (Windows machines).
     /// </remarks>
+    [SupportedOSPlatformGuard("windows")]
+    [SupportedOSPlatformGuard("linux")]
+    [SupportedOSPlatformGuard("osx")]
     public static bool IsSupported => MsQuicApi.IsQuicSupported;
 
     /// <summary>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.Unsupported.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.Unsupported.cs
@@ -1,9 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.Quic;
 
 public sealed partial class QuicListener
 {
+    [SupportedOSPlatformGuard("windows")]
+    [SupportedOSPlatformGuard("linux")]
+    [SupportedOSPlatformGuard("osx")]
     public static bool IsSupported => false;
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -6,6 +6,7 @@ using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Channels;
@@ -36,6 +37,9 @@ public sealed partial class QuicListener : IAsyncDisposable
     /// The current implementation depends on <see href="https://github.com/microsoft/msquic">MsQuic</see> native library, this property checks its presence (Linux machines).
     /// It also checks whether TLS 1.3, requirement for QUIC protocol, is available and enabled (Windows machines).
     /// </remarks>
+    [SupportedOSPlatformGuard("windows")]
+    [SupportedOSPlatformGuard("linux")]
+    [SupportedOSPlatformGuard("osx")]
     public static bool IsSupported => MsQuicApi.IsQuicSupported;
 
     /// <summary>


### PR DESCRIPTION
This should make the `IsSupported` properties **not** trigger the compiler warning about using unsupported API,  in other words avoiding this:
```
warning CA1416: This call site is reachable on all platforms. 'QuicListener.IsSupported' is only supported on: 'linux', 'macOS/OSX', 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
```
for a simple:
```C#
if (QuicListener.IsSupported)
{
    ...
}
```

We might even try if we could get away with using the `QuicConnection.IsSupported` as a trimming guard (instead of `IsHttp3Supported()`) in HTTP code.

EDIT: Analyzer is in main. ~PR as a draft for now since it depends on https://github.com/dotnet/roslyn-analyzers/pull/7326~
