### PR TITLE
Move runtime-deps CentOS Stream 8 package to CentOS Stream 9.

### DIFF
--- a/docs/project/dogfooding.md
+++ b/docs/project/dogfooding.md
@@ -185,7 +185,7 @@ $ bin\Debug\net8.0\win-x64\publish\App.exe
 | **Linux-musl (arm)** | <br>[tar.gz][linux-musl-arm-targz-8.0.X] ([Checksum][linux-musl-arm-targz-checksum-8.0.X]) |
 | **Linux-musl (arm64)** | <br>[tar.gz][linux-musl-arm64-targz-8.0.X] ([Checksum][linux-musl-arm64-targz-checksum-8.0.X]) |
 | **Dpkg Based Systems (x64)** | <br>[Runtime-Deps][deb-runtime-deps-8.0.X] ([Checksum][deb-runtime-deps-checksum-8.0.X])<br>[Host][deb-host-8.0.X] ([Checksum][deb-host-checksum-8.0.X])<br>[App Hosts][deb-apphost-pack-8.0.X] ([Checksum][deb-apphost-pack-checksum-8.0.X])<br>[Host FX Resolver][deb-hostfxr-8.0.X] ([Checksum][deb-hostfxr-checksum-8.0.X])<br>[Targeting Pack][deb-targeting-pack-8.0.X] ([Checksum][deb-targeting-pack-checksum-8.0.X])<br>[Shared Framework][deb-sharedfx-8.0.X] ([Checksum][deb-sharedfx-checksum-8.0.X]) |
-| **CentOS 8 (x64)** | <br>[Runtime-Deps][centos-8-runtime-deps-8.0.X] ([Checksum][centos-8-runtime-deps-checksum-8.0.X])<br>[Host][centos-8-host-8.0.X] ([Checksum][centos-8-host-checksum-8.0.X])<br>[App Hosts][centos-8-apphost-pack-8.0.X] ([Checksum][centos-8-apphost-pack-checksum-8.0.X])<br>[Host FX Resolver][centos-8-hostfxr-8.0.X] ([Checksum][centos-8-hostfxr-checksum-8.0.X])<br>[Targeting Pack][centos-8-targeting-pack-8.0.X] ([Checksum][centos-8-targeting-pack-checksum-8.0.X])<br>[Shared Framework][centos-8-sharedfx-8.0.X] ([Checksum][centos-8-sharedfx-checksum-8.0.X]) |
+| **CentOS 9 (x64)** | <br>[Runtime-Deps][centos-9-runtime-deps-8.0.X] ([Checksum][centos-9-runtime-deps-checksum-8.0.X])<br>[Host][centos-9-host-8.0.X] ([Checksum][centos-9-host-checksum-8.0.X])<br>[App Hosts][centos-9-apphost-pack-8.0.X] ([Checksum][centos-9-apphost-pack-checksum-8.0.X])<br>[Host FX Resolver][centos-9-hostfxr-8.0.X] ([Checksum][centos-9-hostfxr-checksum-8.0.X])<br>[Targeting Pack][centos-9-targeting-pack-8.0.X] ([Checksum][centos-9-targeting-pack-checksum-8.0.X])<br>[Shared Framework][centos-9-sharedfx-8.0.X] ([Checksum][centos-9-sharedfx-checksum-8.0.X]) |
 | **RHEL 8 (x64)** | <br>[Host][rhel8-host-8.0.X] ([Checksum][rhel8-host-checksum-8.0.X])<br>[App Hosts][rhel8-apphost-pack-8.0.X] ([Checksum][rhel8-apphost-pack-checksum-8.0.X])<br>[Host FX Resolver][rhel8-hostfxr-8.0.X] ([Checksum][rhel8-hostfxr-checksum-8.0.X])<br>[Targeting Pack][rhel8-targeting-pack-8.0.X] ([Checksum][rhel8-targeting-pack-checksum-8.0.X])<br>[Shared Framework][rhel8-sharedfx-8.0.X] ([Checksum][rhel8-sharedfx-checksum-8.0.X]) |
 | **Fedora 27 (x64)** | <br>[Runtime-Deps][fedora-27-runtime-deps-8.0.X] ([Checksum][fedora-27-runtime-deps-checksum-8.0.X])<br>[Host][fedora-27-host-8.0.X] ([Checksum][fedora-27-host-checksum-8.0.X])<br>[App Hosts][fedora-27-apphost-pack-8.0.X] ([Checksum][fedora-27-apphost-pack-checksum-8.0.X])<br>[Host FX Resolver][fedora-27-hostfxr-8.0.X] ([Checksum][fedora-27-hostfxr-checksum-8.0.X])<br>[Targeting Pack][fedora-27-targeting-pack-8.0.X] ([Checksum][fedora-27-targeting-pack-checksum-8.0.X])<br>[Shared Framework][fedora-27-sharedfx-8.0.X] ([Checksum][fedora-27-sharedfx-checksum-8.0.X]) |
 | **SLES 12 (x64)** | <br>[Runtime-Deps][sles-12-runtime-deps-8.0.X] ([Checksum][sles-12-runtime-deps-checksum-8.0.X])<br>[Host][sles-12-host-8.0.X] ([Checksum][sles-12-host-checksum-8.0.X])<br>[App Hosts][sles-12-apphost-pack-8.0.X] ([Checksum][sles-12-apphost-pack-checksum-8.0.X])<br>[Host FX Resolver][sles-12-hostfxr-8.0.X] ([Checksum][sles-12-hostfxr-checksum-8.0.X])<br>[Targeting Pack][sles-12-targeting-pack-8.0.X] ([Checksum][sles-12-targeting-pack-checksum-8.0.X])<br>[Shared Framework][sles-12-sharedfx-8.0.X] ([Checksum][sles-12-sharedfx-checksum-8.0.X]) |
