### PR TITLE
[8.0] Add a config flag to experiment with some work item prioritization changes in cases involving a lot of sync-over-async

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -383,12 +383,12 @@ namespace System.Threading
 
 #if CORECLR
         // This config var can be used to enable an experimental mode that may reduce the effects of some priority inversion
-        // issues seen in cases involving a lot of sync-over-async. See EnqueueForPrioritizationTest() for more information. The
-        // mode is experimental and may change in the future.
-        internal static readonly bool s_prioritizationTest =
+        // issues seen in cases involving a lot of sync-over-async. See EnqueueForPrioritizationExperiment() for more
+        // information. The mode is experimental and may change in the future.
+        internal static readonly bool s_prioritizationExperiment =
             AppContextConfigHelper.GetBooleanConfig(
-                "System.Threading.ThreadPool.PrioritizationTest",
-                "DOTNET_ThreadPool_PrioritizationTest",
+                "System.Threading.ThreadPool.PrioritizationExperiment",
+                "DOTNET_ThreadPool_PrioritizationExperiment",
                 defaultValue: false);
 #endif
 
@@ -407,7 +407,7 @@ namespace System.Threading
 
 #if CORECLR
         internal readonly ConcurrentQueue<object> lowPriorityWorkItems =
-            s_prioritizationTest ? new ConcurrentQueue<object>() : null!;
+            s_prioritizationExperiment ? new ConcurrentQueue<object>() : null!;
 #endif
 
         // SOS's ThreadPool command depends on the following name. The global queue doesn't scale well beyond a point of
@@ -615,9 +615,9 @@ namespace System.Threading
                 FrameworkEventSource.Log.ThreadPoolEnqueueWorkObject(callback);
 
 #if CORECLR
-            if (s_prioritizationTest)
+            if (s_prioritizationExperiment)
             {
-                EnqueueForPrioritizationTest(callback, forceGlobal);
+                EnqueueForPrioritizationExperiment(callback, forceGlobal);
             }
             else
 #endif
@@ -642,7 +642,7 @@ namespace System.Threading
 
 #if CORECLR
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void EnqueueForPrioritizationTest(object callback, bool forceGlobal)
+        private void EnqueueForPrioritizationExperiment(object callback, bool forceGlobal)
         {
             ThreadPoolWorkQueueThreadLocals? tl = ThreadPoolWorkQueueThreadLocals.threadLocals;
             if (!forceGlobal && tl != null)
@@ -754,7 +754,7 @@ namespace System.Threading
 
 #if CORECLR
             // Check for low-priority work items
-            if (s_prioritizationTest && lowPriorityWorkItems.TryDequeue(out workItem))
+            if (s_prioritizationExperiment && lowPriorityWorkItems.TryDequeue(out workItem))
             {
                 return workItem;
             }
@@ -820,7 +820,7 @@ namespace System.Threading
             {
                 long count = (long)highPriorityWorkItems.Count + workItems.Count;
 #if CORECLR
-                if (s_prioritizationTest)
+                if (s_prioritizationExperiment)
                 {
                     count += lowPriorityWorkItems.Count;
                 }
@@ -1716,7 +1716,7 @@ namespace System.Threading
             }
 
 #if CORECLR
-            if (ThreadPoolWorkQueue.s_prioritizationTest)
+            if (ThreadPoolWorkQueue.s_prioritizationExperiment)
             {
                 // Enumerate low-priority global queue
                 foreach (object workItem in s_workQueue.lowPriorityWorkItems)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -381,6 +381,17 @@ namespace System.Threading
             }
         }
 
+#if CORECLR
+        // This config var can be used to enable an experimental mode that may reduce the effects of some priority inversion
+        // issues seen in cases involving a lot of sync-over-async. See EnqueueForPrioritizationTest() for more information. The
+        // mode is experimental and may change in the future.
+        internal static readonly bool s_prioritizationTest =
+            AppContextConfigHelper.GetBooleanConfig(
+                "System.Threading.ThreadPool.PrioritizationTest",
+                "DOTNET_ThreadPool_PrioritizationTest",
+                defaultValue: false);
+#endif
+
         private const int ProcessorsPerAssignableWorkItemQueue = 16;
         private static readonly int s_assignableWorkItemQueueCount =
             Environment.ProcessorCount <= 32 ? 0 :
@@ -393,6 +404,11 @@ namespace System.Threading
         // SOS's ThreadPool command depends on the following names
         internal readonly ConcurrentQueue<object> workItems = new ConcurrentQueue<object>();
         internal readonly ConcurrentQueue<object> highPriorityWorkItems = new ConcurrentQueue<object>();
+
+#if CORECLR
+        internal readonly ConcurrentQueue<object> lowPriorityWorkItems =
+            s_prioritizationTest ? new ConcurrentQueue<object>() : null!;
+#endif
 
         // SOS's ThreadPool command depends on the following name. The global queue doesn't scale well beyond a point of
         // concurrency. Some additional queues may be added and assigned to a limited number of worker threads if necessary to
