### PR TITLE
Use RtlDllShutdownInProgress to detect process shutdown on Windows

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1109,7 +1109,7 @@ void DebuggerController::DisableAll()
         // thus leaving the patchtable in an inconsistent state such that we may fail trying to walk it.
         // Since we're exiting anyways, leaving int3 in the code can't harm anybody.
         //
-        if (!g_fProcessDetach)
+        if (!IsAtProcessExit())
         {
             HASHFIND f;
             for (DebuggerControllerPatch *patch = g_patches->GetFirstPatch(&f);

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -2492,7 +2492,7 @@ public:
         }
         CONTRACTL_END;
 
-        if (g_fProcessDetach)
+        if (IsAtProcessExit())
             return true;
 
         if (g_pEEInterface->GetThread())

--- a/src/coreclr/debug/ee/debuggermodule.cpp
+++ b/src/coreclr/debug/ee/debuggermodule.cpp
@@ -113,8 +113,8 @@ DebuggerModuleTable::~DebuggerModuleTable()
 #ifdef _DEBUG
 bool DebuggerModuleTable::ThreadHoldsLock()
 {
-    // In shutdown (g_fProcessDetach), the shutdown thread implicitly holds all locks.
-    return g_fProcessDetach || g_pDebugger->HasDebuggerDataLock();
+    // In shutdown (IsAtProcessExit()), the shutdown thread implicitly holds all locks.
+    return IsAtProcessExit() || g_pDebugger->HasDebuggerDataLock();
 }
 #endif
 

--- a/src/coreclr/debug/ee/frameinfo.cpp
+++ b/src/coreclr/debug/ee/frameinfo.cpp
@@ -1899,7 +1899,7 @@ bool ShouldSendUMLeafChain(Thread * pThread)
     // If we're in shutodown, don't bother trying to sniff for an UM leaf chain.
     // @todo - we'd like to never even be trying to stack trace on shutdown, this
     // comes up when we do helper thread duty on shutdown.
-    if (g_fProcessDetach)
+    if (IsAtProcessExit())
     {
         return false;
     }

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -858,7 +858,7 @@ void DebuggerRCThread::MainLoop()
         PRECONDITION(m_thread != NULL);
         PRECONDITION(ThisIsHelperThreadWorker());
         PRECONDITION(IsDbgHelperSpecialThread());   // Can only be called on native debugger helper thread
-        PRECONDITION((!ThreadStore::HoldingThreadStore()) || g_fProcessDetach);
+        PRECONDITION((!ThreadStore::HoldingThreadStore()) || IsAtProcessExit());
     }
     CONTRACTL_END;
 
@@ -960,7 +960,7 @@ void DebuggerRCThread::MainLoop()
             {
 
                 // If they called continue, then we must have released the TSL.
-                _ASSERTE(!ThreadStore::HoldingThreadStore() || g_fProcessDetach);
+                _ASSERTE(!ThreadStore::HoldingThreadStore() || IsAtProcessExit());
 
                 // Let's release the lock here since runtime is resumed.
                 debugLockHolderSuspended.Release();
@@ -1062,7 +1062,7 @@ LWaitTimedOut:
                 // We also hold debugger lock the whole time that Runtime is stopped. We will release the debugger lock
                 // when we receive the Continue event that resumes the runtime.
 
-                _ASSERTE(ThreadStore::HoldingThreadStore() || g_fProcessDetach);
+                _ASSERTE(ThreadStore::HoldingThreadStore() || IsAtProcessExit());
             }
             else
             {
@@ -1107,7 +1107,7 @@ void DebuggerRCThread::TemporaryHelperThreadMainLoop()
         // It should be holding the debugger lock!!!
         //
         PRECONDITION(m_debugger->ThreadHoldsLock());
-        PRECONDITION((ThreadStore::HoldingThreadStore()) || g_fProcessDetach);
+        PRECONDITION((ThreadStore::HoldingThreadStore()) || IsAtProcessExit());
         PRECONDITION(ThisIsTempHelperThread());
     }
     CONTRACTL_END;
@@ -1177,7 +1177,7 @@ void DebuggerRCThread::TemporaryHelperThreadMainLoop()
             if (fWasContinue)
             {
                 // If they called continue, then we must have released the TSL.
-                _ASSERTE(!ThreadStore::HoldingThreadStore() || g_fProcessDetach);
+                _ASSERTE(!ThreadStore::HoldingThreadStore() || IsAtProcessExit());
 
 #ifdef _DEBUG
                 // Always reset the syncSpinCount to 0 on a continue so that we have the maximum number of possible
@@ -1241,7 +1241,7 @@ LWaitTimedOut:
             dwWaitTimeout = INFINITE;
 
             // Note: we hold the thread store lock now and debugger lock...
-            _ASSERTE(ThreadStore::HoldingThreadStore() || g_fProcessDetach);
+            _ASSERTE(ThreadStore::HoldingThreadStore() || IsAtProcessExit());
 
         }
     }

