### PR TITLE
Set callconv in unicodedata callback and update doc

### DIFF
--- a/src/libraries/System.Private.CoreLib/Tools/GenUnicodeProp/Updating-Unicode-Versions.md
+++ b/src/libraries/System.Private.CoreLib/Tools/GenUnicodeProp/Updating-Unicode-Versions.md
@@ -41,7 +41,15 @@ This should be done automatically by dependency-flow, so in theory there shouldn
    - System.Globalization.Tests.csproj
    - System.Globalization.Nls.Tests.csproj
    - System.Text.Encodings.Web.Tests.csproj
-4. If the new Unicode data contains casing changes/updates, then we will also need to update `src/native/minipal/UnicodeDataGenerator/unicodedata.c` file. This file is used by most of the reflection stack whenever you specify the `BindingFlags.IgnoreCase`. In order to regenerate the contents of the `unicdedata.c` file, you need to run the Program located at `src/native/minipal/UnicodeDataGenerator/unicodedata.cs` and give a full path to the new UnicodeData.txt as a parameter.
+4. If the new Unicode data contains casing changes/updates, then we will also need to update `src/native/minipal/unicodedata.c` file. This file is used by most of the reflection stack whenever you specify the `BindingFlags.IgnoreCase`. In order to regenerate the contents of the `unicdedata.c` file, you need to run the Program located at `src/native/minipal/UnicodeDataGenerator/unicodedata.cs` and give a full path to the new UnicodeData.txt as a parameter. e.g. in Unix shell:
+    ```sh
+    # download UnicodeData.txt
+    $ curl -sSLo /tmp/UnicodeData.txt https://www.unicode.org/Public/14.0.0/ucd/UnicodeData.txt
+
+    # update unicodedata.c
+    $ cd runtime
+    $ ./dotnet.sh run --project src/native/minipal/UnicodeDataGenerator /tmp/UnicodeData.txt > src/native/minipal/unicodedata.c
+    ```
 5. Update the Regex casing equivalence table using the UnicodeData.txt file from the new Unicode version. You can find the instructions on how to do this [here](../../../System.Text.RegularExpressions/tools/Readme.md).
 6. Finally, last step is to update the license for the Unicode data into our [Third party notices](../../../../../THIRD-PARTY-NOTICES.TXT) by copying the contents located in `https://www.unicode.org/license.html` to the section that has the Unicode license in our notices.
 7. That's it, now commit all of the changed files, and send a PR into dotnet/runtime with the updates. If there were any special things you had to do that are not noted on this document, PLEASE UPDATE THESE INSTRUCTIONS to facilitate future updates.

