### PR TITLE
Improve Span.Count

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -3793,11 +3793,9 @@ namespace System
                     }
 
                     // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
-                    {
-                        ulong mask = Vector512.Equals(Vector512.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-                        mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
-                        count += BitOperations.PopCount(mask);
-                    }
+                    ulong mask = Vector512.Equals(Vector512.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
+                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
+                    count += BitOperations.PopCount(mask);
                 }
                 else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
                 {
@@ -3810,11 +3808,9 @@ namespace System
                     }
 
                     // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
-                    {
-                        uint mask = Vector256.Equals(Vector256.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-                        mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
-                        count += BitOperations.PopCount(mask);
-                    }
+                    uint mask = Vector256.Equals(Vector256.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
+                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
+                    count += BitOperations.PopCount(mask);
                 }
                 else
                 {
@@ -3827,11 +3823,9 @@ namespace System
                     }
 
                     // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
-                    {
-                        uint mask = Vector128.Equals(Vector128.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-                        mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
-                        count += BitOperations.PopCount(mask);
-                    }
+                    uint mask = Vector128.Equals(Vector128.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
+                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
+                    count += BitOperations.PopCount(mask);
                 }
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -3786,92 +3786,65 @@ namespace System
                 {
                     Vector512<T> targetVector = Vector512.Create(value);
                     ref T oneVectorAwayFromEnd = ref Unsafe.Subtract(ref end, Vector512<T>.Count);
-                    do
+                    while (Unsafe.IsAddressLessThan(ref current, ref oneVectorAwayFromEnd))
                     {
                         count += BitOperations.PopCount(Vector512.Equals(Vector512.LoadUnsafe(ref current), targetVector).ExtractMostSignificantBits());
                         current = ref Unsafe.Add(ref current, Vector512<T>.Count);
                     }
-                    while (!Unsafe.IsAddressGreaterThan(ref current, ref oneVectorAwayFromEnd));
 
-                    // If there are just a few elements remaining, then processing these elements by the scalar loop
-                    // is cheaper than doing bitmask + popcount on the full last vector. To avoid complicated type
-                    // based checks, other remainder-count based logic to determine the correct cut-off, for simplicity
-                    // a half-vector size is chosen (based on benchmarks).
-                    uint remaining = (uint)Unsafe.ByteOffset(ref current, ref end) / (uint)Unsafe.SizeOf<T>();
-                    if (remaining > Vector512<T>.Count / 2)
+                    // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
                     {
                         ulong mask = Vector512.Equals(Vector512.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-
-                        // The mask contains some elements that may be double-checked, so shift them away in order to get the correct pop-count.
-                        uint overlaps = (uint)Vector512<T>.Count - remaining;
-                        mask >>= (int)overlaps;
+                        mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
                         count += BitOperations.PopCount(mask);
-
-                        return count;
                     }
                 }
                 else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
                 {
                     Vector256<T> targetVector = Vector256.Create(value);
                     ref T oneVectorAwayFromEnd = ref Unsafe.Subtract(ref end, Vector256<T>.Count);
-                    do
+                    while (Unsafe.IsAddressLessThan(ref current, ref oneVectorAwayFromEnd))
                     {
                         count += BitOperations.PopCount(Vector256.Equals(Vector256.LoadUnsafe(ref current), targetVector).ExtractMostSignificantBits());
                         current = ref Unsafe.Add(ref current, Vector256<T>.Count);
                     }
-                    while (!Unsafe.IsAddressGreaterThan(ref current, ref oneVectorAwayFromEnd));
 
-                    // If there are just a few elements remaining, then processing these elements by the scalar loop
-                    // is cheaper than doing bitmask + popcount on the full last vector. To avoid complicated type
-                    // based checks, other remainder-count based logic to determine the correct cut-off, for simplicity
-                    // a half-vector size is chosen (based on benchmarks).
-                    uint remaining = (uint)Unsafe.ByteOffset(ref current, ref end) / (uint)Unsafe.SizeOf<T>();
-                    if (remaining > Vector256<T>.Count / 2)
+                    // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
                     {
                         uint mask = Vector256.Equals(Vector256.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-
-                        // The mask contains some elements that may be double-checked, so shift them away in order to get the correct pop-count.
-                        uint overlaps = (uint)Vector256<T>.Count - remaining;
-                        mask >>= (int)overlaps;
+                        mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
                         count += BitOperations.PopCount(mask);
-
-                        return count;
                     }
                 }
                 else
                 {
                     Vector128<T> targetVector = Vector128.Create(value);
                     ref T oneVectorAwayFromEnd = ref Unsafe.Subtract(ref end, Vector128<T>.Count);
-                    do
+                    while (Unsafe.IsAddressLessThan(ref current, ref oneVectorAwayFromEnd))
                     {
                         count += BitOperations.PopCount(Vector128.Equals(Vector128.LoadUnsafe(ref current), targetVector).ExtractMostSignificantBits());
                         current = ref Unsafe.Add(ref current, Vector128<T>.Count);
                     }
-                    while (!Unsafe.IsAddressGreaterThan(ref current, ref oneVectorAwayFromEnd));
 
-                    uint remaining = (uint)Unsafe.ByteOffset(ref current, ref end) / (uint)Unsafe.SizeOf<T>();
-                    if (remaining > Vector128<T>.Count / 2)
+                    // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
                     {
                         uint mask = Vector128.Equals(Vector128.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-
-                        // The mask contains some elements that may be double-checked, so shift them away in order to get the correct pop-count.
-                        uint overlaps = (uint)Vector128<T>.Count - remaining;
-                        mask >>= (int)overlaps;
+                        mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
                         count += BitOperations.PopCount(mask);
-
-                        return count;
                     }
                 }
             }
-
-            while (Unsafe.IsAddressLessThan(ref current, ref end))
+            else
             {
-                if (current.Equals(value))
+                while (Unsafe.IsAddressLessThan(ref current, ref end))
                 {
-                    count++;
-                }
+                    if (current.Equals(value))
+                    {
+                        count++;
+                    }
 
-                current = ref Unsafe.Add(ref current, 1);
+                    current = ref Unsafe.Add(ref current, 1);
+                }
             }
 
             return count;


### PR DESCRIPTION
We're currently calculating the number of remaining elements after the vectorized loop and falling back to the scalar path if we have less than half a vector's worth of data remaining.

It's simpler and faster if we just unconditionally process the last vector.

```c#
public class CountBenchmarks<T> where T : struct, INumber<T>
{
    private T[][] _numbers;

    [GlobalSetup]
    public void Setup()
    {
        _numbers = new T[10_000][];

        var rng = new Random(42);

        for (int i = 0; i < _numbers.Length; i++)
        {
            _numbers[i] = new T[rng.Next(0, 256 / Unsafe.SizeOf<T>())];
            rng.NextBytes(MemoryMarshal.AsBytes(_numbers[i].AsSpan()));
        }
    }

    [Benchmark]
    public int Count()
    {
        int count = 0;
        foreach (T[] numbers in _numbers) count += numbers.AsSpan().Count(T.CreateChecked(42));
        return count;
    }
}
```

| Method | Toolchain | Type  | Mean      | Error    | Ratio |
|------- |---------- |------ |----------:|---------:|------:|
| Count  | main      | byte  |  175.4 us |  0.82 us |  1.00 |
| Count  | pr        | byte  |  100.1 us |  0.25 us |  0.57 |
|        |           |       |           |          |       |
| Count  | main      | short |  147.6 us |  0.24 us |  1.00 |
| Count  | pr        | short |  102.7 us |  0.17 us |  0.70 |
|        |           |       |           |          |       |
| Count  | main      | int   | 143.01 us | 0.277 us |  1.00 |
| Count  | pr        | int   |  98.10 us | 0.262 us |  0.69 |
|        |           |       |           |          |       |
| Count  | main      | long  | 134.13 us | 2.157 us |  1.00 |
| Count  | pr        | long  |  99.87 us | 0.618 us |  0.74 |

@gfoidl this goes against your numbers in #82687, presumably because you were testing with a single `Length` at a time and all the branches were predictable?