### PR TITLE
JIT: Test old block layout in outerloop pipelines

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -537,7 +537,7 @@ jobs:
             - jitosr_stress
             - jitpartialcompilation_pgo
             - jitoptrepeat
-            - jitrpolayout
+            - jitoldlayout
           ${{ else }}:
             scenarios:
             - jitosr_stress
@@ -550,7 +550,7 @@ jobs:
             - jitphysicalpromotion_full
             - jitrlcse
             - jitoptrepeat
-            - jitrpolayout
+            - jitoldlayout
         ${{ if in(parameters.testGroup, 'jit-cfg') }}:
           scenarios:
           - jitcfg

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -71,4 +71,4 @@ extends:
                     - syntheticpgo
                     - syntheticpgo_blend
                     - jitrlcse
-                    - jitrpolayout
+                    - jitoldlayout

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -244,7 +244,7 @@
     <TestEnvironment Include="syntheticpgo_blend" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitSynthesizeCounts="3" JitCheckSynthesizedCounts="1" />
     <TestEnvironment Include="jitrlcse" JitRLCSEGreedy="1" />
     <TestEnvironment Include="jitoptrepeat" JitEnableOptRepeat="1" JitOptRepeat="*" JitOptRepeatCount="2"/>
-    <TestEnvironment Include="jitrpolayout" JitDoReversePostOrderLayout="1"/>
+    <TestEnvironment Include="jitoldlayout" JitDoReversePostOrderLayout="0"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' == 'true'" GCName="clrgc.dll"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' != 'true'" GCName="libclrgc.so"/>
     <TestEnvironment Include="gcstandaloneserver" Condition="'$(TargetsWindows)' == 'true'" gcServer="1" GCName="clrgc.dll"/>


### PR DESCRIPTION
Since the new RPO-based layout is enabled by default, test the old layout in `runtime-jit-experimental` and `runtime-coreclr libraries-pgo` to keep it from bit-rotting. @AndyAyersMS PTAL, thanks!