### PR TITLE
Expose the constants in TimeSpan

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogInternal.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogInternal.cs
@@ -55,7 +55,7 @@ namespace System.Diagnostics
 
         private const string EventLogKey = "SYSTEM\\CurrentControlSet\\Services\\EventLog";
         private const string eventLogMutexName = "netfxeventlog.1.0";
-        private const int SecondsPerDay = 60 * 60 * 24;
+        private const int SecondsPerDay = 60 * 60 * 24; // can't pull in the new TimeSpan constant because this builds in older CLR versions
 
         private const int Flag_notifying = 0x1;           // keeps track of whether we're notifying our listeners - to prevent double notifications
         private const int Flag_forwards = 0x2;     // whether the cache contains entries in forwards order (true) or backwards (false)

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.Windows.cs
@@ -77,7 +77,7 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException(nameof(fileTime), SR.ArgumentOutOfRange_DateTimeBadTicks);
             }
-            return CreateDateTimeFromSystemTime(in time, fileTime % TicksPerMillisecond);
+            return CreateDateTimeFromSystemTime(in time, fileTime % TimeSpan.TicksPerMillisecond);
         }
 
         private static unsafe ulong ToFileTimeLeapSecondsAware(long ticks)
@@ -112,20 +112,20 @@ namespace System
             ReadOnlySpan<uint> days = IsLeapYear((int)year) ? DaysToMonth366 : DaysToMonth365;
             int month = time.Month - 1;
             uint n = DaysToYear(year) + days[month] + time.Day - 1;
-            ulong ticks = n * (ulong)TicksPerDay;
+            ulong ticks = n * (ulong)TimeSpan.TicksPerDay;
 
-            ticks += time.Hour * (ulong)TicksPerHour;
-            ticks += time.Minute * (ulong)TicksPerMinute;
+            ticks += time.Hour * (ulong)TimeSpan.TicksPerHour;
+            ticks += time.Minute * (ulong)TimeSpan.TicksPerMinute;
             uint second = time.Second;
             if (second <= 59)
             {
-                ulong tmp = second * (uint)TicksPerSecond + time.Milliseconds * (uint)TicksPerMillisecond + hundredNanoSecond;
+                ulong tmp = second * (uint)TimeSpan.TicksPerSecond + time.Milliseconds * (uint)TimeSpan.TicksPerMillisecond + hundredNanoSecond;
                 return new DateTime(ticks + tmp | KindUtc);
             }
 
             // we have a leap second, force it to last second in the minute as DateTime doesn't account for leap seconds in its calculation.
             // we use the maxvalue from the milliseconds and the 100-nano seconds to avoid reporting two out of order 59 seconds
-            ticks += TicksPerMinute - 1 | KindUtc;
+            ticks += TimeSpan.TicksPerMinute - 1 | KindUtc;
             return new DateTime(ticks);
         }
 
@@ -166,7 +166,7 @@ namespace System
                     ((delegate* unmanaged[SuppressGCTransition]<long*, void>)pfnGetSystemTime)(&systemTimeResult);
                     ((delegate* unmanaged[SuppressGCTransition]<long*, void>)pfnGetSystemTimePrecise)(&preciseSystemTimeResult);
 
-                    if (Math.Abs(preciseSystemTimeResult - systemTimeResult) <= 100 * TicksPerMillisecond)
+                    if (Math.Abs(preciseSystemTimeResult - systemTimeResult) <= 100 * TimeSpan.TicksPerMillisecond)
                     {
                         pfnGetSystemTime = pfnGetSystemTimePrecise; // use the precise version
                         break;
@@ -194,7 +194,7 @@ namespace System
             // cache will return incorrect values.
 
             Debug.Assert(SystemSupportsLeapSeconds);
-            Debug.Assert(LeapSecondCache.ValidityPeriodInTicks < TicksPerDay - TicksPerSecond, "Leap second cache validity window should be less than 23:59:59.");
+            Debug.Assert(LeapSecondCache.ValidityPeriodInTicks < TimeSpan.TicksPerDay - TimeSpan.TicksPerSecond, "Leap second cache validity window should be less than 23:59:59.");
 
             ulong fileTimeNow;
             LeapSecondCache.s_pfnGetSystemTimeAsFileTime(&fileTimeNow);
@@ -203,7 +203,7 @@ namespace System
             // First, convert the FILETIME to a SYSTEMTIME.
 
             Interop.Kernel32.SYSTEMTIME systemTimeNow;
-            ulong hundredNanoSecondNow = fileTimeNow % TicksPerMillisecond;
+            ulong hundredNanoSecondNow = fileTimeNow % TimeSpan.TicksPerMillisecond;
 
             // We need the FILETIME and the SYSTEMTIME to reflect each other's values.
             // If FileTimeToSystemTime fails, call GetSystemTime and try again until it succeeds.
@@ -267,7 +267,7 @@ namespace System
                 }
 
                 // StartOfValidityWindow = MidnightUtc + 23:59:59 - ValidityPeriod
-                fileTimeAtStartOfValidityWindow = fileTimeAtBeginningOfDay + (TicksPerDay - TicksPerSecond) - LeapSecondCache.ValidityPeriodInTicks;
+                fileTimeAtStartOfValidityWindow = fileTimeAtBeginningOfDay + (TimeSpan.TicksPerDay - TimeSpan.TicksPerSecond) - LeapSecondCache.ValidityPeriodInTicks;
                 if (fileTimeNow - fileTimeAtStartOfValidityWindow >= LeapSecondCache.ValidityPeriodInTicks)
                 {
                     // If we're inside this block, then we slid the validity window back so far that the current time is no
@@ -295,7 +295,7 @@ namespace System
                     return CreateDateTimeFromSystemTime(systemTimeNow, hundredNanoSecondNow);
                 }
 
-                dotnetDateDataAtStartOfValidityWindow = CreateDateTimeFromSystemTime(systemTimeAtBeginningOfDay, 0)._dateData + (TicksPerDay - TicksPerSecond) - LeapSecondCache.ValidityPeriodInTicks;
+                dotnetDateDataAtStartOfValidityWindow = CreateDateTimeFromSystemTime(systemTimeAtBeginningOfDay, 0)._dateData + (TimeSpan.TicksPerDay - TimeSpan.TicksPerSecond) - LeapSecondCache.ValidityPeriodInTicks;
             }
 
             // Finally, update the cache and return UtcNow.
