### PR TITLE
Extend MediaTypeNames

### DIFF
--- a/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
+++ b/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
@@ -325,6 +325,7 @@ namespace System.Net.Mime
         public static partial class Application
         {
             public const string FormUrlEncoded = "application/x-www-form-urlencoded";
+            public const string GZip = "application/gzip";
             public const string Json = "application/json";
             public const string JsonPatch = "application/json-patch+json";
             public const string JsonSequence = "application/json-seq";
@@ -366,11 +367,14 @@ namespace System.Net.Mime
         {
             public const string ByteRanges = "multipart/byteranges";
             public const string FormData = "multipart/form-data";
+            public const string Mixed = "multipart/mixed";
+            public const string Related = "multipart/related";
         }
         public static partial class Text
         {
             public const string Css = "text/css";
             public const string Csv = "text/csv";
+            public const string EventStream = "text/event-stream";
             public const string Html = "text/html";
             public const string JavaScript = "text/javascript";
             public const string Markdown = "text/markdown";

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MediaTypeNames.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MediaTypeNames.cs
@@ -11,6 +11,9 @@ namespace System.Net.Mime
             /// <summary>Specifies that the <see cref="MediaTypeNames.Application"/> data consists of url-encoded key-value pairs.</summary>
             public const string FormUrlEncoded = "application/x-www-form-urlencoded";
 
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Application"/> data is in gzip format.</summary>
+            public const string GZip = "application/gzip";
+
             /// <summary>Specifies that the <see cref="MediaTypeNames.Application"/> data is in JSON format.</summary>
             public const string Json = "application/json";
 
@@ -118,6 +121,12 @@ namespace System.Net.Mime
 
             /// <summary>Specifies that the <see cref="MediaTypeNames.Multipart"/> data is in form data format.</summary>
             public const string FormData = "multipart/form-data";
+
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Multipart"/> data is in mixed format.</summary>
+            public const string Mixed = "multipart/mixed";
+
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Multipart"/> data is in related format.</summary>
+            public const string Related = "multipart/related";
         }
 
         /// <summary>Specifies the kind of text data in an email message attachment.</summary>
@@ -128,6 +137,9 @@ namespace System.Net.Mime
 
             /// <summary>Specifies that the <see cref="MediaTypeNames.Text"/> data is in CSV format.</summary>
             public const string Csv = "text/csv";
+
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Text"/> data is in event stream format.</summary>
+            public const string EventStream = "text/event-stream";
 
             /// <summary>Specifies that the <see cref="MediaTypeNames.Text"/> data is in HTML format.</summary>
             public const string Html = "text/html";


### PR DESCRIPTION
Add some media types to `System.Net.Mime.MediaTypeNames`.

Fixes #95446