### PR TITLE
Ensure that the CvtVectorToMask node is inserted in the right place

### DIFF
--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -157,8 +157,6 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
     // Replace "tree" with "call"
     if (parents.Height() > 1)
     {
-        GenTree* tmpInsertionPoint = insertionPoint;
-
         if (tmpNum != BAD_VAR_NUM)
         {
             result = comp->gtNewLclvNode(tmpNum, retType);
@@ -169,18 +167,17 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
 #if defined(FEATURE_HW_INTRINSICS)
             // No managed call returns TYP_MASK, so convert it from a TYP_SIMD
 
-            var_types simdType = tree->TypeGet();
-            assert(varTypeIsSIMD(simdType));
-
             unsigned    simdSize;
             CorInfoType simdBaseJitType = comp->getBaseJitTypeAndSizeOfSIMDType(call->gtRetClsHnd, &simdSize);
             assert(simdSize != 0);
 
-            GenTree* cvtNode = comp->gtNewSimdCvtVectorToMaskNode(TYP_MASK, result, simdBaseJitType, simdSize);
-            BlockRange().InsertAfter(insertionPoint, LIR::Range(comp->fgSetTreeSeq(cvtNode), cvtNode));
-            result = cvtNode;
+            result = comp->gtNewSimdCvtVectorToMaskNode(TYP_MASK, result, simdBaseJitType, simdSize);
 
-            tmpInsertionPoint = result;
+            if (tmpNum == BAD_VAR_NUM)
+            {
+                // Propagate flags of "call" to its parent.
+                result->gtFlags |= (call->gtFlags & GTF_ALL_EFFECT) | GTF_CALL;
+            }
 #else
             unreached();
 #endif // FEATURE_HW_INTRINSICS
@@ -190,8 +187,23 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
 
         if (tmpNum != BAD_VAR_NUM)
         {
+            // We have a return buffer, so we need to insert both the result and the call
+            // since they are independent trees. If we have a convert node, it will indirectly
+            // insert the local node.
+
             comp->gtSetEvalOrder(result);
-            BlockRange().InsertAfter(tmpInsertionPoint, LIR::Range(comp->fgSetTreeSeq(result), result));
+            BlockRange().InsertAfter(insertionPoint, LIR::Range(comp->fgSetTreeSeq(result), result));
+
+            comp->gtSetEvalOrder(call);
+            BlockRange().InsertAfter(insertionPoint, LIR::Range(comp->fgSetTreeSeq(call), call));
+        }
+        else
+        {
+            // We don't have a return buffer, so we only need to insert the result, which
+            // will indirectly insert the call in the case we have a convert node as well.
+
+            comp->gtSetEvalOrder(result);
+            BlockRange().InsertAfter(insertionPoint, LIR::Range(comp->fgSetTreeSeq(result), result));
         }
     }
     else
@@ -199,18 +211,20 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
         // If there's no parent, the tree being replaced is the root of the
         // statement (and no special handling is necessary).
         *use = result;
+
+        comp->gtSetEvalOrder(call);
+        BlockRange().InsertAfter(insertionPoint, LIR::Range(comp->fgSetTreeSeq(call), call));
     }
 
-    comp->gtSetEvalOrder(call);
-    BlockRange().InsertAfter(insertionPoint, LIR::Range(comp->fgSetTreeSeq(call), call));
-
-    if (result == call)
+    if (tmpNum == BAD_VAR_NUM)
     {
         // Propagate flags of "call" to its parents.
+        GenTreeFlags callFlags = (call->gtFlags & GTF_ALL_EFFECT) | GTF_CALL;
+
         // 0 is current node, so start at 1
         for (int i = 1; i < parents.Height(); i++)
         {
-            parents.Top(i)->gtFlags |= (call->gtFlags & GTF_ALL_EFFECT) | GTF_CALL;
+            parents.Top(i)->gtFlags |= callFlags;
         }
     }
     else


### PR DESCRIPTION
This fixes
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static Vector<byte> M3(SveMaskPattern pattern)
{
    return Sve.CreateTrueMaskByte(pattern);
}
```

Which now correctly generates
```asm
; Method Program:M3(ubyte):System.Numerics.Vector`1[ubyte] (FullOpts)
G_M15394_IG01:  ;; offset=0x0000
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp
						;; size=8 bbWeight=1 PerfScore 1.50

G_M15394_IG02:  ;; offset=0x0008
            uxtb    w0, w0
            movz    x1, #0x6E98      // code for System.Runtime.Intrinsics.Arm.Sve:CreateTrueMaskByte(ubyte):System.Numerics.Vector`1[ubyte]
            movk    x1, #0xE7A8 LSL #16
            movk    x1, #0x7FFC LSL #32
            ldr     x1, [x1]
            blr     x1
            ptrue   p7.b
            cmpne   p0.b, p7/z, z0.b, #0
            mov     z0.b, p0/z, #1
						;; size=36 bbWeight=1 PerfScore 13.00

G_M15394_IG03:  ;; offset=0x002C
            ldp     fp, lr, [sp], #0x10
            ret     lr
						;; size=8 bbWeight=1 PerfScore 2.00
; Total bytes of code: 52
```


Which is to say the IR:
```
N005 (  6,  7) [000003] --C--------                         *  RETURN    simd16 $VN.Void
N004 (  5,  6) [000002] --C--------                         \--*  HWINTRINSIC simd16 ubyte ConvertMaskToVector $200
N003 (  4,  5) [000001] --C--------                            \--*  HWINTRINSIC mask   ubyte CreateTrueMaskByte $140
N002 (  3,  4) [000004] -----------                               \--*  CAST      int <- ubyte <- int $100
N001 (  2,  2) [000000] -----------                                  \--*  LCL_VAR   int    V00 arg0         u:1 (last use) $80
```

rationalizes into:
```
               [000005] -----------                            IL_OFFSET void   INLRT @ 0x000[E-]
N001 (  2,  2) [000000] -----------                    t0 =    LCL_VAR   int    V00 arg0         u:1 (last use) $80
                                                            /--*  t0     int    
N002 (  3,  4) [000004] -----------                    t4 = *  CAST      int <- ubyte <- int $100
                                                            /--*  t4     int    arg0 in x0
N003 ( 17,  7) [000006] --C-G------                    t6 = *  CALL      simd16 System.Runtime.Intrinsics.Arm.Sve:CreateTrueMaskByte(ubyte):System.Numerics.Vector`1[ubyte]
N004 (  1,  1) [000007] -----------                    t7 =    HWINTRINSIC mask   ubyte CreateTrueMaskAll
                                                            /--*  t7     mask   
                                                            +--*  t6     simd16 
N005 ( 19,  9) [000008] --C-G------                    t8 = *  HWINTRINSIC mask   ubyte ConvertVectorToMask
                                                            /--*  t8     mask   
N004 (  5,  6) [000002] --C-G------                    t2 = *  HWINTRINSIC simd16 ubyte ConvertMaskToVector $200
                                                            /--*  t2     simd16 
N005 (  6,  7) [000003] --C-G------                         *  RETURN    simd16 $VN.Void
```