### PR TITLE
Optimize DateOnly properties and deconstruct

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -76,11 +76,11 @@ namespace System
         // Number of days in a non-leap year
         private const int DaysPerYear = 365;
         // Number of days in 4 years
-        private const int DaysPer4Years = DaysPerYear * 4 + 1;       // 1461
+        internal const int DaysPer4Years = DaysPerYear * 4 + 1;       // 1461
         // Number of days in 100 years
         private const int DaysPer100Years = DaysPer4Years * 25 - 1;  // 36524
         // Number of days in 400 years
-        private const int DaysPer400Years = DaysPer100Years * 4 + 1; // 146097
+        internal const int DaysPer400Years = DaysPer100Years * 4 + 1; // 146097
 
         // Number of days from 1/1/0001 to 12/31/1600
         private const int DaysTo1601 = DaysPer400Years * 4;          // 584388
@@ -89,7 +89,7 @@ namespace System
         // Number of days from 1/1/0001 to 12/31/1969
         internal const int DaysTo1970 = DaysPer400Years * 4 + DaysPer100Years * 3 + DaysPer4Years * 17 + DaysPerYear; // 719,162
         // Number of days from 1/1/0001 to 12/31/9999
-        private const int DaysTo10000 = DaysPer400Years * 25 - 366;  // 3652059
+        internal const int DaysTo10000 = DaysPer400Years * 25 - 366;  // 3652059
 
         internal const long MinTicks = 0;
         internal const long MaxTicks = DaysTo10000 * TicksPerDay - 1;
@@ -116,11 +116,11 @@ namespace System
         // Constants used for fast calculation of following subexpressions
         //      x / DaysPer4Years
         //      x % DaysPer4Years / 4
-        private const uint EafMultiplier = (uint)(((1UL << 32) + DaysPer4Years - 1) / DaysPer4Years);   // 2,939,745
-        private const uint EafDivider = EafMultiplier * 4;                                              // 11,758,980
+        internal const uint EafMultiplier = (uint)(((1UL << 32) + DaysPer4Years - 1) / DaysPer4Years);   // 2,939,745
+        internal const uint EafDivider = EafMultiplier * 4;                                              // 11,758,980
 
         private const ulong TicksPer6Hours = TicksPerHour * 6;
-        private const int March1BasedDayOfNewYear = 306;              // Days between March 1 and January 1
+        internal const int March1BasedDayOfNewYear = 306;              // Days between March 1 and January 1
 
         internal static ReadOnlySpan<uint> DaysToMonth365 => [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365];
         internal static ReadOnlySpan<uint> DaysToMonth366 => [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366];

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
@@ -41,19 +41,7 @@ namespace System.Globalization
         internal const int MillisPerHour = MillisPerMinute * 60;
         internal const int MillisPerDay = MillisPerHour * 24;
 
-        // Number of days in a non-leap year
-        internal const int DaysPerYear = 365;
-        // Number of days in 4 years
-        internal const int DaysPer4Years = DaysPerYear * 4 + 1;
-        // Number of days in 100 years
-        internal const int DaysPer100Years = DaysPer4Years * 25 - 1;
-        // Number of days in 400 years
-        internal const int DaysPer400Years = DaysPer100Years * 4 + 1;
-
-        // Number of days from 1/1/0001 to 1/1/10000
-        internal const int DaysTo10000 = DaysPer400Years * 25 - 366;
-
-        internal const long MaxMillis = (long)DaysTo10000 * MillisPerDay;
+        internal const long MaxMillis = (long)DateTime.DaysTo10000 * MillisPerDay;
 
         private int _currentEraValue = -1;
 


### PR DESCRIPTION
Algorithms are modified copies of the respective `DateTime` properties (and `GetDate` method).

It is possible to make the code shared between `DateTime` and `DateOnly`. Could probably be done with an input "six hour count", but it feels a bit weird. Opinions?

Benchmark results ([source](https://github.com/dotnet/performance/blob/10a3e2e6c4c4724b202e269a3361c86b8da82cbd/src/benchmarks/micro/libraries/System.Runtime/Perf.TestPr.cs)): 
```
| Method               | Job        | value      | Mean      | Error     | StdDev    | Median    | Min       | Max       | Ratio | RatioSD | Allocated | Alloc Ratio |
|--------------------- |----------- |----------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
| DateOnly_Year        | main       | 2024-06-12 | 0.8427 ns | 0.0283 ns | 0.0236 ns | 0.8522 ns | 0.7961 ns | 0.8689 ns |  1.00 |    0.04 |         - |          NA |
| DateOnly_Year        | pr         | 2024-06-12 | 0.2751 ns | 0.0086 ns | 0.0067 ns | 0.2786 ns | 0.2601 ns | 0.2794 ns |  0.33 |    0.01 |         - |          NA |
| DateOnly_Month       | main       | 2024-06-12 | 3.2173 ns | 0.0443 ns | 0.0392 ns | 3.2148 ns | 3.1718 ns | 3.2948 ns |  1.00 |    0.02 |         - |          NA |
| DateOnly_Month       | pr         | 2024-06-12 | 1.2608 ns | 0.0096 ns | 0.0090 ns | 1.2587 ns | 1.2493 ns | 1.2742 ns |  0.39 |    0.01 |         - |          NA |
| DateOnly_Day         | main       | 2024-06-12 | 2.9684 ns | 0.0451 ns | 0.0399 ns | 2.9505 ns | 2.9356 ns | 3.0554 ns |  1.00 |    0.02 |         - |          NA |
| DateOnly_Day         | pr         | 2024-06-12 | 1.1118 ns | 0.0086 ns | 0.0076 ns | 1.1123 ns | 1.0947 ns | 1.1211 ns |  0.37 |    0.01 |         - |          NA |
| DateOnly_DayOfYear   | main       | 2024-06-12 | 0.8781 ns | 0.0075 ns | 0.0063 ns | 0.8777 ns | 0.8680 ns | 0.8878 ns |  1.00 |    0.01 |         - |          NA |
| DateOnly_DayOfYear   | pr         | 2024-06-12 | 0.1715 ns | 0.0087 ns | 0.0081 ns | 0.1737 ns | 0.1586 ns | 0.1822 ns |  0.20 |    0.01 |         - |          NA |
| DateOnly_Deconstruct | main       | 2024-06-12 | 5.2509 ns | 0.0390 ns | 0.0364 ns | 5.2378 ns | 5.2140 ns | 5.3214 ns |  1.00 |    0.01 |         - |          NA |
| DateOnly_Deconstruct | pr         | 2024-06-12 | 4.6530 ns | 0.0267 ns | 0.0236 ns | 4.6589 ns | 4.6075 ns | 4.6817 ns |  0.89 |    0.01 |         - |          NA |
```