### PR TITLE
[mono] Add exists condition for copying hostfxr & hostpolicy symbol files

### DIFF
--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -122,7 +122,7 @@
     <ItemGroup>
       <RuntimeFiles Include="@(HostFxrFile)" Condition="Exists('@(HostFxrFile)') and '$(TargetsMobile)' != 'true'"/>
       <RuntimeFiles Include="@(HostPolicyFile)" Condition="Exists('@(HostPolicyFile)') and '$(TargetsMobile)' != 'true'" />
-      <RuntimeFiles Include="@(_HostSymbols)" IsNative="true" Condition="'$(TargetsMobile)' != 'true'" />
+      <RuntimeFiles Include="@(_HostSymbols)" IsNative="true" Condition="Exists('@(_HostSymbols)') and '$(TargetsMobile)' != 'true'" />
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
       <!-- Setup runtime pack native. -->
       <ReferenceCopyLocalPaths Include="@(MonoCrossFiles)"


### PR DESCRIPTION
This was missing from https://github.com/dotnet/runtime/pull/103304 and it causes build issues on windows mono runs

Fixes https://github.com/dotnet/runtime/issues/103642