--- a/src/coreclr/vm/cachelinealloc.cpp
+++ b/src/coreclr/vm/cachelinealloc.cpp
@@ -67,7 +67,7 @@ CCacheLineAllocator::~CCacheLineAllocator()
         {
             if(tempPtr->m_pAddr[i] != NULL)
             {
-                if (!g_fProcessDetach)
+                if (!IsAtProcessExit())
                     VFree(tempPtr->m_pAddr[i]);
             }
         }

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1192,7 +1192,7 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
     // ungracefully. This check is an attempt to recognize that case
     // and avoid the impending hang when attempting to get the helper
     // thread to do things for us.
-    if ((g_pDebugInterface != NULL) && g_fProcessDetach)
+    if ((g_pDebugInterface != NULL) && IsAtProcessExit())
         g_pDebugInterface->EarlyHelperThreadDeath();
 #endif // DEBUGGING_SUPPORTED
 
@@ -1209,7 +1209,7 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         // Indicate the EE is the shut down phase.
         g_fEEShutDown |= ShutDown_Start;
 
-        if (!g_fProcessDetach && !g_fFastExitProcess)
+        if (!IsAtProcessExit() && !g_fFastExitProcess)
         {
             g_fEEShutDown |= ShutDown_Finalize1;
 
@@ -1219,7 +1219,7 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         }
 
         // Ok.  Let's stop the EE.
