### PR TITLE
[QUIC] Adding `CompleteWritesAsync`

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -286,7 +286,7 @@ namespace System.Net.Test.Common
 
             if (isFinal)
             {
-                _stream.CompleteWrites();
+                await _stream.CompleteWritesAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -445,7 +445,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    _stream.CompleteWrites();
+                    await _stream.CompleteWritesAsync().ConfigureAwait(false);
                 }
 
                 if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestContentStop(bytesWritten);

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -126,7 +126,9 @@ namespace System.Net.Quic
         public void Abort(System.Net.Quic.QuicAbortDirection abortDirection, long errorCode) { }
         public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback? callback, object? state) { throw null; }
         public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback? callback, object? state) { throw null; }
+        [System.ObsoleteAttribute("Will be removed soon, use CompleteWritesAsync instead.")]
         public void CompleteWrites() { }
+        public System.Threading.Tasks.ValueTask CompleteWritesAsync() { throw null; }
         protected override void Dispose(bool disposing) { }
         public override System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public override int EndRead(System.IAsyncResult asyncResult) { throw null; }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -1029,7 +1029,7 @@ namespace System.Net.Quic.Tests
                         }
                     }
 
-                    stream.CompleteWrites();
+                    await stream.CompleteWritesAsync();
                 },
                 async serverConnection =>
                 {
@@ -1046,7 +1046,7 @@ namespace System.Net.Quic.Tests
                     int expectedTotalBytes = writes.SelectMany(x => x).Sum();
                     Assert.Equal(expectedTotalBytes, totalBytes);
 
-                    stream.CompleteWrites();
+                    await stream.CompleteWritesAsync();
                 });
         }
 
@@ -1339,7 +1339,7 @@ namespace System.Net.Quic.Tests
 
                     if (!closeWithData)
                     {
-                        serverStream.CompleteWrites();
+                        await serverStream.CompleteWritesAsync();
                     }
 
                     readLength = await clientStream.ReadAsync(actual);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -320,8 +320,6 @@ namespace System.Net.Quic.Tests
                     await stream.WriteAsync(buffer);
 
                     await clientFunction(stream);
-
-                    stream.CompleteWrites();
                 },
                 serverFunction: async connection =>
                 {
@@ -329,8 +327,6 @@ namespace System.Net.Quic.Tests
                     Assert.Equal(1, await stream.ReadAsync(buffer));
 
                     await serverFunction(stream);
-
-                    stream.CompleteWrites();
                 },
                 iterations,
                 millisecondsTimeout


### PR DESCRIPTION
#### Implements async `CompleteWritesAsync` which will eventually replace sync `CompleteWrites`.

The behavior in this PR now mimics combination of  `CompleteWrites` and `WritesClosed`. This PR also changes behavior of `WritesAsync(..., completeWrites: true)` to also wait for `SEND_SHUTDOWN_COMPLETE` (or abort). This PR brings few breaking behavioral changes:
- `WritesAsync(..., completeWrites: true)`
  - it's now not possible to separate when the data are buffered (SEND_COMPLETE) and when the completion is ACKed, making the "last write" potentially much longer
  - the "last write" now may start throwing in case of local `Abort(write)` (RESET_STREAM) or remote `Abort(read)` (STOP_SENDING)
- `CompleteWritesAsync`
  - as it's now async, the user doesn't have an easy way to fire-and-forget stream write completion

The behavior is up for discussion, some options: 
- don't do anything and leave the `QuicStream` as it was before this change
- only report success in `CompletWritesAsync` and never throw (Exception is still part of `CompleteWrites` task)

Unfortunately, this effectively reverts #103902 as the WriteAsync now have to chain to async calls in a row...

Fixes #103434