### PR TITLE
JIT: Make stack size computation in `fgCanFastTailCall` more precise

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5409,7 +5409,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
         if (stackSize > 0)
         {
             calleeArgStackSize = roundUp(calleeArgStackSize, arg.AbiInfo.ByteAlignment);
-            calleeArgStackSize += arg.AbiInfo.GetStackByteSize();
+            calleeArgStackSize += stackSize;
         }
 
 #if defined(TARGET_ARM) || defined(TARGET_RISCV64)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5405,8 +5405,12 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
 
     for (CallArg& arg : callee->gtArgs.Args())
     {
-        calleeArgStackSize = roundUp(calleeArgStackSize, arg.AbiInfo.ByteAlignment);
-        calleeArgStackSize += arg.AbiInfo.GetStackByteSize();
+        unsigned stackSize = arg.AbiInfo.GetStackByteSize();
+        if (stackSize > 0)
+        {
+            calleeArgStackSize = roundUp(calleeArgStackSize, arg.AbiInfo.ByteAlignment);
+            calleeArgStackSize += arg.AbiInfo.GetStackByteSize();
+        }
 
 #if defined(TARGET_ARM) || defined(TARGET_RISCV64)
         if (arg.AbiInfo.IsSplit())

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5351,7 +5351,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
     callee->gtArgs.AddFinalArgsAndDetermineABIInfo(this, callee);
 
     unsigned calleeArgStackSize = 0;
-    unsigned callerArgStackSize = info.compArgStackSize;
+    unsigned callerArgStackSize = roundUp(info.compArgStackSize, TARGET_POINTER_SIZE);
 
     auto reportFastTailCallDecision = [&](const char* thisFailReason) {
         if (failReason != nullptr)


### PR DESCRIPTION
Two changes:
1. Skip applying alignment when computing a call's arg stack size, which does not make sense/is not correct
2. Round up the incoming parameter stack space in terms of number of slots

Without (1) we overestimate the stack size usage for some calls. Without (2) we underestimate the incoming stack size for some methods. Both of these just result in fewer tailcalls than possible, so cause no correctness issues. However, I hit some diffs in #103537 because of them.