### PR TITLE
Fix #97736 in MemoryCache.cs with a lock around the TriggerOvercapacityC... method

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -474,8 +474,8 @@ namespace Microsoft.Extensions.Caching.Memory
             return true;
         }
 
-        private int lockFlag = 0;
-        
+        private int lockFlag;
+
         private void TriggerOvercapacityCompaction()
         {
             if (_logger.IsEnabled(LogLevel.Debug))
@@ -483,7 +483,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             // If no threads are currently running compact - enter lock and start compact
             // If there is already a thread that is running compact - do nothing
-            if (Interlocked.CompareExchange(ref lockFlag, 1, 0) == 0) 
+            if (Interlocked.CompareExchange(ref lockFlag, 1, 0) == 0)
                 // Spawn background thread for compaction
                 ThreadPool.QueueUserWorkItem(s =>
                 {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -491,7 +491,8 @@ namespace Microsoft.Extensions.Caching.Memory
                     {
                         ((MemoryCache)s!).OvercapacityCompaction();
                     }
-                    finally {
+                    finally 
+                    {
                         lockFlag = 0; // Release the lock
                     }
                 }, this);

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -491,7 +491,7 @@ namespace Microsoft.Extensions.Caching.Memory
                     {
                         ((MemoryCache)s!).OvercapacityCompaction();
                     }
-                    finally 
+                    finally
                     {
                         lockFlag = 0; // Release the lock
                     }


### PR DESCRIPTION
This solves https://github.com/dotnet/runtime/issues/97736
This PR addresses the excessive CPU and memory usage during the MemoryCache compaction process by limiting the number of concurrent compaction tasks to one. The change ensures that only one thread performs the compaction at any given time, reducing resource spikes and improving overall performance.