@@ -598,22 +614,67 @@ namespace System.Threading
             if (_loggingEnabled && FrameworkEventSource.Log.IsEnabled())
                 FrameworkEventSource.Log.ThreadPoolEnqueueWorkObject(callback);
 
-            ThreadPoolWorkQueueThreadLocals? tl;
-            if (!forceGlobal && (tl = ThreadPoolWorkQueueThreadLocals.threadLocals) != null)
+#if CORECLR
+            if (s_prioritizationTest)
             {
-                tl.workStealingQueue.LocalPush(callback);
+                EnqueueForPrioritizationTest(callback, forceGlobal);
             }
             else
+#endif
             {
-                ConcurrentQueue<object> queue =
-                    s_assignableWorkItemQueueCount > 0 && (tl = ThreadPoolWorkQueueThreadLocals.threadLocals) != null
-                        ? tl.assignedGlobalWorkItemQueue
-                        : workItems;
-                queue.Enqueue(callback);
+                ThreadPoolWorkQueueThreadLocals? tl;
+                if (!forceGlobal && (tl = ThreadPoolWorkQueueThreadLocals.threadLocals) != null)
+                {
+                    tl.workStealingQueue.LocalPush(callback);
+                }
+                else
+                {
+                    ConcurrentQueue<object> queue =
+                        s_assignableWorkItemQueueCount > 0 && (tl = ThreadPoolWorkQueueThreadLocals.threadLocals) != null
+                            ? tl.assignedGlobalWorkItemQueue
+                            : workItems;
+                    queue.Enqueue(callback);
+                }
             }
 
             EnsureThreadRequested();
         }
+
+#if CORECLR
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void EnqueueForPrioritizationTest(object callback, bool forceGlobal)
+        {
+            ThreadPoolWorkQueueThreadLocals? tl = ThreadPoolWorkQueueThreadLocals.threadLocals;
+            if (!forceGlobal && tl != null)
+            {
+                tl.workStealingQueue.LocalPush(callback);
+                return;
+            }
+
+            ConcurrentQueue<object> queue;
+
+            // This is a rough and experimental attempt at identifying work items that should be lower priority than other
+            // global work items (even ones that haven't been queued yet), and to queue them to a low-priority global queue that
+            // is checked after all other global queues. In some cases, a work item may queue another work item that is part of
+            // the same set of work. For global work items, the second work item would typically get queued behind other global
+            // work items. In some cases involving a lot of sync-over-async, that can significantly delay worker threads from
+            // getting unblocked.
+            if (tl == null && callback is QueueUserWorkItemCallbackBase)
+            {
+                queue = lowPriorityWorkItems;
+            }
+            else if (s_assignableWorkItemQueueCount > 0 && tl != null)
+            {
+                queue = tl.assignedGlobalWorkItemQueue;
+            }
+            else
+            {
+                queue = workItems;
+            }
+
+            queue.Enqueue(callback);
+        }
+#endif
 
         public void EnqueueAtHighPriority(object workItem)
         {
@@ -691,6 +752,14 @@ namespace System.Threading
                 }
             }
 
