### PR TITLE
Generalize IControlFlowGraph successors

### DIFF
--- a/src/tools/illink/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 // This is needed due to NativeAOT which doesn't enable nullable globally yet
 #nullable enable
@@ -65,13 +66,12 @@ namespace ILLink.Shared.DataFlow
 				this.cfg = cfg;
 				this.lattice = lattice;
 
-				var entryOut = cfg.GetFallThroughSuccessor (cfg.Entry);
+				IControlFlowGraph<TBlock, TRegion>.ControlFlowBranch? entryOut = cfg.GetSuccessors (cfg.Entry).SingleOrDefault ();
 				Debug.Assert (entryOut != null);
-				Debug.Assert (cfg.GetConditionalSuccessor (cfg.Entry) == null);
 				if (entryOut == null)
 					return;
 
-				branchInput[entryOut!.Value] = new TState () {
+				branchInput[entryOut.Value] = new TState () {
 					Lattice = lattice,
 					Current = entryValue,
 					Exception = null
@@ -187,35 +187,20 @@ namespace ILLink.Shared.DataFlow
 		)
 		{
 			TConditionValue? conditionValue = transfer.Transfer (block, state);
-
-			if (cfg.GetConditionalSuccessor (block) is IControlFlowGraph<TBlock, TRegion>.ControlFlowBranch conditionalBranch) {
-				// Duplicate the current state so that it's not shared with fall-through state.
-				TValue conditionalCurrentState = lattice.Meet (lattice.Top, state.Current);
-
+			foreach (var successor in cfg.GetSuccessors (block)) {
+				// Duplicate the state so that it's not shared between branches.
+				TValue branchState = lattice.Meet (lattice.Top, state.Current);
 				if (conditionValue != null) {
+					Debug.Assert (successor.ConditionKind is ConditionKind.WhenTrue or ConditionKind.WhenFalse);
 					transfer.ApplyCondition (
-						// ConditionKind 'WhenTrue' means the condition is true in the conditional branch.
-						block.ConditionKind is ConditionKind.WhenTrue
+						// ConditionKind 'WhenTrue' means the condition is true in this branch.
+						successor.ConditionKind is ConditionKind.WhenTrue
 							? conditionValue.Value
 							: conditionValue.Value.Negate (),
-						ref conditionalCurrentState);
+						ref branchState);
 				}
 
-				updateState (conditionalBranch, conditionalCurrentState);
-			}
-
-			if (cfg.GetFallThroughSuccessor (block) is IControlFlowGraph<TBlock, TRegion>.ControlFlowBranch fallThroughBranch) {
-				TValue fallThroughCurrentState = state.Current;
-				if (conditionValue != null) {
-					transfer.ApplyCondition (
-						// ConditionKind 'WhenFalse' means the condition is true in the fall-through branch (false in the conditional branch).
-						block.ConditionKind is ConditionKind.WhenFalse
-							? conditionValue.Value
-							: conditionValue.Value.Negate (),
-						ref fallThroughCurrentState);
-				}
-
-				updateState (fallThroughBranch, fallThroughCurrentState);
+				updateState (successor, branchState);
 			}
 		}
 
@@ -423,11 +408,11 @@ namespace ILLink.Shared.DataFlow
 						changed = true;
 
 					TBlock lastFinallyBlock = cfg.LastBlock (exitedFinally);
-					Debug.Assert (cfg.GetConditionalSuccessor (lastFinallyBlock) == null);
-					IControlFlowGraph<TBlock, TRegion>.ControlFlowBranch? finallyExit = cfg.GetFallThroughSuccessor (lastFinallyBlock);
+					IControlFlowGraph<TBlock, TRegion>.ControlFlowBranch? finallyExit = cfg.GetSuccessors (lastFinallyBlock).SingleOrDefault ();
 					Debug.Assert (finallyExit != null);
 					if (finallyExit == null)
 						continue;
+					Debug.Assert (finallyExit.Value.ConditionKind == ConditionKind.Unconditional);
 					predecessorState = cfgState.Get (finallyExit.Value).Current;
 				}
 			}

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
@@ -21,9 +21,10 @@ namespace ILLink.Shared.DataFlow
 
 	public enum ConditionKind
 	{
-		None,
+		Unconditional,
 		WhenFalse,
 		WhenTrue,
+		Unknown
 	}
 
 	public interface IRegion<TRegion> : IEquatable<TRegion>
