### PR TITLE
JIT: Token based named intrinsic lookup

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1834,6 +1834,8 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
     info.compClassName  = eeGetClassName(info.compClassHnd);
     info.compFullName   = eeGetMethodFullName(methodHnd);
 
+    m_scopeToIntrinsicLookupMap = nullptr;
+
     info.compMethodSuperPMIIndex = g_jitHost->getIntConfigValue(W("SuperPMIMethodContextNumber"), -1);
 
     if (!compIsForInlining())

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4831,6 +4831,28 @@ private:
     bool impIsThis(GenTree* obj);
 
     void impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call);
+    
+    typedef JitHashTable<mdMethodDef, JitSmallPrimitiveKeyFuncs<mdMethodDef>, NamedIntrinsic> MethodTokenToNamedIntrinsicMap;
+    typedef JitHashTable<CORINFO_MODULE_HANDLE, JitPtrKeyFuncs<CORINFO_MODULE_STRUCT_>, MethodTokenToNamedIntrinsicMap*> ScopeToIntrinsicLookupMap;
+
+    ScopeToIntrinsicLookupMap* m_scopeToIntrinsicLookupMap;
+
+    MethodTokenToNamedIntrinsicMap* GetMethodTokenToNamedIntrinsicMap()
+    {
+        if (m_scopeToIntrinsicLookupMap == nullptr)
+        {
+            m_scopeToIntrinsicLookupMap = new (getAllocator()) ScopeToIntrinsicLookupMap(getAllocator());
+        }
+
+        MethodTokenToNamedIntrinsicMap* methodTokenToNamedIntrinsicMap = nullptr;
+        if (!m_scopeToIntrinsicLookupMap->Lookup(info.compScopeHnd, &methodTokenToNamedIntrinsicMap))
+        {
+            methodTokenToNamedIntrinsicMap = new (getAllocator()) MethodTokenToNamedIntrinsicMap(getAllocator());
+            m_scopeToIntrinsicLookupMap->Set(info.compScopeHnd, methodTokenToNamedIntrinsicMap);
+        }
+
+        return methodTokenToNamedIntrinsicMap;
+    }
 
 public:
     static bool impCheckImplicitArgumentCoercion(var_types sigType, var_types nodeType);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -9759,7 +9759,7 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     const char* methodName =
         info.compCompHnd->getMethodNameFromMetadata(method, &className, &namespaceName, &enclosingClassName);
 
-    const mdMethodDef mdToken = info.compCompHnd->getMethodDefFromMethod(method);
+    const mdMethodDef tkMethod = info.compCompHnd->getMethodDefFromMethod(method);
 
     JITDUMP("Named Intrinsic ");
 
@@ -9808,9 +9808,9 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     NamedIntrinsic result = NI_Illegal;
 
     MethodTokenToNamedIntrinsicMap* methodTokenToNamedIntrinsicMap = GetMethodTokenToNamedIntrinsicMap();
-    if (!IsNilToken(mdToken) && methodTokenToNamedIntrinsicMap->Lookup(mdToken, &result))
+    if (!IsNilToken(tkMethod) && methodTokenToNamedIntrinsicMap->Lookup(tkMethod, &result))
     {
-        JITDUMP("Recognized - method = 0x%x, scope = 0x%llx\n", mdToken, reinterpret_cast<INT64>(info.compScopeHnd));
+        JITDUMP("Recognized - method = 0x%x, scope = 0x%llx\n", tkMethod, reinterpret_cast<INT64>(info.compScopeHnd));
         return result;
     }
 
@@ -10586,8 +10586,8 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     }
     else
     {
-        _ASSERTE(!IsNilToken(mdToken));
-        methodTokenToNamedIntrinsicMap->Set(mdToken, result);
+        _ASSERTE(!IsNilToken(tkMethod));
+        methodTokenToNamedIntrinsicMap->Set(tkMethod, result);
         JITDUMP("Recognized\n");
     }
     return result;

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -9759,6 +9759,8 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     const char* methodName =
         info.compCompHnd->getMethodNameFromMetadata(method, &className, &namespaceName, &enclosingClassName);
 
+    const mdMethodDef mdToken = info.compCompHnd->getMethodDefFromMethod(method);
+
     JITDUMP("Named Intrinsic ");
 
     if (namespaceName != nullptr)
@@ -9804,6 +9806,13 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     JITDUMP(": ");
 
     NamedIntrinsic result = NI_Illegal;
+
+    MethodTokenToNamedIntrinsicMap* methodTokenToNamedIntrinsicMap = GetMethodTokenToNamedIntrinsicMap();
+    if (!IsNilToken(mdToken) && methodTokenToNamedIntrinsicMap->Lookup(mdToken, &result))
+    {
+        JITDUMP("Recognized - method = 0x%x, scope = 0x%llx\n", mdToken, reinterpret_cast<INT64>(info.compScopeHnd));
+        return result;
+    }
 
     if (strncmp(namespaceName, "System", 6) == 0)
     {
@@ -10577,6 +10586,8 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     }
     else
     {
+        _ASSERTE(!IsNilToken(mdToken));
+        methodTokenToNamedIntrinsicMap->Set(mdToken, result);
         JITDUMP("Recognized\n");
     }
     return result;


### PR DESCRIPTION
Adding a lookup map to serve as cache while doing named intrinsic lookup, so that we only need to do `strcmp` when we see a new named intrinsic for the first time.

Save ~318 times of string comparisons due to named intrinsic lookup for a simple hello world program. 
