### PR TITLE
[PERF] Update the artifact path for the maui benchmarks app

### DIFF
--- a/eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
@@ -148,7 +148,7 @@ steps:
 # Remove the embed assemblies from source
   - script: |
       ../dotnet build ./src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj --configuration Release -bl:BenchmarksDroid.binlog /p:TF_Build=False /p:ForceNet8Current=true
-      mv ./src/Core/tests/Benchmarks.Droid/bin/Release/${{parameters.framework}}-android/android-arm64/com.microsoft.maui.benchmarks-Signed.apk ./MonoBenchmarksDroid.apk
+      mv ./artifacts/bin/Benchmarks.Droid/Release/${{parameters.framework}}-android/android-arm64/com.microsoft.maui.benchmarks-Signed.apk ./MonoBenchmarksDroid.apk
     displayName:  Build BDN Android App
     workingDirectory: $(Build.SourcesDirectory)/maui
 


### PR DESCRIPTION
Update the artifact path for the maui benchmarks app to fix android testing.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2473560&view=results, the single android failure is unrelated to this PR, instead being due to machine issues.