### PR TITLE
call gtFoldExpr after fgMorphExpandInstanceField

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4883,8 +4883,6 @@ GenTree* Compiler::fgMorphFieldAddr(GenTree* tree, MorphAddrContext* mac)
         assert(!"Normal statics are expected to be handled in the importer");
     }
 
-    tree = gtFoldExpr(tree);
-
     // Pass down the current mac; if non null we are computing an address
     GenTree* result;
     if (tree->OperIsSimple())

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5112,6 +5112,9 @@ GenTree* Compiler::fgMorphExpandInstanceField(GenTree* tree, MorphAddrContext* m
         {
             addr->SetHasOrderingSideEffect();
         }
+
+        // Fold it if we have const-handle + const-offset
+        addr = gtFoldExpr(addr);
     }
 
     if (addExplicitNullCheck)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4883,6 +4883,8 @@ GenTree* Compiler::fgMorphFieldAddr(GenTree* tree, MorphAddrContext* mac)
         assert(!"Normal statics are expected to be handled in the importer");
     }
 
+    tree = gtFoldExpr(tree);
+
     // Pass down the current mac; if non null we are computing an address
     GenTree* result;
     if (tree->OperIsSimple())

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5111,8 +5111,11 @@ GenTree* Compiler::fgMorphExpandInstanceField(GenTree* tree, MorphAddrContext* m
             addr->SetHasOrderingSideEffect();
         }
 
-        // Fold it if we have const-handle + const-offset
-        addr = gtFoldExpr(addr);
+        if (addr->gtGetOp1()->OperIsConst() && addr->gtGetOp2()->OperIsConst())
+        {
+            // Fold it if we have const-handle + const-offset
+            addr = gtFoldExprConst(addr);
+        }
     }
 
     if (addExplicitNullCheck)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/103577

it's a pretty annoying assert that we should probably just delete - `gtMarkAddrMode` may hit that assert when it encounters `cns + cns` like foldable trees in tier0 (with opts) or tier1, because it does its own foldings and after that runs some validations

`fgMorphExpandInstanceField` may return:
```
[000023] -----------                         *  ADD       long
[000003] H----------                         +--*  CNS_INT(h) long   0x1c880109658 static Fseq[foo]
[000022] -----------                         \--*  CNS_INT   long   4
```