### PR TITLE
[wasm] Move hardcoded `_BoolPropertiesThatTriggerRelinking` to `wasm-props.json` included in the runtime pack

### DIFF
--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -325,7 +325,15 @@
     ],
     "WasmOptConfigurationFlags": [@(WasmOptConfigurationFlags -> '%22%(Identity)%22', ',')],
     "EmccDefaultExportedFunctions": [@(EmccExportedFunction -> '%22%(Identity)%22', ',')],
-    "EmccDefaultExportedRuntimeMethods": [@(EmccExportedRuntimeMethod -> '%22%(Identity)%22', ',')]
+    "EmccDefaultExportedRuntimeMethods": [@(EmccExportedRuntimeMethod -> '%22%(Identity)%22', ',')],
+    "BoolPropertiesThatTriggerRelinking": [
+      { "identity": "InvariantTimezone",            "defaultValueInRuntimePack": "false" },
+      { "identity": "InvariantGlobalization",       "defaultValueInRuntimePack": "false" },
+      { "identity": "WasmNativeStrip",              "defaultValueInRuntimePack": "true" },
+      { "identity": "WasmSingleFileBundle",         "defaultValueInRuntimePack": "false" },
+      { "identity": "WasmEnableSIMD",               "defaultValueInRuntimePack": "true" },
+      { "identity": "WasmEnableExceptionHandling",  "defaultValueInRuntimePack": "true" },
+    ],
   }
 }
 ]]>

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -23,6 +23,10 @@
   <PropertyGroup>
     <ICULibDir Condition="'$(WasmEnableThreads)' != 'true'">$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_NETCore_Runtime_ICU_Transport)', 'runtimes', 'browser-wasm', 'native', 'lib'))</ICULibDir>
     <ICULibDir Condition="'$(WasmEnableThreads)' == 'true'">$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_NETCore_Runtime_ICU_Transport)', 'runtimes', 'browser-wasm-threads', 'native', 'lib'))</ICULibDir>
+    <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
+    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
+    <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">true</WasmNativeStrip>
+    <WasmSingleFileBundle Condition="'$(WasmSingleFileBundle)' == ''">false</WasmSingleFileBundle>
     <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">true</WasmEnableSIMD>
     <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == ''">true</WasmEnableExceptionHandling>
     <WasmEnableJsInteropByValue Condition="'$(WasmEnableJsInteropByValue)' == '' and '$(WasmEnableThreads)' == 'true'">true</WasmEnableJsInteropByValue>
@@ -327,12 +331,12 @@
     "EmccDefaultExportedFunctions": [@(EmccExportedFunction -> '%22%(Identity)%22', ',')],
     "EmccDefaultExportedRuntimeMethods": [@(EmccExportedRuntimeMethod -> '%22%(Identity)%22', ',')],
     "BoolPropertiesThatTriggerRelinking": [
-      { "identity": "InvariantTimezone",            "defaultValueInRuntimePack": "false" },
-      { "identity": "InvariantGlobalization",       "defaultValueInRuntimePack": "false" },
-      { "identity": "WasmNativeStrip",              "defaultValueInRuntimePack": "true" },
-      { "identity": "WasmSingleFileBundle",         "defaultValueInRuntimePack": "false" },
-      { "identity": "WasmEnableSIMD",               "defaultValueInRuntimePack": "true" },
-      { "identity": "WasmEnableExceptionHandling",  "defaultValueInRuntimePack": "true" }
+      { "identity": "InvariantTimezone",            "defaultValueInRuntimePack": "$(InvariantTimezone)" },
+      { "identity": "InvariantGlobalization",       "defaultValueInRuntimePack": "$(InvariantGlobalization)" },
+      { "identity": "WasmNativeStrip",              "defaultValueInRuntimePack": "$(WasmNativeStrip)" },
+      { "identity": "WasmSingleFileBundle",         "defaultValueInRuntimePack": "$(WasmSingleFileBundle)" },
+      { "identity": "WasmEnableSIMD",               "defaultValueInRuntimePack": "$(WasmEnableSIMD)" },
+      { "identity": "WasmEnableExceptionHandling",  "defaultValueInRuntimePack": "$(WasmEnableExceptionHandling)" }
     ]
   }
 }

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -332,8 +332,8 @@
       { "identity": "WasmNativeStrip",              "defaultValueInRuntimePack": "true" },
       { "identity": "WasmSingleFileBundle",         "defaultValueInRuntimePack": "false" },
       { "identity": "WasmEnableSIMD",               "defaultValueInRuntimePack": "true" },
