### PR TITLE
Enable `TryFormat_MatchesToString` for `HybridGlobalization`

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -105,16 +105,18 @@ jobs:
       scenarios:
         - WasmTestOnNodeJS
 
-  # Library tests - Windows
+  # Library tests - Windows - this only runs on the extra pipeline
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:
       platforms:
         - browser_wasm_win
+      nameSuffix: _NodeJs
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       # Don't run for rolling builds, as this is covered
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       scenarios:
-        - WasmTestOnChrome
         - WasmTestOnNodeJS
 
   # EAT Library tests - only run on linux

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
@@ -2734,7 +2734,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(StandardFormatSpecifiers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/95623", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
         public static void TryFormat_MatchesToString(string format)
         {
             DateTime dt = DateTime.UtcNow;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95623. I cannot reproduce locally.

This PR fixes NodeJS Windows runs, they were not triggered by extra platforms. It also removes a duplicated run of libraries on Windows with Chrome host - it was both in extra platforms and in runtime.