### PR TITLE
ARm64/Sve: Fix the SVE_ComputeAddress*

### DIFF
--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -555,8 +555,10 @@ struct HWIntrinsicInfo
         return static_cast<CORINFO_InstructionSet>(result);
     }
 
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH)
     static int lookupIval(Compiler* comp, NamedIntrinsic id, var_types simdBaseType);
+#elif defined(TARGET_ARM64)
+    static int lookupIval(NamedIntrinsic id);
 #endif
 
     static bool tryLookupSimdSize(NamedIntrinsic id, unsigned* pSimdSize)

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -153,6 +153,31 @@ CORINFO_InstructionSet HWIntrinsicInfo::lookupIsa(const char* className, const c
 }
 
 //------------------------------------------------------------------------
+// lookupIval: Gets a the implicit immediate value for the given intrinsic
+//
+// Arguments:
+//    id           - The intrinsic for which to get the ival
+//
+// Return Value:
+//    The immediate value for the given intrinsic or -1 if none exists
+int HWIntrinsicInfo::lookupIval(NamedIntrinsic id)
+{
+    switch (id)
+    {
+        case NI_Sve_Compute16BitAddresses:
+            return 1;
+        case NI_Sve_Compute32BitAddresses:
+            return 2;
+        case NI_Sve_Compute64BitAddresses:
+            return 4;
+        case NI_Sve_Compute8BitAddresses:
+            return 0;
+        default:
+            unreached();
+    }
+    return -1;
+}
+//------------------------------------------------------------------------
 // isFullyImplementedIsa: Gets a value that indicates whether the InstructionSet is fully implemented
 //
 // Arguments:

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -169,7 +169,7 @@ int HWIntrinsicInfo::lookupIval(NamedIntrinsic id)
         case NI_Sve_Compute32BitAddresses:
             return 2;
         case NI_Sve_Compute64BitAddresses:
-            return 4;
+            return 3;
         case NI_Sve_Compute8BitAddresses:
             return 0;
         default:

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -2121,8 +2121,13 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 static_assert_no_msg(AreContiguous(NI_Sve_Compute16BitAddresses, NI_Sve_Compute32BitAddresses,
                                                    NI_Sve_Compute64BitAddresses, NI_Sve_Compute8BitAddresses));
 
-                GetEmitter()->emitInsSve_R_R_R_I(ins, EA_SCALABLE, targetReg, op1Reg, op2Reg,
-                                                 (intrin.id - NI_Sve_Compute16BitAddresses), opt,
+                //  imm     intrinsic
+                //  1       NI_Sve_Compute16BitAddresses
+                //  2       NI_Sve_Compute32BitAddresses
+                //  3       NI_Sve_Compute64BitAddresses
+                //  0       NI_Sve_Compute8BitAddresses
+                size_t imm = ((intrin.id - NI_Sve_Compute16BitAddresses) + 1) % 4;
+                GetEmitter()->emitInsSve_R_R_R_I(ins, EA_SCALABLE, targetReg, op1Reg, op2Reg, imm, opt,
                                                  INS_SCALABLE_OPTS_LSL_N);
                 break;
             }

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -2118,17 +2118,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             case NI_Sve_Compute32BitAddresses:
             case NI_Sve_Compute64BitAddresses:
             {
-                static_assert_no_msg(AreContiguous(NI_Sve_Compute16BitAddresses, NI_Sve_Compute32BitAddresses,
-                                                   NI_Sve_Compute64BitAddresses, NI_Sve_Compute8BitAddresses));
-
-                //  imm     intrinsic
-                //  1       NI_Sve_Compute16BitAddresses
-                //  2       NI_Sve_Compute32BitAddresses
-                //  3       NI_Sve_Compute64BitAddresses
-                //  0       NI_Sve_Compute8BitAddresses
-                size_t imm = ((intrin.id - NI_Sve_Compute16BitAddresses) + 1) % 4;
-                GetEmitter()->emitInsSve_R_R_R_I(ins, EA_SCALABLE, targetReg, op1Reg, op2Reg, imm, opt,
-                                                 INS_SCALABLE_OPTS_LSL_N);
+                GetEmitter()->emitInsSve_R_R_R_I(ins, EA_SCALABLE, targetReg, op1Reg, op2Reg,
+                                                 HWIntrinsicInfo::lookupIval(intrin.id), opt, INS_SCALABLE_OPTS_LSL_N);
                 break;
             }
 


### PR DESCRIPTION
In #103778, we readjusted the ordering, but didn't encode that information in the instruction correctly. 

https://github.com/dotnet/runtime/pull/103778/files#diff-3a0ae3f52b3651d14625d26a4ff55d5028a7116a6f8375a6ca13caa44ed8685f