### PR TITLE
JIT: Produce less convoluted IR for boolean `isinst` checks

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4774,8 +4774,10 @@ public:
     bool impIsCastHelperEligibleForClassProbe(GenTree* tree);
     bool impIsCastHelperMayHaveProfileData(CorInfoHelpFunc helper);
 
+    bool impMatchIsInstBooleanConversion(const BYTE* codeAddr, const BYTE* codeEndp, int* consumed);
+
     GenTree* impCastClassOrIsInstToTree(
-        GenTree* op1, GenTree* op2, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass, IL_OFFSET ilOffset);
+        GenTree* op1, GenTree* op2, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass, bool* booleanCheck, IL_OFFSET ilOffset);
 
     GenTree* impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass);
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5638,7 +5638,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
 
     if (*booleanCheck)
     {
-        GenTreeOp*    condMT   = gtNewOperNode(GT_EQ, TYP_INT, gtNewMethodTableLookup(op1Clone), op2);
+        GenTreeOp*    condMT   = gtNewOperNode(GT_NE, TYP_INT, gtNewMethodTableLookup(op1Clone), op2);
         GenTreeOp*    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewNull());
         GenTreeQmark* qmarkMT =
             gtNewQmarkNode(TYP_REF, condMT,

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5491,13 +5491,11 @@ bool Compiler::impMatchIsInstBooleanConversion(const BYTE* codeAddr, const BYTE*
     {
         case CEE_BRFALSE:
         case CEE_BRFALSE_S:
+        case CEE_BRTRUE:
+        case CEE_BRTRUE_S:
             // BRFALSE/BRTRUE importation are expected to transparently handle
             // that the created tree is a TYP_INT instead of TYP_REF, so we do
             // not consume them here.
-            *consumed = 0;
-            return true;
-        case CEE_BRTRUE:
-        case CEE_BRTRUE_S:
             *consumed = 0;
             return true;
         case CEE_LDNULL:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5614,8 +5614,9 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
     {
         GenTreeOp*    condMT   = gtNewOperNode(GT_EQ, TYP_INT, gtNewMethodTableLookup(op1Clone), op2);
         GenTreeOp*    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewNull());
+        GenTreeQmark* qmarkMT   = gtNewQmarkNode(TYP_REF, condMT, gtNewColonNode(TYP_INT, gtNewZeroConNode(TYP_INT), gtNewOneConNode(TYP_INT)));
         GenTreeQmark* qmarkNull =
-            gtNewQmarkNode(TYP_INT, condNull, gtNewColonNode(TYP_INT, gtNewZeroConNode(TYP_INT), condMT));
+            gtNewQmarkNode(TYP_INT, condNull, gtNewColonNode(TYP_INT, gtNewZeroConNode(TYP_INT), qmarkMT));
 
         // Make QMark node a top level node by spilling it.
         const unsigned result = lvaGrabTemp(true DEBUGARG("spilling qmarkNull"));
@@ -9673,7 +9674,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     if (!usingReadyToRunHelper)
 #endif
                     {
-                        bool reverse     = false;
                         int consumed = 0;
                         bool booleanCheck = impMatchIsInstBooleanConversion(codeAddr + sz, codeEndp, &consumed);
                         op1 = impCastClassOrIsInstToTree(op1, op2, &resolvedToken, false, &booleanCheck, opcodeOffs);


### PR DESCRIPTION
Currently the IR for boolean `isinst` checks ends up being something like `(typecheck(x) ? x : null) != null`, which the JIT ends up having a hard time clean up early. With object stack allocation this pattern usually leads to unnecessary address exposure.

This adds a simple pattern match during import to produce less convoluted IR in the common cases where the `isinst` is just used as a boolean check.


Example from #36649:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static bool Is_Slow(object obj) =>
    obj is int;
```

```diff
 ; Method C:Is_Slow(System.Object):ubyte (FullOpts)
 G_M38459_IG01:  ;; offset=0x0000
 						;; size=0 bbWeight=1 PerfScore 0.00
 
 G_M38459_IG02:  ;; offset=0x0000
        test     rcx, rcx
        je       SHORT G_M38459_IG05
 						;; size=5 bbWeight=1 PerfScore 1.25
 
 G_M38459_IG03:  ;; offset=0x0005
        mov      rax, 0x7FFB89FA1C00      ; System.Int32
        cmp      qword ptr [rcx], rax
        jne      SHORT G_M38459_IG05
 						;; size=15 bbWeight=0.25 PerfScore 1.06
 
 G_M38459_IG04:  ;; offset=0x0014
+       mov      eax, 1
        jmp      SHORT G_M38459_IG06
-						;; size=2 bbWeight=0.12 PerfScore 0.25
+						;; size=7 bbWeight=0.12 PerfScore 0.28
 
-G_M38459_IG05:  ;; offset=0x0016
-       xor      rcx, rcx
+G_M38459_IG05:  ;; offset=0x001B
+       xor      eax, eax
 						;; size=2 bbWeight=0.25 PerfScore 0.06
 
-G_M38459_IG06:  ;; offset=0x0018
-       test     rcx, rcx
-       setne    al
-       movzx    rax, al
-						;; size=9 bbWeight=1 PerfScore 1.50
-
-G_M38459_IG07:  ;; offset=0x0021
+G_M38459_IG06:  ;; offset=0x001D
        ret      
 						;; size=1 bbWeight=1 PerfScore 1.00
-; Total bytes of code: 34
+; Total bytes of code: 30

```

Fix #36649