### PR TITLE
SPMI: Increase timeout for superpmi-diffs job

### DIFF
--- a/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
@@ -5,7 +5,7 @@ parameters:
   osSubgroup: ''                  # optional -- operating system subgroup
   condition: true
   pool: ''
-  timeoutInMinutes: 240           # build timeout
+  timeoutInMinutes: 360           # build timeout
   variables: {}
   helixQueues: ''
   runJobTemplate: '/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml'


### PR DESCRIPTION
We are seeing x86 Helix jobs waiting multiple hours before they start running, which can result in us hitting this timeout.

Fix #103505