### PR TITLE
Add NULL checks to GetClassWithPossibleAV

### DIFF
--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -30,7 +30,7 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
 
     TADDR addr = m_pCanonMT;
 #ifdef DACCESS_COMPILE
-    if (addr == 0)
+    if (addr == (TADDR)NULL)
     {
         DacError(E_UNEXPECTED);
     }
@@ -45,7 +45,7 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
         // pointer to canonical MethodTable.
         TADDR canonicalMethodTable = union_getPointer(addr);
 #ifdef DACCESS_COMPILE
-        if (canonicalMethodTable == 0)
+        if (canonicalMethodTable == (TADDR)NULL)
         {
             DacError(E_UNEXPECTED);
         }

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -30,7 +30,7 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
 
     TADDR addr = m_pCanonMT;
 #ifdef DACCESS_COMPILE
-    if (addr == NULL)
+    if (addr == 0)
     {
         DacError(E_UNEXPECTED);
     }
@@ -45,7 +45,7 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
         // pointer to canonical MethodTable.
         TADDR canonicalMethodTable = union_getPointer(addr);
 #ifdef DACCESS_COMPILE
-        if (canonicalMethodTable == NULL)
+        if (canonicalMethodTable == 0)
         {
             DacError(E_UNEXPECTED);
         }

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -29,7 +29,12 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
     LIMITED_METHOD_DAC_CONTRACT;
 
     TADDR addr = m_pCanonMT;
-
+#ifdef DACCESS_COMPILE
+    if (addr == NULL)
+    {
+        DacError(E_UNEXPECTED);
+    }
+#endif
     LowBits lowBits = union_getLowBits(addr);
     if (lowBits == UNION_EECLASS)
     {
@@ -39,6 +44,12 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
     {
         // pointer to canonical MethodTable.
         TADDR canonicalMethodTable = union_getPointer(addr);
+#ifdef DACCESS_COMPILE
+        if (canonicalMethodTable == NULL)
+        {
+            DacError(E_UNEXPECTED);
+        }
+#endif
         // a canonical method table always points at its EEClass, and m_pEEClass has no mask bit, so just return it
         return PTR_MethodTable(canonicalMethodTable)->m_pEEClass;
     }


### PR DESCRIPTION
Fixes the SIGSEGV in the Alpine SOS tests.