### PR TITLE
Suppress another credscan finding in TestData.cs

### DIFF
--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -11,20 +11,6 @@
     }
   },
   "results": {
-    "3b1bb0185d74dd310884a85ad1252953dab0747790f5aecd5bf5bb3c1e2b515c": {
-      "signature": "3b1bb0185d74dd310884a85ad1252953dab0747790f5aecd5bf5bb3c1e2b515c",
-      "alternativeSignatures": [],
-      "target": "src/libraries/System.Security.Cryptography/tests/X509Certificates/TestData.cs",
-      "line": 3441,
-      "memberOf": [
-        "default"
-      ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0060",
-      "createdDate": "2024-04-10 20:32:31Z",
-      "expirationDate": "2024-09-28 00:14:56Z",
-      "justification": "This error is baselined with an expiration date of 180 days from 2024-04-11 00:14:56Z"
-    },
     "2e4598005fdee72a4700697760c5f1b199c25d15a7c54de438ce939f125f3710": {
       "signature": "2e4598005fdee72a4700697760c5f1b199c25d15a7c54de438ce939f125f3710",
       "alternativeSignatures": [

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/TestData.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/TestData.cs
@@ -3440,6 +3440,7 @@ YvvL0LiXzFyomg==
             "05577F12AE24040408D04E60444B79672302030927C1").HexToByteArray();
 
         internal static readonly byte[] Pkcs12NoPassword100MRounds = Convert.FromBase64String(
+            /* [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Self-signed cert created specifically for inclusion in public-facing unit tests.")] */
             "MIIDygIBAzCCA4QGCSqGSIb3DQEHAaCCA3UEggNxMIIDbTCCA2kGCSqGSIb3DQEHBqCCA1owggNW" +
             "AgEAMIIDTwYJKoZIhvcNAQcBMF4GCSqGSIb3DQEFDTBRMDAGCSqGSIb3DQEFDDAjBBCNparJkj/3" +
             "Uk8N7n0KCMeQAgEBMAwGCCqGSIb3DQILBQAwHQYJYIZIAWUDBAEqBBAcqpBrSDFcXYAWVWKcsEi9" +


### PR DESCRIPTION
Instead of using the .gdnbaselines we can suppress it inline in code like we do for other places in this file.