### PR TITLE
Fix official builds

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -121,8 +121,7 @@
     <!-- CLR NativeAot only builds in a subset of the matrix -->
     <_NativeAotSupportedOS Condition="'$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvossimulator' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'freebsd'">true</_NativeAotSupportedOS>
     <_NativeAotSupportedArch Condition="'$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm' or ('$(TargetOS)' == 'windows' and '$(TargetArchitecture)' == 'x86')">true</_NativeAotSupportedArch>
-    <NativeAotSupported Condition="'$(_NativeAotSupportedOS)' == 'true' and '$(_NativeAotSupportedArch)' == 'true'">true</NativeAotSupported>
-    <UseNativeAotForComponents Condition="'$(NativeAotSupported)' == 'true' and '$(TargetOS)' == '$(HostOS)' and ('$(TargetOS)' != 'windows' or '$(TargetArchitecture)' != 'x86') and '$(TargetsLinuxBionic)' != 'true' and ('$(TargetsLinuxMusl)' != 'true' or '$(TargetArchitecture)' != 'arm')">true</UseNativeAotForComponents>
+    <NativeAotSupported Condition="'$(_NativeAotSupportedOS)' == 'true' and $(_NativeAotSupportedArch) == 'true'">true</NativeAotSupported>
 
     <!-- If we're building clr.nativeaotlibs and not building the CLR runtime, compile libraries against NativeAOT CoreLib -->
     <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')) and !$(_subset.Contains('+clr.corelib+')))">true</UseNativeAotCoreLib>
@@ -287,12 +286,7 @@
       AdditionalProperties="%(AdditionalProperties);
                             ClrCrossComponentsSubset=true;
                             HostArchitecture=$(BuildArchitecture);
-                            TargetArchitecture=$(TargetArchitecture);
                             HostCrossOS=$(HostOS);
-                            HostOS=$(HostOS);
-                            TargetOS=$(TargetOS);
-                            RuntimeIdentifier=$(RuntimeIdentifier);
-                            NETCoreSdkPortableRuntimeIdentifier=$(NETCoreSdkPortableRuntimeIdentifier);
                             PgoInstrument=false;
                             NoPgoOptimize=true;
                             CrossBuild=false;

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -292,7 +292,6 @@
                             HostOS=$(HostOS);
                             TargetOS=$(TargetOS);
                             RuntimeIdentifier=$(RuntimeIdentifier);
-                            NETCoreSdkRuntimeIdentifier=$(NETCoreSdkRuntimeIdentifier);
                             NETCoreSdkPortableRuntimeIdentifier=$(NETCoreSdkPortableRuntimeIdentifier);
                             PgoInstrument=false;
                             NoPgoOptimize=true;

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -10,15 +10,20 @@
   <!-- BEGIN: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
-    <PublishAot Condition="'$(UseNativeAotForComponents)' == 'true'">true</PublishAot>
-    <SysRoot Condition="'$(UseNativeAotForComponents)' == 'true' and '$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
-    <PublishReadyToRun Condition="'$(UseNativeAotForComponents)' != 'true'">true</PublishReadyToRun>
-    <PublishSingleFile Condition="'$(UseNativeAotForComponents)' != 'true'">true</PublishSingleFile>
-    <PublishTrimmed Condition="'$(UseNativeAotForComponents)' != 'true'">true</PublishTrimmed>
+    <NativeAotSupported Condition="$(OutputRID.StartsWith('tizen')) == 'true'">false</NativeAotSupported>
+    <NativeAotSupported Condition="$(OutputRID.EndsWith('-arm')) == 'true'">false</NativeAotSupported>
+    <NativeAotSupported Condition="$(OutputRID.EndsWith('-x86')) == 'true'">false</NativeAotSupported>
+    <!-- Disable native AOT on FreeBSD when cross building from Linux. -->
+    <NativeAotSupported Condition="'$(TargetOS)' == 'freebsd' and '$(CrossBuild)' == 'true'">false</NativeAotSupported>
+    <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
+    <SysRoot Condition="'$(NativeAotSupported)' == 'true' and '$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
+    <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
+    <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
+    <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(UseNativeAotForComponents)' == 'true'">
+  <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
     <PackageReference Include="runtime.$(ToolsRID).Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
   </ItemGroup>
@@ -48,7 +53,7 @@
   </Target>
 
   <Target Name="LocateNativeCompiler"
-          Condition="'$(UseNativeAotForComponents)' == 'true' and '$(HostOS)' != 'windows'"
+          Condition="'$(NativeAotSupported)' == 'true' and '$(HostOS)' != 'windows'"
           BeforeTargets="SetupOSSpecificProps">
     <PropertyGroup>
       <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
@@ -70,7 +75,7 @@
       <_XcodeVersion>$([System.Text.RegularExpressions.Regex]::Match($(_XcodeVersionString), '[1-9]\d*'))</_XcodeVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(UseNativeAotForComponents)' == 'true' and '$(_IsApplePlatform)' == 'true'">
