### PR TITLE
Fix the ICU time format conversion logic

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -396,7 +396,7 @@ namespace System.Globalization
                         break;
 
                     default:
-                        // Treat non-ASCII characters as literals
+                        // Characters that are not ASCII letters are literal texts
                         if (!char.IsAsciiLetter(current))
                         {
                             result[resultPos++] = current;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -387,7 +387,8 @@ namespace System.Globalization
                         {
                             break;
                         }
-                        for (i++; i < icuFormatString.Length; i++)
+                        i++;
+                        for (; i < icuFormatString.Length; i++)
                         {
                             current = icuFormatString[i];
                             if (current == '\'')

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -365,6 +365,7 @@ namespace System.Globalization
                 switch (current)
                 {
                     case '\\':
+                        // The ICU format does not use backslashes to escape while the .NET format does
                         result[resultPos++] = '\\';
                         result[resultPos++] = '\\';
                         break;
@@ -397,6 +398,7 @@ namespace System.Globalization
                             }
                             if (current == '\\')
                             {
+                                // The same backslash escaping mentioned above
                                 result[resultPos++] = '\\';
                             }
                             result[resultPos++] = current;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -369,34 +369,37 @@ namespace System.Globalization
                         result[resultPos++] = '\\';
                         break;
                     case '\'':
-                        int i0 = i;
-                        result[resultPos++] = icuFormatString[i++];
-                        while (i < icuFormatString.Length)
+                        static bool HandleQuoteLiteral(ReadOnlySpan<char> icuFormatString, ref int i, Span<char> result, ref int resultPos)
+                        {
+                            if (i + 1 < icuFormatString.Length && icuFormatString[i + 1] == '\'')
+                            {
+                                result[resultPos++] = '\\';
+                                result[resultPos++] = '\'';
+                                i++;
+                                return true;
+                            }
+                            return false;
+                        }
+
+                        if (HandleQuoteLiteral(icuFormatString, ref i, result, ref resultPos)) break;
+                        result[resultPos++] = '\'';
+                        for (i++; i < icuFormatString.Length; i++)
                         {
                             current = icuFormatString[i];
-                            result[resultPos++] = current;
                             if (current == '\'')
                             {
-                                if (i - i0 <= 1)
+                                if (HandleQuoteLiteral(icuFormatString, ref i, result, ref resultPos))
                                 {
-                                    // Two adjacent single vertical quotes ('') represents a literal single quote, outside quoted text.
-                                    result[resultPos - 2] = '\\';
-                                    break;
+                                    continue;
                                 }
-                                if (i + 1 < icuFormatString.Length && icuFormatString[i + 1] == '\'')
-                                {
-                                    // Two adjacent single vertical quotes ('') represents a literal single quote, inside quoted text.
-                                    result[resultPos - 1] = '\\';
-                                    result[resultPos++] = '\'';
-                                    i++;
-                                }
-                                else break;
+                                result[resultPos++] = '\'';
+                                break;
                             }
-                            else if (current == '\\')
+                            if (current == '\\')
                             {
                                 result[resultPos++] = '\\';
                             }
-                            i++;
+                            result[resultPos++] = current;
                         }
                         break;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -379,11 +379,14 @@ namespace System.Globalization
                                 i++;
                                 return true;
                             }
+                            result[resultPos++] = '\'';
                             return false;
                         }
 
-                        if (HandleQuoteLiteral(icuFormatString, ref i, result, ref resultPos)) break;
-                        result[resultPos++] = '\'';
+                        if (HandleQuoteLiteral(icuFormatString, ref i, result, ref resultPos))
+                        {
+                            break;
+                        }
                         for (i++; i < icuFormatString.Length; i++)
                         {
                             current = icuFormatString[i];
@@ -393,7 +396,6 @@ namespace System.Globalization
                                 {
                                     continue;
                                 }
-                                result[resultPos++] = '\'';
                                 break;
                             }
                             if (current == '\\')

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -378,18 +378,15 @@ namespace System.Globalization
                         }
                         break;
 
-                    case ':':
-                    case '.':
                     case 'H':
                     case 'h':
                     case 'm':
                     case 's':
-                    case ' ':
-                    case '\u00A0': // no-break space
-                    case '\u202F': // narrow no-break space
                         result[resultPos++] = current;
                         break;
                     case 'a': // AM/PM
+                    case 'b': // am, pm, noon, midnight
+                    case 'B': // flexible day periods
                         if (!amPmAdded)
                         {
                             amPmAdded = true;
@@ -398,6 +395,13 @@ namespace System.Globalization
                         }
                         break;
 
