### PR TITLE
JIT: Avoid invalidating DFS tree unconditionally after RBO

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5395,7 +5395,7 @@ public:
 
     void fgMergeBlockReturn(BasicBlock* block);
 
-    bool fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg));
+    bool fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg), bool invalidateDfsTreeOnFGChange = true);
     void fgMorphStmtBlockOps(BasicBlock* block, Statement* stmt);
 
     //------------------------------------------------------------------------------------------------------------
@@ -6078,7 +6078,7 @@ public:
 
     BasicBlock* fgEndBBAfterMainFunction();
 
-    BasicBlock* fgGetDomSpeculatively(const BasicBlock* block);
+    BasicBlock* optGetDomSpeculatively(const BasicBlock* block);
 
     void fgUnlinkRange(BasicBlock* bBeg, BasicBlock* bEnd);
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2775,51 +2775,6 @@ bool Compiler::fgSimpleLowerCastOfSmpOp(LIR::Range& range, GenTreeCast* cast)
 }
 
 //------------------------------------------------------------------------------
-// fgGetDomSpeculatively: Try determine a more accurate dominator than cached bbIDom
-//
-// Arguments:
-//    block - Basic block to get a dominator for
-//
-// Return Value:
-//    Basic block that dominates this block
-//
-BasicBlock* Compiler::fgGetDomSpeculatively(const BasicBlock* block)
-{
-    assert(m_domTree != nullptr);
-    BasicBlock* lastReachablePred = nullptr;
-
-    // Check if we have unreachable preds
-    for (const FlowEdge* predEdge : block->PredEdges())
-    {
-        BasicBlock* predBlock = predEdge->getSourceBlock();
-        if (predBlock == block)
-        {
-            continue;
-        }
-
-        // We check pred's count of InEdges - it's quite conservative.
-        // We, probably, could use optReachable(fgFirstBb, pred) here to detect unreachable preds
-        if (predBlock->countOfInEdges() > 0)
-        {
-            if (lastReachablePred != nullptr)
-            {
-                // More than one of "reachable" preds - return cached result
-                return block->bbIDom;
-            }
-            lastReachablePred = predBlock;
-        }
-        else if (predBlock == block->bbIDom)
-        {
-            // IDom is unreachable, so assume this block is too.
-            //
-            return nullptr;
-        }
-    }
-
-    return lastReachablePred == nullptr ? block->bbIDom : lastReachablePred;
-}
-
-//------------------------------------------------------------------------------
 // fgLastBBInMainFunction: Return the last basic block in the main part of the function.
 // With funclets, it is the block immediately before the first funclet.
 //

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1170,8 +1170,15 @@ PhaseStatus Compiler::optInductionVariables()
     bool changed = false;
 
     optReachableBitVecTraits = nullptr;
-    m_dfsTree                = fgComputeDfs();
-    m_loops                  = FlowGraphNaturalLoops::Find(m_dfsTree);
+    if (m_dfsTree == nullptr)
+    {
+        m_dfsTree = fgComputeDfs();
+    }
+
+    if (m_loops == nullptr)
+    {
+        m_loops = FlowGraphNaturalLoops::Find(m_dfsTree);
+    }
 
     LoopLocalOccurrences loopLocals(m_loops);
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13425,9 +13425,11 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 // fgMorphBlockStmt: morph a single statement in a block.
 //
 // Arguments:
-//    block - block containing the statement
-//    stmt - statement to morph
-//    msg - string to identify caller in a dump
+//    block                       - block containing the statement
+//    stmt                        - statement to morph
+//    msg                         - string to identify caller in a dump
+//    invalidateDFSTreeOnFGChange - whether or not the DFS tree should be invalidated
+//                                  by this function if it makes a flow graph change
 //
 // Returns:
 //    true if 'stmt' was removed from the block.
@@ -13436,7 +13438,11 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 // Notes:
 //   Can be called anytime, unlike fgMorphStmts() which should only be called once.
 //
-bool Compiler::fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg))
+//   Invalidates the DFS tree if a branch was folded.
+//
+bool Compiler::fgMorphBlockStmt(BasicBlock*     block,
+                                Statement* stmt DEBUGARG(const char* msg),
+                                bool            invalidateDFSTreeOnFGChange)
 {
     assert(block != nullptr);
     assert(stmt != nullptr);
@@ -13502,7 +13508,11 @@ bool Compiler::fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(cons
     if (!removedStmt && (stmt->GetNextStmt() == nullptr) && !fgRemoveRestOfBlock)
     {
         FoldResult const fr = fgFoldConditional(block);
-        removedStmt         = (fr == FoldResult::FOLD_REMOVED_LAST_STMT);
+        if (invalidateDFSTreeOnFGChange && (fr != FoldResult::FOLD_DID_NOTHING))
+        {
+            fgInvalidateDfsTree();
+        }
+        removedStmt = (fr == FoldResult::FOLD_REMOVED_LAST_STMT);
     }
 
     if (!removedStmt)
@@ -13542,6 +13552,11 @@ bool Compiler::fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(cons
         {
             // Convert block to a throw bb
             fgConvertBBToThrowBB(block);
+
+            if (invalidateDFSTreeOnFGChange)
+            {
+                fgInvalidateDfsTree();
+            }
         }
 
 #ifdef DEBUG


### PR DESCRIPTION
Instead of invalidating the DFS tree unconditionally after RBO, we can invalidate it only as part of RBO or assertion prop when they actually make any flowgraph changes. The benefit is that when no flowgraph changes are made, IV opts get access to the DFS tree, loops and dominator tree without having to recompute them from scratch. This helps on TP.

Making this work takes a bit of finesse since assertion prop has no knowledge of when it actually made FG changes; instead we invalidate the DFS tree directly from the morph function that can change the FG, with the exception of when it is called from RBO, since RBO relies on the dominator tree even after changing the flowgraph.

Also rename `fgGetDomSpeculatively` -> `optGetDomSpeculatively` and move it into RBO, to make it more clear that it is only within RBO that relying on the outdated dominators may be ok.