### PR TITLE
Cleanup certificates before running ConnectWithRevocation_WithCallback_Core on Windows

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -196,6 +196,11 @@ namespace System.Net.Security.Tests
 
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
 
+            if (PlatformDetection.IsWindows && testName != null)
+            {
+                TestHelper.CleanupCertificates(testName);
+            }
+
             CertificateAuthority.BuildPrivatePki(
                 PkiOptions.EndEntityRevocationViaOcsp | PkiOptions.CrlEverywhere,
                 out RevocationResponder responder,


### PR DESCRIPTION
Attempt to fix #101835.

Looking at other usages of BuildPrivatePki on Windows, this is the only difference I see, and other tests seem to pass without problems.