### PR TITLE
ILCompiler: don't strip debug info from 'ilc' during source-build.

### DIFF
--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -6,7 +6,7 @@
     <OptimizationPreference>Speed</OptimizationPreference>
     <ControlFlowGuard>Guard</ControlFlowGuard>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <StripSymbols Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(KeepNativeSymbols)' == 'true'">false</StripSymbols>
+    <StripSymbols Condition="'$(KeepNativeSymbols)' == 'true'">false</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -6,6 +6,7 @@
     <OptimizationPreference>Speed</OptimizationPreference>
     <ControlFlowGuard>Guard</ControlFlowGuard>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <StripSymbols Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(KeepNativeSymbols)' == 'true'">false</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -16,7 +16,6 @@
     <!-- Disable native AOT on FreeBSD when cross building from Linux. -->
     <NativeAotSupported Condition="'$(TargetOS)' == 'freebsd' and '$(CrossBuild)' == 'true'">false</NativeAotSupported>
     <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
-    <StripSymbols Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(KeepNativeSymbols)' == 'true'">false</StripSymbols>
     <SysRoot Condition="'$(NativeAotSupported)' == 'true' and '$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
     <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -16,6 +16,7 @@
     <!-- Disable native AOT on FreeBSD when cross building from Linux. -->
     <NativeAotSupported Condition="'$(TargetOS)' == 'freebsd' and '$(CrossBuild)' == 'true'">false</NativeAotSupported>
     <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
+    <StripSymbols Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(KeepNativeSymbols)' == 'true'">false</StripSymbols>
     <SysRoot Condition="'$(NativeAotSupported)' == 'true' and '$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
     <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>


### PR DESCRIPTION
@jkotas ptal.

cc @omajid @ViktorHofer