### PR TITLE
Don't dispose timers if we're in our UnhandledException handler.

### DIFF
--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -239,10 +239,10 @@ namespace System.Runtime.Caching
             Dispose();
         }
 
-        internal bool InUnhandledExceptionHandler => _inUnhandledExceptionHandler == 1;
+        internal bool InUnhandledExceptionHandler => Volatile.Read(ref _inUnhandledExceptionHandler) > 0;
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
         {
-            Interlocked.Exchange(ref _inUnhandledExceptionHandler, 1);
+            Interlocked.Increment(ref _inUnhandledExceptionHandler);
 
             // if the CLR is terminating, dispose the cache.
             // This will dispose the perf counters
@@ -250,6 +250,8 @@ namespace System.Runtime.Caching
             {
                 Dispose();
             }
+
+            Interlocked.Decrement(ref _inUnhandledExceptionHandler);
         }
 
         private static void ValidatePolicy(CacheItemPolicy policy)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -239,7 +239,7 @@ namespace System.Runtime.Caching
             Dispose();
         }
 
-        internal bool InUnhandledExceptionHandler => Volatile.Read(ref _inUnhandledExceptionHandler) > 0;
+        internal bool InUnhandledExceptionHandler => _inUnhandledExceptionHandler > 0;
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
         {
             Interlocked.Increment(ref _inUnhandledExceptionHandler);

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -40,6 +40,7 @@ namespace System.Runtime.Caching
         private bool _throwOnDisposed;
         private EventHandler _onAppDomainUnload;
         private UnhandledExceptionEventHandler _onUnhandledException;
+        private int _inUnhandledExceptionHandler;
 #if NET
         [UnsupportedOSPlatformGuard("browser")]
         private static bool _countersSupported => !OperatingSystem.IsBrowser();
@@ -238,8 +239,11 @@ namespace System.Runtime.Caching
             Dispose();
         }
 
+        internal bool InUnhandledExceptionHandler => _inUnhandledExceptionHandler == 1;
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
         {
+            Interlocked.Exchange(ref _inUnhandledExceptionHandler, 1);
+
             // if the CLR is terminating, dispose the cache.
             // This will dispose the perf counters
             if (eventArgs.IsTerminating)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
@@ -340,10 +340,15 @@ namespace System.Runtime.Caching
                     GCHandleRef<Timer> timerHandleRef = _timerHandleRef;
                     if (timerHandleRef != null && Interlocked.CompareExchange(ref _timerHandleRef, null, timerHandleRef) == timerHandleRef)
                     {
-                        // #64115 and #102666 - It's not safe to dispose timers in our unhandled exception handler. But if we're in the unhandled
-                        // exception handler, then the process is going away. We don't really need to clean up timers. (Interactions of
-                        // processes/AppDomains/Timers/PerfCounters/etc were different in NetFx from which this package is derived.)
-                        if (!_memoryCache.InUnhandledExceptionHandler)
+                        // If inside an unhandled exception handler, Timers may be succeptible to deadlocks. Use a safer approach.
+                        if (_memoryCache.InUnhandledExceptionHandler)
+                        {
+                            // This does not stop/dispose the timer. But the callback on the timer is protected by _disposed, which we have already
+                            // set above.
+                            timerHandleRef.FreeHandle();
+                            Dbg.Trace("MemoryCacheStats", "Freed CacheMemoryTimers");
+                        }
+                        else
                         {
                             timerHandleRef.Dispose();
                             Dbg.Trace("MemoryCacheStats", "Stopped CacheMemoryTimers");

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/SRef.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/SRef.cs
@@ -59,6 +59,11 @@ namespace System.Runtime.Caching
         public void Dispose()
         {
             Target.Dispose();
+            FreeHandle();
+        }
+
+        internal void FreeHandle()
+        {
             // Safe to call Dispose more than once but not thread-safe
             if (_handle.IsAllocated)
             {


### PR DESCRIPTION
Fixes #64115 (and #102666 that I want to leave open so this can be triaged from the Timer side of things as well.)

The locks causing deadlock here are not known to MemoryCache at all. They exist in Timer and ThreadPool components. But to summarize, the .Net Timer class made changes in 5.0 that reduced contention and made Timer more performant. But this also introduced multiple locks into the mechanics of Timer, which can be taken in the wrong order if an unhandled exception throws during timer processing and an `UnhandledException` handler does something with Timers.

I believe the mantra has always been to `Dispose()` things that are `IDisposable`. MemoryCache itself is one of these things. If somebody calls Dispose() on MemoryCache purposefully, then it's reasonable to clean up our stuff - especially any Timers we've got firing periodically. So this PR aims to maintain that behavior; even if our Dispose() actions aren't as critical to perform as they were in NetFx when they also had to clean up perf counters that are shared machine-wide.

However, if we are in the process of cleaning up after an unhandled exception where we don't know if it's safe to Dispose() our Timers... I think it's safe to not do anything with the Timer, since the process will be going away shortly.

Unfortunately, we can only know if we are in our own UnhandledException handler. This won't solve any issue that arises from somebody else calling MemoryCache.Dispose() - Timer.Dispose() for that matter - in their UnhandledException handler. In those cases, I think we'd have to recommend the same approach we have had to take here with `Timer`. _Don't dispose `MemoryCache` in an unhandled exception handler._ We still have our handler hooked up and will clean ourselves up anyway - minus the Timer of course.