### PR TITLE
Use `allows ref struct` in comparer interfaces

### DIFF
--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -223,10 +223,10 @@ namespace System
         public static System.Span<T> AsSpan<T>(this T[]? array, System.Range range) { throw null; }
         public static int BinarySearch<T>(this System.ReadOnlySpan<T> span, System.IComparable<T> comparable) { throw null; }
         public static int BinarySearch<T>(this System.Span<T> span, System.IComparable<T> comparable) { throw null; }
-        public static int BinarySearch<T, TComparer>(this System.ReadOnlySpan<T> span, T value, TComparer comparer) where TComparer : System.Collections.Generic.IComparer<T> { throw null; }
-        public static int BinarySearch<T, TComparable>(this System.ReadOnlySpan<T> span, TComparable comparable) where TComparable : System.IComparable<T> { throw null; }
-        public static int BinarySearch<T, TComparer>(this System.Span<T> span, T value, TComparer comparer) where TComparer : System.Collections.Generic.IComparer<T> { throw null; }
-        public static int BinarySearch<T, TComparable>(this System.Span<T> span, TComparable comparable) where TComparable : System.IComparable<T> { throw null; }
+        public static int BinarySearch<T, TComparer>(this System.ReadOnlySpan<T> span, T value, TComparer comparer) where TComparer : System.Collections.Generic.IComparer<T>, allows ref struct { throw null; }
+        public static int BinarySearch<T, TComparable>(this System.ReadOnlySpan<T> span, TComparable comparable) where TComparable : System.IComparable<T>, allows ref struct { throw null; }
+        public static int BinarySearch<T, TComparer>(this System.Span<T> span, T value, TComparer comparer) where TComparer : System.Collections.Generic.IComparer<T>, allows ref struct { throw null; }
+        public static int BinarySearch<T, TComparable>(this System.Span<T> span, TComparable comparable) where TComparable : System.IComparable<T>, allows ref struct { throw null; }
         public static int CommonPrefixLength<T>(this System.Span<T> span, System.ReadOnlySpan<T> other) { throw null; }
         public static int CommonPrefixLength<T>(this System.Span<T> span, System.ReadOnlySpan<T> other, System.Collections.Generic.IEqualityComparer<T>? comparer) { throw null; }
         public static int CommonPrefixLength<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> other) { throw null; }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IAlternateEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IAlternateEqualityComparer.cs
@@ -9,7 +9,9 @@ namespace System.Collections.Generic
     /// </summary>
     /// <typeparam name="TAlternate">The alternate type to compare.</typeparam>
     /// <typeparam name="T">The type to compare.</typeparam>
