### PR TITLE
Add test case for `IDynamicInterfaceCastable` on `ValueType`s.

### DIFF
--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -334,6 +334,15 @@ namespace IDynamicInterfaceCastableTests
         }
     }
 
+    public struct ValueTypeDynamicInterfaceCastable : IDynamicInterfaceCastable
+    {
+        public bool IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
+            => throw new Exception("ValueType implementations are ignored");
+
+        public RuntimeTypeHandle GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
+            => throw new Exception("ValueType implementations are ignored");
+    }
+
     [ActiveIssue("https://github.com/dotnet/runtime/issues/55742", TestRuntimes.Mono)]
     public class Program
     {
@@ -564,6 +573,27 @@ namespace IDynamicInterfaceCastableTests
             castableObj.InvalidImplementation = BadDynamicInterfaceCastable.InvalidReturn.DefaultHandle;
             ex = Assert.Throws<InvalidCastException>(() => testObj.GetMyType());
             Console.WriteLine($" ---- {ex.GetType().Name}: {ex.Message}");
+        }
+
+        [Fact]
+        public static void ValidateValueTypeImplementationIgnored()
+        {
+            Console.WriteLine($"Running {nameof(ValidateValueTypeImplementationIgnored)}");
+
+            Console.WriteLine(" -- Validate casting is ignored");
+            object notCastableVC = Create();
+
+            // Confirm the ValueType implements IDynamicInterfaceCastable
+            Assert.True(notCastableVC.GetType().IsValueType);
+            Assert.True(notCastableVC is IDynamicInterfaceCastable);
+
+            // Confirm the IDynamicInterfaceCastable implementation isn't called.
+            Assert.False(notCastableVC is ITest);
+            Assert.Null(notCastableVC as ITest);
+            Assert.Throws<InvalidCastException>(() => { var testObj = (ITest)notCastableVC; });
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static object Create() => (object)new ValueTypeDynamicInterfaceCastable();
         }
     }
 }

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -337,10 +338,10 @@ namespace IDynamicInterfaceCastableTests
     public struct ValueTypeDynamicInterfaceCastable : IDynamicInterfaceCastable
     {
         public bool IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
-            => throw new Exception("ValueType implementations are ignored");
+            => throw new UnreachableException("ValueType implementations are ignored");
 
         public RuntimeTypeHandle GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
-            => throw new Exception("ValueType implementations are ignored");
+            => throw new UnreachableException("ValueType implementations are ignored");
     }
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/55742", TestRuntimes.Mono)]


### PR DESCRIPTION
Add test that validates `IDynamicInterfaceCastable` is ignored when implemented on a `ValueType`.