### PR TITLE
[NRBF] change StartsWithPayloadHeader to accept a Span rather than array

### DIFF
--- a/src/libraries/System.Formats.Nrbf/ref/System.Formats.Nrbf.cs
+++ b/src/libraries/System.Formats.Nrbf/ref/System.Formats.Nrbf.cs
@@ -48,7 +48,7 @@ namespace System.Formats.Nrbf
         public static System.Formats.Nrbf.SerializationRecord Decode(System.IO.Stream payload, out System.Collections.Generic.IReadOnlyDictionary<System.Formats.Nrbf.SerializationRecordId, System.Formats.Nrbf.SerializationRecord> recordMap, System.Formats.Nrbf.PayloadOptions options=null, bool leaveOpen=false) { throw null; }
         public static System.Formats.Nrbf.SerializationRecord Decode(System.IO.Stream payload, System.Formats.Nrbf.PayloadOptions? options=null, bool leaveOpen=false) { throw null; }
         public static System.Formats.Nrbf.ClassRecord DecodeClassRecord(System.IO.Stream payload, System.Formats.Nrbf.PayloadOptions? options=null, bool leaveOpen=false) { throw null; }
-        public static bool StartsWithPayloadHeader(byte[] bytes) { throw null; }
+        public static bool StartsWithPayloadHeader(System.ReadOnlySpan<byte> bytes) { throw null; }
         public static bool StartsWithPayloadHeader(System.IO.Stream stream) { throw null; }
     }
     public sealed partial class PayloadOptions


### PR DESCRIPTION
During the API Review I was asked why this method accepts an array rather than a readonly span of bytes. I've answered that because it's impossible to implement it for NS2.0 due to lack of primitives for endianness conversion. Back then I did not know that `BinaryPrimitives.ReverseEndianness` is supported on older frameworks. 