-        if (!g_fProcessDetach)
+        if (!IsAtProcessExit())
         {
             // Convert key locks into "shutdown" mode. A lock in shutdown mode means:
             // - Only the finalizer/helper/shutdown threads will be able to take the lock.
@@ -1321,7 +1321,7 @@ part2:
         // are already in use, then skip phase 2. This will happen only when those locks
         // are orphaned. In Vista, the penalty for attempting to enter such locks is
         // instant process termination.
-        if (g_fProcessDetach)
+        if (IsAtProcessExit())
         {
             // The assert below is a bit too aggressive and has generally brought cases that have been race conditions
             // and not easily reproed to validate a bug. A typical race scenario is when there are two threads,
@@ -1387,7 +1387,7 @@ part2:
     EX_END_CATCH(SwallowAllExceptions);
 
     ClrFlsClearThreadType(ThreadType_Shutdown);
-    if (!g_fProcessDetach)
+    if (!IsAtProcessExit())
     {
         g_pEEShutDownEvent->Set();
     }

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -396,6 +396,12 @@ BOOL g_singleVersionHosting;
 typedef BOOL(WINAPI* PINITIALIZECONTEXT2)(PVOID Buffer, DWORD ContextFlags, PCONTEXT* Context, PDWORD ContextLength, ULONG64 XStateCompactionMask);
 PINITIALIZECONTEXT2 g_pfnInitializeContext2 = NULL;
 
+static BOOLEAN WINAPI RtlDllShutdownInProgressFallback()
+{
+    return g_fProcessDetach;
+}
+PRTLDLLSHUTDOWNINPROGRESS g_pfnRtlDllShutdownInProgress = &RtlDllShutdownInProgressFallback;
+
 #ifdef TARGET_X86
 typedef VOID(__cdecl* PRTLRESTORECONTEXT)(PCONTEXT ContextRecord, struct _EXCEPTION_RECORD* ExceptionRecord);
 PRTLRESTORECONTEXT g_pfnRtlRestoreContext = NULL;
@@ -406,8 +412,12 @@ void InitializeOptionalWindowsAPIPointers()
     HMODULE hm = GetModuleHandleW(_T("kernel32.dll"));
     g_pfnInitializeContext2 = (PINITIALIZECONTEXT2)GetProcAddress(hm, "InitializeContext2");
 
-#ifdef TARGET_X86
     hm = GetModuleHandleW(_T("ntdll.dll"));
+    PRTLDLLSHUTDOWNINPROGRESS pfn = (PRTLDLLSHUTDOWNINPROGRESS)GetProcAddress(hm, "RtlDllShutdownInProgress");
+    if (pfn != NULL)
+        g_pfnRtlDllShutdownInProgress = pfn;
+
+#ifdef TARGET_X86
     g_pfnRtlRestoreContext = (PRTLRESTORECONTEXT)GetProcAddress(hm, "RtlRestoreContext");
 #endif //TARGET_X86
 }
@@ -1159,11 +1169,6 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
     Thread * pThisThread = GetThreadNULLOk();
 #endif
 
-    // If the process is detaching then set the global state.
-    // This is used to get around FreeLibrary problems.
-    if(fIsDllUnloading)
-        g_fProcessDetach = true;
-
     if (IsDbgHelperSpecialThread())
     {
         // Our debugger helper thread does not allow Thread object to be set up.
@@ -1478,17 +1483,6 @@ BOOL IsThreadInSTA()
 // Actual shut down logic is factored out to EEShutDownHelper which may be called
 // directly by EEShutDown, or indirectly on another thread (see code:#STAShutDown).
 //
-// In order that callees may also know the value of fIsDllUnloading, EEShutDownHelper
-// sets g_fProcessDetach = fIsDllUnloading, and g_fProcessDetach may then be retrieved
-// via code:IsAtProcessExit.
-//
-// NOTE 1: Actually, g_fProcessDetach is set to TRUE if fIsDllUnloading is TRUE. But
-// g_fProcessDetach doesn't appear to be explicitly set to FALSE. (Apparently
-// g_fProcessDetach is implicitly initialized to FALSE as clr.dll is loaded.)
-//
-// NOTE 2: EEDllMain(DLL_PROCESS_DETACH) already sets g_fProcessDetach to TRUE, so it
-// appears EEShutDownHelper doesn't have to.
-//
 void STDMETHODCALLTYPE EEShutDown(BOOL fIsDllUnloading)
 {
     CONTRACTL {
@@ -1729,25 +1723,13 @@ struct TlsDestructionMonitor
                     thread->m_pFrame = FRAME_TOP;
                     GCX_COOP_NO_DTOR_END();
                 }
-#ifdef _DEBUG
-                BOOL oldGCOnTransitionsOK = thread->m_GCOnTransitionsOK;
-                thread->m_GCOnTransitionsOK = FALSE;
-#endif
-                if (!IsAtProcessExit() && !g_fEEShutDown)
-                {
-                    GCX_COOP_NO_DTOR();
-                    FreeThreadStaticData(&t_ThreadStatics, thread);
-                    GCX_COOP_NO_DTOR_END();
-                }
-#ifdef _DEBUG
-                thread->m_GCOnTransitionsOK = oldGCOnTransitionsOK;
-#endif
+
                 thread->DetachThread(TRUE);
             }
             else
             {
                 // Since we don't actually cleanup the TLS data along this path, verify that it is already cleaned up
-                AssertThreadStaticDataFreed(&t_ThreadStatics);
+                AssertThreadStaticDataFreed();
             }
 
             ThreadDetaching();

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -3550,7 +3550,7 @@ void ExecutionManager::CleanupCodeHeaps()
     }
     CONTRACTL_END;
 
-    _ASSERTE (g_fProcessDetach || (GCHeapUtilities::IsGCInProgress()  && ::IsGCThread()));
+    _ASSERTE (IsAtProcessExit() || (GCHeapUtilities::IsGCInProgress()  && ::IsGCThread()));
 
     GetEEJitManager()->CleanupCodeHeaps();
 }
@@ -3564,7 +3564,7 @@ void EEJitManager::CleanupCodeHeaps()
     }
     CONTRACTL_END;
 
-    _ASSERTE (g_fProcessDetach || (GCHeapUtilities::IsGCInProgress() && ::IsGCThread()));
+    _ASSERTE (IsAtProcessExit() || (GCHeapUtilities::IsGCInProgress() && ::IsGCThread()));
 
 	// Quick out, don't even take the lock if we have not cleanup to do.
 	// This is important because ETW takes the CodeHeapLock when it is doing

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -3103,7 +3103,7 @@ void ComMethodTable::Cleanup()
 
     if (m_pDispatchInfo)
         delete m_pDispatchInfo;
-    if (m_pITypeInfo && !g_fProcessDetach)
+    if (m_pITypeInfo && !IsAtProcessExit())
         SafeRelease(m_pITypeInfo);
 
     // The m_pMDescr and the current instance is allocated from the related LoaderAllocator

--- a/src/coreclr/vm/crst.cpp
+++ b/src/coreclr/vm/crst.cpp
@@ -392,7 +392,7 @@ void CrstBase::PreEnter()
     STATIC_CONTRACT_GC_NOTRIGGER;
 
     // Are we in the shutdown sequence and in phase 2 of it?
-    if (g_fProcessDetach && (g_fEEShutDown & ShutDown_Phase2))
+    if (IsAtProcessExit() && (g_fEEShutDown & ShutDown_Phase2))
     {
         // Ensure that this lock has been flagged to be taken during shutdown
         _ASSERTE_MSG(CanBeTakenDuringShutdown(), "Attempting to take a lock at shutdown that is not CRST_TAKEN_DURING_SHUTDOWN");
@@ -569,7 +569,7 @@ void CrstBase::PreLeave()
     }
 
     // Are we in the shutdown sequence and in phase 2 of it?
-    if (g_fProcessDetach && (g_fEEShutDown & ShutDown_Phase2))
+    if (IsAtProcessExit() && (g_fEEShutDown & ShutDown_Phase2))
     {
         // Ensure that this lock has been flagged to be taken during shutdown
         _ASSERTE_MSG(CanBeTakenDuringShutdown(), "Attempting to leave a lock at shutdown that is not CRST_TAKEN_DURING_SHUTDOWN");

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -97,10 +97,6 @@
 #define ShutDown_IUnknown                       0x00000040
 #define ShutDown_Phase2                         0x00000080
 
-#ifndef DACCESS_COMPILE
-extern bool g_fProcessDetach;
-extern DWORD g_fEEShutDown;
-#endif
 // Total count of Crst lock  of the type (Shutdown) that are currently in use
 extern Volatile<LONG> g_ShutdownCrstUsageCount;
 

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -725,7 +725,7 @@ bool
 ep_rt_process_detach (void)
 {
 	STATIC_CONTRACT_NOTHROW;
-	return (bool)g_fProcessDetach;
+	return (bool)IsAtProcessExit();
 }
 
 static

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -1196,7 +1196,7 @@ void MinorCleanupSyncBlockComData(InteropSyncBlockInfo* pInteropInfo)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION( GCHeapUtilities::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ) );
+        PRECONDITION( GCHeapUtilities::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && IsAtProcessExit() ) );
     }
     CONTRACTL_END;
 
@@ -1225,7 +1225,7 @@ void CleanupSyncBlockComData(InteropSyncBlockInfo* pInteropInfo)
     }
     CONTRACTL_END;
 