@@ -330,7 +330,7 @@ namespace System
         private sealed class LeapSecondCache
         {
             // The length of the validity window. Must be less than 23:59:59.
-            internal const ulong ValidityPeriodInTicks = TicksPerMinute * 5;
+            internal const ulong ValidityPeriodInTicks = TimeSpan.TicksPerMinute * 5;
 
             // The FILETIME value at the beginning of the validity window.
             internal ulong OSFileTimeTicksAtStartOfValidityWindow;

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -56,23 +56,6 @@ namespace System
           ISpanParsable<DateTime>,
           IUtf8SpanFormattable
     {
-        // Number of 100ns ticks per time unit
-        internal const int MicrosecondsPerMillisecond = 1000;
-        private const long TicksPerMicrosecond = 10;
-        private const long TicksPerMillisecond = TicksPerMicrosecond * MicrosecondsPerMillisecond;
-
-        private const int HoursPerDay = 24;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
-        private const long TicksPerMinute = TicksPerSecond * 60;
-        private const long TicksPerHour = TicksPerMinute * 60;
-        private const long TicksPerDay = TicksPerHour * HoursPerDay;
-
-        // Number of milliseconds per time unit
-        private const int MillisPerSecond = 1000;
-        private const int MillisPerMinute = MillisPerSecond * 60;
-        private const int MillisPerHour = MillisPerMinute * 60;
-        private const int MillisPerDay = MillisPerHour * HoursPerDay;
-
         // Number of days in a non-leap year
         private const int DaysPerYear = 365;
         // Number of days in 4 years
@@ -92,20 +75,20 @@ namespace System
         private const int DaysTo10000 = DaysPer400Years * 25 - 366;  // 3652059
 
         internal const long MinTicks = 0;
-        internal const long MaxTicks = DaysTo10000 * TicksPerDay - 1;
-        private const long MaxMicroseconds = MaxTicks / TicksPerMicrosecond;
-        private const long MaxMillis = MaxTicks / TicksPerMillisecond;
-        private const long MaxSeconds = MaxTicks / TicksPerSecond;
-        private const long MaxMinutes = MaxTicks / TicksPerMinute;
-        private const long MaxHours = MaxTicks / TicksPerHour;
+        internal const long MaxTicks = DaysTo10000 * TimeSpan.TicksPerDay - 1;
+        private const long MaxMicroseconds = MaxTicks / TimeSpan.TicksPerMicrosecond;
+        private const long MaxMillis = MaxTicks / TimeSpan.TicksPerMillisecond;
+        private const long MaxSeconds = MaxTicks / TimeSpan.TicksPerSecond;
+        private const long MaxMinutes = MaxTicks / TimeSpan.TicksPerMinute;
+        private const long MaxHours = MaxTicks / TimeSpan.TicksPerHour;
         private const long MaxDays = (long)DaysTo10000 - 1;
 
-        internal const long UnixEpochTicks = DaysTo1970 * TicksPerDay;
-        private const long FileTimeOffset = DaysTo1601 * TicksPerDay;
-        private const long DoubleDateOffset = DaysTo1899 * TicksPerDay;
+        internal const long UnixEpochTicks = DaysTo1970 * TimeSpan.TicksPerDay;
+        private const long FileTimeOffset = DaysTo1601 * TimeSpan.TicksPerDay;
+        private const long DoubleDateOffset = DaysTo1899 * TimeSpan.TicksPerDay;
         // The minimum OA date is 0100/01/01 (Note it's year 100).
         // The maximum OA date is 9999/12/31
-        private const long OADateMinAsTicks = (DaysPer100Years - DaysPerYear) * TicksPerDay;
+        private const long OADateMinAsTicks = (DaysPer100Years - DaysPerYear) * TimeSpan.TicksPerDay;
         // All OA dates must be greater than (not >=) OADateMinAsDouble
         private const double OADateMinAsDouble = -657435.0;
         // All OA dates must be less than (not <=) OADateMaxAsDouble
@@ -119,7 +102,7 @@ namespace System
         private const uint EafMultiplier = (uint)(((1UL << 32) + DaysPer4Years - 1) / DaysPer4Years);   // 2,939,745
         private const uint EafDivider = EafMultiplier * 4;                                              // 11,758,980
 
-        private const ulong TicksPer6Hours = TicksPerHour * 6;
+        private const ulong TicksPer6Hours = TimeSpan.TicksPerHour * 6;
         private const int March1BasedDayOfNewYear = 306;              // Days between March 1 and January 1
 
         internal static ReadOnlySpan<uint> DaysToMonth365 => [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365];
@@ -221,8 +204,8 @@ namespace System
 
         private static void ThrowTicksOutOfRange() => throw new ArgumentOutOfRangeException("ticks", SR.ArgumentOutOfRange_DateTimeBadTicks);
         private static void ThrowInvalidKind() => throw new ArgumentException(SR.Argument_InvalidDateTimeKind, "kind");
-        private static void ThrowMillisecondOutOfRange() => throw new ArgumentOutOfRangeException("millisecond", SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
-        private static void ThrowMicrosecondOutOfRange() => throw new ArgumentOutOfRangeException("microsecond", SR.Format(SR.ArgumentOutOfRange_Range, 0, MicrosecondsPerMillisecond - 1));
+        private static void ThrowMillisecondOutOfRange() => throw new ArgumentOutOfRangeException("millisecond", SR.Format(SR.ArgumentOutOfRange_Range, 0, TimeSpan.MillisecondsPerSecond - 1));
+        private static void ThrowMicrosecondOutOfRange() => throw new ArgumentOutOfRangeException("microsecond", SR.Format(SR.ArgumentOutOfRange_Range, 0, TimeSpan.MicrosecondsPerMillisecond - 1));
         private static void ThrowDateArithmetic(int param) => throw new ArgumentOutOfRangeException(param switch { 0 => "value", 1 => "t", _ => "months" }, SR.ArgumentOutOfRange_DateArithmetic);
         private static void ThrowAddOutOfRange() => throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_AddValue);
 
@@ -304,7 +287,7 @@ namespace System
         {
             ArgumentNullException.ThrowIfNull(calendar);
 
-            if ((uint)millisecond >= MillisPerSecond) ThrowMillisecondOutOfRange();
+            if ((uint)millisecond >= TimeSpan.MillisecondsPerSecond) ThrowMillisecondOutOfRange();
             if ((uint)kind > (uint)DateTimeKind.Local) ThrowInvalidKind();
 
             if (second != 60 || !SystemSupportsLeapSeconds)
@@ -666,9 +649,9 @@ namespace System
         public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, DateTimeKind kind)
         {
             ulong ticks = Init(year, month, day, hour, minute, second, millisecond, kind);
-            if ((uint)microsecond >= MicrosecondsPerMillisecond) ThrowMicrosecondOutOfRange();
+            if ((uint)microsecond >= TimeSpan.MicrosecondsPerMillisecond) ThrowMicrosecondOutOfRange();
 
-            ulong newTicks = (ticks & TicksMask) + (ulong)(microsecond * TicksPerMicrosecond);
+            ulong newTicks = (ticks & TicksMask) + (ulong)(microsecond * TimeSpan.TicksPerMicrosecond);
 
             Debug.Assert(newTicks <= MaxTicks);
             _dateData = newTicks | (ticks & FlagsMask);
@@ -799,7 +782,7 @@ namespace System
         public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, Calendar calendar, DateTimeKind kind)
             : this(year, month, day, hour, minute, second, millisecond, calendar, kind)
         {
-            if ((uint)microsecond >= MicrosecondsPerMillisecond)
+            if ((uint)microsecond >= TimeSpan.MicrosecondsPerMillisecond)
             {
                 ThrowMicrosecondOutOfRange();
             }
@@ -809,13 +792,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong Init(int year, int month, int day, int hour, int minute, int second, int millisecond, DateTimeKind kind = DateTimeKind.Unspecified)
         {
-            if ((uint)millisecond >= MillisPerSecond) ThrowMillisecondOutOfRange();
+            if ((uint)millisecond >= TimeSpan.MillisecondsPerSecond) ThrowMillisecondOutOfRange();
             if ((uint)kind > (uint)DateTimeKind.Local) ThrowInvalidKind();
 
             if (second != 60 || !SystemSupportsLeapSeconds)
             {
                 ulong ticks = DateToTicks(year, month, day) + TimeToTicks(hour, minute, second);
-                ticks += (uint)millisecond * (uint)TicksPerMillisecond;
+                ticks += (uint)millisecond * (uint)TimeSpan.TicksPerMillisecond;
                 Debug.Assert(ticks <= MaxTicks, "Input parameters validated already");
                 return ticks | ((ulong)kind << KindShift);
             }
@@ -906,7 +889,7 @@ namespace System
         /// <returns>
         /// An object whose value is the sum of the date and time represented by this instance and the number of days represented by value.
         /// </returns>
-        public DateTime AddDays(double value) => AddUnits(value, MaxDays, TicksPerDay);
+        public DateTime AddDays(double value) => AddUnits(value, MaxDays, TimeSpan.TicksPerDay);
 
         /// <summary>
         /// Returns a new <see cref="DateTime"/> that adds the specified number of hours to the value of this instance.
@@ -915,7 +898,7 @@ namespace System
         /// <returns>
         /// An object whose value is the sum of the date and time represented by this instance and the number of hours represented by value.
         /// </returns>
-        public DateTime AddHours(double value) => AddUnits(value, MaxHours, TicksPerHour);
+        public DateTime AddHours(double value) => AddUnits(value, MaxHours, TimeSpan.TicksPerHour);
 
         /// <summary>
         /// Returns a new <see cref="DateTime"/> that adds the specified number of milliseconds to the value of this instance.
@@ -924,7 +907,7 @@ namespace System
         /// <returns>
         /// An object whose value is the sum of the date and time represented by this instance and the number of milliseconds represented by value.
         /// </returns>
-        public DateTime AddMilliseconds(double value) => AddUnits(value, MaxMillis, TicksPerMillisecond);
+        public DateTime AddMilliseconds(double value) => AddUnits(value, MaxMillis, TimeSpan.TicksPerMillisecond);
 
         /// <summary>
         /// Returns a new <see cref="DateTime"/> that adds the specified number of microseconds to the value of this instance.
@@ -950,7 +933,7 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The resulting <see cref="DateTime"/> is less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>.
         /// </exception>
-        public DateTime AddMicroseconds(double value) => AddUnits(value, MaxMicroseconds, TicksPerMicrosecond);
+        public DateTime AddMicroseconds(double value) => AddUnits(value, MaxMicroseconds, TimeSpan.TicksPerMicrosecond);
 
         /// <summary>
         /// Returns a new <see cref="DateTime"/> that adds the specified number of minutes to the value of this instance.
@@ -959,7 +942,7 @@ namespace System
         /// <returns>
         /// An object whose value is the sum of the date and time represented by this instance and the number of minutes represented by value.
         /// </returns>
-        public DateTime AddMinutes(double value) => AddUnits(value, MaxMinutes, TicksPerMinute);
+        public DateTime AddMinutes(double value) => AddUnits(value, MaxMinutes, TimeSpan.TicksPerMinute);
 
         // Returns the DateTime resulting from adding the given number of
         // months to this DateTime. The result is computed by incrementing
@@ -993,7 +976,7 @@ namespace System
             int days = (int)(daysTo[m] - daysToMonth);
             if (d > days) d = days;
             uint n = DaysToYear((uint)y) + daysToMonth + (uint)d - 1;
-            return new DateTime(n * (ulong)TicksPerDay + UTicks % TicksPerDay | InternalKind);
+            return new DateTime(n * (ulong)TimeSpan.TicksPerDay + UTicks % TimeSpan.TicksPerDay | InternalKind);
         }
 
         /// <summary>
@@ -1003,7 +986,7 @@ namespace System
         /// <returns>
         /// An object whose value is the sum of the date and time represented by this instance and the number of seconds represented by value.
         /// </returns>
-        public DateTime AddSeconds(double value) => AddUnits(value, MaxSeconds, TicksPerSecond);
+        public DateTime AddSeconds(double value) => AddUnits(value, MaxSeconds, TimeSpan.TicksPerSecond);
 
         // Returns the DateTime resulting from adding the given number of
         // 100-nanosecond ticks to this DateTime. The value argument
@@ -1059,7 +1042,7 @@ namespace System
                 n += DaysToMonth365[m];
             }
             n += (uint)d;
-            return new DateTime(n * (ulong)TicksPerDay + UTicks % TicksPerDay | InternalKind);
+            return new DateTime(n * (ulong)TimeSpan.TicksPerDay + UTicks % TimeSpan.TicksPerDay | InternalKind);
         }
 
         // Compares two DateTime values, returning an integer that indicates
@@ -1113,7 +1096,7 @@ namespace System
             }
 
             uint n = DaysToYear((uint)year) + days[month - 1] + (uint)day - 1;
