### PR TITLE
[release/8.0 staging] Port fix for 103477 to 8.0

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1883,6 +1883,12 @@ public:
         return m_block;
     }
 
+    // True if NextSuccessor will return the first successor or null
+    bool AtStart() const
+    {
+        return m_curSucc == UINT_MAX;
+    }
+
     // Returns the next available successor or `nullptr` if there are no more successors.
     BasicBlock* NextSuccessor(Compiler* comp)
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6334,7 +6334,7 @@ public:
     PhaseStatus optCloneLoops();
     void optCloneLoop(unsigned loopInd, LoopCloneContext* context);
     PhaseStatus optUnrollLoops(); // Unrolls loops (needs to have cost info)
-    void        optRemoveRedundantZeroInits();
+    void        optRemoveRedundantZeroInits(bool hasCycle);
     PhaseStatus optIfConversion(); // If conversion
 
 protected:

--- a/src/coreclr/jit/ssabuilder.h
+++ b/src/coreclr/jit/ssabuilder.h
@@ -101,4 +101,6 @@ private:
     BitVec       m_visited;
 
     SsaRenameState m_renameStack;
+
+    bool m_hasCycle;
 };

--- a/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_103477
+{
+    static int s_count;
+
+    [Fact]
+    public static int Test()
+    {
+        int result = -1;
+        try
+        {
+            Problem();
+            result = 100;
+        }
+        catch (Exception)
+        {
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Problem()
+    {
+        string s = "12151";
+        int i = 0;
+
+        char? a = null;
+        int count = 0;
+        while (true)
+        {
+            string? res = get(s, ref i, ref a);
+            if (res != null)
+            {
+                Count(res);
+                a = null; // !!! this line is removed from the published version
+                continue;
+            }
+
+            if (i >= s.Length)
+                break;
+
+            a = '.';
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Count(string s)
+    {
+        s_count++;
+        if (s_count > 5) throw new Exception();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static string? get(string s, ref int index, ref char? a)
+    {
+        if (index >= s.Length)
+            return null;
+
+        if (a == '.')
+            return ".";
+
+        a ??= s[index++];
+        return (a == '1') ? "1" : null;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_103477/Runtime_103477.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
"Port" the changes from #103788 to .NET 8.

We don't have the DFS tree, so enhance the topological sort that SSA uses to detect cycles and backedges.

Use this info to stop searching for redundant zero inits once flow from entry has entered a cycle.

Fixes #103477 (for .NET 8).

-----

## Customer Impact

- [X] Customer reported
- [ ] Found internally

In #103477 the customer reported silent bad code where a necessary zero initialization was removed via JIT optimization. 

## Regression

- [x] Yes
- [ ] No

The issue was introduced in .NET 8

## Testing

Verified repro (with jitted code) now passes; added test case. SPMI runs show we now keep a small number of other zero initializations that were previously (correctly) deemed redundant.

## Risk

Low. This is making an optimization more conservative.