@@ -285,8 +285,8 @@ $ bin\Debug\net8.0\win-x64\publish\App.exe
 
 [rhel8-badge-8.0.X]: https://aka.ms/dotnet/8.0/daily/sharedfx_rhel.8-x64_Release_version_badge.svg?no-cache
 [rhel8-version-8.0.X]: https://aka.ms/dotnet/8.0/daily/runtime-productVersion.txt
-[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm
-[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm.sha512
+[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-rhel.8-x64.rpm
+[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-rhel.8-x64.rpm.sha512
 [rhel8-apphost-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm
 [rhel8-apphost-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm.sha512
 [rhel8-host-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-host-x64.rpm
@@ -298,20 +298,20 @@ $ bin\Debug\net8.0\win-x64\publish\App.exe
 [rhel8-targeting-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm
 [rhel8-targeting-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm.sha512
 
-[centos-8-badge-8.0.X]: https://aka.ms/dotnet/8.0/daily/sharedfx_centos.9-x64_Release_version_badge.svg?no-cache
-[centos-8-version-8.0.X]: https://aka.ms/dotnet/8.0/daily/runtime-productVersion.txt
-[centos-8-runtime-deps-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm
-[centos-8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm.sha512
-[centos-8-apphost-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm
-[centos-8-apphost-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm.sha512
-[centos-8-host-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-host-x64.rpm
-[centos-8-host-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-host-x64.rpm.sha512
-[centos-8-hostfxr-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-hostfxr-x64.rpm
-[centos-8-hostfxr-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-hostfxr-x64.rpm.sha512
-[centos-8-sharedfx-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-x64.rpm
-[centos-8-sharedfx-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-x64.rpm.sha512
-[centos-8-targeting-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm
-[centos-8-targeting-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm.sha512
+[centos-9-badge-8.0.X]: https://aka.ms/dotnet/8.0/daily/sharedfx_centos.9-x64_Release_version_badge.svg?no-cache
+[centos-9-version-8.0.X]: https://aka.ms/dotnet/8.0/daily/runtime-productVersion.txt
+[centos-9-runtime-deps-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm
+[centos-9-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm.sha512
+[centos-9-apphost-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm
+[centos-9-apphost-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm.sha512
+[centos-9-host-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-host-x64.rpm
+[centos-9-host-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-host-x64.rpm.sha512
+[centos-9-hostfxr-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-hostfxr-x64.rpm
+[centos-9-hostfxr-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-hostfxr-x64.rpm.sha512
+[centos-9-sharedfx-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-x64.rpm
+[centos-9-sharedfx-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-x64.rpm.sha512
+[centos-9-targeting-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm
+[centos-9-targeting-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm.sha512
 
 [fedora-27-badge-8.0.X]: https://aka.ms/dotnet/8.0/daily/sharedfx_fedora.27-x64_Release_version_badge.svg?no-cache
 [fedora-27-version-8.0.X]: https://aka.ms/dotnet/8.0/daily/runtime-productVersion.txt

--- a/docs/project/dogfooding.md
+++ b/docs/project/dogfooding.md
@@ -285,8 +285,8 @@ $ bin\Debug\net8.0\win-x64\publish\App.exe
 
 [rhel8-badge-8.0.X]: https://aka.ms/dotnet/8.0/daily/sharedfx_rhel.8-x64_Release_version_badge.svg?no-cache
 [rhel8-version-8.0.X]: https://aka.ms/dotnet/8.0/daily/runtime-productVersion.txt
-[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.8-x64.rpm
-[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.8-x64.rpm.sha512
+[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm
+[rhel8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm.sha512
 [rhel8-apphost-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm
 [rhel8-apphost-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm.sha512
 [rhel8-host-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-host-x64.rpm
@@ -298,10 +298,10 @@ $ bin\Debug\net8.0\win-x64\publish\App.exe
 [rhel8-targeting-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm
 [rhel8-targeting-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-targeting-pack-x64.rpm.sha512
 
-[centos-8-badge-8.0.X]: https://aka.ms/dotnet/8.0/daily/sharedfx_centos.8-x64_Release_version_badge.svg?no-cache
+[centos-8-badge-8.0.X]: https://aka.ms/dotnet/8.0/daily/sharedfx_centos.9-x64_Release_version_badge.svg?no-cache
 [centos-8-version-8.0.X]: https://aka.ms/dotnet/8.0/daily/runtime-productVersion.txt
-[centos-8-runtime-deps-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.8-x64.rpm
-[centos-8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.8-x64.rpm.sha512
+[centos-8-runtime-deps-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm
+[centos-8-runtime-deps-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-runtime-deps-centos.9-x64.rpm.sha512
 [centos-8-apphost-pack-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm
 [centos-8-apphost-pack-checksum-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-apphost-pack-x64.rpm.sha512
 [centos-8-host-8.0.X]: https://aka.ms/dotnet/8.0/daily/dotnet-host-x64.rpm

--- a/src/installer/pkg/sfx/installers.proj
+++ b/src/installer/pkg/sfx/installers.proj
@@ -11,7 +11,7 @@
 
   <ItemGroup Condition="'$(BuildRpmPackage)' == 'true'">
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-azl.3.proj" />
-    <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-centos.8.proj" />
+    <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-centos.9.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.1.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.2.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-fedora.27.proj" />

--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-centos.9.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-centos.9.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <GenerateInstallers Condition="'$(BuildRpmPackage)' != 'true'">false</GenerateInstallers>
-    <PackageTargetOS>centos.8</PackageTargetOS>
+    <PackageTargetOS>centos.9</PackageTargetOS>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/102344
