### PR TITLE
[RISC-V] Fix System.Net.Sockets.Tests on Qemu

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -309,13 +309,7 @@ namespace System
         {
             if (IsLinux)
             {
-                foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
-                {
-                    if (((String)entry.Key).ToUpper() == "DOTNET_RUNNING_UNDER_QEMU")
-                    {
-                        return true;
-                    }
-                }
+                return Environment.GetEnvironmentVariable("DOTNET_RUNNING_UNDER_QEMU") != null;
             }
             return false;
         }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -31,7 +31,7 @@ namespace System
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
-        public static bool IsQemuLinux => IsQemu();
+        public static bool IsNotQemuLinux => !IsQemuLinux;
 
         // OSX family
         public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;
@@ -109,6 +109,19 @@ namespace System
                 }
 
                 return Interop.OpenSslNoInit.OpenSslIsAvailable;
+            }
+        }
+
+        public static bool IsQemuLinux
+        {
+            get
+            {
+                if (IsLinux)
+                {
+                    return Environment.GetEnvironmentVariable("DOTNET_RUNNING_UNDER_QEMU") != null;
+                }
+
+                return false;
             }
         }
 
@@ -300,15 +313,6 @@ namespace System
                 }
             }
 
-            return false;
-        }
-
-        private static bool IsQemu()
-        {
-            if (IsLinux)
-            {
-                return Environment.GetEnvironmentVariable("DOTNET_RUNNING_UNDER_QEMU") != null;
-            }
             return false;
         }
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -31,6 +31,7 @@ namespace System
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
+        public static bool IsQemuLinux => IsLinux && Environment.GetEnvironmentVariable("DOTNET_RUNNING_UNDER_QEMU") != null;
         public static bool IsNotQemuLinux => !IsQemuLinux;
 
         // OSX family
@@ -109,19 +110,6 @@ namespace System
                 }
 
                 return Interop.OpenSslNoInit.OpenSslIsAvailable;
-            }
-        }
-
-        public static bool IsQemuLinux
-        {
-            get
-            {
-                if (IsLinux)
-                {
-                    return Environment.GetEnvironmentVariable("DOTNET_RUNNING_UNDER_QEMU") != null;
-                }
-
-                return false;
             }
         }
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -32,7 +32,6 @@ namespace System
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
         public static bool IsQemuLinux => IsQemu();
-        public static bool IsNotQemuLinux => !IsQemuLinux;
 
         // OSX family
         public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -30,6 +30,7 @@ namespace System
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
+        public static bool IsNotRiscV64Ubuntu => !IsUbuntu || !IsRiscV64Process;
 
         // OSX family
         public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Collections;
 
 namespace System
 {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -32,7 +32,8 @@ namespace System
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
-        public static bool IsNotQemuLinux => !IsQemuLinux();
+        public static bool IsQemuLinux => IsQemu();
+        public static bool IsNotQemuLinux => !IsQemuLinux;
 
         // OSX family
         public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;
@@ -304,13 +305,13 @@ namespace System
             return false;
         }
 
-        private static bool IsQemuLinux()
+        private static bool IsQemu()
         {
             if (IsLinux)
             {
                 foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
                 {
-                    if (((String)entry.Key).ToUpper().Contains("QEMU"))
+                    if (((String)entry.Key).ToUpper() == "DOTNET_RUNNING_UNDER_QEMU")
                     {
                         return true;
                     }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Collections;
 
 namespace System
 {
@@ -30,7 +32,7 @@ namespace System
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
-        public static bool IsNotRiscV64Ubuntu => !IsUbuntu || !IsRiscV64Process;
+        public static bool IsNotQemuLinux => !IsQemuLinux();
 
         // OSX family
         public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;
@@ -299,6 +301,21 @@ namespace System
                 }
             }
 
+            return false;
+        }
+
+        private static bool IsQemuLinux()
+        {
+            if (IsLinux)
+            {
+                foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+                {
+                    if (((String)entry.Key).ToUpper().Contains("QEMU"))
+                    {
+                        return true;
+                    }
+                }
+            }
             return false;
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Net.Sockets.Tests
@@ -792,7 +792,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // API throws PNSE on Unix
         [InlineData(0)]
         [InlineData(1)]
@@ -800,11 +800,11 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104542)]
                 if (PlatformDetection.IsQemuLinux && invalidatingAction == 1)
                 {
-                    return;
+                    throw new SkipTestException("Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104542)]");
                 }
