### PR TITLE
[LoongArch64] change instructions in IMAGE_REL_LOONGARCH64_PC & fix genCodeForJumpCompare

### DIFF
--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -3312,6 +3312,26 @@ void PutArm64Rel21(UINT32 * pCode, INT32 imm21);
 void PutArm64Rel12(UINT32 * pCode, INT32 imm12);
 
 //*****************************************************************************
+//  Extract the PC-Relative page address and page offset from pcalau12i+add/ld
+//*****************************************************************************
+INT64 GetLoongArch64PC12(UINT32 * pCode);
+
+//*****************************************************************************
+//  Extract the jump offset into pcaddu18i+jirl instructions
+//*****************************************************************************
+INT64 GetLoongArch64JIR(UINT32 * pCode);
+
+//*****************************************************************************
+//  Deposit the PC-Relative page address and page offset into pcalau12i+add/ld
+//*****************************************************************************
+void PutLoongArch64PC12(UINT32 * pCode, INT64 imm);
+
+//*****************************************************************************
+//  Deposit the jump offset into pcaddu18i+jirl instructions
+//*****************************************************************************
+void PutLoongArch64JIR(UINT32 * pCode, INT64 imm);
+
+//*****************************************************************************
 // Returns whether the offset fits into bl instruction
 //*****************************************************************************
 inline bool FitsInThumb2BlRel24(INT32 imm24)

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2058,10 +2058,10 @@ void emitter::emitIns_R_AI(instruction  ins,
 
     // INS_OPTS_RELOC: placeholders.  2-ins:
     //  case:EA_HANDLE_CNS_RELOC
-    //   pcaddu12i  reg, off-hi-20bits
+    //   pcalau12i  reg, off-hi-20bits
     //   addi_d  reg, reg, off-lo-12bits
     //  case:EA_PTR_DSP_RELOC
-    //   pcaddu12i  reg, off-hi-20bits
+    //   pcalau12i  reg, off-hi-20bits
     //   ld_d  reg, reg, off-lo-12bits
 
     instrDesc* id = emitNewInstr(attr);
@@ -3231,21 +3231,21 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_OPTS_RELOC:
         {
             //  case:EA_HANDLE_CNS_RELOC
-            //   pcaddu12i  reg, off-hi-20bits
+            //   pcalau12i  reg, off-hi-20bits
             //   addi_d  reg, reg, off-lo-12bits
             //  case:EA_PTR_DSP_RELOC
-            //   pcaddu12i  reg, off-hi-20bits
+            //   pcalau12i  reg, off-hi-20bits
             //   ld_d  reg, reg, off-lo-12bits
 
             regNumber reg1 = id->idReg1();
 
-            *(code_t*)dstRW = 0x1c000000 | (code_t)reg1;
+            *(code_t*)dstRW = 0x1a000000 | (code_t)reg1;
 
             dstRW += 4;
 
 #ifdef DEBUG
-            code = emitInsCode(INS_pcaddu12i);
-            assert(code == 0x1c000000);
+            code = emitInsCode(INS_pcalau12i);
+            assert(code == 0x1a000000);
             code = emitInsCode(INS_addi_d);
             assert(code == 0x02c00000);
             code = emitInsCode(INS_ld_d);

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -17,7 +17,7 @@ namespace ILCompiler.DependencyAnalysis
         IMAGE_REL_BASED_THUMB_BRANCH24       = 0x13,   // Thumb2: based B, BL
         IMAGE_REL_BASED_THUMB_MOV32_PCREL    = 0x14,   // Thumb2: based MOVW/MOVT
         IMAGE_REL_BASED_ARM64_BRANCH26       = 0x15,   // Arm64: B, BL
-        IMAGE_REL_BASED_LOONGARCH64_PC       = 0x16,   // LoongArch64: pcaddu12i+imm12
+        IMAGE_REL_BASED_LOONGARCH64_PC       = 0x16,   // LoongArch64: pcalau12i+imm12
         IMAGE_REL_BASED_LOONGARCH64_JIR      = 0x17,   // LoongArch64: pcaddu18i+jirl
         IMAGE_REL_BASED_RISCV64_PC           = 0x18,   // RiscV64: auipc
         IMAGE_REL_BASED_RELPTR32             = 0x7C,   // 32-bit relative address from byte starting reloc
@@ -334,43 +334,39 @@ namespace ILCompiler.DependencyAnalysis
 
             // then get the low 12 bits,
             pcInstr = *(pCode + 1);
-            imm += ((int)(((pcInstr >> 10) & 0xFFF) << 20)) >> 20;
+            imm |= (int)((pcInstr >> 10) & 0xFFF);
 
             return imm;
         }
 
         //  case:EA_HANDLE_CNS_RELOC
-        //   pcaddu12i  reg, off-hi-20bits
+        //   pcalau12i  reg, off-hi-20bits
         //   addi_d  reg, reg, off-lo-12bits
         //  case:EA_PTR_DSP_RELOC
-        //   pcaddu12i  reg, off-hi-20bits
+        //   pcalau12i  reg, off-hi-20bits
         //   ld_d  reg, reg, off-lo-12bits
-        private static unsafe void PutLoongArch64PC12(uint* pCode, long imm32)
+        private static unsafe void PutLoongArch64PC12(uint* pCode, long imm)
         {
             // Verify that we got a valid offset
-            Debug.Assert((int)imm32 == imm32);
+            Debug.Assert((int)imm == imm);
 
             uint pcInstr = *pCode;
 
-            Debug.Assert((pcInstr & 0xFE000000) == 0x1c000000);  // Must be pcaddu12i
+            Debug.Assert((pcInstr & 0xFE000000) == 0x1a000000);  // Must be pcalau12i
 
-            int relOff = (int)imm32 & 0x800;
-            int imm = (int)imm32 + relOff;
-            relOff = ((imm & 0x7ff) - relOff) & 0xfff;
-
-            // Assemble the pc-relative high 20 bits of 'imm32' into the pcaddu12i instruction
-            pcInstr |= (uint)(((imm >> 12) & 0xFFFFF) << 5);
+            // Assemble the pc-relative high 20 bits of 'imm' into the pcalau12i instruction
+            pcInstr |= (uint)((imm >> 7) & 0x1FFFFE0);
 
             *pCode = pcInstr;          // write the assembled instruction
 
             pcInstr = *(pCode + 1);
 
-            // Assemble the pc-relative low 12 bits of 'imm32' into the addid or ld instruction
-            pcInstr |= (uint)(relOff << 10);
+            // Assemble the pc-relative low 12 bits of 'imm' into the addid or ld instruction
+            pcInstr |= (uint)((imm & 0xFFF) << 10);
 
             *(pCode + 1) = pcInstr;          // write the assembled instruction
 
-            Debug.Assert(GetLoongArch64PC12(pCode) == imm32);
+            Debug.Assert(GetLoongArch64PC12(pCode) == imm);
         }
 
         private static unsafe long GetLoongArch64JIR(uint* pCode)
@@ -402,14 +398,14 @@ namespace ILCompiler.DependencyAnalysis
             long imm = imm38 + relOff;
             relOff = (((imm & 0x1ffff) - relOff) >> 2) & 0xffff;
 
-            // Assemble the pc-relative high 20 bits of 'imm38' into the pcaddu12i instruction
+            // Assemble the pc-relative high 20 bits of 'imm38' into the pcaddu18i instruction
             pcInstr |= (uint)(((imm >> 18) & 0xFFFFF) << 5);
 
             *pCode = pcInstr;          // write the assembled instruction
 
             pcInstr = *(pCode + 1);
 
-            // Assemble the pc-relative low 18 bits of 'imm38' into the addid or ld instruction
+            // Assemble the pc-relative low 18 bits of 'imm38' into the jirl instruction
             pcInstr |= (uint)(relOff << 10);
 
             *(pCode + 1) = pcInstr;          // write the assembled instruction

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64Emitter.cs
@@ -40,18 +40,18 @@ namespace ILCompiler.DependencyAnalysis.LoongArch64
         public void EmitMOV(Register regDst, ISymbolNode symbol)
         {
             Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_LOONGARCH64_PC);
-            // pcaddu12i  reg, off-hi-20bits
-            Builder.EmitUInt(0x1c000000u | (uint)regDst);
+            // pcalau12i  reg, off-hi-20bits
+            Builder.EmitUInt(0x1a000000u | (uint)regDst);
 
             // addi_d  reg, reg, off-lo-12bits
             Builder.EmitUInt(0x02c00000u | (uint)(((uint)regDst << 5) | (uint)regDst));
         }
 