--- a/src/native/minipal/UnicodeDataGenerator/Program.cs
+++ b/src/native/minipal/UnicodeDataGenerator/Program.cs
@@ -7,8 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 
-Console.WriteLine(@"
-// Licensed to the .NET Foundation under one or more agreements.
+Console.WriteLine(@"// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 //
@@ -16,8 +15,9 @@ Console.WriteLine(@"
 // IF YOU NEED TO UPDATE UNICODE VERSION FOLLOW THE GUIDE AT src/libraries/System.Private.CoreLib/Tools/GenUnicodeProp/Updating-Unicode-Versions.md
 //
 
-#include <minipal/strings.h>
 #include <inttypes.h>
+#include <minipal/utils.h>
+#include <minipal/strings.h>
 
 typedef struct
 {
@@ -71,7 +71,7 @@ Console.WriteLine($@"
 #define UNICODE_DATA_SIZE {numberOfCases}");
 
 Console.WriteLine(@"
-static int UnicodeDataComp(const void *opposingCode, const void *elem)
+static int CALLBACK_CALLCONV UnicodeDataComp(const void *opposingCode, const void *elem)
 {
     CHAR16_T code = ((UnicodeDataRec*)elem)->code;
 

--- a/src/native/minipal/UnicodeDataGenerator/Program.cs
+++ b/src/native/minipal/UnicodeDataGenerator/Program.cs
@@ -71,7 +71,7 @@ Console.WriteLine($@"
 #define UNICODE_DATA_SIZE {numberOfCases}");
 
 Console.WriteLine(@"
-static int CALLBACK_CALLCONV UnicodeDataComp(const void *opposingCode, const void *elem)
+static int LIBC_CALLBACK UnicodeDataComp(const void *opposingCode, const void *elem)
 {
     CHAR16_T code = ((UnicodeDataRec*)elem)->code;
 

--- a/src/native/minipal/unicodedata.c
+++ b/src/native/minipal/unicodedata.c
@@ -2385,7 +2385,7 @@ static const UnicodeDataRec UnicodeData[] =
 
 #define UNICODE_DATA_SIZE 2359
 
-static int CALLBACK_CALLCONV UnicodeDataComp(const void *opposingCode, const void *elem)
+static int LIBC_CALLBACK UnicodeDataComp(const void *opposingCode, const void *elem)
 {
     CHAR16_T code = ((UnicodeDataRec*)elem)->code;
 

--- a/src/native/minipal/unicodedata.c
+++ b/src/native/minipal/unicodedata.c
@@ -1,4 +1,3 @@
-
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -7,8 +6,9 @@
 // IF YOU NEED TO UPDATE UNICODE VERSION FOLLOW THE GUIDE AT src/libraries/System.Private.CoreLib/Tools/GenUnicodeProp/Updating-Unicode-Versions.md
 //
 
-#include <minipal/strings.h>
 #include <inttypes.h>
+#include <minipal/utils.h>
+#include <minipal/strings.h>
 
 typedef struct
 {
@@ -2385,7 +2385,7 @@ static const UnicodeDataRec UnicodeData[] =
 
 #define UNICODE_DATA_SIZE 2359
 
-static int UnicodeDataComp(const void *opposingCode, const void *elem)
+static int CALLBACK_CALLCONV UnicodeDataComp(const void *opposingCode, const void *elem)
 {
     CHAR16_T code = ((UnicodeDataRec*)elem)->code;
 

--- a/src/native/minipal/utils.h
+++ b/src/native/minipal/utils.h
@@ -33,7 +33,7 @@
 #endif
 
 #if defined(_MSC_VER)
-#define LIBC_CALLBACK _cdecl
+#define LIBC_CALLBACK __cdecl
 #else
 #define LIBC_CALLBACK
 #endif
@@ -58,11 +58,11 @@
 
 #if defined(_MSC_VER)
 #  ifdef SANITIZER_SHARED_RUNTIME
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) _cdecl
-#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) _cdecl
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) __cdecl
+#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) __cdecl
 #  else
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) _cdecl
-#    define SANITIZER_INTERFACE_CALLCONV _cdecl
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) __cdecl
+#    define SANITIZER_INTERFACE_CALLCONV __cdecl
 #  endif
 #else
 #  ifdef SANITIZER_SHARED_RUNTIME

--- a/src/native/minipal/utils.h
+++ b/src/native/minipal/utils.h
@@ -51,12 +51,18 @@
 #endif
 
 #if defined(_MSC_VER)
+#define CALLBACK_CALLCONV _cdecl
+#else
+#define CALLBACK_CALLCONV
+#endif
+
+#if defined(_MSC_VER)
 #  ifdef SANITIZER_SHARED_RUNTIME
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) __cdecl
-#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) __cdecl
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) CALLBACK_CALLCONV
+#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) CALLBACK_CALLCONV
 #  else
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) __cdecl
-#    define SANITIZER_INTERFACE_CALLCONV __cdecl
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) CALLBACK_CALLCONV
+#    define SANITIZER_INTERFACE_CALLCONV CALLBACK_CALLCONV
 #  endif
 #else
 #  ifdef SANITIZER_SHARED_RUNTIME

--- a/src/native/minipal/utils.h
+++ b/src/native/minipal/utils.h
@@ -51,18 +51,18 @@
 #endif
 
 #if defined(_MSC_VER)
-#define CALLBACK_CALLCONV _cdecl
+#define LIBC_CALLBACK _cdecl
 #else
-#define CALLBACK_CALLCONV
+#define LIBC_CALLBACK
 #endif
 
 #if defined(_MSC_VER)
 #  ifdef SANITIZER_SHARED_RUNTIME
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) CALLBACK_CALLCONV
-#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) CALLBACK_CALLCONV
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) LIBC_CALLBACK
+#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) LIBC_CALLBACK
 #  else
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) CALLBACK_CALLCONV
-#    define SANITIZER_INTERFACE_CALLCONV CALLBACK_CALLCONV
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) LIBC_CALLBACK
+#    define SANITIZER_INTERFACE_CALLCONV LIBC_CALLBACK
 #  endif
 #else
 #  ifdef SANITIZER_SHARED_RUNTIME

--- a/src/native/minipal/utils.h
+++ b/src/native/minipal/utils.h
@@ -33,6 +33,12 @@
 #endif
 
 #if defined(_MSC_VER)
+#define LIBC_CALLBACK _cdecl
+#else
+#define LIBC_CALLBACK
+#endif
+
+#if defined(_MSC_VER)
 #  if defined(__SANITIZE_ADDRESS__)
 #    define HAS_ADDRESS_SANITIZER
 #    define DISABLE_ASAN __declspec(no_sanitize_address)
@@ -51,18 +57,12 @@
 #endif
 
 #if defined(_MSC_VER)
-#define LIBC_CALLBACK _cdecl
-#else
-#define LIBC_CALLBACK
-#endif
-
-#if defined(_MSC_VER)
 #  ifdef SANITIZER_SHARED_RUNTIME
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) LIBC_CALLBACK
-#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) LIBC_CALLBACK
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(dllexport no_sanitize_address) _cdecl
+#    define SANITIZER_INTERFACE_CALLCONV __declspec(dllimport) _cdecl
 #  else
-#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) LIBC_CALLBACK
-#    define SANITIZER_INTERFACE_CALLCONV LIBC_CALLBACK
+#    define SANITIZER_CALLBACK_CALLCONV __declspec(no_sanitize_address) _cdecl
+#    define SANITIZER_INTERFACE_CALLCONV _cdecl
 #  endif
 #else
 #  ifdef SANITIZER_SHARED_RUNTIME


### PR DESCRIPTION
<del>toupper/lower in C++ only transforms the case of ASCII characters. It's different than what we expect in coreclr-pal and generally in C#. This change switches to minpal's toupper/lower which takes care of chars with opposite case in 0..0xFFFF range.</del>

Repurposed: set callconv for x86 and update docs.