### PR TITLE
Fix missing hashcode set in OrderedDictionary.SetAt

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
@@ -809,8 +809,8 @@ namespace System.Collections.Generic
             }
 
             // The key doesn't match that index. If it exists elsewhere in the collection, fail.
-            uint _ = 0, collisionCount = 0;
-            if (IndexOf(key, ref _, ref collisionCount) >= 0)
+            uint hashCode = 0, collisionCount = 0;
+            if (IndexOf(key, ref hashCode, ref collisionCount) >= 0)
             {
                 ThrowHelper.ThrowDuplicateKey(key);
             }
@@ -820,6 +820,7 @@ namespace System.Collections.Generic
             // (we could check for this, but in a properly balanced dictionary the chances should
             // be low for a match, so it's not worth it).
             RemoveEntryFromBucket(index);
+            e.HashCode = hashCode;
             e.Key = key;
             e.Value = value;
             PushEntryIntoBucket(ref e, index);

--- a/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
@@ -308,6 +308,25 @@ namespace System.Collections.Tests
             }
         }
 
+        [Fact]
+        public void OrderedDictionary_SetAt_KeyValuePairSubsequentlyAvailable()
+        {
+            TKey key0 = CreateTKey(0), key1 = CreateTKey(1);
+            TValue value0 = CreateTValue(0), value1 = CreateTValue(1);
+
+            var dict = new OrderedDictionary<TKey, TValue>
+            {
+                [key0] = value0,
+            };
+
+            dict.SetAt(index: 0, key1, value1);
+
+            Assert.Equal(1, dict.Count);
+            Assert.Equal([new(key1, value1)], dict);
+            Assert.False(dict.ContainsKey(key0));
+            Assert.True(dict.ContainsKey(key1));
+        }
+
         #endregion
 
         #region Remove(..., out TValue)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/103637