### PR TITLE
Performance improvements in `JsonValue`.

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -75,6 +75,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonArray.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonArray.IList.cs" />
+    <Compile Include="System\Text\Json\Nodes\JsonValueOfElement.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonNode.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonNode.Operators.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonNode.Parse.cs" />
@@ -378,12 +379,6 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\StringSyntaxAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresDynamicCodeAttribute.cs" />
     <Compile Include="System\Text\Json\Reader\JsonReaderHelper.netstandard.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="System\Text\Json\OrderedDictionary.cs" />
-    <None Include="System\Text\Json\OrderedDictionary.KeyCollection.cs" />
-    <None Include="System\Text\Json\OrderedDictionary.ValueCollection.cs" />
   </ItemGroup>
 
   <!-- Application tfms (.NETCoreApp, .NETFramework) need to use the same or higher version of .NETStandard's dependencies. -->

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -118,6 +118,13 @@ namespace System.Text.Json
             return _parsedData.GetJsonTokenType(index);
         }
 
+        internal bool GetHasComplexChildren(int index)
+        {
+            CheckNotDisposed();
+            DbRow row = _parsedData.Get(index);
+            return row.HasComplexChildren;
+        }
+
         internal int GetArrayLength(int index)
         {
             CheckNotDisposed();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1164,6 +1164,13 @@ namespace System.Text.Json
             return _parent.GetNameOfPropertyValue(_idx);
         }
 
+        internal ReadOnlySpan<byte> GetPropertyNameRaw()
+        {
+            CheckValidInstance();
+
+            return _parent.GetPropertyNameRaw(_idx);
+        }
+
         /// <summary>
         ///   Gets the original input data backing this value, returning it as a <see cref="string"/>.
         /// </summary>
@@ -1199,9 +1206,9 @@ namespace System.Text.Json
             // TODO make public https://github.com/dotnet/runtime/issues/77666
             get
             {
-                Debug.Assert(ValueKind is JsonValueKind.String);
                 CheckValidInstance();
-                return _parent.GetHasComplexChildren(_idx);
+
+                return _parent.ValueIsEscaped(_idx, isPropertyName: false);
             }
         }
 
@@ -1210,9 +1217,135 @@ namespace System.Text.Json
             // TODO make public https://github.com/dotnet/runtime/issues/77666
             get
             {
-                Debug.Assert(ValueKind is JsonValueKind.String);
                 CheckValidInstance();
+
                 return _parent.GetRawValue(_idx, includeQuotes: false).Span;
+            }
+        }
+
+        // TODO make public https://github.com/dotnet/runtime/issues/33388
+        internal static bool DeepEquals(JsonElement left, JsonElement right)
+        {
+            Debug.Assert(left._parent != null);
+            Debug.Assert(right._parent != null);
+
+            JsonValueKind kind = left.ValueKind;
+            if (kind != right.ValueKind)
+            {
+                return false;
+            }
+
+            switch (kind)
+            {
+                case JsonValueKind.Null or JsonValueKind.False or JsonValueKind.True:
+                    return true;
+
+                case JsonValueKind.Number:
+                    // JSON numbers are equal if their raw representations are equal.
+                    return left.GetRawValue().Span.SequenceEqual(right.GetRawValue().Span);
+
+                case JsonValueKind.String:
+                    if (right.ValueIsEscaped)
+                    {
+                        if (left.ValueIsEscaped)
+                        {
+                            // Both values are escaped, force an allocation to unescape the RHS.
+                            return left.ValueEquals(right.GetString());
+                        }
+
+                        // Swap values so that unescaping is handled by the LHS.
+                        (left, right) = (right, left);
+                    }
+
+                    return left.ValueEquals(right.ValueSpan);
+
+                case JsonValueKind.Array:
+                    ArrayEnumerator rightArrayEnumerator = right.EnumerateArray();
+                    foreach (JsonElement leftElement in left.EnumerateArray())
+                    {
+                        if (!rightArrayEnumerator.MoveNext() || !DeepEquals(leftElement, rightArrayEnumerator.Current))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return !rightArrayEnumerator.MoveNext();
+
+                default:
+                    Debug.Assert(kind is JsonValueKind.Object);
+                    ObjectEnumerator leftObjectEnumerator = left.EnumerateObject();
+                    ObjectEnumerator rightObjectEnumerator = right.EnumerateObject();
+
+                    // Two JSON objects are considered equal if they define the same set of properties.
+                    // Start optimistically with sequential comparison, but fall back to unordered
+                    // comparison as soon as a mismatch is encountered.
+
+                    while (leftObjectEnumerator.MoveNext())
+                    {
+                        if (!rightObjectEnumerator.MoveNext())
+                        {
+                            return false;
+                        }
+
+                        JsonProperty leftProp = leftObjectEnumerator.Current;
+                        JsonProperty rightProp = rightObjectEnumerator.Current;
+
+                        if (!NameEquals(leftProp, rightProp))
+                        {
+                            // We have our first mismatch, fall back to unordered comparison.
+                            return UnorderedObjectDeepEquals(leftObjectEnumerator, rightObjectEnumerator);
+                        }
+
+                        if (!DeepEquals(leftProp.Value, rightProp.Value))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return !rightObjectEnumerator.MoveNext();
+
+                    static bool UnorderedObjectDeepEquals(ObjectEnumerator left, ObjectEnumerator right)
+                    {
+                        Dictionary<string, JsonElement> rightElements = new(StringComparer.Ordinal);
+                        do
+                        {
+                            JsonProperty prop = right.Current;
+                            rightElements.TryAdd(prop.Name, prop.Value);
+                        }
+                        while (right.MoveNext());
+
+                        int leftCount = 0;
+                        do
+                        {
+                            JsonProperty prop = left.Current;
+                            if (!rightElements.TryGetValue(prop.Name, out JsonElement rightElement) || !DeepEquals(prop.Value, rightElement))
+                            {
+                                return false;
+                            }
+
+                            leftCount++;
+                        }
+                        while (left.MoveNext());
+
+                        return leftCount == rightElements.Count;
+                    }
+
+                    static bool NameEquals(JsonProperty left, JsonProperty right)
+                    {
+                        if (right.NameIsEscaped)
+                        {
+                            if (left.NameIsEscaped)
+                            {
+                                // Both values are escaped, force an allocation to unescape the RHS.
+                                return left.NameEquals(right.Name);
+                            }
+
+                            // Swap values so that unescaping is handled by the LHS
+                            (left, right) = (right, left);
+                        }
+
+                        return left.NameEquals(right.NameSpan);
+                    }
             }
         }
 
@@ -1312,6 +1445,13 @@ namespace System.Text.Json
             CheckValidInstance();
 
             return _parent.TextEquals(_idx, text, isPropertyName);
+        }
+
+        internal bool ValueIsEscapedHelper(bool isPropertyName)
+        {
+            CheckValidInstance();
+
+            return _parent.ValueIsEscaped(_idx, isPropertyName);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1194,6 +1194,28 @@ namespace System.Text.Json
             return _parent.GetPropertyRawValueAsString(_idx);
         }
 
+        internal bool ValueIsEscaped
+        {
+            // TODO make public https://github.com/dotnet/runtime/issues/77666
+            get
+            {
+                Debug.Assert(ValueKind is JsonValueKind.String);
+                CheckValidInstance();
+                return _parent.GetHasComplexChildren(_idx);
+            }
+        }
+
+        internal ReadOnlySpan<byte> ValueSpan
+        {
+            // TODO make public https://github.com/dotnet/runtime/issues/77666
+            get
+            {
+                Debug.Assert(ValueKind is JsonValueKind.String);
+                CheckValidInstance();
+                return _parent.GetRawValue(_idx, includeQuotes: false).Span;
+            }
+        }
+
         /// <summary>
         ///   Compares <paramref name="text" /> to the string value of this element.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
@@ -18,10 +18,9 @@ namespace System.Text.Json
         public JsonElement Value { get; }
         private string? _name { get; }
 
-        internal JsonProperty(JsonElement value, string? name = null)
+        internal JsonProperty(JsonElement value)
         {
             Value = value;
-            _name = name;
         }
 
         /// <summary>
@@ -93,6 +92,10 @@ namespace System.Text.Json
         {
             return Value.TextEqualsHelper(utf8Text, isPropertyName: true, shouldUnescape: false);
         }
+
+        // TODO make public https://github.com/dotnet/runtime/issues/77666
+        internal bool NameIsEscaped => Value.ValueIsEscapedHelper(isPropertyName: true);
+        internal ReadOnlySpan<byte> NameSpan => Value.GetPropertyNameRaw();
 
         /// <summary>
         ///   Write the property into the provided writer as a named JSON object property.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
@@ -23,6 +23,8 @@ namespace System.Text.Json.Nodes
         private JsonElement? _jsonElement;
         private List<JsonNode?>? _list;
 
+        internal override JsonElement? UnderlyingElement => _jsonElement;
+
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonArray"/> class that is empty.
         /// </summary>
@@ -93,11 +95,11 @@ namespace System.Text.Json.Nodes
             return jsonArray;
         }
 
