### PR TITLE
[RISC-V] Fix coreclr test coreroot_determinism.sh

### DIFF
--- a/src/tests/readytorun/coreroot_determinism/Program.cs
+++ b/src/tests/readytorun/coreroot_determinism/Program.cs
@@ -94,7 +94,7 @@ public class Program
             Directory.Delete(outDir, true);
         }
         Directory.CreateDirectory(outDir);
-        ProcessStartInfo processStartInfo = new ProcessStartInfo(coreRunPath, $"{superIlcPath} compile-directory -cr {coreRootPath} -in {compilationInputFolder} --nojit --noexe --large-bubble --release --nocleanup -out {outDir}");
+        ProcessStartInfo processStartInfo = new ProcessStartInfo(coreRunPath, $"{superIlcPath} compile-directory -cr {coreRootPath} -in {compilationInputFolder} --nojit --noexe --large-bubble --release --nocleanup -ct 30 -out {outDir}");
         var process = Process.Start(processStartInfo);
         process.WaitForExit();
         if (process.ExitCode != 0)


### PR DESCRIPTION
To make test passing we increase _TimeoutMilliseconds_ to 30 min.

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung