### PR TITLE
[release/8.0-staging] [HybridGlobalization]Pass non-breaking space / narrow non-breaking space characters

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -282,5 +282,13 @@ namespace System.Globalization.Tests
                 }
             }
         }
+
+        [Fact]
+        public void LongTimePattern_CheckTimeFormatWithSpaces()
+        {
+            var date = DateTime.Today + TimeSpan.FromHours(15) + TimeSpan.FromMinutes(15);
+            var culture = new CultureInfo("en-US");
+            Assert.Equal("3:15:00 PM", date.ToString("T", culture));
+        }
     }
 }

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -288,7 +288,13 @@ namespace System.Globalization.Tests
         {
             var date = DateTime.Today + TimeSpan.FromHours(15) + TimeSpan.FromMinutes(15);
             var culture = new CultureInfo("en-US");
-            Assert.Equal("3:15:00 PM", date.ToString("T", culture));
+            string formattedDate = date.ToString("t", culture);
+            bool containsSpace = formattedDate.Contains(' ');
+            bool containsNoBreakSpace = formattedDate.Contains('\u00A0');
+            bool containsNarrowNoBreakSpace = formattedDate.Contains('\u202F');
+
+            Assert.True(containsSpace || containsNoBreakSpace || containsNarrowNoBreakSpace,
+                $"Formatted date string '{formattedDate}' does not contain any of the specified spaces.");
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -259,7 +259,13 @@ namespace System.Globalization.Tests
         {
             var date = DateTime.Today + TimeSpan.FromHours(15) + TimeSpan.FromMinutes(15);
             var culture = new CultureInfo("en-US");
-            Assert.Equal("3:15 PM", date.ToString("t", culture));
+            string formattedDate = date.ToString("t", culture);
+            bool containsSpace = formattedDate.Contains(' ');
+            bool containsNoBreakSpace = formattedDate.Contains('\u00A0');
+            bool containsNarrowNoBreakSpace = formattedDate.Contains('\u202F');
+
+            Assert.True(containsSpace || containsNoBreakSpace || containsNarrowNoBreakSpace,
+                $"Formatted date string '{formattedDate}' does not contain any of the specified spaces.");
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -253,5 +253,13 @@ namespace System.Globalization.Tests
         {
             Assert.Throws<InvalidOperationException>(() => DateTimeFormatInfo.InvariantInfo.ShortTimePattern = "HH:mm");
         }
+
+        [Fact]
+        public void ShortTimePattern_CheckTimeFormatWithSpaces()
+        {
+            var date = DateTime.Today + TimeSpan.FromHours(15) + TimeSpan.FromMinutes(15);
+            var culture = new CultureInfo("en-US");
+            Assert.Equal("3:15 PM", date.ToString("t", culture));
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -267,7 +267,12 @@ namespace System.Globalization
             if (GlobalizationMode.Hybrid)
             {
                 string res = Interop.Globalization.GetLocaleTimeFormatNative(_sWindowsName, shortFormat);
-                span = res != null ? new ReadOnlySpan<char>(ref res.GetRawStringData(), res.Length) : ReadOnlySpan<char>.Empty;
+                if (string.IsNullOrEmpty(res))
+                {
+                    Debug.Fail("[CultureData.GetTimeFormatString(bool shortFormat)] Failed");
+                    return string.Empty;
+                }
+                span = res.AsSpan();
             }
             else
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -262,18 +262,29 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(_sWindowsName != null, "[CultureData.GetTimeFormatString(bool shortFormat)] Expected _sWindowsName to be populated already");
 
-            char* buffer = stackalloc char[ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY];
-
-            bool result = Interop.Globalization.GetLocaleTimeFormat(_sWindowsName, shortFormat, buffer, ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY);
-            if (!result)
+            ReadOnlySpan<char> span;
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+            if (GlobalizationMode.Hybrid)
             {
-                // Failed, just use empty string
-                Debug.Fail("[CultureData.GetTimeFormatString(bool shortFormat)] Failed");
-                return string.Empty;
+                string res = Interop.Globalization.GetLocaleTimeFormatNative(_sWindowsName, shortFormat);
+                span = res != null ? new ReadOnlySpan<char>(ref res.GetRawStringData(), res.Length) : ReadOnlySpan<char>.Empty;
+            }
+            else
+#endif
+            {
+                char* buffer = stackalloc char[ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY];
+                bool result = Interop.Globalization.GetLocaleTimeFormat(_sWindowsName, shortFormat, buffer, ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY);
+                if (!result)
+                {
+                    // Failed, just use empty string
+                    Debug.Fail("[CultureData.GetTimeFormatString(bool shortFormat)] Failed");
+                    return string.Empty;
+                }
+                span = new ReadOnlySpan<char>(buffer, ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY);
+                span = span.Slice(0, span.IndexOf('\0'));
             }
 
-            var span = new ReadOnlySpan<char>(buffer, ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY);
-            return ConvertIcuTimeFormatString(span.Slice(0, span.IndexOf('\0')));
+            return ConvertIcuTimeFormatString(span);
         }
 
         // no support to lookup by region name, other than the hard-coded list in CultureData

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Unix.cs
@@ -25,11 +25,7 @@ namespace System.Globalization
 
         private string[]? GetTimeFormatsCore(bool shortFormat)
         {
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            string format = GlobalizationMode.Hybrid ? GetTimeFormatStringNative(shortFormat) : IcuGetTimeFormatString(shortFormat);
-#else
             string format = IcuGetTimeFormatString(shortFormat);
-#endif
             return new string[] { format };
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -1992,11 +1992,7 @@ namespace System.Globalization
                     }
                     else
                     {
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-                        string? longTimeFormat =  GlobalizationMode.Hybrid ? GetTimeFormatStringNative() : IcuGetTimeFormatString();
-#else
                         string? longTimeFormat = ShouldUseUserOverrideNlsData ? NlsGetTimeFormatString() : IcuGetTimeFormatString();
-#endif
                         if (string.IsNullOrEmpty(longTimeFormat))
                         {
                             longTimeFormat = LongTimes[0];

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
@@ -7,22 +7,6 @@ namespace System.Globalization
 {
     internal sealed partial class CultureData
     {
-        private const int LOC_FULLNAME_CAPACITY = 157;           // max size of locale name
-
-        /// <summary>
-        /// This method uses the sRealName field (which is initialized by the constructor before this is called) to
-        /// initialize the rest of the state of CultureData based on the underlying OS globalization library.
-        /// </summary>
-        private bool InitAppleCultureDataCore()
-        {
-            Debug.Assert(_sRealName != null);
-            Debug.Assert(!GlobalizationMode.Invariant);
-            string realNameBuffer = _sRealName;
-
-            _sWindowsName = _sName = _sRealName = GetLocaleNameNative(realNameBuffer);
-            return true;
-        }
-
         internal static string GetLocaleNameNative(string localeName)
         {
             return Interop.Globalization.GetLocaleNameNative(localeName);
@@ -77,72 +61,6 @@ namespace System.Globalization
             }
 
             return new int[] { primaryGroupingSize, secondaryGroupingSize };
-        }
-
-        private string GetTimeFormatStringNative() => GetTimeFormatStringNative(shortFormat: false);
-
-        private string GetTimeFormatStringNative(bool shortFormat)
-        {
-            Debug.Assert(_sWindowsName != null, "[CultureData.GetTimeFormatStringNative(bool shortFormat)] Expected _sWindowsName to be populated already");
-
-            string result = Interop.Globalization.GetLocaleTimeFormatNative(_sWindowsName, shortFormat);
-
-            return ConvertNativeTimeFormatString(result);
-        }
-
-        private static string ConvertNativeTimeFormatString(string nativeFormatString)
-        {
-            Span<char> result = stackalloc char[LOC_FULLNAME_CAPACITY];
-
-            bool amPmAdded = false;
-            int resultPos = 0;
-
-            for (int i = 0; i < nativeFormatString.Length; i++)
-            {
-                switch (nativeFormatString[i])
-                {
-                    case '\'':
-                        result[resultPos++] = nativeFormatString[i++];
-                        while (i < nativeFormatString.Length)
-                        {
-                            char current = nativeFormatString[i];
-                            result[resultPos++] = current;
-                            if (current == '\'')
-                            {
-                                break;
-                            }
-                            i++;
-                        }
-                        break;
-
-                    case ':':
-                    case '.':
-                    case 'H':
-                    case 'h':
-                    case 'm':
-                    case 's':
-                        result[resultPos++] = nativeFormatString[i];
-                        break;
-
-                    case ' ':
-                    case '\u00A0':
-                        // Convert nonbreaking spaces into regular spaces
-                        result[resultPos++] = ' ';
-                        break;
-
-                    case 'a': // AM/PM
-                        if (!amPmAdded)
-                        {
-                            amPmAdded = true;
-                            result[resultPos++] = 't';
-                            result[resultPos++] = 't';
-                        }
-                        break;
-
-                }
-            }
-
-            return result.Slice(0, resultPos).ToString();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
@@ -7,6 +7,20 @@ namespace System.Globalization
 {
     internal sealed partial class CultureData
     {
+        /// <summary>
+        /// This method uses the sRealName field (which is initialized by the constructor before this is called) to
+        /// initialize the rest of the state of CultureData based on the underlying OS globalization library.
+        /// </summary>
+        private bool InitAppleCultureDataCore()
+        {
+            Debug.Assert(_sRealName != null);
+            Debug.Assert(!GlobalizationMode.Invariant);
+            string realNameBuffer = _sRealName;
+
+            _sWindowsName = _sName = _sRealName = GetLocaleNameNative(realNameBuffer);
+            return true;
+        }
+
         internal static string GetLocaleNameNative(string localeName)
         {
             return Interop.Globalization.GetLocaleNameNative(localeName);


### PR DESCRIPTION
## Description
Backport of https://github.com/dotnet/runtime/pull/103226 to release/8.0-staging


## Customer Impact

- [X] Customer reported https://github.com/dotnet/runtime/issues/102250
- [ ] Found internally

Customer reported when using hybrid globalization on iOS and using the short time specifier, there is no space in front of the "AM" or "PM".

## Regression
- [ ] Yes
- [x] No

## Testing
Tests were added to the original PR.

## Risk
Affects Globalization code on Apple mobile scenario when `HybridGlobalization` is enabled.