### PR TITLE
[browser] Fix missing 'RelativePath' metadata in items produced by AOT compiler

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -448,6 +448,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
     <ItemGroup Condition="@(WasmAssembliesFinal->Count()) > 0">
       <_WasmResolvedFilesToPublish Include="@(WasmAssembliesFinal)" />
+      <!-- Ensure we have 'RelativePath' required by ComputeWasmPublishAssets. 9+ version of MonoAOTCompiler is copying this metadata, but when targeting downlevel versions it doesn't. -->
+      <_WasmResolvedFilesToPublish RelativePath="%(FileName)%(Extension)" Condition="'%(_WasmResolvedFilesToPublish.RelativePath)' == ''" />
 
       <!-- remove the original assemblies -->
       <ResolvedFileToPublish Remove="@(WasmAssembliesToBundle)" />


### PR DESCRIPTION
- It manifests only when we target downlevel version using current SDK
- In current SDK it is fixed by changes from https://github.com/dotnet/runtime/pull/90436
- Tested manually