-            return n * (ulong)TicksPerDay;
+            return n * (ulong)TimeSpan.TicksPerDay;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1135,16 +1118,16 @@ namespace System
             }
 
             int totalSeconds = hour * 3600 + minute * 60 + second;
-            return (uint)totalSeconds * (ulong)TicksPerSecond;
+            return (uint)totalSeconds * (ulong)TimeSpan.TicksPerSecond;
         }
 
         internal static ulong TimeToTicks(int hour, int minute, int second, int millisecond)
         {
             ulong ticks = TimeToTicks(hour, minute, second);
 
-            if ((uint)millisecond >= MillisPerSecond) ThrowMillisecondOutOfRange();
+            if ((uint)millisecond >= TimeSpan.MillisecondsPerSecond) ThrowMillisecondOutOfRange();
 
-            ticks += (uint)millisecond * (uint)TicksPerMillisecond;
+            ticks += (uint)millisecond * (uint)TimeSpan.TicksPerMillisecond;
 
             Debug.Assert(ticks <= MaxTicks, "Input parameters validated already");
 
@@ -1155,9 +1138,9 @@ namespace System
         {
             ulong ticks = TimeToTicks(hour, minute, second, millisecond);
 
-            if ((uint)microsecond >= MicrosecondsPerMillisecond) ThrowMicrosecondOutOfRange();
+            if ((uint)microsecond >= TimeSpan.MicrosecondsPerMillisecond) ThrowMicrosecondOutOfRange();
 
-            ticks += (uint)microsecond * (uint)TicksPerMicrosecond;
+            ticks += (uint)microsecond * (uint)TimeSpan.TicksPerMicrosecond;
 
             Debug.Assert(ticks <= MaxTicks, "Input parameters validated already");
 
@@ -1183,19 +1166,19 @@ namespace System
                 throw new ArgumentException(SR.Arg_OleAutDateInvalid);
 
             // Conversion to long will not cause an overflow here, as at this point the "value" is in between OADateMinAsDouble and OADateMaxAsDouble
-            long millis = (long)(value * MillisPerDay + (value >= 0 ? 0.5 : -0.5));
+            long millis = (long)(value * TimeSpan.MillisecondsPerDay + (value >= 0 ? 0.5 : -0.5));
             // The interesting thing here is when you have a value like 12.5 it all positive 12 days and 12 hours from 01/01/1899
             // However if you a value of -12.25 it is minus 12 days but still positive 6 hours, almost as though you meant -11.75 all negative
-            // This line below fixes up the millis in the negative case
+            // This line below fixes up the milliseconds in the negative case
             if (millis < 0)
             {
-                millis -= (millis % MillisPerDay) * 2;
+                millis -= (millis % TimeSpan.MillisecondsPerDay) * 2;
             }
 
-            millis += DoubleDateOffset / TicksPerMillisecond;
+            millis += DoubleDateOffset / TimeSpan.TicksPerMillisecond;
 
             if (millis < 0 || millis > MaxMillis) throw new ArgumentException(SR.Arg_OleAutDateScale);
-            return millis * TicksPerMillisecond;
+            return millis * TimeSpan.TicksPerMillisecond;
         }
 
         // Checks if this DateTime is equal to a given object. Returns
@@ -1232,7 +1215,7 @@ namespace System
                 // local date.
                 long ticks = dateData & (unchecked((long)TicksMask));
                 // Negative ticks are stored in the top part of the range and should be converted back into a negative number
-                if (ticks > TicksCeiling - TicksPerDay)
+                if (ticks > TicksCeiling - TimeSpan.TicksPerDay)
                 {
                     ticks -= TicksCeiling;
                 }
@@ -1260,7 +1243,7 @@ namespace System
                 // to compare times of day
                 if (ticks < 0)
                 {
-                    ticks += TicksPerDay;
+                    ticks += TimeSpan.TicksPerDay;
                 }
                 if ((ulong)ticks > MaxTicks)
                 {
@@ -1371,7 +1354,7 @@ namespace System
             get
             {
                 ulong ticks = UTicks;
-                return new DateTime((ticks - ticks % TicksPerDay) | InternalKind);
+                return new DateTime((ticks - ticks % TimeSpan.TicksPerDay) | InternalKind);
             }
         }
 
@@ -1405,7 +1388,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void GetTime(out int hour, out int minute, out int second)
         {
-            ulong seconds = UTicks / TicksPerSecond;
+            ulong seconds = UTicks / TimeSpan.TicksPerSecond;
             ulong minutes = seconds / 60;
             second = (int)(seconds - (minutes * 60));
             ulong hours = minutes / 60;
@@ -1416,7 +1399,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void GetTime(out int hour, out int minute, out int second, out int millisecond)
         {
-            ulong milliseconds = UTicks / TicksPerMillisecond;
+            ulong milliseconds = UTicks / TimeSpan.TicksPerMillisecond;
             ulong seconds = milliseconds / 1000;
             millisecond = (int)(milliseconds - (seconds * 1000));
             ulong minutes = seconds / 60;
@@ -1430,8 +1413,8 @@ namespace System
         internal void GetTimePrecise(out int hour, out int minute, out int second, out int tick)
         {
             ulong ticks = UTicks;
-            ulong seconds = ticks / TicksPerSecond;
-            tick = (int)(ticks - (seconds * TicksPerSecond));
+            ulong seconds = ticks / TimeSpan.TicksPerSecond;
+            tick = (int)(ticks - (seconds * TimeSpan.TicksPerSecond));
             ulong minutes = seconds / 60;
             second = (int)(seconds - (minutes * 60));
             ulong hours = minutes / 60;
@@ -1461,7 +1444,7 @@ namespace System
         // Monday, 2 indicates Tuesday, 3 indicates Wednesday, 4 indicates
         // Thursday, 5 indicates Friday, and 6 indicates Saturday.
         //
-        public DayOfWeek DayOfWeek => (DayOfWeek)(((uint)(UTicks / TicksPerDay) + 1) % 7);
+        public DayOfWeek DayOfWeek => (DayOfWeek)(((uint)(UTicks / TimeSpan.TicksPerDay) + 1) % 7);
 
         // Returns the day-of-year part of this DateTime. The returned value
         // is an integer between 1 and 366.
@@ -1480,7 +1463,7 @@ namespace System
         // Returns the hour part of this DateTime. The returned value is an
         // integer between 0 and 23.
         //
-        public int Hour => (int)((uint)(UTicks / TicksPerHour) % 24);
+        public int Hour => (int)((uint)(UTicks / TimeSpan.TicksPerHour) % 24);
 
         internal bool IsAmbiguousDaylightSavingTime() =>
             InternalKind == KindLocalAmbiguousDst;
@@ -1499,22 +1482,22 @@ namespace System
         // Returns the millisecond part of this DateTime. The returned value
         // is an integer between 0 and 999.
         //
-        public int Millisecond => (int)((UTicks / TicksPerMillisecond) % 1000);
+        public int Millisecond => (int)((UTicks / TimeSpan.TicksPerMillisecond) % 1000);
 
         /// <summary>
         /// The microseconds component, expressed as a value between 0 and 999.
         /// </summary>
-        public int Microsecond => (int)((UTicks / TicksPerMicrosecond) % 1000);
+        public int Microsecond => (int)((UTicks / TimeSpan.TicksPerMicrosecond) % 1000);
 
         /// <summary>
         /// The nanoseconds component, expressed as a value between 0 and 900 (in increments of 100 nanoseconds).
         /// </summary>
-        public int Nanosecond => (int)(UTicks % TicksPerMicrosecond) * 100;
+        public int Nanosecond => (int)(UTicks % TimeSpan.TicksPerMicrosecond) * 100;
 
         // Returns the minute part of this DateTime. The returned value is
         // an integer between 0 and 59.
         //
-        public int Minute => (int)((UTicks / TicksPerMinute) % 60);
+        public int Minute => (int)((UTicks / TimeSpan.TicksPerMinute) % 60);
 
         // Returns the month part of this DateTime. The returned value is an
         // integer between 1 and 12.
@@ -1556,7 +1539,7 @@ namespace System
         // Returns the second part of this DateTime. The returned value is
         // an integer between 0 and 59.
         //
-        public int Second => (int)((UTicks / TicksPerSecond) % 60);
+        public int Second => (int)((UTicks / TimeSpan.TicksPerSecond) % 60);
 
         // Returns the tick count for this DateTime. The returned value is
         // the number of 100-nanosecond intervals that have elapsed since 1/1/0001
@@ -1567,7 +1550,7 @@ namespace System
         // Returns the time-of-day part of this DateTime. The returned value
         // is a TimeSpan that indicates the time elapsed since midnight.
         //
-        public TimeSpan TimeOfDay => new TimeSpan((long)(UTicks % TicksPerDay));
+        public TimeSpan TimeOfDay => new TimeSpan((long)(UTicks % TimeSpan.TicksPerDay));
 
         // Returns a DateTime representing the current date. The date part
         // of the returned value is the current date, and the time-of-day part of
@@ -1696,19 +1679,19 @@ namespace System
         {
             if (value == 0)
                 return 0.0;  // Returns OleAut's zero'ed date value.
-            if (value < TicksPerDay) // This is a fix for VB. They want the default day to be 1/1/0001 rathar then 12/30/1899.
+            if (value < TimeSpan.TicksPerDay) // This is a fix for VB. They want the default day to be 1/1/0001 rathar then 12/30/1899.
                 value += DoubleDateOffset; // We could have moved this fix down but we would like to keep the bounds check.
             if (value < OADateMinAsTicks)
                 throw new OverflowException(SR.Arg_OleAutDateInvalid);
             // Currently, our max date == OA's max date (12/31/9999), so we don't
             // need an overflow check in that direction.
-            long millis = (value - DoubleDateOffset) / TicksPerMillisecond;
+            long millis = (value - DoubleDateOffset) / TimeSpan.TicksPerMillisecond;
             if (millis < 0)
             {
-                long frac = millis % MillisPerDay;
-                if (frac != 0) millis -= (MillisPerDay + frac) * 2;
+                long frac = millis % TimeSpan.MillisecondsPerDay;
+                if (frac != 0) millis -= (TimeSpan.MillisecondsPerDay + frac) * 2;
             }
-            return (double)millis / MillisPerDay;
+            return (double)millis / TimeSpan.MillisecondsPerDay;
         }
 
         // Converts the DateTime instance into an OLE Automation compatible
@@ -2020,7 +2003,7 @@ namespace System
             {
                 return false;
             }
-            if ((uint)hour >= 24 || (uint)minute >= 60 || (uint)millisecond >= MillisPerSecond)
+            if ((uint)hour >= 24 || (uint)minute >= 60 || (uint)millisecond >= TimeSpan.MillisecondsPerSecond)
             {
                 return false;
             }
@@ -2030,11 +2013,11 @@ namespace System
             {
                 return false;
             }
-            ulong ticks = (DaysToYear((uint)year) + days[month - 1] + (uint)day - 1) * (ulong)TicksPerDay;
+            ulong ticks = (DaysToYear((uint)year) + days[month - 1] + (uint)day - 1) * (ulong)TimeSpan.TicksPerDay;
 
             if ((uint)second < 60)
             {
-                ticks += TimeToTicks(hour, minute, second) + (uint)millisecond * (uint)TicksPerMillisecond;
+                ticks += TimeToTicks(hour, minute, second) + (uint)millisecond * (uint)TimeSpan.TicksPerMillisecond;
             }
             else if (second == 60 && SystemSupportsLeapSeconds && IsValidTimeWithLeapSeconds(year, month, day, hour, minute, DateTimeKind.Unspecified))
             {
@@ -2043,7 +2026,7 @@ namespace System
                 // of this minute.
                 // if it is not valid time, we'll eventually throw.
                 // although this is unspecified datetime kind, we'll assume the passed time is UTC to check the leap seconds.
-                ticks += TimeToTicks(hour, minute, 59) + 999 * TicksPerMillisecond;
+                ticks += TimeToTicks(hour, minute, 59) + 999 * TimeSpan.TicksPerMillisecond;
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -250,7 +250,7 @@ namespace System
         public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, TimeSpan offset)
             : this(year, month, day, hour, minute, second, millisecond, offset)
         {
-            if ((uint)microsecond >= DateTime.MicrosecondsPerMillisecond)
+            if ((uint)microsecond >= TimeSpan.MicrosecondsPerMillisecond)
             {
                 throw new ArgumentOutOfRangeException(nameof(microsecond), SR.ArgumentOutOfRange_BadHourMinuteSecond);
             }
@@ -327,7 +327,7 @@ namespace System
         public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, Calendar calendar, TimeSpan offset)
         : this(year, month, day, hour, minute, second, millisecond, calendar, offset)
         {
-            if ((uint)microsecond >= DateTime.MicrosecondsPerMillisecond)
+            if ((uint)microsecond >= TimeSpan.MicrosecondsPerMillisecond)
             {
                 throw new ArgumentOutOfRangeException(nameof(microsecond), SR.ArgumentOutOfRange_BadHourMinuteSecond);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
@@ -10,9 +10,6 @@ namespace System.Diagnostics
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public partial class Stopwatch
     {
-        private const long TicksPerMillisecond = 10000;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
-
         private long _elapsed;
         private long _startTimeStamp;
         private bool _isRunning;
@@ -27,7 +24,7 @@ namespace System.Diagnostics
         // performance-counter frequency, in counts per ticks.
         // This can speed up conversion from high frequency performance-counter
         // to ticks.
-        private static readonly double s_tickFrequency = (double)TicksPerSecond / Frequency;
+        private static readonly double s_tickFrequency = (double)TimeSpan.TicksPerSecond / Frequency;
 
         public Stopwatch()
         {
@@ -109,7 +106,7 @@ namespace System.Diagnostics
 
         public long ElapsedMilliseconds
         {
-            get { return GetElapsedDateTimeTicks() / TicksPerMillisecond; }
+            get { return GetElapsedDateTimeTicks() / TimeSpan.TicksPerMillisecond; }
         }
 
         public long ElapsedTicks

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
@@ -28,19 +28,6 @@ namespace System.Globalization
 
     public abstract class Calendar : ICloneable
     {
-        // Number of 100ns (10E-7 second) ticks per time unit
-        internal const long TicksPerMillisecond = 10000;
-        internal const long TicksPerSecond = TicksPerMillisecond * 1000;
-        internal const long TicksPerMinute = TicksPerSecond * 60;
-        internal const long TicksPerHour = TicksPerMinute * 60;
-        internal const long TicksPerDay = TicksPerHour * 24;
-
-        // Number of milliseconds per time unit
-        internal const int MillisPerSecond = 1000;
-        internal const int MillisPerMinute = MillisPerSecond * 60;
-        internal const int MillisPerHour = MillisPerMinute * 60;
-        internal const int MillisPerDay = MillisPerHour * 24;
-
         // Number of days in a non-leap year
         internal const int DaysPerYear = 365;
         // Number of days in 4 years
@@ -53,7 +40,7 @@ namespace System.Globalization
         // Number of days from 1/1/0001 to 1/1/10000
         internal const int DaysTo10000 = DaysPer400Years * 25 - 366;
 
-        internal const long MaxMillis = (long)DaysTo10000 * MillisPerDay;
+        internal const long MaxMillis = (long)DaysTo10000 * TimeSpan.MillisecondsPerDay;
 
         private int _currentEraValue = -1;
 
@@ -156,7 +143,7 @@ namespace System.Globalization
             }
 
             long millis = (long)tempMillis;
-            long ticks = time.Ticks + millis * TicksPerMillisecond;
+            long ticks = time.Ticks + millis * TimeSpan.TicksPerMillisecond;
             CheckAddResult(ticks, MinSupportedDateTime, MaxSupportedDateTime);
             return new DateTime(ticks);
         }
@@ -182,7 +169,7 @@ namespace System.Globalization
         /// </summary>
         public virtual DateTime AddDays(DateTime time, int days)
         {
-            return Add(time, days, MillisPerDay);
+            return Add(time, days, (int)TimeSpan.MillisecondsPerDay);
         }
 
         /// <summary>
@@ -194,7 +181,7 @@ namespace System.Globalization
         /// </summary>
         public virtual DateTime AddHours(DateTime time, int hours)
         {
-            return Add(time, hours, MillisPerHour);
+            return Add(time, hours, (int)TimeSpan.MillisecondsPerHour);
         }
 
         /// <summary>
@@ -206,7 +193,7 @@ namespace System.Globalization
         /// </summary>
         public virtual DateTime AddMinutes(DateTime time, int minutes)
         {
-            return Add(time, minutes, MillisPerMinute);
+            return Add(time, minutes, (int)TimeSpan.MillisecondsPerMinute);
         }
 
         /// <summary>
@@ -238,7 +225,7 @@ namespace System.Globalization
         /// </summary>
         public virtual DateTime AddSeconds(DateTime time, int seconds)
         {
-            return Add(time, seconds, MillisPerSecond);
+            return Add(time, seconds, (int)TimeSpan.MillisecondsPerSecond);
         }
 
         // Returns the DateTime resulting from adding a number of
@@ -695,16 +682,16 @@ namespace System.Globalization
             {
                 throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadHourMinuteSecond);
             }
-            if ((uint)millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= TimeSpan.MillisecondsPerSecond)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(millisecond),
                     millisecond,
-                    SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
+                    SR.Format(SR.ArgumentOutOfRange_Range, 0, TimeSpan.MillisecondsPerSecond - 1));
             }
 
             int totalSeconds = hour * 3600 + minute * 60 + second;
-            return totalSeconds * TicksPerSecond + millisecond * TicksPerMillisecond;
+            return totalSeconds * TimeSpan.TicksPerSecond + millisecond * TimeSpan.TicksPerMillisecond;
         }
 
         internal static int GetSystemTwoDigitYearSetting(CalendarId CalID, int defaultYearValue)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendricalCalculationsHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendricalCalculationsHelper.cs
@@ -15,7 +15,6 @@ namespace System.Globalization
         private const double MeanSpeedOfSun = MeanTropicalYearInDays / FullCircleOfArc;
         private const double LongitudeSpring = 0.0;
         private const double TwoDegreesAfterSpring = 2.0;
-        private const int SecondsPerDay = 24 * 60 * 60; // 24 hours * 60 minutes * 60 seconds
         private const int DaysInUniformLengthCentury = 36525;
 
         private static readonly long s_startOf1810 = GetNumberOfDays(new DateTime(1810, 1, 1));
@@ -59,12 +58,12 @@ namespace System.Globalization
 
         internal static long GetNumberOfDays(DateTime date)
         {
-            return date.Ticks / Calendar.TicksPerDay;
+            return date.Ticks / TimeSpan.TicksPerDay;
         }
 
         private static int GetGregorianYear(double numberOfDays)
         {
-            return new DateTime(Math.Min((long)(Math.Floor(numberOfDays) * Calendar.TicksPerDay), DateTime.MaxValue.Ticks)).Year;
+            return new DateTime(Math.Min((long)(Math.Floor(numberOfDays) * TimeSpan.TicksPerDay), DateTime.MaxValue.Ticks)).Year;
         }
 
         private enum CorrectionAlgorithm
@@ -148,13 +147,13 @@ namespace System.Globalization
             long january1stOfYear = GetNumberOfDays(new DateTime(gregorianYear, 1, 1));
             double daysSinceStartOf1810 = january1stOfYear - s_startOf1810;
             double x = TwelveHours + daysSinceStartOf1810;
-            return ((Math.Pow(x, 2) / 41048480) - 15) / SecondsPerDay;
+            return ((Math.Pow(x, 2) / 41048480) - 15) / TimeSpan.SecondsPerDay;
         }
 
         private static double EphemerisCorrection1988to2019(int gregorianYear)
         {
             Debug.Assert(1988 <= gregorianYear && gregorianYear <= 2019);
-            return (double)(gregorianYear - 1933) / SecondsPerDay;
+            return (double)(gregorianYear - 1933) / TimeSpan.SecondsPerDay;
         }
 
         private static double EphemerisCorrection1900to1987(int gregorianYear)
@@ -175,14 +174,14 @@ namespace System.Globalization
         {
             Debug.Assert(1700 <= gregorianYear && gregorianYear <= 1799);
             double yearsSince1700 = gregorianYear - 1700;
-            return PolynomialSum(Coefficients1700to1799, yearsSince1700) / SecondsPerDay;
+            return PolynomialSum(Coefficients1700to1799, yearsSince1700) / TimeSpan.SecondsPerDay;
         }
 
         private static double EphemerisCorrection1620to1699(int gregorianYear)
         {
             Debug.Assert(1620 <= gregorianYear && gregorianYear <= 1699);
             double yearsSince1600 = gregorianYear - 1600;
-            return PolynomialSum(Coefficients1620to1699, yearsSince1600) / SecondsPerDay;
+            return PolynomialSum(Coefficients1620to1699, yearsSince1600) / TimeSpan.SecondsPerDay;
         }
 
         // ephemeris-correction: correction to account for the slowing down of the rotation of the earth

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
@@ -484,7 +484,7 @@ namespace System
                         tokenLen = ParseRepeatPattern(format, i, ch);
                         if (tokenLen <= MaxSecondsFractionDigits)
                         {
-                            int fraction = (int)(dateTime.Ticks % Calendar.TicksPerSecond);
+                            int fraction = (int)(dateTime.Ticks % TimeSpan.TicksPerSecond);
                             fraction /= TimeSpanParse.Pow10UpToMaxFractionDigits(MaxSecondsFractionDigits - tokenLen);
                             if (ch == 'f')
                             {
@@ -792,7 +792,7 @@ namespace System
             {
                 // No offset. The instance is a DateTime and the output should be the local time zone
 
-                if (timeOnly && dateTime.Ticks < Calendar.TicksPerDay)
+                if (timeOnly && dateTime.Ticks < TimeSpan.TicksPerDay)
                 {
                     // For time only format and a time only input, the time offset on 0001/01/01 is less
                     // accurate than the system's current offset because of daylight saving time.
@@ -1144,7 +1144,7 @@ namespace System
             // Gregorian year 0001, an exception will be thrown when we try to get the Japanese year for
             // Gregorian year 0001. Therefore, the workaround allows them to call ToString() for time of
             // day from a DateTime by formatting as ISO 8601 format.
-            dateTime.Ticks < Calendar.TicksPerDay &&
+            dateTime.Ticks < TimeSpan.TicksPerDay &&
             dtfi.Calendar.ID is
                 CalendarId.JAPAN or
                 CalendarId.TAIWAN or

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -2710,7 +2710,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
 
             if (raw.fraction > 0)
             {
-                if (!time.TryAddTicks((long)Math.Round(raw.fraction * Calendar.TicksPerSecond), out time))
+                if (!time.TryAddTicks((long)Math.Round(raw.fraction * TimeSpan.TicksPerSecond), out time))
                 {
                     result.SetBadDateTimeFailure();
                     TPTraceExit("0100 (time.TryAddTicks)", dps);
@@ -2897,7 +2897,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             resultTicks -= result.timeZoneOffset.Ticks;
             if (resultTicks < 0)
             {
-                resultTicks += Calendar.TicksPerDay;
+                resultTicks += TimeSpan.TicksPerDay;
             }
 
             if (resultTicks < DateTime.MinTicks || resultTicks > DateTime.MaxTicks)
@@ -2922,7 +2922,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             // Convert to local ticks
             TimeZoneInfo tz = TimeZoneInfo.Local;
             bool isAmbiguousLocalDst = false;
-            if (resultTicks < Calendar.TicksPerDay)
+            if (resultTicks < TimeSpan.TicksPerDay)
             {
                 //
                 // This is time of day.
@@ -2935,7 +2935,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
 
                 if (resultTicks < 0)
                 {
-                    resultTicks += Calendar.TicksPerDay;
+                    resultTicks += TimeSpan.TicksPerDay;
                 }
             }
             else
@@ -3071,7 +3071,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 return false;
             }
 
-            if (!time.TryAddTicks((long)Math.Round(partSecond * Calendar.TicksPerSecond), out time))
+            if (!time.TryAddTicks((long)Math.Round(partSecond * TimeSpan.TicksPerSecond), out time))
             {
                 result.SetBadDateTimeFailure();
                 return false;
@@ -4739,7 +4739,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             }
             if (result.fraction > 0)
             {
-                if (!result.parsedDate.TryAddTicks((long)Math.Round(result.fraction * Calendar.TicksPerSecond), out result.parsedDate))
+                if (!result.parsedDate.TryAddTicks((long)Math.Round(result.fraction * TimeSpan.TicksPerSecond), out result.parsedDate))
                 {
                     result.SetBadDateTimeFailure();
                     return false;
@@ -5084,7 +5084,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 return false;
             }
 
-            if (!dateTime.TryAddTicks((long)Math.Round(fraction * Calendar.TicksPerSecond), out result.parsedDate))
+            if (!dateTime.TryAddTicks((long)Math.Round(fraction * TimeSpan.TicksPerSecond), out result.parsedDate))
             {
                 result.SetBadDateTimeFailure();
                 return false;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendar.cs
@@ -113,7 +113,7 @@ namespace System.Globalization
         /// </summary>
         private static long DateToTicks(int year, int month, int day)
         {
-            return GetAbsoluteDate(year, month, day) * TicksPerDay;
+            return GetAbsoluteDate(year, month, day) * TimeSpan.TicksPerDay;
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace System.Globalization
             {
                 d = days;
             }
-            long ticks = DateToTicks(y, m, d) + time.Ticks % TicksPerDay;
+            long ticks = DateToTicks(y, m, d) + time.Ticks % TimeSpan.TicksPerDay;
             CheckAddResult(ticks, MinSupportedDateTime, MaxSupportedDateTime);
 
             return new DateTime(ticks);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
@@ -566,7 +566,7 @@ namespace System.Globalization
                     d = days;
                 }
 
-                return new DateTime(ToDateTime(y, i, d, 0, 0, 0, 0).Ticks + (time.Ticks % TicksPerDay));
+                return new DateTime(ToDateTime(y, i, d, 0, 0, 0, 0).Ticks + (time.Ticks % TimeSpan.TicksPerDay));
             }
             // We expect ArgumentException and ArgumentOutOfRangeException (which is subclass of ArgumentException)
             // If exception is thrown in the calls above, we are out of the supported range of this calendar.
@@ -597,7 +597,7 @@ namespace System.Globalization
                 d = days;
             }
 
-            long ticks = ToDateTime(y, m, d, 0, 0, 0, 0).Ticks + (time.Ticks % TicksPerDay);
+            long ticks = ToDateTime(y, m, d, 0, 0, 0, 0).Ticks + (time.Ticks % TimeSpan.TicksPerDay);
             CheckAddResult(ticks, MinSupportedDateTime, MaxSupportedDateTime);
             return new DateTime(ticks);
         }
@@ -647,7 +647,7 @@ namespace System.Globalization
                 beginOfYearDate = ToDateTime(year, 1, 1, 0, 0, 0, 0, CurrentEra);
             }
 
-            return (int)((time.Ticks - beginOfYearDate.Ticks) / TicksPerDay) + 1;
+            return (int)((time.Ticks - beginOfYearDate.Ticks) / TimeSpan.TicksPerDay) + 1;
         }
 
         public override int GetDaysInMonth(int year, int month, int era)
@@ -825,7 +825,7 @@ namespace System.Globalization
             int days = GetDayDifference(lunarYearType, hebrewMonth, hebrewDay, hebrewDateOfJan1.month, hebrewDateOfJan1.day);
 
             DateTime gregorianNewYear = new DateTime(gregorianYear, 1, 1);
-            return new DateTime(gregorianNewYear.Ticks + days * TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
+            return new DateTime(gregorianNewYear.Ticks + days * TimeSpan.TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
         }
 
         public override DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/HijriCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/HijriCalendar.cs
@@ -198,7 +198,7 @@ namespace System.Globalization
 
             // Get the absolute date. The absolute date is the number of days from January 1st, 1 A.D.
             // 1/1/0001 is absolute date 1.
-            long numDays = ticks / TicksPerDay + 1;
+            long numDays = ticks / TimeSpan.TicksPerDay + 1;
 
             // See how much we need to backup or advance
             numDays += HijriAdjustment;
@@ -296,7 +296,7 @@ namespace System.Globalization
                 d = days;
             }
 
-            long ticks = GetAbsoluteDateHijri(y, m, d) * TicksPerDay + (time.Ticks % TicksPerDay);
+            long ticks = GetAbsoluteDateHijri(y, m, d) * TimeSpan.TicksPerDay + (time.Ticks % TimeSpan.TicksPerDay);
             CheckAddResult(ticks, MinSupportedDateTime, MaxSupportedDateTime);
             return new DateTime(ticks);
         }
@@ -413,7 +413,7 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadYearMonthDay);
             }
 
-            return new DateTime(lDate * TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
+            return new DateTime(lDate * TimeSpan.TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
         }
 
         private const int DefaultTwoDigitYearMax = 1451;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/JulianCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/JulianCalendar.cs
@@ -115,9 +115,9 @@ namespace System.Globalization
         {
             // Gregorian 1/1/0001 is Julian 1/3/0001. Remember DateTime(0) is referred to Gregorian 1/1/0001.
             // The following line convert Gregorian ticks to Julian ticks.
-            long julianTicks = ticks + TicksPerDay * 2;
+            long julianTicks = ticks + TimeSpan.TicksPerDay * 2;
             // n = number of days since 1/1/0001
-            int n = (int)(julianTicks / TicksPerDay);
+            int n = (int)(julianTicks / TimeSpan.TicksPerDay);
             // y4 = number of whole 4-year periods within 100-year period
             int y4 = n / JulianDaysPer4Years;
             // n = day number within 4-year period
@@ -174,7 +174,7 @@ namespace System.Globalization
             // Gregorian 1/1/0001 is Julian 1/3/0001. n * TicksPerDay is the ticks in JulianCalendar.
             // Therefore, we subtract two days in the following to convert the ticks in JulianCalendar
             // to ticks in Gregorian calendar.
-            return (n - 2) * TicksPerDay;
+            return (n - 2) * TimeSpan.TicksPerDay;
         }
 
         public override DateTime AddMonths(DateTime time, int months)
@@ -209,7 +209,7 @@ namespace System.Globalization
                 d = days;
             }
 
-            long ticks = DateToTicks(y, m, d) + time.Ticks % TicksPerDay;
+            long ticks = DateToTicks(y, m, d) + time.Ticks % TimeSpan.TicksPerDay;
             CheckAddResult(ticks, MinSupportedDateTime, MaxSupportedDateTime);
             return new DateTime(ticks);
         }
