### PR TITLE
[RISC-V] Add riscv64 arch to tracing/eventpipe/processinfo tests

### DIFF
--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -220,13 +220,9 @@ namespace Tracing.Tests.ProcessInfoValidation
             // see eventpipeeventsource.cpp for these values
             string expectedArchValue = RuntimeInformation.ProcessArchitecture switch
             {
-                Architecture.X86 => "x86",
-                Architecture.X64 => "x64",
                 Architecture.Arm => "arm32",
-                Architecture.Arm64 => "arm64",
-                Architecture.RiscV64 => "riscv64",
-                Architecture.LoongArch64 => "loongarch64",
-                _ => "Unknown"
+                // All other architectures match the enum member name
+                _ => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()
             };
 
             Utils.Assert(expectedArchValue.Equals(arch), $"Arch must match current Architecture. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -225,6 +225,7 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Architecture.Arm => "arm32",
                 Architecture.Arm64 => "arm64",
                 Architecture.RiscV64 => "riscv64",
+                Architecture.LoongArch64 => "loongarch64",
                 _ => "Unknown"
             };
 

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -224,10 +224,11 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Architecture.X64 => "x64",
                 Architecture.Arm => "arm32",
                 Architecture.Arm64 => "arm64",
+                Architecture.RiscV64 => "riscv64",
                 _ => "Unknown"
             };
 
-            Utils.Assert(expectedArchValue.Equals(arch), $"OS must match current Operating System. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");
+            Utils.Assert(expectedArchValue.Equals(arch), $"Arch must match current Architecture. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");
 
             Utils.Assert(end == totalSize, $"Full payload should have been read. Expected: {totalSize}, Received: {end}");
 

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
@@ -225,10 +225,11 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Architecture.X64 => "x64",
                 Architecture.Arm => "arm32",
                 Architecture.Arm64 => "arm64",
+                Architecture.RiscV64 => "riscv64",
                 _ => "Unknown"
             };
 
-            Utils.Assert(expectedArchValue.Equals(arch), $"OS must match current Operating System. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");
+            Utils.Assert(expectedArchValue.Equals(arch), $"Arch must match current Architecture. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");
 
             // VALIDATE ManagedEntrypointAssemblyName
             start = end;

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
@@ -226,6 +226,7 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Architecture.Arm => "arm32",
                 Architecture.Arm64 => "arm64",
                 Architecture.RiscV64 => "riscv64",
+                Architecture.LoongArch64 => "loongarch64",
                 _ => "Unknown"
             };
 

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
@@ -221,13 +221,9 @@ namespace Tracing.Tests.ProcessInfoValidation
             // see eventpipeeventsource.cpp for these values
             string expectedArchValue = RuntimeInformation.ProcessArchitecture switch
             {
-                Architecture.X86 => "x86",
-                Architecture.X64 => "x64",
                 Architecture.Arm => "arm32",
-                Architecture.Arm64 => "arm64",
-                Architecture.RiscV64 => "riscv64",
-                Architecture.LoongArch64 => "loongarch64",
-                _ => "Unknown"
+                // All other architectures match the enum member name
+                _ => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()
             };
 
             Utils.Assert(expectedArchValue.Equals(arch), $"Arch must match current Architecture. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");

--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
@@ -229,13 +229,9 @@ namespace Tracing.Tests.ProcessInfoValidation
             // see eventpipeeventsource.cpp for these values
             string expectedArchValue = RuntimeInformation.ProcessArchitecture switch
             {
-                Architecture.X86 => "x86",
-                Architecture.X64 => "x64",
                 Architecture.Arm => "arm32",
-                Architecture.Arm64 => "arm64",
-                Architecture.RiscV64 => "riscv64",
-                Architecture.LoongArch64 => "loongarch64",
-                _ => "Unknown"
+                // All other architectures match the enum member name
+                _ => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()
             };
 
             Utils.Assert(expectedArchValue.Equals(arch), $"Arch must match current Architecture. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");

--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
@@ -233,10 +233,11 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Architecture.X64 => "x64",
                 Architecture.Arm => "arm32",
                 Architecture.Arm64 => "arm64",
+                Architecture.RiscV64 => "riscv64",
                 _ => "Unknown"
             };
 
-            Utils.Assert(expectedArchValue.Equals(arch), $"OS must match current Operating System. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");
+            Utils.Assert(expectedArchValue.Equals(arch), $"Arch must match current Architecture. Expected: \"{expectedArchValue}\", Received: \"{arch}\"");
 
             // VALIDATE ManagedEntrypointAssemblyName
             start = end;

--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
@@ -234,6 +234,7 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Architecture.Arm => "arm32",
                 Architecture.Arm64 => "arm64",
                 Architecture.RiscV64 => "riscv64",
+                Architecture.LoongArch64 => "loongarch64",
                 _ => "Unknown"
             };
 


### PR DESCRIPTION
With TieredCompilation tracing/eventpipe/processinfo tests are skipped by theirs .sh launchers. Disabling TieredCompilation leads to fails like:

```
               Unhandled exception. System.Exception: OS must match current Operating System. Expected: "Unknown", Received: "riscv64"^M
                  at Tracing.Tests.Common.Utils.Assert(Boolean predicate, String message)^M
                  at Tracing.Tests.ProcessInfoValidation.ProcessInfoValidation.Main()^M
```

This patch adds RiscV64 and makes pass tracing/eventpipe/processinfo tests with `DOTNET_TieredCompilation="0"` option. Tests influenced:

```
tracing/eventpipe/processinfo/processinfo/processinfo.sh
tracing/eventpipe/processinfo2/processinfo2/processinfo2.sh
tracing/eventpipe/processinfo3/processinfo3/processinfo3.sh
```

cc @dotnet/samsung. Part of https://github.com/dotnet/runtime/issues/84834.

cc @shushanhf @LuckyXu-HF seems Loongarch64 needs same changes.