### PR TITLE
Fix infinite loop in IGenericCacheEntry.CreateAndCache

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
@@ -157,9 +157,12 @@ namespace System
                         }
 
                         TCache newEntry = TCache.Create(type);
-                        if (Interlocked.CompareExchange(ref TCache.GetStorageRef(compositeCache), newEntry, null) == null)
-                            return newEntry;
-                        // We lost the race, try again.
+                        // Try to put our entry in the composite cache, but only if someone else hasn't set the entry.
+                        TCache? currentEntry = Interlocked.CompareExchange(ref TCache.GetStorageRef(compositeCache), newEntry, null);
+
+                        // If currentEntry == null, then we won the race.
+                        // Otherwise, we lost and should return the existing entry.
+                        return currentEntry ?? newEntry;
                     }
                 }
             }


### PR DESCRIPTION
CreateAndCache should give up if it's lost the race to the point of another thread putting an entry in the right slot in the composite cache. It won't ever overwrite a filled slot.

Reported by ASP.NET

cc: @BrennanConroy 