### PR TITLE
[RISC-V] Disable EnableWriteXorExecute by default on riscv64 architectue

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -722,6 +722,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_LTTng, W("LTTng"), 1, "If DOTNET_LTTng is s
 //
 // Executable code
 //
+// TODO: https://github.com/dotnet/runtime/issues/103465
 #ifdef TARGET_RISCV64
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableWriteXorExecute, W("EnableWriteXorExecute"), 0, "Enable W^X for executable memory.");
 #else

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -722,7 +722,11 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_LTTng, W("LTTng"), 1, "If DOTNET_LTTng is s
 //
 // Executable code
 //
+#ifdef TARGET_RISCV64
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableWriteXorExecute, W("EnableWriteXorExecute"), 0, "Enable W^X for executable memory.");
+#else
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableWriteXorExecute, W("EnableWriteXorExecute"), 1, "Enable W^X for executable memory.");
+#endif // TARGET_RISCV64
 
 #ifdef FEATURE_GDBJIT
 ///


### PR DESCRIPTION
On riscv64 architectue any dotnet process that loads corossgened assembly without DOTNET_EnableWriteXorExecute=0 environment variable set crashes with "Segmentation fault" error.

For example System.Private.CoreLib.dll is compiled with crossgen2 by default during build phase so this crash applies to any processes that loads it.

Setting EnableWriteXorExecute=0 disables this options on riscv64 architecure and prevents these crashes.

Co-authored-by: Dong-Heon Jung <clamp03@gmail.com>

Part of #84834, cc @dotnet/samsung