### PR TITLE
[release/8.0] Fix incorrect time patterns for some cultures on browser in `HybridGlobalization`

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFullDateTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFullDateTimePattern.cs
@@ -28,13 +28,13 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, "dddd، d MMMM yyyy h:mm:ss tt" }; // dddd، d MMMM yyyy g h:mm:ss tt
             yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, "yyyy MMMM d, dddd h:mm:ss tt" };
-            yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, "dddd, d MMMM yyyy г. H:mm:ss ч." }; // dddd, d MMMM yyyy 'г'. H:mm:ss
+            yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, "dddd, d MMMM yyyy 'г'. H:mm:ss ч." }; // dddd, d MMMM yyyy 'г'. H:mm:ss
             yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, "dddd, d MMMM, yyyy h:mm:ss tt" };
             yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, "dddd, d MMMM, yyyy h:mm:ss tt" };
-            yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, "dddd, d de MMMM de yyyy H:mm:ss" }; // dddd, d MMMM 'de' yyyy H:mm:ss
-            yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, "dddd, d de MMMM de yyyy H:mm:ss" }; // dddd, d MMMM 'de' yyyy H:mm:ss
+            yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy H:mm:ss" }; // dddd, d MMMM 'de' yyyy H:mm:ss
+            yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy H:mm:ss" }; // dddd, d MMMM 'de' yyyy H:mm:ss
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, "dddd d. MMMM yyyy H:mm:ss" };
-            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, "dddd den d. MMMM yyyy HH.mm.ss" }; // dddd 'den' d. MMMM yyyy HH.mm.ss
+            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, "dddd 'den' d. MMMM yyyy HH.mm.ss" };
             yield return new object[] { new CultureInfo("de-AT").DateTimeFormat, "dddd, d. MMMM yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("de-BE").DateTimeFormat, "dddd, d. MMMM yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("de-CH").DateTimeFormat, "dddd, d. MMMM yyyy HH:mm:ss" };
@@ -146,15 +146,15 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-ZA").DateTimeFormat, "dddd, d MMMM yyyy HH:mm:ss" }; // dddd, dd MMMM yyyy HH:mm:ss
             yield return new object[] { new CultureInfo("en-ZM").DateTimeFormat, "dddd, d MMMM yyyy h:mm:ss tt" };
             yield return new object[] { new CultureInfo("en-ZW").DateTimeFormat, "dddd, d MMMM yyyy HH:mm:ss" }; // dddd, dd MMMM yyyy HH:mm:ss
-            yield return new object[] { new CultureInfo("es-419").DateTimeFormat, "dddd, d de MMMM de yyyy HH:mm:ss" }; // dddd, d 'de' MMMM 'de' yyyy HH:mm:ss
-            yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, "dddd, d de MMMM de yyyy H:mm:ss" }; // dddd, d 'de' MMMM 'de' yyyy H:mm:ss
-            yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, "dddd, d de MMMM de yyyy HH:mm:ss" }; // dddd, d 'de' MMMM 'de' yyyy H:mm:ss
+            yield return new object[] { new CultureInfo("es-419").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy HH:mm:ss" };
+            yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy H:mm:ss" };
+            yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, "dddd, d. MMMM yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, "yyyy MMMM d, dddd H:mm:ss" };
             yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, "dddd d. MMMM yyyy H.mm.ss" };
             yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, "dddd, MMMM d, yyyy h:mm:ss tt" };
             yield return new object[] { new CultureInfo("fr-BE").DateTimeFormat, "dddd d MMMM yyyy HH:mm:ss" };
-            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "dddd d MMMM yyyy HH h mm min ss s" }; // dddd d MMMM yyyy HH 'h' mm 'min' ss 's'
+            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "dddd d MMMM yyyy HH 'h' mm 'min' ss 's'" }; // dddd d MMMM yyyy HH 'h' mm 'min' ss 's'
             yield return new object[] { new CultureInfo("fr-CH").DateTimeFormat, "dddd, d MMMM yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, "dddd d MMMM yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("gu-IN").DateTimeFormat, "dddd, d MMMM, yyyy hh:mm:ss tt" };
