### PR TITLE
Do not warn on `MakeGeneric` when `class` constraint present

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
@@ -89,6 +89,10 @@ namespace ILLink.Shared.TrimAnalysis
                                             }
                                         }
                                     }
+                                    else if (typeInstantiated.Instantiation.IsConstrainedToBeReferenceTypes())
+                                    {
+                                        // This will always succeed thanks to the runtime type loader
+                                    }
                                     else
                                     {
                                         triggersWarning = true;
@@ -147,6 +151,10 @@ namespace ILLink.Shared.TrimAnalysis
                                                 _reflectionMarker.RuntimeDeterminedDependencies.Add(new MakeGenericMethodSite(methodInstantiated));
                                             }
                                         }
+                                    }
+                                    else if (methodInstantiated.Instantiation.IsConstrainedToBeReferenceTypes())
+                                    {
+                                        // This will always succeed thanks to the runtime type loader
                                     }
                                     else
                                     {
@@ -675,5 +683,17 @@ namespace ILLink.Shared.TrimAnalysis
             }
         }
 
+    }
+
+    file static class Extensions
+    {
+        public static bool IsConstrainedToBeReferenceTypes(this Instantiation inst)
+        {
+            foreach (GenericParameterDesc param in inst)
+                if (!param.HasReferenceTypeConstraint)
+                    return false;
+
+            return true;
+        }
     }
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresDynamicCodeAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresDynamicCodeAnalyzer.cs
@@ -49,8 +49,9 @@ namespace ILLink.RoslynAnalyzer
 			case IntrinsicId.Type_MakeGenericType: {
 					if (!instance.IsEmpty ()) {
 						foreach (var value in instance.AsEnumerable ()) {
-							if (value is SystemTypeValue) {
-								if (!IsKnownInstantiation (arguments[0])) {
+							if (value is SystemTypeValue typeValue) {
+								if (!IsKnownInstantiation (arguments[0])
+									&& !IsConstrainedToBeReferenceTypes(typeValue.RepresentedType.GetGenericParameters())) {
 									return false;
 								}
 							} else {
@@ -64,7 +65,8 @@ namespace ILLink.RoslynAnalyzer
 					if (!instance.IsEmpty ()) {
 						foreach (var methodValue in instance.AsEnumerable ()) {
 							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
-								if (!IsKnownInstantiation (arguments[0])) {
+								if (!IsKnownInstantiation (arguments[0])
+									&& !IsConstrainedToBeReferenceTypes(methodBaseValue.RepresentedMethod.GetGenericParameters())) {
 									return false;
 								}
 							} else {
@@ -108,6 +110,14 @@ namespace ILLink.RoslynAnalyzer
 					}
 				}
 
+				return true;
+			}
+
+			static bool IsConstrainedToBeReferenceTypes(ImmutableArray<GenericParameterProxy> parameters)
+			{
+				foreach (GenericParameterProxy param in parameters)
+					if (!param.TypeParameterSymbol.HasReferenceTypeConstraint)
+						return false;
 				return true;
 			}
 		}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
@@ -377,6 +377,22 @@ build_property.{MSBuildPropertyOptionNames.EnableAotAnalyzer} = true")));
 		}
 
 		[Fact]
+		public Task MakeGenericTypeWithConstraint ()
+		{
+			const string src = $$"""
+			using System;
+			class C
+			{
+				public void M() => typeof(Gen<>).MakeGenericType(GetObject());
+				static Type GetObject() => typeof(object);
+			}
+			class Gen<T> where T : class { }
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src);
+		}
+
+		[Fact]
 		public Task MakeGenericTypeWithUnknownDefinition ()
 		{
 			const string src = $$"""
@@ -434,6 +450,22 @@ build_property.{MSBuildPropertyOptionNames.EnableAotAnalyzer} = true")));
 			{
 				public void M<T>() => typeof(C).GetMethod(nameof(N)).MakeGenericMethod(typeof(T));
 				public void N<T>() { }
+			}
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src);
+		}
+
+		[Fact]
+		public Task MakeGenericMethodWithConstraint ()
+		{
+			const string src = $$"""
+			using System;
+			class C
+			{
+				public void M() => typeof(C).GetMethod(nameof(N)).MakeGenericMethod(GetObject());
+				public void N<T>() where T : class { }
+				static Type GetObject() => typeof(object);
 			}
 			""";
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class MakeGenericType
 		{
 			class Gen<T> { }
+			class GenConstrained<T> where T : class { }
 
 			static Type GrabUnknownType () => null;
 
@@ -25,6 +26,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				TestRecognizedIntrinsic ();
 				TestRecognizedGenericIntrinsic<object> ();
+				TestRecognizedConstraint ();
 				TestUnknownOwningType ();
 				TestUnknownArgument ();
 			}
@@ -32,6 +34,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public static void TestRecognizedIntrinsic () => typeof (Gen<>).MakeGenericType (typeof (object));
 
 			public static void TestRecognizedGenericIntrinsic<T> () => typeof (Gen<>).MakeGenericType (typeof (T));
+
+			public static void TestRecognizedConstraint () => typeof (GenConstrained<>).MakeGenericType (GrabUnknownType ());
 
 			[ExpectedWarning ("IL2055", nameof (Type.MakeGenericType))]
 			[ExpectedWarning ("IL3050", nameof (Type.MakeGenericType), Tool.Analyzer | Tool.NativeAot, "")]
@@ -44,6 +48,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class MakeGenericMethod
 		{
 			public static void Gen<T> () { }
+			public static void GenConstrained<T> () where T : class { }
 
 			static MethodInfo GrabUnknownMethod () => null;
 
@@ -53,6 +58,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				TestRecognizedIntrinsic ();
 				TestRecognizedGenericIntrinsic<object> ();
+				TestRecognizedConstraint ();
 				TestUnknownOwningMethod ();
 				TestUnknownArgument ();
 			}
@@ -60,6 +66,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public static void TestRecognizedIntrinsic () => typeof (MakeGenericMethod).GetMethod (nameof (Gen)).MakeGenericMethod (typeof (object));
 
 			public static void TestRecognizedGenericIntrinsic<T> () => typeof (MakeGenericMethod).GetMethod (nameof (Gen)).MakeGenericMethod (typeof (T));
+
+			public static void TestRecognizedConstraint () => typeof (MakeGenericMethod).GetMethod (nameof (GenConstrained)).MakeGenericMethod (GrabUnknownType ());
 
 			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]
 			[ExpectedWarning ("IL3050", nameof (MethodInfo.MakeGenericMethod), Tool.Analyzer | Tool.NativeAot, "")]


### PR DESCRIPTION
Fixing both the Roslyn analyzer and ILC not to warn if `MakeGeneric` APIs are used on something that has `class` constraint.

Contributes to #97408

Cc @dotnet/illink 