-        // pcaddi regDst, 0
+        // pcalau12i regDst, 0
         public void EmitPC(Register regDst)
         {
             Debug.Assert((uint)regDst > 0 && (uint)regDst < 32);
-            Builder.EmitUInt(0x18000000 | (uint)regDst);
+            Builder.EmitUInt(0x1a000000 | (uint)regDst);
         }
 
         // addi.d regDst, regSrc, imm12
@@ -93,7 +93,7 @@ namespace ILCompiler.DependencyAnalysis.LoongArch64
         {
             if (symbol.RepresentsIndirectionCell)
             {
-                // pcaddi R21, 0
+                // pcalau12i R21, 0
                 EmitPC(Register.R21);
 
                 EmitLD(Register.R21, Register.R21, 0x10);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
@@ -221,6 +221,11 @@ namespace ILCompiler.PEWriter
                     }
 
                 case RelocType.IMAGE_REL_BASED_LOONGARCH64_PC:
+                    {
+                        relocationLength = 8;
+                        delta = (int)(targetRVA - (sourceRVA & ~0xfff) + ((targetRVA & 0x800) << 1));
+                        break;
+                    }
                 case RelocType.IMAGE_REL_BASED_LOONGARCH64_JIR:
                     {
                         relocationLength = 8;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11421,6 +11421,28 @@ void CEEJitInfo::recordRelocation(void * location,
 
 #endif // TARGET_ARM64
 
+#ifdef TARGET_LOONGARCH64
+    case IMAGE_REL_LOONGARCH64_PC:
+        {
+            _ASSERTE(addlDelta == 0);
+
+            INT64 imm = (INT64)target - ((INT64)location & 0xFFFFFFFFFFFFF000LL);
+            imm += ((INT64)target & 0x800) << 1;
+            PutLoongArch64PC12((UINT32 *)locationRW, imm);
+        }
+        break;
+
+    case IMAGE_REL_LOONGARCH64_JIR:
+        {
+            _ASSERTE(addlDelta == 0);
+
+            INT64 imm = (INT64)target - (INT64)location;
+            PutLoongArch64JIR((UINT32 *)locationRW, imm);
+        }
+        break;
+
+#endif // TARGET_LOONGARCH64
+
     default:
         _ASSERTE(!"Unknown reloc type");
         break;


### PR DESCRIPTION
Change pcaddu12i to pcalau12i in relocation IMAGE_REL_LOONGARCH64_PC.
Fix GT_CNS_INT generation in CodeGen::genCodeForJumpCompare.