+    <ItemGroup Condition="'$(NativeAotSupported)' == 'true' and '$(_IsApplePlatform)' == 'true'">
       <CustomLinkerArg Condition="'$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
     </ItemGroup>
 
@@ -81,7 +86,7 @@
     </PropertyGroup>
   </Target>
 
-  <ItemGroup Condition="'$(UseNativeAotForComponents)' == 'true'">
+  <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
     <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(BuildArchitecture)' == '$(_targetArchitecture)' and '$(HostOS)' != 'windows' and '$(_IsApplePlatform)' != 'true'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
   </ItemGroup>
 

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
@@ -7,6 +7,11 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <NativeAotSupported Condition="$(OutputRID.StartsWith('tizen')) == 'true'">false</NativeAotSupported>
+    <NativeAotSupported Condition="$(OutputRID.EndsWith('-arm')) == 'true'">false</NativeAotSupported>
+    <NativeAotSupported Condition="$(OutputRID.EndsWith('-x86')) == 'true'">false</NativeAotSupported>
+    <!-- Publish crossgen2 as a single-file app on native-OS builds. Cross-OS NativeAOT compilation is not supported yet -->
+    <NativeAotSupported Condition="'$(CrossBuild)' == 'true' and '$(TargetOS)' != '$(HostOS)'">false</NativeAotSupported>
     <PublishTrimmed>true</PublishTrimmed>
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
@@ -16,7 +21,7 @@
 
   <Import Project="crossgen2.props" />
 
-  <PropertyGroup Condition="'$(UseNativeAotForComponents)' != 'true'">
+  <PropertyGroup Condition="'$(NativeAotSupported)' != 'true'">
     <PublishSingleFile>true</PublishSingleFile>
     <PublishReadyToRun>true</PublishReadyToRun>
     <!-- Disable crossgen on NetBSD, illumos, Solaris, and Haiku for now. This can be revisited when we have full support. -->
@@ -36,7 +41,7 @@
   <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" />
   <Import Project="$(RepositoryEngineeringDir)codeOptimization.targets" />
 
-  <PropertyGroup Condition="'$(UseNativeAotForComponents)' == 'true'">
+  <PropertyGroup Condition="'$(NativeAotSupported)' == 'true'">
     <IlcToolsPath>$(CoreCLRILCompilerDir)</IlcToolsPath>
     <IlcToolsPath Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(EnableNativeSanitizers)' != ''">$(CoreCLRCrossILCompilerDir)</IlcToolsPath>
     <SysRoot Condition="('$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)') and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
@@ -53,12 +58,12 @@
     <DynamicCodeSupport>false</DynamicCodeSupport>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(UseNativeAotForComponents)' == 'true'">
+  <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
     <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_IsApplePlatform)' != 'true' and '$(_hostOS)' != 'windows'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
   </ItemGroup>
 
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets"
-          Condition="'$(UseNativeAotForComponents)' == 'true'" />
+          Condition="'$(NativeAotSupported)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)nativeSanitizers.targets" />
 
   <!-- Needed for the amd64 -> amd64 musl cross-build to pass the target flag. -->
@@ -86,7 +91,7 @@
   </Target>
 
   <Target Name="LocateNativeCompiler"
-          Condition="'$(UseNativeAotForComponents)' == 'true' and '$(HostOS)' != 'windows'"
+          Condition="'$(NativeAotSupported)' == 'true' and '$(HostOS)' != 'windows'"
           BeforeTargets="SetupOSSpecificProps">
       <PropertyGroup>
         <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -15,6 +15,8 @@
     <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
     <!-- Publishing as single-file or NativeAOT means we can't examine the interior DLLs -->
     <ShouldVerifyClosure>false</ShouldVerifyClosure>
+    <!-- Publish crossgen2 as a single-file app on native-OS builds. Cross-OS NativeAOT compilation is not supported yet -->
+    <NativeAotSupported Condition="'$(CrossBuild)' == 'true' and '$(TargetOS)' != '$(HostOS)'">false</NativeAotSupported>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/native/managed/compile-native.proj
+++ b/src/native/managed/compile-native.proj
@@ -13,11 +13,26 @@
         <NativeLibsProjectsToBuild Include="$(MSBuildThisFileDirectory)cdacreader/src/cdacreader.csproj" />
     </ItemGroup>
 
