### PR TITLE
[release/8.0-staging] Add non-public SetEntryAssembly() API to System.Reflection

### DIFF
--- a/src/coreclr/System.Private.CoreLib/CompatibilitySuppressions.xml
+++ b/src/coreclr/System.Private.CoreLib/CompatibilitySuppressions.xml
@@ -1,5 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Reflection.Assembly.SetEntryAssembly(System.Reflection.Assembly)</Target>
+    <Left>ref/net8.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net8.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0015</DiagnosticId>
     <Target>M:System.Diagnostics.Tracing.EventSource.Write``1(System.String,``0):[T:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute]</Target>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
@@ -959,6 +960,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.TypedReference.get_IsNull</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Reflection.Assembly.SetEntryAssembly(System.Reflection.Assembly)</Target>
+    <Left>ref/net8.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net8.0/System.Private.CoreLib.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0014</DiagnosticId>

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -59,7 +59,7 @@
     <Compile Include="System\Configuration\ConfigurationElementTests.cs" />
     <Compile Include="System\Configuration\ConfigurationPropertyAttributeTests.cs" />
     <Compile Include="System\Configuration\ConfigurationPathTests.cs" />
-    <Compile Include="System\Configuration\CustomHostTests.cs" />
+    <Compile Include="System\Configuration\CustomHostTests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <Compile Include="System\Configuration\ConfigurationPropertyTests.cs" />
     <Compile Include="System\Configuration\ConfigurationTests.cs" />
     <Compile Include="System\Configuration\BasicCustomSectionTests.cs" />

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/CustomHostTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/CustomHostTests.cs
@@ -36,8 +36,8 @@ namespace System.Configuration.Tests
         private static void MakeAssemblyGetEntryAssemblyReturnNull()
         {
             typeof(Assembly)
-                .GetField("s_forceNullEntryPoint", BindingFlags.NonPublic | BindingFlags.Static)
-                .SetValue(null, true);
+                .GetMethod("SetEntryAssembly", BindingFlags.Public | BindingFlags.Static)
+                .Invoke(null, new object[]{ null });
 
             Assert.Null(Assembly.GetEntryAssembly());
         }

--- a/src/libraries/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests/DefaultTraceListenerClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests/DefaultTraceListenerClassTests.cs
@@ -174,8 +174,8 @@ namespace System.Diagnostics.TraceSourceTests
         private static void MakeAssemblyGetEntryAssemblyReturnNull()
         {
             typeof(Assembly)
-                .GetField("s_forceNullEntryPoint", BindingFlags.NonPublic | BindingFlags.Static)
-                .SetValue(null, true);
+                .GetMethod("SetEntryAssembly", BindingFlags.Public | BindingFlags.Static)
+                .Invoke(null, new object[]{ null });
 
             Assert.Null(Assembly.GetEntryAssembly());
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -217,13 +217,39 @@ namespace System.Reflection
             return type.Module?.Assembly;
         }
 
+        private static object? s_overriddenEntryAssembly;
+
+        /// <summary>
+        /// Sets the application's entry assembly to the provided assembly object.
+        /// </summary>
+        /// <param name="assembly">
+        /// Assembly object that represents the application's new entry assembly.
+        /// </param>
+        /// <remarks>
+        /// The assembly passed to this function has to be a runtime defined Assembly
+        /// type object. Otherwise, an exception will be thrown.
+        /// </remarks>
+        public static void SetEntryAssembly(Assembly? assembly)
+        {
+            if (assembly is null)
+            {
+                s_overriddenEntryAssembly = string.Empty;
+                return;
+            }
+
+            if (assembly is not RuntimeAssembly)
+                throw new ArgumentException(SR.Argument_MustBeRuntimeAssembly);
+
+            s_overriddenEntryAssembly = assembly;
+        }
+
         // internal test hook
         private static bool s_forceNullEntryPoint;
 
         public static Assembly? GetEntryAssembly()
         {
-            if (s_forceNullEntryPoint)
-                return null;
+            if (s_overriddenEntryAssembly is not null)
+                return s_overriddenEntryAssembly as Assembly;
 
             return GetEntryAssemblyInternal();
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -243,9 +243,6 @@ namespace System.Reflection
             s_overriddenEntryAssembly = assembly;
         }
 
-        // internal test hook
-        private static bool s_forceNullEntryPoint;
-
         public static Assembly? GetEntryAssembly()
         {
             if (s_overriddenEntryAssembly is not null)

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -208,7 +208,7 @@ namespace System.Reflection.Tests
             }).Dispose();
         }
 
-        private static SetEntryAssembly(Assembly assembly)
+        private static void SetEntryAssembly(Assembly assembly)
         {
             typeof(Assembly)
                 .GetMethod("SetEntryAssembly", BindingFlags.Public | BindingFlags.Static)

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -197,14 +197,6 @@ namespace System.Reflection.Tests
                 
                 SetEntryAssembly(testAssembly);
                 Assert.Equal(Assembly.GetEntryAssembly(), testAssembly);
-                
-                var invalidAssembly = new PersistedAssemblyBuilder(
-                    new AssemblyName("NotaRuntimeAssemblyTest"),
-                    typeof(object).Assembly
-                );
-                Assert.Throws<ArgumentException>(
-                    () => Assembly.SetEntryAssembly(invalidAssembly)
-                );
             }).Dispose();
         }
 

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -184,7 +184,7 @@ namespace System.Reflection.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        public void SetEntryAssembly()
+        public void TestSetEntryAssembly()
         {
             Assert.NotNull(Assembly.GetEntryAssembly());
 

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TestRuntime>true</TestRuntime>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- SYSLIB0013: Uri.EscapeUriString is obsolete
          SYSLIB0037: AssemblyName members HashAlgorithm, ProcessorArchitecture, and VersionCompatibility are obsolete. -->

--- a/src/mono/System.Private.CoreLib/CompatibilitySuppressions.xml
+++ b/src/mono/System.Private.CoreLib/CompatibilitySuppressions.xml
@@ -1,5 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Reflection.Assembly.SetEntryAssembly(System.Reflection.Assembly)</Target>
+    <Left>ref/net8.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net8.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0014</DiagnosticId>
     <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(System.Object)-&gt;object?:[T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute]</Target>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/102271 to release/8.0

Implements the API proposal detailed and approved in issue #101616. This new API will allow developers to change the entry assembly of their .NET apps on the fly, should they require it. One important scenario is app launchers. With the usage of this API, then functions like `GetEntryAssembly()` will return the right value, and thus we will be able to ensure the information is consistent and correct.

## Customer Impact
The Azure functions team is using this API in .NET 9 and want to bring this APi back to .NET 8 in order to avoid adding too much unnecessary code for the scenario they are trying to support. This API will only be available via reflection.

## Testing
Added automated tests that use reflection to call the API

## Risk
Low risk.
