### PR TITLE
Mark StringContent mediaType parameters as nullable

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -476,10 +476,10 @@ namespace System.Net.Http
     public partial class StringContent : System.Net.Http.ByteArrayContent
     {
         public StringContent(string content) : base (default(byte[])) { }
-        public StringContent(string content, System.Net.Http.Headers.MediaTypeHeaderValue mediaType) : base (default(byte[])) { }
+        public StringContent(string content, System.Net.Http.Headers.MediaTypeHeaderValue? mediaType) : base (default(byte[])) { }
         public StringContent(string content, System.Text.Encoding? encoding) : base (default(byte[])) { }
-        public StringContent(string content, System.Text.Encoding? encoding, System.Net.Http.Headers.MediaTypeHeaderValue mediaType) : base (default(byte[])) { }
-        public StringContent(string content, System.Text.Encoding? encoding, string mediaType) : base (default(byte[])) { }
+        public StringContent(string content, System.Text.Encoding? encoding, System.Net.Http.Headers.MediaTypeHeaderValue? mediaType) : base (default(byte[])) { }
+        public StringContent(string content, System.Text.Encoding? encoding, string? mediaType) : base (default(byte[])) { }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
         /// <summary>Creates a new instance of the <see cref="StringContent"/> class.</summary>
         /// <param name="content">The content used to initialize the <see cref="StringContent"/>.</param>
         /// <param name="mediaType">The media type to use for the content.</param>
-        public StringContent(string content, MediaTypeHeaderValue mediaType)
+        public StringContent(string content, MediaTypeHeaderValue? mediaType)
             : this(content, DefaultStringEncoding, mediaType)
         {
         }
@@ -45,7 +45,7 @@ namespace System.Net.Http
         /// <param name="content">The content used to initialize the <see cref="StringContent"/>.</param>
         /// <param name="encoding">The encoding to use for the content.</param>
         /// <param name="mediaType">The media type to use for the content.</param>
-        public StringContent(string content, Encoding? encoding, string mediaType)
+        public StringContent(string content, Encoding? encoding, string? mediaType)
             : base(GetContentByteArray(content, encoding))
         {
             Debug.Assert(DefaultStringEncoding.WebName == "utf-8");
@@ -77,7 +77,7 @@ namespace System.Net.Http
         /// <param name="content">The content used to initialize the <see cref="StringContent"/>.</param>
         /// <param name="encoding">The encoding to use for the content.</param>
         /// <param name="mediaType">The media type to use for the content.</param>
-        public StringContent(string content, Encoding? encoding, MediaTypeHeaderValue mediaType)
+        public StringContent(string content, Encoding? encoding, MediaTypeHeaderValue? mediaType)
             : base(GetContentByteArray(content, encoding))
         {
             Headers.ContentType = mediaType;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -275,7 +275,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, uri) =>
                 {
                     var request = new HttpRequestMessage(HttpMethod.Post, uri);
-                    request.Content = new StringContent("", null, ((MediaTypeHeaderValue)null)!);
+                    request.Content = new StringContent("", null, (MediaTypeHeaderValue)null);
 
                     Task<HttpResponseMessage> requestTask = client.SendAsync(request);
                     await server.AcceptConnectionAsync(async connection =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
@@ -131,7 +131,7 @@ namespace System.Net.Http.Functional.Tests
         {
             string sourceString = "\u00C4\u00E4\u00FC\u00DC";
             Encoding defaultStringEncoding = Encoding.GetEncoding("utf-8");
-            var content = new StringContent(sourceString, defaultStringEncoding, ((Headers.MediaTypeHeaderValue)null)!);
+            var content = new StringContent(sourceString, defaultStringEncoding, (MediaTypeHeaderValue)null);
 
             // If no media header value is passed-in, there is none
             Assert.Null(content.Headers.ContentType);


### PR DESCRIPTION
Closes #83423

This PR doesn't change the behavior of `MediaTypeHeaderValue? mediaType` overloads where `null` currently means "no media type".
If we decide that's something we want to do, we can do so as a follow-up.

We have existing tests covering passing `null` to these consturctors.