-    if ((g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach )
+    if ((g_fEEShutDown & ShutDown_SyncBlock) && IsAtProcessExit() )
         MinorCleanupSyncBlockComData(pInteropInfo);
 
 #ifdef FEATURE_COMINTEROP_UNMANAGED_ACTIVATION

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -1709,7 +1709,7 @@ void RCW::MinorCleanup()
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(GCHeapUtilities::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ));
+        PRECONDITION(GCHeapUtilities::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && IsAtProcessExit() ));
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/stdinterfaces.cpp
+++ b/src/coreclr/vm/stdinterfaces.cpp
@@ -222,7 +222,7 @@ Unknown_AddRef_Internal(IUnknown* pUnk)
     if (pSimpleWrap  && (pOuter = pSimpleWrap->GetOuter()) != NULL)
     {
         // If we are in process detach, we cannot safely call release on our outer.
-        if (g_fProcessDetach)
+        if (IsAtProcessExit())
             return 1;
 
         ULONG cbRef = pOuter->AddRef();
@@ -284,7 +284,7 @@ Unknown_Release_Internal(IUnknown* pUnk)
     if (pSimpleWrap  && (pOuter = pSimpleWrap->GetOuter()) != NULL)
     {
         // If we are in process detach, we cannot safely call release on our outer.
-        if (g_fProcessDetach)
+        if (IsAtProcessExit())
             cbRef = 1;
 
         cbRef = SafeReleasePreemp(pOuter);

--- a/src/coreclr/vm/stringliteralmap.cpp
+++ b/src/coreclr/vm/stringliteralmap.cpp
@@ -341,7 +341,7 @@ GlobalStringLiteralMap::~GlobalStringLiteralMap()
     {
         // We are shutting down, the OS will reclaim the memory from the StringLiteralEntries,
         // m_MemoryPool and m_StringToEntryHashTable.
-        _ASSERTE(g_fProcessDetach);
+        _ASSERTE(IsAtProcessExit());
     }
 }
 

--- a/src/coreclr/vm/syncclean.cpp
+++ b/src/coreclr/vm/syncclean.cpp
@@ -66,7 +66,7 @@ void SyncClean::CleanUp ()
     LIMITED_METHOD_CONTRACT;
 
     // Only GC thread can call this.
-    _ASSERTE (g_fProcessDetach ||
+    _ASSERTE (IsAtProcessExit() ||
               IsGCSpecialThread() ||
               (GCHeapUtilities::IsGCInProgress()  && GetThreadNULLOk() == ThreadSuspend::GetSuspensionThread()));
     if (m_HashMap)

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -854,22 +854,6 @@ void DestroyThread(Thread *th)
         th->UnmarkThreadForAbort();
     }
 
-    // Clear any outstanding stale EH state that maybe still active on the thread.
-#ifdef FEATURE_EH_FUNCLETS
-    ExceptionTracker::PopTrackers((void*)-1);
-#else // !FEATURE_EH_FUNCLETS
-#ifdef TARGET_X86
-    PTR_ThreadExceptionState pExState = th->GetExceptionState();
-    if (pExState->IsExceptionInProgress())
-    {
-        GCX_COOP();
-        pExState->GetCurrentExceptionTracker()->UnwindExInfo((void *)-1);
-    }
-#else // !TARGET_X86
-#error Unsupported platform
-#endif // TARGET_X86
-#endif // FEATURE_EH_FUNCLETS
-
     if (g_fEEShutDown == 0)
     {
         th->SetThreadState(Thread::TS_ReportDead);
@@ -889,22 +873,6 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
     // !!! and then GetThread()=NULL, and dtor of contract does not work any more.
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
-
-    // Clear any outstanding stale EH state that maybe still active on the thread.
-#ifdef FEATURE_EH_FUNCLETS
-    ExceptionTracker::PopTrackers((void*)-1);
-#else // !FEATURE_EH_FUNCLETS
-#ifdef TARGET_X86
-    PTR_ThreadExceptionState pExState = GetExceptionState();
-    if (pExState->IsExceptionInProgress())
-    {
-        GCX_COOP();
-        pExState->GetCurrentExceptionTracker()->UnwindExInfo((void *)-1);
-    }
-#else // !TARGET_X86
-#error Unsupported platform
-#endif // TARGET_X86
-#endif // FEATURE_EH_FUNCLETS
 
 #ifdef FEATURE_COMINTEROP
     IErrorInfo *pErrorInfo;
@@ -962,19 +930,7 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
         m_ThreadHandleForClose = hThread;
     }
 
-    if (GCHeapUtilities::IsGCHeapInitialized())
-    {
-        // If the GC heap is initialized, we need to fix the alloc context for this detaching thread.
-        GCX_COOP();
-        // GetTotalAllocatedBytes reads dead_threads_non_alloc_bytes, but will suspend EE, being in COOP mode we cannot race with that
-        // however, there could be other threads terminating and doing the same Add.
-        InterlockedExchangeAdd64((LONG64*)&dead_threads_non_alloc_bytes, t_runtime_thread_locals.alloc_context.alloc_limit - t_runtime_thread_locals.alloc_context.alloc_ptr);
-        GCHeapUtilities::GetGCHeap()->FixAllocContext(&t_runtime_thread_locals.alloc_context, NULL, NULL);
-        t_runtime_thread_locals.alloc_context.init(); // re-initialize the context.
-
-        // Clear out the alloc context pointer for this thread. When TLS is gone, this pointer will point into freed memory.
-        m_pRuntimeThreadLocals = nullptr;
-    }
+    CooperativeCleanup();
 
     // We need to make sure that TLS are touched last here.
     SetThread(NULL);
@@ -2774,6 +2730,52 @@ void Thread::CleanupCOMState()
 }
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
+// Thread cleanup that must be run in cooperative mode before the thread is destroyed.
+void Thread::CooperativeCleanup()
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_TRIGGERS;
+    }
+    CONTRACTL_END;
+
+    // Skip the cleanup during process exit. Switch to cooperative mode can deadlock during process exit on Windows.
+    if (IsAtProcessExit())
+        return;
+
+    GCX_COOP();
+
+    // Clear any outstanding stale EH state that maybe still active on the thread.
+#ifdef FEATURE_EH_FUNCLETS
+    ExceptionTracker::PopTrackers((void*)-1);
+#else // !FEATURE_EH_FUNCLETS
+    PTR_ThreadExceptionState pExState = GetExceptionState();
+    if (pExState->IsExceptionInProgress())
+    {
+        pExState->GetCurrentExceptionTracker()->UnwindExInfo((void *)-1);
+    }
+#endif // FEATURE_EH_FUNCLETS
+
+    if (m_ThreadLocalDataPtr != NULL)
+    {
+        FreeThreadStaticData(this);
+        m_ThreadLocalDataPtr = NULL;
+    }
+
+    if (GCHeapUtilities::IsGCHeapInitialized())
+    {
+        // If the GC heap is initialized, we need to fix the alloc context for this detaching thread.
+        // GetTotalAllocatedBytes reads dead_threads_non_alloc_bytes, but will suspend EE, being in COOP mode we cannot race with that
+        // however, there could be other threads terminating and doing the same Add.
+        InterlockedExchangeAdd64((LONG64*)&dead_threads_non_alloc_bytes, t_runtime_thread_locals.alloc_context.alloc_limit - t_runtime_thread_locals.alloc_context.alloc_ptr);
+        GCHeapUtilities::GetGCHeap()->FixAllocContext(&t_runtime_thread_locals.alloc_context, NULL, NULL);
+        t_runtime_thread_locals.alloc_context.init(); // re-initialize the context.
+
+        // Clear out the alloc context pointer for this thread. When TLS is gone, this pointer will point into freed memory.
+        m_pRuntimeThreadLocals = nullptr;
+    }
+}
+
 // See general comments on thread destruction (code:#threadDestruction) above.
 void Thread::OnThreadTerminate(BOOL holdingLock)
 {
@@ -2809,6 +2811,11 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
     }
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
+    if (this == GetThreadNULLOk())
+    {
+        CooperativeCleanup();
+    }
+
     if (g_fEEShutDown != 0)
     {
         // We have started shutdown.  Not safe to touch CLR state.
@@ -2836,24 +2843,8 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
         // Destroy the LastThrown handle (and anything that violates the above assert).
         SafeSetThrowables(NULL);
 
-        // Free all structures related to thread statics for this thread
-        DeleteThreadStaticData();
-
-    }
-
-    if  (GCHeapUtilities::IsGCHeapInitialized())
-    {
-        // Guaranteed to NOT be a shutdown case, because we tear down the heap before
-        // we tear down any threads during shutdown.
-        if (ThisThreadID == CurrentThreadID && GetAllocContext() != nullptr)
-        {
-            GCX_COOP();
-            // GetTotalAllocatedBytes reads dead_threads_non_alloc_bytes, but will suspend EE, being in COOP mode we cannot race with that
-            // however, there could be other threads terminating and doing the same Add.
-            InterlockedExchangeAdd64((LONG64*)&dead_threads_non_alloc_bytes, GetAllocContext()->alloc_limit - GetAllocContext()->alloc_ptr);
-            GCHeapUtilities::GetGCHeap()->FixAllocContext(GetAllocContext(), NULL, NULL);
-            GetAllocContext()->init(); // re-initialize the context.
-        }
+        // Free loader allocator structures related to this thread
+        FreeLoaderAllocatorHandlesForTLSData(this);
     }
 
     // We switch a thread to dead when it has finished doing useful work.  But it
