### PR TITLE
Vectorize a few more conversions in TensorPrimitives.ConvertXx

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
+++ b/src/libraries/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
@@ -37,6 +37,7 @@
     <Compile Include="System\Numerics\Tensors\netcore\Common\TensorPrimitives.ITernaryOperator.cs" />
     <Compile Include="System\Numerics\Tensors\netcore\Common\TensorPrimitives.IUnaryInputBinaryOutput.cs" />
     <Compile Include="System\Numerics\Tensors\netcore\Common\TensorPrimitives.IUnaryOneToTwoOperator.cs" />
+    <Compile Include="System\Numerics\Tensors\netcore\Common\TensorPrimitives.IUnaryOneToFourOperator.cs" />
     <Compile Include="System\Numerics\Tensors\netcore\Common\TensorPrimitives.IUnaryOperator.cs" />
     <Compile Include="System\Numerics\Tensors\netcore\Common\TensorPrimitives.IUnaryTwoToOneOperator.cs" />
     <Compile Include="System\Numerics\Tensors\netcore\TensorPrimitives.Abs.cs" />

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToFourOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToFourOperator.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+
+#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
+
+namespace System.Numerics.Tensors
+{
+    public static unsafe partial class TensorPrimitives
+    {
+        /// <summary>Operator that takes one input value and returns a single value.</summary>
+        /// <remarks>The input type must be half the size of the output type.</remarks>
+        private interface IUnaryOneToFourOperator<TInput, TOutput>
+        {
+            static abstract bool Vectorizable { get; }
+            static abstract TOutput Invoke(TInput x);
+            static abstract (Vector128<TOutput>, Vector128<TOutput>, Vector128<TOutput>, Vector128<TOutput>) Invoke(Vector128<TInput> x);
+            static abstract (Vector256<TOutput>, Vector256<TOutput>, Vector256<TOutput>, Vector256<TOutput>) Invoke(Vector256<TInput> x);
+            static abstract (Vector512<TOutput>, Vector512<TOutput>, Vector512<TOutput>, Vector512<TOutput>) Invoke(Vector512<TInput> x);
+        }
+
+        /// <summary>Performs an element-wise operation on <paramref name="x"/> and writes the results to <paramref name="destination"/>.</summary>
+        /// <typeparam name="TInput">The element input type.</typeparam>
+        /// <typeparam name="TOutput">The element output type. Must be four times the size of TInput.</typeparam>
+        /// <typeparam name="TUnaryOperator">Specifies the operation to perform on each element loaded from <paramref name="x"/>.</typeparam>
+        /// <remarks>This should only be used when it's known that TInput/TOutput are vectorizable and the size of TInput is a fourth that of TOutput.</remarks>
+        private static void InvokeSpanIntoSpan_1to4<TInput, TOutput, TUnaryOperator>(
+            ReadOnlySpan<TInput> x, Span<TOutput> destination)
+            where TUnaryOperator : struct, IUnaryOneToFourOperator<TInput, TOutput>
+        {
+            Debug.Assert(sizeof(TInput) * 4 == sizeof(TOutput));
+
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            ref TInput sourceRef = ref MemoryMarshal.GetReference(x);
+            ref TOutput destinationRef = ref MemoryMarshal.GetReference(destination);
+            int i = 0, oneVectorFromEnd;
+
+            if (Vector512.IsHardwareAccelerated && TUnaryOperator.Vectorizable)
+            {
+                Debug.Assert(Vector512<TInput>.IsSupported);
+                Debug.Assert(Vector512<TOutput>.IsSupported);
+
+                oneVectorFromEnd = x.Length - Vector512<TInput>.Count;
+                if (i <= oneVectorFromEnd)
+                {
+                    // Loop handling one input vector / four output vectors at a time.
+                    do
+                    {
+                        (Vector512<TOutput>, Vector512<TOutput>, Vector512<TOutput>, Vector512<TOutput>) results = TUnaryOperator.Invoke(Vector512.LoadUnsafe(ref sourceRef, (uint)i));
+                        results.Item1.StoreUnsafe(ref destinationRef, (uint)i);
+                        results.Item2.StoreUnsafe(ref destinationRef, (uint)(i + Vector512<TOutput>.Count));
+                        results.Item3.StoreUnsafe(ref destinationRef, (uint)(i + (Vector512<TOutput>.Count * 2)));
+                        results.Item4.StoreUnsafe(ref destinationRef, (uint)(i + (Vector512<TOutput>.Count * 3)));
+
+                        i += Vector512<TInput>.Count;
+                    }
+                    while (i <= oneVectorFromEnd);
+
+                    // Handle any remaining elements with a final input vector.
+                    if (i != x.Length)
+                    {
+                        i = x.Length - Vector512<TInput>.Count;
+
+                        (Vector512<TOutput>, Vector512<TOutput>, Vector512<TOutput>, Vector512<TOutput>) results = TUnaryOperator.Invoke(Vector512.LoadUnsafe(ref sourceRef, (uint)i));
+                        results.Item1.StoreUnsafe(ref destinationRef, (uint)i);
+                        results.Item2.StoreUnsafe(ref destinationRef, (uint)(i + Vector512<TOutput>.Count));
+                        results.Item3.StoreUnsafe(ref destinationRef, (uint)(i + (Vector512<TOutput>.Count * 2)));
+                        results.Item4.StoreUnsafe(ref destinationRef, (uint)(i + (Vector512<TOutput>.Count * 3)));
+                    }
+
+                    return;
+                }
+            }
+
+            if (Vector256.IsHardwareAccelerated && TUnaryOperator.Vectorizable)
+            {
+                Debug.Assert(Vector256<TInput>.IsSupported);
+                Debug.Assert(Vector256<TOutput>.IsSupported);
+
+                oneVectorFromEnd = x.Length - Vector256<TInput>.Count;
+                if (i <= oneVectorFromEnd)
+                {
+                    // Loop handling one input vector / two output vectors at a time.
+                    do
+                    {
+                        (Vector256<TOutput>, Vector256<TOutput>, Vector256<TOutput>, Vector256<TOutput>) results = TUnaryOperator.Invoke(Vector256.LoadUnsafe(ref sourceRef, (uint)i));
+                        results.Item1.StoreUnsafe(ref destinationRef, (uint)i);
+                        results.Item2.StoreUnsafe(ref destinationRef, (uint)(i + Vector256<TOutput>.Count));
+                        results.Item3.StoreUnsafe(ref destinationRef, (uint)(i + (Vector256<TOutput>.Count * 2)));
+                        results.Item4.StoreUnsafe(ref destinationRef, (uint)(i + (Vector256<TOutput>.Count * 3)));
+
+                        i += Vector256<TInput>.Count;
+                    }
+                    while (i <= oneVectorFromEnd);
+
+                    // Handle any remaining elements with a final input vector.
+                    if (i != x.Length)
+                    {
+                        i = x.Length - Vector256<TInput>.Count;
+
+                        (Vector256<TOutput>, Vector256<TOutput>, Vector256<TOutput>, Vector256<TOutput>) results = TUnaryOperator.Invoke(Vector256.LoadUnsafe(ref sourceRef, (uint)i));
+                        results.Item1.StoreUnsafe(ref destinationRef, (uint)i);
+                        results.Item2.StoreUnsafe(ref destinationRef, (uint)(i + Vector256<TOutput>.Count));
+                        results.Item3.StoreUnsafe(ref destinationRef, (uint)(i + (Vector256<TOutput>.Count * 2)));
+                        results.Item4.StoreUnsafe(ref destinationRef, (uint)(i + (Vector256<TOutput>.Count * 3)));
+                    }
+
+                    return;
+                }
+            }
+
+            if (Vector128.IsHardwareAccelerated && TUnaryOperator.Vectorizable)
+            {
+                Debug.Assert(Vector128<TInput>.IsSupported);
+                Debug.Assert(Vector128<TOutput>.IsSupported);
+
+                oneVectorFromEnd = x.Length - Vector128<TInput>.Count;
+                if (i <= oneVectorFromEnd)
+                {
+                    // Loop handling one input vector / two output vectors at a time.
+                    do
+                    {
+                        (Vector128<TOutput>, Vector128<TOutput>, Vector128<TOutput>, Vector128<TOutput>) results = TUnaryOperator.Invoke(Vector128.LoadUnsafe(ref sourceRef, (uint)i));
+                        results.Item1.StoreUnsafe(ref destinationRef, (uint)i);
+                        results.Item2.StoreUnsafe(ref destinationRef, (uint)(i + Vector128<TOutput>.Count));
+                        results.Item3.StoreUnsafe(ref destinationRef, (uint)(i + (Vector128<TOutput>.Count * 2)));
+                        results.Item4.StoreUnsafe(ref destinationRef, (uint)(i + (Vector128<TOutput>.Count * 3)));
+
+                        i += Vector128<TInput>.Count;
+                    }
+                    while (i <= oneVectorFromEnd);
+
+                    // Handle any remaining elements with a final input vector.
+                    if (i != x.Length)
+                    {
+                        i = x.Length - Vector128<TInput>.Count;
+
+                        (Vector128<TOutput>, Vector128<TOutput>, Vector128<TOutput>, Vector128<TOutput>) results = TUnaryOperator.Invoke(Vector128.LoadUnsafe(ref sourceRef, (uint)i));
+                        results.Item1.StoreUnsafe(ref destinationRef, (uint)i);
+                        results.Item2.StoreUnsafe(ref destinationRef, (uint)(i + Vector128<TOutput>.Count));
+                        results.Item3.StoreUnsafe(ref destinationRef, (uint)(i + (Vector128<TOutput>.Count * 2)));
+                        results.Item4.StoreUnsafe(ref destinationRef, (uint)(i + (Vector128<TOutput>.Count * 3)));
+                    }
+
+                    return;
+                }
+            }
+
+            while (i < x.Length)
+            {
+                Unsafe.Add(ref destinationRef, i) = TUnaryOperator.Invoke(Unsafe.Add(ref sourceRef, i));
+                i++;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToFourOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToFourOperator.cs
@@ -13,7 +13,7 @@ namespace System.Numerics.Tensors
     public static unsafe partial class TensorPrimitives
     {
         /// <summary>Operator that takes one input value and returns a single value.</summary>
-        /// <remarks>The input type must be half the size of the output type.</remarks>
+        /// <remarks>The input type must be a quarter of the size of the output type.</remarks>
         private interface IUnaryOneToFourOperator<TInput, TOutput>
         {
             static abstract bool Vectorizable { get; }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToTwoOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToTwoOperator.cs
@@ -25,7 +25,7 @@ namespace System.Numerics.Tensors
 
         /// <summary>Performs an element-wise operation on <paramref name="x"/> and writes the results to <paramref name="destination"/>.</summary>
         /// <typeparam name="TInput">The element input type.</typeparam>
-        /// <typeparam name="TOutput">The element output type. Must be the same size as TInput if TInput and TOutput both support vectorization.</typeparam>
+        /// <typeparam name="TOutput">The element output type. Must be twice the size of TInput.</typeparam>
         /// <typeparam name="TUnaryOperator">Specifies the operation to perform on each element loaded from <paramref name="x"/>.</typeparam>
         /// <remarks>This should only be used when it's known that TInput/TOutput are vectorizable and the size of TInput is half that of TOutput.</remarks>
         private static void InvokeSpanIntoSpan_1to2<TInput, TOutput, TUnaryOperator>(

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ConvertHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ConvertHelpers.cs
@@ -31,88 +31,133 @@ namespace System.Numerics.Tensors
                 return true;
             }
 
-            if (IsInt32Like<TFrom>() && typeof(TTo) == typeof(float))
+            if (typeof(TFrom) == typeof(byte))
             {
-                InvokeSpanIntoSpan<int, float, ConvertInt32ToSingle>(Rename<TFrom, int>(source), Rename<TTo, float>(destination));
-                return true;
+                if (typeof(TTo) == typeof(short) || typeof(TTo) == typeof(ushort))
+                {
+                    InvokeSpanIntoSpan_1to2<byte, ushort, WidenByteToUInt16Operator>(Rename<TFrom, byte>(source), Rename<TTo, ushort>(destination));
+                    return true;
+                }
+
+                if (IsInt32Like<TTo>() || IsUInt32Like<TTo>())
+                {
+                    InvokeSpanIntoSpan_1to4<byte, uint, WidenByteToUInt32Operator>(Rename<TFrom, byte>(source), Rename<TTo, uint>(destination));
+                    return true;
+                }
+
+                if (typeof(TTo) == typeof(float))
+                {
+                    InvokeSpanIntoSpan_1to4<byte, float, WidenByteToSingleOperator>(Rename<TFrom, byte>(source), Rename<TTo, float>(destination));
+                    return true;
+                }
             }
 
-            if (IsUInt32Like<TFrom>() && typeof(TTo) == typeof(float))
+            if (typeof(TFrom) == typeof(sbyte))
             {
-                InvokeSpanIntoSpan<uint, float, ConvertUInt32ToSingle>(Rename<TFrom, uint>(source), Rename<TTo, float>(destination));
-                return true;
+                if (typeof(TTo) == typeof(short))
+                {
+                    InvokeSpanIntoSpan_1to2<sbyte, short, WidenSByteToInt16Operator>(Rename<TFrom, sbyte>(source), Rename<TTo, short>(destination));
+                    return true;
+                }
             }
 
-            if (IsInt64Like<TFrom>() && typeof(TTo) == typeof(double))
+            if (typeof(TFrom) == typeof(ushort))
             {
-                InvokeSpanIntoSpan<long, double, ConvertInt64ToDouble>(Rename<TFrom, long>(source), Rename<TTo, double>(destination));
-                return true;
+                if (IsUInt32Like<TTo>() || IsInt32Like<TTo>())
+            {
+                    InvokeSpanIntoSpan_1to2<ushort, uint, WidenUInt16ToUInt32Operator>(Rename<TFrom, ushort>(source), Rename<TTo, uint>(destination));
+                    return true;
+                }
             }
 
-            if (IsUInt64Like<TFrom>() && typeof(TTo) == typeof(double))
+            if (typeof(TFrom) == typeof(short))
             {
-                InvokeSpanIntoSpan<ulong, double, ConvertUInt64ToDouble>(Rename<TFrom, ulong>(source), Rename<TTo, double>(destination));
-                return true;
+                if (IsInt32Like<TTo>())
+                {
+                    InvokeSpanIntoSpan_1to2<short, int, WidenInt16ToInt32Operator>(Rename<TFrom, short>(source), Rename<TTo, int>(destination));
+                    return true;
+                }
             }
 
-            if (typeof(TFrom) == typeof(float) && typeof(TTo) == typeof(Half))
+            if (IsUInt32Like<TFrom>())
             {
-                InvokeSpanIntoSpan_2to1<float, ushort, NarrowSingleToHalfAsUInt16Operator>(Rename<TFrom, float>(source), Rename<TTo, ushort>(destination));
-                return true;
+                if (IsInt64Like<TTo>() || IsUInt64Like<TTo>())
+                {
+                    InvokeSpanIntoSpan_1to2<uint, ulong, WidenUInt32ToUInt64Operator>(Rename<TFrom, uint>(source), Rename<TTo, ulong>(destination));
+                    return true;
+                }
+
+                if (typeof(TTo) == typeof(float))
+                {
+                    InvokeSpanIntoSpan<uint, float, ConvertUInt32ToSingle>(Rename<TFrom, uint>(source), Rename<TTo, float>(destination));
+                    return true;
+                }
             }
 
-            if (typeof(TFrom) == typeof(Half) && typeof(TTo) == typeof(float))
+            if (IsInt32Like<TFrom>())
             {
-                InvokeSpanIntoSpan_1to2<short, float, WidenHalfAsInt16ToSingleOperator>(Rename<TFrom, short>(source), Rename<TTo, float>(destination));
-                return true;
+                if (IsInt64Like<TTo>())
+                {
+                    InvokeSpanIntoSpan_1to2<int, long, WidenInt32ToInt64Operator>(Rename<TFrom, int>(source), Rename<TTo, long>(destination));
+                    return true;
+                }
+
+                if (typeof(TTo) == typeof(float))
+                {
+                    InvokeSpanIntoSpan<int, float, ConvertInt32ToSingle>(Rename<TFrom, int>(source), Rename<TTo, float>(destination));
+                    return true;
+                }
             }
 
-            if (typeof(TFrom) == typeof(float) && typeof(TTo) == typeof(double))
+            if (IsUInt64Like<TFrom>())
             {
-                InvokeSpanIntoSpan_1to2<float, double, WidenSingleToDoubleOperator>(Rename<TFrom, float>(source), Rename<TTo, double>(destination));
-                return true;
+                if (typeof(TTo) == typeof(double))
+                {
+                    InvokeSpanIntoSpan<ulong, double, ConvertUInt64ToDouble>(Rename<TFrom, ulong>(source), Rename<TTo, double>(destination));
+                    return true;
+                }
             }
 
-            if (typeof(TFrom) == typeof(double) && typeof(TTo) == typeof(float))
+            if (IsInt64Like<TFrom>())
             {
-                InvokeSpanIntoSpan_2to1<double, float, NarrowDoubleToSingleOperator>(Rename<TFrom, double>(source), Rename<TTo, float>(destination));
-                return true;
+                if (typeof(TTo) == typeof(double))
+                {
+                    InvokeSpanIntoSpan<long, double, ConvertInt64ToDouble>(Rename<TFrom, long>(source), Rename<TTo, double>(destination));
+                    return true;
+                }
             }
 
-            if (typeof(TFrom) == typeof(byte) && typeof(TTo) == typeof(ushort))
+            if (typeof(TFrom) == typeof(Half))
             {
-                InvokeSpanIntoSpan_1to2<byte, ushort, WidenByteToUInt16Operator>(Rename<TFrom, byte>(source), Rename<TTo, ushort>(destination));
-                return true;
+                if (typeof(TTo) == typeof(float))
+                {
+                    InvokeSpanIntoSpan_1to2<short, float, WidenHalfAsInt16ToSingleOperator>(Rename<TFrom, short>(source), Rename<TTo, float>(destination));
+                    return true;
+                }
             }
 
-            if (typeof(TFrom) == typeof(sbyte) && typeof(TTo) == typeof(short))
+            if (typeof(TFrom) == typeof(float))
             {
-                InvokeSpanIntoSpan_1to2<sbyte, short, WidenSByteToInt16Operator>(Rename<TFrom, sbyte>(source), Rename<TTo, short>(destination));
-                return true;
+                if (typeof(TTo) == typeof(Half))
+                {
+                    InvokeSpanIntoSpan_2to1<float, ushort, NarrowSingleToHalfAsUInt16Operator>(Rename<TFrom, float>(source), Rename<TTo, ushort>(destination));
+                    return true;
+                }
+
+                if (typeof(TTo) == typeof(double))
+                {
+                    InvokeSpanIntoSpan_1to2<float, double, WidenSingleToDoubleOperator>(Rename<TFrom, float>(source), Rename<TTo, double>(destination));
+                    return true;
+                }
             }
 
-            if (typeof(TFrom) == typeof(ushort) && IsUInt32Like<TTo>())
+            if (typeof(TFrom) == typeof(double))
             {
-                InvokeSpanIntoSpan_1to2<ushort, uint, WidenUInt16ToUInt32Operator>(Rename<TFrom, ushort>(source), Rename<TTo, uint>(destination));
-                return true;
-            }
-
-            if (typeof(TFrom) == typeof(short) && IsInt32Like<TTo>())
-            {
-                InvokeSpanIntoSpan_1to2<short, int, WidenInt16ToInt32Operator>(Rename<TFrom, short>(source), Rename<TTo, int>(destination));
-                return true;
-            }
-
-            if (IsUInt32Like<TTo>() && IsUInt64Like<TTo>())
-            {
-                InvokeSpanIntoSpan_1to2<uint, ulong, WidenUInt32ToUInt64Operator>(Rename<TFrom, uint>(source), Rename<TTo, ulong>(destination));
-                return true;
-            }
-
-            if (IsInt32Like<TFrom>() && IsInt64Like<TTo>())
-            {
-                InvokeSpanIntoSpan_1to2<int, long, WidenInt32ToInt64Operator>(Rename<TFrom, int>(source), Rename<TTo, long>(destination));
-                return true;
+                if (typeof(TTo) == typeof(float))
+                {
+                    InvokeSpanIntoSpan_2to1<double, float, NarrowDoubleToSingleOperator>(Rename<TFrom, double>(source), Rename<TTo, float>(destination));
+                    return true;
+                }
             }
 
             return false;
@@ -193,6 +238,85 @@ namespace System.Numerics.Tensors
             public static (Vector128<ushort> Lower, Vector128<ushort> Upper) Invoke(Vector128<byte> x) => Vector128.Widen(x);
             public static (Vector256<ushort> Lower, Vector256<ushort> Upper) Invoke(Vector256<byte> x) => Vector256.Widen(x);
             public static (Vector512<ushort> Lower, Vector512<ushort> Upper) Invoke(Vector512<byte> x) => Vector512.Widen(x);
+        }
+
+        /// <summary>(uint)byte</summary>
+        private readonly struct WidenByteToUInt32Operator : IUnaryOneToFourOperator<byte, uint>
+        {
+            public static bool Vectorizable => true;
+
+            public static uint Invoke(byte x) => x;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (Vector128<uint>, Vector128<uint>, Vector128<uint>, Vector128<uint>) Invoke(Vector128<byte> x)
+            {
+                (Vector128<ushort> Lower, Vector128<ushort> Upper) ushorts = Vector128.Widen(x);
+                (Vector128<uint> Lower, Vector128<uint> Upper) uintsLower = Vector128.Widen(ushorts.Lower);
+                (Vector128<uint> Lower, Vector128<uint> Upper) uintsUpper = Vector128.Widen(ushorts.Upper);
+                return (uintsLower.Lower, uintsLower.Upper, uintsUpper.Lower, uintsUpper.Upper);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (Vector256<uint>, Vector256<uint>, Vector256<uint>, Vector256<uint>) Invoke(Vector256<byte> x)
+            {
+                (Vector256<ushort> Lower, Vector256<ushort> Upper) ushorts = Vector256.Widen(x);
+                (Vector256<uint> Lower, Vector256<uint> Upper) uintsLower = Vector256.Widen(ushorts.Lower);
+                (Vector256<uint> Lower, Vector256<uint> Upper) uintsUpper = Vector256.Widen(ushorts.Upper);
+                return (uintsLower.Lower, uintsLower.Upper, uintsUpper.Lower, uintsUpper.Upper);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (Vector512<uint>, Vector512<uint>, Vector512<uint>, Vector512<uint>) Invoke(Vector512<byte> x)
+            {
+                (Vector512<ushort> Lower, Vector512<ushort> Upper) ushorts = Vector512.Widen(x);
+                (Vector512<uint> Lower, Vector512<uint> Upper) uintsLower = Vector512.Widen(ushorts.Lower);
+                (Vector512<uint> Lower, Vector512<uint> Upper) uintsUpper = Vector512.Widen(ushorts.Upper);
+                return (uintsLower.Lower, uintsLower.Upper, uintsUpper.Lower, uintsUpper.Upper);
+            }
+        }
+
+        /// <summary>(float)byte</summary>
+        private readonly struct WidenByteToSingleOperator : IUnaryOneToFourOperator<byte, float>
+        {
+            public static bool Vectorizable => true;
+
+            public static float Invoke(byte x) => x;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (Vector128<float>, Vector128<float>, Vector128<float>, Vector128<float>) Invoke(Vector128<byte> x)
+            {
+                var results = WidenByteToUInt32Operator.Invoke(x);
+                return (
+                    Vector128.ConvertToSingle(results.Item1),
+                    Vector128.ConvertToSingle(results.Item2),
+                    Vector128.ConvertToSingle(results.Item3),
+                    Vector128.ConvertToSingle(results.Item4)
+                    );
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (Vector256<float>, Vector256<float>, Vector256<float>, Vector256<float>) Invoke(Vector256<byte> x)
+            {
+                var results = WidenByteToUInt32Operator.Invoke(x);
+                return (
+                    Vector256.ConvertToSingle(results.Item1),
+                    Vector256.ConvertToSingle(results.Item2),
+                    Vector256.ConvertToSingle(results.Item3),
+                    Vector256.ConvertToSingle(results.Item4)
+                    );
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (Vector512<float>, Vector512<float>, Vector512<float>, Vector512<float>) Invoke(Vector512<byte> x)
+            {
+                var results = WidenByteToUInt32Operator.Invoke(x);
+                return (
+                    Vector512.ConvertToSingle(results.Item1),
+                    Vector512.ConvertToSingle(results.Item2),
+                    Vector512.ConvertToSingle(results.Item3),
+                    Vector512.ConvertToSingle(results.Item4)
+                    );
+            }
         }
 
         /// <summary>(short)sbyte</summary>


### PR DESCRIPTION
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Numerics.Tensors;

BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

[MemoryDiagnoser]
public class Tests
{
    private byte[] _bytes;
    private float[] _floats;

    [GlobalSetup]
    public void Setup()
    {
        _bytes = new byte[1024];
        new Random(42).NextBytes(_bytes);
        _floats = new float[_bytes.Length];
    }

    [Benchmark]
    public void Convert() => TensorPrimitives.ConvertTruncating<byte, float>(_bytes, _floats);
}
```

On my laptop with AVX512...

Before:

| Method  | Mean     |
|-------- |---------:|
| Convert | 1.429 us |

After:

| Method  | Mean     |
|-------- |---------:|
| Convert | 46.59 ns |