### PR TITLE
Fix linux arm64 release build

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -8583,6 +8583,10 @@ int MethodTable::GetFieldAlignmentRequirement()
     return min((int)GetNumInstanceFieldBytes(), TARGET_POINTER_SIZE);
 }
 
+#if defined(TARGET_LINUX) && defined(TARGET_ARM64)
+// Workaround bug https://github.com/dotnet/runtime/issues/103489
+[[clang::optnone]]
+#endif
 UINT32 MethodTable::GetNativeSize()
 {
     CONTRACTL

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -8583,7 +8583,7 @@ int MethodTable::GetFieldAlignmentRequirement()
     return min((int)GetNumInstanceFieldBytes(), TARGET_POINTER_SIZE);
 }
 
-#if defined(TARGET_LINUX) && defined(TARGET_ARM64)
+#if defined(TARGET_ARM64) && defined(__llvm__)
 // Workaround bug https://github.com/dotnet/runtime/issues/103489
 [[clang::optnone]]
 #endif


### PR DESCRIPTION
- Workaround issue where the link register isn't being reported properly in the unwind data

Works around #103489