+
                 switch (invalidatingAction)
                 {
                     case 0:
@@ -828,7 +828,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // API throws PNSE on Unix
         [InlineData(0)]
         [InlineData(1)]
@@ -838,11 +838,11 @@ namespace System.Net.Sockets.Tests
 
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104542)]
                 if (PlatformDetection.IsQemuLinux && invalidatingAction == 1)
                 {
-                    return;
+                    throw new SkipTestException("Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104542)]");
                 }
+
                 switch (invalidatingAction)
                 {
                     case 0:

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -800,7 +800,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // Skip on Qemu due to https://github.com/dotnet/runtime/issues/104542
+                // Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104542)]
                 if (PlatformDetection.IsQemuLinux && invalidatingAction == 1)
                 {
                     return;
@@ -838,7 +838,7 @@ namespace System.Net.Sockets.Tests
 
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // Skip on Qemu due to https://github.com/dotnet/runtime/issues/104542
+                // Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104542)]
                 if (PlatformDetection.IsQemuLinux && invalidatingAction == 1)
                 {
                     return;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -800,7 +800,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // On Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
+                // Skip on Qemu due to https://github.com/dotnet/runtime/issues/104542
                 if (PlatformDetection.IsQemuLinux && invalidatingAction == 1)
                 {
                     return;
@@ -838,8 +838,8 @@ namespace System.Net.Sockets.Tests
 
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // On Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
-                if (!PlatformDetection.IsNotQemuLinux && invalidatingAction == 1)
+                // Skip on Qemu due to https://github.com/dotnet/runtime/issues/104542
+                if (PlatformDetection.IsQemuLinux && invalidatingAction == 1)
                 {
                     return;
                 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -794,18 +794,20 @@ namespace System.Net.Sockets.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // API throws PNSE on Unix
-        [InlineData(0)]
-        [InlineData(1)]
-        public void Connect_ConnectTwice_NotSupported(int invalidatingAction)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Connect_ConnectTwice_NotSupported(bool invalidatingAction)
         {
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                switch (invalidatingAction)
+                // On RISC-V Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
+                bool invalidatingActionOnPlatform = invalidatingAction && PlatformDetection.IsNotRiscV64Ubuntu;
+                switch (invalidatingActionOnPlatform)
                 {
-                    case 0:
+                    case false:
                         IntPtr handle = client.Handle; // exposing the underlying handle
                         break;
-                    case 1:
+                    case true:
                         client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.Debug, 1); // untracked socket option
                         break;
                 }
@@ -825,20 +827,22 @@ namespace System.Net.Sockets.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // API throws PNSE on Unix
-        [InlineData(0)]
-        [InlineData(1)]
-        public void ConnectAsync_ConnectTwice_NotSupported(int invalidatingAction)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ConnectAsync_ConnectTwice_NotSupported(bool invalidatingAction)
         {
             AutoResetEvent completed = new AutoResetEvent(false);
 
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                switch (invalidatingAction)
+                // On RISC-V Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
+                bool invalidatingActionOnPlatform = invalidatingAction && PlatformDetection.IsNotRiscV64Ubuntu;
+                switch (invalidatingActionOnPlatform)
                 {
-                    case 0:
+                    case false:
                         IntPtr handle = client.Handle; // exposing the underlying handle
                         break;
-                    case 1:
+                    case true:
                         client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.Debug, 1); // untracked socket option
                         break;
                 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -794,20 +794,23 @@ namespace System.Net.Sockets.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // API throws PNSE on Unix
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Connect_ConnectTwice_NotSupported(bool invalidatingAction)
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Connect_ConnectTwice_NotSupported(int invalidatingAction)
         {
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // On RISC-V Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
-                bool invalidatingActionOnPlatform = invalidatingAction && PlatformDetection.IsNotRiscV64Ubuntu;
-                switch (invalidatingActionOnPlatform)
+                // On Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
+                if (!PlatformDetection.IsNotQemuLinux && invalidatingAction == 1)
                 {
-                    case false:
+                    return;
+                }
+                switch (invalidatingAction)
+                {
+                    case 0:
                         IntPtr handle = client.Handle; // exposing the underlying handle
                         break;
-                    case true:
+                    case 1:
                         client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.Debug, 1); // untracked socket option
                         break;
                 }
@@ -827,22 +830,25 @@ namespace System.Net.Sockets.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // API throws PNSE on Unix
-        [InlineData(false)]
-        [InlineData(true)]
-        public void ConnectAsync_ConnectTwice_NotSupported(bool invalidatingAction)
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ConnectAsync_ConnectTwice_NotSupported(int invalidatingAction)
         {
             AutoResetEvent completed = new AutoResetEvent(false);
 
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
-                // On RISC-V Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
-                bool invalidatingActionOnPlatform = invalidatingAction && PlatformDetection.IsNotRiscV64Ubuntu;
-                switch (invalidatingActionOnPlatform)
+                // On Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
+                if (!PlatformDetection.IsNotQemuLinux && invalidatingAction == 1)
                 {
-                    case false:
+                    return;
+                }
+                switch (invalidatingAction)
+                {
+                    case 0:
                         IntPtr handle = client.Handle; // exposing the underlying handle
                         break;
-                    case true:
+                    case 1:
                         client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.Debug, 1); // untracked socket option
                         break;
                 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -801,7 +801,7 @@ namespace System.Net.Sockets.Tests
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 // On Qemu we omit one test case due to: https://gitlab.com/qemu-project/qemu/-/issues/2410
-                if (!PlatformDetection.IsNotQemuLinux && invalidatingAction == 1)
+                if (PlatformDetection.IsQemuLinux && invalidatingAction == 1)
                 {
                     return;
                 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
@@ -121,7 +121,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotQemuLinux))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotQemuLinux))] // Skip on Qemu due to https://gitlab.com/qemu-project/qemu/-/issues/2390
         public void Socket_Get_KeepAlive_Time_AsByteArray_OptionLengthZero_Failure()
         {
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -146,6 +146,7 @@ namespace System.Net.Sockets.Tests
         {
             if (!PlatformDetection.IsNotQemuLinux && (buffer == null || buffer.Length == 0))
             {
+                // Skip on Qemu due to https://gitlab.com/qemu-project/qemu/-/issues/2390
                 return;
             }
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
@@ -121,7 +121,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotQemuLinux))]
         public void Socket_Get_KeepAlive_Time_AsByteArray_OptionLengthZero_Failure()
         {
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -144,6 +144,10 @@ namespace System.Net.Sockets.Tests
         [InlineData(new byte[3] { 0, 0, 0 })]
         public void Socket_Get_KeepAlive_Time_AsByteArray_BufferNullOrTooSmall_Failure(byte[] buffer)
         {
+            if (!PlatformDetection.IsNotQemuLinux && (buffer == null || buffer.Length == 0))
+            {
+                return;
+            }
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 if (PlatformDetection.IsWindows)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
@@ -121,7 +121,8 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotQemuLinux))] // Skip on Qemu due to https://gitlab.com/qemu-project/qemu/-/issues/2390
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/104545", typeof(PlatformDetection), nameof(PlatformDetection.IsQemuLinux))]
         public void Socket_Get_KeepAlive_Time_AsByteArray_OptionLengthZero_Failure()
         {
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -144,9 +145,9 @@ namespace System.Net.Sockets.Tests
         [InlineData(new byte[3] { 0, 0, 0 })]
         public void Socket_Get_KeepAlive_Time_AsByteArray_BufferNullOrTooSmall_Failure(byte[] buffer)
         {
-            if (!PlatformDetection.IsNotQemuLinux && (buffer == null || buffer.Length == 0))
+            if (PlatformDetection.IsQemuLinux && (buffer == null || buffer.Length == 0))
             {
-                // Skip on Qemu due to https://gitlab.com/qemu-project/qemu/-/issues/2390
+                // Skip on Qemu due to https://github.com/dotnet/runtime/issues/104545
                 return;
             }
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Net.Sockets.Tests
@@ -139,7 +140,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(null)]
         [InlineData(new byte[0])]
         [InlineData(new byte[3] { 0, 0, 0 })]
@@ -147,9 +148,9 @@ namespace System.Net.Sockets.Tests
         {
             if (PlatformDetection.IsQemuLinux && (buffer == null || buffer.Length == 0))
             {
-                // Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104545)]
-                return;
+                throw new SkipTestException("Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104545)]");
             }
+
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 if (PlatformDetection.IsWindows)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
@@ -147,7 +147,7 @@ namespace System.Net.Sockets.Tests
         {
             if (PlatformDetection.IsQemuLinux && (buffer == null || buffer.Length == 0))
             {
-                // Skip on Qemu due to https://github.com/dotnet/runtime/issues/104545
+                // Skip on Qemu due to [ActiveIssue(https://github.com/dotnet/runtime/issues/104545)]
                 return;
             }
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -15,7 +15,7 @@ namespace System.Net.Sockets.Tests
     public partial class SocketOptionNameTest
     {
         private static bool SocketsReuseUnicastPortSupport => Capability.SocketsReuseUnicastPortSupport().HasValue;
-        private static bool SupportedOnPlatform = PlatformDetection.IsNotWindowsNanoNorServerCore && PlatformDetection.IsNotRiscV64Ubuntu;
+        private static bool SupportedOnPlatform = PlatformDetection.IsNotWindowsNanoNorServerCore && PlatformDetection.IsNotQemuLinux;
 
         [ConditionalFact(nameof(SocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketGetOption()
@@ -51,7 +51,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotRiscV64Ubuntu))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotQemuLinux))]
         public void MulticastOption_CreateSocketSetGetOption_GroupAndInterfaceIndex_SetSucceeds_GetThrows()
         {
             int interfaceIndex = 0;
@@ -65,7 +65,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and RISC-V Qemu
+        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and Qemu
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"
@@ -121,7 +121,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and RISC-V Qemu
+        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and Qemu
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "Expected behavior is different on OSX or FreeBSD")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52124", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task MulticastInterface_Set_IPv6_AnyInterface_Succeeds()

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -15,7 +15,6 @@ namespace System.Net.Sockets.Tests
     public partial class SocketOptionNameTest
     {
         private static bool SocketsReuseUnicastPortSupport => Capability.SocketsReuseUnicastPortSupport().HasValue;
-        private static bool SupportedOnPlatform = PlatformDetection.IsNotWindowsNanoNorServerCore && PlatformDetection.IsNotQemuLinux;
 
         [ConditionalFact(nameof(SocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketGetOption()
@@ -51,7 +50,8 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotQemuLinux))]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/104547", typeof(PlatformDetection), nameof(PlatformDetection.IsQemuLinux))]
         public void MulticastOption_CreateSocketSetGetOption_GroupAndInterfaceIndex_SetSucceeds_GetThrows()
         {
             int interfaceIndex = 0;
@@ -65,7 +65,8 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and Qemu
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/104547", typeof(PlatformDetection), nameof(PlatformDetection.IsQemuLinux))]
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"
@@ -121,9 +122,10 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and Qemu
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "Expected behavior is different on OSX or FreeBSD")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52124", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/104547", typeof(PlatformDetection), nameof(PlatformDetection.IsQemuLinux))]
         public async Task MulticastInterface_Set_IPv6_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -15,6 +15,7 @@ namespace System.Net.Sockets.Tests
     public partial class SocketOptionNameTest
     {
         private static bool SocketsReuseUnicastPortSupport => Capability.SocketsReuseUnicastPortSupport().HasValue;
+        private static bool SupportedOnPlatform = PlatformDetection.IsNotWindowsNanoNorServerCore && PlatformDetection.IsNotRiscV64Ubuntu;
 
         [ConditionalFact(nameof(SocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketGetOption()
@@ -50,7 +51,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotRiscV64Ubuntu))]
         public void MulticastOption_CreateSocketSetGetOption_GroupAndInterfaceIndex_SetSucceeds_GetThrows()
         {
             int interfaceIndex = 0;
@@ -64,7 +65,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286
+        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and RISC-V Qemu
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"
@@ -120,7 +121,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286
+        [ConditionalFact(nameof(SupportedOnPlatform))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286 and RISC-V Qemu
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "Expected behavior is different on OSX or FreeBSD")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52124", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task MulticastInterface_Set_IPv6_AnyInterface_Succeeds()

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -2088,6 +2088,7 @@ int32_t SystemNative_GetSockOpt(
     {
         return Error_EFAULT;
     }
+
     int fd = ToFileDescriptor(socket);
 
     //

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -2088,15 +2088,6 @@ int32_t SystemNative_GetSockOpt(
     {
         return Error_EFAULT;
     }
-   #if defined(TARGET_RISCV64)
-    uint8_t nonEmptyOptionValueBuffer;
-        if (socketOptionLevel == SocketOptionLevel_SOL_TCP && socketOptionName == SocketOptionName_SO_TCP_KEEPALIVE_TIME && optionValue == NULL
-                && *optionLen == 0)
-        {
-            // It's workaround for Qemu bug: https://gitlab.com/qemu-project/qemu/-/issues/2390.
-            optionValue = &nonEmptyOptionValueBuffer;
-        }
-    #endif
     int fd = ToFileDescriptor(socket);
 
     //

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -2088,7 +2088,15 @@ int32_t SystemNative_GetSockOpt(
     {
         return Error_EFAULT;
     }
-
+   #if defined(TARGET_RISCV64)
+    uint8_t nonEmptyOptionValueBuffer;
+        if (socketOptionLevel == SocketOptionLevel_SOL_TCP && socketOptionName == SocketOptionName_SO_TCP_KEEPALIVE_TIME && optionValue == NULL
+                && *optionLen == 0)
+        {
+            // It's workaround for Qemu bug: https://gitlab.com/qemu-project/qemu/-/issues/2390.
+            optionValue = &nonEmptyOptionValueBuffer;
+        }
+    #endif
     int fd = ToFileDescriptor(socket);
 
     //


### PR DESCRIPTION
Before this change there are 8 failures from System.Net.Sockets.Tests with following reports:
```
root@69fa7050f168:/runtime/artifacts/bin/System.Net.Sockets.Tests/Release/net9.0-unix# /runtime/artifacts/bin/testhost/net9.0-linux-Release-riscv64/dotnet  exec --runtimeconfig System.Net.Sockets.Tests.runtimeconfig.json --depsfile  System.Net.Sockets.Tests.deps.json  xunit.console.dll System.Net.Sockets.Tests.dll -xml testResults.xml -nologo -notrait category=nonnetcoreapptests -notrait category=nonlinuxtests -notrait category=failing -maxthreads 32
  Discovering: System.Net.Sockets.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.Net.Sockets.Tests (found 1672 of 1820 test cases)
  Starting:    System.Net.Sockets.Tests (parallel test collections = on [32 threads], stop on fail = off)
    System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_NotSupported_ExpectedError [SKIP]
      Condition(s) not met: "NotSupportsRawSockets"
    System.Net.Sockets.Tests.KeepAliveTest.Socket_Get_KeepAlive_Time_AsByteArray_OptionLengthZero_Failure [FAIL]
      System.Net.Sockets.SocketException : Bad address
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(2145,0): at System.Net.Sockets.Socket.GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionLength)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs(136,0): at System.Net.Sockets.Tests.KeepAliveTest.Socket_Get_KeepAlive_Time_AsByteArray_OptionLengthZero_Failure()

           at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
        /runtime/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs(57,0): at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    System.Net.Sockets.Tests.ArgumentValidation.Connect_ConnectTwice_NotSupported(invalidatingAction: 1) [FAIL]
      System.Net.Sockets.SocketException : Protocol not available
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3466,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue, Boolean silent)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(1966,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs(809,0): at System.Net.Sockets.Tests.ArgumentValidation.Connect_ConnectTwice_NotSupported(Int32 invalidatingAction)
           at InvokeStub_ArgumentValidation.Connect_ConnectTwice_NotSupported(Object, Span`1)
           at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_AnyInterface_Succeeds [FAIL]
      System.Net.Sockets.SocketException : Unknown socket error
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3479,0): at System.Net.Sockets.Socket.SetMulticastOption(SocketOptionName optionName, MulticastOption MR)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(2021,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Object optionValue)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs(96,0): at System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_Helper(Int32 interfaceIndex)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs(71,0): at System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_AnyInterface_Succeeds()
        --- End of stack trace from previous location ---
    System.Net.Sockets.Tests.KeepAliveTest.Socket_Get_KeepAlive_Time_AsByteArray_BufferNullOrTooSmall_Failure(buffer: null) [FAIL]
      System.Net.Sockets.SocketException : Bad address
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(2121,0): at System.Net.Sockets.Socket.GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Byte[] optionValue)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs(156,0): at System.Net.Sockets.Tests.KeepAliveTest.Socket_Get_KeepAlive_Time_AsByteArray_BufferNullOrTooSmall_Failure(Byte[] buffer)

           at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
        /runtime/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs(178,0): at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
    System.Net.Sockets.Tests.KeepAliveTest.Socket_Get_KeepAlive_Time_AsByteArray_BufferNullOrTooSmall_Failure(buffer: []) [FAIL]
      System.Net.Sockets.SocketException : Bad address
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(2121,0): at System.Net.Sockets.Socket.GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Byte[] optionValue)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs(156,0): at System.Net.Sockets.Tests.KeepAliveTest.Socket_Get_KeepAlive_Time_AsByteArray_BufferNullOrTooSmall_Failure(Byte[] buffer)
           at InvokeStub_KeepAliveTest.Socket_Get_KeepAlive_Time_AsByteArray_BufferNullOrTooSmall_Failure(Object, Span`1)
           at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    System.Net.Sockets.Tests.SocketOptionNameTest.MulticastOption_CreateSocketSetGetOption_GroupAndInterfaceIndex_SetSucceeds_GetThrows [FAIL]
      System.Net.Sockets.SocketException : Unknown socket error
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3479,0): at System.Net.Sockets.Socket.SetMulticastOption(SocketOptionName optionName, MulticastOption MR)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(2021,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Object optionValue)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs(61,0): at System.Net.Sockets.Tests.SocketOptionNameTest.MulticastOption_CreateSocketSetGetOption_GroupAndInterfaceIndex_SetSucceeds_GetThrows()

           at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
        /runtime/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs(57,0): at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_IPv6_AnyInterface_Succeeds [FAIL]
      System.Net.Sockets.SocketException : Protocol not available
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3466,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue, Boolean silent)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(1966,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs(199,0): at System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_IPv6_Helper(Int32 interfaceIndex)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs(129,0): at System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_IPv6_AnyInterface_Succeeds()
        --- End of stack trace from previous location ---
    System.Net.Sockets.Tests.ArgumentValidation.ConnectAsync_ConnectTwice_NotSupported(invalidatingAction: 1) [FAIL]
      System.Net.Sockets.SocketException : Protocol not available
      Stack Trace:
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3737,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3728,0): at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(3466,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue, Boolean silent)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(1966,0): at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs(842,0): at System.Net.Sockets.Tests.ArgumentValidation.ConnectAsync_ConnectTwice_NotSupported(Int32 invalidatingAction)
           at InvokeStub_ArgumentValidation.ConnectAsync_ConnectTwice_NotSupported(Object, Span`1)
           at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  Finished:    System.Net.Sockets.Tests
=== TEST EXECUTION SUMMARY ===
   System.Net.Sockets.Tests  Total: 2874, Errors: 0, Failed: 8, Skipped: 1, Time: 139.280s
```
Those failures are caused by Qemu's buggy and/or implementation defined behavior reported as active issues:
https://github.com/dotnet/runtime/issues/104542
https://github.com/dotnet/runtime/issues/104545
https://github.com/dotnet/runtime/issues/104547

In this patch we add couple of workarounds to make all System.Net.Sockets.Tests passing.

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung