### PR TITLE
[NativeAOT] collect garbage when memory is low

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
@@ -39,7 +39,7 @@ namespace System.Runtime
                 {
                     // RhpWaitForFinalizerRequest() returned false and indicated that memory is low. We help
                     // out by initiating a garbage collection and then go back to waiting for another request.
-                    InternalCalls.RhCollect(-1, InternalGCCollectionMode.Blocking);
+                    InternalCalls.RhCollect(0, InternalGCCollectionMode.Blocking, lowMemoryP: true);
                 }
             }
         }

--- a/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
@@ -27,6 +27,8 @@ GPTR_DECL(Thread, g_pFinalizerThread);
 CLREventStatic g_FinalizerEvent;
 CLREventStatic g_FinalizerDoneEvent;
 
+static HANDLE g_lowMemoryNotification = NULL;
+
 EXTERN_C void QCALLTYPE ProcessFinalizers();
 
 // Unmanaged front-end to the finalizer thread. We require this because at the point the GC creates the
@@ -76,6 +78,7 @@ bool RhInitializeFinalization()
         return false;
     if (!g_FinalizerDoneEvent.CreateManualEventNoThrow(false))
         return false;
+    g_lowMemoryNotification = PalCreateLowMemoryResourceNotification();
 
     // Create the finalizer thread itself.
     if (!PalStartFinalizerThread(FinalizerStart, (void*)g_FinalizerEvent.GetOSEvent()))
@@ -132,17 +135,12 @@ EXTERN_C UInt32_BOOL QCALLTYPE RhpWaitForFinalizerRequest()
     // two second timeout expires.
     do
     {
-        HANDLE  lowMemEvent = NULL;
-#if 0 // TODO: hook up low memory notification
-        lowMemEvent = pHeap->GetLowMemoryNotificationEvent();
+        HANDLE  lowMemEvent = g_lowMemoryNotification;
         HANDLE  rgWaitHandles[] = { g_FinalizerEvent.GetOSEvent(), lowMemEvent };
         uint32_t  cWaitHandles = (fLastEventWasLowMemory || (lowMemEvent == NULL)) ? 1 : 2;
         uint32_t  uTimeout = fLastEventWasLowMemory ? 2000 : INFINITE;
 
-        uint32_t uResult = PalWaitForMultipleObjectsEx(cWaitHandles, rgWaitHandles, FALSE, uTimeout, FALSE);
-#else
-        uint32_t uResult = PalWaitForSingleObjectEx(g_FinalizerEvent.GetOSEvent(), INFINITE, FALSE);
-#endif
+        uint32_t uResult = PalCompatibleWaitAny(/*alertable=*/ FALSE, uTimeout, cWaitHandles, rgWaitHandles, /*allowReentrantWait=*/ FALSE);
 
         switch (uResult)
         {

--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -706,6 +706,8 @@ REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalMarkThunksAsValidCallTargets(
 
 REDHAWK_PALIMPORT uint32_t REDHAWK_PALAPI PalCompatibleWaitAny(UInt32_BOOL alertable, uint32_t timeout, uint32_t count, HANDLE* pHandles, UInt32_BOOL allowReentrantWait);
 
+REDHAWK_PALIMPORT HANDLE PalCreateLowMemoryResourceNotification();
+
 REDHAWK_PALIMPORT void REDHAWK_PALAPI PalAttachThread(void* thread);
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalDetachThread(void* thread);
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1094,6 +1094,11 @@ REDHAWK_PALEXPORT uint32_t REDHAWK_PALAPI PalCompatibleWaitAny(UInt32_BOOL alert
     return WaitForSingleObjectEx(pHandles[0], timeout, alertable);
 }
 
+REDHAWK_PALEXPORT HANDLE PalCreateLowMemoryResourceNotification()
+{
+    return NULL;
+}
+
 #if !__has_builtin(_mm_pause)
 extern "C" void _mm_pause()
 // Defined for implementing PalYieldProcessor in PalRedhawk.h

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -312,6 +312,11 @@ REDHAWK_PALEXPORT uint32_t REDHAWK_PALAPI PalCompatibleWaitAny(UInt32_BOOL alert
     }
 }
 
+REDHAWK_PALEXPORT HANDLE PalCreateLowMemoryResourceNotification()
+{
+    return CreateMemoryResourceNotification(LowMemoryResourceNotification);
+}
+
 REDHAWK_PALEXPORT void REDHAWK_PALAPI PalSleep(uint32_t milliseconds)
 {
     return Sleep(milliseconds);


### PR DESCRIPTION
This matches the existing feature in CoreCLR:

https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/finalizerthread.cpp#L250

I tested with the following program. I observed that the finalizer was not triggered until I created a low memory condition on my computer.

```csharp
using System;
using System.Runtime.CompilerServices;
using System.Threading;


internal class Program
{
    static void Main(string[] args)
    {
        // The managed finalize loop (which checks for low memory) is not started until the first finalization request.
        // This program does not allocate enough for the GC to request finalization, so we manually trigger it.
        GC.WaitForPendingFinalizers();
        Alloc();
        Thread.Sleep(-1);
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    static void Alloc() => new MyFinalizableObject();
}

class MyFinalizableObject
{
    ~MyFinalizableObject()
    {
        Console.WriteLine("~MyFinalizableObject");
    }
}
```

Some notes:

* `PalCompatibleWaitAny` only supports multiple objects on Windows. The low memory event is only available on Windows, so this works out.
* It looks like CoreCLR only collects generation 0 on low memory. I have updated NativeAot to do the same, but I'm not sure that is ideal. Would collecting all generations make more sense?