### PR TITLE
Fix paltests build

### DIFF
--- a/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test2/ReadFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test2/ReadFile.cpp
@@ -129,8 +129,8 @@ PALTEST(file_io_ReadFile_test2_paltest_readfile_test2, "file_io/ReadFile/test2/p
 
     DWORD dwByteCount[] = { 0,
                             10,
-                            strlen(szStringTest),
-                            pageSize
+                            (DWORD)strlen(szStringTest),
+                            (DWORD)pageSize
     // Commented out two negative test cases : Refer VSW 312690
     //                            2 * pageSize,
     //                           -1

--- a/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test2/WriteFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test2/WriteFile.cpp
@@ -59,7 +59,7 @@ BOOL writeTest_WriteFile_test2(DWORD dwByteCount, DWORD dwBytesWrittenResult, BO
 PALTEST(file_io_WriteFile_test2_paltest_writefile_test2, "file_io/WriteFile/test2/paltest_writefile_test2")
 {
     const char * testString = "The quick fox jumped over the lazy dog's back.";
-    const DWORD testStringLen = strlen(testString);
+    const DWORD testStringLen = (DWORD)strlen(testString);
 
     DWORD dwByteCount[4] =   {(DWORD)-1,    10,   testStringLen, 0};
     DWORD dwByteWritten[4] = {0,     10,   testStringLen, 0};

--- a/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test2/WriteFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test2/WriteFile.cpp
@@ -59,10 +59,10 @@ BOOL writeTest_WriteFile_test2(DWORD dwByteCount, DWORD dwBytesWrittenResult, BO
 PALTEST(file_io_WriteFile_test2_paltest_writefile_test2, "file_io/WriteFile/test2/paltest_writefile_test2")
 {
     const char * testString = "The quick fox jumped over the lazy dog's back.";
-    const int testStringLen = strlen(testString);
+    const DWORD testStringLen = strlen(testString);
 
-    DWORD dwByteCount[4] =   {(DWORD)-1,    10,   (DWORD)testStringLen, 0};
-    DWORD dwByteWritten[4] = {0,     10,   (DWORD)testStringLen, 0};
+    DWORD dwByteCount[4] =   {(DWORD)-1,    10,   testStringLen, 0};
+    DWORD dwByteWritten[4] = {0,     10,   testStringLen, 0};
     BOOL bResults[] =        {FALSE, TRUE, TRUE,          TRUE};
 
     const int BUFFER_SIZE = 2 * PAGESIZE;

--- a/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test2/WriteFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test2/WriteFile.cpp
@@ -61,8 +61,8 @@ PALTEST(file_io_WriteFile_test2_paltest_writefile_test2, "file_io/WriteFile/test
     const char * testString = "The quick fox jumped over the lazy dog's back.";
     const int testStringLen = strlen(testString);
 
-    DWORD dwByteCount[4] =   {-1,    10,   testStringLen, 0};
-    DWORD dwByteWritten[4] = {0,     10,   testStringLen, 0};
+    DWORD dwByteCount[4] =   {(DWORD)-1,    10,   (DWORD)testStringLen, 0};
+    DWORD dwByteWritten[4] = {0,     10,   (DWORD)testStringLen, 0};
     BOOL bResults[] =        {FALSE, TRUE, TRUE,          TRUE};
 
     const int BUFFER_SIZE = 2 * PAGESIZE;


### PR DESCRIPTION
https://dev.azure.com/dnceng-public/public/_build/results?buildId=708804&view=logs&jobId=a3b522d2-1fcb-58aa-d1da-345566122d64&j=a3b522d2-1fcb-58aa-d1da-345566122d64&t=28177cd9-7046-57c0-17a4-2d126beee140

```
/__w/1/s/build.sh -ci -arch arm64 -os linux -cross -s clr.paltests+clr.paltestlist      
...
  [ 70%] Building CXX object pal/tests/palsuite/CMakeFiles/paltests.dir/file_io/ReadFile/test3/ReadFile.cpp.o
  /__w/1/s/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test2/ReadFile.cpp:132:29: error: non-constant-expression cannot be narrowed from type 'size_t' (aka 'unsigned long') to 'DWORD' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
    132 |                             strlen(szStringTest),
        |                             ^~~~~~~~~~~~~~~~~~~~
  /__w/1/s/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test2/ReadFile.cpp:132:29: note: insert an explicit cast to silence this issue
    132 |                             strlen(szStringTest),
        |                             ^~~~~~~~~~~~~~~~~~~~
        |                             static_cast<DWORD>( )
  /__w/1/s/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test2/ReadFile.cpp:133:29: error: non-constant-expression cannot be narrowed from type 'long' to 'DWORD' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
    133 |                             pageSize
        |                             ^~~~~~~~
  /__w/1/s/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test2/ReadFile.cpp:133:29: note: insert an explicit cast to silence this issue
    133 |                             pageSize
        |                             ^~~~~~~~
        |                             static_cast<DWORD>( )
  [ 70%] Building CXX object pal/tests/palsuite/CMakeFiles/paltests.dir/file_io/ReadFile/test4/readfile.cpp.o
  2 errors generated.

```