### PR TITLE
Improve perf of JsonValue.CreateFromElement by calling ValueKind once

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -181,13 +181,15 @@ namespace System.Text.Json.Nodes
 
         internal static JsonValue? CreateFromElement(ref readonly JsonElement element, JsonNodeOptions? options = null)
         {
-            if (element.ValueKind is JsonValueKind.Null)
+            JsonValueKind kind = element.ValueKind;
+
+            if (kind is JsonValueKind.Null)
             {
                 return null;
             }
 
             // Force usage of JsonArray and JsonObject instead of supporting those in an JsonValue.
-            if (element.ValueKind is JsonValueKind.Object or JsonValueKind.Array)
+            if (kind is JsonValueKind.Object or JsonValueKind.Array)
             {
                 ThrowHelper.ThrowInvalidOperationException_NodeElementCannotBeObjectOrArray();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -189,9 +189,7 @@ namespace System.Text.Json.Nodes
                 case JsonValueKind.Array:
                     // Force usage of JsonArray and JsonObject instead of supporting those in an JsonValue.
                     ThrowHelper.ThrowInvalidOperationException_NodeElementCannotBeObjectOrArray();
-
-                    // The above method will throw, but the compiler doesn't know that.
-                    return default;
+                    return null;
 
                 default:
                     return new JsonValueOfElement(element, options);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -185,8 +185,7 @@ namespace System.Text.Json.Nodes
                 case JsonValueKind.Null:
                     return null;
 
-                case JsonValueKind.Object:
-                case JsonValueKind.Array:
+                case JsonValueKind.Object or JsonValueKind.Array:
                     // Force usage of JsonArray and JsonObject instead of supporting those in an JsonValue.
                     ThrowHelper.ThrowInvalidOperationException_NodeElementCannotBeObjectOrArray();
                     return null;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
@@ -181,20 +180,22 @@ namespace System.Text.Json.Nodes
 
         internal static JsonValue? CreateFromElement(ref readonly JsonElement element, JsonNodeOptions? options = null)
         {
-            JsonValueKind kind = element.ValueKind;
-
-            if (kind is JsonValueKind.Null)
+            switch (element.ValueKind)
             {
-                return null;
-            }
+                case JsonValueKind.Null:
+                    return null;
 
-            // Force usage of JsonArray and JsonObject instead of supporting those in an JsonValue.
-            if (kind is JsonValueKind.Object or JsonValueKind.Array)
-            {
-                ThrowHelper.ThrowInvalidOperationException_NodeElementCannotBeObjectOrArray();
-            }
+                case JsonValueKind.Object:
+                case JsonValueKind.Array:
+                    // Force usage of JsonArray and JsonObject instead of supporting those in an JsonValue.
+                    ThrowHelper.ThrowInvalidOperationException_NodeElementCannotBeObjectOrArray();
 
-            return new JsonValueOfElement(element, options);
+                    // The above method will throw, but the compiler doesn't know that.
+                    return default;
+
+                default:
+                    return new JsonValueOfElement(element, options);
+            }
         }
     }
 }


### PR DESCRIPTION
Following https://github.com/dotnet/runtime/pull/104048#discussion_r1655556845

`JsonElement.ValueKind` actually does quite a few operations as described below. This PR is a small change so that it's only called once.

```csharp
public JsonValueKind ValueKind => TokenType.ToValueKind();`
```

```csharp
private JsonTokenType TokenType => _parent?.GetJsonTokenType(_idx) ?? JsonTokenType.None
```

```csharp
internal JsonTokenType GetJsonTokenType(int index)
{
    CheckNotDisposed();

    return _parsedData.GetJsonTokenType(index);
}
```

```csharp
internal JsonTokenType GetJsonTokenType(int index)
{
    AssertValidIndex(index);
    uint union = MemoryMarshal.Read<uint>(_data.AsSpan(index + NumberOfRowsOffset));

    return (JsonTokenType)(union >> 28);
}
```

cc @eiriktsarpalis 