@@ -303,12 +303,12 @@ namespace System.Globalization
             CheckYearEraRange(year, era);
             CheckMonthRange(month);
             CheckDayRange(year, month, day);
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if (millisecond < 0 || millisecond >= TimeSpan.MillisecondsPerSecond)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(millisecond),
                     millisecond,
-                    SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
+                    SR.Format(SR.ArgumentOutOfRange_Range, 0, TimeSpan.MillisecondsPerSecond - 1));
             }
 
             if (hour < 0 || hour >= 24 || minute < 0 || minute >= 60 || second < 0 || second >= 60)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/PersianCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/PersianCalendar.cs
@@ -21,7 +21,7 @@ namespace System.Globalization
     {
         public static readonly int PersianEra = 1;
 
-        private static readonly long s_persianEpoch = new DateTime(622, 3, 22).Ticks / TicksPerDay;
+        private static readonly long s_persianEpoch = new DateTime(622, 3, 22).Ticks / TimeSpan.TicksPerDay;
         private const int ApproximateHalfYear = 180;
 
         private const int DatePartYear = 0;
@@ -147,7 +147,7 @@ namespace System.Globalization
 
             // Get the absolute date. The absolute date is the number of days from January 1st, 1 A.D.
             // 1/1/0001 is absolute date 1.
-            long numDays = ticks / TicksPerDay + 1;
+            long numDays = ticks / TimeSpan.TicksPerDay + 1;
 
             // Calculate the appromixate Persian Year.
             long yearStart = CalendricalCalculationsHelper.PersianNewYearOnOrBefore(numDays);
@@ -197,7 +197,7 @@ namespace System.Globalization
 
             // Get the absolute date. The absolute date is the number of days from January 1st, 1 A.D.
             // 1/1/0001 is absolute date 1.
-            long numDays = ticks / TicksPerDay + 1;
+            long numDays = ticks / TimeSpan.TicksPerDay + 1;
 
             // Calculate the appromixate Persian Year.
             long yearStart = CalendricalCalculationsHelper.PersianNewYearOnOrBefore(numDays);
@@ -245,7 +245,7 @@ namespace System.Globalization
                 d = days;
             }
 
