### PR TITLE
JIT: Prezero memory for RefPosition and Interval (version 2)

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1620,7 +1620,14 @@ private:
     RefPosition* activeRefPosition;
 #endif // DEBUG
 
-    IntervalList intervals;
+    char* currentIntervalsBuffer = nullptr;
+    char* currentIntervalsBufferEnd = nullptr;
+
+    Interval* intervalsHead = nullptr;
+    Interval** intervalsTailSlot = &intervalsHead;
+#ifdef DEBUG
+    unsigned numIntervals = 0;
+#endif
 
     RegRecord physRegs[REG_COUNT];
 
@@ -1701,17 +1708,17 @@ private:
         return enregisterLocalVars;
     }
 
-    char* currentRefPositionsBuffer;
-    char* currentRefPositionsBufferEnd;
+    char* currentRefPositionsBuffer = nullptr;
+    char* currentRefPositionsBufferEnd = nullptr;
 
-    RefPosition* allRefPositionsHead;
-    RefPosition* allRefPositionsTail;
-    RefPosition** allRefPositionsTailSlot;
+    RefPosition* allRefPositionsHead = nullptr;
+    RefPosition* allRefPositionsTail = nullptr;
+    RefPosition** allRefPositionsTailSlot = &allRefPositionsHead;
 
     // Head of linked list of RefTypeKill ref positions
-    RefPosition* killHead;
+    RefPosition* killHead = nullptr;
     // Tail slot of linked list of RefTypeKill ref positions
-    RefPosition** killTail;
+    RefPosition** killTail = &killHead;
 #ifdef DEBUG
     unsigned numRefPositions = 0;
 #endif
@@ -2181,32 +2188,7 @@ public:
     Interval(RegisterType registerType, SingleTypeRegSet registerPreferences)
         : Referenceable(registerType)
         , registerPreferences(registerPreferences)
-        , registerAversion(RBM_NONE)
-        , relatedInterval(nullptr)
-        , assignedReg(nullptr)
-        , varNum(0)
         , physReg(REG_COUNT)
-        , isActive(false)
-        , isLocalVar(false)
-        , isSplit(false)
-        , isSpilled(false)
-        , isInternal(false)
-        , isStructField(false)
-        , isPromotedStruct(false)
-        , hasConflictingDefUse(false)
-        , hasInterferingUses(false)
-        , isSpecialPutArg(false)
-        , preferCalleeSave(false)
-        , isConstant(false)
-#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        , isUpperVector(false)
-        , isPartiallySpilled(false)
-#endif
-        , isWriteThru(false)
-        , isSingleDef(false)
-#ifdef DEBUG
-        , intervalIndex(0)
-#endif
     {
     }
 
@@ -2220,6 +2202,9 @@ public:
 #endif // DEBUG
 
     void setLocalNumber(Compiler* compiler, unsigned lclNum, LinearScan* l);
+
+    // Next interval in linked list of all intervals
+    Interval* nextInterval;
 
     // Fixed registers for which this Interval has a preference
     SingleTypeRegSet registerPreferences;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -444,9 +444,6 @@ inline bool RefTypeIsDef(RefType refType)
 typedef regNumberSmall* VarToRegMap;
 
 typedef jitstd::list<Interval>                      IntervalList;
-typedef jitstd::list<RefPosition>                   RefPositionList;
-typedef jitstd::list<RefPosition>::iterator         RefPositionIterator;
-typedef jitstd::list<RefPosition>::reverse_iterator RefPositionReverseIterator;
 
 class Referenceable
 {
@@ -1704,13 +1701,20 @@ private:
         return enregisterLocalVars;
     }
 
-    // Ordered list of RefPositions
-    RefPositionList refPositions;
+    char* currentRefPositionsBuffer;
+    char* currentRefPositionsBufferEnd;
+
+    RefPosition* allRefPositionsHead;
+    RefPosition* allRefPositionsTail;
+    RefPosition** allRefPositionsTailSlot;
 
     // Head of linked list of RefTypeKill ref positions
     RefPosition* killHead;
     // Tail slot of linked list of RefTypeKill ref positions
     RefPosition** killTail;
+#ifdef DEBUG
+    unsigned numRefPositions = 0;
+#endif
 
     // Per-block variable location mappings: an array indexed by block number that yields a
     // pointer to an array of regNumber, one per variable.
@@ -1907,6 +1911,11 @@ private:
     {
         resetAvailableRegs();
         regsBusyUntilKill = RBM_NONE;
+    }
+
+    RefPosition* getAllRefPositionsTail()
+    {
+        return allRefPositionsTail;
     }
 
     bool conflictingFixedRegReference(regNumber regNum, RefPosition* refPosition);
