### PR TITLE
[cdac] Implement ISOSDacInterface::GetNestedExceptionData

### DIFF
--- a/docs/design/datacontracts/Exception.md
+++ b/docs/design/datacontracts/Exception.md
@@ -1,0 +1,28 @@
+# Contract Thread
+
+This contract is for getting information about exceptions in the process.
+
+## APIs of contract
+
+``` csharp
+TargetPointer GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException);
+```
+
+## Version 1
+
+Data descriptors used:
+- `ExceptionInfo`
+
+``` csharp
+TargetPointer GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException)
+{
+    if (exception == TargetPointer.Null)
+        throw new InvalidArgumentException();
+
+    nextNestedException = target.ReadPointer(address + /* ExceptionInfo::PreviousNestedInfo offset*/);
+    TargetPointer thrownObjHandle = target.ReadPointer(address + /* ExceptionInfo::ThrownObject offset */);
+    return = thrownObjHandle != TargetPointer.Null
+        ? target.ReadPointer(thrownObjHandle)
+        : TargetPointer.Null;
+}
+```

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -46,7 +46,6 @@ record struct ThreadData (
 ThreadStoreData GetThreadStoreData();
 ThreadStoreCounts GetThreadCounts();
 ThreadData GetThreadData(TargetPointer threadPointer);
-TargetPointer GetNestedExceptionInfo(TargetPointer nestedExceptionPointer, out TargetPointer nextNestedException);
 TargetPointer GetManagedThreadObject(TargetPointer threadPointer);
 ```
 
@@ -114,26 +113,6 @@ ThreadData GetThreadData(TargetPointer threadPointer)
         FirstNestedException : firstNestedException,
         NextThread : ThreadListReader.GetHead.GetNext(threadPointer)
     );
-}
-
-TargetPointer GetNestedExceptionInfo(TargetPointer nestedExceptionPointer, out TargetPointer nextNestedException)
-{
-    if (nestedExceptionPointer == TargetPointer.Null)
-    {
-        throw new InvalidArgumentException();
-    }
-    if (Target.ReadGlobalInt32("FEATURE_EH_FUNCLETS"))
-    {
-        var exData = new ExceptionTrackerBase(Target, nestedExceptionPointer);
-        nextNestedException = exData.m_pPrevNestedInfo;
-        return Contracts.GCHandle.GetObject(exData.m_hThrowable);
-    }
-    else
-    {
-        var exData = new ExInfo(Target, nestedExceptionPointer);
-        nextNestedException = exData.m_pPrevNestedInfo;
-        return Contracts.GCHandle.GetObject(exData.m_hThrowable);
-    }
 }
 
 TargetPointer GetManagedThreadObject(TargetPointer threadPointer)

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -1231,6 +1231,7 @@ public:
 
     HRESULT GetThreadDataImpl(CLRDATA_ADDRESS threadAddr, struct DacpThreadData *threadData);
     HRESULT GetThreadStoreDataImpl(struct DacpThreadStoreData *data);
+    HRESULT GetNestedExceptionDataImpl(CLRDATA_ADDRESS exception, CLRDATA_ADDRESS *exceptionObject, CLRDATA_ADDRESS *nextNestedException);
 
     BOOL IsExceptionFromManagedCode(EXCEPTION_RECORD * pExceptionRecord);
 #ifndef TARGET_UNIX

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3233,7 +3233,6 @@ ClrDataAccess::GetUsefulGlobals(struct DacpUsefulGlobalsData *globalsData)
     return hr;
 }
 
-
 HRESULT
 ClrDataAccess::GetNestedExceptionData(CLRDATA_ADDRESS exception, CLRDATA_ADDRESS *exceptionObject, CLRDATA_ADDRESS *nextNestedException)
 {
@@ -3242,6 +3241,39 @@ ClrDataAccess::GetNestedExceptionData(CLRDATA_ADDRESS exception, CLRDATA_ADDRESS
 
     SOSDacEnter();
 
+    if (m_cdacSos != NULL)
+    {
+        // Try the cDAC first - it will return E_NOTIMPL if it doesn't support this method yet. Fall back to the DAC.
+        hr = m_cdacSos->GetNestedExceptionData(exception, exceptionObject, nextNestedException);
+        if (FAILED(hr))
+        {
+            hr = GetNestedExceptionDataImpl(exception, exceptionObject, nextNestedException);
+        }
+#ifdef _DEBUG
+    else
+    {
+            // Assert that the data is the same as what we get from the DAC.
+            CLRDATA_ADDRESS exceptionObjectLocal;
+            CLRDATA_ADDRESS nextNestedExceptionLocal;
+            HRESULT hrLocal = GetNestedExceptionDataImpl(exception, &exceptionObjectLocal, &nextNestedExceptionLocal);
+            _ASSERTE(hr == hrLocal);
+            _ASSERTE(*exceptionObject == exceptionObjectLocal);
+            _ASSERTE(*nextNestedException == nextNestedExceptionLocal);
+        }
+#endif
+    }
+    else
+    {
+        hr = GetNestedExceptionDataImpl(exception, exceptionObject, nextNestedException);
+    }
+
+    SOSDacLeave();
+    return hr;
+}
+
+HRESULT
+ClrDataAccess::GetNestedExceptionDataImpl(CLRDATA_ADDRESS exception, CLRDATA_ADDRESS *exceptionObject, CLRDATA_ADDRESS *nextNestedException)
+{
 #ifdef FEATURE_EH_FUNCLETS
     ExceptionTrackerBase *pExData = PTR_ExceptionTrackerBase(TO_TADDR(exception));
 #else
@@ -3249,19 +3281,12 @@ ClrDataAccess::GetNestedExceptionData(CLRDATA_ADDRESS exception, CLRDATA_ADDRESS
 #endif // FEATURE_EH_FUNCLETS
 
     if (!pExData)
-    {
-        hr = E_INVALIDARG;
-    }
-    else
-    {
-        *exceptionObject = TO_CDADDR(*PTR_TADDR(pExData->m_hThrowable));
-        *nextNestedException = PTR_HOST_TO_TADDR(pExData->m_pPrevNestedInfo);
-    }
+        return E_INVALIDARG;
 
-    SOSDacLeave();
-    return hr;
+    *exceptionObject = TO_CDADDR(*PTR_TADDR(pExData->m_hThrowable));
+    *nextNestedException = PTR_HOST_TO_TADDR(pExData->m_pPrevNestedInfo);
+    return S_OK;
 }
-
 
 HRESULT
 ClrDataAccess::GetDomainLocalModuleData(CLRDATA_ADDRESS addr, struct DacpDomainLocalModuleData *pLocalModuleData)

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3250,8 +3250,8 @@ ClrDataAccess::GetNestedExceptionData(CLRDATA_ADDRESS exception, CLRDATA_ADDRESS
             hr = GetNestedExceptionDataImpl(exception, exceptionObject, nextNestedException);
         }
 #ifdef _DEBUG
-    else
-    {
+        else
+        {
             // Assert that the data is the same as what we get from the DAC.
             CLRDATA_ADDRESS exceptionObjectLocal;
             CLRDATA_ADDRESS nextNestedExceptionLocal;

--- a/src/coreclr/debug/runtimeinfo/contracts.jsonc
+++ b/src/coreclr/debug/runtimeinfo/contracts.jsonc
@@ -9,7 +9,7 @@
 // cdac-build-tool can take multiple "-c contract_file" arguments
 // so to conditionally include contracts, put additional contracts in a separate file
 {
+  "Exception": 1,
   "Thread": 1,
   "SOSBreakingChangeVersion": 1 // example contract: "runtime exports an SOS breaking change version global"
 }
-

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -139,8 +139,10 @@ CDAC_TYPE_END(GCAllocContext)
 CDAC_TYPE_BEGIN(ExceptionInfo)
 CDAC_TYPE_INDETERMINATE(ExceptionInfo)
 #if FEATURE_EH_FUNCLETS
+CDAC_TYPE_FIELD(ExceptionInfo, /*pointer*/, ThrownObject, offsetof(ExceptionTrackerBase, m_hThrowable))
 CDAC_TYPE_FIELD(PreviousNestedInfo, /*pointer*/, PreviousNestedInfo, offsetof(ExceptionTrackerBase, m_pPrevNestedInfo))
 #else
+CDAC_TYPE_FIELD(ExceptionInfo, /*pointer*/, ThrownObject, offsetof(ExInfo, m_hThrowable))
 CDAC_TYPE_FIELD(PreviousNestedInfo, /*pointer*/, PreviousNestedInfo, offsetof(ExInfo, m_pPrevNestedInfo))
 #endif
 CDAC_TYPE_END(ExceptionInfo)

--- a/src/native/managed/cdacreader/src/Contracts/Exception.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Exception.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+internal interface IException : IContract
+{
+    static string IContract.Name { get; } = nameof(Exception);
+    static IContract IContract.Create(Target target, int version)
+    {
+        return version switch
+        {
+            1 => new Exception_1(target),
+            _ => default(Exception),
+        };
+    }
+
+    public virtual TargetPointer GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException) => throw new NotImplementedException();
+}
+
+internal readonly struct Exception : IException
+{
+    // Everything throws NotImplementedException
+}

--- a/src/native/managed/cdacreader/src/Contracts/Exception_1.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Exception_1.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+internal readonly struct Exception_1 : IException
+{
+    private readonly Target _target;
+
+    internal Exception_1(Target target)
+    {
+        _target = target;
+    }
+
+    TargetPointer IException.GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException)
+    {
+        Data.ExceptionInfo exceptionInfo = _target.ProcessedData.GetOrAdd<Data.ExceptionInfo>(exception);
+        nextNestedException = exceptionInfo.PreviousNestedInfo;
+        return exceptionInfo.ThrownObject.Object;
+    }
+}

--- a/src/native/managed/cdacreader/src/Contracts/Registry.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Registry.cs
@@ -18,6 +18,7 @@ internal sealed class Registry
         _target = target;
     }
 
+    public IException Exception => GetContract<IException>();
     public IThread Thread => GetContract<IThread>();
 
     private T GetContract<T>() where T : IContract

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -58,7 +58,6 @@ internal interface IThread : IContract
     public virtual ThreadStoreData GetThreadStoreData() => throw new NotImplementedException();
     public virtual ThreadStoreCounts GetThreadCounts() => throw new NotImplementedException();
     public virtual ThreadData GetThreadData(TargetPointer thread) => throw new NotImplementedException();
-    public virtual TargetPointer GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException) => throw new NotImplementedException();
 }
 
 internal readonly struct Thread : IThread
@@ -130,13 +129,6 @@ internal readonly struct Thread_1 : IThread
             thread.TEB,
             thread.LastThrownObject.Handle,
             GetThreadFromLink(thread.LinkNext));
-    }
-
-    TargetPointer IThread.GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException)
-    {
-        Data.ExceptionInfo exceptionInfo = _target.ProcessedData.GetOrAdd<Data.ExceptionInfo>(exception);
-        nextNestedException = exceptionInfo.PreviousNestedInfo;
-        return exceptionInfo.ThrownObject.Object;
     }
 
     private TargetPointer GetThreadFromLink(TargetPointer threadLink)

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -58,6 +58,7 @@ internal interface IThread : IContract
     public virtual ThreadStoreData GetThreadStoreData() => throw new NotImplementedException();
     public virtual ThreadStoreCounts GetThreadCounts() => throw new NotImplementedException();
     public virtual ThreadData GetThreadData(TargetPointer thread) => throw new NotImplementedException();
+    public virtual TargetPointer GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException) => throw new NotImplementedException();
 }
 
 internal readonly struct Thread : IThread
@@ -127,8 +128,15 @@ internal readonly struct Thread_1 : IThread
             thread.Frame,
             firstNestedException,
             thread.TEB,
-            thread.LastThrownObject,
+            thread.LastThrownObject.Handle,
             GetThreadFromLink(thread.LinkNext));
+    }
+
+    TargetPointer IThread.GetExceptionInfo(TargetPointer exception, out TargetPointer nextNestedException)
+    {
+        Data.ExceptionInfo exceptionInfo = _target.ProcessedData.GetOrAdd<Data.ExceptionInfo>(exception);
+        nextNestedException = exceptionInfo.PreviousNestedInfo;
+        return exceptionInfo.ThrownObject.Object;
     }
 
     private TargetPointer GetThreadFromLink(TargetPointer threadLink)

--- a/src/native/managed/cdacreader/src/Data/ExceptionInfo.cs
+++ b/src/native/managed/cdacreader/src/Data/ExceptionInfo.cs
@@ -13,7 +13,10 @@ internal sealed class ExceptionInfo : IData<ExceptionInfo>
         Target.TypeInfo type = target.GetTypeInfo(DataType.ExceptionInfo);
 
         PreviousNestedInfo = target.ReadPointer(address + (ulong)type.Fields[nameof(PreviousNestedInfo)].Offset);
+        ThrownObject = target.ProcessedData.GetOrAdd<ObjectHandle>(
+            target.ReadPointer(address + (ulong)type.Fields[nameof(ThrownObject)].Offset));
     }
 
     public TargetPointer PreviousNestedInfo { get; init; }
+    public ObjectHandle ThrownObject { get; init; }
 }

--- a/src/native/managed/cdacreader/src/Data/ObjectHandle.cs
+++ b/src/native/managed/cdacreader/src/Data/ObjectHandle.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal sealed class ObjectHandle : IData<ObjectHandle>
+{
+    static ObjectHandle IData<ObjectHandle>.Create(Target target, TargetPointer address)
+        => new ObjectHandle(target, address);
+
+    public ObjectHandle(Target target, TargetPointer address)
+    {
+        Handle = address;
+        if (address != TargetPointer.Null)
+            Object = target.ReadPointer(address);
+    }
+
+    public TargetPointer Handle { get; init; }
+    public TargetPointer Object { get; init; } = TargetPointer.Null;
+}

--- a/src/native/managed/cdacreader/src/Data/Thread.cs
+++ b/src/native/managed/cdacreader/src/Data/Thread.cs
@@ -27,7 +27,8 @@ internal sealed class Thread : IData<Thread>
         TEB = type.Fields.TryGetValue(nameof(TEB), out Target.FieldInfo fieldInfo)
             ? target.ReadPointer(address + (ulong)fieldInfo.Offset)
             : TargetPointer.Null;
-        LastThrownObject = target.ReadPointer(address + (ulong)type.Fields[nameof(LastThrownObject)].Offset);
+        LastThrownObject = target.ProcessedData.GetOrAdd<ObjectHandle>(
+            target.ReadPointer(address + (ulong)type.Fields[nameof(LastThrownObject)].Offset));
         LinkNext = target.ReadPointer(address + (ulong)type.Fields[nameof(LinkNext)].Offset);
 
         // Address of the exception tracker - how it should be read depends on EH funclets feature global value
@@ -41,7 +42,7 @@ internal sealed class Thread : IData<Thread>
     public GCAllocContext? AllocContext { get; init; }
     public TargetPointer Frame { get; init; }
     public TargetPointer TEB { get; init; }
-    public TargetPointer LastThrownObject { get; init; }
+    public ObjectHandle LastThrownObject { get; init; }
     public TargetPointer LinkNext { get; init; }
     public TargetPointer ExceptionTracker { get; init; }
 }

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -89,7 +89,24 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
     public unsafe int GetMethodTableTransparencyData(ulong mt, void* data) => HResults.E_NOTIMPL;
     public unsafe int GetModule(ulong addr, void** mod) => HResults.E_NOTIMPL;
     public unsafe int GetModuleData(ulong moduleAddr, void* data) => HResults.E_NOTIMPL;
-    public unsafe int GetNestedExceptionData(ulong exception, ulong* exceptionObject, ulong* nextNestedException) => HResults.E_NOTIMPL;
+
+    public unsafe int GetNestedExceptionData(ulong exception, ulong* exceptionObject, ulong* nextNestedException)
+    {
+        try
+        {
+            Contracts.IThread contract = _target.Contracts.Thread;
+            TargetPointer exceptionObjectLocal = contract.GetExceptionInfo(exception, out TargetPointer nextNestedExceptionLocal);
+            *exceptionObject = exceptionObjectLocal;
+            *nextNestedException = nextNestedExceptionLocal;
+        }
+        catch (Exception ex)
+        {
+            return ex.HResult;
+        }
+
+        return HResults.S_OK;
+    }
+
     public unsafe int GetObjectClassName(ulong obj, uint count, char* className, uint* pNeeded) => HResults.E_NOTIMPL;
     public unsafe int GetObjectData(ulong objAddr, void* data) => HResults.E_NOTIMPL;
     public unsafe int GetObjectStringData(ulong obj, uint count, char* stringData, uint* pNeeded) => HResults.E_NOTIMPL;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -94,7 +94,7 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
     {
         try
         {
-            Contracts.IThread contract = _target.Contracts.Thread;
+            Contracts.IException contract = _target.Contracts.Exception;
             TargetPointer exceptionObjectLocal = contract.GetExceptionInfo(exception, out TargetPointer nextNestedExceptionLocal);
             *exceptionObject = exceptionObjectLocal;
             *nextNestedException = nextNestedExceptionLocal;


### PR DESCRIPTION
- Implement `GetExceptionInfo` in `Exception` contract
- Implement `ISOSDacInterface::GetNestedExceptionData` in cDAC
- Add `ObjectHandle` to cDAC types

Contributes to https://github.com/dotnet/runtime/issues/99302