### PR TITLE
[RISC-V] Add RiscV64 arch to tests/JIT/Stress/ABI/

### DIFF
--- a/src/tests/JIT/Stress/ABI/ABIs.cs
+++ b/src/tests/JIT/Stress/ABI/ABIs.cs
@@ -186,4 +186,34 @@ namespace ABIStress
             return size;
         }
     }
+
+    internal class Riscv64Abi : IAbi
+    {
+        // For Riscv64 structs larger than 16 bytes are passed by-ref and will
+        // inhibit tailcalls, so we exclude those.
+        public Type[] TailCalleeCandidateArgTypes { get; } =
+            new[]
+            {
+                typeof(byte), typeof(short), typeof(int), typeof(long),
+                typeof(float), typeof(double), typeof(Int128),
+                typeof(Vector<int>), typeof(Vector128<int>),
+                typeof(S1P), typeof(S2P), typeof(S2U), typeof(S3U),
+                typeof(S4P), typeof(S4U), typeof(S5U), typeof(S6U),
+                typeof(S7U), typeof(S8P), typeof(S8U), typeof(S9U),
+                typeof(S10U), typeof(S11U), typeof(S12U), typeof(S13U),
+                typeof(S14U), typeof(S15U), typeof(S16U),
+                typeof(Hfa1), typeof(I128_1)
+            };
+
+        public CallingConvention[] PInvokeConventions { get; } = { CallingConvention.Cdecl };
+
+        public int ApproximateArgStackAreaSize(List<TypeEx> parameters)
+        {
+            int size = 0;
+            foreach (TypeEx pm in parameters)
+                size += Util.RoundUp(pm.Size, 8);
+
+            return size;
+        }
+    }
 }

--- a/src/tests/JIT/Stress/ABI/Program.cs
+++ b/src/tests/JIT/Stress/ABI/Program.cs
@@ -408,6 +408,11 @@ namespace ABIStress
                     Console.WriteLine("Selecting armhf ABI.");
                     return new Arm32Abi();
                 }
+                if (RuntimeInformation.ProcessArchitecture == Architecture.RiscV64)
+                {
+                    Console.WriteLine("Selecting riscv64 ABI.");
+                    return new Riscv64Abi();
+                }
 
                 Trace.Assert(RuntimeInformation.ProcessArchitecture == Architecture.X64);
                 Console.WriteLine("Selecting SysV ABI");


### PR DESCRIPTION
With TieredCompilation JIT/Stress/ABI/ tests are skipped by theirs .sh launchers. Disabling TieredCompilation leads to fails like:
```
FAILED   - [  17s]JIT/Stress/ABI/tailcalls_do/tailcalls_do.sh
               
               BEGIN EXECUTION
               /opt/usr/coreclr-tc/coreroot/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true tailcalls_do.dll '--tailcalls' '--num-calls' '1000' '--no-ctrlc-summary'
               Stressing tailcalls
               OSVersion: Unix 6.6.17.2
               OSArchitecture: RiscV64
               ProcessArchitecture: RiscV64
               Process terminated. Assertion Failed
                  at ABIStress.Program.SelectAbi()
                  at ABIStress.Program..cctor()
                  at ABIStress.Program.DoTailCall(Int32 callerIndex)
                  at ABIStress.Program.DoCall(Int32 index)
                  at ABIStress.Program.Main(String[] args)
               
               ./tailcalls_do.sh: line 375: 1286782 Aborted                 $LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED
```

This patch adds RiscV64 ABI and makes pass JIT/Stress/ABI/ tests with `DOTNET_TieredCompilation="0"` option. Tests influenced:
```
./JIT/Stress/ABI/pinvokes_d/pinvokes_d.sh
./JIT/Stress/ABI/pinvokes_do/pinvokes_do.sh
./JIT/Stress/ABI/stubs_do/stubs_do.sh
./JIT/Stress/ABI/tailcalls_d/tailcalls_d.sh
./JIT/Stress/ABI/tailcalls_do/tailcalls_do.sh
```

cc @dotnet/samsung. Part of #84834.

cc @shushanhf @LuckyXu-HF seems Loongarch64 needs same changes.