### PR TITLE
JIT: rely on DFS for cycle entry detection in optRemoveRedundantZeroInits

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5925,9 +5925,11 @@ void Compiler::optRemoveRedundantZeroInits()
             // See if this block is a cycle entry
             //
             bool stop = false;
-            for (BasicBlock* const pred : block->PredBlocks())
+            for (FlowEdge* predEdge = BlockPredsWithEH(block); predEdge != nullptr;
+                 predEdge           = predEdge->getNextPredEdge())
             {
-                if (m_dfsTree->IsAncestor(block, pred))
+                BasicBlock* const predBlock = predEdge->getSourceBlock();
+                if (m_dfsTree->IsAncestor(block, predBlock))
                 {
                     JITDUMP(FMT_BB " is part of a cycle, stopping the block scan\n", block->bbNum);
                     stop = true;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_103477
+{
+    static int s_count;
+
+    [Fact]
+    public static int Test()
+    {
+        int result = -1;
+        try
+        {
+            Problem();
+            result = 100;
+        }
+        catch (Exception)
+        {
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Problem()
+    {
+        string s = "12151";
+        int i = 0;
+
+        char? a = null;
+        int count = 0;
+        while (true)
+        {
+            string? res = get(s, ref i, ref a);
+            if (res != null)
+            {
+                Count(res);
+                a = null; // !!! this line is removed from the published version
+                continue;
+            }
+
+            if (i >= s.Length)
+                break;
+
+            a = '.';
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Count(string s)
+    {
+        s_count++;
+        if (s_count > 5) throw new Exception();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static string? get(string s, ref int index, ref char? a)
+    {
+        if (index >= s.Length)
+            return null;
+
+        if (a == '.')
+            return ".";
+
+        a ??= s[index++];
+        return (a == '1') ? "1" : null;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If a block is DFS ancestor of one of its preds, the block is a cycle entry. Use this instead of `BBF_BACKWARD_JUMP` to stop the scan of blocks when looking for redundant zero inits.

Fixes #103477 (in main).