-            long ticks = GetAbsoluteDatePersian(y, m, d) * TicksPerDay + time.Ticks % TicksPerDay;
+            long ticks = GetAbsoluteDatePersian(y, m, d) * TimeSpan.TicksPerDay + time.Ticks % TimeSpan.TicksPerDay;
             CheckAddResult(ticks, MinSupportedDateTime, MaxSupportedDateTime);
             return new DateTime(ticks);
         }
@@ -384,7 +384,7 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadYearMonthDay);
             }
 
-            return new DateTime(lDate * TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
+            return new DateTime(lDate * TimeSpan.TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
         }
 
         private const int DefaultTwoDigitYearMax = 1410;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/UmAlQuraCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/UmAlQuraCalendar.cs
@@ -341,7 +341,7 @@ namespace System.Globalization
             // Find the index where we should start our search by quessing the Hijri year that we will be in HijriYearInfo.
             // A Hijri year is 354 or 355 days.  Use 355 days so that we will search from a lower index.
 
-            int index = (int)((time.Ticks - s_minDate.Ticks) / TicksPerDay) / 355;
+            int index = (int)((time.Ticks - s_minDate.Ticks) / TimeSpan.TicksPerDay) / 355;
             do
             {
             } while (time.CompareTo(s_hijriYearInfo[++index].GregorianDate) > 0); // while greater
@@ -444,7 +444,7 @@ namespace System.Globalization
             }
 
             CheckYearRange(y, UmAlQuraEra);
