### PR TITLE
[coreclr] Remove CatchHardwareExceptionHolder

### DIFF
--- a/src/coreclr/dlls/mscordac/mscordac_unixexports.src
+++ b/src/coreclr/dlls/mscordac/mscordac_unixexports.src
@@ -20,8 +20,6 @@ IID_ICLRDataEnumMemoryRegionsCallback
 nativeStringResourceTable_mscorrc
 
 ; All the # exports are prefixed with DAC_
-#PAL_CatchHardwareExceptionHolderEnter
-#PAL_CatchHardwareExceptionHolderExit
 #PAL_CopyModuleData
 #PAL_GetLogicalCpuCountFromOS
 #PAL_GetTotalCpuCount

--- a/src/coreclr/inc/ex.h
+++ b/src/coreclr/inc/ex.h
@@ -7,7 +7,6 @@
 
 #ifdef HOST_UNIX
 #define EX_TRY_HOLDER                                   \
-    HardwareExceptionHolder                             \
     NativeExceptionHolderCatchAll __exceptionHolder;    \
     __exceptionHolder.Push();                           \
 

--- a/src/coreclr/inc/palclr.h
+++ b/src/coreclr/inc/palclr.h
@@ -310,8 +310,6 @@
 
 #include "staticcontract.h"
 
-#define HardwareExceptionHolder
-
 // Note: PAL_SEH_RESTORE_GUARD_PAGE is only ever defined in clrex.h, so we only restore guard pages automatically
 // when these macros are used from within the VM.
 #define PAL_SEH_RESTORE_GUARD_PAGE

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -4143,46 +4143,6 @@ PALAPI
 PAL_SetTerminationRequestHandler(
     IN PTERMINATION_REQUEST_HANDLER terminationRequestHandler);
 
-PALIMPORT
-VOID
-PALAPI
-PAL_CatchHardwareExceptionHolderEnter();
-
-PALIMPORT
-VOID
-PALAPI
-PAL_CatchHardwareExceptionHolderExit();
-
-//
-// This holder is used to indicate that a hardware
-// exception should be raised as a C++ exception
-// to better emulate SEH on the xplat platforms.
-//
-class CatchHardwareExceptionHolder
-{
-public:
-    CatchHardwareExceptionHolder()
-    {
-        PAL_CatchHardwareExceptionHolderEnter();
-    }
-
-    ~CatchHardwareExceptionHolder()
-    {
-        PAL_CatchHardwareExceptionHolderExit();
-    }
-
-    static bool IsEnabled();
-};
-
-//
-// NOTE: This is only defined in one PAL test.
-//
-#ifdef FEATURE_ENABLE_HARDWARE_EXCEPTIONS
-#define HardwareExceptionHolder CatchHardwareExceptionHolder __catchHardwareException;
-#else
-#define HardwareExceptionHolder
-#endif // FEATURE_ENABLE_HARDWARE_EXCEPTIONS
-
 class NativeExceptionHolderBase;
 
 PALIMPORT
@@ -4344,7 +4304,6 @@ public:
     };                                                                          \
     try                                                                         \
     {                                                                           \
-        HardwareExceptionHolder                                                 \
         auto __exceptionHolder = NativeExceptionHolderFactory::CreateHolder(&exceptionFilter); \
         __exceptionHolder.Push();                                               \
         tryBlock(__param);                                                      \
@@ -4380,7 +4339,6 @@ public:
     {                                   \
         try                             \
         {                               \
-            HardwareExceptionHolder     \
             tryBlock(__param);          \
         }                               \
         catch (...)                     \
@@ -4396,7 +4354,7 @@ public:
 
 #define PAL_CPP_THROW(type, obj) { throw obj; }
 #define PAL_CPP_RETHROW { throw; }
-#define PAL_CPP_TRY                     try { HardwareExceptionHolder
+#define PAL_CPP_TRY                     try {
 #define PAL_CPP_CATCH_EXCEPTION(ident)  } catch (Exception *ident) {
 #define PAL_CPP_CATCH_EXCEPTION_NOARG   } catch (Exception *) {
 #define PAL_CPP_CATCH_DERIVED(type, ident) } catch (type *ident) {

--- a/src/coreclr/pal/src/exception/seh.cpp
+++ b/src/coreclr/pal/src/exception/seh.cpp
@@ -274,13 +274,6 @@ SEHProcessException(PAL_SEHException* exception)
                 // The exception was a single step or a breakpoint and it was not handled by the debugger.
             }
         }
