### PR TITLE
Exclude cdacreader from mono packs

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -121,7 +121,7 @@
       </CoreCLRCrossTargetFiles>
     </ItemGroup>
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
-      <RuntimeFiles Include="$(MonoArtifactsPath)\*.*" />
+      <RuntimeFiles Include="$(MonoArtifactsPath)\*.*" Exclude="$(MonoArtifactsPath)\*cdacreader*" />
       <RuntimeFiles>
         <IsNative>true</IsNative>
       </RuntimeFiles>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -120,9 +120,12 @@
     <PlatformManifestFileEntry Include="mscordaccore.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.dylib" IsNative="true" />
+
+    <!-- We don't want to ship cdacreader yet -->
     <PlatformManifestFileEntry Include="cdacreader.dll" ExcludeFromDataFiles="true" />
     <PlatformManifestFileEntry Include="libcdacreader.so" ExcludeFromDataFiles="true" />
     <PlatformManifestFileEntry Include="libcdacreader.dylib" ExcludeFromDataFiles="true" />
+
     <PlatformManifestFileEntry Include="mscordbi.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.dylib" IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -120,12 +120,6 @@
     <PlatformManifestFileEntry Include="mscordaccore.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.dylib" IsNative="true" />
-
-    <!-- We don't want to ship cdacreader yet -->
-    <PlatformManifestFileEntry Include="cdacreader.dll" ExcludeFromDataFiles="true" />
-    <PlatformManifestFileEntry Include="libcdacreader.so" ExcludeFromDataFiles="true" />
-    <PlatformManifestFileEntry Include="libcdacreader.dylib" ExcludeFromDataFiles="true" />
-
     <PlatformManifestFileEntry Include="mscordbi.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.dylib" IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -120,6 +120,7 @@
     <PlatformManifestFileEntry Include="mscordaccore.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Include="cdacreader.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libcdacreader.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libcdacreader.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="mscordbi.dll" IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -120,6 +120,8 @@
     <PlatformManifestFileEntry Include="mscordaccore.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Include="libcdacreader.so" IsNative="true" />
+    <PlatformManifestFileEntry Include="libcdacreader.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="mscordbi.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.dylib" IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -120,9 +120,9 @@
     <PlatformManifestFileEntry Include="mscordaccore.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.dylib" IsNative="true" />
-    <PlatformManifestFileEntry Include="cdacreader.dll" IsNative="true" />
-    <PlatformManifestFileEntry Include="libcdacreader.so" IsNative="true" />
-    <PlatformManifestFileEntry Include="libcdacreader.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Include="cdacreader.dll" ExcludeFromDataFiles="true" />
+    <PlatformManifestFileEntry Include="libcdacreader.so" ExcludeFromDataFiles="true" />
+    <PlatformManifestFileEntry Include="libcdacreader.dylib" ExcludeFromDataFiles="true" />
     <PlatformManifestFileEntry Include="mscordbi.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordbi.dylib" IsNative="true" />


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/103486