### PR TITLE
[wasm] Added `ReleaseCores` to `BuildEngine` usages that did not have it.

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -524,7 +524,8 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         else
         {
             int allowedParallelism = DisableParallelAot ? 1 : Math.Min(_assembliesToCompile.Count, Environment.ProcessorCount);
-            if (BuildEngine is IBuildEngine9 be9)
+            IBuildEngine9? be9 = BuildEngine as IBuildEngine9;
+            if (be9 is not null)
                 allowedParallelism = be9.RequestCores(allowedParallelism);
 
             /*
@@ -553,20 +554,26 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
                 Instead, we want to use work-stealing so jobs can be run by any partition.
             */
-            ParallelLoopResult result = Parallel.ForEach(
+            try
+            {
+                ParallelLoopResult result = Parallel.ForEach(
                                             Partitioner.Create(argsList, EnumerablePartitionerOptions.NoBuffering),
                                             new ParallelOptions { MaxDegreeOfParallelism = allowedParallelism },
                                             PrecompileLibraryParallel);
-
-            if (result.IsCompleted)
-            {
-                int numUnchanged = _totalNumAssemblies - _numCompiled;
-                if (numUnchanged > 0 && numUnchanged != _totalNumAssemblies)
-                    Log.LogMessage(MessageImportance.High, $"[{numUnchanged}/{_totalNumAssemblies}] skipped unchanged assemblies.");
+                if (result.IsCompleted)
+                {
+                    int numUnchanged = _totalNumAssemblies - _numCompiled;
+                    if (numUnchanged > 0 && numUnchanged != _totalNumAssemblies)
+                        Log.LogMessage(MessageImportance.High, $"[{numUnchanged}/{_totalNumAssemblies}] skipped unchanged assemblies.");
+                }
+                else if (!Log.HasLoggedErrors)
+                {
+                    Log.LogError($"Precompiling failed due to unknown reasons. Check log for more info");
+                }
             }
-            else if (!Log.HasLoggedErrors)
+            finally
             {
-                Log.LogError($"Precompiling failed due to unknown reasons. Check log for more info");
+                be9?.ReleaseCores(allowedParallelism);
             }
         }
 

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -75,9 +75,12 @@ public class ILStrip : Microsoft.Build.Utilities.Task
         Log.LogMessage(MessageImportance.High, "IL stripping assemblies");
 
         int allowedParallelism = DisableParallelStripping ? 1 : Math.Min(Assemblies.Length, Environment.ProcessorCount);
-        if (BuildEngine is IBuildEngine9 be9)
+        IBuildEngine9? be9 = BuildEngine as IBuildEngine9;
+        if (be9 is not null)
             allowedParallelism = be9.RequestCores(allowedParallelism);
-        ParallelLoopResult result = Parallel.ForEach(Assemblies,
+        try
+        {
+            ParallelLoopResult result = Parallel.ForEach(Assemblies,
                                                     new ParallelOptions { MaxDegreeOfParallelism = allowedParallelism },
                                                     (assemblyItem, state) =>
                                                     {
@@ -93,14 +96,19 @@ public class ILStrip : Microsoft.Build.Utilities.Task
                                                         }
                                                     });
 
-        if (TrimIndividualMethods)
-        {
-            UpdatedAssemblies = ConvertAssembliesDictToOrderedList(_processedAssemblies, Assemblies).ToArray();
-        }
+            if (TrimIndividualMethods)
+            {
+                UpdatedAssemblies = ConvertAssembliesDictToOrderedList(_processedAssemblies, Assemblies).ToArray();
+            }
 
-        if (!result.IsCompleted && !Log.HasLoggedErrors)
+            if (!result.IsCompleted && !Log.HasLoggedErrors)
+            {
+                Log.LogError("Unknown failure occurred while IL stripping assemblies. Check logs to get more details.");
+            }
+        }
+        finally
         {
-            Log.LogError("Unknown failure occurred while IL stripping assemblies. Check logs to get more details.");
+            be9?.ReleaseCores(allowedParallelism);
         }
 
         return !Log.HasLoggedErrors;

--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -131,7 +131,8 @@ namespace Microsoft.WebAssembly.Build.Tasks
                 Directory.CreateDirectory(_tempPath);
 
                 int allowedParallelism = DisableParallelCompile ? 1 : Math.Min(SourceFiles.Length, Environment.ProcessorCount);
-                if (BuildEngine is IBuildEngine9 be9)
+                IBuildEngine9? be9 = BuildEngine as IBuildEngine9;
+                if (be9 is not null)
                     allowedParallelism = be9.RequestCores(allowedParallelism);
 
                 /*
@@ -160,17 +161,24 @@ namespace Microsoft.WebAssembly.Build.Tasks
 
                     Instead, we want to use work-stealing so jobs can be run by any partition.
                 */
-                ParallelLoopResult result = Parallel.ForEach(
+                try
+                {
+                    ParallelLoopResult result = Parallel.ForEach(
                                                 Partitioner.Create(filesToCompile, EnumerablePartitionerOptions.NoBuffering),
                                                 new ParallelOptions { MaxDegreeOfParallelism = allowedParallelism },
                                                 (toCompile, state) =>
+                    {
+                        if (!ProcessSourceFile(toCompile.Item1, toCompile.Item2))
+                            state.Stop();
+                    });
+                    if (!result.IsCompleted && !Log.HasLoggedErrors)
+                        Log.LogError("Unknown failure occurred while compiling. Check logs to get more details.");
+                }
+                finally
                 {
-                    if (!ProcessSourceFile(toCompile.Item1, toCompile.Item2))
-                        state.Stop();
-                });
+                    be9?.ReleaseCores(allowedParallelism);
+                }
 
-                if (!result.IsCompleted && !Log.HasLoggedErrors)
-                    Log.LogError("Unknown failure occurred while compiling. Check logs to get more details.");
 
                 if (!Log.HasLoggedErrors)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95431, applied same change as https://github.com/dotnet/runtime/pull/95426 has done to `EmitBundleBase`.