### PR TITLE
Improve use of PAL's RawData for X509Certificate

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.AndroidKeyStore.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.AndroidKeyStore.cs
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             private static string GetCertificateHashString(ICertificatePal certPal)
             {
-                return X509Certificate.GetCertHashString(HashAlgorithmName.SHA256, certPal);
+                return X509Certificate.GetCertHashString(HashAlgorithmName.SHA256, certPal.RawData);
             }
 
             private struct EnumCertificatesContext

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -25,6 +25,7 @@ namespace System.Security.Cryptography.X509Certificates
         private volatile string? _lazyKeyAlgorithm;
         private volatile byte[]? _lazyKeyAlgorithmParameters;
         private volatile byte[]? _lazyPublicKey;
+        private volatile byte[]? _lazyRawData;
         private DateTime _lazyNotBefore = DateTime.MinValue;
         private DateTime _lazyNotAfter = DateTime.MinValue;
 
@@ -37,6 +38,7 @@ namespace System.Security.Cryptography.X509Certificates
             _lazyKeyAlgorithm = null;
             _lazyKeyAlgorithmParameters = null;
             _lazyPublicKey = null;
+            _lazyRawData = null;
             _lazyNotBefore = DateTime.MinValue;
             _lazyNotAfter = DateTime.MinValue;
 
@@ -242,6 +244,16 @@ namespace System.Security.Cryptography.X509Certificates
             throw new PlatformNotSupportedException();
         }
 
+        private protected ReadOnlyMemory<byte> PalRawDataMemory
+        {
+            get
+            {
+                ThrowIfInvalid();
+                return _lazyRawData ??= Pal.RawData;
+            }
+        }
+
+
         public IntPtr Handle => Pal is null ? IntPtr.Zero : Pal.Handle;
 
         public string Issuer
@@ -343,12 +355,7 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual byte[] GetCertHash(HashAlgorithmName hashAlgorithm)
         {
             ThrowIfInvalid();
-            return GetCertHash(hashAlgorithm, Pal);
-        }
-
-        private static byte[] GetCertHash(HashAlgorithmName hashAlgorithm, ICertificatePalCore certPal)
-        {
-            return CryptographicOperations.HashData(hashAlgorithm, certPal.RawData);
+            return CryptographicOperations.HashData(hashAlgorithm, PalRawDataMemory.Span);
         }
 
         public virtual bool TryGetCertHash(
@@ -358,7 +365,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ThrowIfInvalid();
 
-            return CryptographicOperations.TryHashData(hashAlgorithm, Pal.RawData, destination, out bytesWritten);
+            return CryptographicOperations.TryHashData(hashAlgorithm, PalRawDataMemory.Span, destination, out bytesWritten);
         }
 
         public virtual string GetCertHashString()
@@ -370,13 +377,15 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual string GetCertHashString(HashAlgorithmName hashAlgorithm)
         {
             ThrowIfInvalid();
-
-            return GetCertHashString(hashAlgorithm, Pal);
+            return GetCertHashString(hashAlgorithm, PalRawDataMemory.Span);
         }
 
-        internal static string GetCertHashString(HashAlgorithmName hashAlgorithm, ICertificatePalCore certPal)
+        internal static string GetCertHashString(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> rawData)
         {
-            return GetCertHash(hashAlgorithm, certPal).ToHexStringUpper();
+            Span<byte> buffer = stackalloc byte[64]; // Largest supported hash size is 512 bits
+
+            int written = CryptographicOperations.HashData(hashAlgorithm, rawData, buffer);
+            return Convert.ToHexString(buffer.Slice(0, written));
         }
 
         // Only use for internal purposes when the returned byte[] will not be mutated
@@ -409,7 +418,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ThrowIfInvalid();
 
-            return Pal.RawData.CloneByteArray();
+            return PalRawDataMemory.ToArray();
         }
 
         public override int GetHashCode()

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -253,7 +253,6 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-
         public IntPtr Handle => Pal is null ? IntPtr.Zero : Pal.Handle;
 
         public string Issuer

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -16,7 +16,6 @@ namespace System.Security.Cryptography.X509Certificates
 {
     public class X509Certificate2 : X509Certificate
     {
-        private volatile byte[]? _lazyRawData;
         private volatile Oid? _lazySignatureAlgorithm;
         private volatile int _lazyVersion;
         private volatile X500DistinguishedName? _lazySubjectName;
@@ -30,7 +29,6 @@ namespace System.Security.Cryptography.X509Certificates
 
         public override void Reset()
         {
-            _lazyRawData = null;
             _lazySignatureAlgorithm = null;
             _lazyVersion = 0;
             _lazySubjectName = null;
@@ -327,15 +325,7 @@ namespace System.Security.Cryptography.X509Certificates
         /// Unlike <see cref="RawData" />, this does not create a fresh copy of the data
         /// every time.
         /// </remarks>
-        public ReadOnlyMemory<byte> RawDataMemory
-        {
-            get
-            {
-                ThrowIfInvalid();
-
-                return _lazyRawData ??= Pal.RawData;
-            }
-        }
+        public ReadOnlyMemory<byte> RawDataMemory => PalRawDataMemory;
 
         public string SerialNumber => GetSerialNumberString();
 


### PR DESCRIPTION
This change pushes down the memoization of `RawData` from X509Certificate2 to X509Certificate (so we don't have it memoized twice). This is because the `RawData` property on the `ICertificatePal` may allocate, such as the case of the OpenSSL PAL.

Since the memoized value is available in the base X509Certificate, use it where appropriate such as creating the hash of a certificate. This also makes a small optimization of using the stack for the intermediate bytes between the hash and the hex value.

See https://github.com/dotnet/runtime/pull/103814 for some background.