### PR TITLE
Remove the OCSP nonce

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -485,7 +485,6 @@ extern bool g_libSslUses32BitTime;
     REQUIRED_FUNCTION(OCSP_cert_to_id) \
     REQUIRED_FUNCTION(OCSP_check_nonce) \
     REQUIRED_FUNCTION(OCSP_request_add0_id) \
-    REQUIRED_FUNCTION(OCSP_request_add1_nonce) \
     REQUIRED_FUNCTION(OCSP_REQUEST_free) \
     REQUIRED_FUNCTION(OCSP_REQUEST_new) \
     REQUIRED_FUNCTION(OCSP_resp_find_status) \
@@ -1014,7 +1013,6 @@ extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
 #define OCSP_check_nonce OCSP_check_nonce_ptr
 #define OCSP_CERTID_free OCSP_CERTID_free_ptr
 #define OCSP_request_add0_id OCSP_request_add0_id_ptr
-#define OCSP_request_add1_nonce OCSP_request_add1_nonce_ptr
 #define OCSP_REQUEST_free OCSP_REQUEST_free_ptr
 #define OCSP_REQUEST_new OCSP_REQUEST_new_ptr
 #define OCSP_resp_find_status OCSP_resp_find_status_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -946,7 +946,8 @@ static X509VerifyStatusCode CheckOcspGetExpiry(OCSP_REQUEST* req,
         int nonceCheck = req == NULL ? 1 : OCSP_check_nonce(req, basicResp);
 
         // Treat "response has no nonce" as success, since not all responders set the nonce.
-        if (nonceCheck == -1)
+        // Treat "neither has a nonce" as success, since we do not send nonces in our requests.
+        if (nonceCheck == -1 || nonceCheck == 2)
         {
             nonceCheck = 1;
         }

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -1188,8 +1188,9 @@ static OCSP_REQUEST* BuildOcspRequest(X509* subject, X509* issuer)
     // Ownership was successfully transferred to req
     certId = NULL;
 
-    // Add a random nonce.
-    OCSP_request_add1_nonce(req, NULL, -1);
+    // We return the request without setting a nonce on it. Most public CA OCSP responders ignore the nonce, and in some
+    // cases flat out error when presented with a nonce.
+    // This behavior also matches Windows and Apple platforms.
     return req;
 }
 


### PR DESCRIPTION
Context and reasoning is explained as a comment.