-
-        if (CatchHardwareExceptionHolder::IsEnabled())
-        {
-            EnsureExceptionRecordsOnHeap(exception);
-            exception->IsExternal = true;
-            PAL_ThrowExceptionFromContext(exception->GetContextRecord(), exception);
-        }
     }
 
     // Unhandled hardware exception pointers->ExceptionRecord->ExceptionCode at pointers->ExceptionRecord->ExceptionAddress
@@ -335,36 +328,6 @@ PAL_ERROR SEHDisable(CPalThread *pthrCurrent)
 #else // HAVE_MACH_EXCEPTIONS
 #error not yet implemented
 #endif // HAVE_MACH_EXCEPTIONS
-}
-
-/*++
-
-  CatchHardwareExceptionHolder implementation
-
---*/
-
-extern "C"
-void
-PALAPI
-PAL_CatchHardwareExceptionHolderEnter()
-{
-    CPalThread *pThread = InternalGetCurrentThread();
-    pThread->IncrementHardwareExceptionHolderCount();
-}
-
-extern "C"
-void
-PALAPI
-PAL_CatchHardwareExceptionHolderExit()
-{
-    CPalThread *pThread = InternalGetCurrentThread();
-    pThread->DecrementHardwareExceptionHolderCount();
-}
-
-bool CatchHardwareExceptionHolder::IsEnabled()
-{
-    CPalThread *pThread = GetCurrentPalThread();
-    return pThread ? pThread->IsHardwareExceptionsEnabled() : false;
 }
 
 /*++

--- a/src/coreclr/pal/src/include/pal/thread.hpp
+++ b/src/coreclr/pal/src/include/pal/thread.hpp
@@ -256,10 +256,6 @@ namespace CorUnix
         mach_port_t m_machPortSelf;
 #endif
 
-        // > 0 when there is an exception holder which causes h/w
-        // exceptions to be sent down the C++ exception chain.
-        int m_hardwareExceptionHolderCount;
-
         //
         // Start info
         //
@@ -333,7 +329,6 @@ namespace CorUnix
 #if HAVE_MACH_THREADS
             m_machPortSelf(0),
 #endif
-            m_hardwareExceptionHolderCount(0),
             m_lpStartAddress(NULL),
             m_lpStartParameter(NULL),
             m_bCreateSuspended(FALSE),
@@ -497,24 +492,6 @@ namespace CorUnix
             return m_machPortSelf;
         };
 #endif
-
-        bool
-        IsHardwareExceptionsEnabled()
-        {
-            return m_hardwareExceptionHolderCount > 0;
-        }
-
-        inline void
-        IncrementHardwareExceptionHolderCount()
-        {
-            ++m_hardwareExceptionHolderCount;
-        }
-
-        inline void
-        DecrementHardwareExceptionHolderCount()
-        {
-            --m_hardwareExceptionHolderCount;
-        }
 
         LPTHREAD_START_ROUTINE
         GetStartAddress(

--- a/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
+++ b/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(CLR_CMAKE_HOST_UNIX)
-    add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
-endif(CLR_CMAKE_HOST_UNIX)
-
 # Set the RPATH of paltest_pal_sxs_test1 so that it can find dependencies without needing to set LD_LIBRARY
 # For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
 if(CORECLR_SET_RPATH)

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -5,7 +5,6 @@ remove_definitions(-D_UNICODE)
 
 add_definitions(-DFEATURE_NO_HOST)
 add_definitions(-DSELF_NO_HOST)
-add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
 
 if(CLR_CMAKE_HOST_WIN32)
   #use static crt

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2614,8 +2614,6 @@ static PCODE PreStubWorker_Preemptive(
     UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
 
     {
-        HardwareExceptionHolder;
-
         // Give debugger opportunity to stop here
         ThePreStubPatch();
     }
@@ -2719,8 +2717,6 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
         UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
 
         {
-            HardwareExceptionHolder;
-
             // Give debugger opportunity to stop here
             ThePreStubPatch();
         }


### PR DESCRIPTION
It's job was to turn Unix Segv signals into C++ exceptions. It was supposed to be used in the DAC on Unix, but proved unreliable.  It is currently unused except in a pair of tests.

Removing it to remove the temptation to use it for something else.