### PR TITLE
Improve resiliency when rooting broken assemblies

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
@@ -99,9 +99,7 @@ namespace ILCompiler
 
         private static void CheckTypeCanBeUsedInSignature(TypeDesc type)
         {
-            MetadataType defType = type as MetadataType;
-
-            defType?.ComputeTypeContainsGCPointers();
+            ((CompilerTypeSystemContext)type.Context).EnsureLoadableType(type);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
@@ -46,7 +46,14 @@ namespace ILCompiler
 
         public void AddReflectionRoot(TypeDesc type, string reason)
         {
-            _factory.TypeSystemContext.EnsureLoadableType(type);
+            TypeDesc lookedAtType = type;
+            do
+            {
+                _factory.TypeSystemContext.EnsureLoadableType(lookedAtType);
+                lookedAtType = (lookedAtType as MetadataType)?.ContainingType;
+            }
+            while (lookedAtType != null);
+
             _rootAdder(_factory.ReflectedType(type), reason);
         }
 
@@ -64,6 +71,7 @@ namespace ILCompiler
             if (!_factory.MetadataManager.IsReflectionBlocked(field))
             {
                 _factory.TypeSystemContext.EnsureLoadableType(field.OwningType);
+                _factory.TypeSystemContext.EnsureLoadableType(field.FieldType);
                 _rootAdder(_factory.ReflectedField(field), reason);
             }
         }


### PR DESCRIPTION
Do a couple more upfront checks to trigger exceptions when it's recoverable. Fixes #103843.

We still eventually crash when generating debug information since we don't have fine grained tracking of what parts of the type we looked at. The user would need to drop debug info generation, or stop feeding the compiler garbage.

Cc @dotnet/ilc-contrib