### PR TITLE
Allow GC on the first instruction of NoGC region (except in prologs/epilogs)

### DIFF
--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -119,9 +119,9 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
     assert(block->KindIs(BBJ_CALLFINALLY));
 
-    GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
-
     BasicBlock* nextBlock = block->Next();
+
+    GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
 
     if (block->HasFlag(BBF_RETLESS_CALL))
     {
@@ -138,12 +138,11 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 
         // Because of the way the flowgraph is connected, the liveness info for this one instruction
         // after the call is not (can not be) correct in cases where a variable has a last use in the
-        // handler.  So turn off GC reporting for this single instruction.
+        // handler.  So turn off GC reporting once we execute the call and reenable after the jmp/nop
         GetEmitter()->emitDisableGC();
 
-        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
-
         // Now go to where the finally funclet needs to return to.
+        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
         if (nextBlock->NextIs(finallyContinuation) && !compiler->fgInDifferentRegions(nextBlock, finallyContinuation))
         {
             // Fall-through.

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -121,10 +121,10 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 
     BasicBlock* nextBlock = block->Next();
 
-    GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
-
     if (block->HasFlag(BBF_RETLESS_CALL))
     {
+        GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
+
         if ((nextBlock == nullptr) || !BasicBlock::sameEHRegion(block, nextBlock))
         {
             instGen(INS_BREAKPOINT);
@@ -140,6 +140,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // after the call is not (can not be) correct in cases where a variable has a last use in the
         // handler.  So turn off GC reporting once we execute the call and reenable after the jmp/nop
         GetEmitter()->emitDisableGC();
+        GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
 
         // Now go to where the finally funclet needs to return to.
         BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1368,6 +1368,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
     assert(block->KindIs(BBJ_CALLFINALLY));
 
+    BasicBlock* const nextBlock = block->Next();
+
     // Generate a call to the finally, like this:
     //      mov  a0,qword ptr [fp + 10H] / sp    // Load a0 with PSPSym, or sp if PSPSym is not used
     //      bl  finally-funclet
@@ -1382,12 +1384,11 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         GetEmitter()->emitIns_R_R_I(INS_ori, EA_PTRSIZE, REG_A0, REG_SPBASE, 0);
     }
-    GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
-
-    BasicBlock* const nextBlock = block->Next();
 
     if (block->HasFlag(BBF_RETLESS_CALL))
     {
+        GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
+
         // We have a retless call, and the last instruction generated was a call.
         // If the next block is in a different EH region (or is the end of the code
         // block), then we need to generate a breakpoint here (since it will never
@@ -1404,12 +1405,12 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         // Because of the way the flowgraph is connected, the liveness info for this one instruction
         // after the call is not (can not be) correct in cases where a variable has a last use in the
-        // handler.  So turn off GC reporting for this single instruction.
+        // handler.  So turn off GC reporting once we execute the call and reenable after the jmp/nop
         GetEmitter()->emitDisableGC();
-
-        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
+        GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
 
         // Now go to where the finally funclet needs to return to.
+        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
         if (nextBlock->NextIs(finallyContinuation) && !compiler->fgInDifferentRegions(nextBlock, finallyContinuation))
         {
             // Fall-through.

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1397,6 +1397,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
     assert(block->KindIs(BBJ_CALLFINALLY));
 
+    BasicBlock* const nextBlock = block->Next();
+
     // Generate a call to the finally, like this:
     //      mov  a0,qword ptr [fp + 10H] / sp    // Load a0 with PSPSym, or sp if PSPSym is not used
     //      jal  finally-funclet
@@ -1411,12 +1413,11 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         GetEmitter()->emitIns_R_R_I(INS_ori, EA_PTRSIZE, REG_A0, REG_SPBASE, 0);
     }
-    GetEmitter()->emitIns_J(INS_jal, block->GetTarget());
-
-    BasicBlock* const nextBlock = block->Next();
 
     if (block->HasFlag(BBF_RETLESS_CALL))
     {
+        GetEmitter()->emitIns_J(INS_jal, block->GetTarget());
+
         // We have a retless call, and the last instruction generated was a call.
         // If the next block is in a different EH region (or is the end of the code
         // block), then we need to generate a breakpoint here (since it will never
@@ -1433,12 +1434,12 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         // Because of the way the flowgraph is connected, the liveness info for this one instruction
         // after the call is not (can not be) correct in cases where a variable has a last use in the
-        // handler.  So turn off GC reporting for this single instruction.
+        // handler.  So turn off GC reporting once we execute the call and reenable after the jmp/nop
         GetEmitter()->emitDisableGC();
-
-        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
+        GetEmitter()->emitIns_J(INS_jal, block->GetTarget());
 
         // Now go to where the finally funclet needs to return to.
+        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
         if (nextBlock->NextIs(finallyContinuation) && !compiler->fgInDifferentRegions(nextBlock, finallyContinuation))
         {
             // Fall-through.

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -232,10 +232,11 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         {
             GetEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_ARG_0, compiler->lvaPSPSym, 0);
         }
-        GetEmitter()->emitIns_J(INS_call, block->GetTarget());
 
         if (block->HasFlag(BBF_RETLESS_CALL))
         {
+            GetEmitter()->emitIns_J(INS_call, block->GetTarget());
+
             // We have a retless call, and the last instruction generated was a call.
             // If the next block is in a different EH region (or is the end of the code
             // block), then we need to generate a breakpoint here (since it will never
@@ -253,9 +254,11 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 #ifndef JIT32_GCENCODER
             // Because of the way the flowgraph is connected, the liveness info for this one instruction
             // after the call is not (can not be) correct in cases where a variable has a last use in the
-            // handler.  So turn off GC reporting for this single instruction.
+            // handler.  So turn off GC reporting once we execute the call and reenable after the jmp/nop
             GetEmitter()->emitDisableGC();
 #endif // JIT32_GCENCODER
+
+            GetEmitter()->emitIns_J(INS_call, block->GetTarget());
 
             BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -260,9 +260,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 
             GetEmitter()->emitIns_J(INS_call, block->GetTarget());
 
-            BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
-
             // Now go to where the finally funclet needs to return to.
+            BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
             if (nextBlock->NextIs(finallyContinuation) &&
                 !compiler->fgInDifferentRegions(nextBlock, finallyContinuation))
             {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10492,7 +10492,7 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
 //    A completion of an epilog will close NoGC region in progress and clear the request count
 //    regardless of request nesting. If a block after the epilog needs to be no-GC, it needs
 //    to call emitDisableGC() again.
-// 
+//
 // Notes:
 //    The semantic of NoGC region is that once the first instruction executes,
 //    some tracking invariants are violated and GC cannot happen, until the execution

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10482,7 +10482,27 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
 }
 
 #if !defined(JIT32_GCENCODER)
-// Start a new instruction group that is not interruptible
+//------------------------------------------------------------------------
+// emitDisableGC: Requests that the following instruction groups are not GC-interruptible.
+//
+// Assumptions:
+//    A NoGC request can be closed by a coresponding emitEnableGC.
+//    Overlapping/nested NoGC requests are supported - when number of requests
+//    drops to zero the region is closed. This is not expected to be common.
+//    A completion of an epilog will close NoGC region in progress and clear the request count
+//    regardless of request nesting. If a block after the epilog needs to be no-GC, it needs
+//    to call emitDisableGC() again.
+// 
+// Notes:
+//    The semantic of NoGC region is that once the first instruction executes,
+//    some tracking invariants are violated and GC cannot happen, until the execution
+//    of the last instruction in the region makes GC safe again.
+//    In particular - once the IP is on the first instruction, but not executed it yet,
+//    it is still safe to do GC.
+//    The only special case is when NoGC region is used for prologs/epilogs.
+//    In such case the GC info could be incorrect until the prolog completes and epilogs
+//    may have unwindability restrictions, so the first instruction cannot have GC.
+
 void emitter::emitDisableGC()
 {
     assert(emitNoGCRequestCount < 10); // We really shouldn't have many nested "no gc" requests.
@@ -10511,7 +10531,17 @@ void emitter::emitDisableGC()
     }
 }
 
-// Start a new instruction group that is interruptible
+//------------------------------------------------------------------------
+// emitEnableGC(): Removes a request that the following instruction groups are not GC-interruptible.
+//
+// Assumptions:
+//    We should have nonzero count of NoGC requests.
+//    "emitEnableGC()" reduces the number of requests by 1.
+//    If the number of requests goes to 0, the subsequent instruction groups are GC-interruptible.
+//
+// Notes:
+//    See emitDisableGC for more details.
+
 void emitter::emitEnableGC()
 {
     assert(emitNoGCRequestCount > 0);

--- a/src/coreclr/jit/emitinl.h
+++ b/src/coreclr/jit/emitinl.h
@@ -589,9 +589,11 @@ bool emitter::emitGenNoGCLst(Callback& cb)
 {
     for (insGroup* ig = emitIGlist; ig; ig = ig->igNext)
     {
-        if (ig->igFlags & IGF_NOGCINTERRUPT)
+        if ((ig->igFlags & IGF_NOGCINTERRUPT) && ig->igSize > 0)
         {
             emitter::instrDesc* id = emitFirstInstrDesc(ig->igData);
+            assert(id != nullptr);
+            assert(id->idCodeSize() > 0);
             if (!cb(ig->igFuncIdx, ig->igOffs, ig->igSize, id->idCodeSize(),
                     ig->igFlags & (IGF_FUNCLET_PROLOG | IGF_FUNCLET_EPILOG | IGF_EPILOG)))
             {

--- a/src/coreclr/jit/emitinl.h
+++ b/src/coreclr/jit/emitinl.h
@@ -592,7 +592,8 @@ bool emitter::emitGenNoGCLst(Callback& cb)
         if (ig->igFlags & IGF_NOGCINTERRUPT)
         {
             emitter::instrDesc* id = emitFirstInstrDesc(ig->igData);
-            if (!cb(ig->igFuncIdx, ig->igOffs, ig->igSize, id->idCodeSize(), ig->igFlags & (IGF_FUNCLET_PROLOG)))
+            if (!cb(ig->igFuncIdx, ig->igOffs, ig->igSize, id->idCodeSize(),
+                    ig->igFlags & (IGF_FUNCLET_PROLOG | IGF_FUNCLET_EPILOG | IGF_EPILOG)))
             {
                 return false;
             }

--- a/src/coreclr/jit/emitinl.h
+++ b/src/coreclr/jit/emitinl.h
@@ -591,7 +591,8 @@ bool emitter::emitGenNoGCLst(Callback& cb)
     {
         if (ig->igFlags & IGF_NOGCINTERRUPT)
         {
-            if (!cb(ig->igFuncIdx, ig->igOffs, ig->igSize))
+            emitter::instrDesc* id = emitFirstInstrDesc(ig->igData);
+            if (!cb(ig->igFuncIdx, ig->igOffs, ig->igSize, id->idCodeSize(), ig->igFlags & (IGF_FUNCLET_PROLOG)))
             {
                 return false;
             }

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4011,11 +4011,12 @@ void GCInfo::gcInfoBlockHdrSave(GcInfoEncoder* gcInfoEncoder, unsigned methodSiz
 //
 // Encoder should be either GcInfoEncoder or GcInfoEncoderWithLogging
 //
-struct InterruptibleRangeReporter
+class InterruptibleRangeReporter
 {
     unsigned m_uninterruptibleEnd;
     Encoder* m_gcInfoEncoder;
 
+public:
     InterruptibleRangeReporter(unsigned prologSize, Encoder* gcInfo)
         : m_uninterruptibleEnd(prologSize)
         , m_gcInfoEncoder(gcInfo)
@@ -4051,6 +4052,11 @@ struct InterruptibleRangeReporter
         }
         m_uninterruptibleEnd = igOffs + igSize;
         return true;
+    }
+
+    unsigned UninterruptibleEnd()
+    {
+        return m_uninterruptibleEnd;
     }
 };
 
@@ -4406,7 +4412,7 @@ void GCInfo::gcMakeRegPtrTable(
 
             InterruptibleRangeReporter reporter(prologSize, gcInfoEncoderWithLog);
             compiler->GetEmitter()->emitGenNoGCLst(reporter);
-            unsigned uninterruptibleEnd = reporter.m_uninterruptibleEnd;
+            unsigned uninterruptibleEnd = reporter.UninterruptibleEnd();
 
             // Report any remainder
             if (uninterruptibleEnd < codeSize)

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4026,7 +4026,8 @@ struct InterruptibleRangeReporter
     // Report everything between the previous region and the current
     // region as interruptible.
 
-    bool operator()(unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isFuncletProlog)
+    bool operator()(
+        unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isInPrologOrEpilog)
     {
         if (igOffs < m_uninterruptibleEnd)
         {
@@ -4040,14 +4041,13 @@ struct InterruptibleRangeReporter
         if (igOffs > m_uninterruptibleEnd)
         {
             // Once the first instruction in IG executes, we cannot have GC.
-            // But it is ok to have GC while the IP is on the first instruction, unless we are in prolog.
+            // But it is ok to have GC while the IP is on the first instruction, unless we are in prolog/epilog.
             unsigned interruptibleEnd = igOffs;
-            if (!isFuncletProlog)
+            if (!isInPrologOrEpilog)
             {
                 interruptibleEnd += firstInstrSize;
             }
-            m_gcInfoEncoder->DefineInterruptibleRange(m_uninterruptibleEnd,
-                                                             interruptibleEnd - m_uninterruptibleEnd);
+            m_gcInfoEncoder->DefineInterruptibleRange(m_uninterruptibleEnd, interruptibleEnd - m_uninterruptibleEnd);
         }
         m_uninterruptibleEnd = igOffs + igSize;
         return true;

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4013,37 +4013,43 @@ void GCInfo::gcInfoBlockHdrSave(GcInfoEncoder* gcInfoEncoder, unsigned methodSiz
 //
 struct InterruptibleRangeReporter
 {
-    unsigned prevStart;
-    Encoder* gcInfoEncoderWithLog;
+    unsigned m_uninterruptibleEnd;
+    Encoder* m_gcInfoEncoder;
 
-    InterruptibleRangeReporter(unsigned _prevStart, Encoder* _gcInfo)
-        : prevStart(_prevStart)
-        , gcInfoEncoderWithLog(_gcInfo)
+    InterruptibleRangeReporter(unsigned prologSize, Encoder* gcInfo)
+        : m_uninterruptibleEnd(prologSize)
+        , m_gcInfoEncoder(gcInfo)
     {
     }
 
-    // This callback is called for each insGroup marked with
-    // IGF_NOGCINTERRUPT (currently just prologs and epilogs).
+    // This callback is called for each insGroup marked with IGF_NOGCINTERRUPT.
     // Report everything between the previous region and the current
     // region as interruptible.
 
-    bool operator()(unsigned igFuncIdx, unsigned igOffs, unsigned igSize)
+    bool operator()(unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isFuncletProlog)
     {
-        if (igOffs < prevStart)
+        if (igOffs < m_uninterruptibleEnd)
         {
-            // We're still in the main method prolog, which has already
-            // had it's interruptible range reported.
+            // We're still in the main method prolog, which we know is not interruptible.
             assert(igFuncIdx == 0);
-            assert(igOffs + igSize <= prevStart);
+            assert(igOffs + igSize <= m_uninterruptibleEnd);
             return true;
         }
 
-        assert(igOffs >= prevStart);
-        if (igOffs > prevStart)
+        assert(igOffs >= m_uninterruptibleEnd);
+        if (igOffs > m_uninterruptibleEnd)
         {
-            gcInfoEncoderWithLog->DefineInterruptibleRange(prevStart, igOffs - prevStart);
+            // Once the first instruction in IG executes, we cannot have GC.
+            // But it is ok to have GC while the IP is on the first instruction, unless we are in prolog.
+            unsigned interruptibleEnd = igOffs;
+            if (!isFuncletProlog)
+            {
+                interruptibleEnd += firstInstrSize;
+            }
+            m_gcInfoEncoder->DefineInterruptibleRange(m_uninterruptibleEnd,
+                                                             interruptibleEnd - m_uninterruptibleEnd);
         }
-        prevStart = igOffs + igSize;
+        m_uninterruptibleEnd = igOffs + igSize;
         return true;
     }
 };
@@ -4396,17 +4402,16 @@ void GCInfo::gcMakeRegPtrTable(
         {
             assert(prologSize <= codeSize);
 
-            // Now exempt any other region marked as IGF_NOGCINTERRUPT
-            // Currently just prologs and epilogs.
+            // Now exempt any region marked as IGF_NOGCINTERRUPT
 
             InterruptibleRangeReporter reporter(prologSize, gcInfoEncoderWithLog);
             compiler->GetEmitter()->emitGenNoGCLst(reporter);
-            prologSize = reporter.prevStart;
+            unsigned uninterruptibleEnd = reporter.m_uninterruptibleEnd;
 
             // Report any remainder
-            if (prologSize < codeSize)
+            if (uninterruptibleEnd < codeSize)
             {
-                gcInfoEncoderWithLog->DefineInterruptibleRange(prologSize, codeSize - prologSize);
+                gcInfoEncoderWithLog->DefineInterruptibleRange(uninterruptibleEnd, codeSize - uninterruptibleEnd);
             }
         }
     }


### PR DESCRIPTION
NoGC regions are used to temporarily disable GC in otherwise interruptible code. A typical use is during block-copying data that may contain GC references via temporaries that are not GC-reported.

The semantic of NoGC region is that once the first instruction executes, tracking invariants are violated and GC cannot happen, until the execution of the last instruction in the region makes GC safe again.  
In particular - once the IP is on the first instruction, but not executed it yet, it is still safe to do GC. 

The only special case is when NoGC region is used for prologs/epilogs. In such case the GC info could be incorrect until the prolog completes and epilogs may have unwindability restrictions, so the first instruction cannot have GC.

======   What prompted this change:

While working on https://github.com/dotnet/runtime/pull/102680. I have discovered that sometimes we start NoGC region on the next instruction after a call. Without this change it means that once the call executes, the caller is in a NoGC state. 
As a result there is a rare combination where:
- the calee was hijacked and upon return tries to initiate a stackwalk at the call site in the caller. 
- the caller is fully-interruptible, thus it checks if a stackwalk starts in interruptible code.

That leads to an assert in `gcinfodecoder.cpp:801`  `executionAborted`.
We do not expect to be asked for GC info in non-interruptible code unless it is the `executionAborted` case.

It would be nice to not mark instructions as NoGC unnecessarily. In particular we should not do that to GC-capable call sites.