### PR TITLE
Show the linker cmake is using

### DIFF
--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -91,6 +91,8 @@ if (NOT CLR_CMAKE_HOST_WIN32)
   else(CLR_CMAKE_HOST_OSX OR CLR_CMAKE_HOST_MACCATALYST)
     set(LD_OSX 1)
   endif()
+  string(STRIP "${ldVersionOutput}" ldVersionOutput)
+  message("-- The linker identification is ${ldVersionOutput}")
 endif()
 
 # This introspection depends on CMAKE_STRINGS, which is why it's in this file instead of configureplatform


### PR DESCRIPTION
This adds some extra line to the messages that cmake prints out:

    -- The C compiler identification is Clang 18.1.6
    ...
    -- The linker identification is LLD 18.1.6 (compatible with GNU linkers)
    ...

This makes it easier to see which linker is being used by the runtime. This is useful in debugging, specially in scenarios where we pick the wrong linker and then produce a broken runtime (like https://github.com/dotnet/runtime/issues/43349), but have no quick way to tell what linker was actually used.