### PR TITLE
Revert "[vm] fix confusing use of m_pCanonMT (NFC) (#102936)"

### DIFF
--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -39,8 +39,7 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
     {
         // pointer to canonical MethodTable.
         TADDR canonicalMethodTable = union_getPointer(addr);
-        // a canonical method table always points at its EEClass, and m_pEEClass has no mask bit, so just return it
-        return PTR_MethodTable(canonicalMethodTable)->m_pEEClass;
+        return PTR_EEClass(PTR_MethodTable(canonicalMethodTable)->m_pCanonMT);
     }
 }
 


### PR DESCRIPTION
This reverts commit 1ab68885edf33d5633071c695e0e438aec295584.

The change broke the DAC.

