### PR TITLE
Avoid rare deadlocks when using TypeDescriptor

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -82,7 +82,6 @@ namespace System.ComponentModel
 
         internal static Guid ExtenderProviderKey { get; } = Guid.NewGuid();
 
-        private static readonly object s_internalSyncObject = new object();
         /// <summary>
         /// Creates a new ReflectTypeDescriptionProvider. The type is the
         /// type we will obtain type information for.
@@ -224,7 +223,7 @@ namespace System.ComponentModel
 
             Debug.Assert(table != null, "COMPAT: Editor table should not be null"); // don't throw; RTM didn't so we can't do it either.
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 Hashtable editorTables = EditorTables;
                 if (!editorTables.ContainsKey(editorBaseType))
@@ -436,7 +435,7 @@ namespace System.ComponentModel
                 //
                 if (table == null)
                 {
-                    lock (s_internalSyncObject)
+                    lock (TypeDescriptor.s_commonSyncObject)
                     {
                         table = editorTables[editorBaseType];
                         if (table == null)
@@ -863,7 +862,7 @@ namespace System.ComponentModel
         {
             List<Type> typeList = new List<Type>();
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 Dictionary<Type, ReflectedTypeData>? typeData = _typeData;
                 if (typeData != null)
@@ -936,7 +935,7 @@ namespace System.ComponentModel
                 return td;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 if (_typeData != null && _typeData.TryGetValue(type, out td))
                 {
@@ -999,7 +998,7 @@ namespace System.ComponentModel
                 return;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 if (_typeData != null && _typeData.ContainsKey(componentType))
                 {
@@ -1024,7 +1023,7 @@ namespace System.ComponentModel
                 return td;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 if (_typeData != null && _typeData.TryGetValue(type, out td))
                 {
@@ -1122,7 +1121,7 @@ namespace System.ComponentModel
                 return attrs;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 attrs = (Attribute[]?)attributeCache[type];
                 if (attrs == null)
@@ -1150,7 +1149,7 @@ namespace System.ComponentModel
                 return attrs;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 attrs = (Attribute[]?)attributeCache[member];
                 if (attrs == null)
@@ -1178,7 +1177,7 @@ namespace System.ComponentModel
                 return events;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 events = (EventDescriptor[]?)eventCache[type];
                 if (events == null)
@@ -1275,7 +1274,7 @@ namespace System.ComponentModel
             ReflectPropertyDescriptor[]? extendedProperties = (ReflectPropertyDescriptor[]?)extendedPropertyCache[providerType];
             if (extendedProperties == null)
             {
-                lock (s_internalSyncObject)
+                lock (TypeDescriptor.s_commonSyncObject)
                 {
                     extendedProperties = (ReflectPropertyDescriptor[]?)extendedPropertyCache[providerType];
 
@@ -1363,7 +1362,7 @@ namespace System.ComponentModel
                 return properties;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 properties = (PropertyDescriptor[]?)propertyCache[type];
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/103265

Running the full suite of ComponentModel.TypeConverter.Tests (7,852 tests) results in a deadlock in a median of 1 in about of 150 cases when running locally (sample size of 4).

The cause is having two lock objects that can be locked in different orders. The fix here is to combine the locks, instead of fixing the one known case that cause a lock to be out of order compared to the other cases. Changing to a single lock avoids any other potentially unknown cases and helps prevent new cases. Combining the locks increased perf ~5% of the unit tests likely due to the same thread now only needing one lock instead of two in many scenarios; in a real-world scenario with many threads there may be a minor decrease in throughput during warmup \ startup. These lock objects are only used to add or update cache due to cache misses.

For testing, there was not a reliable way to add a unit test to trigger the rare case. With the fixes here, the verification included running the full test suite 4,000 times without a deadlock vs. ~150 times without the fix before encountering the deadlock. This was done by running a `.bat` file in the test artifacts folder (e.g. `artifacts\bin\System.ComponentModel.TypeConverter.Tests\Release\net9.0`) of the following:
```
@echo off
FOR /L %%A IN (1,1,2000) DO (
echo run# %%A
call ..\..\..\..\..\artifacts\bin\testhost\net9.0-windows-Release-x64\dotnet exec --runtimeconfig System.ComponentModel.TypeConverter.Tests.runtimeconfig.json --depsfile System.ComponentModel.TypeConverter.Tests.deps.json xunit.console.dll System.ComponentModel.TypeConverter.Tests.dll -xml testResults.xml -nologo -nocolor -notrait category=IgnoreForCI -notrait category=OuterLoop -notrait category=failing >result.txt
findstr /c:"Failed: 0" result.txt
if errorlevel 1 goto Fail
)
goto End
:Fail
echo FAILED
call type result.txt
:End
@echo on
````

The single known culprit is a call to [`TypeDescriptor.GetAttributes()`](https://github.com/dotnet/runtime/blob/ed6bbe69709283e468c4563dcbdd17125585400e/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs#L1278-L1287) when there is already a lock on `s_internalSyncObject`. This may cause a lock on [`TypeProvider.s_providerTable`](https://github.com/dotnet/runtime/blob/ed6bbe69709283e468c4563dcbdd17125585400e/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs#L49) in a different lock ordering than other cases.

Sample call stacks:
```csharp
// This locks one way:
TypeDescriptor.GetProperties(new XElement("someElement1"));
// * ReflectTypeDescriptionProvider.GetTypeData(System.Type, bool).  // s_internalSyncObject lock
// - ReflectTypeDescriptionProvider.IsPopulated(System.Type)
// - TypeDescriptor.Refresh(System.Type)
// - TypeDescriptor.AddProvider(System.ComponentModel.TypeDescriptionProvider, System.Type)
// - TypeDescriptor.AddDefaultProvider(System.Type)
// * TypeDescriptor.CheckDefaultProvider(System.Type). // s_providerTable lock
// - TypeDescriptor.NodeFor(System.Type, bool)
// - TypeDescriptor.NodeFor(System.Type)
// - TypeDescriptor.NodeFor(object, bool)
// - TypeDescriptor.NodeFor(object)
// - TypeDescriptor.GetDescriptor(object, bool)
// - TypeDescriptor.GetPropertiesImpl(object, System.Attribute[], bool, bool)
// - TypeDescriptor.GetProperties(object, bool)
// - TypeDescriptor.GetProperties(object)

// This locks another way:
using TestComponent testComponent = new TestComponent();
testComponent.Site = new TestSiteWithService();
testComponent.Disposed += (object obj, EventArgs args) => { };
TypeDescriptor.GetProperties(testComponent);
// * TypeDescriptor.CheckDefaultProvider(System.Type) // s_providerTable lock
// - TypeDescriptor.NodeFor(System.Type, bool)
// - TypeDescriptor.NodeFor(System.Type)
// - TypeDescriptor.GetDescriptor(System.Type, string)
// - TypeDescriptor.GetAttributes(System.Type)
// - ReflectTypeDescriptionProvider.ReflectedTypeData.GetAttributes()
// - ReflectTypeDescriptionProvider.GetAttributes(System.Type)
// - TypeDescriptor.DefaultTypeDescriptor.GetAttributes()
// - TypeDescriptor.GetAttributes(System.Type)
// * ReflectTypeDescriptionProvider.ReflectGetExtendedProperties(System.ComponentModel.IExtenderProvider) // s_internalSyncObject lock
// - ReflectTypeDescriptionProvider.GetExtendedProperties(object)
// - TypeDescriptor.TypeDescriptionNode.DefaultExtendedTypeDescriptor.System.ComponentModel.ICustomTypeDescriptor.GetProperties()
// - TypeDescriptor.GetPropertiesImpl(object, System.Attribute[], bool, bool)
// - TypeDescriptor.GetProperties(object, bool)
// - TypeDescriptor.GetProperties(object)

```