-            DateTime dt = new DateTime(GetAbsoluteDateUmAlQura(y, m, d) * TicksPerDay + time.Ticks % TicksPerDay);
+            DateTime dt = new DateTime(GetAbsoluteDateUmAlQura(y, m, d) * TimeSpan.TicksPerDay + time.Ticks % TimeSpan.TicksPerDay);
             CheckAddResult(dt.Ticks, MinSupportedDateTime, MaxSupportedDateTime);
             return dt;
         }
@@ -591,7 +591,7 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadYearMonthDay);
             }
 
-            return new DateTime(lDate * TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
+            return new DateTime(lDate * TimeSpan.TicksPerDay + TimeToTicks(hour, minute, second, millisecond));
         }
 
         private const int DefaultTwoDigitYearMax = 1451;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -582,9 +582,7 @@ namespace System.IO
 
         private static long UnixTimeSecondsToNanoseconds(DateTimeOffset time, long seconds)
         {
-            const long TicksPerMillisecond = 10000;
-            const long TicksPerSecond = TicksPerMillisecond * 1000;
-            return (time.UtcDateTime.Ticks - DateTimeOffset.UnixEpoch.Ticks - seconds * TicksPerSecond) * NanosecondsPerTick;
+            return (time.UtcDateTime.Ticks - DateTimeOffset.UnixEpoch.Ticks - seconds * TimeSpan.TicksPerSecond) * NanosecondsPerTick;
         }
 
         private void ThrowNotFound(string? path)

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -40,7 +40,7 @@ namespace System
         /// <remarks>
         /// The value of this constant is 100.
         /// </remarks>