@@ -169,8 +169,8 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ja-JP").DateTimeFormat, "yyyy年M月d日dddd H:mm:ss" };
             yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, "dddd, MMMM d, yyyy hh:mm:ss tt" };
             yield return new object[] { new CultureInfo("ko-KR").DateTimeFormat, "yyyy년 M월 d일 dddd tt h:mm:ss" };
-            yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, "yyyy m. MMMM d d., dddd HH:mm:ss" }; // yyyy 'm'. MMMM d 'd'., dddd HH:mm:ss
-            yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, "dddd, yyyy. gada d. MMMM HH:mm:ss" }; // dddd, yyyy. 'gada' d. MMMM HH:mm:ss
+            yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, "yyyy 'm'. MMMM d 'd'., dddd HH:mm:ss" };
+            yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, "dddd, yyyy. 'gada' d. MMMM HH:mm:ss" };
             yield return new object[] { new CultureInfo("ml-IN").DateTimeFormat, "yyyy, MMMM d, dddd h:mm:ss tt" };
             yield return new object[] { new CultureInfo("mr-IN").DateTimeFormat, "dddd, d MMMM, yyyy h:mm:ss tt" };
             yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, "dddd, d MMMM yyyy h:mm:ss tt" }; // dd MMMM yyyy h:mm:ss tt
@@ -182,10 +182,10 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, "dddd d MMMM yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, "dddd d MMMM yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, "dddd, d MMMM yyyy HH:mm:ss" };
-            yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, "dddd, d de MMMM de yyyy HH:mm:ss" }; // dddd, d 'de' MMMM 'de' yyyy HH:mm:ss
-            yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, "dddd, d de MMMM de yyyy HH:mm:ss" }; // dddd, d 'de' MMMM 'de' yyyy HH:mm:ss
+            yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy HH:mm:ss" }; 
+            yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("ro-RO").DateTimeFormat, "dddd, d MMMM yyyy HH:mm:ss" };
-            yield return new object[] { new CultureInfo("ru-RU").DateTimeFormat, "dddd, d MMMM yyyy г. HH:mm:ss" }; // dddd, d MMMM yyyy 'г'. HH:mm:ss
+            yield return new object[] { new CultureInfo("ru-RU").DateTimeFormat, "dddd, d MMMM yyyy 'г'. HH:mm:ss" };
             yield return new object[] { new CultureInfo("sk-SK").DateTimeFormat, "dddd d. MMMM yyyy H:mm:ss" };
             yield return new object[] { new CultureInfo("sl-SI").DateTimeFormat, "dddd, d. MMMM yyyy HH:mm:ss" }; // dddd, dd. MMMM yyyy HH:mm:ss
             yield return new object[] { new CultureInfo("sr-Cyrl-RS").DateTimeFormat, "dddd, d. MMMM yyyy. HH:mm:ss" }; // dddd, dd. MMMM yyyy. HH:mm:ss
@@ -204,7 +204,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("th-TH").DateTimeFormat, "ddddที่ d MMMM g yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("tr-CY").DateTimeFormat, "d MMMM yyyy dddd h:mm:ss tt" };
             yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, "d MMMM yyyy dddd HH:mm:ss" };
-            yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, "dddd, d MMMM yyyy р. HH:mm:ss" }; // dddd, d MMMM yyyy 'р'. HH:mm:ss
+            yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, "dddd, d MMMM yyyy 'р'. HH:mm:ss" };
             yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, "dddd, d MMMM, yyyy HH:mm:ss" };
             yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, "yyyy年M月d日dddd HH:mm:ss" }; // yyyy年M月d日dddd tth:mm:ss
             yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, "yyyy年M月d日dddd tth:mm:ss" };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongDatePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongDatePattern.cs