@@ -2950,14 +2941,6 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
 
         // If nobody else is holding onto the thread, we may destruct it here:
         ULONG   oldCount = DecExternalCount(TRUE);
-        // If we are shutting down the process, we only have one thread active in the
-        // system.  So we can disregard all the reasons that hold this thread alive --
-        // TLS is about to be reclaimed anyway.
-        if (IsAtProcessExit())
-            while (oldCount > 0)
-            {
-                oldCount = DecExternalCount(TRUE);
-            }
 
         // ASSUME THAT THE THREAD IS DELETED, FROM HERE ON
 
@@ -7588,32 +7571,6 @@ Frame * Thread::NotifyFrameChainOfExceptionUnwind(Frame* pStartFrame, LPVOID pvL
 
     // return the frame after the last one notified of the unwind
     return pFrame;
-}
-
-//+----------------------------------------------------------------------------
-//
-//  Method:     Thread::DeleteThreadStaticData   private
-//
-//  Synopsis:   Delete the static data for each appdomain that this thread
-//              visited.
-//
-//
-//+----------------------------------------------------------------------------
-
-void Thread::DeleteThreadStaticData()
-{
-    CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_COOPERATIVE;
-    }
-    CONTRACTL_END;
-
-    FreeLoaderAllocatorHandlesForTLSData(this);
-    if (!IsAtProcessExit() && !g_fEEShutDown)
-    {
-        FreeThreadStaticData(m_ThreadLocalDataPtr, this);
-    }
 }
 
 OBJECTREF Thread::GetCulture(BOOL bUICulture)

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1180,6 +1180,8 @@ public:
     void            BaseWinRTUninitialize();
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
+    void        CooperativeCleanup();
+
     void        OnThreadTerminate(BOOL holdingLock);
 
     static void CleanupDetachedThreads();
