### PR TITLE
Disable BackwardsCompat_Downgrade test on WinHttpHandler

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -324,6 +324,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         }
 
         [ConditionalFact(nameof(TestsBackwardsCompatibilityEnabled))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/103754")]
         public async Task BackwardsCompatibility_DowngradeToHttp11()
         {
             TaskCompletionSource<object> completeStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Affecting CI heavily, related to #103754