### PR TITLE
Make GC stress usable with Libraries tests

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49322,10 +49322,10 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
 
         int rgen = StressRNG(100);
 
-        // gen0:gen1:gen2 distribution: 80:15:5
-        if (rgen >= 95)
+        // gen0:gen1:gen2 distribution: 90:8:2
+        if (rgen >= 98)
             rgen = 2;
-        else if (rgen >= 80)
+        else if (rgen >= 90)
             rgen = 1;
         else
             rgen = 0;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49310,7 +49310,29 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
     }
     Interlocked::Decrement(&OneAtATime);
 #endif // !MULTIPLE_HEAPS
-    if (IsConcurrentGCEnabled())
+
+    if (g_pConfig->GetGCStressLevel() & EEConfig::GCSTRESS_INSTR_JIT)
+    {
+        // When GCSTRESS_INSTR_JIT is set we see lots of GCs - on every GC-eligible instruction.
+        // We do not want all these GC to be gen2 because:
+        // - doing only or mostly gen2 is very expensive in this mode
+        // - doing only or mostly gen2 prevents coverage of generation-aware behaviors
+        // - the main value of this stress mode is to catch stack scanning issues at various/rare locations
+        //    in the code and gen2 is not needed for that.
+
+        int rgen = StressRNG(100);
+
+        // gen0:gen1:gen2 distribution: 80:15:5
+        if (rgen >= 95)
+            rgen = 2;
+        else if (rgen >= 80)
+            rgen = 1;
+        else
+            rgen = 0;
+
+        GarbageCollectTry (rgen, FALSE, collection_gcstress);
+    }
+    else if (IsConcurrentGCEnabled())
     {
         int rgen = StressRNG(10);
 
@@ -49319,7 +49341,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
             rgen = 2;
         else if (rgen >= 4)
             rgen = 1;
-    else
+        else
             rgen = 0;
 
         GarbageCollectTry (rgen, FALSE, collection_gcstress);

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -27,7 +27,7 @@ using namespace clr;
 // is relied on by the EH code and the JIT code (for handling patched
 // managed code, and GC stress exception) after GC stress is dynamically
 // turned off.
-Volatile<DWORD> GCStressPolicy::InhibitHolder::s_nGcStressDisabled = 0;
+int GCStressPolicy::InhibitHolder::s_nGcStressDisabled = 0;
 #endif // STRESS_HEAP
 
 /**************************************************************/

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -569,6 +569,16 @@ void FinalizerThread::FinalizerThreadWait()
 
         EnableFinalization();
 
-        hEventFinalizerDone->Wait(INFINITE,TRUE);
+        // Under GC stress the finalizer queue may never go empty as frequent
+        // GCs will keep filling up the queue with items.
+        // We will disable GC stress to make sure the current thread is not permanently blocked on that.
+        GCStressPolicy::InhibitHolder iholder;
+
+        //----------------------------------------------------
+        // Do appropriate wait and pump messages if necessary
+        //----------------------------------------------------
+
+        DWORD status = hEventFinalizerDone->Wait(INFINITE,TRUE);
+        _ASSERTE(status == WAIT_OBJECT_0);
     }
 }

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -578,7 +578,8 @@ void FinalizerThread::FinalizerThreadWait()
         // Do appropriate wait and pump messages if necessary
         //----------------------------------------------------
 
-        DWORD status = hEventFinalizerDone->Wait(INFINITE,TRUE);
+        DWORD status;
+        status = hEventFinalizerDone->Wait(INFINITE,TRUE);
         _ASSERTE(status == WAIT_OBJECT_0);
     }
 }

--- a/src/coreclr/vm/gccover.cpp
+++ b/src/coreclr/vm/gccover.cpp
@@ -1417,16 +1417,9 @@ BOOL OnGcCoverageInterrupt(PCONTEXT regs)
         RemoveGcCoverageInterrupt(instrPtr, savedInstrPtr, gcCover, offset);
         return TRUE;
     }
-
-    // If the thread is in preemptive mode then we must be in a
-    // PInvoke stub, a method that has an inline PInvoke frame,
-    // or be in a reverse PInvoke stub that's about to return.
-    //
-    // The PInvoke cases should should properly report GC refs if we
-    // trigger GC here. But a reverse PInvoke stub may over-report
-    // leading to spurious failures, as we would not normally report
-    // anything for this method at this point.
-    if (!pThread->PreemptiveGCDisabled() && pMD->HasUnmanagedCallersOnlyAttribute())
+    
+    // The thread is in preemptive mode. Normally, it should not be able to trigger GC.
+    if (!pThread->PreemptiveGCDisabled())
     {
         RemoveGcCoverageInterrupt(instrPtr, savedInstrPtr, gcCover, offset);
         return TRUE;

--- a/src/coreclr/vm/gcstress.h
+++ b/src/coreclr/vm/gcstress.h
@@ -80,9 +80,9 @@ namespace GCStressPolicy
 
         FORCEINLINE static void Enable()
         {
-            int newVal = Interlocked::Decrement(&InhibitHolder::s_nGcStressDisabled);
+            int newVal;
+            newVal = Interlocked::Decrement(&InhibitHolder::s_nGcStressDisabled);
             _ASSERTE(newVal >= 0);
-            __UNUSED(newVal);
         }
 
     public:

--- a/src/coreclr/vm/gcstress.h
+++ b/src/coreclr/vm/gcstress.h
@@ -82,6 +82,7 @@ namespace GCStressPolicy
         {
             int newVal = Interlocked::Decrement(&InhibitHolder::s_nGcStressDisabled);
             _ASSERTE(newVal >= 0);
+            __UNUSED(newVal);
         }
 
     public:

--- a/src/coreclr/vm/gcstress.h
+++ b/src/coreclr/vm/gcstress.h
@@ -90,7 +90,7 @@ namespace GCStressPolicy
     } UNUSED_ATTR;
 
     FORCEINLINE bool IsEnabled()
-    { return Interlocked::ExchangeAdd(&InhibitHolder::s_nGcStressDisabled, 0) == 0; }
+    { return VolatileLoadWithoutBarrier(&InhibitHolder::s_nGcStressDisabled) == 0; }
 
     FORCEINLINE void GlobalDisable()
     { Interlocked::Increment(&InhibitHolder::s_nGcStressDisabled); }

--- a/src/tests/baseservices/RuntimeConfiguration/TestConfigTester.csproj
+++ b/src/tests/baseservices/RuntimeConfiguration/TestConfigTester.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for GCStressIncompatible and others -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/101150

Also useful to investigate failures like: https://github.com/dotnet/runtime/issues/102919

- Speed up GC stress with GCSTRESS_INSTR_JIT
- Disable GC stress when WaitForPendingFinalizers is in progress
- Do not initiate GC stress when thread is in preemptive mode
