### PR TITLE
fix hang when `prepare_to_change_heap_count` fails

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -25628,8 +25628,6 @@ void gc_heap::check_heap_count ()
             // background GC is running - reset the new heap count
             dynamic_heap_count_data.new_n_heaps = n_heaps;
             dprintf (6666, ("can't change heap count! BGC in progress"));
-
-            GCToEEInterface::RestartEE(TRUE);
         }
 #endif //BACKGROUND_GC
     }
@@ -25652,6 +25650,8 @@ void gc_heap::check_heap_count ()
 
         dprintf (6666, ("heap count stays the same %d, no work to do, set processed sample count to %Id",
             dynamic_heap_count_data.new_n_heaps, dynamic_heap_count_data.current_samples_count));
+
+        GCToEEInterface::RestartEE(TRUE);
 
         return;
     }


### PR DESCRIPTION
when `prepare_to_change_heap_count` fails, we need to make sure to restart the EE otherwise the GC thread still holds the thread store lock and you'll observe hang like this -

```
0:061> k
 # Child-SP          RetAddr               Call Site
00 000000a0`b87ff138 00007ff8`a0d43c03     ntdll!ZwWaitForAlertByThreadId+0x14 [minkernel\ntdll\daytona\objfre\amd64\usrstubs.asm @ 4059] 
01 (Inline Function) --------`--------     ntdll!RtlpWaitOnAddressWithTimeout+0x43 [minkernel\ntos\rtl\waitaddr.c @ 851] 
02 (Inline Function) --------`--------     ntdll!RtlpWaitOnAddress+0xe5 [minkernel\ntos\rtl\waitaddr.c @ 1094] 
03 000000a0`b87ff140 00007ff8`a0d318e4     ntdll!RtlpWaitOnCriticalSection+0x1e3 [minkernel\ntos\rtl\resource.c @ 1604] 
04 000000a0`b87ff250 00007ff8`a0d316d2     ntdll!RtlpEnterCriticalSectionContended+0x204 [minkernel\ntos\rtl\resource.c @ 2318] 
05 000000a0`b87ff2d0 00007fff`a6f6f880     ntdll!RtlEnterCriticalSection+0x42 [minkernel\ntos\rtl\resource.c @ 1923] 
06 000000a0`b87ff300 00007fff`a6f9ccae     coreclr!CrstBase::Enter+0x90 [D:\runtime9.0\src\coreclr\vm\crst.cpp @ 328] 
07 (Inline Function) --------`--------     coreclr!ThreadStore::Enter+0x10 [D:\runtime9.0\src\coreclr\vm\threads.cpp @ 5136] 
08 000000a0`b87ff330 00007fff`a6f411d3     coreclr!ThreadSuspend::LockThreadStore+0x82 [D:\runtime9.0\src\coreclr\vm\threadsuspend.cpp @ 1885] 
09 (Inline Function) --------`--------     coreclr!ThreadStore::LockThreadStore+0x5 [D:\runtime9.0\src\coreclr\vm\threads.cpp @ 5158] 
0a (Inline Function) --------`--------     coreclr!StateHolder<&ThreadStore::LockThreadStore,&ThreadStore::UnlockThreadStore>::Acquire+0x5 [D:\runtime9.0\src\coreclr\inc\holder.h @ 349] 
0b (Inline Function) --------`--------     coreclr!StateHolder<&ThreadStore::LockThreadStore,&ThreadStore::UnlockThreadStore>::{ctor}+0x5 [D:\runtime9.0\src\coreclr\inc\holder.h @ 335] 
0c 000000a0`b87ff360 00007fff`a6ffdf85     coreclr!ThreadStore::AddThread+0x1f [D:\runtime9.0\src\coreclr\vm\threads.cpp @ 5184] 
0d 000000a0`b87ff390 00007fff`a6ffdd87     coreclr!SetupThread+0x1b5 [D:\runtime9.0\src\coreclr\vm\threads.cpp @ 725] 
0e 000000a0`b87ff430 00007fff`a6ffdc31     coreclr!SetupThreadNoThrow+0x6f [D:\runtime9.0\src\coreclr\vm\threads.cpp @ 821] 
0f 000000a0`b87ff4c0 00007fff`a6fff22f     coreclr!JIT_ReversePInvokeEnterRare+0x4d [D:\runtime9.0\src\coreclr\vm\jithelpers.cpp @ 5900] 
10 000000a0`b87ff510 00007fff`a376ab0a     coreclr!JIT_ReversePInvokeEnter+0x5f [D:\runtime9.0\src\coreclr\vm\jithelpers.cpp @ 6030] 
11 000000a0`b87ff540 00007ff8`a0d403bd     System_Private_CoreLib! [D:\runtime9.0\src\libraries\System.Private.CoreLib\src\System\Diagnostics\Tracing\EventProvider.cs @ 840] 
12 000000a0`b87ff5d0 00007ff8`a0d41ade     ntdll!EtwpEventApiCallback+0xe9 [minkernel\etw\ntdll\evntapi.c @ 310] 
13 000000a0`b87ff680 00007ff8`a0d6e787     ntdll!EtwpUpdateEnableInfoAndCallback+0xd6 [minkernel\etw\ntdll\evntsup.c @ 1586] 
14 000000a0`b87ff6d0 00007ff8`a0d6e33f     ntdll!EtwpProcessNotification+0x53 [minkernel\etw\ntdll\evntsup.c @ 1014] 
15 000000a0`b87ff700 00007ff8`a0d6e19d     ntdll!EtwDeliverDataBlock+0xcf [minkernel\etw\ntdll\evntsup.c @ 1089] 
16 000000a0`b87ff7e0 00007ff8`a0d5e2a2     ntdll!EtwpNotificationThread+0x6d [minkernel\etw\ntdll\notify.c @ 440] 
17 000000a0`b87ff970 00007ff8`a0d8ca7c     ntdll!TppExecuteWaitCallback+0xae [minkernel\threadpool\ntdll\wait.c @ 1611] 
18 000000a0`b87ff9c0 00007ff8`a0d45986     ntdll!TppDirectExecuteCallback+0xdc [minkernel\threadpool\ntdll\pool.c @ 3975] 
19 000000a0`b87ffa20 00007ff8`9fd5257d     ntdll!TppWorkerThread+0x8f6 [minkernel\threadpool\ntdll\worker.c @ 1149] 
1a 000000a0`b87ffd00 00007ff8`a0d6aa48     KERNEL32!BaseThreadInitThunk+0x1d [clientcore\base\win32\client\thread.c @ 75] 
1b 000000a0`b87ffd30 00000000`00000000     ntdll!RtlUserThreadStart+0x28 [minkernel\ntdll\rtlstrt.c @ 1166] 
```