@@ -30,13 +30,13 @@ namespace System.Globalization.Tests
             // see the comments on the right to check the non-Hybrid result, if it differs
             yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, "dddd، d MMMM yyyy" }; // dddd، d MMMM yyyy g
             yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, "yyyy MMMM d, dddd" };
-            yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, "dddd, d MMMM yyyy г." }; // "dddd, d MMMM yyyy 'г'." 
+            yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, "dddd, d MMMM yyyy 'г'." };
             yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, "dddd, d MMMM, yyyy" };
             yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, "dddd, d MMMM, yyyy" };
-            yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, "dddd, d de MMMM de yyyy" }; // "dddd, d MMMM 'de' yyyy"
-            yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, "dddd, d de MMMM de yyyy" }; // "dddd, d MMMM 'de' yyyy"
+            yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy" }; // "dddd, d MMMM 'de' yyyy"
+            yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy" }; // "dddd, d MMMM 'de' yyyy"
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, "dddd d. MMMM yyyy" };
-            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, "dddd den d. MMMM yyyy" }; // dddd 'den' d. MMMM yyyy
+            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, "dddd 'den' d. MMMM yyyy" };
             yield return new object[] { new CultureInfo("de-AT").DateTimeFormat, "dddd, d. MMMM yyyy" };
             yield return new object[] { new CultureInfo("de-BE").DateTimeFormat, "dddd, d. MMMM yyyy" };
             yield return new object[] { new CultureInfo("de-CH").DateTimeFormat, "dddd, d. MMMM yyyy" };
@@ -149,9 +149,9 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-ZM").DateTimeFormat, "dddd, d MMMM yyyy" };
             yield return new object[] { new CultureInfo("en-ZW").DateTimeFormat, "dddd, d MMMM yyyy" }; // "dddd, dd MMMM yyyy"
             yield return new object[] { new CultureInfo("en-US").DateTimeFormat, "dddd, MMMM d, yyyy" };
-            yield return new object[] { new CultureInfo("es-419").DateTimeFormat, "dddd, d de MMMM de yyyy" }; // dddd, d 'de' MMMM 'de' yyyy
-            yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, "dddd, d de MMMM de yyyy" }; // dddd, d 'de' MMMM 'de' yyyy
-            yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, "dddd, d de MMMM de yyyy" }; // dddd, d 'de' MMMM 'de' yyyy
+            yield return new object[] { new CultureInfo("es-419").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy" };
+            yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy" };
+            yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy" };
             yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, "dddd, d. MMMM yyyy" };
             yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, "yyyy MMMM d, dddd" };
             yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, "dddd d. MMMM yyyy" };
@@ -172,8 +172,8 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ja-JP").DateTimeFormat, "yyyy年M月d日dddd" };
             yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, "dddd, MMMM d, yyyy" };
             yield return new object[] { new CultureInfo("ko-KR").DateTimeFormat, "yyyy년 M월 d일 dddd" };
-            yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, "yyyy m. MMMM d d., dddd" }; // "yyyy 'm'. MMMM d 'd'., dddd"
-            yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, "dddd, yyyy. gada d. MMMM" }; // "dddd, yyyy. 'gada' d. MMMM"
+            yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, "yyyy 'm'. MMMM d 'd'., dddd" };
+            yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, "dddd, yyyy. 'gada' d. MMMM" };
             yield return new object[] { new CultureInfo("ml-IN").DateTimeFormat, "yyyy, MMMM d, dddd" };
             yield return new object[] { new CultureInfo("mr-IN").DateTimeFormat, "dddd, d MMMM, yyyy" };
             yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, "dddd, d MMMM yyyy" }; // "dd MMMM yyyy"
@@ -185,10 +185,10 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, "dddd d MMMM yyyy" };
             yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, "dddd d MMMM yyyy" };
             yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, "dddd, d MMMM yyyy" };
