### PR TITLE
Extend RunClassConstructor intrinsic handling to accept NonPublicConstructors

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -266,8 +266,6 @@ namespace System.Runtime.CompilerServices
         {
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2059:UnrecognizedReflectionPattern",
-            Justification = "We keep class constructors of all types with an MethodTable")]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
             Justification = "Constructed MethodTable of a Nullable forces a constructed MethodTable of the element type")]
         public static unsafe object GetUninitializedObject(

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -133,6 +133,8 @@ namespace ILLink.Shared.TrimAnalysis
 							=> new SystemTypeValue (typeHandle.RepresentedType),
 						RuntimeTypeHandleForGenericParameterValue genericParam
 							=> _annotations.GetGenericParameterValue (genericParam.GenericParameter),
+						RuntimeTypeHandleForValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers
+							=> valueWithDynamicallyAccessedMembers.UnderlyingTypeValue,
 						_ => annotatedMethodReturnValue
 					});
 				}
@@ -157,6 +159,8 @@ namespace ILLink.Shared.TrimAnalysis
 								=> new RuntimeTypeHandleValue (typeHandle.RepresentedType),
 							GenericParameterValue genericParam
 								=> new RuntimeTypeHandleForGenericParameterValue (genericParam.GenericParameter),
+							ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers
+								=> new RuntimeTypeHandleForValueWithDynamicallyAccessedMembers(valueWithDynamicallyAccessedMembers),
 							_ => annotatedMethodReturnValue
 						});
 					else
@@ -286,6 +290,9 @@ namespace ILLink.Shared.TrimAnalysis
 				foreach (var typeHandleValue in argumentValues[0].AsEnumerable ()) {
 					if (typeHandleValue is RuntimeTypeHandleValue runtimeTypeHandleValue) {
 						MarkStaticConstructor (runtimeTypeHandleValue.RepresentedType);
+					} else if (typeHandleValue is RuntimeTypeHandleForValueWithDynamicallyAccessedMembers damAnnotatedHandle
+						&& (damAnnotatedHandle.UnderlyingTypeValue.DynamicallyAccessedMemberTypes & DynamicallyAccessedMemberTypes.NonPublicConstructors) != 0) {
+						// No action needed, NonPublicConstructors keeps the static constructor on the type
 					} else {
 						_diagnosticContext.AddDiagnostic (DiagnosticId.UnrecognizedTypeInRuntimeHelpersRunClassConstructor, calledMethod.GetDisplayName ());
 					}

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForValueWithDynamicallyAccessedMembers.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForValueWithDynamicallyAccessedMembers.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using ILLink.Shared.DataFlow;
+using ILLink.Shared.TypeSystemProxy;
+
+// This is needed due to NativeAOT which doesn't enable nullable globally yet
+#nullable enable
+
+namespace ILLink.Shared.TrimAnalysis
+{
+	/// <summary>
+	/// This represents a type handle obtained from a Type with DynamicallyAccessedMembers annotations.
+	/// </summary>
+	internal sealed record RuntimeTypeHandleForValueWithDynamicallyAccessedMembers : SingleValue
+	{
+		public RuntimeTypeHandleForValueWithDynamicallyAccessedMembers (in ValueWithDynamicallyAccessedMembers underlyingTypeValue)
+		{
+			UnderlyingTypeValue = underlyingTypeValue;
+		}
+
+		public readonly ValueWithDynamicallyAccessedMembers UnderlyingTypeValue;
+
+		public override SingleValue DeepCopy () => this; // This value is immutable
+
+		public override string ToString () => this.ValueToString (UnderlyingTypeValue);
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestTypeOfFromGeneric<TestType> ();
 			TestGetTypeHandle ();
 			TestGetTypeHandleFromGeneric<TestType> ();
-			TestUnsupportedPatterns (typeof (TestType));
+			TestFlowThroughGetTypeHandleGetTypeFromHandle (typeof (TestType));
 			TestNull ();
 			TestNoValue ();
 		}
@@ -58,8 +58,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			Type.GetTypeFromHandle (typeof (T).TypeHandle).RequiresPublicFields ();
 		}
 
-		[ExpectedWarning ("IL2072", nameof (Type.GetTypeFromHandle), nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
-		static void TestUnsupportedPatterns ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type typeWithMethods)
+		static void TestFlowThroughGetTypeHandleGetTypeFromHandle ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type typeWithMethods)
 		{
 			Type.GetTypeFromHandle (typeWithMethods.TypeHandle).RequiresPublicMethods ();
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -16,6 +17,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNull ();
 			TestNoValue ();
 			TestDataFlowType ();
+			TestNonPublicConstructorDataFlowType ();
+			TestPublicConstructorDataFlowType ();
 			TestIfElseUsingRuntimeTypeHandle (1);
 			TestIfElseUsingType (1);
 		}
@@ -59,6 +62,37 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestDataFlowType ()
 		{
 			Type type = FindType ();
+			RuntimeHelpers.RunClassConstructor (type.TypeHandle);
+		}
+
+		[Kept]
+		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		static Type FindTypeWithNonPublicConstructors ()
+		{
+			return null;
+		}
+
+		[Kept]
+		static void TestNonPublicConstructorDataFlowType ()
+		{
+			Type type = FindTypeWithNonPublicConstructors ();
+			RuntimeHelpers.RunClassConstructor (type.TypeHandle);
+		}
+
+		[Kept]
+		[return: KeptAttributeAttribute(typeof (DynamicallyAccessedMembersAttribute))]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+		static Type FindTypeWithPublicConstructors ()
+		{
+			return null;
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL2059", nameof (RuntimeHelpers) + "." + nameof (RuntimeHelpers.RunClassConstructor))]
+		static void TestPublicConstructorDataFlowType ()
+		{
+			Type type = FindTypeWithPublicConstructors ();
 			RuntimeHelpers.RunClassConstructor (type.TypeHandle);
 		}
 


### PR DESCRIPTION
This should not generate a warning since the static constructor will be kept.

This also requires #103946 to be correct on native AOT side.

Fixes #103679.

Cc @dotnet/illink