### PR TITLE
Remove allocation of state machine in QuicStream.WriteAsync

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -262,7 +262,7 @@ public sealed partial class QuicStream
     }
 
     /// <inheritdoc />
-    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
@@ -283,41 +283,21 @@ public sealed partial class QuicStream
             cancellationToken.ThrowIfCancellationRequested();
         }
 
-        if (TryReadAsyncInternal(buffer, out int totalCopied, out ValueTask valueTask, cancellationToken))
-        {
-            // hot path: there was data available.
-            Debug.Assert(valueTask.IsCompletedSuccessfully, "No pending read expected.");
-            valueTask.GetAwaiter().GetResult();
-
-            FinalizeRead(totalCopied);
-            return ValueTask.FromResult(totalCopied);
-        }
-
-        // cold path: no data available, await pending read
-        return ReadAsyncCold(buffer, valueTask, cancellationToken);
-
-        async ValueTask<int> ReadAsyncCold(Memory<byte> buffer, ValueTask pendingTask, CancellationToken cancellationToken)
-        {
-            await pendingTask.ConfigureAwait(false);
-
-            bool success = TryReadAsyncInternal(buffer, out int totalCopied, out pendingTask, cancellationToken);
-            Debug.Assert(success, "TryReadAsyncInternal should succeed after the await.");
-            Debug.Assert(pendingTask.IsCompletedSuccessfully, "No pending read expected.");
-            pendingTask.GetAwaiter().GetResult();
-
-            FinalizeRead(totalCopied);
-            return totalCopied;
-        }
-
-        bool TryReadAsyncInternal(Memory<byte> buffer, out int read, out ValueTask valueTask, CancellationToken cancellationToken)
+        // The following loop will repeat at most twice depending whether some data are readily available in the buffer (one iteration) or not.
+        // In which case, it'll wait on RECEIVE or any of PEER_SEND_(SHUTDOWN|ABORTED) event and attempt to copy data in the second iteration.
+        int totalCopied = 0;
+        do
         {
             // Concurrent call, this one lost the race.
-            if (!_receiveTcs.TryGetValueTask(out valueTask, this, cancellationToken))
+            if (!_receiveTcs.TryGetValueTask(out ValueTask valueTask, this, cancellationToken))
             {
                 throw new InvalidOperationException(SR.Format(SR.net_io_invalidnestedcall, "read"));
             }
 
-            read = _receiveBuffers.CopyTo(buffer, out bool complete, out bool empty);
+            // Copy data from the buffer, reduce target and increment total.
+            int copied = _receiveBuffers.CopyTo(buffer, out bool complete, out bool empty);
+            buffer = buffer.Slice(copied);
+            totalCopied += copied;
 
             // Make sure the task transitions into final state before the method finishes.
             if (complete)
@@ -326,33 +306,38 @@ public sealed partial class QuicStream
             }
 
             // Unblock the next await to end immediately, i.e. there were/are any data in the buffer.
-            if (read > 0 || !empty)
+            if (totalCopied > 0 || !empty)
             {
                 _receiveTcs.TrySetResult();
             }
 
-            return read > 0 || !empty || complete;
-        }
+            // This will either wait for RECEIVE event (no data in buffer) or complete immediately and reset the task.
+            await valueTask.ConfigureAwait(false);
 
-        void FinalizeRead(int totalCopied)
+            // This is the last read, finish even despite not copying anything.
+            if (complete)
+            {
+                break;
+            }
+        } while (!buffer.IsEmpty && totalCopied == 0);  // Exit the loop if target buffer is full we at least copied something.
+
+        if (totalCopied > 0 && Interlocked.CompareExchange(ref _receivedNeedsEnable, 0, 1) == 1)
         {
-            if (totalCopied > 0 && Interlocked.CompareExchange(ref _receivedNeedsEnable, 0, 1) == 1)
+            unsafe
             {
-                unsafe
-                {
-                    ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamReceiveSetEnabled(
-                        _handle,
-                        1),
-                    "StreamReceivedSetEnabled failed");
-                }
-            }
-
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Info(this, $"{this} Stream read '{totalCopied}' bytes.");
+                ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamReceiveSetEnabled(
+                    _handle,
+                    1),
+                "StreamReceivedSetEnabled failed");
             }
         }
 
+        if (NetEventSource.Log.IsEnabled())
+        {
+            NetEventSource.Info(this, $"{this} Stream read '{totalCopied}' bytes.");
+        }
+
+        return totalCopied;
     }
 
     /// <inheritdoc />

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -353,12 +354,12 @@ public sealed partial class QuicStream
     {
         if (_disposed == 1)
         {
-            return ValueTask.FromException(new ObjectDisposedException(nameof(QuicStream)));
+            return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(QuicStream))));
         }
 
         if (!_canWrite)
         {
-            return ValueTask.FromException(new InvalidOperationException(SR.net_quic_writing_notallowed));
+            return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new InvalidOperationException(SR.net_quic_writing_notallowed)));
         }
 
         if (NetEventSource.Log.IsEnabled())
@@ -376,7 +377,7 @@ public sealed partial class QuicStream
         // Concurrent call, this one lost the race.
         if (!_sendTcs.TryGetValueTask(out ValueTask valueTask, this, cancellationToken))
         {
-            return ValueTask.FromException(new InvalidOperationException(SR.Format(SR.net_io_invalidnestedcall, "write")));
+            return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new InvalidOperationException(SR.Format(SR.net_io_invalidnestedcall, "write"))));
         }
 
         // No need to call anything since we already have a result, most likely an exception.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -349,7 +349,7 @@ public sealed partial class QuicStream
     /// <param name="buffer">The region of memory to write data from.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <param name="completeWrites">Notifies the peer about gracefully closing the write side, i.e.: sends FIN flag with the data.</param>
-    public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, bool completeWrites, CancellationToken cancellationToken = default)
+    public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, bool completeWrites, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
@@ -379,8 +379,7 @@ public sealed partial class QuicStream
         // No need to call anything since we already have a result, most likely an exception.
         if (valueTask.IsCompleted)
         {
-            await valueTask.ConfigureAwait(false);
-            return;
+            return valueTask;
         }
 
         // For an empty buffer complete immediately, close the writing side of the stream if necessary.
@@ -391,8 +390,7 @@ public sealed partial class QuicStream
             {
                 CompleteWrites();
             }
-            await valueTask.ConfigureAwait(false);
-            return;
+            return valueTask;
         }
 
         // We own the lock, abort might happen, but exception will get stored instead.
@@ -428,7 +426,7 @@ public sealed partial class QuicStream
             }
         }
 
-        await valueTask.ConfigureAwait(false);
+        return valueTask;
     }
 
     /// <summary>


### PR DESCRIPTION
The function does not use any using blocks, and always returns after awaiting the task. This needlessly allocates a state machine since the await always yields (we are waiting for callback from msquic)