### PR TITLE
Fix AV in GcInfoDecoder

### DIFF
--- a/src/coreclr/gcinfo/gcinfoencoder.cpp
+++ b/src/coreclr/gcinfo/gcinfoencoder.cpp
@@ -2547,17 +2547,6 @@ void GcInfoEncoder::EliminateRedundantLiveDeadPairs(LifetimeTransition** ppTrans
 //
 BYTE* GcInfoEncoder::Emit()
 {
-    // GcInfoDecoder prefetches one size_t ahead for efficiency of sub-byte reads.
-    // To ensure prefetching is safe even if the stream ends on size_t boundary, add one bit padding.
-    if (m_Info2.GetByteCount() != 0)
-    {
-        m_Info2.Write(0, 1);
-    }
-    else
-    {
-        m_Info1.Write(0, 1);
-    }
-
     size_t cbGcInfoSize = m_Info1.GetByteCount() +
                           m_Info2.GetByteCount();
 

--- a/src/coreclr/gcinfo/gcinfoencoder.cpp
+++ b/src/coreclr/gcinfo/gcinfoencoder.cpp
@@ -2547,6 +2547,17 @@ void GcInfoEncoder::EliminateRedundantLiveDeadPairs(LifetimeTransition** ppTrans
 //
 BYTE* GcInfoEncoder::Emit()
 {
+    // GcInfoDecoder prefetches one size_t ahead for efficiency of sub-byte reads.
+    // To ensure prefetching is safe even if the stream ends on size_t boundary, add one bit padding.
+    if (m_Info2.GetByteCount() != 0)
+    {
+        m_Info2.Write(0, 1);
+    }
+    else
+    {
+        m_Info1.Write(0, 1);
+    }
+
     size_t cbGcInfoSize = m_Info1.GetByteCount() +
                           m_Info2.GetByteCount();
 

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -364,7 +364,7 @@ public:
         m_pCurrent = m_pBuffer + adjPos / BITS_PER_SIZE_T;
         m_RelPos = (int)(adjPos % BITS_PER_SIZE_T);
 
-        // we always set current position just before reading.
+        // we always call SetCurrentPos just before reading.
         // It is ok to prefetch.
         m_current = *m_pCurrent >> m_RelPos;
         _ASSERTE(GetCurrentPos() == pos);
@@ -379,7 +379,8 @@ public:
         m_pCurrent = m_pBuffer + adjPos / BITS_PER_SIZE_T;
         m_RelPos = (int)(adjPos % BITS_PER_SIZE_T);
 
-        // Skipping ahead may go to a position beyound the stream.
+        // Skipping ahead may go to a position at the edge-exclusive
+        // end of the stream.The location may have no more data.
         // We will not prefetch on word boundary - in case
         // the next word in in an unreadable page.
         if (m_RelPos == 0)

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -303,15 +303,6 @@ public:
 
         _ASSERTE(numBits > 0 && numBits <= BITS_PER_SIZE_T);
 
-        // "m_RelPos == BITS_PER_SIZE_T" means that m_current
-        // is not yet fetched. Do that now.
-        if(m_RelPos == BITS_PER_SIZE_T)
-        {
-            m_pCurrent++;
-            m_current = *m_pCurrent;
-            m_RelPos = 0;
-        }
-
         size_t result = m_current;
         m_current >>= numBits;
         int newRelPos = m_RelPos + numBits;
@@ -387,6 +378,7 @@ public:
         {
             m_pCurrent--;
             m_RelPos = BITS_PER_SIZE_T;
+            m_current = 0;
         }
         else
         {

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -268,6 +268,8 @@ public:
 
         m_pCurrent = m_pBuffer = dac_cast<PTR_size_t>((size_t)dac_cast<TADDR>(pBuffer) & ~((size_t)sizeof(size_t)-1));
         m_RelPos = m_InitialRelPos = (int)((size_t)dac_cast<TADDR>(pBuffer) % sizeof(size_t)) * 8/*BITS_PER_BYTE*/;
+        // There are always some bits in the GC info, at least the header.
+        // It is ok to prefetch.
         m_current = *m_pCurrent >> m_RelPos;
     }
 
@@ -301,10 +303,19 @@ public:
 
         _ASSERTE(numBits > 0 && numBits <= BITS_PER_SIZE_T);
 
+        // "m_RelPos == BITS_PER_SIZE_T" means that m_current
+        // is not yet fetched. Do that now.
+        if(m_RelPos == BITS_PER_SIZE_T)
+        {
+            m_pCurrent++;
+            m_current = *m_pCurrent;
+            m_RelPos = 0;
+        }
+
         size_t result = m_current;
         m_current >>= numBits;
         int newRelPos = m_RelPos + numBits;
-        if(newRelPos >= BITS_PER_SIZE_T)
+        if(newRelPos > BITS_PER_SIZE_T)
         {
             m_pCurrent++;
             m_current = *m_pCurrent;
@@ -324,14 +335,19 @@ public:
     {
         SUPPORTS_DAC;
 
-        size_t result = m_current & 1;
-        m_current >>= 1;
-        if(++m_RelPos == BITS_PER_SIZE_T)
+        // "m_RelPos == BITS_PER_SIZE_T" means that m_current
+        // is not yet fetched. Do that now.
+        if(m_RelPos == BITS_PER_SIZE_T)
         {
             m_pCurrent++;
             m_current = *m_pCurrent;
             m_RelPos = 0;
         }
+
+        m_RelPos++;
+        size_t result = m_current & 1;
+        m_current >>= 1;
+
         return result;
     }
 
@@ -347,6 +363,9 @@ public:
         size_t adjPos = pos + m_InitialRelPos;
         m_pCurrent = m_pBuffer + adjPos / BITS_PER_SIZE_T;
         m_RelPos = (int)(adjPos % BITS_PER_SIZE_T);
+
+        // we always set current position just before reading.
+        // It is ok to prefetch.
         m_current = *m_pCurrent >> m_RelPos;
         _ASSERTE(GetCurrentPos() == pos);
     }
@@ -355,15 +374,25 @@ public:
     {
         SUPPORTS_DAC;
 
-        SetCurrentPos(GetCurrentPos() + numBitsToSkip);
-    }
-
-    __forceinline size_t ReadBitAtPos( size_t pos )
-    {
+        size_t pos = GetCurrentPos() + numBitsToSkip;
         size_t adjPos = pos + m_InitialRelPos;
-        size_t* ptr = m_pBuffer + adjPos / BITS_PER_SIZE_T;
-        int relPos = (int)(adjPos % BITS_PER_SIZE_T);
-        return (*ptr) & (((size_t)1) << relPos);
+        m_pCurrent = m_pBuffer + adjPos / BITS_PER_SIZE_T;
+        m_RelPos = (int)(adjPos % BITS_PER_SIZE_T);
+
+        // Skipping ahead may go to a position beyound the stream.
+        // We will not prefetch on word boundary - in case
+        // the next word in in an unreadable page.
+        if (m_RelPos == 0)
+        {
+            m_pCurrent--;
+            m_RelPos = BITS_PER_SIZE_T;
+        }
+        else
+        {
+            m_current = *m_pCurrent >> m_RelPos;
+        }
+
+        _ASSERTE(GetCurrentPos() == pos);
     }
 
 

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -380,7 +380,7 @@ public:
         m_RelPos = (int)(adjPos % BITS_PER_SIZE_T);
 
         // Skipping ahead may go to a position at the edge-exclusive
-        // end of the stream.The location may have no more data.
+        // end of the stream. The location may have no more data.
         // We will not prefetch on word boundary - in case
         // the next word in in an unreadable page.
         if (m_RelPos == 0)

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -526,7 +526,10 @@ UINT32 GcInfoDecoder::FindSafePoint(UINT32 breakOffset)
         }
     }
 
-    m_Reader.SetCurrentPos(savedPos + m_NumSafePoints * numBitsPerOffset);
+    // Cannot just set the "savedPos + m_NumSafePoints * numBitsPerOffset" as
+    // there could be no more data if method tracks no variables of any kind.
+    // Must use Skip, which handles potential stream end.
+    m_Reader.Skip(savedPos + m_NumSafePoints * numBitsPerOffset - m_Reader.GetCurrentPos());
     return result;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/103894

GcInfoDecoder prefetches one `size_t` ahead for efficiency of sub-byte reads. In rare cases this can result in an off by one buffer overrun. 
We will not prefetch eagerly in cases where the position may be beyond the last `size_t` word of the bit stream.