### PR TITLE
Update ws to a version without recorded vulnerabilities

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/package-lock.json
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "node-abort-controller": "3.0.1",
         "node-fetch": "2.6.7",
-        "ws": "8.4.0"
+        "ws": "^8.17.1"
       }
     },
     "node_modules/node-abort-controller": {
@@ -55,15 +55,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.17.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha1-kpPaUwu1SP68lTcdkPnIeHJ9kZs=",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -109,9 +110,9 @@
       }
     },
     "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.17.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha1-kpPaUwu1SP68lTcdkPnIeHJ9kZs=",
       "requires": {}
     }
   }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/package.json
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/package.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "node-abort-controller": "3.0.1",
     "node-fetch": "2.6.7",
-    "ws": "8.4.0"
+    "ws": "^8.17.1"
   }
 }

--- a/src/libraries/System.Net.WebSockets.Client/tests/package-lock.json
+++ b/src/libraries/System.Net.WebSockets.Client/tests/package-lock.json
@@ -6,22 +6,21 @@
   "packages": {
     "": {
       "name": "system.net.websockets.client.tests",
-      "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
-        "ws": "^8.4.0"
+        "ws": "^8.17.1"
       }
     },
     "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.17.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha1-kpPaUwu1SP68lTcdkPnIeHJ9kZs=",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -35,9 +34,9 @@
   },
   "dependencies": {
     "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.17.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha1-kpPaUwu1SP68lTcdkPnIeHJ9kZs=",
       "requires": {}
     }
   }

--- a/src/libraries/System.Net.WebSockets.Client/tests/package.json
+++ b/src/libraries/System.Net.WebSockets.Client/tests/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "ws": "8.4.0"
+    "ws": "^8.17.1"
   }
 }


### PR DESCRIPTION
ws 8.4.0 has a CVE recorded against it. Upgrade to avoid CG warnings.