### PR TITLE
Support overriding MsQuic.dll in the application directory on Windows.

### DIFF
--- a/src/libraries/Common/src/System/AppContextSwitchHelper.cs
+++ b/src/libraries/Common/src/System/AppContextSwitchHelper.cs
@@ -12,6 +12,11 @@ namespace System
 
         internal static bool GetBooleanConfig(string switchName, string envVariable, bool defaultValue = false)
         {
+            if (AppContext.TryGetSwitch(switchName, out bool value))
+            {
+                return value;
+            }
+
             if (Environment.GetEnvironmentVariable(envVariable) is string str)
             {
                 if (str == "1" || string.Equals(str, bool.TrueString, StringComparison.OrdinalIgnoreCase))
@@ -24,7 +29,7 @@ namespace System
                 }
             }
 
-            return GetBooleanConfig(switchName, defaultValue);
+            return defaultValue;
         }
     }
 }

--- a/src/libraries/Common/src/System/AppContextSwitchHelper.cs
+++ b/src/libraries/Common/src/System/AppContextSwitchHelper.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace System
+{
+    internal static class AppContextSwitchHelper
+    {
+        internal static bool GetBooleanConfig(string switchName, bool defaultValue) =>
+            AppContext.TryGetSwitch(switchName, out bool value) ? value : defaultValue;
+
+        internal static bool GetBooleanConfig(string switchName, string envVariable, bool defaultValue = false)
+        {
+            if (Environment.GetEnvironmentVariable(envVariable) is string str)
+            {
+                if (str == "1" || string.Equals(str, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                if (str == "1" || string.Equals(str, bool.FalseString, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return GetBooleanConfig(switchName, defaultValue);
+        }
+    }
+}

--- a/src/libraries/Common/src/System/AppContextSwitchHelper.cs
+++ b/src/libraries/Common/src/System/AppContextSwitchHelper.cs
@@ -23,7 +23,7 @@ namespace System
                 {
                     return true;
                 }
-                if (str == "1" || string.Equals(str, bool.FalseString, StringComparison.OrdinalIgnoreCase))
+                if (str == "0" || string.Equals(str, bool.FalseString, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }

--- a/src/libraries/Common/src/System/AppContextSwitchHelper.cs
+++ b/src/libraries/Common/src/System/AppContextSwitchHelper.cs
@@ -7,7 +7,7 @@ namespace System
 {
     internal static class AppContextSwitchHelper
     {
-        internal static bool GetBooleanConfig(string switchName, bool defaultValue) =>
+        internal static bool GetBooleanConfig(string switchName, bool defaultValue = false) =>
             AppContext.TryGetSwitch(switchName, out bool value) ? value : defaultValue;
 
         internal static bool GetBooleanConfig(string switchName, string envVariable, bool defaultValue = false)

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -25,6 +25,7 @@
     <Compile Include="System\Net\Quic\**\*.cs" Exclude="System\Net\Quic\*.Unsupported.cs"/>
     <!-- System.Net common -->
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
+    <Compile Include="$(CommonPath)System\AppContextSwitchHelper.cs" Link="Common\System\AppContextSwitchHelper.cs" />
     <Compile Include="$(CommonPath)System\Net\SafeHandleCache.cs" Link="Common\System\Net\SafeHandleCache.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="Common\System\Net\ArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="Common\System\Net\MultiArrayBuffer.cs" />

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -280,5 +280,7 @@ internal sealed unsafe partial class MsQuicApi
         return false;
     }
 
-    private static bool AllowAppLocalMsQuic() => AppContextSwitchHelper.GetBooleanConfig("System.Net.Quic.AppLocalMsQuic", "DOTNET_SYSTEM_NET_QUIC_APPLOCALMSQUIC");
+    private static bool IsAppLocalMsQuicAllowed() => AppContextSwitchHelper.GetBooleanConfig(
+        "System.Net.Quic.AppLocalMsQuic",
+        "DOTNET_SYSTEM_NET_QUIC_APPLOCALMSQUIC");
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -95,7 +95,7 @@ internal sealed unsafe partial class MsQuicApi
             // Windows ships msquic in the assembly directory next to System.Net.Quic, so load that.
             // For single-file deployments, the assembly location is an empty string so we fall back
             // to AppContext.BaseDirectory which is the directory containing the single-file executable.
-            string path = typeof(MsQuicApi).Assembly.Location is string assemblyLocation && !string.IsNullOrEmpty(assemblyLocation) && !AllowAppLocalMsQuic()
+            string path = !ShouldUseAppLocalMsQuic() && typeof(MsQuicApi).Assembly.Location is string assemblyLocation && !string.IsNullOrEmpty(assemblyLocation)
                 ? System.IO.Path.GetDirectoryName(assemblyLocation)!
                 : AppContext.BaseDirectory;
 
@@ -280,7 +280,6 @@ internal sealed unsafe partial class MsQuicApi
         return false;
     }
 
-    private static bool IsAppLocalMsQuicAllowed() => AppContextSwitchHelper.GetBooleanConfig(
-        "System.Net.Quic.AppLocalMsQuic",
-        "DOTNET_SYSTEM_NET_QUIC_APPLOCALMSQUIC");
+    private static bool ShouldUseAppLocalMsQuic() => AppContextSwitchHelper.GetBooleanConfig(
+        "System.Net.Quic.AppLocalMsQuic");
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -76,7 +76,7 @@ internal sealed unsafe partial class MsQuicApi
     static MsQuicApi()
     {
         bool loaded = false;
-        IntPtr msQuicHandle;
+        IntPtr msQuicHandle = IntPtr.Zero;
         Version = default;
 
         // MsQuic is using DualMode sockets and that will fail even for IPv4 if AF_INET6 is not available.
@@ -95,7 +95,7 @@ internal sealed unsafe partial class MsQuicApi
             // Windows ships msquic in the assembly directory next to System.Net.Quic, so load that.
             // For single-file deployments, the assembly location is an empty string so we fall back
             // to AppContext.BaseDirectory which is the directory containing the single-file executable.
-            string path = typeof(MsQuicApi).Assembly.Location is string assemblyLocation && !string.IsNullOrEmpty(assemblyLocation)
+            string path = typeof(MsQuicApi).Assembly.Location is string assemblyLocation && !string.IsNullOrEmpty(assemblyLocation) && !AllowAppLocalMsQuic()
                 ? System.IO.Path.GetDirectoryName(assemblyLocation)!
                 : AppContext.BaseDirectory;
 
@@ -279,4 +279,6 @@ internal sealed unsafe partial class MsQuicApi
 #endif
         return false;
     }
+
+    private static bool AllowAppLocalMsQuic() => AppContextSwitchHelper.GetBooleanConfig("System.Net.Quic.AppLocalMsQuic", "DOTNET_SYSTEM_NET_QUIC_APPLOCALMSQUIC");
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
+using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Quic;
 using static Microsoft.Quic.MsQuic;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.Cache.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.Cache.cs
@@ -16,27 +16,9 @@ namespace System.Net.Quic;
 
 internal static partial class MsQuicConfiguration
 {
-    private const string DisableCacheEnvironmentVariable = "DOTNET_SYSTEM_NET_QUIC_DISABLE_CONFIGURATION_CACHE";
-    private const string DisableCacheCtxSwitch = "System.Net.Quic.DisableConfigurationCache";
-
-    internal static bool ConfigurationCacheEnabled { get; } = GetConfigurationCacheEnabled();
-
-    private static bool GetConfigurationCacheEnabled()
-    {
-        // AppContext switch takes precedence
-        if (AppContext.TryGetSwitch(DisableCacheCtxSwitch, out bool value))
-        {
-            return !value;
-        }
-        // check environment variable second
-        else if (Environment.GetEnvironmentVariable(DisableCacheEnvironmentVariable) is string envVar)
-        {
-            return !(envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
-        }
-
-        // enabled by default
-        return true;
-    }
+    internal static bool ConfigurationCacheEnabled { get; } = !AppContextSwitchHelper.GetBooleanConfig(
+        "System.Net.Quic.DisableConfigurationCache",
+        "DOTNET_SYSTEM_NET_QUIC_DISABLE_CONFIGURATION_CACHE");
 
     private static readonly MsQuicConfigurationCache s_configurationCache = new MsQuicConfigurationCache();
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -720,7 +720,7 @@ namespace System.Net.Quic.Tests
             await serverConnection.DisposeAsync();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(QuicTestCollection), nameof(QuicTestCollection.IsUsingSchannelBackend))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public async Task Server_CertificateWithEphemeralKey_Throws()
         {
@@ -764,7 +764,7 @@ namespace System.Net.Quic.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(QuicTestCollection), nameof(QuicTestCollection.IsUsingSchannelBackend))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public async Task Client_CertificateWithEphemeralKey_Throws()
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -44,6 +44,18 @@ namespace System.Net.Quic.Tests
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
         public static TimeSpan PassingTestTimeout => TimeSpan.FromMilliseconds(PassingTestTimeoutMilliseconds);
 
+        static QuicTestBase()
+        {
+            // Opt in to run with OpenSSL version on MsQuic on older windows where Schannel
+            // version is not supported.
+            //
+            // This has to happen here in order to be called before QuicTestBase.IsSupported
+            if (PlatformDetection.IsWindows && !QuicTestCollection.IsWindowsVersionWithSchannelSupport())
+            {
+                AppContext.SetSwitch("System.Net.Quic.AppLocalMsQuic", true);
+            }
+        }
+
         public QuicTestBase(ITestOutputHelper output)
         {
             _output = output;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -50,7 +50,7 @@ namespace System.Net.Quic.Tests
             // version is not supported.
             //
             // This has to happen here in order to be called before QuicTestBase.IsSupported
-            if (PlatformDetection.IsWindows && !QuicTestCollection.IsWindowsVersionWithSchannelSupport())
+            if (PlatformDetection.IsWindows && !QuicTestCollection.IsWindowsVersionWithSchannelSupport() && PlatformDetection.IsWindows10OrLater)
             {
                 AppContext.SetSwitch("System.Net.Quic.AppLocalMsQuic", true);
             }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -50,7 +50,7 @@ namespace System.Net.Quic.Tests
             // version is not supported.
             //
             // This has to happen here in order to be called before QuicTestBase.IsSupported
-            if (PlatformDetection.IsWindows && !QuicTestCollection.IsWindowsVersionWithSchannelSupport() && PlatformDetection.IsWindows10OrLater)
+            if (PlatformDetection.IsWindows10OrLater && !QuicTestCollection.IsWindowsVersionWithSchannelSupport())
             {
                 AppContext.SetSwitch("System.Net.Quic.AppLocalMsQuic", true);
             }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -28,7 +28,7 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
         string msQuicLibraryVersion = GetMsQuicLibraryVersion();
         string tlsBackend = IsUsingSchannelBackend() ? "Schannel" : "OpenSSL";
         // If any of the reflection bellow breaks due to changes in "System.Net.Quic.MsQuicApi", also check and fix HttpStress project as it uses the same hack.
-        Console.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{msQuicLibraryVersion}' {(IsSupported ? "({tlsBackend})" : "")}.");
+        Console.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{msQuicLibraryVersion}' {(IsSupported ? $"({tlsBackend})" : "")}.");
 
         if (IsSupported)
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -102,8 +102,7 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
     {
         // copied from MsQuicApi implementation to avoid triggering the static constructor
         Version minWindowsVersion = new Version(10, 0, 20145, 1000);
-        return OperatingSystem.IsWindowsVersionAtLeast(minWindowsVersion.Major,
-        minWindowsVersion.Minor, minWindowsVersion.Build, minWindowsVersion.Revision);
+        return OperatingSystem.IsWindowsVersionAtLeast(minWindowsVersion.Major, minWindowsVersion.Minor, minWindowsVersion.Build, minWindowsVersion.Revision);
     }
 
     private static Version GetMsQuicVersion()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -28,7 +28,7 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
         string msQuicLibraryVersion = GetMsQuicLibraryVersion();
         string tlsBackend = IsUsingSchannelBackend() ? "Schannel" : "OpenSSL";
         // If any of the reflection bellow breaks due to changes in "System.Net.Quic.MsQuicApi", also check and fix HttpStress project as it uses the same hack.
-        Console.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{msQuicLibraryVersion}' ({tlsBackend}).");
+        Console.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{msQuicLibraryVersion}' {(IsSupported ? "({tlsBackend})" : "")}.");
 
         if (IsSupported)
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -98,6 +98,14 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
         Console.WriteLine($"Unobserved exceptions of {s_unobservedExceptions.Count} different types: {Environment.NewLine}{string.Join(Environment.NewLine + new string('=', 120) + Environment.NewLine, s_unobservedExceptions.Select(pair => $"Count {pair.Value}: {pair.Key}"))}");
     }
 
+    internal static bool IsWindowsVersionWithSchannelSupport()
+    {
+        // copied from MsQuicApi implementation to avoid triggering the static constructor
+        Version minWindowsVersion = new Version(10, 0, 20145, 1000);
+        return OperatingSystem.IsWindowsVersionAtLeast(minWindowsVersion.Major,
+        minWindowsVersion.Minor, minWindowsVersion.Build, minWindowsVersion.Revision);
+    }
+
     private static Version GetMsQuicVersion()
     {
         Type msQuicApiType = Type.GetType("System.Net.Quic.MsQuicApi, System.Net.Quic");
@@ -110,13 +118,6 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
         Type msQuicApiType = Type.GetType("System.Net.Quic.MsQuicApi, System.Net.Quic");
 
         return (string)msQuicApiType.GetProperty("MsQuicLibraryVersion", BindingFlags.NonPublic | BindingFlags.Static).GetGetMethod(true).Invoke(null, Array.Empty<object?>());
-    }
-
-    internal static bool IsWindowsVersionWithSchannelSupport()
-    {
-        Type msQuicApiType = Type.GetType("System.Net.Quic.MsQuicApi, System.Net.Quic");
-
-        return (bool)msQuicApiType.GetMethod("IsWindowsVersionSupported", BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, Array.Empty<object?>());
     }
 
     internal static bool IsUsingSchannelBackend()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -26,8 +26,9 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
     public QuicTestCollection()
     {
         string msQuicLibraryVersion = GetMsQuicLibraryVersion();
+        string tlsBackend = IsUsingSchannelBackend() ? "Schannel" : "OpenSSL";
         // If any of the reflection bellow breaks due to changes in "System.Net.Quic.MsQuicApi", also check and fix HttpStress project as it uses the same hack.
-        Console.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{msQuicLibraryVersion}'.");
+        Console.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{msQuicLibraryVersion}' ({tlsBackend}).");
 
         if (IsSupported)
         {
@@ -109,6 +110,20 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
         Type msQuicApiType = Type.GetType("System.Net.Quic.MsQuicApi, System.Net.Quic");
 
         return (string)msQuicApiType.GetProperty("MsQuicLibraryVersion", BindingFlags.NonPublic | BindingFlags.Static).GetGetMethod(true).Invoke(null, Array.Empty<object?>());
+    }
+
+    internal static bool IsWindowsVersionWithSchannelSupport()
+    {
+        Type msQuicApiType = Type.GetType("System.Net.Quic.MsQuicApi, System.Net.Quic");
+
+        return (bool)msQuicApiType.GetMethod("IsWindowsVersionSupported", BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, Array.Empty<object?>());
+    }
+
+    internal static bool IsUsingSchannelBackend()
+    {
+        Type msQuicApiType = Type.GetType("System.Net.Quic.MsQuicApi, System.Net.Quic");
+
+        return (bool)msQuicApiType.GetProperty("UsesSChannelBackend", BindingFlags.NonPublic | BindingFlags.Static).GetGetMethod(true).Invoke(null, Array.Empty<object?>());
     }
 
     private static QUIC_API_TABLE* GetApiTable()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -54,7 +54,7 @@
 
   </ItemGroup>
   <Target Name="CopyCustomContent" AfterTargets="Build" BeforeTargets="PrepareForRun" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
-      <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(OutDir)" />
   </Target>
   <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish" BeforeTargets="PrepareForRun" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
     <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(PublishDir)" />

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -53,10 +53,10 @@
                       GeneratePathProperty="true" />
 
   </ItemGroup>
-  <Target Name="CopyCustomContent" AfterTargets="AfterBuild" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+  <Target Name="CopyCustomContent" AfterTargets="Build" BeforeTargets="PrepareForRun" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
       <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(OutDir)" />
   </Target>
-  <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+  <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish" BeforeTargets="PrepareForRun" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
     <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(PublishDir)" />
   </Target>
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -42,4 +42,22 @@
   <ItemGroup>
     <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataVersion)" />
   </ItemGroup>
+
+  <!-- Support running tests on older windows by explicitly including OpenSSL version of MsQuic,
+       The binary will be used only if "System.Net.Quic.AppLocalMsQuic" appctx switch is 'true',
+       Which we manually flip in the test setup on appropriate platform. -->
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+    <PackageReference Include="Microsoft.Native.Quic.MsQuic.OpenSSL"
+                      Version="$(MicrosoftNativeQuicMsQuicSchannelVersion)"
+                      PrivateAssets="all"
+                      GeneratePathProperty="true" />
+
+  </ItemGroup>
+  <Target Name="CopyCustomContent" AfterTargets="AfterBuild" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+      <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(OutDir)" />
+  </Target>
+  <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish" Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+    <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(PublishDir)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Closes #101200.

This PR allows (via some explicit user action) to use OpenSSL version of MsQuic to enable use of System.Net.Quic on Windows 10 and other OSes where the Schannel build of MsQuic is not supported.

To use OpenSSL build of MsQuic, you can use e.g. the following snippet in csproj.

```xml
  <ItemGroup>
    <PackageReference Include="Microsoft.Native.Quic.MsQuic.OpenSSL"
                      Version="2.3.5"
                      PrivateAssets="all"
                      GeneratePathProperty="true" />

    <RuntimeHostConfigurationOption Include="System.Net.Quic.AppLocalMsQuic" Value="true" />
  </ItemGroup>

  <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
    <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(OutDir)" />
  </Target>
  <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish">
    <Copy SourceFiles="$(PkgMicrosoft_Native_Quic_MsQuic_OpenSSL)\build\native\bin\x64\msquic.dll" DestinationFolder="$(PublishDir)" />
  </Target>

```