### PR TITLE
Reduce some allocations in SslStream handshake.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -159,7 +159,16 @@ internal static partial class Interop
 
             if (sslAuthenticationOptions.IsClient)
             {
-                var key = new SslContextCacheKey(protocols, sslAuthenticationOptions.CertificateContext?.TargetCertificate.GetCertHash(HashAlgorithmName.SHA256));
+                byte[]? hash = null;
+
+                if (sslAuthenticationOptions.CertificateContext?.TargetCertificate is X509Certificate2 cert)
+                {
+                    // This is equivalent to cert.GetCertHash(HashAlgorithmName.Sha256), but this
+                    // way the code does not allocate a new byte[] with raw cert contents.every time
+                    hash = SHA256.HashData(cert.RawDataMemory.Span);
+                }
+
+                var key = new SslContextCacheKey(protocols, hash);
                 return s_clientSslContexts.GetOrCreate(key, static (args) =>
                 {
                     var (sslAuthOptions, protocols, allowCached) = args;

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -159,16 +159,7 @@ internal static partial class Interop
 
             if (sslAuthenticationOptions.IsClient)
             {
-                byte[]? hash = null;
-
-                if (sslAuthenticationOptions.CertificateContext?.TargetCertificate is X509Certificate2 cert)
-                {
-                    // This is equivalent to cert.GetCertHash(HashAlgorithmName.Sha256), but this
-                    // way the code does not allocate a new byte[] with raw cert contents.every time
-                    hash = SHA256.HashData(cert.RawDataMemory.Span);
-                }
-
-                var key = new SslContextCacheKey(protocols, hash);
+                var key = new SslContextCacheKey(protocols, sslAuthenticationOptions.CertificateContext?.TargetCertificate.GetCertHash(HashAlgorithmName.SHA256));
                 return s_clientSslContexts.GetOrCreate(key, static (args) =>
                 {
                     var (sslAuthOptions, protocols, allowCached) = args;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -149,7 +149,7 @@ namespace System.Net.Security
 
         private static SslProtocols FilterOutIncompatibleSslProtocols(SslProtocols protocols)
         {
-            if (protocols.HasFlag(SslProtocols.Tls12) || protocols.HasFlag(SslProtocols.Tls13))
+            if ((protocols & (SslProtocols.Tls12 | SslProtocols.Tls13)) != SslProtocols.None)
             {
 #pragma warning disable 0618
                 // SSL2 is mutually exclusive with >= TLS1.2

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
@@ -23,7 +24,22 @@ namespace System.Net.Security
         internal static TimeSpan RefreshAfterFailureBackOffInterval => TimeSpan.FromSeconds(5);
 
         private const bool TrimRootCertificate = true;
-        internal readonly ConcurrentDictionary<SslProtocols, SafeSslContextHandle> SslContexts;
+        internal ConcurrentDictionary<SslProtocols, SafeSslContextHandle> SslContexts
+        {
+            get
+            {
+                ConcurrentDictionary<SslProtocols, SafeSslContextHandle>? sslContexts = _sslContexts;
+                if (sslContexts is null)
+                {
+                    Interlocked.CompareExchange(ref _sslContexts, new(), null);
+                    sslContexts = _sslContexts;
+                }
+
+                return sslContexts;
+            }
+        }
+
+        private ConcurrentDictionary<SslProtocols, SafeSslContextHandle>? _sslContexts;
         internal readonly SafeX509Handle CertificateHandle;
         internal readonly SafeEvpPKeyHandle KeyHandle;
 
@@ -57,7 +73,6 @@ namespace System.Net.Security
 
             TargetCertificate = target;
             Trust = trust;
-            SslContexts = new ConcurrentDictionary<SslProtocols, SafeSslContextHandle>();
 
             using (RSAOpenSsl? rsa = (RSAOpenSsl?)target.GetRSAPrivateKey())
             {


### PR DESCRIPTION
This removes some unnecessary allocations on TLS handshakes, mostly on Linux.

```

BenchmarkDotNet v0.13.13-nightly.20240311.145, Ubuntu 22.04.4 LTS (Jammy Jellyfish)
Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores
.NET SDK 9.0.100-preview.5.24307.3
  [Host]     : .NET 9.0.0 (9.0.24.30607), X64 RyuJIT AVX2
  Job-QJUXKM : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-OFJRMC : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

```
| Method                                 | Job        | Toolchain      | Mean      | Error     | StdDev    | Median    | Min       | Max       | Ratio | RatioSD | Allocated | Alloc Ratio |
|--------------------------------------- |----------- |--------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
| DefaultHandshakeContextIPv4Async       | Job-QJUXKM | /9.0.0/corerun |  1.089 ms | 0.0267 ms | 0.0297 ms |  1.083 ms |  1.048 ms |  1.146 ms |  1.03 |    0.03 |   5.81 KB |        0.98 |
| DefaultHandshakeContextIPv4Async       | Job-OFJRMC | /main/corerun  |  1.058 ms | 0.0147 ms | 0.0137 ms |  1.059 ms |  1.034 ms |  1.079 ms |  1.00 |    0.02 |   5.96 KB |        1.00 |
|                                        |            |                |           |           |           |           |           |           |       |         |           |             |
| DefaultMutualHandshakeContextIPv4Async | Job-QJUXKM | /9.0.0/corerun |  1.432 ms | 0.0217 ms | 0.0181 ms |  1.432 ms |  1.395 ms |  1.459 ms |  1.01 |    0.02 |   8.06 KB |        0.75 |
| DefaultMutualHandshakeContextIPv4Async | Job-OFJRMC | /main/corerun  |  1.424 ms | 0.0262 ms | 0.0269 ms |  1.430 ms |  1.362 ms |  1.468 ms |  1.00 |    0.03 |  10.73 KB |        1.00 |
|                                        |            |                |           |           |           |           |           |           |       |         |           |             |
| DefaultHandshakeIPv4Async              | Job-QJUXKM | /9.0.0/corerun |  6.375 ms | 0.3801 ms | 0.3904 ms |  6.319 ms |  5.923 ms |  7.178 ms |  1.07 |    0.07 |   9.67 KB |        1.00 |
| DefaultHandshakeIPv4Async              | Job-OFJRMC | /main/corerun  |  5.961 ms | 0.1159 ms | 0.1084 ms |  5.973 ms |  5.755 ms |  6.219 ms |  1.00 |    0.02 |   9.69 KB |        1.00 |
|                                        |            |                |           |           |           |           |           |           |       |         |           |             |
| DefaultMutualHandshakeIPv4Async        | Job-QJUXKM | /9.0.0/corerun | 11.515 ms | 0.4361 ms | 0.5022 ms | 11.386 ms | 10.935 ms | 12.586 ms |  1.02 |    0.05 |  14.56 KB |        0.84 |
| DefaultMutualHandshakeIPv4Async        | Job-OFJRMC | /main/corerun  | 11.323 ms | 0.2131 ms | 0.1994 ms | 11.356 ms | 11.020 ms | 11.657 ms |  1.00 |    0.02 |  17.37 KB |        1.00 |
