### PR TITLE
Mark generic arguments for unresolved generic types

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -2733,22 +2733,16 @@ namespace Mono.Linker.Steps
 		{
 			var arguments = instance.GenericArguments;
 
-			var generic_element = GetGenericProviderFromInstance (instance);
-			if (generic_element == null)
-				return;
-
-			var parameters = generic_element.GenericParameters;
-
-			if (arguments.Count != parameters.Count)
-				return;
+			IGenericParameterProvider? generic_element = GetGenericProviderFromInstance (instance);
+			Collection<GenericParameter>? parameters = generic_element?.GenericParameters;
 
 			for (int i = 0; i < arguments.Count; i++) {
 				var argument = arguments[i];
-				var parameter = parameters[i];
+				var parameter = parameters?[i];
 
 				var argumentTypeDef = MarkType (argument, new DependencyInfo (DependencyKind.GenericArgumentType, instance), origin);
 
-				if (Annotations.FlowAnnotations.RequiresGenericArgumentDataFlowAnalysis (parameter)) {
+				if (parameter is not null && Annotations.FlowAnnotations.RequiresGenericArgumentDataFlowAnalysis (parameter)) {
 					// The only two implementations of IGenericInstance both derive from MemberReference
 					Debug.Assert (instance is MemberReference);
 
@@ -2762,7 +2756,7 @@ namespace Mono.Linker.Steps
 
 				_dependencyGraph.AddRoot (_nodeFactory.GetTypeIsRelevantToVariantCastingNode (argumentTypeDef), "Generic Argument");
 
-				if (parameter.HasDefaultConstructorConstraint)
+				if (parameter?.HasDefaultConstructorConstraint == true)
 					MarkDefaultConstructor (argumentTypeDef, new DependencyInfo (DependencyKind.DefaultCtorForNewConstrainedGenericArgument, instance), origin);
 			}
 		}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/GenericsTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/GenericsTests.g.cs
@@ -76,6 +76,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task UnresolvedGenerics ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task UsedOverloadedGenericMethodInGenericClassIsNotStripped ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/Dependencies/UnresolvedGenericsLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/Dependencies/UnresolvedGenericsLibrary.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Mono.Linker.Tests.Cases.Generics.Dependencies
+{
+	public class UnresolvedGenericsLibrary
+	{
+		public class GenericClass<T> { }
+
+		public static void GenericMethod<T> () { }
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/UnresolvedGenerics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/UnresolvedGenerics.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Generics.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Generics
+{
+	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/103843", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
+	[SetupCompileBefore ("UnresolvedGenericsLibrary.dll", new[] { "Dependencies/UnresolvedGenericsLibrary.cs" },
+		removeFromLinkerInput: true)]
+	class UnresolvedGenerics
+	{
+		static void Main ()
+		{
+			UnresolvedGenericType ();
+			UnresolvedGenericBaseType ();
+			UnresolvedGenericMethod ();
+		}
+
+		[Kept]
+		class GenericTypeArgument { }
+
+		[Kept]
+		static void UnresolvedGenericType ()
+		{
+			new UnresolvedGenericsLibrary.GenericClass<GenericTypeArgument> ();
+		}
+
+		[Kept]
+		class BaseTypeGenericArgument { }
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (UnresolvedGenericsLibrary.GenericClass<BaseTypeGenericArgument>))]
+		class HasBaseType : UnresolvedGenericsLibrary.GenericClass<BaseTypeGenericArgument> { }
+
+		[Kept]
+		static void UnresolvedGenericBaseType ()
+		{
+			new HasBaseType ();
+		}
+
+		[Kept]
+		class GenericMethodArgument { }
+
+		[Kept]
+		static void UnresolvedGenericMethod ()
+		{
+			UnresolvedGenericsLibrary.GenericMethod<GenericMethodArgument> ();
+		}
+	}
+}


### PR DESCRIPTION
Fixes an ILLink crash when a base generic type is not resolvable. See https://github.com/dotnet/runtime/issues/93797#issuecomment-2174611753 for context. The failure mode was this:

- A generic type isn't resolvable because it's defined in an unreferenced assembly
- But the generic arguments are resolvable. Before the fix, we wouldn't necessarily mark these when the generic type isn't resolvable.
- When sweeping the assembly, we drop the typeref for the unmarked generic argument type.
- When writing the assembly, we try to write out the generic type reference, but crash because the generic argument type doesn't exist anymore.

This fixes it by marking the generic argument types even when the generic type definition can't be resolved.

Fixes https://github.com/dotnet/runtime/issues/93797

@dotnet/illink