### PR TITLE
Improve perf of CredentialCache.GetCredential

### DIFF
--- a/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
+++ b/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
@@ -58,8 +58,9 @@ namespace System.Net
         private bool IsPrefix(Uri uri, int prefixLen)
         {
             Debug.Assert(uri != null);
+            Uri uriPrefix = UriPrefix;
 
-            if (UriPrefix.Scheme != uri.Scheme || UriPrefix.Host != uri.Host || UriPrefix.Port != uri.Port)
+            if (uriPrefix.Scheme != uri.Scheme || uriPrefix.Host != uri.Host || uriPrefix.Port != uri.Port)
             {
                 return false;
             }
@@ -69,7 +70,7 @@ namespace System.Net
                 return false;
             }
 
-            return string.Compare(uri.AbsolutePath, 0, UriPrefix.AbsolutePath, 0, UriPrefixLength, StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Compare(uri.AbsolutePath, 0, uriPrefix.AbsolutePath, 0, UriPrefixLength, StringComparison.OrdinalIgnoreCase) == 0;
         }
 
         public override int GetHashCode() =>
@@ -106,6 +107,12 @@ namespace System.Net
             mostSpecificMatch = null;
             mostSpecificMatchUri = null;
 
+            if (cache.Count == 0)
+            {
+                return false;
+            }
+
+            // precompute the length of the prefix
             int uriPrefixLength = uriPrefix.AbsolutePath.LastIndexOf('/');
 
             // Enumerate through every credential in the cache, get match with longest prefix

--- a/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
+++ b/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
@@ -25,7 +25,7 @@ namespace System.Net
             AuthenticationType = authenticationType;
         }
 
-        internal bool Match(Uri uri, string authenticationType)
+        internal bool Match(Uri uri, int prefixLen, string authenticationType)
         {
             if (uri == null || authenticationType == null)
             {
@@ -40,12 +40,12 @@ namespace System.Net
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Match({UriPrefix} & {uri})");
 
-            return IsPrefix(uri, UriPrefix);
+            return IsPrefix(uri, prefixLen);
         }
 
         // IsPrefix (Uri)
         //
-        // Determines whether <prefixUri> is a prefix of this URI. A prefix
+        // Determines whether <this> is a prefix of this URI. A prefix
         // match is defined as:
         //
         //     scheme match
@@ -55,23 +55,21 @@ namespace System.Net
         //
         // Returns:
         // True if <prefixUri> is a prefix of this URI
-        private static bool IsPrefix(Uri uri, Uri prefixUri)
+        private bool IsPrefix(Uri uri, int prefixLen)
         {
             Debug.Assert(uri != null);
-            Debug.Assert(prefixUri != null);
 
-            if (prefixUri.Scheme != uri.Scheme || prefixUri.Host != uri.Host || prefixUri.Port != uri.Port)
+            if (UriPrefix.Scheme != uri.Scheme || UriPrefix.Host != uri.Host || UriPrefix.Port != uri.Port)
             {
                 return false;
             }
 
-            int prefixLen = prefixUri.AbsolutePath.LastIndexOf('/');
-            if (prefixLen > uri.AbsolutePath.LastIndexOf('/'))
+            if (UriPrefixLength > prefixLen)
             {
                 return false;
             }
 
-            return string.Compare(uri.AbsolutePath, 0, prefixUri.AbsolutePath, 0, prefixLen, StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Compare(uri.AbsolutePath, 0, UriPrefix.AbsolutePath, 0, UriPrefixLength, StringComparison.OrdinalIgnoreCase) == 0;
         }
 
         public override int GetHashCode() =>
@@ -108,21 +106,31 @@ namespace System.Net
             mostSpecificMatch = null;
             mostSpecificMatchUri = null;
 
-            // Enumerate through every credential in the cache
+            int uriPrefixLength = uriPrefix.AbsolutePath.LastIndexOf('/');
+
+            // Enumerate through every credential in the cache, get match with longest prefix
             foreach ((CredentialCacheKey key, NetworkCredential value) in cache)
             {
-                // Determine if this credential is applicable to the current Uri/AuthType
-                if (key.Match(uriPrefix, authType))
-                {
-                    int prefixLen = key.UriPrefixLength;
+                int prefixLen = key.UriPrefixLength;
 
-                    // Check if the match is better than the current-most-specific match
-                    if (prefixLen > longestMatchPrefix)
+                if (prefixLen <= longestMatchPrefix)
+                {
+                    // this credential can't provide a longer prefix match
+                    continue;
+                }
+
+                // Determine if this credential is applicable to the current Uri/AuthType
+                if (key.Match(uriPrefix, uriPrefixLength, authType))
+                {
+                    // update the information about currently preferred match
+                    longestMatchPrefix = prefixLen;
+                    mostSpecificMatch = value;
+                    mostSpecificMatchUri = key.UriPrefix;
+
+                    if (uriPrefixLength == prefixLen)
                     {
-                        // Yes: update the information about currently preferred match
-                        longestMatchPrefix = prefixLen;
-                        mostSpecificMatch = value;
-                        mostSpecificMatchUri = key.UriPrefix;
+                        // we can't get any better than this
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Fixes #101991.
Fixes #102281.

Not sure what introduced the original regression, but we can save some time by first checking if candidate credential can have longer prefix match before we start comparing auth schemes and uri, and we can stop early if we find exact match.