### PR TITLE
Revert Enum.ToObject parsing of float/double enums

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -2206,8 +2206,6 @@ namespace System
                 case TypeCode.Byte: return ToObject(enumType, (byte)value);
                 case TypeCode.UInt16: return ToObject(enumType, (ushort)value);
                 case TypeCode.UInt64: return ToObject(enumType, (ulong)value);
-                case TypeCode.Single: return ToObject(enumType, BitConverter.SingleToInt32Bits((float)value));
-                case TypeCode.Double: return ToObject(enumType, BitConverter.DoubleToInt64Bits((double)value));
                 case TypeCode.Char: return ToObject(enumType, (char)value);
                 case TypeCode.Boolean: return ToObject(enumType, (bool)value ? 1L : 0L);
             };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/EnumTests.cs
@@ -86,14 +86,10 @@ namespace System.Tests
                 // Single
                 yield return new object[] { "Value1", false, Enum.GetValues(s_floatEnumType).GetValue(1) };
                 yield return new object[] { "vaLue2", true, Enum.GetValues(s_floatEnumType).GetValue(2) };
-                yield return new object[] { "1", false, Enum.GetValues(s_floatEnumType).GetValue(1) };
-                yield return new object[] { "1.0", false, Enum.GetValues(s_floatEnumType).GetValue(1) };
 
                 // Double
                 yield return new object[] { "Value1", false, Enum.GetValues(s_doubleEnumType).GetValue(1) };
                 yield return new object[] { "vaLue2", true, Enum.GetValues(s_doubleEnumType).GetValue(2) };
-                yield return new object[] { "1", false, Enum.GetValues(s_doubleEnumType).GetValue(1) };
-                yield return new object[] { "1.0", false, Enum.GetValues(s_doubleEnumType).GetValue(1) };
             }
 
             // SimpleEnum
@@ -204,6 +200,16 @@ namespace System.Tests
                 // Char
                 yield return new object[] { s_charEnumType, ((char)1).ToString(), false, typeof(ArgumentException) };
                 yield return new object[] { s_charEnumType, ((char)5).ToString(), false, typeof(ArgumentException) };
+
+                // Single
+                yield return new object[] { s_floatEnumType, "1", false, typeof(ArgumentException) };
+                yield return new object[] { s_floatEnumType, "5", false, typeof(ArgumentException) };
+                yield return new object[] { s_floatEnumType, "1.0", false, typeof(ArgumentException) };
+
+                // Double
+                yield return new object[] { s_doubleEnumType, "1", false, typeof(ArgumentException) };
+                yield return new object[] { s_doubleEnumType, "5", false, typeof(ArgumentException) };
+                yield return new object[] { s_doubleEnumType, "1.0", false, typeof(ArgumentException) };
 
                 // IntPtr
                 yield return new object[] { s_intPtrEnumType, "1", false, typeof(InvalidCastException) };
@@ -931,14 +937,6 @@ namespace System.Tests
                 // Char
                 yield return new object[] { s_charEnumType, (char)1, Enum.Parse(s_charEnumType, "Value1") };
                 yield return new object[] { s_charEnumType, (char)2, Enum.Parse(s_charEnumType, "Value2") };
-
-                // Float
-                yield return new object[] { s_floatEnumType, 1.0f, Enum.Parse(s_floatEnumType, "Value1") };
-                yield return new object[] { s_floatEnumType, 2.0f, Enum.Parse(s_floatEnumType, "Value2") };
-
-                // Double
-                yield return new object[] { s_doubleEnumType, 1.0, Enum.Parse(s_doubleEnumType, "Value1") };
-                yield return new object[] { s_doubleEnumType, 2.0, Enum.Parse(s_doubleEnumType, "Value2") };
             }
         }
 
@@ -982,6 +980,8 @@ namespace System.Tests
 
             if (PlatformDetection.IsReflectionEmitSupported && PlatformDetection.IsRareEnumsSupported)
             {
+                yield return new object[] { s_floatEnumType, 1.0f, typeof(ArgumentException) };
+                yield return new object[] { s_doubleEnumType, 1.0, typeof(ArgumentException) };
                 yield return new object[] { s_intPtrEnumType, (IntPtr)1, typeof(ArgumentException) };
                 yield return new object[] { s_uintPtrEnumType, (UIntPtr)1, typeof(ArgumentException) };
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95697

@jkotas, this is https://github.com/dotnet/runtime/issues/95697#issuecomment-2190749226 if you'd like to go ahead with it.