### PR TITLE
Validate generic constraints in ILLink tests

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Attributes.OnlyKeepUsedTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Attributes.OnlyKeepUsedTests.g.cs
@@ -64,7 +64,13 @@ namespace ILLink.RoslynAnalyzer.Tests.Attributes
 		}
 
 		[Fact]
-		public Task NullableOnConstraints ()
+		public Task NullableOnConstraintsKept ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
+		public Task NullableOnConstraintsRemoved ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/GenericsTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/GenericsTests.g.cs
@@ -16,6 +16,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task ByRefLike ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task CorrectOverloadedMethodGetsStrippedInGenericClass ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttributeOnConstraintAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttributeOnConstraintAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage (AttributeTargets.GenericParameter, Inherited = false)]
+	public class KeptAttributeOnConstraintAttribute : KeptAttribute
+	{
+		public KeptAttributeOnConstraintAttribute (Type constraintType, Type attributeType)
+		{
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptGenericParamAttributesAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptGenericParamAttributesAttribute.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage (AttributeTargets.All, Inherited = false)]
+	public class KeptGenericParamAttributesAttribute : KeptAttribute
+	{
+		public KeptGenericParamAttributesAttribute (GenericParameterAttributes attributes)
+		{
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
@@ -19,7 +21,10 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		[Kept]
-		static void Method<T> () where T : unmanaged
+		static void Method<
+			[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+			T
+		> () where T : unmanaged
 		{
 		}
 	}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraintsKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraintsKept.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
+{
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupLinkerTrimMode ("link")]
+	public class NullableOnConstraintsKept
+	{
+		public static void Main ()
+		{
+			Test.Run ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (I))]
+		class Test : I
+		{
+			[Kept]
+			public static void Run ()
+			{
+				new C<Test> ();
+				Method<Test> ();
+			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (NullableContextAttribute))]
+			static T? Method<
+				[KeptGenericParamAttributes (GenericParameterAttributes.ReferenceTypeConstraint)] 
+				[KeptAttributeAttribute (typeof (NullableAttribute))]
+				T
+			> ()
+				where T : class, I?
+			{
+				return default;
+			}
+		}
+
+		[Kept]
+		interface I
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class C<
+			[KeptAttributeOnConstraint (typeof (I), typeof (NullableAttribute))]
+			T
+		>
+			where T : I?
+		{
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraintsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraintsRemoved.cs
@@ -1,5 +1,8 @@
 #nullable enable
 
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
@@ -9,7 +12,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[SetupLinkerTrimMode ("link")]
 	[IgnoreDescriptors (false)]
-	public class NullableOnConstraints
+	public class NullableOnConstraintsRemoved
 	{
 		public static void Main ()
 		{
@@ -28,21 +31,24 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 			}
 
 			[Kept]
-			static T? Method<T> () where T : class, I?
+			static T? Method<
+				[KeptGenericParamAttributes (GenericParameterAttributes.ReferenceTypeConstraint)] 
+				T
+			> () where T : class, I?
 			{
 				return default;
 			}
 		}
-	}
 
-	[Kept]
-	interface I
-	{
-	}
+		[Kept]
+		interface I
+		{
+		}
 
-	[Kept]
-	[KeptMember (".ctor()")]
-	class C<T> where T : I?
-	{
+		[Kept]
+		[KeptMember (".ctor()")]
+		class C<T> where T : I?
+		{
+		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraintsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraintsRemoved.cs
@@ -2,7 +2,6 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
-
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using DAM = System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute;
@@ -131,14 +132,22 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		static void NullableOfAnnotatedGenericParameterRequiresPublicProperties<[KeptAttributeAttribute (typeof (DAM))][DAM (DAMT.PublicProperties)] T> () where T : struct
+		static void NullableOfAnnotatedGenericParameterRequiresPublicProperties<
+			[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+			[KeptAttributeAttribute (typeof (DAM))]
+			[DAM (DAMT.PublicProperties)]
+			T
+		> () where T : struct
 		{
 			Nullable.GetUnderlyingType (typeof (Nullable<T>)).RequiresPublicProperties ();
 		}
 
 		[Kept]
 		[ExpectedWarning ("IL2087")]
-		static void NullableOfUnannotatedGenericParameterRequiresPublicProperties<T> () where T : struct
+		static void NullableOfUnannotatedGenericParameterRequiresPublicProperties<
+			[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+			T
+		> () where T : struct
 		{
 			Nullable.GetUnderlyingType (typeof (Nullable<T>)).RequiresPublicProperties ();
 		}
@@ -240,7 +249,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		static void UnderlyingTypeOfCreatedNullableOfAnnotatedTRequiresPublicProperties<[KeptAttributeAttribute (typeof (DAM))][DAM (DAMT.PublicProperties)] T> () where T : struct
+		static void UnderlyingTypeOfCreatedNullableOfAnnotatedTRequiresPublicProperties<
+			[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+			[KeptAttributeAttribute (typeof (DAM))]
+			[DAM (DAMT.PublicProperties)]
+			T
+		> () where T : struct
 		{
 			Type t = typeof (Nullable<T>);
 			t = Nullable.GetUnderlyingType (t);
@@ -262,13 +276,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[Kept]
 		[ExpectedWarning ("IL2091")]
-		static void NullableOfUnannotatedGenericParamPassedAsGenericParamRequiresPublicFields<T> () where T : struct
+		static void NullableOfUnannotatedGenericParamPassedAsGenericParamRequiresPublicFields<
+			[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+			T
+		> () where T : struct
 		{
 			RequirePublicFieldsOnGenericParam<Nullable<T>> ();
 		}
 
 		[Kept]
-		static void NullableOfAnnotatedGenericParamPassedAsGenericParamRequiresPublicFields<[KeptAttributeAttribute (typeof (DAM))][DAM (DAMT.PublicFields)] T> () where T : struct
+		static void NullableOfAnnotatedGenericParamPassedAsGenericParamRequiresPublicFields<
+			[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+			[KeptAttributeAttribute (typeof (DAM))]
+			[DAM (DAMT.PublicFields)] T
+		> () where T : struct
 		{
 			RequirePublicFieldsOnGenericParam<Nullable<T>> ();
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/ByRefLike.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/ByRefLike.cs
@@ -8,6 +8,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Generics
 {
 	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/82447", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	class ByRefLike
 	{
 		static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/ByRefLike.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/ByRefLike.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Generics
+{
+	class ByRefLike
+	{
+		static void Main ()
+		{
+			Test ();
+		}
+
+		[Kept]
+		static void Test ()
+		{
+			G<RefStruct> g = new ();
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (IsByRefLikeAttribute))]
+		[KeptAttributeAttribute (typeof (ObsoleteAttribute))] // Signals this is unsupported to older compilers
+		[KeptAttributeAttribute (typeof (CompilerFeatureRequiredAttribute))]
+		ref struct RefStruct {
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (IsByRefLikeAttribute))]
+		[KeptAttributeAttribute (typeof (ObsoleteAttribute))] // Signals this is unsupported to older compilers
+		[KeptAttributeAttribute (typeof (CompilerFeatureRequiredAttribute))]
+		ref struct G<
+			[KeptGenericParamAttributes (GenericParameterAttributes.AllowByRefLike)]
+			T
+		> where T : allows ref struct {
+			[Kept]
+			public T t;
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/ByRefLike.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/ByRefLike.cs
@@ -7,6 +7,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Generics
 {
+	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/82447", IgnoredBy = Tool.NativeAot)]
 	class ByRefLike
 	{
 		static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/NewConstraintOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/NewConstraintOnClass.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Generics
@@ -36,7 +37,10 @@ namespace Mono.Linker.Tests.Cases.Generics
 
 			[Kept]
 			[KeptMember (".ctor()")]
-			class WithConstraint<T> where T : new()
+			class WithConstraint<
+				[KeptGenericParamAttributes (GenericParameterAttributes.DefaultConstructorConstraint)]
+				T
+			> where T : new()
 			{
 			}
 
@@ -70,7 +74,10 @@ namespace Mono.Linker.Tests.Cases.Generics
 
 			[Kept]
 			[KeptMember (".ctor()")]
-			class WithConstraint<T> where T : struct
+			class WithConstraint<
+				[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+				T
+			> where T : struct
 			{
 			}
 
@@ -104,7 +111,11 @@ namespace Mono.Linker.Tests.Cases.Generics
 
 			[Kept]
 			[KeptMember (".ctor()")]
-			class WithConstraint<[KeptAttributeAttribute (typeof (IsUnmanagedAttribute))] T> where T : unmanaged
+			class WithConstraint<
+				[KeptAttributeAttribute (typeof (IsUnmanagedAttribute))]
+				[KeptGenericParamAttributes (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)]
+				T
+			> where T : unmanaged
 			{
 			}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/VariantCasting.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/VariantCasting.cs
@@ -1,11 +1,16 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using System.Reflection;
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Generics
 {
 	public class VariantCasting
 	{
 		[Kept]
-		interface IVariant<out T> { }
+		interface IVariant<
+			[KeptGenericParamAttributes (GenericParameterAttributes.Covariant)]
+			out T
+		> { }
 
 		[Kept]
 		interface IFoo { }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructWithNestedStructImplementingInterface.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructWithNestedStructImplementingInterface.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType
@@ -33,7 +35,10 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType
 		}
 
 		[Kept]
-		public interface IBuildable<T> : IBuildable where T : IBuilder, new()
+		public interface IBuildable<
+			[KeptGenericParamAttributes (GenericParameterAttributes.DefaultConstructorConstraint)]
+			T
+		> : IBuildable where T : IBuilder, new()
 		{
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructWithNestedStructImplementingInterface.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructWithNestedStructImplementingInterface.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethodsLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethodsLibrary.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Reflection;
-
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethodsLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethodsLibrary.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Reflection;
+
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -410,7 +412,10 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
 			}
 
 			[Kept]
-			internal static void CallExplicitImplMethod<T> () where T : IStaticAndInstanceMethods, new()
+			internal static void CallExplicitImplMethod<
+				[KeptGenericParamAttributes (GenericParameterAttributes.DefaultConstructorConstraint)]
+				T
+			> () where T : IStaticAndInstanceMethods, new()
 			{
 				T.StaticMethodExplicitImpl ();
 				IStaticAndInstanceMethods x = new T ();
@@ -418,7 +423,10 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
 			}
 
 			[Kept]
-			internal static void CallExplicitImplMethodInternalUsed<T> () where T : IStaticAndInstanceMethodsInternalUsed, new()
+			internal static void CallExplicitImplMethodInternalUsed<
+				[KeptGenericParamAttributes (GenericParameterAttributes.DefaultConstructorConstraint)]
+				T
+			> () where T : IStaticAndInstanceMethodsInternalUsed, new()
 			{
 				T.StaticMethodExplicitImpl ();
 				IStaticAndInstanceMethodsInternalUsed x = new T ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/VarianceBasic.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/VarianceBasic.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection;
+
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
@@ -11,13 +13,19 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
 			TestEntrypoint.Test ();
 		}
 		[Kept]
-		public interface InterfaceScenario1<in T>
+		public interface InterfaceScenario1<
+			[KeptGenericParamAttributes (GenericParameterAttributes.Contravariant)]
+			in T
+		>
 		{
 			[Kept]
 			static abstract int Method ();
 		}
 		[Kept]
-		public interface InterfaceScenario2<in T>
+		public interface InterfaceScenario2<
+			[KeptGenericParamAttributes (GenericParameterAttributes.Contravariant)]
+			in T
+		>
 		{
 			[Kept]
 			static abstract int Method ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/VarianceBasic.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/VarianceBasic.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -541,7 +541,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
-		private static void TestCreateInstanceOfTWithNewConstraint<T> () where T : new()
+		private static void TestCreateInstanceOfTWithNewConstraint<
+			[KeptGenericParamAttributes (GenericParameterAttributes.DefaultConstructorConstraint)]
+			T
+		> () where T : new()
 		{
 			Activator.CreateInstance<T> ();
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -195,9 +196,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				[Kept]
 				[KeptMember (".cctor()")]
 				class Generic<
+					[KeptGenericParamAttributes (GenericParameterAttributes.DefaultConstructorConstraint)]
 					[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-				TWithMethods> where TWithMethods : new()
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+					TWithMethods
+				> where TWithMethods : new()
 				{
 					[Kept]
 					static TWithMethods ReturnAnnotated () { return new TWithMethods (); }


### PR DESCRIPTION
And add a test for byref-like types.

Closes https://github.com/dotnet/runtime/issues/98519