+#if CORECLR
+            // Check for low-priority work items
+            if (s_prioritizationTest && lowPriorityWorkItems.TryDequeue(out workItem))
+            {
+                return workItem;
+            }
+#endif
+
             // Try to steal from other threads' local work items
             {
                 WorkStealingQueue localWsq = tl.workStealingQueue;
@@ -750,6 +819,13 @@ namespace System.Threading
             get
             {
                 long count = (long)highPriorityWorkItems.Count + workItems.Count;
+#if CORECLR
+                if (s_prioritizationTest)
+                {
+                    count += lowPriorityWorkItems.Count;
+                }
+#endif
+
                 for (int i = 0; i < s_assignableWorkItemQueueCount; i++)
                 {
                     count += _assignableWorkItemQueues[i].Count;
@@ -1638,6 +1714,17 @@ namespace System.Threading
             {
                 yield return workItem;
             }
+
+#if CORECLR
+            if (ThreadPoolWorkQueue.s_prioritizationTest)
+            {
+                // Enumerate low-priority global queue
+                foreach (object workItem in s_workQueue.lowPriorityWorkItems)
+                {
+                    yield return workItem;
+                }
+            }
+#endif
 
             // Enumerate each local queue
             foreach (ThreadPoolWorkQueue.WorkStealingQueue wsq in ThreadPoolWorkQueue.WorkStealingQueueList.Queues)

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1161,13 +1161,13 @@ namespace System.Threading.ThreadPools.Tests
         }
 
         [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
-        public static void PrioritizationTestConfigVarTest()
+        public static void PrioritizationExperimentConfigVarTest()
         {
             // Avoid contaminating the main process' environment
             RemoteExecutor.Invoke(() =>
             {
                 // The actual test process below will inherit the config var
-                Environment.SetEnvironmentVariable("DOTNET_ThreadPool_PrioritizationTest", "1");
+                Environment.SetEnvironmentVariable("DOTNET_ThreadPool_PrioritizationExperiment", "1");
 
                 RemoteExecutor.Invoke(() =>
                 {

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1160,6 +1160,89 @@ namespace System.Threading.ThreadPools.Tests
             }).Dispose();
         }
 
+        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
+        public static void PrioritizationTestConfigVarTest()
+        {
+            // Avoid contaminating the main process' environment
+            RemoteExecutor.Invoke(() =>
+            {
+                // The actual test process below will inherit the config var
+                Environment.SetEnvironmentVariable("DOTNET_ThreadPool_PrioritizationTest", "1");
+
+                RemoteExecutor.Invoke(() =>
+                {
+                    const int WorkItemCountPerKind = 100;
+
+                    int completedWorkItemCount = 0;
+                    var allWorkItemsCompleted = new AutoResetEvent(false);
+                    Action<int> workItem = _ =>
+                    {
+                        if (Interlocked.Increment(ref completedWorkItemCount) == WorkItemCountPerKind * 3)
+                        {
+                            allWorkItemsCompleted.Set();
+                        }
+                    };
+
+                    var startTest = new ManualResetEvent(false);
+
+                    var t = new Thread(() =>
+                    {
+                        // Enqueue global work from a non-thread-pool thread
+
+                        startTest.CheckedWait();
+
+                        for (int i = 0; i < WorkItemCountPerKind; i++)
+                        {
+                            ThreadPool.UnsafeQueueUserWorkItem(workItem, 0, preferLocal: false);
+                        }
+                    });
+                    t.IsBackground = true;
+                    t.Start();
+
+                    ThreadPool.UnsafeQueueUserWorkItem(
+                        _ =>
+                        {
+                            // Enqueue global work from a thread pool worker thread
+
+                            startTest.CheckedWait();
+
+                            for (int i = 0; i < WorkItemCountPerKind; i++)
+                            {
+                                ThreadPool.UnsafeQueueUserWorkItem(workItem, 0, preferLocal: false);
+                            }
+                        },
+                        0,
+                        preferLocal: false);
+
+                    t = new Thread(() =>
+                    {
+                        // Enqueue local work from thread pool worker threads
+
+                        Assert.True(WorkItemCountPerKind / 10 * 10 == WorkItemCountPerKind);
+                        Action<int> localWorkItemEnqueuer = _ =>
+                        {
+                            for (int i = 0; i < WorkItemCountPerKind / 10; i++)
+                            {
+                                ThreadPool.UnsafeQueueUserWorkItem(workItem, 0, preferLocal: true);
+                            }
+                        };
+
+                        startTest.CheckedWait();
+
+                        for (int i = 0; i < 10; i++)
+                        {
+                            ThreadPool.UnsafeQueueUserWorkItem(localWorkItemEnqueuer, 0, preferLocal: false);
+                        }
+                    });
+                    t.IsBackground = true;
+                    t.Start();
+
+                    startTest.Set();
+                    allWorkItemsCompleted.CheckedWait();
+                }).Dispose();
+            }).Dispose();
+        }
+
         public static bool IsThreadingAndRemoteExecutorSupported =>
             PlatformDetection.IsThreadingSupported && RemoteExecutor.IsSupported;
 


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/103983 to 8.0

Some services that use a lot of sync-over-async were seen to experience stalls due to some priority inversion issues in work items that get queued to the thread pool. For instance, a work item W1 queues another work item W2 to the global queue and blocks waiting for a task to complete, where W2 would need to run in order to complete the task, but W2 is queued behind a number of other work items that operate like W1, and this sometimes leads to long-duration stalls. This change adds an experimental config option that when enabled, enqueues some kinds of work items to a new low-priority global queue that is checked after all other global queues. This was seen to help in some cases. The change is limited to CoreCLR for experimentation.

## Customer Impact

Some 1p services that use a lot of sync-over-async are experiencing stalls due to some priority inversion issues in work items that get queued to the thread pool. In some situations, the services stall for a long time until a large number of worker threads are injected, which can take a long time. Due to having to handle existing synchronous APIs using async-only libraries, the sync-over-async is not easy to avoid. Increasing the rate of thread injection through config was not desirable due to other performance issues with high worker thread counts.

## Regression?

No

## Testing

Validated on a reduced test case provided by a customer.

## Risk

Low:
- The behavioral changes are under a config switch that is disabled by default (and only in CoreCLR)
- Although the config var is checked on some hot paths (enqueuing/dequeuing TP work items), tiered compilation would remove the checks, and the alternate code paths in the hot sections are minimal in size

However:
- When enabled, the change may not resolve all of the issues in the actual services. Working around some but not all of the priority inversion issues involved may just shift the issue to another location without resolving the long stall.
- When enabled, the change may deprioritize some work items that shouldn't be deprioritized
- The change and the config var as proposed are probably not how we would want it to look long-term. If the change appears fruitful, and with further information, we can consider a better solution for the future.