### PR TITLE
Change X509CertificateLoader to wrap unsupported algorithms with a CryptographicException

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
@@ -647,6 +647,12 @@ namespace System.Security.Cryptography.X509Certificates
                         saveOffset,
                         written);
                 }
+                catch (PlatformNotSupportedException pnse)
+                {
+                    // May be thrown by PBE decryption if the platform does not support the algorithm.
+                    ThrowWithHResult(SR.Cryptography_Pfx_BadPassword, ERROR_INVALID_PASSWORD, pnse);
+                    throw; // This is unreachable because of the throw helper, but the compiler does not know that.
+                }
                 catch (CryptographicException e)
                 {
                     CryptographicOperations.ZeroMemory(


### PR DESCRIPTION
Before the X509CertificateLoader was merged, the `ReadECDsaPrivateKey_BrainpoolP160r1_Pfx` test on Android was passing, but for the wrong reason. The test is asserting that the platform throws a CryptographicException for brainpool curves. On Android it was throwing a CryptographicException because the PFX is protected with RC2, which is unavailable on Android.

This PR changes the PBE decryption to wrap the PlatformNotSupportedException with a CryptographicException with the same message, restoring the previous behavior.

We should probably investigate fixing the brainpool test to use an algorithm other than RC2 so we can confirm the Android tests fail for the right reason, but this unblocks CI.

Before loader merge:

```
   Exception messages: System.Security.Cryptography.CryptographicException : The certificate data cannot be read with the provided password, the password may be incorrect.
---- System.PlatformNotSupportedException : Algorithm 'RC2' is not supported on this platform.   Exception stack traces:    at System.Security.Cryptography.X509Certificates.UnixPkcs12Reader.Decrypt(SafePasswordHandle password, Boolean ephemeralSpecified)
   at System.Security.Cryptography.X509Certificates.AndroidCertificatePal.ReadPkcs12(ReadOnlySpan`1 rawData, SafePasswordHandle password, Boolean ephemeralSpecified)
   at System.Security.Cryptography.X509Certificates.AndroidCertificatePal.FromBlob(ReadOnlySpan`1 rawData, SafePasswordHandle password, Boolean readingFromFile, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.AndroidCertificatePal.FromBlob(ReadOnlySpan`1 rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.CertificatePal.FromBlob(ReadOnlySpan`1 rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(Byte[] rawData, String password, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(Byte[] rawData, String password)
   at System.Security.Cryptography.X509Certificates.X509Certificate2..ctor(Byte[] rawData, String password)
```

After this pull request:

```
   Exception messages: System.Security.Cryptography.CryptographicException : The certificate data cannot be read with the provided password, the password may be incorrect.
---- System.PlatformNotSupportedException : Algorithm 'RC2' is not supported on this platform.   Exception stack traces:    at System.Security.Cryptography.X509Certificates.X509CertificateLoader.ThrowWithHResult(String message, Int32 hResult, Exception innerException)
   at System.Security.Cryptography.X509Certificates.X509CertificateLoader.BagState.DecryptSafeContents(AlgorithmIdentifierAsn& algorithmIdentifier, ReadOnlySpan`1 passwordSpan, ReadOnlySpan`1 encryptedContent)
   at System.Security.Cryptography.X509Certificates.X509CertificateLoader.DecryptSafeContents(ContentInfoAsn safeContentsAsn, Pkcs12LoaderLimits loaderLimits, ReadOnlySpan`1 passwordSpan, BagState& bagState, Nullable`1& workRemaining)
   at System.Security.Cryptography.X509Certificates.X509CertificateLoader.ReadCertsAndKeys(BagState& bagState, ReadOnlyMemory`1 data, ReadOnlySpan`1& password, Pkcs12LoaderLimits loaderLimits)
   at System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12(ReadOnlyMemory`1 data, ReadOnlySpan`1 password, X509KeyStorageFlags keyStorageFlags, Pkcs12LoaderLimits loaderLimits)
   at System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12Pal(ReadOnlySpan`1 data, ReadOnlySpan`1 password, X509KeyStorageFlags keyStorageFlags, Pkcs12LoaderLimits loaderLimits)
   at System.Security.Cryptography.X509Certificates.AndroidCertificatePal.FromBlob(ReadOnlySpan`1 rawData, SafePasswordHandle password, Boolean readingFromFile, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.AndroidCertificatePal.FromBlob(ReadOnlySpan`1 rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.CertificatePal.FromBlob(ReadOnlySpan`1 rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(Byte[] rawData, String password, X509KeyStorageFlags keyStorageFlags)
   at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(Byte[] rawData, String password)
   at System.Security.Cryptography.X509Certificates.X509Certificate2..ctor(Byte[] rawData, String password)
```

Fixes #104030