### PR TITLE
[wasi] Enable passing test from `System.Runtime.Serialization.Xml.ReflectionOnly.Tests`, and `System.Runtime.Serialization.Xml.Tests`

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4124,7 +4124,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/85690", TestPlatforms.Wasi)]
     public static void DCS_FileStreamSurrogate()
     {
         using (var testFile = TempFile.Create())


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/85690.