### PR TITLE
Consistently report unresolved members in illink

### DIFF
--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -803,7 +803,7 @@ namespace Mono.Linker
 				return null;
 
 			if (methodresolveCache.TryGetValue (methodReference, out MethodDefinition? md)) {
-				if (md == null & !IgnoreUnresolved)
+				if (md == null && !IgnoreUnresolved)
 					ReportUnresolved (methodReference);
 				return md;
 			}

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -802,8 +802,11 @@ namespace Mono.Linker
 			if (methodReference is null)
 				return null;
 
-			if (methodresolveCache.TryGetValue (methodReference, out MethodDefinition? md))
+			if (methodresolveCache.TryGetValue (methodReference, out MethodDefinition? md)) {
+				if (md == null & !IgnoreUnresolved)
+					ReportUnresolved (methodReference);
 				return md;
+			}
 
 #pragma warning disable RS0030 // Cecil's resolve is banned -- this provides the wrapper
 			md = methodReference.Resolve ();
@@ -847,8 +850,11 @@ namespace Mono.Linker
 			if (fieldReference is null)
 				return null;
 
-			if (fieldresolveCache.TryGetValue (fieldReference, out FieldDefinition? fd))
+			if (fieldresolveCache.TryGetValue (fieldReference, out FieldDefinition? fd)) {
+				if (fd == null && !IgnoreUnresolved)
+					ReportUnresolved (fieldReference);
 				return fd;
+			}
 
 			fd = fieldReference.Resolve ();
 			if (fd == null && !IgnoreUnresolved)
@@ -888,8 +894,11 @@ namespace Mono.Linker
 			if (typeReference is null)
 				return null;
 
-			if (typeresolveCache.TryGetValue (typeReference, out TypeDefinition? td))
+			if (typeresolveCache.TryGetValue (typeReference, out TypeDefinition? td)) {
+				if (td == null && !IgnoreUnresolved)
+					ReportUnresolved (typeReference);
 				return td;
+			}
 
 			//
 			// Types which never have TypeDefinition or can have ambiguous definition should not be passed in


### PR DESCRIPTION
Just fixing something I noticed while investigating another issue. The resolution cache is shared between `Resolve` and `TryResolve`, so we should call `ReportUnresolved` from `Resolve` when we see a cached null result (that could have been cached during `TryResolve`). Should make no difference to supported scenarios because we always run with `IgnoreUnresolved` `true`.

Looks like I regressed this in https://github.com/dotnet/linker/pull/2253.