### PR TITLE
Add ValueType to the core types used by ref emit

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -37,6 +37,7 @@ namespace System.Reflection.Emit
         private bool _hasGlobalBeenCreated;
         private Type?[]? _coreTypes;
         private MetadataBuilder _pdbBuilder = new();
+        // The order of the types should match with the CoreTypeId enum values order.
         private static readonly Type[] s_coreTypes = { typeof(void), typeof(object), typeof(bool), typeof(char), typeof(sbyte),
                                                        typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
                                                        typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(string),

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -37,8 +37,10 @@ namespace System.Reflection.Emit
         private bool _hasGlobalBeenCreated;
         private Type?[]? _coreTypes;
         private MetadataBuilder _pdbBuilder = new();
-        private static readonly Type[] s_coreTypes = { typeof(void), typeof(object), typeof(bool), typeof(char), typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int),
-                                                       typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(string), typeof(nint), typeof(nuint), typeof(TypedReference) };
+        private static readonly Type[] s_coreTypes = { typeof(void), typeof(object), typeof(bool), typeof(char), typeof(sbyte),
+                                                       typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
+                                                       typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(string),
+                                                       typeof(nint), typeof(nuint), typeof(TypedReference), typeof(ValueType) };
 
         internal ModuleBuilderImpl(string name, Assembly coreAssembly, MetadataBuilder builder, PersistedAssemblyBuilder assemblyBuilder)
         {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -294,6 +294,7 @@ namespace System.Reflection.Emit
         }
     }
 
+    // The order of the enum values should match with the ModuleBuilderImpl.s_coreTypes array elements order.
     internal enum CoreTypeId
     {
         Void,

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -314,5 +314,6 @@ namespace System.Reflection.Emit
         IntPtr,
         UIntPtr,
         TypedReference,
+        ValueType
     }
 }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -645,6 +645,7 @@ namespace System.Reflection.Emit
         protected override bool IsByRefImpl() => false;
         protected override bool IsPointerImpl() => false;
         protected override bool IsPrimitiveImpl() => false;
+        protected override bool IsValueTypeImpl() => IsSubclassOf(_module.GetTypeFromCoreAssembly(CoreTypeId.ValueType));
         protected override bool HasElementTypeImpl() => false;
         protected override TypeAttributes GetAttributeFlagsImpl() => _attributes;
         protected override bool IsCOMObjectImpl()

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -2707,7 +2707,7 @@ internal class Dummy
             {
                 Assembly coreAssembly = mlc.CoreAssembly!;
                 Type valueTypeType = coreAssembly.GetType("System.ValueType")!;
-                PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssembly"), coreAssembly);
+                PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssemblyWithValueType"), coreAssembly);
                 ModuleBuilder mob = ab.DefineDynamicModule("MyModule");
 
                 TypeBuilder valueTb = mob.DefineType("MyValueType", 0, valueTypeType);

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Loader;
 using Xunit;
 
 namespace System.Reflection.Emit.Tests
@@ -2696,6 +2697,47 @@ internal class Dummy
                 MethodInfo method = typeFromDisk.GetMethod("Test")!;
                 method.Invoke(null, null); // just make sure token works
                 tlc.Unload();
+            }
+        }
+
+        [Fact]
+        public void ValueTypeParentTest()
+        {
+            using (MetadataLoadContext mlc = new MetadataLoadContext(new CoreMetadataAssemblyResolver()))
+            {
+                Assembly coreAssembly = mlc.CoreAssembly!;
+                Type valueTypeType = coreAssembly.GetType("System.ValueType")!;
+                PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssembly"), coreAssembly);
+                ModuleBuilder mob = ab.DefineDynamicModule("MyModule");
+
+                TypeBuilder valueTb = mob.DefineType("MyValueType", 0, valueTypeType);
+                MethodBuilder vMeb = valueTb.DefineMethod("Method", MethodAttributes.Public, typeof(int), null);
+                ILGenerator il = vMeb.GetILGenerator();
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Ret);
+                valueTb.CreateType();
+                Assert.True(valueTb.IsValueType);
+
+                TypeBuilder tb = mob.DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
+                MethodBuilder meb = tb.DefineMethod("MyMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), null);
+                il = meb.GetILGenerator();
+                il.BeginScope();
+                il.DeclareLocal(valueTb);
+                il.Emit(OpCodes.Ldloca_S, 0);
+                il.Emit(OpCodes.Initobj, valueTb);
+                il.Emit(OpCodes.Ldloca_S, 0);
+                il.Emit(OpCodes.Call, valueTb.GetMethod("Method"));
+                il.EndScope();
+                il.Emit(OpCodes.Ret);
+                tb.CreateType();
+
+                using var stream = new MemoryStream();
+                ab.Save(stream);
+                stream.Seek(0, SeekOrigin.Begin);
+                var assembly = AssemblyLoadContext.Default.LoadFromStream(stream);
+                var method = assembly.GetType("MyType")!.GetMethod("MyMethod");
+                int result = (int)method!.Invoke(null, null);
+                Assert.Equal(1, result);
             }
         }
     }


### PR DESCRIPTION
When the `ValueType` is loaded from `MetadataLoadContext` assembly context it is not equal to the runtime `ValueType`, therefore for `TypeBuidler` derived from such `ValueType` `TypeBuilder.IsValueType` returns false causing the bug reported in https://github.com/dotnet/runtime/issues/103796. 

Looks we should add the `ValueType` into the core types in order to fix this bug

Fixes https://github.com/dotnet/runtime/issues/103796