### PR TITLE
Capture first line of linker version only

### DIFF
--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -77,8 +77,7 @@ endif()
 
 if (NOT CLR_CMAKE_HOST_WIN32)
   # detect linker
-  separate_arguments(ldVersion UNIX_COMMAND "${CMAKE_C_COMPILER} ${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version")
-  execute_process(COMMAND ${ldVersion}
+  execute_process(COMMAND sh -c "${CMAKE_C_COMPILER} ${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version | head -1"
     ERROR_QUIET
     OUTPUT_VARIABLE ldVersionOutput)
 
@@ -91,7 +90,6 @@ if (NOT CLR_CMAKE_HOST_WIN32)
   else(CLR_CMAKE_HOST_OSX OR CLR_CMAKE_HOST_MACCATALYST)
     set(LD_OSX 1)
   endif()
-  string(STRIP "${ldVersionOutput}" ldVersionOutput)
   message("-- The linker identification is ${ldVersionOutput}")
 endif()
 

--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -79,7 +79,8 @@ if (NOT CLR_CMAKE_HOST_WIN32)
   # detect linker
   execute_process(COMMAND sh -c "${CMAKE_C_COMPILER} ${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version | head -1"
     ERROR_QUIET
-    OUTPUT_VARIABLE ldVersionOutput)
+    OUTPUT_VARIABLE ldVersionOutput
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if("${ldVersionOutput}" MATCHES "LLD")
     set(LD_LLVM 1)


### PR DESCRIPTION
We really don't need the subsequent ones

```
  -- The linker identification is GNU ld (GNU Binutils for Debian) 2.40
  Copyright (C) 2023 Free Software Foundation, Inc.
  This program is free software; you may redistribute it under the terms of
  the GNU General Public License version 3 or (at your option) a later version.
  This program has absolutely no warranty.
```