-        internal override bool DeepEqualsCore(JsonNode? node)
+        internal override bool DeepEqualsCore(JsonNode node)
         {
             switch (node)
             {
-                case null or JsonObject:
+                case JsonObject:
                     return false;
                 case JsonValue value:
                     // JsonValue instances have special comparison semantics, dispatch to their implementation.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
@@ -44,13 +44,12 @@ namespace System.Text.Json.Nodes
             // Special case for string; don't quote it.
             if (this is JsonValue)
             {
-                if (this is JsonValue<string> jsonString)
+                if (this is JsonValuePrimitive<string> jsonString)
                 {
                     return jsonString.Value;
                 }
 
-                if (this is JsonValue<JsonElement> jsonElement &&
-                    jsonElement.Value.ValueKind == JsonValueKind.String)
+                if (this is JsonValueOfElement { Value.ValueKind: JsonValueKind.String } jsonElement)
                 {
                     return jsonElement.Value.GetString()!;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
@@ -14,6 +14,9 @@ namespace System.Text.Json.Nodes
     /// declared as an <see cref="object"/> should be deserialized as a <see cref="JsonNode"/>.
     public abstract partial class JsonNode
     {
+        // Default options instance used when calling built-in JsonNode converters.
+        private protected static readonly JsonSerializerOptions s_defaultOptions = new();
+
         private JsonNode? _parent;
         private JsonNodeOptions? _options;
 
@@ -375,7 +378,7 @@ namespace System.Text.Json.Nodes
             }
 
             var jsonTypeInfo = (JsonTypeInfo<T>)JsonSerializerOptions.Default.GetTypeInfo(typeof(T));
-            return new JsonValueCustomized<T>(value, jsonTypeInfo, options);
+            return JsonValue.CreateFromTypeInfo(value, jsonTypeInfo, options);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
@@ -21,6 +21,11 @@ namespace System.Text.Json.Nodes
         private JsonNodeOptions? _options;
 
         /// <summary>
+        /// The underlying JsonElement if the node is backed by a JsonElement.
+        /// </summary>
+        internal virtual JsonElement? UnderlyingElement => null;
+
+        /// <summary>
         ///   Options to control the behavior.
         /// </summary>
         public JsonNodeOptions? Options
@@ -303,11 +308,15 @@ namespace System.Text.Json.Nodes
             {
                 return node2 is null;
             }
+            else if (node2 is null)
+            {
+                return false;
+            }
 
             return node1.DeepEqualsCore(node2);
         }
 
-        internal abstract bool DeepEqualsCore(JsonNode? node);
+        internal abstract bool DeepEqualsCore(JsonNode node);
 
         /// <summary>
         /// Replaces this node with a new value.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
@@ -25,6 +25,11 @@ namespace System.Text.Json.Nodes
         /// </exception>
         public void Add(string propertyName, JsonNode? value)
         {
+            if (propertyName is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
+            }
+
             Dictionary.Add(propertyName, value);
             value?.AssignParent(this);
         }
@@ -74,7 +79,15 @@ namespace System.Text.Json.Nodes
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="propertyName"/> is <see langword="null"/>.
         /// </exception>
-        public bool ContainsKey(string propertyName) => Dictionary.ContainsKey(propertyName);
+        public bool ContainsKey(string propertyName)
+        {
+            if (propertyName is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
+            }
+
+            return Dictionary.ContainsKey(propertyName);
+        }
 
         /// <summary>
         ///   Gets the number of elements contained in <see cref="JsonObject"/>.
@@ -180,7 +193,15 @@ namespace System.Text.Json.Nodes
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="propertyName"/> is <see langword="null"/>.
         /// </exception>
-        bool IDictionary<string, JsonNode?>.TryGetValue(string propertyName, out JsonNode? jsonNode) => Dictionary.TryGetValue(propertyName, out jsonNode);
+        bool IDictionary<string, JsonNode?>.TryGetValue(string propertyName, out JsonNode? jsonNode)
+        {
+            if (propertyName is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
+            }
+
+            return Dictionary.TryGetValue(propertyName, out jsonNode);
+        }
 
         /// <summary>
         ///   Returns <see langword="false"/>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IList.cs
@@ -23,6 +23,11 @@ namespace System.Text.Json.Nodes
         /// <exception cref="InvalidOperationException"><paramref name="value"/> already has a parent.</exception>
         public void SetAt(int index, string propertyName, JsonNode? value)
         {
+            if (propertyName is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
+            }
+
             OrderedDictionary<string, JsonNode?> dictionary = Dictionary;
             KeyValuePair<string, JsonNode?> existing = dictionary.GetAt(index);
             dictionary.SetAt(index, propertyName, value);
@@ -48,7 +53,15 @@ namespace System.Text.Json.Nodes
         /// <param name="propertyName">The property name to locate.</param>
         /// <returns>The index of <paramref name="propertyName"/> if found; otherwise, -1.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is null.</exception>
-        public int IndexOf(string propertyName) => Dictionary.IndexOf(propertyName);
+        public int IndexOf(string propertyName)
+        {
+            if (propertyName is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
+            }
+
+            return Dictionary.IndexOf(propertyName);
+        }
 
         /// <summary>Inserts a property into the object at the specified index.</summary>
         /// <param name="index">The zero-based index at which the property should be inserted.</param>
@@ -59,6 +72,11 @@ namespace System.Text.Json.Nodes
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than 0 or greater than <see cref="Count"/>.</exception>
         public void Insert(int index, string propertyName, JsonNode? value)
         {
+            if (propertyName is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
+            }
+
             Dictionary.Insert(index, propertyName, value);
             value?.AssignParent(this);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -116,8 +116,15 @@ namespace System.Text.Json.Nodes
         /// <returns>
         ///   <see langword="true"/> if a property with the specified name was found; otherwise, <see langword="false"/>.
         /// </returns>
-        public bool TryGetPropertyValue(string propertyName, out JsonNode? jsonNode) =>
-            Dictionary.TryGetValue(propertyName, out jsonNode);
+        public bool TryGetPropertyValue(string propertyName, out JsonNode? jsonNode)
+        {
+            if (propertyName is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
+            }
+
+            return Dictionary.TryGetValue(propertyName, out jsonNode);
+        }
 
         /// <inheritdoc/>
         public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Nodes
     {
         private JsonElement? _jsonElement;
 
+        internal override JsonElement? UnderlyingElement => _jsonElement;
+
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonObject"/> class that is empty.
         /// </summary>
@@ -165,11 +167,11 @@ namespace System.Text.Json.Nodes
 
         private protected override JsonValueKind GetValueKindCore() => JsonValueKind.Object;
 
-        internal override bool DeepEqualsCore(JsonNode? node)
+        internal override bool DeepEqualsCore(JsonNode node)
         {
             switch (node)
             {
-                case null or JsonArray:
+                case JsonArray:
                     return false;
                 case JsonValue value:
                     // JsonValue instances have special comparison semantics, dispatch to their implementation.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.CreateOverloads.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.CreateOverloads.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(bool value, JsonNodeOptions? options = null) => new JsonValuePrimitive<bool>(value, JsonMetadataServices.BooleanConverter);
+        public static JsonValue Create(bool value, JsonNodeOptions? options = null) => new JsonValuePrimitive<bool>(value, JsonMetadataServices.BooleanConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -22,7 +22,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(bool? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<bool>(value.Value, JsonMetadataServices.BooleanConverter) : null;
+        public static JsonValue? Create(bool? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<bool>(value.Value, JsonMetadataServices.BooleanConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -30,7 +30,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(byte value, JsonNodeOptions? options = null) => new JsonValuePrimitive<byte>(value, JsonMetadataServices.ByteConverter);
+        public static JsonValue Create(byte value, JsonNodeOptions? options = null) => new JsonValuePrimitive<byte>(value, JsonMetadataServices.ByteConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -38,7 +38,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(byte? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<byte>(value.Value, JsonMetadataServices.ByteConverter) : null;
+        public static JsonValue? Create(byte? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<byte>(value.Value, JsonMetadataServices.ByteConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -46,7 +46,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(char value, JsonNodeOptions? options = null) => new JsonValuePrimitive<char>(value, JsonMetadataServices.CharConverter);
+        public static JsonValue Create(char value, JsonNodeOptions? options = null) => new JsonValuePrimitive<char>(value, JsonMetadataServices.CharConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -54,7 +54,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(char? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<char>(value.Value, JsonMetadataServices.CharConverter) : null;
+        public static JsonValue? Create(char? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<char>(value.Value, JsonMetadataServices.CharConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -62,7 +62,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(DateTime value, JsonNodeOptions? options = null) => new JsonValuePrimitive<DateTime>(value, JsonMetadataServices.DateTimeConverter);
+        public static JsonValue Create(DateTime value, JsonNodeOptions? options = null) => new JsonValuePrimitive<DateTime>(value, JsonMetadataServices.DateTimeConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -70,7 +70,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(DateTime? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<DateTime>(value.Value, JsonMetadataServices.DateTimeConverter) : null;
+        public static JsonValue? Create(DateTime? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<DateTime>(value.Value, JsonMetadataServices.DateTimeConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -78,7 +78,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(DateTimeOffset value, JsonNodeOptions? options = null) => new JsonValuePrimitive<DateTimeOffset>(value, JsonMetadataServices.DateTimeOffsetConverter);
+        public static JsonValue Create(DateTimeOffset value, JsonNodeOptions? options = null) => new JsonValuePrimitive<DateTimeOffset>(value, JsonMetadataServices.DateTimeOffsetConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -86,7 +86,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(DateTimeOffset? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<DateTimeOffset>(value.Value, JsonMetadataServices.DateTimeOffsetConverter) : null;
+        public static JsonValue? Create(DateTimeOffset? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<DateTimeOffset>(value.Value, JsonMetadataServices.DateTimeOffsetConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -94,7 +94,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(decimal value, JsonNodeOptions? options = null) => new JsonValuePrimitive<decimal>(value, JsonMetadataServices.DecimalConverter);
+        public static JsonValue Create(decimal value, JsonNodeOptions? options = null) => new JsonValuePrimitive<decimal>(value, JsonMetadataServices.DecimalConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -102,7 +102,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(decimal? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<decimal>(value.Value, JsonMetadataServices.DecimalConverter) : null;
+        public static JsonValue? Create(decimal? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<decimal>(value.Value, JsonMetadataServices.DecimalConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -110,7 +110,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(double value, JsonNodeOptions? options = null) => new JsonValuePrimitive<double>(value, JsonMetadataServices.DoubleConverter);
+        public static JsonValue Create(double value, JsonNodeOptions? options = null) => new JsonValuePrimitive<double>(value, JsonMetadataServices.DoubleConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -118,7 +118,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(double? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<double>(value.Value, JsonMetadataServices.DoubleConverter) : null;
+        public static JsonValue? Create(double? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<double>(value.Value, JsonMetadataServices.DoubleConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -126,7 +126,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(Guid value, JsonNodeOptions? options = null) => new JsonValuePrimitive<Guid>(value, JsonMetadataServices.GuidConverter);
+        public static JsonValue Create(Guid value, JsonNodeOptions? options = null) => new JsonValuePrimitive<Guid>(value, JsonMetadataServices.GuidConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -134,7 +134,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(Guid? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<Guid>(value.Value, JsonMetadataServices.GuidConverter) : null;
+        public static JsonValue? Create(Guid? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<Guid>(value.Value, JsonMetadataServices.GuidConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -142,7 +142,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(short value, JsonNodeOptions? options = null) => new JsonValuePrimitive<short>(value, JsonMetadataServices.Int16Converter);
+        public static JsonValue Create(short value, JsonNodeOptions? options = null) => new JsonValuePrimitive<short>(value, JsonMetadataServices.Int16Converter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -150,7 +150,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(short? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<short>(value.Value, JsonMetadataServices.Int16Converter) : null;
+        public static JsonValue? Create(short? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<short>(value.Value, JsonMetadataServices.Int16Converter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -158,7 +158,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(int value, JsonNodeOptions? options = null) => new JsonValuePrimitive<int>(value, JsonMetadataServices.Int32Converter);
+        public static JsonValue Create(int value, JsonNodeOptions? options = null) => new JsonValuePrimitive<int>(value, JsonMetadataServices.Int32Converter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -166,7 +166,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(int? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<int>(value.Value, JsonMetadataServices.Int32Converter) : null;
+        public static JsonValue? Create(int? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<int>(value.Value, JsonMetadataServices.Int32Converter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -174,7 +174,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(long value, JsonNodeOptions? options = null) => new JsonValuePrimitive<long>(value, JsonMetadataServices.Int64Converter);
+        public static JsonValue Create(long value, JsonNodeOptions? options = null) => new JsonValuePrimitive<long>(value, JsonMetadataServices.Int64Converter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -182,16 +182,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(long? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<long>(value.Value, JsonMetadataServices.Int64Converter) : null;
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
-        /// </summary>
-        /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
-        /// <param name="options">Options to control the behavior.</param>
-        /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        [CLSCompliantAttribute(false)]
-        public static JsonValue Create(sbyte value, JsonNodeOptions? options = null) => new JsonValuePrimitive<sbyte>(value, JsonMetadataServices.SByteConverter);
+        public static JsonValue? Create(long? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<long>(value.Value, JsonMetadataServices.Int64Converter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -200,7 +191,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [CLSCompliantAttribute(false)]
-        public static JsonValue? Create(sbyte? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<sbyte>(value.Value, JsonMetadataServices.SByteConverter) : null;
+        public static JsonValue Create(sbyte value, JsonNodeOptions? options = null) => new JsonValuePrimitive<sbyte>(value, JsonMetadataServices.SByteConverter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -208,7 +199,8 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue Create(float value, JsonNodeOptions? options = null) => new JsonValuePrimitive<float>(value, JsonMetadataServices.SingleConverter);
+        [CLSCompliantAttribute(false)]
+        public static JsonValue? Create(sbyte? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<sbyte>(value.Value, JsonMetadataServices.SByteConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -216,7 +208,15 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(float? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<float>(value.Value, JsonMetadataServices.SingleConverter) : null;
+        public static JsonValue Create(float value, JsonNodeOptions? options = null) => new JsonValuePrimitive<float>(value, JsonMetadataServices.SingleConverter, options);
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
+        /// </summary>
+        /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
+        /// <param name="options">Options to control the behavior.</param>
+        /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
+        public static JsonValue? Create(float? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<float>(value.Value, JsonMetadataServices.SingleConverter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -225,7 +225,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [return: NotNullIfNotNull(nameof(value))]
-        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) => value != null ? new JsonValuePrimitive<string?>(value, JsonMetadataServices.StringConverter) : null;
+        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) => value != null ? new JsonValuePrimitive<string>(value, JsonMetadataServices.StringConverter!, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -234,7 +234,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [CLSCompliantAttribute(false)]
-        public static JsonValue Create(ushort value, JsonNodeOptions? options = null) => new JsonValuePrimitive<ushort>(value, JsonMetadataServices.UInt16Converter);
+        public static JsonValue Create(ushort value, JsonNodeOptions? options = null) => new JsonValuePrimitive<ushort>(value, JsonMetadataServices.UInt16Converter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -243,7 +243,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [CLSCompliantAttribute(false)]
-        public static JsonValue? Create(ushort? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<ushort>(value.Value, JsonMetadataServices.UInt16Converter) : null;
+        public static JsonValue? Create(ushort? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<ushort>(value.Value, JsonMetadataServices.UInt16Converter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -252,7 +252,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [CLSCompliantAttribute(false)]
-        public static JsonValue Create(uint value, JsonNodeOptions? options = null) => new JsonValuePrimitive<uint>(value, JsonMetadataServices.UInt32Converter);
+        public static JsonValue Create(uint value, JsonNodeOptions? options = null) => new JsonValuePrimitive<uint>(value, JsonMetadataServices.UInt32Converter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -261,7 +261,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [CLSCompliantAttribute(false)]
-        public static JsonValue? Create(uint? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<uint>(value.Value, JsonMetadataServices.UInt32Converter) : null;
+        public static JsonValue? Create(uint? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<uint>(value.Value, JsonMetadataServices.UInt32Converter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -270,7 +270,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [CLSCompliantAttribute(false)]
-        public static JsonValue Create(ulong value, JsonNodeOptions? options = null) => new JsonValuePrimitive<ulong>(value, JsonMetadataServices.UInt64Converter);
+        public static JsonValue Create(ulong value, JsonNodeOptions? options = null) => new JsonValuePrimitive<ulong>(value, JsonMetadataServices.UInt64Converter, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -279,7 +279,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [CLSCompliantAttribute(false)]
-        public static JsonValue? Create(ulong? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<ulong>(value.Value, JsonMetadataServices.UInt64Converter) : null;
+        public static JsonValue? Create(ulong? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValuePrimitive<ulong>(value.Value, JsonMetadataServices.UInt64Converter, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -287,17 +287,7 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(JsonElement value, JsonNodeOptions? options = null)
-        {
-            if (value.ValueKind == JsonValueKind.Null)
-            {
-                return null;
-            }
-
-            VerifyJsonElementIsNotArrayOrObject(ref value);
-
-            return new JsonValuePrimitive<JsonElement>(value, JsonMetadataServices.JsonElementConverter);
-        }
+        public static JsonValue? Create(JsonElement value, JsonNodeOptions? options = null) => JsonValue.CreateFromElement(ref value, options);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -305,22 +295,6 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
-        public static JsonValue? Create(JsonElement? value, JsonNodeOptions? options = null)
-        {
-            if (value == null)
-            {
-                return null;
-            }
-
-            JsonElement element = value.Value;
-            if (element.ValueKind == JsonValueKind.Null)
-            {
-                return null;
-            }
-
-            VerifyJsonElementIsNotArrayOrObject(ref element);
-
-            return new JsonValuePrimitive<JsonElement>(element, JsonMetadataServices.JsonElementConverter);
-        }
+        public static JsonValue? Create(JsonElement? value, JsonNodeOptions? options = null) => value is JsonElement element ? JsonValue.CreateFromElement(ref element, options) : null;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -16,7 +16,24 @@ namespace System.Text.Json.Nodes
         internal const string CreateUnreferencedCodeMessage = "Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed.";
         internal const string CreateDynamicCodeMessage = "Creating JsonValue instances with non-primitive types requires generating code at runtime.";
 
-        private protected JsonValue(JsonNodeOptions? options = null) : base(options) { }
+        private protected JsonValue(JsonNodeOptions? options) : base(options) { }
+
+        /// <summary>
+        ///   Tries to obtain the current JSON value and returns a value that indicates whether the operation succeeded.
+        /// </summary>
+        /// <remarks>
+        ///   {T} can be the type or base type of the underlying value.
+        ///   If the underlying value is a <see cref="JsonElement"/> then {T} can also be the type of any primitive
+        ///   value supported by current <see cref="JsonElement"/>.
+        ///   Specifying the <see cref="object"/> type for {T} will always succeed and return the underlying value as <see cref="object"/>.<br />
+        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is an instance of <see cref="JsonElement"/>,
+        ///   otherwise it's the value specified when the <see cref="JsonValue"/> was created.
+        /// </remarks>
+        /// <seealso cref="JsonNode.GetValue{T}"></seealso>
+        /// <typeparam name="T">The type of value to obtain.</typeparam>
+        /// <param name="value">When this method returns, contains the parsed value.</param>
+        /// <returns><see langword="true"/> if the value can be successfully obtained; otherwise, <see langword="false"/>.</returns>
+        public abstract bool TryGetValue<T>([NotNullWhen(true)] out T? value);
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
@@ -89,29 +106,60 @@ namespace System.Text.Json.Nodes
             return CreateFromTypeInfo(value, jsonTypeInfo, options);
         }
 
+        internal override bool DeepEqualsCore(JsonNode otherNode)
+        {
+            if (GetValueKind() != otherNode.GetValueKind())
+            {
+                return false;
+            }
+
+            // Fall back to slow path that converts the nodes to JsonElement.
+            JsonElement thisElement = ToJsonElement(this, out JsonDocument? thisDocument);
+            JsonElement otherElement = ToJsonElement(otherNode, out JsonDocument? otherDocument);
+            try
+            {
+                return JsonElement.DeepEquals(thisElement, otherElement);
+            }
+            finally
+            {
+                thisDocument?.Dispose();
+                otherDocument?.Dispose();
+            }
+
+            static JsonElement ToJsonElement(JsonNode node, out JsonDocument? backingDocument)
+            {
+                if (node.UnderlyingElement is { } element)
+                {
+                    backingDocument = null;
+                    return element;
+                }
+
+                Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(
+                    options: default,
+                    JsonSerializerOptions.BufferSizeDefault,
+                    out PooledByteBufferWriter output);
+
+                try
+                {
+                    node.WriteTo(writer);
+                    writer.Flush();
+                    Utf8JsonReader reader = new(output.WrittenMemory.Span);
+                    backingDocument = JsonDocument.ParseValue(ref reader);
+                    return backingDocument.RootElement;
+                }
+                finally
+                {
+                    Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, output);
+                }
+            }
+        }
+
         internal sealed override void GetPath(ref ValueStringBuilder path, JsonNode? child)
         {
             Debug.Assert(child == null);
 
             Parent?.GetPath(ref path, this);
         }
-
-        /// <summary>
-        ///   Tries to obtain the current JSON value and returns a value that indicates whether the operation succeeded.
-        /// </summary>
-        /// <remarks>
-        ///   {T} can be the type or base type of the underlying value.
-        ///   If the underlying value is a <see cref="JsonElement"/> then {T} can also be the type of any primitive
-        ///   value supported by current <see cref="JsonElement"/>.
-        ///   Specifying the <see cref="object"/> type for {T} will always succeed and return the underlying value as <see cref="object"/>.<br />
-        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is an instance of <see cref="JsonElement"/>,
-        ///   otherwise it's the value specified when the <see cref="JsonValue"/> was created.
-        /// </remarks>
-        /// <seealso cref="JsonNode.GetValue{T}"></seealso>
-        /// <typeparam name="T">The type of value to obtain.</typeparam>
-        /// <param name="value">When this method returns, contains the parsed value.</param>
-        /// <returns><see langword="true"/> if the value can be successfully obtained; otherwise, <see langword="false"/>.</returns>
-        public abstract bool TryGetValue<T>([NotNullWhen(true)] out T? value);
 
         internal static JsonValue CreateFromTypeInfo<T>(T value, JsonTypeInfo<T> jsonTypeInfo, JsonNodeOptions? options = null)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Nodes
@@ -166,7 +167,9 @@ namespace System.Text.Json.Nodes
             Debug.Assert(jsonTypeInfo.IsConfigured);
             Debug.Assert(value != null);
 
-            if (jsonTypeInfo.EffectiveConverter.IsInternalConverter && JsonValue<T>.TypeIsSupportedPrimitive)
+            if (JsonValue<T>.TypeIsSupportedPrimitive &&
+                jsonTypeInfo is { EffectiveConverter.IsInternalConverter: true } &&
+                (jsonTypeInfo.EffectiveNumberHandling & JsonNumberHandling.WriteAsString) is 0)
             {
                 // If the type is using the built-in converter for a known primitive,
                 // switch to the more efficient JsonValuePrimitive<T> implementation.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfElement.cs
@@ -1,0 +1,232 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.Json.Nodes
+{
+    /// <summary>
+    /// Defines a primitive JSON value that is wrapping a <see cref="JsonElement"/>.
+    /// </summary>
+    internal sealed class JsonValueOfElement : JsonValue<JsonElement>
+    {
+        public JsonValueOfElement(JsonElement value, JsonNodeOptions? options = null) : base(value, options)
+        {
+            Debug.Assert(value.ValueKind is JsonValueKind.False or JsonValueKind.True or JsonValueKind.Number or JsonValueKind.String);
+        }
+
+        private protected override JsonValueKind GetValueKindCore() => Value.ValueKind;
+        internal override JsonNode DeepCloneCore() => new JsonValueOfElement(Value.Clone(), Options);
+
+        internal override bool DeepEqualsCore(JsonNode? otherNode)
+        {
+            if (otherNode is JsonValueOfElement { Value: JsonElement otherElement })
+            {
+                JsonElement thisElement = Value;
+                if (thisElement.ValueKind != otherElement.ValueKind)
+                {
+                    return false;
+                }
+
+                switch (thisElement.ValueKind)
+                {
+                    case JsonValueKind.Null:
+                    case JsonValueKind.True:
+                    case JsonValueKind.False:
+                        return true;
+
+                    case JsonValueKind.String:
+                        if (otherElement.ValueIsEscaped)
+                        {
+                            if (thisElement.ValueIsEscaped)
+                            {
+                                // Both values contain escaping, force an allocation to unescape the RHS.
+                                return thisElement.ValueEquals(otherElement.GetString());
+                            }
+
+                            // Swap values so that unescaping is handled by the LHS.
+                            (thisElement, otherElement) = (otherElement, thisElement);
+                        }
+
+                        return thisElement.ValueEquals(otherElement.ValueSpan);
+
+                    case JsonValueKind.Number:
+                        return thisElement.GetRawValue().Span.SequenceEqual(otherElement.GetRawValue().Span);
+                    default:
+                        Debug.Fail("Object and Array JsonElements cannot be contained in JsonValue.");
+                        break;
+                }
+            }
+
+            return base.DeepEqualsCore(otherNode);
+        }
+
+        public override TypeToConvert GetValue<TypeToConvert>()
+        {
+            if (!TryGetValue(out TypeToConvert? value))
+            {
+                ThrowHelper.ThrowInvalidOperationException_NodeUnableToConvertElement(Value.ValueKind, typeof(TypeToConvert));
+            }
+
+            return value;
+        }
+
+        public override bool TryGetValue<TypeToConvert>([NotNullWhen(true)] out TypeToConvert value)
+        {
+            bool success;
+
+            if (Value is TypeToConvert element)
+            {
+                value = element;
+                return true;
+            }
+
+            switch (Value.ValueKind)
+            {
+                case JsonValueKind.Number:
+                    if (typeof(TypeToConvert) == typeof(int) || typeof(TypeToConvert) == typeof(int?))
+                    {
+                        success = Value.TryGetInt32(out int result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(long) || typeof(TypeToConvert) == typeof(long?))
+                    {
+                        success = Value.TryGetInt64(out long result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(double) || typeof(TypeToConvert) == typeof(double?))
+                    {
+                        success = Value.TryGetDouble(out double result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(short) || typeof(TypeToConvert) == typeof(short?))
+                    {
+                        success = Value.TryGetInt16(out short result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(decimal) || typeof(TypeToConvert) == typeof(decimal?))
+                    {
+                        success = Value.TryGetDecimal(out decimal result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(byte) || typeof(TypeToConvert) == typeof(byte?))
+                    {
+                        success = Value.TryGetByte(out byte result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(float) || typeof(TypeToConvert) == typeof(float?))
+                    {
+                        success = Value.TryGetSingle(out float result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(uint) || typeof(TypeToConvert) == typeof(uint?))
+                    {
+                        success = Value.TryGetUInt32(out uint result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(ushort) || typeof(TypeToConvert) == typeof(ushort?))
+                    {
+                        success = Value.TryGetUInt16(out ushort result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(ulong) || typeof(TypeToConvert) == typeof(ulong?))
+                    {
+                        success = Value.TryGetUInt64(out ulong result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(sbyte) || typeof(TypeToConvert) == typeof(sbyte?))
+                    {
+                        success = Value.TryGetSByte(out sbyte result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+                    break;
+
+                case JsonValueKind.String:
+                    if (typeof(TypeToConvert) == typeof(string))
+                    {
+                        string? result = Value.GetString();
+                        Debug.Assert(result != null);
+                        value = (TypeToConvert)(object)result;
+                        return true;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(DateTime) || typeof(TypeToConvert) == typeof(DateTime?))
+                    {
+                        success = Value.TryGetDateTime(out DateTime result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(DateTimeOffset) || typeof(TypeToConvert) == typeof(DateTimeOffset?))
+                    {
+                        success = Value.TryGetDateTimeOffset(out DateTimeOffset result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(Guid) || typeof(TypeToConvert) == typeof(Guid?))
+                    {
+                        success = Value.TryGetGuid(out Guid result);
+                        value = (TypeToConvert)(object)result;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(char) || typeof(TypeToConvert) == typeof(char?))
+                    {
+                        string? result = Value.GetString();
+                        Debug.Assert(result != null);
+                        if (result.Length == 1)
+                        {
+                            value = (TypeToConvert)(object)result[0];
+                            return true;
+                        }
+                    }
+                    break;
+
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    if (typeof(TypeToConvert) == typeof(bool) || typeof(TypeToConvert) == typeof(bool?))
+                    {
+                        value = (TypeToConvert)(object)Value.GetBoolean();
+                        return true;
+                    }
+                    break;
+            }
+
+            value = default!;
+            return false;
+        }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)
+        {
+            if (writer is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(writer));
+            }
+
+            Value.WriteTo(writer);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
@@ -16,12 +16,7 @@ namespace System.Text.Json.Nodes
         {
             Debug.Assert(value != null);
             Debug.Assert(value is not JsonElement or JsonElement { ValueKind: not JsonValueKind.Null });
-
-            if (value is JsonNode)
-            {
-                ThrowHelper.ThrowArgumentException_NodeValueNotAllowed(nameof(value));
-            }
-
+            Debug.Assert(value is not JsonNode);
             Value = value;
         }
 
@@ -33,15 +28,11 @@ namespace System.Text.Json.Nodes
                 return returnValue;
             }
 
-            if (Value is JsonElement)
-            {
-                return ConvertJsonElement<T>();
-            }
-
             // Currently we do not support other conversions.
             // Generics (and also boxing) do not support standard cast operators say from 'long' to 'int',
             //  so attempting to cast here would throw InvalidCastException.
-            throw new InvalidOperationException(SR.Format(SR.NodeUnableToConvert, Value!.GetType(), typeof(T)));
+            ThrowHelper.ThrowInvalidOperationException_NodeUnableToConvert(typeof(TValue), typeof(T));
+            return default!;
         }
 
         public override bool TryGetValue<T>([NotNullWhen(true)] out T value)
@@ -53,11 +44,6 @@ namespace System.Text.Json.Nodes
                 return true;
             }
 
-            if (Value is JsonElement)
-            {
-                return TryConvertJsonElement<T>(out value);
-            }
-
             // Currently we do not support other conversions.
             // Generics (and also boxing) do not support standard cast operators say from 'long' to 'int',
             //  so attempting to cast here would throw InvalidCastException.
@@ -65,57 +51,20 @@ namespace System.Text.Json.Nodes
             return false;
         }
 
-        private protected sealed override JsonValueKind GetValueKindCore()
-        {
-            if (Value is JsonElement element)
-            {
-                return element.ValueKind;
-            }
-
-            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(default, JsonSerializerOptions.BufferSizeDefault, out PooledByteBufferWriter output);
-            try
-            {
-                WriteTo(writer);
-                writer.Flush();
-                return JsonElement.ParseValue(output.WrittenMemory.Span, options: default).ValueKind;
-            }
-            finally
-            {
-                Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, output);
-            }
-        }
-
-        internal sealed override bool DeepEqualsCore(JsonNode? otherNode)
+        internal override bool DeepEqualsCore(JsonNode? otherNode)
         {
             if (otherNode is null)
             {
                 return false;
             }
 
-            if (Value is JsonElement thisElement && otherNode is JsonValue<JsonElement> { Value: JsonElement otherElement })
+            if (GetValueKind() != otherNode.GetValueKind())
             {
-                if (thisElement.ValueKind != otherElement.ValueKind)
-                {
-                    return false;
-                }
-
-                switch (thisElement.ValueKind)
-                {
-                    case JsonValueKind.Null:
-                    case JsonValueKind.True:
-                    case JsonValueKind.False:
-                        return true;
-
-                    case JsonValueKind.String:
-                        return thisElement.ValueEquals(otherElement.GetString());
-                    case JsonValueKind.Number:
-                        return thisElement.GetRawValue().Span.SequenceEqual(otherElement.GetRawValue().Span);
-                    default:
-                        Debug.Fail("Object and Array JsonElements cannot be contained in JsonValue.");
-                        return false;
-                }
+                return false;
             }
 
+            // Fall back to slow path equality comparison:
+            // Serialize both nodes and compare the resulting JSON.
             using PooledByteBufferWriter thisOutput = WriteToPooledBuffer(this);
             using PooledByteBufferWriter otherOutput = WriteToPooledBuffer(otherNode);
             return thisOutput.WrittenMemory.Span.SequenceEqual(otherOutput.WrittenMemory.Span);
@@ -129,260 +78,62 @@ namespace System.Text.Json.Nodes
                 var bufferWriter = new PooledByteBufferWriter(bufferSize);
                 using var writer = new Utf8JsonWriter(bufferWriter, writerOptions);
                 node.WriteTo(writer, options);
+                writer.Flush();
                 return bufferWriter;
             }
         }
 
-        internal TypeToConvert ConvertJsonElement<TypeToConvert>()
+        /// <summary>
+        /// Whether <typeparamref name="TValue"/> is a built-in type that admits primitive JsonValue representation.
+        /// </summary>
+        internal static bool TypeIsSupportedPrimitive => s_valueKind.HasValue;
+        private static readonly JsonValueKind? s_valueKind = DetermineValueKindForType(typeof(TValue));
+
+        /// <summary>
+        /// Determines the JsonValueKind for the value of a built-in type.
+        /// </summary>
+        private protected static JsonValueKind DetermineValueKind(TValue value)
         {
-            JsonElement element = (JsonElement)(object)Value!;
+            Debug.Assert(s_valueKind is not null, "Should only be invoked for types that are supported primitives.");
 
-            switch (element.ValueKind)
+            if (value is bool boolean)
             {
-                case JsonValueKind.Number:
-                    if (typeof(TypeToConvert) == typeof(int) || typeof(TypeToConvert) == typeof(int?))
-                    {
-                        return (TypeToConvert)(object)element.GetInt32();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(long) || typeof(TypeToConvert) == typeof(long?))
-                    {
-                        return (TypeToConvert)(object)element.GetInt64();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(double) || typeof(TypeToConvert) == typeof(double?))
-                    {
-                        return (TypeToConvert)(object)element.GetDouble();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(short) || typeof(TypeToConvert) == typeof(short?))
-                    {
-                        return (TypeToConvert)(object)element.GetInt16();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(decimal) || typeof(TypeToConvert) == typeof(decimal?))
-                    {
-                        return (TypeToConvert)(object)element.GetDecimal();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(byte) || typeof(TypeToConvert) == typeof(byte?))
-                    {
-                        return (TypeToConvert)(object)element.GetByte();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(float) || typeof(TypeToConvert) == typeof(float?))
-                    {
-                        return (TypeToConvert)(object)element.GetSingle();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(uint) || typeof(TypeToConvert) == typeof(uint?))
-                    {
-                        return (TypeToConvert)(object)element.GetUInt32();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(ushort) || typeof(TypeToConvert) == typeof(ushort?))
-                    {
-                        return (TypeToConvert)(object)element.GetUInt16();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(ulong) || typeof(TypeToConvert) == typeof(ulong?))
-                    {
-                        return (TypeToConvert)(object)element.GetUInt64();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(sbyte) || typeof(TypeToConvert) == typeof(sbyte?))
-                    {
-                        return (TypeToConvert)(object)element.GetSByte();
-                    }
-                    break;
-
-                case JsonValueKind.String:
-                    if (typeof(TypeToConvert) == typeof(string))
-                    {
-                        return (TypeToConvert)(object)element.GetString()!;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(DateTime) || typeof(TypeToConvert) == typeof(DateTime?))
-                    {
-                        return (TypeToConvert)(object)element.GetDateTime();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(DateTimeOffset) || typeof(TypeToConvert) == typeof(DateTimeOffset?))
-                    {
-                        return (TypeToConvert)(object)element.GetDateTimeOffset();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(Guid) || typeof(TypeToConvert) == typeof(Guid?))
-                    {
-                        return (TypeToConvert)(object)element.GetGuid();
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(char) || typeof(TypeToConvert) == typeof(char?))
-                    {
-                        string? str = element.GetString();
-                        Debug.Assert(str != null);
-                        if (str.Length == 1)
-                        {
-                            return (TypeToConvert)(object)str[0];
-                        }
-                    }
-                    break;
-
-                case JsonValueKind.True:
-                case JsonValueKind.False:
-                    if (typeof(TypeToConvert) == typeof(bool) || typeof(TypeToConvert) == typeof(bool?))
-                    {
-                        return (TypeToConvert)(object)element.GetBoolean();
-                    }
-                    break;
+                // Boolean requires special handling since kind varies by value.
+                return boolean ? JsonValueKind.True : JsonValueKind.False;
             }
 
-            throw new InvalidOperationException(SR.Format(SR.NodeUnableToConvertElement,
-                element.ValueKind,
-                typeof(TypeToConvert)));
+            return s_valueKind.Value;
         }
 
-        internal bool TryConvertJsonElement<TypeToConvert>([NotNullWhen(true)] out TypeToConvert result)
+        /// <summary>
+        /// Precomputes the JsonValueKind for a given built-in type where possible.
+        /// </summary>
+        private static JsonValueKind? DetermineValueKindForType(Type type)
         {
-            bool success;
-
-            JsonElement element = (JsonElement)(object)Value!;
-
-            switch (element.ValueKind)
+            if (type == typeof(Guid) || type == typeof(DateTimeOffset))
             {
-                case JsonValueKind.Number:
-                    if (typeof(TypeToConvert) == typeof(int) || typeof(TypeToConvert) == typeof(int?))
-                    {
-                        success = element.TryGetInt32(out int value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(long) || typeof(TypeToConvert) == typeof(long?))
-                    {
-                        success = element.TryGetInt64(out long value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(double) || typeof(TypeToConvert) == typeof(double?))
-                    {
-                        success = element.TryGetDouble(out double value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(short) || typeof(TypeToConvert) == typeof(short?))
-                    {
-                        success = element.TryGetInt16(out short value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(decimal) || typeof(TypeToConvert) == typeof(decimal?))
-                    {
-                        success = element.TryGetDecimal(out decimal value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(byte) || typeof(TypeToConvert) == typeof(byte?))
-                    {
-                        success = element.TryGetByte(out byte value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(float) || typeof(TypeToConvert) == typeof(float?))
-                    {
-                        success = element.TryGetSingle(out float value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(uint) || typeof(TypeToConvert) == typeof(uint?))
-                    {
-                        success = element.TryGetUInt32(out uint value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(ushort) || typeof(TypeToConvert) == typeof(ushort?))
-                    {
-                        success = element.TryGetUInt16(out ushort value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(ulong) || typeof(TypeToConvert) == typeof(ulong?))
-                    {
-                        success = element.TryGetUInt64(out ulong value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(sbyte) || typeof(TypeToConvert) == typeof(sbyte?))
-                    {
-                        success = element.TryGetSByte(out sbyte value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-                    break;
-
-                case JsonValueKind.String:
-                    if (typeof(TypeToConvert) == typeof(string))
-                    {
-                        string? strResult = element.GetString();
-                        Debug.Assert(strResult != null);
-                        result = (TypeToConvert)(object)strResult;
-                        return true;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(DateTime) || typeof(TypeToConvert) == typeof(DateTime?))
-                    {
-                        success = element.TryGetDateTime(out DateTime value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(DateTimeOffset) || typeof(TypeToConvert) == typeof(DateTimeOffset?))
-                    {
-                        success = element.TryGetDateTimeOffset(out DateTimeOffset value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(Guid) || typeof(TypeToConvert) == typeof(Guid?))
-                    {
-                        success = element.TryGetGuid(out Guid value);
-                        result = (TypeToConvert)(object)value;
-                        return success;
-                    }
-
-                    if (typeof(TypeToConvert) == typeof(char) || typeof(TypeToConvert) == typeof(char?))
-                    {
-                        string? str = element.GetString();
-                        Debug.Assert(str != null);
-                        if (str.Length == 1)
-                        {
-                            result = (TypeToConvert)(object)str[0];
-                            return true;
-                        }
-                    }
-                    break;
-
-                case JsonValueKind.True:
-                case JsonValueKind.False:
-                    if (typeof(TypeToConvert) == typeof(bool) || typeof(TypeToConvert) == typeof(bool?))
-                    {
-                        result = (TypeToConvert)(object)element.GetBoolean();
-                        return true;
-                    }
-                    break;
+                return JsonValueKind.String;
             }
 
-            result = default!;
-            return false;
+            return Type.GetTypeCode(type) switch
+            {
+                TypeCode.Boolean => JsonValueKind.Undefined, // Can vary dependending on value.
+                TypeCode.SByte => JsonValueKind.Number,
+                TypeCode.Byte => JsonValueKind.Number,
+                TypeCode.Int16 => JsonValueKind.Number,
+                TypeCode.UInt16 => JsonValueKind.Number,
+                TypeCode.Int32 => JsonValueKind.Number,
+                TypeCode.UInt32 => JsonValueKind.Number,
+                TypeCode.Int64 => JsonValueKind.Number,
+                TypeCode.UInt64 => JsonValueKind.Number,
+                TypeCode.Single => JsonValueKind.Number,
+                TypeCode.Double => JsonValueKind.Number,
+                TypeCode.Decimal => JsonValueKind.Number,
+                TypeCode.String => JsonValueKind.String,
+                TypeCode.DateTime => JsonValueKind.String,
+                TypeCode.Char => JsonValueKind.String,
+                _ => null,
+            };
         }
 
         [ExcludeFromCodeCoverage] // Justification = "Design-time"

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Nodes
 {
@@ -12,15 +12,32 @@ namespace System.Text.Json.Nodes
     /// </summary>
     internal sealed class JsonValuePrimitive<TValue> : JsonValue<TValue>
     {
-        // Default value used when calling into the converter.
-        private static readonly JsonSerializerOptions s_defaultOptions = new();
-
         private readonly JsonConverter<TValue> _converter;
+        private readonly JsonValueKind _valueKind;
 
         public JsonValuePrimitive(TValue value, JsonConverter<TValue> converter, JsonNodeOptions? options = null) : base(value, options)
         {
+            Debug.Assert(typeof(IEquatable<TValue>).IsAssignableFrom(typeof(TValue)), $"{typeof(TValue)} is not equatable.");
+            Debug.Assert(TypeIsSupportedPrimitive, $"The type {typeof(TValue)} is not a supported primitive.");
             Debug.Assert(converter is { IsInternalConverter: true, ConverterStrategy: ConverterStrategy.Value });
+
             _converter = converter;
+            _valueKind = DetermineValueKind(value);
+        }
+
+        private protected override JsonValueKind GetValueKindCore() => _valueKind;
+        internal override JsonNode DeepCloneCore() => new JsonValuePrimitive<TValue>(Value, _converter, Options);
+
+        internal override bool DeepEqualsCore(JsonNode? otherNode)
+        {
+            if (otherNode is JsonValue otherValue && otherValue.TryGetValue(out TValue? v))
+            {
+                // Because TValue is equatable and otherNode returns a matching
+                // type we can short circuit the comparison in this case.
+                return EqualityComparer<TValue>.Default.Equals(Value, v);
+            }
+
+            return base.DeepEqualsCore(otherNode);
         }
 
         public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)
@@ -41,15 +58,6 @@ namespace System.Text.Json.Nodes
             {
                 converter.Write(writer, Value, options);
             }
-        }
-
-        internal override JsonNode DeepCloneCore()
-        {
-            // Primitive JsonValue's are generally speaking immutable so we don't need to do much here.
-            // For the case of JsonElement clone the instance since it could be backed by pooled buffers.
-            return Value is JsonElement element
-                ? new JsonValuePrimitive<JsonElement>(element.Clone(), JsonMetadataServices.JsonElementConverter, Options)
-                : new JsonValuePrimitive<TValue>(Value, _converter, Options);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
@@ -15,9 +15,8 @@ namespace System.Text.Json.Nodes
         private readonly JsonConverter<TValue> _converter;
         private readonly JsonValueKind _valueKind;
 
-        public JsonValuePrimitive(TValue value, JsonConverter<TValue> converter, JsonNodeOptions? options = null) : base(value, options)
+        public JsonValuePrimitive(TValue value, JsonConverter<TValue> converter, JsonNodeOptions? options) : base(value, options)
         {
-            Debug.Assert(typeof(IEquatable<TValue>).IsAssignableFrom(typeof(TValue)), $"{typeof(TValue)} is not equatable.");
             Debug.Assert(TypeIsSupportedPrimitive, $"The type {typeof(TValue)} is not a supported primitive.");
             Debug.Assert(converter is { IsInternalConverter: true, ConverterStrategy: ConverterStrategy.Value });
 
@@ -28,7 +27,7 @@ namespace System.Text.Json.Nodes
         private protected override JsonValueKind GetValueKindCore() => _valueKind;
         internal override JsonNode DeepCloneCore() => new JsonValuePrimitive<TValue>(Value, _converter, Options);
 
-        internal override bool DeepEqualsCore(JsonNode? otherNode)
+        internal override bool DeepEqualsCore(JsonNode otherNode)
         {
             if (otherNode is JsonValue otherValue && otherValue.TryGetValue(out TValue? v))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
@@ -73,7 +73,7 @@ namespace System.Text.Json.Serialization.Converters
                     node = new JsonArray(element, options);
                     break;
                 default:
-                    node = new JsonValuePrimitive<JsonElement>(element, JsonMetadataServices.JsonElementConverter, options);
+                    node = JsonValue.CreateFromElement(ref element, options);
                     break;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
@@ -28,8 +28,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             JsonElement element = JsonElement.ParseValue(ref reader);
-            JsonValue value = new JsonValuePrimitive<JsonElement>(element, JsonMetadataServices.JsonElementConverter, options.GetNodeOptions());
-            return value;
+            return JsonValue.CreateFromElement(ref element, options.GetNodeOptions());
         }
 
         internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
@@ -20,6 +20,7 @@ namespace System.Text.Json.Serialization.Converters
         public NullableConverter(JsonConverter<T> elementConverter)
         {
             _elementConverter = elementConverter;
+            IsInternalConverter = elementConverter.IsInternalConverter;
             IsInternalConverterForNumberType = elementConverter.IsInternalConverterForNumberType;
             ConverterStrategy = elementConverter.ConverterStrategy;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -496,15 +496,7 @@ namespace System.Text.Json
                             return value;
                         }
 
-                        JsonValueKind metadataValueKind = jsonNode switch
-                        {
-                            null => JsonValueKind.Null,
-                            JsonObject => JsonValueKind.Object,
-                            JsonArray => JsonValueKind.Array,
-                            JsonValue<JsonElement> element => element.Value.ValueKind,
-                            _ => JsonValueKind.Undefined,
-                        };
-
+                        JsonValueKind metadataValueKind = jsonNode?.GetValueKind() ?? JsonValueKind.Null;
                         Debug.Assert(metadataValueKind != JsonValueKind.Undefined);
                         ThrowHelper.ThrowJsonException_MetadataValueWasNotString(metadataValueKind);
                         return null!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -505,6 +505,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
+        internal JsonNumberHandling EffectiveNumberHandling => _numberHandling ?? Options.NumberHandling;
         private JsonNumberHandling? _numberHandling;
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
@@ -70,5 +70,17 @@ namespace System.Text.Json
         {
             return new NotSupportedException(SR.CollectionIsReadOnly);
         }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_NodeUnableToConvert(Type sourceType, Type destinationType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.NodeUnableToConvert, sourceType, destinationType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_NodeUnableToConvertElement(JsonValueKind valueKind, Type destinationType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.NodeUnableToConvertElement, valueKind, destinationType));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Xunit;
 
 namespace System.Text.Json.Nodes.Tests
@@ -416,6 +417,20 @@ namespace System.Text.Json.Nodes.Tests
                 JsonValue jsonValue = JsonValue.Create(document.RootElement);
                 Assert.Equal(JsonValueKind.Number, jsonValue.GetValueKind());
             }
+        }
+
+        [Theory]
+        [InlineData(JsonNumberHandling.Strict, JsonValueKind.Number)]
+        [InlineData(JsonNumberHandling.AllowReadingFromString, JsonValueKind.Number)]
+        [InlineData(JsonNumberHandling.AllowNamedFloatingPointLiterals, JsonValueKind.Number)]
+        [InlineData(JsonNumberHandling.WriteAsString, JsonValueKind.String)]
+        [InlineData(JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowNamedFloatingPointLiterals, JsonValueKind.String)]
+        public static void GetValueKind_NumberHandling(JsonNumberHandling numberHandling, JsonValueKind expectedKind)
+        {
+            JsonSerializerOptions options = new(JsonSerializerOptions.Default) { NumberHandling = numberHandling };
+            JsonTypeInfo<int> typeInfo = (JsonTypeInfo<int>)options.GetTypeInfo(typeof(int));
+            JsonValue value = JsonValue.Create(42, typeInfo);
+            Assert.Equal(expectedKind, value.GetValueKind());
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -1,9 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text.Json.Serialization;
-using System.Xml.Linq;
 using Xunit;
 
 namespace System.Text.Json.Nodes.Tests
@@ -429,6 +430,88 @@ namespace System.Text.Json.Nodes.Tests
         {
             public int Id { get; set; }
             public string? Name { get; set; }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPrimitiveTypes))]
+        public static void PrimitiveTypes_ReturnExpectedTypeKind<T>(T value, JsonValueKind expectedKind)
+        {
+            JsonNode node = JsonValue.Create(value);
+            Assert.Equal(expectedKind, node.GetValueKind());
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPrimitiveTypes))]
+        public static void PrimitiveTypes_EqualThemselves<T>(T value, JsonValueKind _)
+        {
+            JsonNode node = JsonValue.Create(value);
+            Assert.True(JsonNode.DeepEquals(node, node));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPrimitiveTypes))]
+        public static void PrimitiveTypes_EqualClonedValue<T>(T value, JsonValueKind _)
+        {
+            JsonNode node = JsonValue.Create(value);
+            JsonNode clone = node.DeepClone();
+
+            Assert.True(JsonNode.DeepEquals(clone, clone));
+            Assert.True(JsonNode.DeepEquals(node, clone));
+            Assert.True(JsonNode.DeepEquals(clone, node));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPrimitiveTypes))]
+        public static void PrimitiveTypes_EqualDeserializedValue<T>(T value, JsonValueKind _)
+        {
+            JsonNode node = JsonValue.Create(value);
+            JsonNode clone = JsonSerializer.Deserialize<JsonNode>(node.ToJsonString());
+
+            Assert.True(JsonNode.DeepEquals(clone, clone));
+            Assert.True(JsonNode.DeepEquals(node, clone));
+            Assert.True(JsonNode.DeepEquals(clone, node));
+        }
+
+        public static IEnumerable<object[]> GetPrimitiveTypes()
+        {
+            yield return Wrap(false, JsonValueKind.False);
+            yield return Wrap(true, JsonValueKind.True);
+            yield return Wrap((bool?)false, JsonValueKind.False);
+            yield return Wrap((bool?)true, JsonValueKind.True);
+            yield return Wrap((byte)42, JsonValueKind.Number);
+            yield return Wrap((sbyte)42, JsonValueKind.Number);
+            yield return Wrap((short)42, JsonValueKind.Number);
+            yield return Wrap((ushort)42, JsonValueKind.Number);
+            yield return Wrap(42, JsonValueKind.Number);
+            yield return Wrap((int?)42, JsonValueKind.Number);
+            yield return Wrap((uint)42, JsonValueKind.Number);
+            yield return Wrap((long)42, JsonValueKind.Number);
+            yield return Wrap((ulong)42, JsonValueKind.Number);
+            yield return Wrap(42.0f, JsonValueKind.Number);
+            yield return Wrap(42.0, JsonValueKind.Number);
+            yield return Wrap(42.0m, JsonValueKind.Number);
+            yield return Wrap('A', JsonValueKind.String);
+            yield return Wrap((char?)'A', JsonValueKind.String);
+            yield return Wrap("A", JsonValueKind.String);
+            yield return Wrap(new byte[] { 1, 2, 3 }, JsonValueKind.String);
+            yield return Wrap(new DateTimeOffset(2024, 06, 20, 10, 29, 0, TimeSpan.Zero), JsonValueKind.String);
+            yield return Wrap(new DateTime(2024, 06, 20, 10, 29, 0), JsonValueKind.String);
+            yield return Wrap(Guid.Empty, JsonValueKind.String);
+            yield return Wrap((Guid?)Guid.Empty, JsonValueKind.String);
+            yield return Wrap(new Uri("http://example.com"), JsonValueKind.String);
+            yield return Wrap(new Version(1, 2, 3, 4), JsonValueKind.String);
+            yield return Wrap(BindingFlags.Public, JsonValueKind.Number);
+            yield return Wrap((BindingFlags?)BindingFlags.Public, JsonValueKind.Number);
+#if NET
+            yield return Wrap(Half.MaxValue, JsonValueKind.Number);
+            yield return Wrap((Int128)42, JsonValueKind.Number);
+            yield return Wrap((Int128)42, JsonValueKind.Number);
+            yield return Wrap((Memory<byte>)new byte[] { 1, 2, 3 }, JsonValueKind.String);
+            yield return Wrap((ReadOnlyMemory<byte>)new byte[] { 1, 2, 3 }, JsonValueKind.String);
+            yield return Wrap(new DateOnly(2024, 06, 20), JsonValueKind.String);
+            yield return Wrap(new TimeOnly(10, 29), JsonValueKind.String);
+#endif
+            static object[] Wrap<T>(T value, JsonValueKind expectedKind) => [value, expectedKind];
         }
     }
 }


### PR DESCRIPTION
One of the oddities of `JsonNode` design is that it permits encapsulation of arbitrary .NET objects via the `JsonValue` type. This is known to create performance problems since it's not possible to introspect `JsonValue` instances without serializing and deserializing the underlying object first. The problem is fairly pervasive since JSON primitives such as boolean, numbers and strings are all represented using `JsonValue`.

This PR refactors the implementation of `JsonValue` so that common primitive types and deserialized values backed by `JsonElement` are fully segregated from the implementation that admits arbitrary objects. Consequently this change records [substantial performance improvements](https://gist.github.com/eiriktsarpalis/38cf615c15b2c414b1611fa6ae58cff1):

| Method                   | Branch | Mean         | Ratio | Allocated | Alloc Ratio |
|------------------------- |------- |-------------:|------:|----------:|------------:|
| DeepEquals               | main   | 2,859.165 ns |  1.00 |    4224 B |        1.00 |
| DeepEquals               | PR     |   270.130 ns |  0.09 |         - |        0.00 |
|                          |        |              |       |           |             |
| DeepEquals_JsonElement   | main   |   660.551 ns |  1.00 |     328 B |        1.00 |
| DeepEquals_JsonElement   | PR     |   432.391 ns |  0.65 |         - |        0.00 |
|                          |        |              |       |           |             |
| GetValueKind             | main   |   612.784 ns | 1.000 |     616 B |        1.00 |
| GetValueKind             | PR     |     5.243 ns | 0.009 |         - |        0.00 |
|                          |        |              |       |           |             |
| GetValueKind_JsonElement | main   |    15.557 ns |  1.00 |         - |          NA |
| GetValueKind_JsonElement | PR     |    11.111 ns |  0.71 |         - |          NA |