### PR TITLE
[HTTP/3] Increased timeout for a slower test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -140,7 +140,6 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await using Http3LoopbackStream stream = await connection.AcceptRequestStreamAsync();
                     await stream.HandleRequestAsync();
-                    _output.WriteLine($"[{DateTime.Now:HH:mm:ss.fffffff}] Server: Finished request {i}");
                 }
             });
 
@@ -160,11 +159,9 @@ namespace System.Net.Http.Functional.Tests
                     };
 
                     tasks[i] = client.SendAsync(request);
-                    _output.WriteLine($"[{DateTime.Now:HH:mm:ss.fffffff}] Client: Started request {i}");
                 });
 
                 var responses = await Task.WhenAll(tasks);
-                _output.WriteLine($"[{DateTime.Now:HH:mm:ss.fffffff}] Client: Got all responses");
                 foreach (var response in responses)
                 {
                     response.Dispose();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -171,7 +171,7 @@ namespace System.Net.Http.Functional.Tests
                 }
             });
 
-            await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(20_000);
+            await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(200_000);
         }
 
         [Theory]


### PR DESCRIPTION
While looking at Kusto data before closing https://github.com/dotnet/runtime/issues/101463, I discovered that this test can take ~30 seconds (based on the logs here: https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-103151-merge-c718bf950a8049f997/System.Net.Http.Functional.Tests/3/console.4d14a340.log?helixlogtype=result).
So increasing timeout and removing the helper logs. The reason for deadlock should already be fixed by https://github.com/dotnet/runtime/pull/102699
