### PR TITLE
fix null check to unblock sdk

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -163,8 +163,10 @@ namespace Microsoft.Extensions.Hosting
                         => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
                             arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
 
-                    if (!args.Any(arg => IsApplicationNameArg(arg)) && assembly?.GetName().Name is string assemblyName)
+                    if (!args.Any(arg => IsApplicationNameArg(arg)) && assembly.GetName().Name is string assemblyName)
+                    {
                         args = args.Concat(new[] { "--applicationName", assemblyName }).ToArray();
+                    }
 
                     var host = hostFactory(args);
                     return GetServiceProvider(host);

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Extensions.Hosting
                         => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
                             arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
 
-                    args = args.Any(arg => IsApplicationNameArg(arg)) || assembly?.GetName().Name is null
+                    args = args.Any(arg => IsApplicationNameArg(arg)) || assembly is null || assembly.GetName().Name is null
                         ? args
                         : args.Concat(new[] { "--applicationName", assembly.GetName().Name }).ToArray();
 

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Extensions.Hosting
                         => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
                             arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
 
-                    args = (args.Any(arg => IsApplicationNameArg(arg)) || assembly is null || assembly.GetName().Name is null
+                    args = (args.Any(arg => IsApplicationNameArg(arg)) || assembly?.GetName().Name is null
                         ? args
                         : args.Concat(new[] { "--applicationName", assembly.GetName().Name }).ToArray())!;
 

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -163,9 +163,9 @@ namespace Microsoft.Extensions.Hosting
                         => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
                             arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
 
-                    args = args.Any(arg => IsApplicationNameArg(arg)) || assembly is null || assembly.GetName().Name is null
+                    args = (args.Any(arg => IsApplicationNameArg(arg)) || assembly is null || assembly.GetName().Name is null
                         ? args
-                        : args.Concat(new[] { "--applicationName", assembly.GetName().Name }).ToArray();
+                        : args.Concat(new[] { "--applicationName", assembly.GetName().Name }).ToArray())!;
 
                     var host = hostFactory(args);
                     return GetServiceProvider(host);

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -163,9 +163,8 @@ namespace Microsoft.Extensions.Hosting
                         => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
                             arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
 
-                    args = (args.Any(arg => IsApplicationNameArg(arg)) || assembly?.GetName().Name is null
-                        ? args
-                        : args.Concat(new[] { "--applicationName", assembly.GetName().Name }).ToArray())!;
+                    if (!args.Any(arg => IsApplicationNameArg(arg)) && assembly?.GetName().Name is string assemblyName)
+                        args = args.Concat(new[] { "--applicationName", assemblyName }).ToArray();
 
                     var host = hostFactory(args);
                     return GetServiceProvider(host);


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/41616
regression https://github.com/dotnet/runtime/pull/102152

```
      EFCore.Benchmarks -> /vmr/src/efcore/artifacts/bin/EFCore.Benchmarks/Release/net8.0/EFCore.Benchmarks.dll
    /vmr/src/efcore/artifacts/sb/package-cache/microsoft.extensions.hostfactoryresolver.sources/9.0.0-preview.6.24315.2/contentFiles/cs/netstandard2.0/HostFactoryResolver.cs(166,28): error CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'. [/vmr/src/efcore/src/EFCore.Design/EFCore.Design.csproj]
##[error]/vmr/src/efcore/artifacts/sb/package-cache/microsoft.extensions.hostfactoryresolver.sources/9.0.0-preview.6.24315.2/contentFiles/cs/netstandard2.0/HostFactoryResolver.cs(166,28): error CS8619: (NETCORE_ENGINEERING_TELEMETRY=Build) Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
      EFCore.SqlServer.Benchmarks -> /vmr/src/efcore/artifacts/bin/EFCore.SqlServer.Benchmarks/Release/net8.0/EFCore.SqlServer.Benchmarks.dll
  
```