@@ -3338,12 +3340,6 @@ public:
     PTR_LOADERHANDLE pLoaderHandles = 0;
     SpinLock m_TlsSpinLock;
     PTR_ThreadLocalData GetThreadLocalDataPtr() { LIMITED_METHOD_DAC_CONTRACT; return m_ThreadLocalDataPtr; }
-
-public:
-
-    // Called during Thread death to clean up all structures
-    // associated with thread statics
-    void DeleteThreadStaticData();
 
 private:
     TailCallTls m_tailCallTls;

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -408,22 +408,21 @@ void FreeLoaderAllocatorHandlesForTLSData(Thread *pThread)
     }
 }
 
-void AssertThreadStaticDataFreed(ThreadLocalData *pThreadLocalData)
+void AssertThreadStaticDataFreed()
 {
     LIMITED_METHOD_CONTRACT;
 
-    if (!IsAtProcessExit() && !g_fEEShutDown)
-    {
-        _ASSERTE(pThreadLocalData->pThread == NULL);
-        _ASSERTE(pThreadLocalData->pCollectibleTlsArrayData == NULL);
-        _ASSERTE(pThreadLocalData->cCollectibleTlsData == 0);
-        _ASSERTE(pThreadLocalData->pNonCollectibleTlsArrayData == NULL);
-        _ASSERTE(pThreadLocalData->cNonCollectibleTlsData == 0);
-        _ASSERTE(pThreadLocalData->pInFlightData == NULL);
-    }
+    ThreadLocalData *pThreadLocalData = &t_ThreadStatics;
+
+    _ASSERTE(pThreadLocalData->pThread == NULL);
+    _ASSERTE(pThreadLocalData->pCollectibleTlsArrayData == NULL);
+    _ASSERTE(pThreadLocalData->cCollectibleTlsData == 0);
+    _ASSERTE(pThreadLocalData->pNonCollectibleTlsArrayData == NULL);
+    _ASSERTE(pThreadLocalData->cNonCollectibleTlsData == 0);
+    _ASSERTE(pThreadLocalData->pInFlightData == NULL);
 }
 
