### PR TITLE
[tests] Use net8.0 for the project used to restore workload manifest nuget, instead of net6.0

### DIFF
--- a/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
+++ b/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Workload.Build.Tasks
             projectFileBuilder.Append(@"
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>");
 

--- a/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
+++ b/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Workload.Build.Tasks
             projectFileBuilder.Append(@"
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
     </PropertyGroup>
     <ItemGroup>");
 


### PR DESCRIPTION
…nuget, instead of net6.0