### PR TITLE
Fix print when outputting disasm

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1859,17 +1859,17 @@ void CodeGen::genGenerateMachineCode()
             {
                 if (compiler->compOpportunisticallyDependsOn(InstructionSet_AVX10v1_V512))
                 {
-                    printf("X86 with AVX10/512");
+                    printf("X64 with AVX10/512");
                 }
                 else
                 {
-                    printf("X86 with AVX10/256");
+                    printf("X64 with AVX10/256");
                 }
             }
             else
             {
                 assert(compiler->compIsaSupportedDebugOnly(InstructionSet_AVX512F));
-                printf("X86 with AVX512");
+                printf("X64 with AVX512");
             }
         }
         else if (compiler->canUseVexEncoding())


### PR DESCRIPTION
Fixing print bug introduced in https://github.com/dotnet/runtime/pull/101938