### PR TITLE
[Android] Fix return type marshalling on IsKeyStorePrivateKeyEntry

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
@@ -33,7 +33,7 @@ internal static partial class Interop
             return encoded;
         }
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509IsKeyStorePrivateKeyEntry")]
-        [return: MarshalAs(UnmanagedType.U1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool IsKeyStorePrivateKeyEntry(IntPtr handle);
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509GetCertificateForPrivateKeyEntry")]
         private static partial IntPtr GetPrivateKeyEntryCertificate(IntPtr privatKeyEntryHandle);


### PR DESCRIPTION
This PR addresses https://github.com/dotnet/runtime/pull/103337#discussion_r1649142815: the C code returns `int32_t` and the managed side specified wrong type.

/cc @akoeplinger @vcsjones 