-            yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, "dddd, d de MMMM de yyyy" }; // dddd, d 'de' MMMM 'de' yyyy
-            yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, "dddd, d de MMMM de yyyy" }; // dddd, d 'de' MMMM 'de' yyyy
+            yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy" };
+            yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, "dddd, d 'de' MMMM 'de' yyyy" };
             yield return new object[] { new CultureInfo("ro-RO").DateTimeFormat, "dddd, d MMMM yyyy" };
-            yield return new object[] { new CultureInfo("ru-RU").DateTimeFormat, "dddd, d MMMM yyyy г." }; // "dddd, d MMMM yyyy 'г'."
+            yield return new object[] { new CultureInfo("ru-RU").DateTimeFormat, "dddd, d MMMM yyyy 'г'." };
             yield return new object[] { new CultureInfo("sk-SK").DateTimeFormat, "dddd d. MMMM yyyy" };
             yield return new object[] { new CultureInfo("sl-SI").DateTimeFormat, "dddd, d. MMMM yyyy" }; // "dddd, dd. MMMM yyyy"
             yield return new object[] { new CultureInfo("sr-Cyrl-RS").DateTimeFormat, "dddd, d. MMMM yyyy." }; // "dddd, dd. MMMM yyyy"
@@ -207,7 +207,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("th-TH").DateTimeFormat, "ddddที่ d MMMM g yyyy" };
             yield return new object[] { new CultureInfo("tr-CY").DateTimeFormat, "d MMMM yyyy dddd" };
             yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, "d MMMM yyyy dddd" };
-            yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, "dddd, d MMMM yyyy р." }; // "dddd, d MMMM yyyy 'р'."
+            yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, "dddd, d MMMM yyyy 'р'." };
             yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, "dddd, d MMMM, yyyy" };
             yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, "yyyy年M月d日dddd" };
             yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, "yyyy年M月d日dddd" };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -145,7 +145,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, "H.mm.ss" };
             yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, "h:mm:ss tt" };
             yield return new object[] { new CultureInfo("fr-BE").DateTimeFormat, "HH:mm:ss" };
-            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "HH h mm min ss s" }; // HH 'h' mm 'min' ss 's'
+            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "HH 'h' mm 'min' ss 's'" };
             yield return new object[] { new CultureInfo("fr-CH").DateTimeFormat, "HH:mm:ss" };
             yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, "HH:mm:ss" };
             yield return new object[] { new CultureInfo("gu-IN").DateTimeFormat, "hh:mm:ss tt" };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -146,7 +146,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, "H.mm" };
             yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, "h:mm tt" };
             yield return new object[] { new CultureInfo("fr-BE").DateTimeFormat, "HH:mm" };
