### PR TITLE
Enable ControlFlowGuard in cdacreader

### DIFF
--- a/src/native/managed/native-library.props
+++ b/src/native/managed/native-library.props
@@ -7,6 +7,7 @@
     -->
     <StripSymbols>false</StripSymbols>
     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
+    <ControlFlowGuard>Guard</ControlFlowGuard>
   </PropertyGroup>
 
   <!-- set the shared library name.  this helps the native linker correctly reference this shared


### PR DESCRIPTION
Official builds are broken because of `BinSkim Error BA2008 - File: artifacts/bin/cdacreader/Release/net9.0/win-x64/native/cdacreader.dll.`