### PR TITLE
Re-enable eventsourceerror for Unix/CoreCLR

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -92,9 +92,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">
             <Issue>https://github.com/dotnet/runtime/issues/46175</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
-            <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/typeequivalence/signatures/nopiatestil/*">
             <Issue>CoreCLR doesn't support type equivalence on Unix</Issue>
         </ExcludeList>


### PR DESCRIPTION
Re-enable after fixes at https://github.com/dotnet/runtime/pull/86180.

See #104095.

cc @EgorBo @dotnet/samsung.