-            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "HH h mm min" }; // HH 'h' mm
+            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "HH 'h' mm 'min'" }; // HH 'h' mm
             yield return new object[] { new CultureInfo("fr-CH").DateTimeFormat, "HH:mm" };
             yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, "HH:mm" };
             yield return new object[] { new CultureInfo("gu-IN").DateTimeFormat, "hh:mm tt" };

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -9,7 +9,7 @@ namespace System.Globalization
 {
     internal sealed partial class CultureData
     {
-        private const int CULTURE_INFO_BUFFER_LEN = 50;
+        private const int CULTURE_INFO_BUFFER_LEN = 60;
 
         private static unsafe CultureData JSLoadCultureInfoFromBrowser(string localeName, CultureData culture)
         {

--- a/src/mono/wasm/runtime/hybrid-globalization/calendar.ts
+++ b/src/mono/wasm/runtime/hybrid-globalization/calendar.ts
@@ -12,6 +12,8 @@ import { INNER_SEPARATOR, OUTER_SEPARATOR } from "./helpers";
 const MONTH_CODE = "MMMM";
 const YEAR_CODE = "yyyy";
 const DAY_CODE = "d";
+const WEEKDAY_CODE = "dddd";
+const keyWords = [MONTH_CODE, YEAR_CODE, DAY_CODE, WEEKDAY_CODE];
 
 // this function joins all calendar info with OUTER_SEPARATOR into one string and returns it back to managed code
 export function mono_wasm_get_calendar_info(culture: MonoStringRef, calendarId: number, dst: number, dstLength: number, isException: Int32Ptr, exAddress: MonoObjectRef): number
@@ -230,10 +232,11 @@ function getLongDatePattern(locale: string | undefined, date: Date): string
     pattern = pattern.replace(yearStr, YEAR_CODE);
     const weekday = date.toLocaleDateString(locale, { weekday: "long" }).toLowerCase();
     const replacedWeekday = getGenitiveForName(date, pattern, weekday, new Intl.DateTimeFormat(locale, { year: "numeric", month: "long", day: "numeric"}));
-    pattern = pattern.replace(replacedWeekday, "dddd");
+    pattern = pattern.replace(replacedWeekday, WEEKDAY_CODE);
     pattern = pattern.replace("22", DAY_CODE);
     const dayStr = date.toLocaleDateString(locale, { day: "numeric" }); // should we replace it for localized digits?
-    return pattern.replace(dayStr, DAY_CODE);
+    pattern = pattern.replace(dayStr, DAY_CODE);
+    return wrapSubstrings(pattern, locale);
 }
 
 function getGenitiveForName(date: Date, pattern: string, name: string, formatWithoutName: Intl.DateTimeFormat)
@@ -377,4 +380,37 @@ function getEraNames(date: Date, locale: string | undefined, calendarId: number)
             ignoredPart: dayStr,
         };
     }
+}
+
+// wraps all substrings in the format in quotes, except for key words
+// transform e.g. "dddd, d MMMM yyyy г." into "dddd, d MMMM yyyy 'г'."
+function wrapSubstrings (str: string, locale: string | undefined) {
+    const words = str.split(/\s+/);
+    // locales that write date nearly without spaces should not have format parts quoted - "ja", "zh"
+    // "ko" format parts should not be quoted but processing it would overcomplicate the logic
+    if (words.length <= 2 || locale?.startsWith("ko")) {
+        return str;
+    }
+
+    for (let i = 0; i < words.length; i++) {
+        if (!keyWords.includes(words[i].replace(",", "")) &&
+            !keyWords.includes(words[i].replace(".", "")) &&
+            !keyWords.includes(words[i].replace("\u060c", "")) &&
+            !keyWords.includes(words[i].replace("\u05d1", ""))) {
+            if (words[i].endsWith(".,")) {
+                // if the "word" appears twice, then the occurence with punctuation is not a code but fixed part of the format
+                // see: "hu-HU" vs "lt-LT" format
+                const wordNoPuctuation = words[i].slice(0, -2);
+                if (words.filter(x => x == wordNoPuctuation).length == 1)
+                    words[i] = `'${words[i].slice(0, -2)}'.,`;
+            } else if (words[i].endsWith(".")) {
+                words[i] = `'${words[i].slice(0, -1)}'.`;
+            } else if (words[i].endsWith(",")) {
+                words[i] = `'${words[i].slice(0, -1)}',`;
+            } else {
+                words[i] = `'${words[i]}'`;
+            }
+        }
+    }
+    return words.join(" ");
 }

--- a/src/mono/wasm/runtime/hybrid-globalization/culture-info.ts
+++ b/src/mono/wasm/runtime/hybrid-globalization/culture-info.ts
@@ -8,6 +8,18 @@ import { Int32Ptr } from "../types/emscripten";
 import { MonoObject, MonoObjectRef, MonoString, MonoStringRef } from "../types/internal";
 import { OUTER_SEPARATOR, normalizeLocale } from "./helpers";
 
