### PR TITLE
Arm64: Shuffle(v, [2, 3, 0, 1]) -> ext_64 v,v,1

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -25989,6 +25989,18 @@ GenTree* Compiler::gtNewSimdShuffleNode(
     uint64_t value  = 0;
     simd_t   vecCns = {};
 
+    if (simdSize == 16)
+    {
+        // Vector128.Shuffle(a, Vector128.Create(2, 3, 0, 1)) -> ExtractVector128(v.AsUInt64(), v.AsUInt64(), 1)
+        if ((op2->GetIntegralVectorConstElement(0, TYP_ULONG) == 0x300000002) &&
+            (op2->GetIntegralVectorConstElement(1, TYP_ULONG) == 0x100000000))
+        {
+            GenTree* op1Clone = fgMakeMultiUse(&op1);
+            return gtNewSimdHWIntrinsicNode(type, op1, op1Clone, gtNewIconNode(1), NI_AdvSimd_ExtractVector128,
+                                            CORINFO_TYPE_ULONG, simdSize);
+        }
+    }
+
     for (size_t index = 0; index < elementCount; index++)
     {
         value = op2->GetIntegralVectorConstElement(index, simdBaseType);


### PR DESCRIPTION
Quick fix for a [pattern found in XxHash128](https://github.com/dotnet/runtime/blob/6e88cf8c62a8100c36eef4bcc26a3d830b60ff35/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs#L688). I put the fix in importer since similar fixes for x64 and arm64 are also located there for Shuffle, but I presume a better long-term strategy is to use generic Shuffle and replace/optimize it in lower/codegen.
```cs
Vector128<int> Test(Vector128<int> a) => Vector128.Shuffle(a, Vector128.Create(2, 3, 0, 1));
```
Current:
```asm
ldr     q16, [@RWD00]
tbl     v0.16b, {v0.16b}, v16.16b
```
New:
```asm
ext     v0.16b, v0.16b, v0.16b, #8
```