### PR TITLE
Also pass NETCoreSdkRuntimeIdentifier to runtime.proj

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -292,6 +292,7 @@
                             HostOS=$(HostOS);
                             TargetOS=$(TargetOS);
                             RuntimeIdentifier=$(RuntimeIdentifier);
+                            NETCoreSdkRuntimeIdentifier=$(NETCoreSdkRuntimeIdentifier);
                             NETCoreSdkPortableRuntimeIdentifier=$(NETCoreSdkPortableRuntimeIdentifier);
                             PgoInstrument=false;
                             NoPgoOptimize=true;


### PR DESCRIPTION
In SingleEntry, we also use this property to formulate the package name: https://github.com/dotnet/runtime/blob/d659dab95bf114aedbc85e1cd616de8b6d8b48ad/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets#L8

cc @MichalStrehovsky 