### PR TITLE
JIT: Avoid check for returns in methods with pinvokes in LSRA

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -620,16 +620,6 @@ RefPosition* LinearScan::newRefPosition(Interval*        theInterval,
     // Spill info
     newRP->isFixedRegRef = isFixedRegister;
 
-#ifndef TARGET_AMD64
-    // We don't need this for AMD because the PInvoke method epilog code is explicit
-    // at register allocation time.
-    if (theInterval != nullptr && theInterval->isLocalVar && compiler->compMethodRequiresPInvokeFrame() &&
-        theInterval->varNum == compiler->genReturnLocal)
-    {
-        mask &= ~(RBM_PINVOKE_TCB | RBM_PINVOKE_FRAME).GetRegSetForType(theInterval->registerType);
-        noway_assert(mask != RBM_NONE);
-    }
-#endif // !TARGET_AMD64
     newRP->registerAssignment = mask;
 
     newRP->setMultiRegIdx(multiRegIdx);

--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -383,14 +383,6 @@
   #define REG_SECRET_STUB_PARAM    REG_R10
   #define RBM_SECRET_STUB_PARAM    RBM_R10
 
-  // Registers used by PInvoke frame setup
-  #define REG_PINVOKE_FRAME        REG_EDI
-  #define RBM_PINVOKE_FRAME        RBM_EDI
-  #define REG_PINVOKE_TCB          REG_EAX
-  #define RBM_PINVOKE_TCB          RBM_EAX
-  #define REG_PINVOKE_SCRATCH      REG_EAX
-  #define RBM_PINVOKE_SCRATCH      RBM_EAX
-
   // The following defines are useful for iterating a regNumber
   #define REG_FIRST                REG_EAX
   #define REG_INT_FIRST            REG_EAX

--- a/src/coreclr/jit/targetarm64.h
+++ b/src/coreclr/jit/targetarm64.h
@@ -224,14 +224,6 @@
   // JMP Indirect call register
   #define REG_INDIRECT_CALL_TARGET_REG    REG_IP0
 
-  // Registers used by PInvoke frame setup
-  #define REG_PINVOKE_FRAME        REG_R9
-  #define RBM_PINVOKE_FRAME        RBM_R9
-  #define REG_PINVOKE_TCB          REG_R10
-  #define RBM_PINVOKE_TCB          RBM_R10
-  #define REG_PINVOKE_SCRATCH      REG_R10
-  #define RBM_PINVOKE_SCRATCH      RBM_R10
-
   // The following defines are useful for iterating a regNumber
   #define REG_FIRST                REG_R0
   #define REG_INT_FIRST            REG_R0

--- a/src/coreclr/jit/targetloongarch64.h
+++ b/src/coreclr/jit/targetloongarch64.h
@@ -195,14 +195,6 @@
 
   #define REG_INDIRECT_CALL_TARGET_REG    REG_T6
 
-  // Registers used by PInvoke frame setup
-  #define REG_PINVOKE_FRAME        REG_T0
-  #define RBM_PINVOKE_FRAME        RBM_T0
-  #define REG_PINVOKE_TCB          REG_T1
-  #define RBM_PINVOKE_TCB          RBM_T1
-  #define REG_PINVOKE_SCRATCH      REG_T1
-  #define RBM_PINVOKE_SCRATCH      RBM_T1
-
   // The following defines are useful for iterating a regNumber
   #define REG_FIRST                REG_R0
   #define REG_INT_FIRST            REG_R0

--- a/src/coreclr/jit/targetriscv64.h
+++ b/src/coreclr/jit/targetriscv64.h
@@ -173,14 +173,6 @@
   // JMP Indirect call register
   #define REG_INDIRECT_CALL_TARGET_REG    REG_T5
 
-  // Registers used by PInvoke frame setup
-  #define REG_PINVOKE_FRAME        REG_T0
-  #define RBM_PINVOKE_FRAME        RBM_T0
-  #define REG_PINVOKE_TCB          REG_T1
-  #define RBM_PINVOKE_TCB          RBM_T1
-  #define REG_PINVOKE_SCRATCH      REG_T1
-  #define RBM_PINVOKE_SCRATCH      RBM_T1
-
   // The following defines are useful for iterating a regNumber
   #define REG_FIRST                REG_R0
   #define REG_INT_FIRST            REG_R0


### PR DESCRIPTION
The pinvoke epilog is explicit on all our targets now, so it seems like this code should be unnecessary everywhere (and in any case, should not have been inside very general and very hot `newRefPosition`).