-    public interface IAlternateEqualityComparer<in TAlternate, T> where TAlternate : allows ref struct
+    public interface IAlternateEqualityComparer<in TAlternate, T>
+        where TAlternate : allows ref struct
+        where T : allows ref struct
     {
         /// <summary>Determines whether the specified <paramref name="alternate"/> equals the specified <paramref name="other"/>.</summary>
         /// <param name="alternate">The instance of type <typeparamref name="TAlternate"/> to compare.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IComparer.cs
@@ -8,7 +8,7 @@ namespace System.Collections.Generic
     // The generic IComparer interface implements a method that compares
     // two objects. It is used in conjunction with the Sort and
     // BinarySearch methods on the Array, List, and SortedList classes.
-    public interface IComparer<in T>
+    public interface IComparer<in T> where T : allows ref struct
     {
         // Compares two objects. An implementation of this method must return a
         // value less than zero if x is less than y, zero if x is equal to y, or a

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IEqualityComparer.cs
@@ -8,7 +8,7 @@ namespace System.Collections.Generic
     // The generic IEqualityComparer interface implements methods to check if two objects are equal
     // and generate Hashcode for an object.
     // It is used in Dictionary class.
-    public interface IEqualityComparer<in T>
+    public interface IEqualityComparer<in T> where T : allows ref struct
     {
         bool Equals(T? x, T? y);
         int GetHashCode([DisallowNull] T obj);

--- a/src/libraries/System.Private.CoreLib/src/System/IComparable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IComparable.cs
@@ -41,7 +41,7 @@ namespace System
 
     // Generic version of IComparable.
 
-    public interface IComparable<in T>
+    public interface IComparable<in T> where T : allows ref struct
     {
         // Interface does not need to be marked with the serializable attribute
 

--- a/src/libraries/System.Private.CoreLib/src/System/IEquatable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IEquatable.cs
@@ -3,7 +3,7 @@
 
 namespace System
 {
-    public interface IEquatable<T> // invariant due to questionable semantics around equality and inheritance
+    public interface IEquatable<T> where T : allows ref struct // invariant due to questionable semantics around equality and inheritance
     {
         /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
         /// <param name="other">An object to compare with this object.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -3138,7 +3138,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int BinarySearch<T, TComparable>(
             this Span<T> span, TComparable comparable)
-            where TComparable : IComparable<T>
+            where TComparable : IComparable<T>, allows ref struct
         {
             return BinarySearch((ReadOnlySpan<T>)span, comparable);
         }
@@ -3164,7 +3164,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int BinarySearch<T, TComparer>(
             this Span<T> span, T value, TComparer comparer)
-            where TComparer : IComparer<T>
+            where TComparer : IComparer<T>, allows ref struct
         {
             return BinarySearch((ReadOnlySpan<T>)span, value, comparer);
         }
@@ -3212,7 +3212,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int BinarySearch<T, TComparable>(
             this ReadOnlySpan<T> span, TComparable comparable)
-            where TComparable : IComparable<T>
+            where TComparable : IComparable<T>, allows ref struct
         {
             return SpanHelpers.BinarySearch(span, comparable);
         }
@@ -3238,7 +3238,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int BinarySearch<T, TComparer>(
             this ReadOnlySpan<T> span, T value, TComparer comparer)
-            where TComparer : IComparer<T>
+            where TComparer : IComparer<T>, allows ref struct
         {
             if (comparer == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparer);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.BinarySearch.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.BinarySearch.cs
@@ -12,7 +12,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int BinarySearch<T, TComparable>(
             this ReadOnlySpan<T> span, TComparable comparable)
-            where TComparable : IComparable<T>
+            where TComparable : IComparable<T>, allows ref struct
         {
             if (comparable == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparable);
@@ -22,7 +22,7 @@ namespace System
 
         public static int BinarySearch<T, TComparable>(
             ref T spanStart, int length, TComparable comparable)
-            where TComparable : IComparable<T>
+            where TComparable : IComparable<T>, allows ref struct
         {
             int lo = 0;
             int hi = length - 1;
@@ -59,8 +59,8 @@ namespace System
         }
 
         // Helper to allow sharing all code via IComparable<T> inlineable
-        internal readonly struct ComparerComparable<T, TComparer> : IComparable<T>
-            where TComparer : IComparer<T>
+        internal readonly ref struct ComparerComparable<T, TComparer> : IComparable<T>
+            where TComparer : IComparer<T>, allows ref struct
         {
             private readonly T _value;
             private readonly TComparer _comparer;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3451,7 +3451,7 @@ namespace System
     {
         int CompareTo(object? obj);
     }
-    public partial interface IComparable<in T>
+    public partial interface IComparable<in T> where T : allows ref struct
     {
         int CompareTo(T? other);
     }
@@ -3484,7 +3484,7 @@ namespace System
     {
         void Dispose();
     }
-    public partial interface IEquatable<T>
+    public partial interface IEquatable<T> where T : allows ref struct
     {
         bool Equals(T? other);
     }
@@ -8170,7 +8170,7 @@ namespace System.Collections
 }
 namespace System.Collections.Generic
 {
-    public interface IAlternateEqualityComparer<in TAlternate, T> where TAlternate : allows ref struct
+    public interface IAlternateEqualityComparer<in TAlternate, T> where TAlternate : allows ref struct where T : allows ref struct
     {
         bool Equals(TAlternate alternate, T other);
         int GetHashCode(TAlternate alternate);
@@ -8195,7 +8195,7 @@ namespace System.Collections.Generic
         void CopyTo(T[] array, int arrayIndex);
         bool Remove(T item);
     }
-    public partial interface IComparer<in T>
+    public partial interface IComparer<in T> where T : allows ref struct
     {
         int Compare(T? x, T? y);
     }
@@ -8217,7 +8217,7 @@ namespace System.Collections.Generic
     {
         new T Current { get; }
     }
-    public partial interface IEqualityComparer<in T>
+    public partial interface IEqualityComparer<in T> where T : allows ref struct
     {
         bool Equals(T? x, T? y);
         int GetHashCode([System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T obj);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/103270
Fixes https://github.com/dotnet/runtime/issues/103323