### PR TITLE
Add System.Formats.Nrbf to the windowsdesktop transport package

### DIFF
--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -232,6 +232,7 @@
       System.Diagnostics.EventLog;
       System.Diagnostics.PerformanceCounter;
       System.DirectoryServices;
+      System.Formats.Nrbf;
       System.IO.Packaging;
       System.Resources.Extensions;
       System.Security.Cryptography.Pkcs;


### PR DESCRIPTION
Unblocks the windowsdesktop dependency flow. See https://github.com/dotnet/windowsdesktop/pull/4459#issuecomment-2175892292