-      { "identity": "WasmEnableExceptionHandling",  "defaultValueInRuntimePack": "true" },
-    ],
+      { "identity": "WasmEnableExceptionHandling",  "defaultValueInRuntimePack": "true" }
+    ]
   }
 }
 ]]>

--- a/src/mono/browser/build/BrowserWasmApp.targets
+++ b/src/mono/browser/build/BrowserWasmApp.targets
@@ -61,9 +61,6 @@
   <ItemGroup>
     <!-- Allow running/debugging from VS -->
     <ProjectCapability Include="DotNetCoreWeb"/>
-
-    <_BoolPropertiesThatTriggerRelinking Include="WasmEnableSIMD" DefaultValueInRuntimePack="true" />
-    <_BoolPropertiesThatTriggerRelinking Include="WasmEnableExceptionHandling" DefaultValueInRuntimePack="true" />
   </ItemGroup>
 
   <Target Name="_GetWasmGenerateAppBundleDependencies">

--- a/src/mono/wasi/Wasi.Build.Tests/SdkMissingTests.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/SdkMissingTests.cs
@@ -31,8 +31,8 @@ public class SdkMissingTests : BuildTestBase
             };
 
     [Theory]
-    [MemberData(nameof(TestDataForNativeBuildFails), "<WasmSingleFileBundle>true</WasmSingleFileBundle>")]
-    [MemberData(nameof(TestDataForNativeBuildFails), "<InvariantGlobalization>true</InvariantGlobalization>")]
+    [MemberData(nameof(TestDataForNativeBuildFails), "<WasmSingleFileBundle>true</WasmSingleFileBundle><WasmBuildNative>true</WasmBuildNative>")]
+    [MemberData(nameof(TestDataForNativeBuildFails), "<InvariantGlobalization>true</InvariantGlobalization><WasmBuildNative>true</WasmBuildNative>")]
     public void NativeBuildOrPublishFails(string config, string extraProperties, bool publish)
     {
         string output = BuildWithInvalidSdkPath(config, extraProperties, publish, expectSuccess: false);

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -46,11 +46,6 @@
     <!--<WasiRunner Condition="'$(WasiRunner)' == ''">wasmtime</WasiRunner>-->
   </PropertyGroup>
 
-  <ItemGroup>
-    <_BoolPropertiesThatTriggerRelinking Include="WasmEnableSIMD" DefaultValueInRuntimePack="false" />
-    <!--<_BoolPropertiesThatTriggerRelinking Include="WasmEnableExceptionHandling" DefaultValueInRuntimePack="true" />-->
-  </ItemGroup>
-
   <Target Name="_GetWasiGenerateAppBundleDependencies">
     <ItemGroup Condition="'$(InvariantGlobalization)' == 'true' or '$(WasmSingleFileBundle)' == 'true'">
       <ReferenceCopyLocalPaths Remove="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)icudt.dat" />

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -152,9 +152,17 @@
 {
   "items": {
     "WasmOptConfigurationFlags": [@(WasmOptConfigurationFlags -> '%22%(Identity)%22', ',')],
+    "BoolPropertiesThatTriggerRelinking": [
+      { "identity": "InvariantTimezone",      "defaultValueInRuntimePack": "false" },
+      { "identity": "InvariantGlobalization", "defaultValueInRuntimePack": "false" },
+      { "identity": "WasmNativeStrip",        "defaultValueInRuntimePack": "true" },
+      { "identity": "WasmSingleFileBundle",   "defaultValueInRuntimePack": "false" },
+      { "identity": "WasmEnableSIMD",         "defaultValueInRuntimePack": "false" },
+    ],
   }
 }
 ]]>
