### PR TITLE
Disable tests with WaitForPendingFinalizers in gcstress testing

### DIFF
--- a/src/tests/JIT/Methodical/Arrays/misc/arrres.cs
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres.cs
@@ -36,6 +36,7 @@ namespace GCTest_arrres_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static void TestEntryPoint()
         {
             Test1();

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres.il
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres.il
@@ -154,6 +154,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       .maxstack  4
       .locals (int32 V_0,

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr.cs
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr.cs
@@ -17,6 +17,7 @@ namespace GCTest_gcarr_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static void TestEntryPoint()
         {
             Test[] arr = new Test[97];

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr.il
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr.il
@@ -12,6 +12,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 
 .assembly extern mscorlib
 {
@@ -46,6 +51,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       .maxstack  3
       .locals (class GCTest_gcarr_il.Test[-10...10] V_0,

--- a/src/tests/JIT/Methodical/Coverage/copy_prop_byref_to_native_int.il
+++ b/src/tests/JIT/Methodical/Coverage/copy_prop_byref_to_native_int.il
@@ -3,6 +3,11 @@
 
 .assembly extern System.Console { auto }
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 
 .assembly 'copy_prop_byref_to_native_int' { }
 .assembly extern xunit.core {}
@@ -22,6 +27,11 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                        67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                        74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                        20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
     .entrypoint
     .locals ( [0] int32 result, [1] int32[] arr )
 

--- a/src/tests/JIT/Methodical/eh/interactions/gcincatch.cs
+++ b/src/tests/JIT/Methodical/eh/interactions/gcincatch.cs
@@ -43,6 +43,7 @@ namespace test2
         /// </summary>
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             int[] ar = new int[] { 1, 2, 3, 4, 5 };

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c.cs
@@ -54,6 +54,7 @@ namespace Test_refarg_c_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             Test(ref s_aa.mm);

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -154,6 +159,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  1

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4.cs
@@ -70,6 +70,7 @@ namespace Test_refarg_f4_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             int exitCode = Test(ref s_aa.mm2);

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -185,6 +190,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  1

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8.cs
@@ -68,6 +68,7 @@ namespace Test_refarg_f8_cs
         }
 
         [Fact]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             Test(ref s_aa.mm1);

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -185,6 +190,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  1

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1.cs
@@ -59,6 +59,7 @@ namespace Test_refarg_i1_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             Test(ref s_aa.mm);

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1.il
@@ -169,6 +169,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  1

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2.cs
@@ -53,6 +53,7 @@ namespace Test_refarg_i2_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             s_aa.self = new AA();

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2.il
@@ -151,6 +151,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       47 (0x2f)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4.cs
@@ -71,6 +71,7 @@ namespace Test_refarg_i4_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             Test(ref s_aa.mm);

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -214,6 +219,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  1

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o.cs
@@ -53,6 +53,7 @@ namespace Test_refarg_o_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             int exitCode = Test(ref s_aa.m_aa);

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -157,6 +162,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  1

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s.cs
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s.cs
@@ -53,6 +53,7 @@ namespace Test_refarg_s_cs
 
         [Fact]
         [OuterLoop]
+        [SkipOnCoreClr("WaitForPendingFinalizers() not supported with GCStress", RuntimeTestModes.AnyGCStress)]
         public static int TestEntryPoint()
         {
             int exitCode = Test(ref s_aa.mm);

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -160,6 +165,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  1

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_c.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_c.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -114,6 +119,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       64 (0x40)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i1.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i1.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -114,6 +119,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       64 (0x40)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i2.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i2.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -114,6 +119,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       64 (0x40)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i4.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i4.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -114,6 +119,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       64 (0x40)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_o.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_o.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -121,6 +126,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       72 (0x48)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_o2.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_o2.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME// as "refloc_o"
 {
 
@@ -122,6 +127,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       72 (0x48)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_r4.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_r4.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME// as "refloc_f4"
 {
 
@@ -121,6 +126,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       67 (0x43)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_r8.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_r8.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME// as "refloc_f8"
 {
 
@@ -114,6 +119,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       71 (0x47)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_u2.il
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_u2.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -115,6 +120,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       65 (0x41)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/misc/refarg_box_f8.il
+++ b/src/tests/JIT/Methodical/explicit/misc/refarg_box_f8.il
@@ -8,6 +8,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 }
@@ -83,6 +88,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       .maxstack  1
       .locals (float64 ZZZZ,  

--- a/src/tests/JIT/Methodical/explicit/misc/refarg_box_val.il
+++ b/src/tests/JIT/Methodical/explicit/misc/refarg_box_val.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -123,6 +128,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       32 (0x20)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/rotate/rotate_i4.il
+++ b/src/tests/JIT/Methodical/explicit/rotate/rotate_i4.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -208,6 +213,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       20 (0x14)
       .maxstack  2

--- a/src/tests/JIT/Methodical/explicit/rotate/rotate_u2.il
+++ b/src/tests/JIT/Methodical/explicit/rotate/rotate_u2.il
@@ -9,6 +9,11 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern Microsoft.DotNet.XUnitExtensions
+{
+  .publickeytoken = (31 BF 38 56 AD 36 4E 35 )                         // 1.8V.6N5
+  .ver 9:0:0:0
+}
 .assembly ASSEMBLY_NAME
 {
 
@@ -224,6 +229,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string,
+                                                                                                  valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = ( 01 00 36 57 61 69 74 46 6F 72 50 65 6E 64 69 6E   // ..6WaitForPendin
+                                                                                                                                                                          67 46 69 6E 61 6C 69 7A 65 72 73 28 29 20 6E 6F   // gFinalizers() no
+                                                                                                                                                                          74 20 73 75 70 70 6F 72 74 65 64 20 77 69 74 68   // t supported with
+                                                                                                                                                                          20 47 43 53 74 72 65 73 73 C0 00 00 00 00 00 )    //  GCStress......
       .entrypoint
       // Code size       20 (0x14)
       .maxstack  2


### PR DESCRIPTION
Some if not all tests from the Methodical suite that use GC.WaitForPendingFinalizers timeout due to the fact that a finalizer of Gen2GcCallback calls a callback that ends up creating another finalizable object that is ready to be finalized. Also a GC memory is allocated in that callback, which triggers the GC stress collection. So the finalization thread keeps finalizing objects on the queue forever and the GC.WaitForPendingFinalizers never exits.

This change disables all tests in the Methodical suite that wait for pending finalizers when running with GC stress enabled.

Closes #104062