+                    default:
+                        // Treat non-ASCII characters as literals
+                        if (!char.IsAsciiLetter(current))
+                        {
+                            result[resultPos++] = current;
+                        }
+                        break;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -364,7 +364,12 @@ namespace System.Globalization
                 char current = icuFormatString[i];
                 switch (current)
                 {
+                    case '\\':
+                        result[resultPos++] = '\\';
+                        result[resultPos++] = '\\';
+                        break;
                     case '\'':
+                        int i0 = i;
                         result[resultPos++] = icuFormatString[i++];
                         while (i < icuFormatString.Length)
                         {
@@ -372,7 +377,24 @@ namespace System.Globalization
                             result[resultPos++] = current;
                             if (current == '\'')
                             {
-                                break;
+                                if (i - i0 <= 1)
+                                {
+                                    // Two adjacent single vertical quotes ('') represents a literal single quote, outside quoted text.
+                                    result[resultPos - 2] = '\\';
+                                    break;
+                                }
+                                if (i + 1 < icuFormatString.Length && icuFormatString[i + 1] == '\'')
+                                {
+                                    // Two adjacent single vertical quotes ('') represents a literal single quote, inside quoted text.
+                                    result[resultPos - 1] = '\\';
+                                    result[resultPos++] = '\'';
+                                    i++;
+                                }
+                                else break;
+                            }
+                            else if (current == '\\')
+                            {
+                                result[resultPos++] = '\\';
                             }
                             i++;
                         }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -58,5 +58,19 @@ namespace System.Globalization.Tests
                 cultureInfo.Name,
                 cultureInfo.Calendar.GetType().Name));
         }
+
+        // These cultures have bad ICU time patterns below the corresponding versions
+        // They are excluded from the VerifyTimePatterns tests
+        public static readonly Dictionary<string, Version> _badIcuTimePatterns = new Dictionary<string, Version>()
+        {
+            { "mi", new Version(65, 0) },
+            { "mi-NZ", new Version(65, 0) },
+        };
+        public static bool HasBadIcuTimePatterns(CultureInfo culture)
+        {
+            return PlatformDetection.IsIcuGlobalizationAndNotHybridOnBrowser
+                && _badIcuTimePatterns.TryGetValue(culture.Name, out var version)
+                && PlatformDetection.ICUVersion < version;
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Xunit;
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -287,8 +287,7 @@ namespace System.Globalization.Tests
         [Fact]
         public void LongTimePattern_VerifyTimePatterns()
         {
-            foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
-            {
+            Assert.All(CultureInfo.GetCultures(CultureTypes.AllCultures), culture => {
                 var pattern = culture.DateTimeFormat.LongTimePattern;
                 bool use24Hour = false;
                 bool use12Hour = false;
@@ -312,7 +311,7 @@ namespace System.Globalization.Tests
                     }
                 }
                 Assert.True((use24Hour || useAMPM) && (use12Hour ^ use24Hour), $"Bad long time pattern for culture {culture.Name}: '{pattern}'");
-            }
+            });
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -305,7 +305,8 @@ namespace System.Globalization.Tests
                         case 't': useAMPM = true; break;
                         case '\\': i++; break;
                         case '\'':