@@ -33,7 +34,6 @@ namespace ILLink.Shared.DataFlow
 
 	public interface IBlock<TBlock> : IEquatable<TBlock>
 	{
-		ConditionKind ConditionKind { get; }
 	}
 
 	public interface IControlFlowGraph<TBlock, TRegion>
@@ -45,7 +45,11 @@ namespace ILLink.Shared.DataFlow
 		public readonly struct ControlFlowBranch : IEquatable<ControlFlowBranch>
 		{
 			public readonly TBlock Source;
+
+			// Might be null in a 'throw' branch.
 			public readonly TBlock? Destination;
+
+			public readonly ConditionKind ConditionKind;
 
 			// The finally regions exited when control flows through this edge.
 			// For example:
@@ -62,13 +66,13 @@ namespace ILLink.Shared.DataFlow
 			// Source() to the block that calls Target(), which exits both
 			// finally regions.
 			public readonly ImmutableArray<TRegion> FinallyRegions;
-			public readonly bool IsConditional;
-			public ControlFlowBranch (TBlock source, TBlock? destination, ImmutableArray<TRegion> finallyRegions, bool isConditional)
+
+			public ControlFlowBranch (TBlock source, TBlock? destination, ImmutableArray<TRegion> finallyRegions, ConditionKind conditionKind)
 			{
 				Source = source;
 				Destination = destination;
 				FinallyRegions = finallyRegions;
-				IsConditional = isConditional;
+				ConditionKind = conditionKind;
 			}
 
 			public bool Equals (ControlFlowBranch other)
@@ -76,7 +80,7 @@ namespace ILLink.Shared.DataFlow
 				if (!Source.Equals (other.Source))
 					return false;
 
-				if (IsConditional != other.IsConditional)
+				if (ConditionKind != other.ConditionKind)
 					return false;
 
 				if (Destination == null)
@@ -95,7 +99,7 @@ namespace ILLink.Shared.DataFlow
 				return HashUtils.Combine (
 					Source.GetHashCode (),
 					Destination?.GetHashCode () ?? typeof (ControlFlowBranch).GetHashCode (),
-					IsConditional.GetHashCode ());
+					ConditionKind.GetHashCode ());
 			}
 		}
 
@@ -108,9 +112,7 @@ namespace ILLink.Shared.DataFlow
 		// control flow from try -> finally or from catch -> finally.
 		IEnumerable<ControlFlowBranch> GetPredecessors (TBlock block);
 
-		ControlFlowBranch? GetConditionalSuccessor (TBlock block);
-
-		ControlFlowBranch? GetFallThroughSuccessor (TBlock block);
+		IEnumerable<ControlFlowBranch> GetSuccessors (TBlock block);
 
 		bool TryGetEnclosingTryOrCatchOrFilter (TBlock block, [NotNullWhen (true)] out TRegion? tryOrCatchOrFilterRegion);
 


### PR DESCRIPTION
IControlFlowGraph was modeled after the Roslyn CFG API, where a block can have at most two successors - a fall-through successor, and a conditional successor. Switch statements are represented as a chain of checks for one case at a time.

This doesn't generalize well to CFGs in IL which can have more than two branch targets for a switch instruction. This changes the interface to expose an IEnumerable<ControlFlowBranch> of successors.

- Move IsConditional on block to ConditionKind on branch
- Introduce GetSuccessors to replace GetConditionalSuccessor and GetFallThroughSuccessor
