### PR TITLE
Set AnyCPU for ProjectReference to source generators

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -56,15 +56,18 @@
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
+                      SetPlatform="Platform=AnyCPU"
                       SetConfiguration="Configuration=$(LibrariesConfiguration)" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\LibraryImportGenerator.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
+                      SetPlatform="Platform=AnyCPU"
                       SetConfiguration="Configuration=$(LibrariesConfiguration)"
                       Condition="@(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\ComInterfaceGenerator\ComInterfaceGenerator.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
+                      SetPlatform="Platform=AnyCPU"
                       SetConfiguration="Configuration=$(LibrariesConfiguration)"
                       Condition="@(EnabledGenerators->AnyHaveMetadataValue('Identity', 'ComInterfaceGenerator'))" />
   </ItemGroup>

--- a/eng/liveILLink.targets
+++ b/eng/liveILLink.targets
@@ -47,6 +47,7 @@
                       ReferenceOutputAssembly="false"
                       Private="false"
                       OutputItemType="Analyzer"
+                      SetPlatform="Platform=AnyCPU"
                       SetConfiguration="Configuration=$(ToolsConfiguration)" />
   </ItemGroup>
 


### PR DESCRIPTION
The source generators are built with AnyCPU. When opening CoreLib in Visual Studio, it tries to load source generators from platform dependent path since CoreLib is platform dependent, and the generators are not in the solution.

An alternative approach is to include them in corelib.sln.