### PR TITLE
Dispose some XmlReader and XmlNodeReader in System.Security.Cryptography.Xml

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDecryptionTransform.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDecryptionTransform.cs
@@ -151,7 +151,7 @@ namespace System.Security.Cryptography.Xml
             XmlDocument document = new XmlDocument();
             document.PreserveWhitespace = true;
             XmlResolver resolver = (ResolverSet ? _xmlResolver : XmlResolverHelper.GetThrowingResolver());
-            XmlReader xmlReader = Utils.PreProcessStreamInput(stream, resolver, BaseURI!);
+            using XmlReader xmlReader = Utils.PreProcessStreamInput(stream, resolver, BaseURI!);
             document.Load(xmlReader);
             _containingDocument = document;
             _nsm = new XmlNamespaceManager(_containingDocument.NameTable);

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigEnvelopedSignatureTransform.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigEnvelopedSignatureTransform.cs
@@ -80,7 +80,7 @@ namespace System.Security.Cryptography.Xml
             XmlDocument doc = new XmlDocument();
             doc.PreserveWhitespace = true;
             XmlResolver resolver = ResolverSet ? _xmlResolver : XmlResolverHelper.GetThrowingResolver();
-            XmlReader xmlReader = Utils.PreProcessStreamInput(stream, resolver, BaseURI!);
+            using XmlReader xmlReader = Utils.PreProcessStreamInput(stream, resolver, BaseURI!);
             doc.Load(xmlReader);
             _containingDocument = doc;
             if (_containingDocument == null)

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXPathTransform.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXPathTransform.cs
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.Xml
                     if (elem.LocalName == "XPath")
                     {
                         _xpathexpr = elem.InnerXml.Trim(null);
-                        XmlNodeReader nr = new XmlNodeReader(elem);
+                        using XmlNodeReader nr = new XmlNodeReader(elem);
                         XmlNameTable nt = nr.NameTable;
                         _nsm = new XmlNamespaceManager(nt);
                         if (!Utils.VerifyAttributes(elem, (string?)null))
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography.Xml
         private void LoadStreamInput(Stream stream)
         {
             XmlResolver resolver = (ResolverSet ? _xmlResolver : XmlResolverHelper.GetThrowingResolver());
-            XmlReader valReader = Utils.PreProcessStreamInput(stream, resolver, BaseURI!);
+            using XmlReader valReader = Utils.PreProcessStreamInput(stream, resolver, BaseURI!);
             _document = new XmlDocument();
             _document.PreserveWhitespace = true;
             _document.Load(valReader);


### PR DESCRIPTION
This was pointed out by a static analysis too. I think this is mostly a code hygeine fix, and doesn't really have a functional impact.