+const NO_PREFIX_24H = "H";
+const PREFIX_24H = "HH";
+const NO_PREFIX_12H = "h";
+const PREFIX_12H = "hh";
+const SECONDS_CODE = "ss";
+const MINUTES_CODE = "mm";
+const DESIGNATOR_CODE = "tt";
+// Note: wrapSubstrings
+// The character "h" can be ambiguous as it might represent an hour code hour code and a fixed (quoted) part of the format.
+// Special Case for "fr-CA": Always recognize "HH" as a keyword and do not quote it, to avoid formatting issues.
+const keyWords = [SECONDS_CODE, MINUTES_CODE, DESIGNATOR_CODE, PREFIX_24H];
+
 export function mono_wasm_get_culture_info(culture: MonoStringRef, dst: number, dstLength: number, isException: Int32Ptr, exAddress: MonoObjectRef): number
 {
     const cultureRoot = mono_wasm_new_external_root<MonoString>(culture),
@@ -89,7 +101,7 @@ function getLongTimePattern(locale: string | undefined, designators: any) : stri
     const shortPmStyle = shortTime.format(pmTime); // 12:15:30 PM
     const minutes = pmTime.toLocaleTimeString(locale, { minute: "numeric" }); // 15
     const seconds = pmTime.toLocaleTimeString(locale, { second: "numeric" }); // 30
-    let pattern = shortPmStyle.replace(designators.pm, "tt").replace(minutes, "mm").replace(seconds, "ss"); // 12:mm:ss tt
+    let pattern = shortPmStyle.replace(designators.pm, DESIGNATOR_CODE).replace(minutes, MINUTES_CODE).replace(seconds, SECONDS_CODE); // 12:mm:ss tt
 
     const isISOStyle = pattern.includes(localizedHour24); // 24h or 12h pattern?
     const localized0 = (0).toLocaleString(locale);
@@ -100,24 +112,24 @@ function getLongTimePattern(locale: string | undefined, designators: any) : stri
     if (isISOStyle) // 24h
     {
         const hasPrefix = h12Style.includes(hour12WithPrefix);
-        hourPattern = hasPrefix ? "HH" : "H";
+        hourPattern = hasPrefix ? PREFIX_24H : NO_PREFIX_24H;
         pattern = pattern.replace(localizedHour24, hourPattern);
     }
     else // 12h
     {
         const hasPrefix = h12Style.includes(hour12WithPrefix);
-        hourPattern = hasPrefix ? "hh" : "h";
+        hourPattern = hasPrefix ? PREFIX_12H : NO_PREFIX_12H;
         pattern = pattern.replace(hasPrefix ? hour12WithPrefix : localizedHour12, hourPattern);
     }
 
-    return pattern;
+    return wrapSubstrings(pattern);
 }
 
 function getShortTimePattern(pattern: string) : string
 {
     // remove seconds:
     // short dotnet pattern does not contain seconds while JS's pattern always contains them
-    const secondsIdx = pattern.indexOf("ss");
+    const secondsIdx = pattern.indexOf(SECONDS_CODE);
     if (secondsIdx > 0)
     {
         const secondsWithSeparator = `${pattern[secondsIdx - 1]}ss`;
@@ -134,4 +146,18 @@ function getShortTimePattern(pattern: string) : string
         }
     }
     return pattern;
+}
+
+// wraps all substrings in the format in quotes, except for key words
+// transform e.g. "HH h mm min ss s" into "HH 'h' mm 'min' ss 's'"
+function wrapSubstrings (str: string) {
+    const words = str.split(/\s+/);
+
+    for (let i = 0; i < words.length; i++) {
+        if (!words[i].includes(":") && !words[i].includes(".") && !keyWords.includes(words[i])) {
+            words[i] = `'${words[i]}'`;
+        }
+    }
+
+    return words.join(" ");
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/103804.

This PR makes improvements to values returned in date/time format APIs.

## Customer Impact

Yes, if they use `HybridGlobalization`, in a few cultures they will see improved format of long date. Reported by a customer in https://github.com/dotnet/runtime/issues/103745.

## Regression

No.

## Testing, Risk

Low risk, automated testing.