### PR TITLE
Disable VolatileTest tests under GCStress

### DIFF
--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_add.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_add.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_ADD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_and.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_and.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_AND</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_div.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_div.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_DIV</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mod.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mod.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_MOD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mul.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mul.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
+    <!-- Needed for GCStressIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <CLRTestPriority>1</CLRTestPriority>
     <DefineConstants>$(DefineConstants);OP_MUL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_or.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_or.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_OR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_shr.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_shr.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_SHR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_sub.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_sub.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_SUB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_xor.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_xor.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
     <DefineConstants>$(DefineConstants);OP_XOR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/103980#issuecomment-2191846137:
> The test seems to be trying to verify that we don't CSE multiple volatile loads of an address. It does so by running a separate background thread that is constantly changing two values, and then verifying that at some point a loop that loads those values sees an inconsistent result in the values, caused by the background thread changing one of them.
> 
> The test quite often requires a large number of iteration before it sees the inconsistency it is looking for, so I think I am going to just mark it as GC stress incompatible.

Also unify their .csproj files and mark them all outerloop.

Fix #103980