### PR TITLE
Use Stream.CopyTo{Async} in NonCryptographicHashAlgorithm.Append{Async}

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -107,21 +108,7 @@ namespace System.IO.Hashing
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
-
-            while (true)
-            {
-                int read = stream.Read(buffer, 0, buffer.Length);
-
-                if (read == 0)
-                {
-                    break;
-                }
-
-                Append(new ReadOnlySpan<byte>(buffer, 0, read));
-            }
-
-            ArrayPool<byte>.Shared.Return(buffer);
+            stream.CopyTo(new CopyToDestinationStream(this));
         }
 
         /// <summary>
@@ -147,30 +134,12 @@ namespace System.IO.Hashing
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            return AppendAsyncCore(stream, cancellationToken);
-        }
-
-        private async Task AppendAsyncCore(Stream stream, CancellationToken cancellationToken)
-        {
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
-
-            while (true)
-            {
-#if NET
-                int read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-#else
-                int read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            return stream.CopyToAsync(
+                new CopyToDestinationStream(this),
+#if !NET
+                81_920, // default size used by Stream.CopyTo{Async}
 #endif
-
-                if (read == 0)
-                {
-                    break;
-                }
-
-                Append(new ReadOnlySpan<byte>(buffer, 0, read));
-            }
-
-            ArrayPool<byte>.Shared.Return(buffer);
+                cancellationToken);
         }
 
         /// <summary>
@@ -346,5 +315,62 @@ namespace System.IO.Hashing
         [DoesNotReturn]
         private protected static void ThrowDestinationTooShort() =>
             throw new ArgumentException(SR.Argument_DestinationTooShort, "destination");
+
+        /// <summary>Stream-derived type used to support copying from a source stream to this instance via CopyTo{Async}.</summary>
+        private sealed class CopyToDestinationStream(NonCryptographicHashAlgorithm hash) : Stream
+        {
+            public override bool CanWrite => true;
+
+            public override void Write(byte[] buffer, int offset, int count) => hash.Append(buffer.AsSpan(offset, count));
+
+            public override void WriteByte(byte value) =>
+                hash.Append(
+#if NET
+                    new ReadOnlySpan<byte>(in value)
+#else
+                    [value]
+#endif
+                    );
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                hash.Append(buffer.AsSpan(offset, count));
+                return Task.CompletedTask;
+            }
+
+#if NET
+            public override void Write(ReadOnlySpan<byte> buffer) => hash.Append(buffer);
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                hash.Append(buffer.Span);
+                return default;
+            }
+
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
+                TaskToAsyncResult.Begin(WriteAsync(buffer, offset, count), callback, state);
+
+            public override void EndWrite(IAsyncResult asyncResult) =>
+                TaskToAsyncResult.End(asyncResult);
+#endif
+
+            public override void Flush() { }
+
+            public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public override bool CanRead => false;
+
+            public override bool CanSeek => false;
+
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
Rather than using a manual loop to copy data from a stream to a buffer, use the `Stream.CopyTo{Async}` method. Downside is there's an extra 32 byte allocation for the temporary destination passthrough Stream object. Upside is it allows the source Stream's to optimize via its CopyTo{Async} override, e.g. MemoryStream.CopyTo just makes a single Write call with its buffer. The base Stream.CopyTo also uses a larger rented buffer size than these APIs were using.

Related to https://github.com/dotnet/runtime/issues/103539

Before:
| Method | Kind         | Mean      | Allocated |
|------- |------------- |----------:|----------:|
| Hash   | MemoryStream |  79.76 us |     568 B |
| Hash   | FileStream   | 837.08 us |     568 B |

After:
| Method | Kind         | Mean      | Allocated |
|------- |------------- |----------:|----------:|
| Hash   | MemoryStream |  59.76 us |     600 B |
| Hash   | FileStream   | 131.51 us |     600 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.IO.Hashing;
using System.Security.Cryptography;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class Tests
{
    private Stream _stream;
    private byte[] _bytes = RandomNumberGenerator.GetBytes(1024 * 1024);

    [Params("MemoryStream", "FileStream")]
    public string Kind { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        switch (Kind)
        {
            case "MemoryStream":
                _stream = new MemoryStream(_bytes);
                break;

            case "FileStream":
                string path = Path.GetRandomFileName();
                File.WriteAllBytes(path, _bytes);
                _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 0, FileOptions.DeleteOnClose);
                break;
        }
    }

    [GlobalCleanup]
    public void Cleanup() => _stream.Dispose();

    [Benchmark]
    public ulong Hash()
    {
        _stream.Position = 0;
        var hash = new XxHash3();
        hash.Append(_stream);
        return hash.GetCurrentHashAsUInt64();
    }
}
```