-        public const long NanosecondsPerTick = 100;
+        public const long NanosecondsPerTick = 100;                                                 //             100
 
         /// <summary>
         /// Represents the number of ticks in 1 microsecond. This field is constant.
@@ -48,7 +48,7 @@ namespace System
         /// <remarks>
         /// The value of this constant is 10.
         /// </remarks>
-        public const long TicksPerMicrosecond = 10;
+        public const long TicksPerMicrosecond = 10;                                                 //              10
 
         /// <summary>
         /// Represents the number of ticks in 1 millisecond. This field is constant.
@@ -57,30 +57,158 @@ namespace System
         /// The value of this constant is 10 thousand; that is, 10,000.
         /// </remarks>
         public const long TicksPerMillisecond = TicksPerMicrosecond * 1000;                         //          10,000
+
+        /// <summary>
+        /// Represents the number of ticks in 1 second. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 10 million; that is, 10,000,000.
+        /// </remarks>
         public const long TicksPerSecond = TicksPerMillisecond * 1000;                              //      10,000,000
+
+        /// <summary>
+        /// Represents the number of ticks in 1 minute. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 600 million; that is, 600,000,000.
+        /// </remarks>
         public const long TicksPerMinute = TicksPerSecond * 60;                                     //     600,000,000
+
+        /// <summary>
+        /// Represents the number of ticks in 1 hour. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 36 billion; that is, 36,000,000,000.
+        /// </remarks>
         public const long TicksPerHour = TicksPerMinute * 60;                                       //  36,000,000,000
+
+        /// <summary>
+        /// Represents the number of ticks in 1 day. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 864 billion; that is, 864,000,000,000.
+        /// </remarks>
         public const long TicksPerDay = TicksPerHour * 24;                                          // 864,000,000,000
 
-        internal const long MicrosecondsPerMillisecond = TicksPerMillisecond / TicksPerMicrosecond; //           1,000
-        internal const long MicrosecondsPerSecond = TicksPerSecond / TicksPerMicrosecond;           //       1,000,000
-        internal const long MicrosecondsPerMinute = TicksPerMinute / TicksPerMicrosecond;           //      60,000,000
-        internal const long MicrosecondsPerHour = TicksPerHour / TicksPerMicrosecond;               //   3,600,000,000
-        internal const long MicrosecondsPerDay = TicksPerDay / TicksPerMicrosecond;                 //  86,400,000,000
+        /// <summary>
+        /// Represents the number of microseconds in 1 millisecond. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 1 thousand; that is, 1,000.
+        /// </remarks>
+        public const long MicrosecondsPerMillisecond = TicksPerMillisecond / TicksPerMicrosecond;   //           1,000
 
-        internal const long MillisecondsPerSecond = TicksPerSecond / TicksPerMillisecond;           //           1,000
-        internal const long MillisecondsPerMinute = TicksPerMinute / TicksPerMillisecond;           //          60,000
-        internal const long MillisecondsPerHour = TicksPerHour / TicksPerMillisecond;               //       3,600,000
-        internal const long MillisecondsPerDay = TicksPerDay / TicksPerMillisecond;                 //      86,400,000
+        /// <summary>
+        /// Represents the number of microseconds in 1 second. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 1 million; that is, 1,000,000.
+        /// </remarks>
+        public const long MicrosecondsPerSecond = TicksPerSecond / TicksPerMicrosecond;             //       1,000,000
 
