### PR TITLE
Remove use of alloca from getexepath

### DIFF
--- a/src/native/minipal/getexepath.h
+++ b/src/native/minipal/getexepath.h
@@ -30,25 +30,15 @@ extern "C" {
 static inline char* minipal_getexepath(void)
 {
 #if defined(__APPLE__)
-    uint32_t path_length = 0;
-    if (_NSGetExecutablePath(NULL, &path_length) != -1)
+    uint32_t len = PATH_MAX;
+    char pathBuf[PATH_MAX];
+    if (_NSGetExecutablePath(pathBuf, &len) != 0)
     {
         errno = EINVAL;
         return NULL;
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Walloca"
-    char* path_buf = (char*)alloca(path_length);
-#pragma clang diagnostic pop
-
-    if (_NSGetExecutablePath(path_buf, &path_length) != 0)
-    {
-        errno = EINVAL;
-        return NULL;
-    }
-
-    return realpath(path_buf, NULL);
+    return realpath(pathBuf, NULL);
 #elif defined(__FreeBSD__)
     static const int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
     char path[PATH_MAX];


### PR DESCRIPTION
length > PATH_MAX fails on mac anyway, so lets align the implementation with FreeBSD and Windows.

Change `1..9` to `1..10` in the following script (under 'round 2') and it will get SIGKILL for both old_code_executable and new_code_executable alike:
```sh
#!/bin/bash

# filename: test-longlen.sh

# Create a deep directory structure
pushd /tmp
DEEP_DIR="deep_dir"
DEEP_PATH=
for i in {1..100}; do
    DEEP_PATH+="${DEEP_DIR}/"
done

mkdir -p "${DEEP_PATH}"
pushd "${DEEP_PATH}"

# round 2 to avoid mkdir/pushd hitting the limits

DEEP_DIR2="deep_dir2"
DEEP_PATH2=
for i in {1..9}; do
    DEEP_PATH2+="${DEEP_DIR2}/"
done

mkdir -p "${DEEP_PATH2}"
pushd "${DEEP_PATH2}"

echo "Path length: $(pwd | wc -c)"

# Old code using dynamic stack allocation
cc -xc -o old_code_executable - <<EOF
#include <stdint.h>
#include <stdlib.h>
#include <mach-o/dyld.h>
#include <errno.h>
#include <limits.h>
#include <stdio.h>

static inline char* minipal_getexepath(void)
{
#if defined(__APPLE__)
    uint32_t path_length = 0;
    if (_NSGetExecutablePath(NULL, &path_length) != -1)
    {
        errno = EINVAL;
        return NULL;
    }

#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Walloca"
    char* path_buf = (char*)alloca(path_length);
#pragma clang diagnostic pop

    if (_NSGetExecutablePath(path_buf, &path_length) != 0)
    {
        errno = EINVAL;
        return NULL;
    }

    return realpath(path_buf, NULL);
#else
    return NULL;
#endif
}

int main() {
    char* path = minipal_getexepath();
    if (path) {
        printf("Executable Path: %s\n", path);
        free(path);
    } else {
        perror("Error getting executable path");
    }
    return 0;
}
EOF

# New code using fixed-size stack allocation
cc -xc -o new_code_executable - <<EOF
#include <stdint.h>
#include <stdlib.h>
#include <mach-o/dyld.h>
#include <errno.h>
#include <limits.h>
#include <stdio.h>

static inline char* minipal_getexepath(void)
{
#if defined(__APPLE__)
    uint32_t len = PATH_MAX;
    char pathBuf[PATH_MAX];
    if (_NSGetExecutablePath(pathBuf, &len) != 0)
    {
        errno = EINVAL;
        return NULL;
    }

    return realpath(pathBuf, NULL);
#else
    return NULL;
#endif
}

int main() {
    char* path = minipal_getexepath();
    if (path) {
        printf("Executable Path: %s\n", path);
        free(path);
    } else {
        perror("Error getting executable path");
    }
    return 0;
}
EOF

# Run both versions and capture the output
echo "Running old code executable:"
./old_code_executable

echo "Running new code executable:"
./new_code_executable

# cleanup
rm -rf /tmp/deep_dir

popd
popd
popd
```