@@ -2463,10 +2472,13 @@ public:
 
     Referenceable* referent;
 
-    // nextRefPosition is the next in code order.
+    // nextRefPosition is the next RP in code order associated with the referent.
     // Note that in either case there is no need for these to be doubly linked, as they
     // are only traversed in the forward direction, and are not moved.
     RefPosition* nextRefPosition;
+
+    RefPosition* nextAllRefPosition;
+    RefPosition* prevAllRefPosition;
 
     // The remaining fields are common to both options
     union
@@ -2595,33 +2607,12 @@ public:
                 LsraLocation    nodeLocation,
                 GenTree*        treeNode,
                 RefType refType DEBUG_ARG(GenTree* buildNode))
-        : referent(nullptr)
-        , nextRefPosition(nullptr)
-        , treeNode(treeNode)
-        , registerAssignment(RBM_NONE)
+        : treeNode(treeNode)
         , bbNum(bbNum)
         , nodeLocation(nodeLocation)
         , refType(refType)
-        , multiRegIdx(0)
-#ifdef TARGET_ARM64
-        , needsConsecutive(false)
-        , regCount(0)
-#endif
-        , lastUse(false)
-        , reload(false)
-        , spillAfter(false)
-        , singleDefSpill(false)
-        , writeThru(false)
-        , copyReg(false)
-        , moveReg(false)
-        , isPhysRegRef(false)
-        , isFixedRegRef(false)
-        , isLocalDefUse(false)
-        , delayRegFree(false)
-        , outOfOrder(false)
 #ifdef DEBUG
         , minRegCandidateCount(1)
