### PR TITLE
[browser] Use DynamicDependencyAttribute contructor friendly to InternalsVisibleTo when registering JSExports

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JavaScriptLibrary/JavaScriptInterop.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JavaScriptLibrary/JavaScriptInterop.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices.JavaScript;
+
+namespace JavaScriptLibrary;
+
+public partial class JavaScriptInterop
+{
+    [JSExport]
+    public static int ExportedMethod(int a, int b) => a + b;
+
+    internal static int ValidationMethod(int a, int b) => a + b;
+}

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JavaScriptLibrary/JavaScriptLibrary.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JavaScriptLibrary/JavaScriptLibrary.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-browser</TargetFrameworks>
+    <!-- Use following lines to write the generated files to disk. -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  </PropertyGroup>
+  <!-- Make debugging easier -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <WasmNativeDebugSymbols>true</WasmNativeDebugSymbols>
+    <WasmNativeStrip>false</WasmNativeStrip>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)JavaScriptInterop.cs" />
+    <InternalsVisibleTo Include="System.Runtime.InteropServices.JavaScript.Tests" />
+    <ProjectReference Include="$(CoreLibProject)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Private.Uri\src\System.Private.Uri.csproj" PrivateAssets="all" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Collections\src\System.Collections.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\src\System.Runtime.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Memory\src\System.Memory.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Threading\src\System.Threading.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Threading.Thread\src\System.Threading.Thread.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System.Runtime.InteropServices.JavaScript.csproj" SkipUseReferenceAssembly="true" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -34,6 +34,7 @@
     <WasmExtraFilesToDeploy Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\JavaScript\SecondRuntimeTest.js" />
     <WasmExtraFilesToDeploy Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\JavaScript\timers.mjs" />
     <ProjectReference Include="$(CoreLibProject)" />
+    <ProjectReference Include="..\JavaScriptLibrary\JavaScriptLibrary.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Private.Uri\src\System.Private.Uri.csproj" PrivateAssets="all" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Collections\src\System.Collections.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\src\System.Runtime.csproj" />

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
@@ -430,5 +430,11 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             res = invoke(value, echoName);
             Assert.Equal<T>(value, res);
         }
+
+        [Fact]
+        public async Task InternalsVisibleToDoesntBreak()
+        {
+            Assert.Equal(JavaScriptLibrary.JavaScriptInterop.ValidationMethod(5, 6), await JavaScriptTestHelper.callJavaScriptLibrary(5, 6));
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -1019,6 +1019,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             return arg1;
         }
+        
+        [JSImport("callJavaScriptLibrary", "JavaScriptTestHelper")]
+        public static partial Task<int> callJavaScriptLibrary(int a, int b);
 
         [JSImport("echopromise", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Promise<JSType.Object>>]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
@@ -427,6 +427,11 @@ export async function backbackAsync(arg1, arg2, arg3) {
     return arg1(arg2, arg3);
 }
 
+export async function callJavaScriptLibrary(a, b) {
+    const exports = await App.runtime.getAssemblyExports("JavaScriptLibrary.dll");
+    return exports.JavaScriptLibrary.JavaScriptInterop.ExportedMethod(a, b);
+}
+
 export const instance = {}
 
 globalThis.javaScriptTestHelper = instance;


### PR DESCRIPTION
Instead of using `typeof(__GeneratedInitializer)`, use overload with string typeName and assemblyName

Fixes https://github.com/dotnet/runtime/issues/103205