+<!-- { "identity": "WasmEnableExceptionHandling",  "defaultValueInRuntimePack": "true" }, -->
       </_WasiPropsJson>
     </PropertyGroup>
 

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -161,7 +161,7 @@
       { "identity": "InvariantGlobalization", "defaultValueInRuntimePack": "$(InvariantGlobalization)" },
       { "identity": "WasmNativeStrip",        "defaultValueInRuntimePack": "$(WasmNativeStrip)" },
       { "identity": "WasmSingleFileBundle",   "defaultValueInRuntimePack": "$(WasmSingleFileBundle)" },
-      { "identity": "WasmEnableSIMD",         "defaultValueInRuntimePack": "$(WasmEnableSIMD)" },
+      { "identity": "WasmEnableSIMD",         "defaultValueInRuntimePack": "$(WasmEnableSIMD)" }
     ]
   }
 }

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -157,12 +157,12 @@
       { "identity": "InvariantGlobalization", "defaultValueInRuntimePack": "false" },
       { "identity": "WasmNativeStrip",        "defaultValueInRuntimePack": "true" },
       { "identity": "WasmSingleFileBundle",   "defaultValueInRuntimePack": "false" },
-      { "identity": "WasmEnableSIMD",         "defaultValueInRuntimePack": "false" },
-    ],
+      { "identity": "WasmEnableSIMD",         "defaultValueInRuntimePack": "false" }
+    ]
   }
 }
 ]]>
-<!-- { "identity": "WasmEnableExceptionHandling",  "defaultValueInRuntimePack": "true" }, -->
+<!-- { "identity": "WasmEnableExceptionHandling", "value": "$(WasmEnableExceptionHandling)", "defaultValueInRuntimePack": "true" }, -->
       </_WasiPropsJson>
     </PropertyGroup>
 

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -8,6 +8,10 @@
   <PropertyGroup>
     <ICULibDir Condition="'$(WasmEnableThreads)' != 'true'">$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_NETCore_Runtime_ICU_Transport)', 'runtimes', 'wasi-wasm', 'native', 'lib'))</ICULibDir>
     <ICULibDir Condition="'$(WasmEnableThreads)' == 'true'">$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_NETCore_Runtime_ICU_Transport)', 'runtimes', 'wasi-wasm-threads', 'native', 'lib'))</ICULibDir>
+    <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
+    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
+    <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">true</WasmNativeStrip>
+    <WasmSingleFileBundle Condition="'$(WasmSingleFileBundle)' == ''">false</WasmSingleFileBundle>
     <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">false</WasmEnableSIMD>
     <FilterSystemTimeZones Condition="'$(FilterSystemTimeZones)' == ''">false</FilterSystemTimeZones>
     <WasiObjDir>$(ArtifactsObjDir)wasi</WasiObjDir>
@@ -153,11 +157,11 @@
   "items": {
     "WasmOptConfigurationFlags": [@(WasmOptConfigurationFlags -> '%22%(Identity)%22', ',')],
     "BoolPropertiesThatTriggerRelinking": [
-      { "identity": "InvariantTimezone",      "defaultValueInRuntimePack": "false" },
-      { "identity": "InvariantGlobalization", "defaultValueInRuntimePack": "false" },
-      { "identity": "WasmNativeStrip",        "defaultValueInRuntimePack": "true" },
-      { "identity": "WasmSingleFileBundle",   "defaultValueInRuntimePack": "false" },
-      { "identity": "WasmEnableSIMD",         "defaultValueInRuntimePack": "false" }
+      { "identity": "InvariantTimezone",      "defaultValueInRuntimePack": "$(InvariantTimezone)" },
+      { "identity": "InvariantGlobalization", "defaultValueInRuntimePack": "$(InvariantGlobalization)" },
+      { "identity": "WasmNativeStrip",        "defaultValueInRuntimePack": "$(WasmNativeStrip)" },
+      { "identity": "WasmSingleFileBundle",   "defaultValueInRuntimePack": "$(WasmSingleFileBundle)" },
+      { "identity": "WasmEnableSIMD",         "defaultValueInRuntimePack": "$(WasmEnableSIMD)" },
     ]
   }
 }

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -117,10 +117,10 @@
     <PrepareInputsForWasmBuildDependsOn>
       $(PrepareInputsForWasmBuildDependsOn);
       _SetupToolchain;
