### PR TITLE
Move protected member check in the class

### DIFF
--- a/src/coreclr/inc/iterator.h
+++ b/src/coreclr/inc/iterator.h
@@ -203,11 +203,10 @@ class IndexerBasePrototype
 };
 };
 
-DEFINE_MEMBER_EXISTENCE_CHECK(m_revision);
-
 template <typename CONTAINER>
 class CheckedIteratorBase
 {
+  DEFINE_MEMBER_EXISTENCE_CHECK(m_revision);
   protected:
 #if defined(_DEBUG)
     const CONTAINER *m_container;


### PR DESCRIPTION
Thanks @gwr for finding a debug build issue with illumos cross setup (gcc 8.4). https://github.com/dotnet/runtime/issues/34944#issuecomment-2195442003
This ensures that the protected member is accessed within the class to make older gcc happy (note the existing syntax is legal in C++ because of `friend class CheckedIteratorBase<SBuffer>` and gcc 9 onwards are fine with it but we are stuck with gcc 8.4 in rootfs for now https://github.com/illumos/sysroot/issues/3).

failing build off of `main`: https://github.com/am11/CrossRepoCITesting/actions/runs/9701959060/job/26776715403
working build with this patch: https://github.com/am11/CrossRepoCITesting/actions/runs/9702500203/job/26778504623