### PR TITLE
[mono] Fix assembly name parser to accommodate non-ASCII UTF8 strings 

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
@@ -301,6 +301,14 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public void TestAssemblyNameWithInternationalChar()
+        {
+            Type testObj = typeof(Hello工程123.Program);
+            var t = Type.GetType(testObj.AssemblyQualifiedName);
+            Assert.NotNull(t);
+        }
+
+        [Fact]
         public void IgnoreLeadingDotForTypeNamesWithoutNamespace()
         {
             Type typeWithNoNamespace = typeof(NoNamespace);

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/Hello工程123/Hello工程123.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/Hello工程123/Hello工程123.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace System.Reflection.Hello工程123
+{
+    public class Program
+    {
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/Hello工程123/Hello工程123.csproj
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/Hello工程123/Hello工程123.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="Hello工程123.cs" />
+    </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/System.Reflection.Tests.csproj
@@ -77,6 +77,7 @@
     <ProjectReference Include="UnloadableAssembly\UnloadableAssembly.csproj" />
     <ProjectReference Include="TestExe\System.Reflection.TestExe.csproj" />
     <ProjectReference Include="TestAssembly\TestAssembly.csproj" />
+    <ProjectReference Include="Hello工程123\Hello工程123.csproj" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetOS)' == 'browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />
@@ -87,5 +88,6 @@
 
     <!-- Assemblies that should be excluded from the bundle -->
     <__ExcludeFromBundle Include="TestAssembly.dll" />
+    <__ExcludeFromBundle Include="Hello工程123.dll" />
   </ItemGroup>
 </Project>

--- a/src/mono/mono/eglib/eglib-remap.h
+++ b/src/mono/mono/eglib/eglib-remap.h
@@ -219,6 +219,7 @@
 #define g_wtf8_to_utf16 monoeg_g_wtf8_to_utf16
 #define g_utf8_to_utf16_custom_alloc monoeg_g_utf8_to_utf16_custom_alloc
 #define g_utf8_to_utf16le_custom_alloc monoeg_g_utf8_to_utf16le_custom_alloc
+#define g_utf8_validate_part monoeg_g_utf8_validate_part
 #define g_utf8_validate monoeg_g_utf8_validate
 #define g_vasprintf monoeg_g_vasprintf
 #define g_assertion_disable_global monoeg_assertion_disable_global

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1067,6 +1067,7 @@ g_async_safe_printf (gchar const *format, ...)
  */
 extern const guchar g_utf8_jump_table[256];
 
+gboolean  g_utf8_validate_part (const unsigned char *inptr, size_t len);
 gboolean  g_utf8_validate      (const gchar *str, gssize max_len, const gchar **end);
 glong     g_utf8_strlen        (const gchar *str, gssize max);
 

--- a/src/mono/mono/eglib/gutf8.c
+++ b/src/mono/mono/eglib/gutf8.c
@@ -30,8 +30,8 @@ const guchar g_utf8_jump_table[256] = {
 	3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3, 4,4,4,4,4,4,4,4,5,5,5,5,6,6,1,1
 };
 
-static gboolean
-utf8_validate (const unsigned char *inptr, size_t len)
+gboolean
+g_utf8_validate_part (const unsigned char *inptr, size_t len)
 {
 	const unsigned char *ptr = inptr + len;
 	unsigned char c;
@@ -105,7 +105,7 @@ g_utf8_validate (const gchar *str, gssize max_len, const gchar **end)
 	if (max_len < 0) {
 		while (*inptr != 0) {
 			length = g_utf8_jump_table[*inptr];
-			if (!utf8_validate (inptr, length)) {
+			if (!g_utf8_validate_part (inptr, length)) {
 				valid = FALSE;
 				break;
 			}
@@ -124,7 +124,7 @@ g_utf8_validate (const gchar *str, gssize max_len, const gchar **end)
 			length = g_utf8_jump_table[*inptr];
 			min = MIN (length, GSSIZE_TO_UINT (max_len - n));
 
-			if (!utf8_validate (inptr, min)) {
+			if (!g_utf8_validate_part (inptr, min)) {
 				valid = FALSE;
 				break;
 			}

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1549,7 +1549,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 	assembly->name = p;
 	s = p;
 	guchar *inptr = (guchar *) p;
-	while (*p && (*p != ',')) {
+	while (*p && (*p != ',') && (*p != '\0')) {
 		if (quoted && (*p == '"'))
 			break;
 		guint length = g_utf8_jump_table[*inptr];
@@ -1557,6 +1557,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 			return 0;
 		}
 		p += length;
+		inptr += length;
 	}
 	if (quoted) {
 		if (*p != '"')

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1548,8 +1548,12 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 	}
 	assembly->name = p;
 	s = p;
-	while (*p && (*p != ','))
-		p++;
+	guchar *inptr = (guchar *) p;
+	while (*p && (*p != ',')) {
+		if (quoted && (*p == '"'))
+			break;
+		p += g_utf8_jump_table[*inptr];
+	}
 	if (quoted) {
 		if (*p != '"')
 			return 1;

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1552,7 +1552,11 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 	while (*p && (*p != ',')) {
 		if (quoted && (*p == '"'))
 			break;
-		p += g_utf8_jump_table[*inptr];
+		guint length = g_utf8_jump_table[*inptr];
+		if (!g_utf8_validate_part (inptr, length)) {
+			return 0;
+		}
+		p += length;
 	}
 	if (quoted) {
 		if (*p != '"')

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1548,7 +1548,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 	}
 	assembly->name = p;
 	s = p;
-	while (*p && (isalnum (*p) || *p == '.' || *p == '-' || *p == '_' || *p == '$' || *p == '@' || g_ascii_isspace (*p)))
+	while (*p && (*p != ','))
 		p++;
 	if (quoted) {
 		if (*p != '"')
@@ -1648,7 +1648,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 			found_sep = 1;
 			continue;
 		}
-		/* failed */
+		/* Done processing */
 		if (!found_sep)
 			return 1;
 	}


### PR DESCRIPTION
Fixes #103276

Manually tested that the testcase failed in the above issue now passed with this change.

Ideally, Mono should share the same assembly name parsing logic as CoreCLR, which is `AssemblyNameParser.TryParse`.