### PR TITLE
[H/3] Wait for `WritesClosed` and `Dispose` as fire-and-forget

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -460,8 +460,8 @@ namespace System.Net.Http
                 else
                 {
                     _stream.CompleteWrites();
+                    await _stream.WritesClosed.ConfigureAwait(false);
                 }
-                await _stream.WritesClosed.ConfigureAwait(false);
 
                 if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestContentStop(bytesWritten);
             }
@@ -527,6 +527,10 @@ namespace System.Net.Http
         {
             await _stream.WriteAsync(_sendBuffer.ActiveMemory, endStream, cancellationToken).ConfigureAwait(false);
             _sendBuffer.Discard(_sendBuffer.ActiveLength);
+            if (endStream)
+            {
+                await _stream.WritesClosed.ConfigureAwait(false);
+            }
 
             await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -527,12 +527,13 @@ namespace System.Net.Http
         {
             await _stream.WriteAsync(_sendBuffer.ActiveMemory, endStream, cancellationToken).ConfigureAwait(false);
             _sendBuffer.Discard(_sendBuffer.ActiveLength);
+
+            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
             if (endStream)
             {
                 await _stream.WritesClosed.ConfigureAwait(false);
             }
-
-            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask DrainContentLength0Frames(CancellationToken cancellationToken)


### PR DESCRIPTION
Alternative to #104032. Solves the perf problem for waiting `Dispose` (with sync-over-async) by waiting on `QuicStream.WritesClosed` at the end of content writing together with doing `QuicStream` disposal as fire-and-forget in case the writes are already closed (avoiding potential data-loss).

cc @liveans 

Fixes #77139