### PR TITLE
[wasi] Revert "Always allocate when computing temp path"

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -103,13 +103,7 @@ namespace System.IO
             int tempPathByteCount = Encoding.UTF8.GetByteCount(tempPath);
             int totalByteCount = tempPathByteCount + fileTemplate.Length + 1;
 
-#if TARGET_BROWSER
-            // https://github.com/emscripten-core/emscripten/issues/18591
-            // The emscripten implementation of __randname uses pointer address as another entry into the randomness.
-            Span<byte> path = new byte[totalByteCount];
-#else
             Span<byte> path = totalByteCount <= 256 ? stackalloc byte[256].Slice(0, totalByteCount) : new byte[totalByteCount];
-#endif
             int pos = Encoding.UTF8.GetBytes(tempPath, path);
             fileTemplate.CopyTo(path.Slice(pos));
             path[^1] = 0;


### PR DESCRIPTION
Fix partially https://github.com/dotnet/runtime/issues/81210.
The mentioned bump was in https://github.com/dotnet/runtime/pull/83998.