### PR TITLE
Support environment variables with empty value

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -612,10 +612,16 @@ namespace System.Diagnostics
         {
             var envp = new string[psi.Environment.Count];
             int index = 0;
-            foreach (var pair in psi.Environment)
+            foreach (KeyValuePair<string, string?> pair in psi.Environment)
             {
-                envp[index++] = pair.Key + "=" + pair.Value;
+                // Ignore null values for consistency with Environment.SetEnvironmentVariable
+                if (pair.Value != null)
+                {
+                    envp[index++] = pair.Key + "=" + pair.Value;
+                }
             }
+            // Resize the array in case we skipped some entries
+            Array.Resize(ref envp, index);
             return envp;
         }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -873,7 +873,13 @@ namespace System.Diagnostics
             var result = new StringBuilder(8 * keys.Length);
             foreach (string key in keys)
             {
-                result.Append(key).Append('=').Append(sd[key]).Append('\0');
+                string? value = sd[key];
+
+                // Ignore null values for consistency with Environment.SetEnvironmentVariable
+                if (value != null)
+                {
+                    result.Append(key).Append('=').Append(value).Append('\0');
+                }
             }
 
             return result.ToString();

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -281,6 +281,30 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void EnvironmentNullValue()
+        {
+            const string NullEnvVar = "TestEnvironmentOfChildProcess_Null";
+            Environment.SetEnvironmentVariable(NullEnvVar, "");
+            try
+            {
+                Process p = CreateProcess(() =>
+                {
+                    // Verify that setting the value to null in StartInfo is going to remove the process environment.
+                    Assert.Null(Environment.GetEnvironmentVariable(NullEnvVar));
+                    return RemoteExecutor.SuccessExitCode;
+                });
+                p.StartInfo.Environment[NullEnvVar] = null;
+                Assert.Null(p.StartInfo.Environment[NullEnvVar]);
+                p.Start();
+                Assert.True(p.WaitForExit(WaitInMS));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(NullEnvVar, null);
+            }
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/76140", TestPlatforms.LinuxBionic)]
         public void EnvironmentGetEnvironmentVariablesIsCaseSensitive()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -235,6 +235,8 @@ namespace System.Diagnostics.Tests
         {
             const string ExtraEnvVar = "TestEnvironmentOfChildProcess_SpecialStuff";
             Environment.SetEnvironmentVariable(ExtraEnvVar, "\x1234" + Environment.NewLine + "\x5678"); // ensure some Unicode characters and newlines are in the output
+            const string EmptyEnvVar = "TestEnvironmentOfChildProcess_Empty";
+            Environment.SetEnvironmentVariable(EmptyEnvVar, "");
             try
             {
                 // Schedule a process to see what env vars it gets.  Have it write out those variables
@@ -274,6 +276,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 Environment.SetEnvironmentVariable(ExtraEnvVar, null);
+                Environment.SetEnvironmentVariable(EmptyEnvVar, null);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Variables.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Variables.Unix.cs
@@ -45,7 +45,7 @@ namespace System
             value = value == null ? null : TrimStringOnFirstZero(value);
             lock (s_environment!)
             {
-                if (string.IsNullOrEmpty(value))
+                if (value == null)
                 {
                     s_environment.Remove(variable);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -67,7 +67,7 @@ namespace System
 
         public static void SetEnvironmentVariable(string variable, string? value)
         {
-            ValidateVariableAndValue(variable, ref value);
+            ValidateVariable(variable);
             SetEnvironmentVariableCore(variable, value);
         }
 
@@ -79,7 +79,7 @@ namespace System
                 return;
             }
 
-            ValidateVariableAndValue(variable, ref value);
+            ValidateVariable(variable);
 
             bool fromMachine = ValidateAndConvertRegistryTarget(target);
             SetEnvironmentVariableFromRegistry(variable, value, fromMachine: fromMachine);
@@ -234,7 +234,7 @@ namespace System
             throw new ArgumentOutOfRangeException(nameof(target), target, SR.Format(SR.Arg_EnumIllegalVal, target));
         }
 
-        private static void ValidateVariableAndValue(string variable, ref string? value)
+        private static void ValidateVariable(string variable)
         {
             ArgumentException.ThrowIfNullOrEmpty(variable);
 
@@ -243,12 +243,6 @@ namespace System
 
             if (variable.Contains('='))
                 throw new ArgumentException(SR.Argument_IllegalEnvVarName, nameof(variable));
-
-            if (string.IsNullOrEmpty(value) || value[0] == '\0')
-            {
-                // Explicitly null out value if it's empty
-                value = null;
-            }
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Environment.SetEnvironmentVariable.cs
@@ -284,7 +284,7 @@ namespace System.Tests
                 Environment.SetEnvironmentVariable(varName, value);
                 Environment.SetEnvironmentVariable(varName, null);
                 Assert.Null(Environment.GetEnvironmentVariable(varName));
-                Assert.False(Environment.GetEnvironmentVariables().ContainsKey(varName));
+                Assert.False(Environment.GetEnvironmentVariables().Contains(varName));
             });
         }
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Environment.SetEnvironmentVariable.cs
@@ -251,6 +251,27 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(EnvironmentTests.EnvironmentVariableTargets), MemberType = typeof(EnvironmentTests))]
+        public void EmptyEnvironmentVariable(EnvironmentVariableTarget target)
+        {
+            string varName = $"Test_EmptyEnvironmentVariable({target})";
+            const string value = "false";
+
+            ExecuteAgainstTarget(target,
+            () =>
+            {
+                // First set the value to something and then ensure that it can be deleted.
+                Environment.SetEnvironmentVariable(varName, value);
+                Environment.SetEnvironmentVariable(varName, string.Empty);
+                Assert.Equal(string.Empty, Environment.GetEnvironmentVariable(varName));
+
+                Environment.SetEnvironmentVariable(varName, value);
+                Environment.SetEnvironmentVariable(varName, NullString);
+                Assert.Equal(string.Empty, Environment.GetEnvironmentVariable(varName));
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(EnvironmentTests.EnvironmentVariableTargets), MemberType = typeof(EnvironmentTests))]
         public void DeleteEnvironmentVariable(EnvironmentVariableTarget target)
         {
             string varName = $"Test_DeleteEnvironmentVariable ({target})";
@@ -261,15 +282,7 @@ namespace System.Tests
             {
                 // First set the value to something and then ensure that it can be deleted.
                 Environment.SetEnvironmentVariable(varName, value);
-                Environment.SetEnvironmentVariable(varName, string.Empty);
-                Assert.Null(Environment.GetEnvironmentVariable(varName));
-
-                Environment.SetEnvironmentVariable(varName, value);
                 Environment.SetEnvironmentVariable(varName, null);
-                Assert.Null(Environment.GetEnvironmentVariable(varName));
-
-                Environment.SetEnvironmentVariable(varName, value);
-                Environment.SetEnvironmentVariable(varName, NullString);
                 Assert.Null(Environment.GetEnvironmentVariable(varName));
             });
         }
