### PR TITLE
Improve getStaticFieldContent for classes without cctors

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2815,6 +2815,10 @@ GenTree* Compiler::impCreateSpanIntrinsic(CORINFO_SIG_INFO* sig)
 
     CORINFO_CLASS_HANDLE fieldOwnerHnd = info.compCompHnd->getFieldClass(fieldToken);
 
+    // We're expanding RuntimeHelpers.CreateSpan<int>((RuntimeFieldHandle)0x...), thus, we need to
+    // statically initialize the class containing that RuntimeFieldHandle
+    info.compCompHnd->initClass(fieldToken, info.compMethodHnd, impTokenLookupContextHandle);
+
     CORINFO_CLASS_HANDLE fieldClsHnd;
     var_types            fieldElementType =
         JITtype2varType(info.compCompHnd->getFieldType(fieldToken, &fieldClsHnd, fieldOwnerHnd));


### PR DESCRIPTION
When a class has no static constructor (cctor), its `pEnclosingMT->IsClassInited()` returns false. It shouldn't stop us from folding RVA fields. Example:

```cs
public class Program
{
    static void Main()
    {
        Test();
    }

    static ReadOnlySpan<int> RvaData => [1, 2, 3, 4];

    [MethodImpl(MethodImplOptions.NoInlining)]
    static int Test() => RvaData[2];
}
```
Codegen of `Test()` in Main (Tier1 or FullOpts):
```asm
; Method Program:Test():int (FullOpts)
       mov      rax, 0x2AEC82D3450
       mov      eax, dword ptr [rax]
       ret
```
New codegen of `Test()`:
```asm
; Method Program:Test():int (FullOpts)
       mov      eax, 3
       ret
```

PS: I have an impression that `pEnclosingMT->IsClassInited()` used to return true in such cases 🤔 Or maybe entrypoint holders always used to have cctors? cc @jkotas 
Perhaps it's some change from DavidWr's statics PR?

The same snippet works well on NAOT.