### PR TITLE
Added test for missing cookie header value

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -148,6 +148,17 @@ namespace System.Net.Http.Functional.Tests
                 });
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddCookieHeader_MissingValue_Throws(string? cookieValue)
+        {
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "http://foo/bar") { Version = UseVersion };
+            Assert.Throws<FormatException>(
+                () => requestMessage.Headers.Add("Cookie", cookieValue)
+            );
+        }
+
         [Fact]
         public async Task GetAsync_AddMultipleCookieHeaders_CookiesSent()
         {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -151,6 +151,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework allows empty value of cookie header while net7+ behaves by the specs and prohibit it")]
         public void AddCookieHeader_MissingValue_Throws(string? cookieValue)
         {
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, "http://foo/bar") { Version = UseVersion };


### PR DESCRIPTION
Addresses: #99416

We decided, to close #99416 as by design and add unit test covering current behavior.