### PR TITLE
JIT: Optimize out write barriers for fields in ref-like structs

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8166,6 +8166,7 @@ public:
     // Get the flags
 
     bool eeIsValueClass(CORINFO_CLASS_HANDLE clsHnd);
+    bool eeIsByrefLike(CORINFO_CLASS_HANDLE clsHnd);
     bool eeIsIntrinsic(CORINFO_METHOD_HANDLE ftn);
     bool eeIsFieldStatic(CORINFO_FIELD_HANDLE fldHnd);
 

--- a/src/coreclr/jit/ee_il_dll.hpp
+++ b/src/coreclr/jit/ee_il_dll.hpp
@@ -54,6 +54,12 @@ bool Compiler::eeIsValueClass(CORINFO_CLASS_HANDLE clsHnd)
 }
 
 FORCEINLINE
+bool Compiler::eeIsByrefLike(CORINFO_CLASS_HANDLE clsHnd)
+{
+    return (info.compCompHnd->getClassAttribs(clsHnd) & CORINFO_FLG_BYREF_LIKE) != 0;
+}
+
+FORCEINLINE
 bool Compiler::eeIsIntrinsic(CORINFO_METHOD_HANDLE ftn)
 {
     return info.compCompHnd->isIntrinsic(ftn);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2672,8 +2672,7 @@ bool Compiler::verCheckTailCallConstraint(OPCODE                  opcode,
         }
 
         // Check that the argument is not a byref-like for tailcalls.
-        if ((ciType == CORINFO_TYPE_VALUECLASS) &&
-            ((info.compCompHnd->getClassAttribs(classHandle) & CORINFO_FLG_BYREF_LIKE) != 0))
+        if ((ciType == CORINFO_TYPE_VALUECLASS) && eeIsByrefLike(classHandle))
         {
             return false;
         }
@@ -10121,8 +10120,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     break;
                 }
 
-                bool isByRefLike =
-                    (info.compCompHnd->getClassAttribs(resolvedToken.hClass) & CORINFO_FLG_BYREF_LIKE) != 0;
+                bool isByRefLike = eeIsByrefLike(resolvedToken.hClass);
                 if (isByRefLike)
                 {
                     // For ByRefLike types we are required to either fold the

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3885,8 +3885,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                             retNode = gtNewIconNode(eeIsValueClass(hClass) ? 1 : 0);
                             break;
                         case NI_System_Type_get_IsByRefLike:
-                            retNode = gtNewIconNode(
-                                (info.compCompHnd->getClassAttribs(hClass) & CORINFO_FLG_BYREF_LIKE) ? 1 : 0);
+                            retNode = gtNewIconNode(eeIsByrefLike(hClass) ? 1 : 0);
                             break;
                         case NI_System_Type_get_IsPrimitive:
                             // getTypeForPrimitiveValueClass returns underlying type for enums, so we check it first

--- a/src/coreclr/jit/layout.cpp
+++ b/src/coreclr/jit/layout.cpp
@@ -432,8 +432,7 @@ void ClassLayout::InitializeGCPtrs(Compiler* compiler)
 bool ClassLayout::IsStackOnly(Compiler* comp) const
 {
     // Byref-like structs are stack only
-    if ((m_classHandle != NO_CLASS_HANDLE) &&
-        (((comp->info.compCompHnd->getClassAttribs(m_classHandle)) & CORINFO_FLG_BYREF_LIKE) != 0))
+    if ((m_classHandle != NO_CLASS_HANDLE) && comp->eeIsByrefLike(m_classHandle))
     {
         return true;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7738,7 +7738,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
         case GT_STOREIND:
             if (op1->OperIs(GT_FIELD_ADDR) && varTypeIsGC(tree))
             {
-                CORINFO_FIELD_HANDLE fieldHandle = tree->AsFieldAddr()->gtFldHnd;
+                CORINFO_FIELD_HANDLE fieldHandle = op1->AsFieldAddr()->gtFldHnd;
                 if (eeIsByrefLike(info.compCompHnd->getFieldClass(fieldHandle)))
                 {
                     JITDUMP("Marking [%06u] STOREIND as GTF_IND_TGT_NOT_HEAP: field's owner is a byref-like struct\n",

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7735,6 +7735,19 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
             }
             break;
 
+        case GT_STOREIND:
+            if (op1->OperIs(GT_FIELD_ADDR) && varTypeIsGC(tree))
+            {
+                CORINFO_FIELD_HANDLE fieldHandle = tree->AsFieldAddr()->gtFldHnd;
+                if (eeIsByrefLike(info.compCompHnd->getFieldClass(fieldHandle)))
+                {
+                    JITDUMP("Marking [%06u] STOREIND as GTF_IND_TGT_NOT_HEAP: field's owner is a byref-like struct\n",
+                            dspTreeID(tree));
+                    tree->gtFlags |= GTF_IND_TGT_NOT_HEAP;
+                }
+            }
+            break;
+
         case GT_DIV:
             // Replace "val / dcon" with "val * (1.0 / dcon)" if dcon is a power of two.
             // Powers of two within range are always exactly represented,


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/9512

Remove write barriers for fields of `ref ByrefLikeStruct` arguments since we know that such refs always point to stack, Example:

```cs
void Test(ref MyStruct s, object o1, object o2)
{
    s.A = o1;
    s.B = o2;
}

ref struct MyStruct
{ 
    public object A;
    public object B;
}
```
Codegen for `Test(...)` on Main:
```asm
; Method Prog:Test(byref,System.Object,System.Object):this (FullOpts)
G_M1451_IG01:
       push     rsi
       push     rbx
       mov      rbx, rdx
       mov      rsi, r9

G_M1451_IG02:
       mov      rcx, rbx
       mov      rdx, r8
       call     CORINFO_HELP_CHECKED_ASSIGN_REF
       lea      rcx, bword ptr [rbx+0x08]
       mov      rdx, rsi
       call     CORINFO_HELP_CHECKED_ASSIGN_REF
       nop      

G_M1451_IG03:
       pop      rbx
       pop      rsi
       ret      
; Total bytes of code: 35
```
This PR:
```asm
; Method Prog:Test(byref,System.Object,System.Object):this (FullOpts)
G_M1451_IG01:
G_M1451_IG02:
       mov      gword ptr [rdx], r8
       mov      gword ptr [rdx+0x08], r9

G_M1451_IG03:
       ret      
; Total bytes of code: 8
```

[Similar case](https://github.com/dotnet/runtime/issues/9512#issuecomment-355770014) when ref struct is "this":
```cs
ref struct RefLike
{
    public object o;

    public void Test(object o)
    {
        this.o = o; // Main: checked-write-barrier, PR: no-barrier
    }
}
```