### PR TITLE
UnixCommandLinePing.cs: improve searching for the system ping binary

### DIFF
--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -29,13 +29,13 @@ namespace System.Net.NetworkInformation
             {
                 string pathv4v6 = Path.Combine(folder, s_ipv4v6PingFile);
                 string path = Path.Combine(folder, fileName);
-                if (File.Exists(pathv4v6))
-                {
-                    return pathv4v6;
-                }
                 if (File.Exists(path))
                 {
                     return path;
+                }
+                if (File.Exists(pathv4v6))
+                {
+                    return pathv4v6;
                 }
             }
 

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -12,7 +12,7 @@ namespace System.Net.NetworkInformation
         // Ubuntu has ping under /bin, OSX under /sbin, ArchLinux under /usr/bin, Android under /system/bin, NixOS under /run/current-system/sw/bin.
         private static readonly string[] s_binFolders = { "/bin", "/sbin", "/usr/bin", "/system/bin", "/run/current-system/sw/bin" };
 
-        private const string s_ipv4PingFile = "ping4";
+        private const string s_ipv4PingFile = "ping";
         private const string s_ipv4v6PingFile = "ping";
         private const string s_ipv6PingFile = "ping6";
 

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -12,7 +12,7 @@ namespace System.Net.NetworkInformation
         // Ubuntu has ping under /bin, OSX under /sbin, ArchLinux under /usr/bin, Android under /system/bin, NixOS under /run/current-system/sw/bin.
         private static readonly string[] s_binFolders = { "/bin", "/sbin", "/usr/bin", "/system/bin", "/run/current-system/sw/bin" };
 
-        private const string s_ipv4PingFile = "ping";
+        private const string s_ipv4PingFile = "ping4";
         private const string s_ipv4v6PingFile = "ping";
         private const string s_ipv6PingFile = "ping6";
 

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -11,7 +11,9 @@ namespace System.Net.NetworkInformation
     {
         // Ubuntu has ping under /bin, OSX under /sbin, ArchLinux under /usr/bin, Android under /system/bin, NixOS under /run/current-system/sw/bin.
         private static readonly string[] s_binFolders = { "/bin", "/sbin", "/usr/bin", "/system/bin", "/run/current-system/sw/bin" };
-        private const string s_ipv4PingFile = "ping";
+
+        private const string s_ipv4PingFile = "ping4";
+        private const string s_ipv4v6PingFile = "ping";
         private const string s_ipv6PingFile = "ping6";
 
         private static readonly string? s_discoveredPing4UtilityPath = GetPingUtilityPath(ipv4: true);
@@ -21,11 +23,18 @@ namespace System.Net.NetworkInformation
         // We don't want to pick up an arbitrary or malicious ping
         // command, so that's why we do the path probing ourselves.
         private static string? GetPingUtilityPath(bool ipv4)
-        {
+        {   
             string fileName = ipv4 ? s_ipv4PingFile : s_ipv6PingFile;
             foreach (string folder in s_binFolders)
             {
+                string pathv4v6 = Path.Combine(folder, s_ipv4v6PingFile);
                 string path = Path.Combine(folder, fileName);
+                
+                if (File.Exists(pathv4v6))
+                {
+                    return pathv4v6;
+                }
+
                 if (File.Exists(path))
                 {
                     return path;

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -23,7 +23,7 @@ namespace System.Net.NetworkInformation
         // We don't want to pick up an arbitrary or malicious ping
         // command, so that's why we do the path probing ourselves.
         private static string? GetPingUtilityPath(bool ipv4)
-        {   
+        {
             string fileName = ipv4 ? s_ipv4PingFile : s_ipv6PingFile;
             foreach (string folder in s_binFolders)
             {

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -29,12 +29,10 @@ namespace System.Net.NetworkInformation
             {
                 string pathv4v6 = Path.Combine(folder, s_ipv4v6PingFile);
                 string path = Path.Combine(folder, fileName);
-                
                 if (File.Exists(pathv4v6))
                 {
                     return pathv4v6;
                 }
-
                 if (File.Exists(path))
                 {
                     return path;


### PR DESCRIPTION
On newer linux systems, binaries ping6 and ping4 are no longer shipped, replaced by a unified ping binary and *maybe* some symlinks that replace ping4 and ping6 for compatibility. dotnet should prefer using the unified ping binary wherever possible on linux for this reason.


This fixes [103736](https://github.com/dotnet/runtime/issues/103736#issue-2363215967)
