### PR TITLE
Change FileStream to be async by default

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -14,7 +14,7 @@ namespace System.IO
     {
         internal const int DefaultBufferSize = 4096;
         internal const FileShare DefaultShare = FileShare.Read;
-        private const bool DefaultIsAsync = false;
+        private const bool DefaultIsAsync = true;
 
         private readonly FileStreamStrategy _strategy;
 


### PR DESCRIPTION
I believe there's no reason to keep `FileStream` non-async by default after we rewrote `FileStream` since .NET 7. 
Flipping the switch to `true` can benefit all APIs like `File.Open`, `File.OpenWrite`, `File.Create` and etc.