### PR TITLE
[x64][SysV] Classify empty structs for passing like padding

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
+++ b/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using ILCompiler;
 using Internal.TypeSystem;
+using System.Runtime.CompilerServices;
 using static Internal.JitInterface.SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR;
 using static Internal.JitInterface.SystemVClassificationType;
 
@@ -207,7 +208,10 @@ namespace Internal.JitInterface
 
             if (numIntroducedFields == 0)
             {
-                return false;
+                // Classify empty struct like padding
+                helper.LargestFieldOffset = startOffsetOfStruct;
+                AssignClassifiedEightByteTypes(ref helper);
+                return true;
             }
 
             // The SIMD and Int128 Intrinsic types are meant to be handled specially and should not be passed as struct registers
@@ -375,8 +379,12 @@ namespace Internal.JitInterface
                 // Calculate the eightbytes and their types.
 
                 int lastFieldOrdinal = sortedFieldOrder[largestFieldOffset];
-                int offsetAfterLastFieldByte = largestFieldOffset + helper.FieldSizes[lastFieldOrdinal];
-                SystemVClassificationType lastFieldClassification = helper.FieldClassifications[lastFieldOrdinal];
+                int lastFieldSize = (lastFieldOrdinal >= 0) ? helper.FieldSizes[lastFieldOrdinal] : 0;
+                int offsetAfterLastFieldByte = largestFieldOffset + lastFieldSize;
+                Debug.Assert(offsetAfterLastFieldByte <= helper.StructSize);
+                SystemVClassificationType lastFieldClassification = (lastFieldOrdinal >= 0)
+                    ? helper.FieldClassifications[lastFieldOrdinal]
+                    : SystemVClassificationTypeNoClass;
 
                 int usedEightBytes = 0;
                 int accumulatedSizeForEightBytes = 0;
@@ -403,6 +411,8 @@ namespace Internal.JitInterface
                         // the SysV ABI spec.
                         fieldSize = 1;
                         fieldClassificationType = offset < offsetAfterLastFieldByte ? SystemVClassificationTypeNoClass : lastFieldClassification;
+                        if (offset % SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES == 0) // new eightbyte
+                            foundFieldInEightByte = false;
                     }
                     else
                     {
@@ -455,7 +465,8 @@ namespace Internal.JitInterface
                         }
                     }
 