-                            for (i++; i < pattern.Length; i++)
+                            i++;
+                            for (; i < pattern.Length; i++)
                             {
                                 var c = pattern[i];
                                 if (c == '\'') break;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -288,6 +288,10 @@ namespace System.Globalization.Tests
         public void LongTimePattern_VerifyTimePatterns()
         {
             Assert.All(CultureInfo.GetCultures(CultureTypes.AllCultures), culture => {
+                if (DateTimeFormatInfoData.HasBadIcuTimePatterns(culture))
+                {
+                    return;
+                }
                 var pattern = culture.DateTimeFormat.LongTimePattern;
                 bool use24Hour = false;
                 bool use12Hour = false;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -285,6 +285,25 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        public void LongTimePattern_VerifyTimePatterns()
+        {
+            foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            {
+                var pattern = culture.DateTimeFormat.LongTimePattern;
+                var segments = pattern.Split('\'');
+                bool use12Hour = false;
+                bool useAMPM = false;
+                for (var i = 0; i < segments.Length; i += 2)
+                {
+                    var segment = segments[i];
+                    use12Hour |= segment.Contains('h', StringComparison.Ordinal);
+                    useAMPM |= segment.Contains('t', StringComparison.Ordinal);
+                }
+                Assert.True(!use12Hour || useAMPM, $"Bad long time pattern for culture {culture.Name}: '{pattern}'");
+            }
+        }
+
+        [Fact]
         public void LongTimePattern_CheckTimeFormatWithSpaces()
         {
             var date = DateTime.Today + TimeSpan.FromHours(15) + TimeSpan.FromMinutes(15);

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -284,7 +284,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
         public void LongTimePattern_VerifyTimePatterns()
         {
             Assert.All(CultureInfo.GetCultures(CultureTypes.AllCultures), culture => {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -290,16 +290,28 @@ namespace System.Globalization.Tests
             foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
             {
                 var pattern = culture.DateTimeFormat.LongTimePattern;
-                var segments = pattern.Split('\'');
+                bool use24Hour = false;
                 bool use12Hour = false;
                 bool useAMPM = false;
-                for (var i = 0; i < segments.Length; i += 2)
+                for (var i = 0; i < pattern.Length; i++)
                 {
-                    var segment = segments[i];
-                    use12Hour |= segment.Contains('h', StringComparison.Ordinal);
-                    useAMPM |= segment.Contains('t', StringComparison.Ordinal);
+                    switch (pattern[i])
+                    {
+                        case 'H': use24Hour = true; break;
+                        case 'h': use12Hour = true; break;
+                        case 't': useAMPM = true; break;
+                        case '\\': i++; break;
+                        case '\'':
+                            for (i++; i < pattern.Length; i++)
+                            {
+                                var c = pattern[i];
+                                if (c == '\'') break;
+                                if (c == '\\') i++;
+                            }
+                            break;
+                    }
                 }
-                Assert.True(!use12Hour || useAMPM, $"Bad long time pattern for culture {culture.Name}: '{pattern}'");
+                Assert.True((use24Hour || useAMPM) && (use12Hour ^ use24Hour), $"Bad long time pattern for culture {culture.Name}: '{pattern}'");
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -258,8 +258,7 @@ namespace System.Globalization.Tests
         [Fact]
         public void ShortTimePattern_VerifyTimePatterns()
         {
-            foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
-            {
+            Assert.All(CultureInfo.GetCultures(CultureTypes.AllCultures), culture => {
                 var pattern = culture.DateTimeFormat.ShortTimePattern;
                 bool use24Hour = false;
                 bool use12Hour = false;
@@ -283,7 +282,7 @@ namespace System.Globalization.Tests
                     }
                 }
                 Assert.True((use24Hour || useAMPM) && (use12Hour ^ use24Hour), $"Bad short time pattern for culture {culture.Name}: '{pattern}'");
-            }
+            });
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -276,7 +276,8 @@ namespace System.Globalization.Tests
                         case 't': useAMPM = true; break;
                         case '\\': i++; break;
                         case '\'':
-                            for (i++; i < pattern.Length; i++)
+                            i++;
+                            for (; i < pattern.Length; i++)
                             {
                                 var c = pattern[i];
                                 if (c == '\'') break;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -256,6 +256,25 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        public void ShortTimePattern_VerifyTimePatterns()
+        {
+            foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            {
+                var pattern = culture.DateTimeFormat.ShortTimePattern;
+                var segments = pattern.Split('\'');
+                bool use12Hour = false;
+                bool useAMPM = false;
+                for (var i = 0; i < segments.Length; i += 2)
+                {
+                    var segment = segments[i];
+                    use12Hour |= segment.Contains('h', StringComparison.Ordinal);
+                    useAMPM |= segment.Contains('t', StringComparison.Ordinal);
+                }
+                Assert.True(!use12Hour || useAMPM, $"Bad short time pattern for culture {culture.Name}: '{pattern}'");
+            }
+        }
+
+        [Fact]
         public void ShortTimePattern_CheckTimeFormatWithSpaces()
         {
             var date = DateTime.Today + TimeSpan.FromHours(15) + TimeSpan.FromMinutes(15);

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -255,7 +255,7 @@ namespace System.Globalization.Tests
             Assert.Throws<InvalidOperationException>(() => DateTimeFormatInfo.InvariantInfo.ShortTimePattern = "HH:mm");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
         public void ShortTimePattern_VerifyTimePatterns()
         {
             Assert.All(CultureInfo.GetCultures(CultureTypes.AllCultures), culture => {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -259,6 +259,10 @@ namespace System.Globalization.Tests
         public void ShortTimePattern_VerifyTimePatterns()
         {
             Assert.All(CultureInfo.GetCultures(CultureTypes.AllCultures), culture => {
+                if (DateTimeFormatInfoData.HasBadIcuTimePatterns(culture))
+                {
+                    return;
+                }
                 var pattern = culture.DateTimeFormat.ShortTimePattern;
                 bool use24Hour = false;
                 bool use12Hour = false;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -261,16 +261,28 @@ namespace System.Globalization.Tests
             foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
             {
                 var pattern = culture.DateTimeFormat.ShortTimePattern;
-                var segments = pattern.Split('\'');
+                bool use24Hour = false;
                 bool use12Hour = false;
                 bool useAMPM = false;
-                for (var i = 0; i < segments.Length; i += 2)
+                for (var i = 0; i < pattern.Length; i++)
                 {
-                    var segment = segments[i];
-                    use12Hour |= segment.Contains('h', StringComparison.Ordinal);
-                    useAMPM |= segment.Contains('t', StringComparison.Ordinal);
+                    switch (pattern[i])
+                    {
+                        case 'H': use24Hour = true; break;
+                        case 'h': use12Hour = true; break;
+                        case 't': useAMPM = true; break;
+                        case '\\': i++; break;
+                        case '\'':
+                            for (i++; i < pattern.Length; i++)
+                            {
+                                var c = pattern[i];
+                                if (c == '\'') break;
+                                if (c == '\\') i++;
+                            }
+                            break;
+                    }
                 }
-                Assert.True(!use12Hour || useAMPM, $"Bad short time pattern for culture {culture.Name}: '{pattern}'");
+                Assert.True((use24Hour || useAMPM) && (use12Hour ^ use24Hour), $"Bad short time pattern for culture {culture.Name}: '{pattern}'");
             }
         }
 


### PR DESCRIPTION
Revise the ICU time format conversion logic to support all unquoted literal texts and the `B` and `b` pattern symbols.

Fix #103592