### PR TITLE
Remove format job runs from coreclr outerloop testing

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -173,16 +173,6 @@ extends:
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
 
       #
-      # Formatting
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-          platforms:
-          - linux_x64
-          - windows_x64
-
-      #
       # PAL Tests
       #
       - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
I don't know why we ran this in outerloop. Removing it as the job is dead since we moved it to GitHub Actions.