### PR TITLE
Optimize performance of `Measurement` constructor

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Diagnostics.Metrics
 {
@@ -76,6 +78,66 @@ namespace System.Diagnostics.Metrics
         public T Value { get; }
 
         // Private helper to copy IEnumerable to array. We have it to avoid adding dependencies on System.Linq
-        private static KeyValuePair<string, object?>[] ToArray(IEnumerable<KeyValuePair<string, object?>>? tags) => tags is null ? Instrument.EmptyTags : new List<KeyValuePair<string, object?>>(tags).ToArray();
+        private static KeyValuePair<string, object?>[] ToArray(IEnumerable<KeyValuePair<string, object?>>? tags)
+        {
+            if (tags is null)
+                return Instrument.EmptyTags;
+
+            // When the input is a collection, we can allocate a correctly sized array and copy directly into it.
+            if (tags is ICollection<KeyValuePair<string, object?>> collection)
+            {
+                int items = collection.Count;
+
+                if (items == 0)
+                    return Instrument.EmptyTags;
+
+                KeyValuePair<string, object?>[] result = new KeyValuePair<string, object?>[items];
+                collection.CopyTo(result, 0);
+                return result;
+            }
+
+            // In any other case, we must enumerate the input.
+            // We use a pooled array as a buffer to avoid allocating until we know the final size we need.
+            // This assumes that there are 32 or fewer tags, which is a reasonable assumption for most cases.
+            // In the worst case, we will grow the buffer by renting a larger array.
+            int count = 0;
+            KeyValuePair<string, object?>[] array = ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(32);
+            int length = array.Length;
+
+            IEnumerator<KeyValuePair<string, object?>> enumerator = tags.GetEnumerator();
+
+            try
+            {
+                while (enumerator.MoveNext())
+                {
+                    if (count == length)
+                        Grow(ref array, ref length);
+
+                    array[count++] = enumerator.Current;
+                }
+
+                if (count == 0)
+                    return Instrument.EmptyTags;
+
+                KeyValuePair<string, object?>[] result = new KeyValuePair<string, object?>[count];
+                array.AsSpan().Slice(0, count).CopyTo(result.AsSpan());
+                return result;
+            }
+            finally
+            {
+                enumerator.Dispose();
+                ArrayPool<KeyValuePair<string, object?>>.Shared.Return(array);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static void Grow(ref KeyValuePair<string, object?>[] array, ref int length)
+            {
+                KeyValuePair<string, object?>[] newArray = ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(length * 2);
+                array.CopyTo(newArray, 0);
+                ArrayPool<KeyValuePair<string, object?>>.Shared.Return(array);
+                array = newArray;
+                length = array.Length;
+            }
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
@@ -104,16 +104,14 @@ namespace System.Diagnostics.Metrics
             KeyValuePair<string, object?>[] array = ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(32);
             int length = array.Length;
 
-            IEnumerator<KeyValuePair<string, object?>> enumerator = tags.GetEnumerator();
-
             try
             {
-                while (enumerator.MoveNext())
+                foreach (KeyValuePair<string, object?> item in tags)
                 {
                     if (count == length)
                         Grow(ref array, ref length);
 
-                    array[count++] = enumerator.Current;
+                    array[count++] = item;
                 }
 
                 if (count == 0)
@@ -125,7 +123,6 @@ namespace System.Diagnostics.Metrics
             }
             finally
             {
-                enumerator.Dispose();
                 ArrayPool<KeyValuePair<string, object?>>.Shared.Return(array);
             }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricsTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricsTests.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics.Metrics.Tests
         [Fact]
         public void MeasurementConstructionTest()
         {
-            for (int i = 0; i < 30; i++)
+            for (int i = 0; i < 35; i++)
             {
                 TagListTests.CreateTagList(i, out TagList tags);
                 TagListTests.ValidateTags(in tags, i);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricsTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.DotNet.RemoteExecutor;
 using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using System.Diagnostics.Tests;
 using System.Linq;
 using System.Threading;


### PR DESCRIPTION
While looking into the overhead of creating `Measurement`s for the runtime metrics work, I noticed some allocations I thought could be removed. This PR proposes a more complex implementation of the `ToArray` helper method that prefers using the `ArrayPool` (if we're happy with the dependency on `System.Buffers`) to avoid the `List` allocation and the `Array` allocations caused by its implementation. As a nice side effect, this code also performs faster. This helper is used by the ctor accepting and  `IEnumerable<KeyValuePair<string, object?>>` for the tags.

Below are my benchmark results, which test calling the ctor with a type implementing both `ICollection` and `IEnumerable` and the case of the type implementing only `IEnumerable`. In each scenario, the benchmarks compare 4 different sizes for the number of tags provided to the ctor. We expect relatively few tags in a real scenario.

Based on these results, this appears to be a worthwhile gain, given the potential number of measurements that could be created in an observed application.

I have a follow-up proposal for further optimization, but it will require a public API proposal, which I'll raise, hopefully, tomorrow.

```
| Method              | Size | Mean         | Error      | StdDev     | Ratio    | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|-------------------- |----- |-------------:|-----------:|-----------:|---------:|--------:|-------:|-------:|----------:|------------:|
| ICollectionOriginal | 1    |    22.805 ns |  0.4518 ns |  0.4226 ns | baseline |         | 0.0089 |      - |     112 B |             |
| ICollectionNew      | 1    |     7.991 ns |  0.1741 ns |  0.2072 ns |     -65% |    2.9% | 0.0032 |      - |      40 B |        -64% |
|                     |      |              |            |            |          |         |        |        |           |             |
| ICollectionOriginal | 20   |    46.178 ns |  0.5204 ns |  0.4868 ns | baseline |         | 0.0573 |      - |     720 B |             |
| ICollectionNew      | 20   |    19.279 ns |  0.2579 ns |  0.2286 ns |     -58% |    1.6% | 0.0274 |      - |     344 B |        -52% |
|                     |      |              |            |            |          |         |        |        |           |             |
| ICollectionOriginal | 40   |    70.554 ns |  1.3998 ns |  1.6120 ns | baseline |         | 0.1084 | 0.0001 |    1360 B |             |
| ICollectionNew      | 40   |    32.411 ns |  0.6583 ns |  0.7043 ns |     -54% |    3.5% | 0.0529 |      - |     664 B |        -51% |
|                     |      |              |            |            |          |         |        |        |           |             |
| ICollectionOriginal | 80   |   125.011 ns |  2.2954 ns |  2.0348 ns | baseline |         | 0.2103 | 0.0005 |    2640 B |             |
| ICollectionNew      | 80   |    58.300 ns |  1.1685 ns |  1.2988 ns |     -53% |    2.3% | 0.1039 |      - |    1304 B |        -51% |
|                     |      |              |            |            |          |         |        |        |           |             |
| IEnumerableOriginal | 1    |    57.392 ns |  1.0447 ns |  0.9261 ns | baseline |         | 0.0197 |      - |     248 B |             |
| IEnumerableNew      | 1    |    41.216 ns |  0.7714 ns |  0.7215 ns |     -28% |    2.6% | 0.0102 |      - |     128 B |        -48% |
|                     |      |              |            |            |          |         |        |        |           |             |
| IEnumerableOriginal | 20   |   464.309 ns |  8.0920 ns |  7.9475 ns | baseline |         | 0.1211 |      - |    1520 B |             |
| IEnumerableNew      | 20   |   288.977 ns |  4.3800 ns |  4.0971 ns |     -38% |    2.3% | 0.0343 |      - |     432 B |        -72% |
|                     |      |              |            |            |          |         |        |        |           |             |
| IEnumerableOriginal | 40   |   928.871 ns | 12.5662 ns | 11.7544 ns | baseline |         | 0.2298 |      - |    2888 B |             |
| IEnumerableNew      | 40   |   619.248 ns | 12.3348 ns | 16.8840 ns |     -33% |    3.6% | 0.0591 |      - |     752 B |        -74% |
|                     |      |              |            |            |          |         |        |        |           |             |
| IEnumerableOriginal | 80   | 1,758.629 ns | 35.1789 ns | 36.1262 ns | baseline |         | 0.4463 | 0.0038 |    5600 B |             |
| IEnumerableNew      | 80   | 1,215.728 ns | 23.7007 ns | 22.1697 ns |     -31% |    2.8% | 0.1106 |      - |    1392 B |        -75% |
```

/cc @noahfalk and @tarekgh 