### PR TITLE
fix the size passed to grow_heap_segment from loh_allocate_in_condemned

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -30812,10 +30812,7 @@ retry:
                 else
                 {
                     if (loh_size_fit_p (size, generation_allocation_pointer (gen), heap_segment_reserved (seg), true) &&
-                        // We are overestimating here by padding with 2 loh_padding_obj_size objects which we shouldn't need
-                        // to do if it's at the end of the region. However, grow_heap_segment is already overestimating by
-                        // a lot more - it would be worth fixing when we are in extreme low memory situations.
-                        (grow_heap_segment (seg, (generation_allocation_pointer (gen) + size + 2* AlignQword (loh_padding_obj_size)))))
+                        (grow_heap_segment (seg, (generation_allocation_pointer (gen) + size + AlignQword (loh_padding_obj_size)))))
                     {
                         dprintf (1235, ("growing seg from %p to %p\n", heap_segment_committed (seg),
                                          (generation_allocation_pointer (gen) + size)));


### PR DESCRIPTION
in `loh_allocate_in_condemned` we call `grow_heap_segment` with 2x  `loh_padding_obj_size` while in `loh_size_fit_p` it specifically says one padding if it's at the end of the segment. while going from the amount of 1 padding to 2 isn't a big deal from `grow_heap_segment`s POV it introduces an inconsistency between `loh_size_fit_p` and `grow_heap_segment` because the former will say fit but the latter will give it a size that does not fit. this triggers the assert -

`assert (high_address <= heap_segment_reserved (seg));`

because `high_address` is 0x20 (pad size) higher than reserved. in retail builds this would just return FALSE if we are right at the end of the segment which is also a problem. 

I reproed this by running GCPerfSim in ReliabilityFramework. 