### PR TITLE
Handle possible null in SerialStream.Dispose() on Windows

### DIFF
--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -769,7 +769,7 @@ namespace System.IO.Ports
                     {
                         lock (this)
                         {
-                            _handle.Close();
+                            _handle?.Close();
                             _handle = null;
                             _threadPoolBinding.Dispose();
                         }


### PR DESCRIPTION
The code expects multiple threads to call it, and it's possible one thread sets `_handle` to null before the second thread enter the block and tries to call `_handle.Close()`.