@@ -305,11 +318,11 @@ namespace System.Tests
             try
             {
                 Environment.SetEnvironmentVariable(varName, value);
-                Assert.Null(Environment.GetEnvironmentVariable(varName));
+                Assert.Equal("", Environment.GetEnvironmentVariable(varName));
             }
             finally
             {
-                Environment.SetEnvironmentVariable(varName, string.Empty);
+                Environment.SetEnvironmentVariable(varName, null);
             }
         }
 
@@ -329,8 +342,8 @@ namespace System.Tests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(varName, string.Empty);
-                Environment.SetEnvironmentVariable(varNamePrefix, string.Empty);
+                Environment.SetEnvironmentVariable(varName, null);
+                Environment.SetEnvironmentVariable(varNamePrefix, null);
             }
         }
 
@@ -349,7 +362,7 @@ namespace System.Tests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(varName, string.Empty);
+                Environment.SetEnvironmentVariable(varName, null);
             }
         }
 
@@ -363,7 +376,7 @@ namespace System.Tests
                 Environment.SetEnvironmentVariable(varName, null);
             }
 
-            Environment.SetEnvironmentVariable("TestDeletingNonExistingEnvironmentVariable", string.Empty);
+            Environment.SetEnvironmentVariable("TestDeletingNonExistingEnvironmentVariable", null);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Environment.SetEnvironmentVariable.cs
@@ -284,6 +284,7 @@ namespace System.Tests
                 Environment.SetEnvironmentVariable(varName, value);
                 Environment.SetEnvironmentVariable(varName, null);
                 Assert.Null(Environment.GetEnvironmentVariable(varName));
+                Assert.False(Environment.GetEnvironmentVariables().ContainsKey(varName));
             });
         }
 


### PR DESCRIPTION
`Environment.SetEnvironment` API did not make distinction between null and empty string value. It treated both as request to delete the environment variable. It made it impossible to create an environment variable with empty string value. This change updates `Environment.SetEnvironment` to treat empty string value as empty string value (null value is still treated as request to delete the environment variable).

Also, this change updates ProcessStartInfo.Environment to treat null vs. empty string the same way as `Environment.SetEnvironment` for consistency.
   
Fixes #50554
Fixes #34446