### PR TITLE
Fix locking in ReflectionComposablePart.ImportsCache

### DIFF
--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePart.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePart.cs
@@ -87,6 +87,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
                 {
                     lock (_lock)
                     {
+                        value = _importsCache;
                         if (value == null)
                         {
                             value = new Dictionary<ImportDefinition, ImportingItem>();


### PR DESCRIPTION
The second check needs to use the value from the field (to see updates made by other threads), not the local variable.

Fixes: #103650