-                    if ((offset + 1) % SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES == 0) // If we just finished checking the last byte of an eightbyte
+                    // If we just finished checking the last byte of an eightbyte or the entire struct
+                    if ((offset + 1) % SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES == 0 || (offset + 1) == helper.StructSize)
                     {
                         if (!foundFieldInEightByte)
                         {

--- a/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
+++ b/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
@@ -470,9 +470,11 @@ namespace Internal.JitInterface
                     {
                         if (!foundFieldInEightByte)
                         {
-                            // If we didn't find a field in an eight-byte (i.e. there are no explicit offsets that start a field in this eightbyte)
+                            // If we didn't find a field in an eightbyte (i.e. there are no explicit offsets that start a field in this eightbyte)
                             // then the classification of this eightbyte might be NoClass. We can't hand a classification of NoClass to the JIT
                             // so set the class to Integer (as though the struct has a char[8] padding) if the class is NoClass.
+                            //
+                            // TODO: Fix JIT, NoClass eightbytes are valid and passing them is broken because of this.
                             if (helper.EightByteClassifications[offset / SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES] == SystemVClassificationTypeNoClass)
                             {
                                 helper.EightByteClassifications[offset / SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES] = SystemVClassificationTypeInteger;

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2685,9 +2685,11 @@ void  MethodTable::AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHe
             {
                 if (!foundFieldInEightByte)
                 {
-                    // If we didn't find a field in an eight-byte (i.e. there are no explicit offsets that start a field in this eightbyte)
+                    // If we didn't find a field in an eightbyte (i.e. there are no explicit offsets that start a field in this eightbyte)
                     // then the classification of this eightbyte might be NoClass. We can't hand a classification of NoClass to the JIT
                     // so set the class to Integer (as though the struct has a char[8] padding) if the class is NoClass.
+                    //
+                    // TODO: Fix JIT, NoClass eightbytes are valid and passing them is broken because of this.
                     if (helperPtr->eightByteClassifications[offset / SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES] == SystemVClassificationTypeNoClass)
                     {
                         helperPtr->eightByteClassifications[offset / SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES] = SystemVClassificationTypeInteger;

--- a/src/tests/JIT/Directed/StructABI/CMakeLists.txt
+++ b/src/tests/JIT/Directed/StructABI/CMakeLists.txt
@@ -2,13 +2,15 @@ project (StructABILib)
 include_directories(${INC_PLATFORM_DIR})
 
 if(CLR_CMAKE_HOST_WIN32)
-    add_compile_options(/TC) # compile all files as C
+    set_source_files_properties(StructABI.c PROPERTIES COMPILE_OPTIONS /TC) # compile as C
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+    set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -fvisibility=hidden -Wno-return-type-c-linkage")
 endif()
 
 # add the executable
 add_library (StructABILib SHARED StructABI.c)
+add_library (EmptyStructsLib SHARED EmptyStructs.cpp)
 
 # add the install targets
-install (TARGETS StructABILib DESTINATION bin)
+install (TARGETS StructABILib EmptyStructsLib DESTINATION bin)

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
@@ -1,0 +1,68 @@
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef _MSC_VER
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT __attribute__((visibility("default")))
+#endif // _MSC_VER
+
+struct Empty
+{
+};
+static_assert(sizeof(Empty) == 1, "Empty struct must be sized like in .NET");
+
+
+struct IntEmpty
+{
+	int32_t FieldI0;
+	Empty FieldE0;
+};
+
+extern "C" DLLEXPORT IntEmpty EchoIntEmptySysV(int i0, IntEmpty val)
+{
+	return val;
+}
+
+
+struct IntEmptyPair
+{
+	IntEmpty FieldIE0;
+	IntEmpty FieldIE1;
+};
+
+extern "C" DLLEXPORT IntEmptyPair EchoIntEmptyPairSysV(int i0, IntEmptyPair val)
+{
+	return val;
+}
+
+
+struct EmptyFloatIntInt
+{
+	Empty FieldE0;
+	float FieldF0;
+	int32_t FieldI0;
+	int32_t FieldI1;
+};
+
+extern "C" DLLEXPORT EmptyFloatIntInt EchoEmptyFloatIntIntSysV(int i0, float f0, EmptyFloatIntInt val)
+{
+	return val;
+}
+
+
+struct FloatFloatEmptyFloat
+{
+	float FieldF0;
+	float FieldF1;
+	Empty FieldE0;
+	float FieldF2;
+};
+
+extern "C" DLLEXPORT FloatFloatEmptyFloat EchoFloatFloatEmptyFloatSysV(float f0, FloatFloatEmptyFloat val)
+{
+	return val;
+}
+

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
@@ -17,8 +17,8 @@ static_assert(sizeof(Empty) == 1, "Empty struct must be sized like in .NET");
 
 struct IntEmpty
 {
-	int32_t FieldI0;
-	Empty FieldE0;
+	int32_t Int0;
+	Empty Empty0;
 };
 
 extern "C" DLLEXPORT IntEmpty EchoIntEmptySysV(int i0, IntEmpty val)
@@ -29,8 +29,8 @@ extern "C" DLLEXPORT IntEmpty EchoIntEmptySysV(int i0, IntEmpty val)
 
 struct IntEmptyPair
 {
-	IntEmpty FieldIE0;
-	IntEmpty FieldIE1;
+	IntEmpty IntEmpty0;
+	IntEmpty IntEmpty1;
 };
 
 extern "C" DLLEXPORT IntEmptyPair EchoIntEmptyPairSysV(int i0, IntEmptyPair val)
@@ -41,10 +41,10 @@ extern "C" DLLEXPORT IntEmptyPair EchoIntEmptyPairSysV(int i0, IntEmptyPair val)
 
 struct EmptyFloatIntInt
 {
-	Empty FieldE0;
-	float FieldF0;
-	int32_t FieldI0;
-	int32_t FieldI1;
+	Empty Empty0;
+	float Float0;
+	int32_t Int0;
+	int32_t Int1;
 };
 
 extern "C" DLLEXPORT EmptyFloatIntInt EchoEmptyFloatIntIntSysV(int i0, float f0, EmptyFloatIntInt val)
@@ -55,10 +55,10 @@ extern "C" DLLEXPORT EmptyFloatIntInt EchoEmptyFloatIntIntSysV(int i0, float f0,
 
 struct FloatFloatEmptyFloat
 {
-	float FieldF0;
-	float FieldF1;
-	Empty FieldE0;
-	float FieldF2;
+	float Float0;
+	float Float1;
+	Empty Empty0;
+	float Float2;
 };
 
 extern "C" DLLEXPORT FloatFloatEmptyFloat EchoFloatFloatEmptyFloatSysV(float f0, FloatFloatEmptyFloat val)

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Program
+{
+	public struct Empty
+	{
+	}
+
+
+	public struct IntEmpty
+	{
+		public int Int0;
+		public Empty Empty0;
+
+		public static IntEmpty Get()
+			=> new IntEmpty { Int0 = 0xBabc1a };
+
+		public bool Equals(IntEmpty other)
+			=> Int0 == other.Int0;
+		
+		public override string ToString()
+			=> $"{{Int0:{Int0:x}}}";
+	}
+
+	[DllImport("EmptyStructsLib")]
+	public static extern IntEmpty EchoIntEmptySysV(int i0, IntEmpty val);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static IntEmpty EchoIntEmptySysVManaged(int i0, IntEmpty val) => val;
+
+	[Fact]
+	public static void TestIntEmptySysV()
+	{
+		IntEmpty expected = IntEmpty.Get();
+		IntEmpty native = EchoIntEmptySysV(0, expected);
+		IntEmpty managed = EchoIntEmptySysVManaged(0, expected);
+
+		Assert.Equal(expected, native);
+		Assert.Equal(expected, managed);
+	}
+
+
+	public struct IntEmptyPair
+	{
+		public IntEmpty IntEmpty0;
+		public IntEmpty IntEmpty1;
+
+		public static IntEmptyPair Get()
+			=> new IntEmptyPair { IntEmpty0 = IntEmpty.Get(), IntEmpty1 = IntEmpty.Get() };
+
+		public bool Equals(IntEmptyPair other)
+			=> IntEmpty0.Equals(other.IntEmpty0) && IntEmpty1.Equals(other.IntEmpty1);
+		
+		public override string ToString()
+			=> $"{{IntEmpty0:{IntEmpty0}, IntEmpty1:{IntEmpty1}}}";
+	}
+
+	[DllImport("EmptyStructsLib")]
+	public static extern IntEmptyPair EchoIntEmptyPairSysV(int i0, IntEmptyPair val);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static IntEmptyPair EchoIntEmptyPairSysVManaged(int i0, IntEmptyPair val) => val;
+
+	[Fact]
+	public static void TestIntEmptyPairSysV()
+	{
+		IntEmptyPair expected = IntEmptyPair.Get();
+		IntEmptyPair native = EchoIntEmptyPairSysV(0, expected);
+		IntEmptyPair managed = EchoIntEmptyPairSysVManaged(0, expected);
+
+		Assert.Equal(expected, native);
+		Assert.Equal(expected, managed);
+	}
+
+
+	public struct EmptyFloatIntInt
+	{
+		public Empty Empty0;
+		public float Float0;
+		public int Int0;
+		public int Int1;
+
+		public static EmptyFloatIntInt Get()
+			=> new EmptyFloatIntInt { Float0 = 2.71828f, Int0 = 0xBabc1a, Int1 = 0xC10c1a };
+
+		public bool Equals(EmptyFloatIntInt other)
+			=> Float0 == other.Float0 && Int0 == other.Int0 && Int1 == other.Int1;
+
+		public override string ToString()
+			=> $"{{Float0:{Float0}, Int0:{Int0:x}, Int1:{Int1:x}}}";
+	}
+
+	[DllImport("EmptyStructsLib")]
+	public static extern EmptyFloatIntInt EchoEmptyFloatIntIntSysV(int i0, float f0, EmptyFloatIntInt val);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static EmptyFloatIntInt EchoEmptyFloatIntIntSysVManaged(int i0, float f0, EmptyFloatIntInt val) => val;
+
+	[Fact]
+	public static void TestEmptyFloatIntIntSysV()
+	{
+		EmptyFloatIntInt expected = EmptyFloatIntInt.Get();
+		EmptyFloatIntInt native = EchoEmptyFloatIntIntSysV(0, 0f, expected);
+		EmptyFloatIntInt managed = EchoEmptyFloatIntIntSysVManaged(0, 0f, expected);
+
+		Assert.Equal(expected, native);
+		Assert.Equal(expected, managed);
+	}
+
+
+	public struct FloatFloatEmptyFloat
+	{
+		public float Float0;
+		public float Float1;
+		public Empty Empty0;
+		public float Float2;
+
+		public static FloatFloatEmptyFloat Get()
+			=> new FloatFloatEmptyFloat { Float0 = 2.71828f, Float1 = 3.14159f, Float2 = 1.61803f };
+
+		public bool Equals(FloatFloatEmptyFloat other)
+			=> Float0 == other.Float0 && Float1 == other.Float1 && Float2 == other.Float2;
+
+		public override string ToString()
+			=> $"{{Float0:{Float0}, Float1:{Float1}, Float2:{Float2}}}";
+	}
+
+	[DllImport("EmptyStructsLib")]
+	public static extern FloatFloatEmptyFloat EchoFloatFloatEmptyFloatSysV(float f0, FloatFloatEmptyFloat val);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static FloatFloatEmptyFloat EchoFloatFloatEmptyFloatSysVManaged(float f0, FloatFloatEmptyFloat val) => val;
+
+	[Fact]
+	public static void TestFloatFloatEmptyFloatSysV()
+	{
+		FloatFloatEmptyFloat expected = FloatFloatEmptyFloat.Get();
+		FloatFloatEmptyFloat native = EchoFloatFloatEmptyFloatSysV(0f, expected);
+		FloatFloatEmptyFloat managed = EchoFloatFloatEmptyFloatSysVManaged(0f, expected);
+
+		Assert.Equal(expected, native);
+		Assert.Equal(expected, managed);
+	}
+}

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.csproj
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="EmptyStructs.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The current implementation barred a struct containing empty struct fields from enregistration. This did not match the behavior of GCC & Clang on Linux and the [System V ABI](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf) which says:

> NO_CLASS This class is used as initializer in the algorithms. It will be used for padding and **empty structures** and unions.

Stems from #101796, part of #84834, cc @dotnet/samsung