+      _ReadWasmProps;
       _SetWasmBuildNativeDefaults;
       _GetDefaultWasmAssembliesToBundle;
       _WasmGetRuntimeConfigPath;
-      _ReadWasmProps;
     </PrepareInputsForWasmBuildDependsOn>
 
     <WasmGenerateAppBundleDependsOn>

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -397,7 +397,7 @@
     </ParameterGroup>
   </UsingTask>
 
-  <Target Name="_ReadWasmProps" Condition="'$(_IsToolchainMissing)' != 'true'">
+  <Target Name="_ReadWasmProps">
     <ReadWasmProps JsonFilePath="$(_WasmRuntimePackSrcDir)wasm-props.json">
       <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
       <Output TaskParameter="EmccDefaultExportedFunctions" ItemName="EmccExportedFunction" />

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -113,13 +113,6 @@
   <UsingTask TaskName="MonoTargetsTasks.MarshalingPInvokeScanner" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" />
   <UsingTask TaskName="EmitBundleObjectFiles" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" />
 
-  <ItemGroup>
-      <_BoolPropertiesThatTriggerRelinking Include="InvariantTimezone" DefaultValueInRuntimePack="false" />
-      <_BoolPropertiesThatTriggerRelinking Include="InvariantGlobalization" DefaultValueInRuntimePack="false" />
-      <_BoolPropertiesThatTriggerRelinking Include="WasmNativeStrip" DefaultValueInRuntimePack="true" />
-      <_BoolPropertiesThatTriggerRelinking Include="WasmSingleFileBundle" DefaultValueInRuntimePack="false" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PrepareInputsForWasmBuildDependsOn>
       $(PrepareInputsForWasmBuildDependsOn);
@@ -400,6 +393,7 @@
       <WasmOptConfigurationFlags ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
       <EmccDefaultExportedFunctions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
       <EmccDefaultExportedRuntimeMethods ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <BoolPropertiesThatTriggerRelinking ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
     </ParameterGroup>
   </UsingTask>
 
@@ -411,6 +405,7 @@
 
       <!-- shared by browser/wasi -->
       <Output TaskParameter="WasmOptConfigurationFlags" ItemName="_DefaulWasmOptConfigurationFlags" />
+      <Output TaskParameter="BoolPropertiesThatTriggerRelinking" ItemName="_BoolPropertiesThatTriggerRelinking" />
     </ReadWasmProps>
 
     <CreateProperty Value="%(_EmccPropItems.Value)" Condition="%(_EmccPropItems.Identity) != ''">

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -397,7 +397,7 @@
     </ParameterGroup>
   </UsingTask>
 
-  <Target Name="_ReadWasmProps">
+  <Target Name="_ReadWasmProps" Condition="'$(_IsToolchainMissing)' != 'true'">
     <ReadWasmProps JsonFilePath="$(_WasmRuntimePackSrcDir)wasm-props.json">
       <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
       <Output TaskParameter="EmccDefaultExportedFunctions" ItemName="EmccExportedFunction" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/91628.

Wasi wbt had an error of not setting `WasmBuildNative=true` in  `NativeBuildOrPublishFails` - this PR fixes it.