### PR TITLE
make the default target lower

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4254,7 +4254,7 @@ private:
     // to smooth out the situation when we rarely pick the gen2 GCs in the first array.
     struct dynamic_heap_count_data_t
     {
-        float target_tcp = 5.0;
+        float target_tcp = 2.0;
         float target_gen2_tcp = 10.0;
 
         static const int recorded_adjustment_size = 4;


### PR DESCRIPTION
2% is a better default as I normally observe apps spent more like 2% in Server GC instead of 5%. I'm still doing some analysis on the effect but for the preview it's better to (hopefully) get data on 2% than 5%. in the local testing with GCPerfSim (only SOH allocations with low surv rate) I'm seeing a small percentage of throughput inc with a bigger percentage of _max_ memory usage. with asp.net benchmarks I'm not seeing nearly as big a difference. 

it can be changed via either the `GCDTargetTCP` env var or the `System.GC.DTargetTCP` runtime config.