### PR TITLE
[release/8.0-staging] [mono] Fix assembly name parser to accommodate non-ASCII UTF8 strings

### DIFF
--- a/src/libraries/System.Reflection/tests/GetTypeTests.cs
+++ b/src/libraries/System.Reflection/tests/GetTypeTests.cs
@@ -262,6 +262,14 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public void TestAssemblyNameWithInternationalChar()
+        {
+            Type testObj = typeof(Hello工程123.Program);
+            var t = Type.GetType(testObj.AssemblyQualifiedName);
+            Assert.NotNull(t);
+        }
+
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/37871", TestRuntimes.Mono)]
         public void GetType_GenericTypeArgumentList()
         {

--- a/src/libraries/System.Reflection/tests/Hello工程123/Hello工程123.cs
+++ b/src/libraries/System.Reflection/tests/Hello工程123/Hello工程123.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace System.Reflection.Hello工程123
+{
+    public class Program
+    {
+    }
+}

--- a/src/libraries/System.Reflection/tests/Hello工程123/Hello工程123.csproj
+++ b/src/libraries/System.Reflection/tests/Hello工程123/Hello工程123.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="Hello工程123.cs" />
+    </ItemGroup>
+</Project>

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -76,6 +76,7 @@
     <ProjectReference Include="UnloadableAssembly\UnloadableAssembly.csproj" />
     <ProjectReference Include="TestExe\System.Reflection.TestExe.csproj" />
     <ProjectReference Include="TestAssembly\TestAssembly.csproj" />
+    <ProjectReference Include="Hello工程123\Hello工程123.csproj" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetOS)' == 'browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />
@@ -86,5 +87,6 @@
 
     <!-- Assemblies that should be excluded from the bundle -->
     <__ExcludeFromBundle Include="TestAssembly.dll" />
+    <__ExcludeFromBundle Include="Hello工程123.dll" />
   </ItemGroup>
 </Project>

--- a/src/mono/mono/eglib/eglib-remap.h
+++ b/src/mono/mono/eglib/eglib-remap.h
@@ -232,6 +232,7 @@
 #define g_utf8_strlen monoeg_g_utf8_strlen
 #define g_utf8_to_utf16 monoeg_g_utf8_to_utf16
 #define g_utf8_to_utf16_custom_alloc monoeg_g_utf8_to_utf16_custom_alloc
+#define g_utf8_validate_part monoeg_g_utf8_validate_part
 #define g_utf8_validate monoeg_g_utf8_validate
 #define g_unichar_to_utf8 monoeg_g_unichar_to_utf8
 #define g_utf8_offset_to_pointer monoeg_g_utf8_offset_to_pointer

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1165,6 +1165,7 @@ int          g_mkdir_with_parents (const gchar *pathname, int mode);
  */
 extern const guchar g_utf8_jump_table[256];
 
+gboolean  g_utf8_validate_part (const unsigned char *inptr, size_t len);
 gboolean  g_utf8_validate      (const gchar *str, gssize max_len, const gchar **end);
 gunichar  g_utf8_get_char_validated (const gchar *str, gssize max_len);
 #define   g_utf8_next_char(p)  ((p) + g_utf8_jump_table[(guchar)(*p)])

--- a/src/mono/mono/eglib/gutf8.c
+++ b/src/mono/mono/eglib/gutf8.c
@@ -30,8 +30,8 @@ const guchar g_utf8_jump_table[256] = {
 	3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3, 4,4,4,4,4,4,4,4,5,5,5,5,6,6,1,1
 };
 
-static gboolean
-utf8_validate (const unsigned char *inptr, size_t len)
+gboolean
+g_utf8_validate_part (const unsigned char *inptr, size_t len)
 {
 	const unsigned char *ptr = inptr + len;
 	unsigned char c;
@@ -105,7 +105,7 @@ g_utf8_validate (const gchar *str, gssize max_len, const gchar **end)
 	if (max_len < 0) {
 		while (*inptr != 0) {
 			length = g_utf8_jump_table[*inptr];
-			if (!utf8_validate (inptr, length)) {
+			if (!g_utf8_validate_part (inptr, length)) {
 				valid = FALSE;
 				break;
 			}
@@ -124,7 +124,7 @@ g_utf8_validate (const gchar *str, gssize max_len, const gchar **end)
 			length = g_utf8_jump_table[*inptr];
 			min = MIN (length, GSSIZE_TO_UINT (max_len - n));
 
-			if (!utf8_validate (inptr, min)) {
+			if (!g_utf8_validate_part (inptr, min)) {
 				valid = FALSE;
 				break;
 			}
@@ -180,13 +180,13 @@ g_utf8_get_char_validated (const gchar *str, gssize max_len)
 	}
 
 	if (max_len > 0) {
-		if (!utf8_validate (inptr, MIN (max_len, n)))
+		if (!g_utf8_validate_part (inptr, MIN (max_len, n)))
 			return -1;
 
 		if (max_len < n)
 			return -2;
 	} else {
-		if (!utf8_validate (inptr, n))
+		if (!g_utf8_validate_part (inptr, n))
 			return -1;
 	}
 

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1530,8 +1530,17 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 	}
 	assembly->name = p;
 	s = p;
-	while (*p && (isalnum (*p) || *p == '.' || *p == '-' || *p == '_' || *p == '$' || *p == '@' || g_ascii_isspace (*p)))
-		p++;
+	guchar *inptr = (guchar *) p;
+	while (*p && (*p != ',') && (*p != '\0')) {
+		if (quoted && (*p == '"'))
+			break;
+		guint length = g_utf8_jump_table[*inptr];
+		if (!g_utf8_validate_part (inptr, length)) {
+			return 0;
+		}
+		p += length;
+		inptr += length;
+	}
 	if (quoted) {
 		if (*p != '"')
 			return 1;
@@ -1630,7 +1639,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 			found_sep = 1;
 			continue;
 		}
-		/* failed */
+		/* Done processing */
 		if (!found_sep)
 			return 1;
 	}


### PR DESCRIPTION
Backport of #103363 to release/8.0

/cc @fanyang-mono

## Customer Impact
Prior to this change, `Type.GetType` fails if using fully qualified assembly names where the assembly has certain international characters, when using Mono runtime.

## Testing
Added a new test, which passed on CI. 
Manually validated the problematic maccatalyst app reported in the original issue. It works correctly now.

## Risk
Moderate risk.