-        , rpNum(0)
         , buildNode(buildNode)
 #endif
     {

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -2074,12 +2074,12 @@ int LinearScan::BuildConsecutiveRegistersForUse(GenTree* treeNode, GenTree* rmwN
         for (GenTreeFieldList::Use& use : treeNode->AsFieldList()->Uses())
         {
             RefPosition*        restoreRefPos = nullptr;
-            RefPositionIterator prevRefPos    = refPositions.backPosition();
+            RefPosition* prevRefPos = allRefPositionsTail;
 
             currRefPos = BuildUse(use.GetNode(), RBM_NONE, 0);
 
             // Check if restore RefPositions were created
-            RefPositionIterator tailRefPos = refPositions.backPosition();
+            RefPosition* tailRefPos = allRefPositionsTail;
             assert(tailRefPos == currRefPos);
             prevRefPos++;
             if (prevRefPos != tailRefPos)
@@ -2161,15 +2161,15 @@ int LinearScan::BuildConsecutiveRegistersForUse(GenTree* treeNode, GenTree* rmwN
     }
     else
     {
-        RefPositionIterator refPositionMark   = refPositions.backPosition();
+        RefPosition* refPositionMark = allRefPositionsTail;
         int                 refPositionsAdded = BuildOperandUses(treeNode);
 
         if (rmwNode != nullptr)
         {
             // Check all the newly created RefPositions for delay free
-            RefPositionIterator iter = refPositionMark;
+            RefPosition* iter = refPositionMark;
 
-            for (iter++; iter != refPositions.end(); iter++)
+            for (iter = iter->nextAllRefPosition; iter != nullptr; iter = iter->nextAllRefPosition)
             {
                 RefPosition* refPositionAdded = &(*iter);
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -178,14 +178,28 @@ Interval* LinearScan::newInterval(RegisterType theRegisterType)
 //
 RefPosition* LinearScan::newRefPositionRaw(LsraLocation nodeLocation, GenTree* treeNode, RefType refType)
 {
-    refPositions.emplace_back(curBBNum, nodeLocation, treeNode, refType DEBUG_ARG(currBuildNode));
-    RefPosition* newRP = &refPositions.back();
+    if (currentRefPositionsBuffer == currentRefPositionsBufferEnd)
+    {
+        currentRefPositionsBuffer = new (compiler, CMK_LSRA_RefPosition) char[64 * sizeof(RefPosition)];
+        currentRefPositionsBufferEnd = currentRefPositionsBuffer + 64 * sizeof(RefPosition);
+        memset(currentRefPositionsBuffer, 0, 64 * sizeof(RefPosition));
+    }
+
+    assert(currentRefPositionsBuffer + sizeof(RefPosition) <= currentRefPositionsBufferEnd);
+
+    RefPosition* newRP = new (currentRefPositionsBuffer, jitstd::placement_t()) RefPosition(curBBNum, nodeLocation, treeNode, refType DEBUG_ARG(currBuildNode));
+    currentRefPositionsBuffer += sizeof(RefPosition);
+
+    newRP->prevAllRefPosition = allRefPositionsTail;
+    *allRefPositionsTailSlot = allRefPositionsTail = newRP;
+    allRefPositionsTailSlot = &newRP->nextAllRefPosition;
+
 #ifdef DEBUG
     // Reset currBuildNode so we do not set it for subsequent refpositions belonging
     // to the same treeNode and hence, avoid printing it for every refposition inside
     // the allocation table.
     currBuildNode = nullptr;
-    newRP->rpNum  = static_cast<unsigned>(refPositions.size() - 1);
+    newRP->rpNum = numRefPositions++;
     if (!enregisterLocalVars)
     {
         assert(!((refType == RefTypeParamDef) || (refType == RefTypeZeroInit) || (refType == RefTypeDummyDef) ||
@@ -1768,7 +1782,7 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, LsraLocation currentLoc
     // If we are constraining the registers for allocation, we will modify all the RefPositions
     // we've built for this node after we've created them. In order to do that, we'll remember
     // the last RefPosition prior to those created for this node.
-    RefPositionIterator refPositionMark = refPositions.backPosition();
+    RefPosition* refPositionMark = allRefPositionsTail;
     int                 oldDefListCount = defList.Count();
     currBuildNode                       = tree;
 #endif // DEBUG
@@ -1793,8 +1807,8 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, LsraLocation currentLoc
         // First, we count them.
         unsigned minRegCount = 0;
 
-        RefPositionIterator iter = refPositionMark;
-        for (iter++; iter != refPositions.end(); iter++)
+        RefPosition* iter = refPositionMark;
+        for (iter = iter->nextAllRefPosition; iter != nullptr; iter = iter->nextAllRefPosition)
         {
             RefPosition* newRefPosition = &(*iter);
             if (newRefPosition->isIntervalRef())
@@ -1838,7 +1852,7 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, LsraLocation currentLoc
             // add one less than the maximum number of registers args to 'minRegCount'.
             minRegCount += MAX_REG_ARG - 1;
         }
-        for (refPositionMark++; refPositionMark != refPositions.end(); refPositionMark++)
+        for (refPositionMark = refPositionMark->nextAllRefPosition; refPositionMark != nullptr; refPositionMark = refPositionMark->nextAllRefPosition)
         {
             RefPosition* newRefPosition    = &(*refPositionMark);
             unsigned     minRegCountForRef = minRegCount;

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -901,8 +901,8 @@ int LinearScan::BuildSelect(GenTreeOp* select)
     GenTree* trueVal  = select->gtOp1;
     GenTree* falseVal = select->gtOp2;
 
-    RefPositionIterator op1UsesPrev = refPositions.backPosition();
-    assert(op1UsesPrev != refPositions.end());
+    RefPosition* op1UsesPrev = getAllRefPositionsTail();
+    assert(op1UsesPrev != nullptr);
 
     RefPosition* uncontainedTrueRP = nullptr;
     if (trueVal->isContained())
@@ -915,7 +915,7 @@ int LinearScan::BuildSelect(GenTreeOp* select)
         srcCount++;
     }
 
-    RefPositionIterator op2UsesPrev = refPositions.backPosition();
+    RefPosition* op2UsesPrev = getAllRefPositionsTail();
 
     RefPosition* uncontainedFalseRP = nullptr;
     if (falseVal->isContained())
@@ -959,19 +959,19 @@ int LinearScan::BuildSelect(GenTreeOp* select)
     // intervals for the ref positions we built above. It marks one of the uses
     // as delay freed when it finds interference (almost never).
     //
-    RefPositionIterator op1Use = op1UsesPrev;
+    RefPosition* op1Use = op1UsesPrev;
     while (op1Use != op2UsesPrev)
     {
-        ++op1Use;
+        op1Use = op1Use->nextAllRefPosition;
 
         if (op1Use->refType != RefTypeUse)
         {
             continue;
         }
 
-        RefPositionIterator op2Use = op2UsesPrev;
-        ++op2Use;
-        while (op2Use != refPositions.end())
+        RefPosition* op2Use = op2UsesPrev;
+        op2Use = op2Use->nextAllRefPosition;
+        while (op2Use != nullptr)
         {
             if (op2Use->refType == RefTypeUse)
             {
@@ -981,7 +981,7 @@ int LinearScan::BuildSelect(GenTreeOp* select)
                     break;
                 }
 
-                ++op2Use;
+                op2Use = op2Use->nextAllRefPosition;
             }
         }
     }


### PR DESCRIPTION
Like #103707, but uses intrusive linked lists instead and manages the memory allocation directly as part of `LinearScan`.