### PR TITLE
Don't run ssl/http stress on release/6.0 and release/7.0

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -11,8 +11,6 @@ schedules:
   branches:
     include:
     - main
-    - release/6.0
-    - release/7.0
     - release/8.0
 
 variables:

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -11,8 +11,6 @@ schedules:
   branches:
     include:
     - main
-    - release/6.0
-    - release/7.0
     - release/8.0
 
 variables:


### PR DESCRIPTION
.NET 7.0 is out of support
.NET 6.0 fails to build (except http stress on Linux)

And we are not monitoring either of them regularly.