-void FreeThreadStaticData(ThreadLocalData *pThreadLocalData, Thread* pThread)
+void FreeThreadStaticData(Thread* pThread)
 {
     CONTRACTL {
         NOTHROW;
@@ -432,47 +431,34 @@ void FreeThreadStaticData(ThreadLocalData *pThreadLocalData, Thread* pThread)
     }
     CONTRACTL_END;
 
-    if (pThreadLocalData == NULL)
-        return;
+    SpinLockHolder spinLock(&pThread->m_TlsSpinLock);
 
-    if (!IsAtProcessExit() && !g_fEEShutDown)
+    ThreadLocalData *pThreadLocalData = &t_ThreadStatics;
+
+    for (int32_t iTlsSlot = 0; iTlsSlot < pThreadLocalData->cCollectibleTlsData; ++iTlsSlot)
     {
-        SpinLockHolder spinLock(&pThread->m_TlsSpinLock);
-
-        if (pThreadLocalData->pThread == NULL)
+        if (!IsHandleNullUnchecked(pThreadLocalData->pCollectibleTlsArrayData[iTlsSlot]))
         {
-            return;
+            DestroyLongWeakHandle(pThreadLocalData->pCollectibleTlsArrayData[iTlsSlot]);
         }
-
-        pThreadLocalData = pThread->m_ThreadLocalDataPtr;
-
-        if (pThreadLocalData == NULL)
-            return;
-
-        for (int32_t iTlsSlot = 0; iTlsSlot < pThreadLocalData->cCollectibleTlsData; ++iTlsSlot)
-        {
-            if (!IsHandleNullUnchecked(pThreadLocalData->pCollectibleTlsArrayData[iTlsSlot]))
-            {
-                DestroyLongWeakHandle(pThreadLocalData->pCollectibleTlsArrayData[iTlsSlot]);
-            }
-        }
-
-        delete[] (uint8_t*)pThreadLocalData->pCollectibleTlsArrayData;
-
-        pThreadLocalData->pCollectibleTlsArrayData = 0;
-        pThreadLocalData->cCollectibleTlsData = 0;
-        pThreadLocalData->pNonCollectibleTlsArrayData = 0;
-        pThreadLocalData->cNonCollectibleTlsData = 0;
-
-        while (pThreadLocalData->pInFlightData != NULL)
-        {
-            InFlightTLSData* pInFlightData = pThreadLocalData->pInFlightData;
-            pThreadLocalData->pInFlightData = pInFlightData->pNext;
-            delete pInFlightData;
-        }
-        pThreadLocalData->pThread->m_ThreadLocalDataPtr = NULL;
-        VolatileStoreWithoutBarrier(&pThreadLocalData->pThread, (Thread*)NULL);
     }
+
+    delete[] (uint8_t*)pThreadLocalData->pCollectibleTlsArrayData;
+
+    pThreadLocalData->pCollectibleTlsArrayData = 0;
+    pThreadLocalData->cCollectibleTlsData = 0;
+    pThreadLocalData->pNonCollectibleTlsArrayData = 0;
+    pThreadLocalData->cNonCollectibleTlsData = 0;
+
+    while (pThreadLocalData->pInFlightData != NULL)
+    {
+        InFlightTLSData* pInFlightData = pThreadLocalData->pInFlightData;
+        pThreadLocalData->pInFlightData = pInFlightData->pNext;
+        delete pInFlightData;
+    }
+
+    _ASSERTE(pThreadLocalData->pThread == pThread);
+    pThreadLocalData->pThread = NULL;
 }
 
 void SetTLSBaseValue(TADDR *ppTLSBaseAddress, TADDR pTLSBaseAddress, bool useGCBarrierInsteadOfHandleStore)

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -329,8 +329,8 @@ PTR_MethodTable LookupMethodTableForThreadStaticKnownToBeAllocated(TLSIndex inde
 void InitializeThreadStaticData();
 void InitializeCurrentThreadsStaticData(Thread* pThread);
 void FreeLoaderAllocatorHandlesForTLSData(Thread* pThread);
-void FreeThreadStaticData(ThreadLocalData *pThreadLocalData, Thread* pThread);
-void AssertThreadStaticDataFreed(ThreadLocalData *pThreadLocalData);
+void FreeThreadStaticData(Thread* pThread);
+void AssertThreadStaticDataFreed();
 void GetTLSIndexForThreadStatic(MethodTable* pMT, bool gcStatic, TLSIndex* pIndex, uint32_t bytesNeeded);
 void FreeTLSIndicesForLoaderAllocator(LoaderAllocator *pLoaderAllocator);
 void* GetThreadLocalStaticBase(TLSIndex index);

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -5543,7 +5543,7 @@ retry_for_debugger:
     // set tls flags for compat with SOS
     ClrFlsSetThreadType(ThreadType_DynamicSuspendEE);
 
-    _ASSERTE(ThreadStore::HoldingThreadStore() || g_fProcessDetach);
+    _ASSERTE(ThreadStore::HoldingThreadStore() || IsAtProcessExit());
 
 #ifdef PROFILING_SUPPORTED
     // If the profiler desires information about GCs, then let it know that one

--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -459,12 +459,24 @@ GVAL_DECL(bool, g_metadataUpdatesApplied);
 #endif
 EXTERN bool g_fManagedAttach;
 
+#ifdef HOST_WINDOWS
+typedef BOOLEAN (WINAPI* PRTLDLLSHUTDOWNINPROGRESS)();
+EXTERN PRTLDLLSHUTDOWNINPROGRESS g_pfnRtlDllShutdownInProgress;
+#endif
+
 // Indicates whether we're executing shut down as a result of DllMain
 // (DLL_PROCESS_DETACH). See comments at code:EEShutDown for details.
-inline BOOL    IsAtProcessExit()
+inline bool IsAtProcessExit()
 {
     SUPPORTS_DAC;
+#if defined(DACCESS_COMPILE) || !defined(HOST_WINDOWS)
     return g_fProcessDetach;
+#else
+    // RtlDllShutdownInProgress provides more accurace information about whether the process is shutting down.
+    // Use it if it is available to avoid shutdown deadlocks.
+    // https://learn.microsoft.com/windows/win32/devnotes/rtldllshutdowninprogress
+    return g_pfnRtlDllShutdownInProgress();
+#endif
 }
 
 enum FWStatus


### PR DESCRIPTION
Switching to cooperative mode is not safe during process shutdown on Windows. Process shutdown can terminate a thread in the middle of the GC. The shutdown thread deadlocks if it tries to switch to cooperative mode and wait for the GC to finish in this situation.

Use RtlDllShutdownInProgress Windows API to detect process shutdown to skip cleanup that has to be done in cooperative mode.

The existing g_fProcessDetach flag is set too late - using this flag to skip cooperative mode switch would lead to shutdown deadlocks, and the existing g_fEEShutDown flag is set too early - using this flag to skip cooperative mode switch would lead to shutdown crashes.

Fixes https://github.com/dotnet/runtime/issues/103624