### PR TITLE
Use ThrowHelper in Queue<T>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
@@ -98,12 +98,12 @@ namespace System.Collections.Generic
 
             if (arrayIndex < 0 || arrayIndex > array.Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, SR.ArgumentOutOfRange_IndexMustBeLessOrEqual);
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.arrayIndex, ExceptionResource.ArgumentOutOfRange_IndexMustBeLessOrEqual);
             }
 
             if (array.Length - arrayIndex < _size)
             {
-                throw new ArgumentException(SR.Argument_InvalidOffLen);
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             }
 
             int numToCopy = _size;
@@ -124,23 +124,23 @@ namespace System.Collections.Generic
 
             if (array.Rank != 1)
             {
-                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported, ExceptionArgument.array);
             }
 
             if (array.GetLowerBound(0) != 0)
             {
-                throw new ArgumentException(SR.Arg_NonZeroLowerBound, nameof(array));
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound, ExceptionArgument.array);
             }
 
             int arrayLen = array.Length;
             if (index < 0 || index > arrayLen)
             {
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_IndexMustBeLessOrEqual);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
             if (arrayLen - index < _size)
             {
-                throw new ArgumentException(SR.Argument_InvalidOffLen);
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             }
 
             int numToCopy = _size;
@@ -159,7 +159,7 @@ namespace System.Collections.Generic
             }
             catch (ArrayTypeMismatchException)
             {
-                throw new ArgumentException(SR.Argument_IncompatibleArrayType, nameof(array));
+                ThrowHelper.ThrowArgumentException_Argument_IncompatibleArrayType();
             }
         }
 
@@ -442,7 +442,7 @@ namespace System.Collections.Generic
 
             public bool MoveNext()
             {
-                if (_version != _q._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                if (_version != _q._version) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
 
                 if (_index == -2)
                     return false;
@@ -493,7 +493,14 @@ namespace System.Collections.Generic
             private void ThrowEnumerationNotStartedOrEnded()
             {
                 Debug.Assert(_index == -1 || _index == -2);
-                throw new InvalidOperationException(_index == -1 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
+                if (_index == -1)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
+                }
+                else
+                {
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
+                }
             }
 
             object? IEnumerator.Current
@@ -503,7 +510,7 @@ namespace System.Collections.Generic
 
             void IEnumerator.Reset()
             {
-                if (_version != _q._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                if (_version != _q._version) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 _index = -1;
                 _currentElement = default;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
@@ -494,7 +494,6 @@ namespace System.Collections.Generic
             {
                 Debug.Assert(_index == -1 || _index == -2);
                 throw new InvalidOperationException(_index == -1 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
-
             }
 
             object? IEnumerator.Current

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
@@ -493,14 +493,8 @@ namespace System.Collections.Generic
             private void ThrowEnumerationNotStartedOrEnded()
             {
                 Debug.Assert(_index == -1 || _index == -2);
-                if (_index == -1)
-                {
-                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
-                }
-                else
-                {
-                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
-                }
+                throw new InvalidOperationException(_index == -1 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
+
             }
 
             object? IEnumerator.Current


### PR DESCRIPTION
Since it is a generic class, would probably be good to use existing helpers to reduce code size