+    <!-- Decide if we're going to do the NativeAOT builds -->
+    <PropertyGroup>
+        <!-- disable on Mono, for now -->
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and '$(RuntimeFlavor)' == 'Mono'">false</SupportsNativeAotComponents>
+        <!-- disable on linux-bionic, for now -->
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and '$(TargetsLinuxBionic)' == 'true'">false</SupportsNativeAotComponents>
+        <!-- NativeAOT doesn't support cross-OS compilation. disable for crossdac-->
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and '$(HostOS)' != '$(TargetOS)'">false</SupportsNativeAotComponents>
+        <!-- unsupported targets -->
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">false</SupportsNativeAotComponents>
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and ('$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel' or '$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'riscv64')">false</SupportsNativeAotComponents>
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and ('$(TargetsWindows)' == 'true' or '$(TargetsOSX)' == 'true' or ('$(TargetsLinux)' == 'true' and '$(TargetsAndroid)' != 'true' and '$(TargetsLinuxMusl)' != 'true'))">true</SupportsNativeAotComponents>
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == ''">false</SupportsNativeAotComponents>
+    </PropertyGroup>
+
     <!-- some special kinds of runtime builds need extra NativeAOT flags -->
     <PropertyGroup>
         <SysRoot Condition="'$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
         <LinkerFlavor Condition="'$(CrossBuild)' == 'true' and '$(TargetsLinux)' == 'true'">lld</LinkerFlavor>
-        <CustomLinkerArgToolchainArg Condition="'$(CrossBuild)' == 'true' and '$(HostArchitecture)' == '$(TargetArchitecture)' and '$(HostOS)' != 'windows'">--gcc-toolchain=$(ROOTFS_DIR)/usr</CustomLinkerArgToolchainArg>
+        <CustomLinkerArgToolchainArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_hostOS)' != 'windows'">--gcc-toolchain=$(ROOTFS_DIR)/usr</CustomLinkerArgToolchainArg>
     </PropertyGroup>
 
     <ItemGroup>
@@ -36,6 +51,6 @@
                           ReferenceOutputAssembly="false"
                           AdditionalProperties="%(AdditionalProperties);$(SplitSubprojectProps)"
                           Targets="LinkNative"
-                          Condition="'$(UseNativeAotForComponents)' == 'true'"/>
+                          Condition="$(SupportsNativeAotComponents)"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
@am11 I have to revert these again, sorry. Out of 5 last official build attempts, 4 failed in the native AOT MUSL x64 or arm64 legs with the

```
cdac-build-tool -> /__w/1/s/artifacts/bin/coreclr/linux.x64.Release/cdac-build-tool/cdac-build-tool.dll
  Generating native code
  /tmp/MSBuildTempcloudtest_azpcontainer/tmp53d7bd47a57a45a0a1b8ba82dd1868de.exec.cmd: line 2: \tools\ilc: command not found
/__w/1/s/.packages/microsoft.dotnet.ilcompiler/9.0.0-preview.6.24307.2/build/Microsoft.NETCore.Native.targets(310,5): error MSB3073: The command ""\tools\\ilc" @"/__w/1/s/artifacts/obj/cdacreader/Release/net9.0/linux-musl-x64/native/libcdacreader.ilc.rsp"" exited with code 127. [/__w/1/s/src/native/managed/cdacreader/src/cdacreader.csproj]
##[error].packages/microsoft.dotnet.ilcompiler/9.0.0-preview.6.24307.2/build/Microsoft.NETCore.Native.targets(310,5): error MSB3073: (NETCORE_ENGINEERING_TELEMETRY=Build) The command ""\tools\\ilc" @"/__w/1/s/artifacts/obj/cdacreader/Release/net9.0/linux-musl-x64/native/libcdacreader.ilc.rsp"" exited with code 127.
```

error that we've seen before. So it looks like it's still there, and still non-deterministic.

The command used is:

```
/__w/1/s/build.sh -ci -arch x64 -os linux -cross -s clr.nativeaotlibs+clr.nativeaotruntime+libs+packs -c Release /p:BuildNativeAOTRuntimePack=true /p:SkipLibrariesNativeRuntimePackages=true    /p:OfficialBuildId=20240626.1  
```

Or

```
/__w/1/s/build.sh -ci -arch arm64 -os linux -cross -s clr.nativeaotlibs+clr.nativeaotruntime+libs+packs -c Release /p:BuildNativeAOTRuntimePack=true /p:SkipLibrariesNativeRuntimePackages=true    /p:OfficialBuildId=20240626.5  
```

I was digging in the binlogs (I don't think I can share them externally because it's from the official build machine and I don't know if there are secrets) and the problem seems to be:

Bad:

![image](https://github.com/dotnet/runtime/assets/13110571/cf6393a8-7a5b-4927-bd5e-86d7be111e25)

Good:

![image](https://github.com/dotnet/runtime/assets/13110571/618e4c26-8356-468d-ba1b-46faa0b4b479)

The cdacreader project is hooked up in a bit of an odd way so maybe it doesn't restore the host ILCompiler runtime pack and we just have a happy accident that something else does restore it before sometimes.

Looks like cdacreader was excluded from building on MUSL before this change and now we've centralized it and it's no longer excluded and we're running into this? Cc @lambdageek @jkoritzinsky 