### PR TITLE
JIT: Fix formatting after liveness change

### DIFF
--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4068,7 +4068,8 @@ void GCInfo::gcMakeRegPtrTable(
     // TODO: Decide on whether we should enable this optimization for all
     // targets: https://github.com/dotnet/runtime/issues/103917
 #ifdef TARGET_XARCH
-    const bool noTrackedGCSlots = compiler->opts.MinOpts() && !compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT);
+    const bool noTrackedGCSlots =
+        compiler->opts.MinOpts() && !compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT);
 #else
     const bool noTrackedGCSlots = false;
 #endif


### PR DESCRIPTION
A formatting error ended up slipping through in #103809 since the jit-format pipeline was broken for a bit yesterday.