### PR TITLE
Do not fold exported UnmanagedCallersOnly symbols

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
@@ -34,6 +34,11 @@ namespace ILCompiler
                 if (body is ISpecialUnboxThunkNode unboxThunk && unboxThunk.IsSpecialUnboxingThunk)
                     continue;
 
+                // Bodies that are visible from outside should not be folded because we don't know
+                // if they're address taken.
+                if (factory.GetSymbolAlternateName(body) != null)
+                    continue;
+
                 var key = new MethodInternKey(body, factory);
                 if (methodHash.TryGetValue(key, out MethodInternKey found))
                 {

--- a/src/tests/nativeaot/SmokeTests/StackTraceMetadata/BodyFoldingTest.cs
+++ b/src/tests/nativeaot/SmokeTests/StackTraceMetadata/BodyFoldingTest.cs
@@ -3,9 +3,16 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 class BodyFoldingTest
 {
+    [UnmanagedCallersOnly(EntryPoint = "FoldableMethod1")]
+    static void FoldableMethod1() { }
+
+    [UnmanagedCallersOnly(EntryPoint = "FoldableMethod2")]
+    static void FoldableMethod2() { }
+
     class SimpleDelegateTargets
     {
         public static object Return1DelStatic() => new object();

--- a/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata.csproj
+++ b/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata.csproj
@@ -12,4 +12,8 @@
     <Compile Include="StackTraceMetadata.cs" />
     <Compile Include="BodyFoldingTest.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <IlcArg Include="--export-unmanaged-entrypoints" />
+  </ItemGroup>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata_Stripped.csproj
+++ b/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata_Stripped.csproj
@@ -14,4 +14,8 @@
     <Compile Include="StackTraceMetadata.cs" />
     <Compile Include="BodyFoldingTest.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <IlcArg Include="--export-unmanaged-entrypoints" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes issue that was ran into at https://github.com/MichalStrehovsky/rt-sz/actions/runs/9611846921.

Cc @Sergio0694 @dotnet/ilc-contrib 