### PR TITLE
[mono][interp] Improve precision of native offset estimation

### DIFF
--- a/src/mono/mono/mini/interp/transform-opt.c
+++ b/src/mono/mono/mini/interp/transform-opt.c
@@ -3387,7 +3387,7 @@ can_propagate_var_def (TransformData *td, int var, InterpLivenessPosition cur_li
 static void
 interp_super_instructions (TransformData *td)
 {
-	interp_compute_native_offset_estimates (td);
+	interp_compute_native_offset_estimates (td, FALSE);
 
 	// Add some actual super instructions
 	for (int bb_dfs_index = 0; bb_dfs_index < td->bblocks_count_eh; bb_dfs_index++) {

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -522,7 +522,7 @@ void
 interp_link_bblocks (TransformData *td, InterpBasicBlock *from, InterpBasicBlock *to);
 
 int
-interp_compute_native_offset_estimates (TransformData *td);
+interp_compute_native_offset_estimates (TransformData *td, gboolean final_code);
 
 void
 interp_optimize_code (TransformData *td);


### PR DESCRIPTION
The interpreter had always had problems with emitting branches, because the interpreter IR is actually executable. So when we generate branches we don't know if the branch will be long or short. A fix for this was to always generate long branches, and before the final codegen we compute conservative native offset estimates for instructions / bblocks (which are always larger that what would end up in the final code). Based on these, we determine if some branches can only be short, in which case, during codegen we emit a short branch.

The problem arises with superinstructions doing branches which only have support for short branches. Before this pass, we need to compute the native offset estimates, in order to know if it is safe to optimize with a branch superins. The problem is that, it is hard to maintain the constraint for the native offset estimates if we are computing them so early in the optimization process. This commit fixes the estimate to account for additional moves that can be inserted by the var offset allocator. We still don't account for instructions inserted by some bblock optimizations (it is not clear if these are hit in practice).

This commit is a conservative fix, addressing an existing precision issue with the computation, but a better long term fix would probably be to either deconstruct the super instruction if we detect it needs to do a long branch during final emit or to just move super instruction generation to a very late stage, after all optimizations and codgen happened, as a peephole optimization, where we can be certain whether a certain branch will be short or long.

Fixes https://github.com/dotnet/runtime/issues/100753