### PR TITLE
Arm64/Sve: Handle ConvertTo* APIs properly

### DIFF
--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1477,6 +1477,16 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
                         break;
                     }
                 }
+#elif defined(TARGET_ARM64)
+                switch (intrinsic)
+                {
+                    case NI_Sve_ConvertToInt32:
+                    case NI_Sve_ConvertToUInt32:
+                        // Save the base type of return SIMD. It is used to contain this intrinsic inside
+                        // ConditionalSelect.
+                        retNode->AsHWIntrinsic()->SetAuxiliaryJitType(getBaseJitTypeOfSIMDType(sig->retTypeSigClass));
+                        break;
+                }
 #endif // TARGET_XARCH
 
                 break;

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1486,6 +1486,8 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
                         // ConditionalSelect.
                         retNode->AsHWIntrinsic()->SetAuxiliaryJitType(getBaseJitTypeOfSIMDType(sig->retTypeSigClass));
                         break;
+                    default:
+                        break;
                 }
 #endif // TARGET_XARCH
 

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -490,6 +490,20 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 {
                     assert(!instrIsRMW);
 
+                    // Special handling for ConvertTo* APIs
+                    // Just need to change the opt here.
+                    switch (intrinEmbMask.id)
+                    {
+                        case NI_Sve_ConvertToInt32:
+                        case NI_Sve_ConvertToUInt32:
+                        {
+                            opt = intrinEmbMask.baseType == TYP_DOUBLE ? INS_OPTS_D_TO_S : INS_OPTS_SCALABLE_S;
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+
                     if (targetReg != falseReg)
                     {
                         // If targetReg is not the same as `falseReg` then need to move

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3347,14 +3347,35 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                 // Handle op2
                 if (op2->OperIsHWIntrinsic())
                 {
-                    uint32_t maskSize = genTypeSize(node->GetSimdBaseType());
-                    uint32_t operSize = genTypeSize(op2->AsHWIntrinsic()->GetSimdBaseType());
-
-                    if ((maskSize == operSize) && IsInvariantInRange(op2, node) &&
-                        op2->isEmbeddedMaskingCompatibleHWIntrinsic())
+                    if (IsInvariantInRange(op2, node) && op2->isEmbeddedMaskingCompatibleHWIntrinsic())
                     {
-                        MakeSrcContained(node, op2);
-                        op2->MakeEmbMaskOp();
+                        uint32_t maskSize = genTypeSize(node->GetSimdBaseType());
+                        uint32_t operSize = genTypeSize(op2->AsHWIntrinsic()->GetSimdBaseType());
+                        if (maskSize == operSize)
+                        {
+                            // If the size of baseType of operation matches that of maskType, then contain
+                            // the operation
+                            MakeSrcContained(node, op2);
+                            op2->MakeEmbMaskOp();
+                        }
+                        else
+                        {
+                            // Else check if this operation has an auxilary type that matches the
+                            // mask size.
+                            GenTreeHWIntrinsic* embOp = op2->AsHWIntrinsic();
+
+                            // For now, make sure that we get here only for intrinsics that we are
+                            // sure about to rely on auxilary type's size.
+                            assert((embOp->GetHWIntrinsicId() == NI_Sve_ConvertToInt32) ||
+                                   (embOp->GetHWIntrinsicId() == NI_Sve_ConvertToUInt32));
+
+                            uint32_t auxSize = genTypeSize(embOp->GetAuxiliaryType());
+                            if (maskSize == auxSize)
+                            {
+                                MakeSrcContained(node, op2);
+                                op2->MakeEmbMaskOp();
+                            }
+                        }
                     }
                 }
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3365,7 +3365,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                             GenTreeHWIntrinsic* embOp = op2->AsHWIntrinsic();
 
                             // For now, make sure that we get here only for intrinsics that we are
-                            // sure about to rely on auxilary type's size.
+                            // sure about to rely on auxiliary type's size.
                             assert((embOp->GetHWIntrinsicId() == NI_Sve_ConvertToInt32) ||
                                    (embOp->GetHWIntrinsicId() == NI_Sve_ConvertToUInt32));
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3360,7 +3360,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                         }
                         else
                         {
-                            // Else check if this operation has an auxilary type that matches the
+                            // Else check if this operation has an auxiliary type that matches the
                             // mask size.
                             GenTreeHWIntrinsic* embOp = op2->AsHWIntrinsic();
 


### PR DESCRIPTION
We were hitting an assert in these tests because we were not handling the wrapping of these intrinsics inside `ConditionalSelect.

- Make sure that `ConvertTo*` APIs get contained inside `ConditionalSelect`. To do that we now store the auxiliary type as baseType of return vector and if that matches with the wrapped mask operation, then we contain the intrinsics.
- Fix the codegen depending on the variant of the operation (see below)


`ConvertToInt32` implements https://docsmirror.github.io/A64/2023-06/fcvtzu_z_p_z.html for following variants:
  - Single-precision to 32-bit  - `FCVTZS <Zd>.S, <Pg>/M, <Zn>.S`
  - Double-precision to 32-bit  - `FCVTZS <Zd>.S, <Pg>/M, <Zn>.D`

`ConvertToUInt32` implements https://docsmirror.github.io/A64/2023-06/fcvtzs_z_p_z.html for following variants:
- Single-precision to 32-bit  - `FCVTZU <Zd>.S, <Pg>/M, <Zn>.S`
- Double-precision to 32-bit  - `FCVTZU <Zd>.S, <Pg>/M, <Zn>.D`