-        internal const long SecondsPerMinute = TicksPerMinute / TicksPerSecond;                     //              60
-        internal const long SecondsPerHour = TicksPerHour / TicksPerSecond;                         //           3,600
-        internal const long SecondsPerDay = TicksPerDay / TicksPerSecond;                           //          86,400
+        /// <summary>
+        /// Represents the number of microseconds in 1 minute. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 60 million; that is, 60,000,000.
+        /// </remarks>
+        public const long MicrosecondsPerMinute = TicksPerMinute / TicksPerMicrosecond;             //      60,000,000
 
-        internal const long MinutesPerHour = TicksPerHour / TicksPerMinute;                         //              60
-        internal const long MinutesPerDay = TicksPerDay / TicksPerMinute;                           //           1,440
+        /// <summary>
+        /// Represents the number of microseconds in 1 hour. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 3.6 billion; that is, 3,600,000,000.
+        /// </remarks>
+        public const long MicrosecondsPerHour = TicksPerHour / TicksPerMicrosecond;                 //   3,600,000,000
 
-        internal const long HoursPerDay = TicksPerDay / TicksPerHour;                               //              24
+        /// <summary>
+        /// Represents the number of microseconds in 1 day. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 86.4 billion; that is, 86,400,000,000.
+        /// </remarks>
+        public const long MicrosecondsPerDay = TicksPerDay / TicksPerMicrosecond;                   //  86,400,000,000
+
+        /// <summary>
+        /// Represents the number of milliseconds in 1 second. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 1 thousand; that is, 1,000.
+        /// </remarks>
+        public const long MillisecondsPerSecond = TicksPerSecond / TicksPerMillisecond;             //           1,000
+
+        /// <summary>
+        /// Represents the number of milliseconds in 1 minute. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 60 thousand; that is, 60,000.
+        /// </remarks>
+        public const long MillisecondsPerMinute = TicksPerMinute / TicksPerMillisecond;             //          60,000
+
+        /// <summary>
+        /// Represents the number of milliseconds in 1 hour. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 3.6 million; that is, 3,600,000.
+        /// </remarks>
+        public const long MillisecondsPerHour = TicksPerHour / TicksPerMillisecond;                 //       3,600,000
+
+        /// <summary>
+        /// Represents the number of milliseconds in 1 day. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 86.4 million; that is, 86,400,000.
+        /// </remarks>
+        public const long MillisecondsPerDay = TicksPerDay / TicksPerMillisecond;                   //      86,400,000
+
+        /// <summary>
+        /// Represents the number of seconds in 1 minute. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 60.
+        /// </remarks>
+        public const long SecondsPerMinute = TicksPerMinute / TicksPerSecond;                       //              60
+
+        /// <summary>
+        /// Represents the number of seconds in 1 hour. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 3.6 thousand; that is, 3,600.
+        /// </remarks>
+        public const long SecondsPerHour = TicksPerHour / TicksPerSecond;                           //           3,600
+
+        /// <summary>
+        /// Represents the number of seconds in 1 day. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 86.4 thousand; that is, 86,400.
+        /// </remarks>
+        public const long SecondsPerDay = TicksPerDay / TicksPerSecond;                             //          86,400
+
+        /// <summary>
+        /// Represents the number of minutes in 1 hour. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 60.
+        /// </remarks>
+        public const long MinutesPerHour = TicksPerHour / TicksPerMinute;                           //              60
+
+        /// <summary>
+        /// Represents the number of minutes in 1 day. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 1440.
+        /// </remarks>
+        public const long MinutesPerDay = TicksPerDay / TicksPerMinute;                             //           1,440
+
+        /// <summary>
+        /// Represents the number of hours in 1 day. This field is constant.
+        /// </summary>
+        /// <remarks>
+        /// The value of this constant is 24.
+        /// </remarks>
+        public const int HoursPerDay = (int)(TicksPerDay / TicksPerHour);                           //              24
 
         internal const long MinTicks = long.MinValue;                                               // -9,223,372,036,854,775,808
         internal const long MaxTicks = long.MaxValue;                                               // +9,223,372,036,854,775,807

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
@@ -1038,8 +1038,6 @@ namespace System.Xml
 
         public static int ToChars(DateTime value, byte[] chars, int offset)
         {
-            const long TicksPerMillisecond = 10000;
-            const long TicksPerSecond = TicksPerMillisecond * 1000;
             int offsetMin = offset;
             // "yyyy-MM-ddTHH:mm:ss.fffffff";
             offset += ToCharsD4(value.Year, chars, offset);
@@ -1053,7 +1051,7 @@ namespace System.Xml
             offset += ToCharsD2(value.Minute, chars, offset);
             chars[offset++] = (byte)':';
             offset += ToCharsD2(value.Second, chars, offset);
-            int ms = (int)(value.Ticks % TicksPerSecond);
+            int ms = (int)(value.Ticks % TimeSpan.TicksPerSecond);
             if (ms != 0)
             {
                 chars[offset++] = (byte)'.';

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XsdDateTime.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XsdDateTime.cs
@@ -108,16 +108,6 @@ namespace System.Xml.Schema
         private static readonly int s_Lz___ = "---".Length;
         private static readonly int s_lz___dd = "---dd".Length;
 
-        // These values were copied from the DateTime class and are
-        // needed to convert ticks to year, month and day. See comment
-        // for method GetYearMonthDay for rationale.
-        // Number of 100ns ticks per time unit
-        private const long TicksPerMillisecond = 10000;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
-        private const long TicksPerMinute = TicksPerSecond * 60;
-        private const long TicksPerHour = TicksPerMinute * 60;
-        private const long TicksPerDay = TicksPerHour * 24;
-
         // Number of days in a non-leap year
         private const int DaysPerYear = 365;
         // Number of days in 4 years
@@ -575,7 +565,7 @@ namespace System.Xml.Schema
         {
             long ticks = _dt.Ticks;
             // n = number of days since 1/1/0001
-            int n = (int)(ticks / TicksPerDay);
+            int n = (int)(ticks / TimeSpan.TicksPerDay);
             // y400 = number of whole 400-year periods since 1/1/0001
             int y400 = n / DaysPer400Years;
             // n = day number within 400-year period

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5947,6 +5947,22 @@ namespace System
         public const long TicksPerMillisecond = (long)10000;
         public const long TicksPerMinute = (long)600000000;
         public const long TicksPerSecond = (long)10000000;
+        public const long MicrosecondsPerMillisecond = (long)1000;
+        public const long MicrosecondsPerSecond = (long)1000000;
+        public const long MicrosecondsPerMinute = (long)60000000;
+        public const long MicrosecondsPerHour = (long)3600000000;
+        public const long MicrosecondsPerDay = (long)86400000000;
+        public const long MillisecondsPerSecond = (long)1000;
+        public const long MillisecondsPerMinute = (long)60000;
+        public const long MillisecondsPerHour = (long)3600000;
+        public const long MillisecondsPerDay = (long)86400000;
+        public const long SecondsPerMinute = (long)60;
+        public const long SecondsPerHour = (long)3600;
+        public const long SecondsPerDay = (long)86400;
+        public const long MinutesPerHour = (long)60;
+        public const long MinutesPerDay = (long)1440;
+        public const int HoursPerDay = 24;
+
         public static readonly System.TimeSpan Zero;
         public TimeSpan(int hours, int minutes, int seconds) { throw null; }
         public TimeSpan(int days, int hours, int minutes, int seconds) { throw null; }


### PR DESCRIPTION
Publicly expose the useful constants that `TimeSpan` had internally declared since they're rooted in hard reality and not changeable, and quite useful elsewhere. Everything is a `long` except `HoursPerDay` because that is useful in many non-TimeSpan contexts and rarely would overflow.

Added /// documentation for newly public constants and updated _System.Runtime.cs_ assembly API reference.

Use the newly exposed values in all the runtime places similar constants are declared in runtime **EXCEPT** did not use the `TimeSpan` constant in _EventLogInternal.cs_ since that source is also built for older frameworks, leave existing internal constant.

In _Calendar.cs_, use an `int` cast at the call-sites to `Add` method to prevent performance degradation, these calls are known not to overflow.

Fixes #94545
