### PR TITLE
Add System.IO.Hashing dependency to windowsdesktop transport pack

### DIFF
--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -233,6 +233,7 @@
       System.Diagnostics.PerformanceCounter;
       System.DirectoryServices;
       System.Formats.Nrbf;
+      System.IO.Hashing;
       System.IO.Packaging;
       System.Resources.Extensions;
       System.Security.Cryptography.Pkcs;


### PR DESCRIPTION
System.IO.Hashing is a dependency of System.Formats.Nrbf.

Didn't realize that until just now. Continuation of https://github.com/dotnet/runtime/commit/91f1481c7a0af3a15e7960684bd419131038cc4a