### PR TITLE
Get rid of fluent assertions in System.Resources.Extensions.BinaryFormat.Tests

### DIFF
--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/ArrayTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/ArrayTests.cs
@@ -17,7 +17,7 @@ public abstract class ArrayTests<T> : SerializationTest<T> where T : ISerializer
     {
         nint[] nints = [42, 43, 44];
         object deserialized = Deserialize(Serialize(nints));
-        deserialized.Should().BeEquivalentTo(nints);
+        Assert.Equal(nints, deserialized);
     }
 
     [Fact]

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/BasicObjectTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/BasicObjectTests.cs
@@ -29,11 +29,11 @@ public abstract class BasicObjectTests<T> : SerializationTest<T> where T : ISeri
                 if (deserialized is StringComparer)
                 {
                     // StringComparer derived classes are not public and they don't serialize the actual type.
-                    value.Should().BeAssignableTo<StringComparer>();
+                    Assert.IsAssignableFrom<StringComparer>(value);
                 }
                 else
                 {
-                    deserialized.Should().BeOfType(value.GetType());
+                    Assert.IsType(value.GetType(), deserialized);
                 }
 
                 bool isSamePlatform = i == platformIndex;
@@ -60,7 +60,7 @@ public abstract class BasicObjectTests<T> : SerializationTest<T> where T : ISeri
             && value is Array array
             && array.Length > 0)
         {
-            deserialized.Should().NotBeSameAs(value);
+            Assert.NotSame(value, deserialized);
         }
 
         EqualityExtensions.CheckEquals(value, deserialized, isSamePlatform: true);

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/ComparerTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/ComparerTests.cs
@@ -28,6 +28,6 @@ public abstract class ComparerTests<T> : SerializationTest<T> where T : ISeriali
     public void NullableComparers_Roundtrip(string expectedType, object obj)
     {
         object roundTrip = RoundTrip(obj);
-        roundTrip.GetType().Name.Should().Be(expectedType);
+        Assert.Equal(expectedType, roundTrip.GetType().Name);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/CorruptedTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/CorruptedTests.cs
@@ -31,8 +31,7 @@ public class CorruptedTests : SerializationTest<FormattedObjectSerializer>
 
         // This fails in the SerializationConstructor in BinaryFormattedObject's deserializer because the
         // type isn't convertible to NodeWithNodeStruct. In BinaryFormatter it fails with fixups.
-        Action action = () => Deserialize(stream);
-        action.Should().Throw<SerializationException>();
+        Assert.Throws<SerializationException>(() => Deserialize(stream));
     }
 
     [Fact]
@@ -51,8 +50,7 @@ public class CorruptedTests : SerializationTest<FormattedObjectSerializer>
 
         stream.Position = 0;
 
-        Action action = () => Deserialize(stream);
-        action.Should().Throw<SerializationException>();
+        Assert.Throws<SerializationException>(() => Deserialize(stream));
     }
 
     [Fact]
@@ -74,8 +72,7 @@ public class CorruptedTests : SerializationTest<FormattedObjectSerializer>
         // Both deserializers create this where every boxed struct is the exact same boxed instance.
         stream.Position = 0;
 
-        Action action = () => Deserialize(stream);
-        action.Should().Throw<SerializationException>();
+        Assert.Throws<SerializationException>(() => Deserialize(stream));
     }
 
     [Fact]

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/CycleTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/CycleTests.cs
@@ -21,8 +21,8 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
 
         var deserialized = (NodeWithValueISerializable)Deserialize(stream);
 
-        deserialized.Value.Should().Be(42);
-        deserialized.Node.Should().BeSameAs(deserialized);
+        Assert.Equal(42, deserialized.Value);
+        Assert.Same(deserialized, deserialized.Node);
     }
 
     [Fact]
@@ -44,9 +44,9 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
         Stream stream = Serialize(node1);
 
         var deserialized = (NodeWithValueISerializable)Deserialize(stream);
-        deserialized.Value.Should().Be(42);
-        deserialized.Node!.Value.Should().Be(43);
-        deserialized.Node.Node.Should().BeSameAs(deserialized);
+        Assert.Equal(42, deserialized.Value);
+        Assert.Equal(43, deserialized.Node!.Value);
+        Assert.Same(deserialized, deserialized.Node.Node);
     }
 
     [Fact]
@@ -60,8 +60,8 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
 
         // BinaryFormatter doesn't handle this round trip.
         var deserialized = (ClassWithValueISerializable<StructWithReferenceISerializable<object>>)Deserialize(stream);
-        deserialized.Value.Value.Should().Be(42);
-        deserialized.Value.Reference.Should().BeSameAs(deserialized);
+        Assert.Equal(42, deserialized.Value.Value);
+        Assert.Same(deserialized, deserialized.Value.Reference);
     }
 
     [Fact]
@@ -75,10 +75,10 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
         Stream stream = Serialize(nints);
         var deserialized = (StructWithSelfArrayReferenceISerializable[])Deserialize(stream);
 
-        deserialized[0].Value.Should().Be(42);
-        deserialized[1].Value.Should().Be(43);
-        deserialized[2].Value.Should().Be(44);
-        deserialized[0].Array.Should().BeSameAs(deserialized);
+        Assert.Equal(42, deserialized[0].Value);
+        Assert.Equal(43, deserialized[1].Value);
+        Assert.Equal(44, deserialized[2].Value);
+        Assert.Same(deserialized, deserialized[0].Array);
     }
 
     [Fact]
@@ -89,8 +89,8 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
 
         NodeWithNodeStruct deserialized = (NodeWithNodeStruct)Deserialize(Serialize(node));
 
-        deserialized.NodeStruct.Node.Should().BeSameAs(deserialized);
-        deserialized.Value.Should().Be("Root");
+        Assert.Same(deserialized, deserialized.NodeStruct.Node);
+        Assert.Equal("Root", deserialized.Value);
     }
 
     [Fact]
@@ -103,9 +103,9 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
 
         NodeWithNodeStruct deserialized = (NodeWithNodeStruct)Deserialize(Serialize(node));
 
-        deserialized.Value.Should().Be("Root");
-        deserialized.NodeStruct.Node!.NodeStruct.Node.Should().BeSameAs(deserialized);
-        deserialized.NodeStruct.Node!.Value.Should().Be("Node2");
+        Assert.Equal("Root", deserialized.Value);
+        Assert.Same(deserialized, deserialized.NodeStruct.Node!.NodeStruct.Node);
+        Assert.Equal("Node2", deserialized.NodeStruct.Node!.Value);
     }
 
     [Fact]
@@ -115,13 +115,13 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
         root.Left = root;
 
         BinaryTreeNode deserialized = (BinaryTreeNode)Deserialize(Serialize(root));
-        deserialized.Left.Should().BeSameAs(deserialized);
-        deserialized.Right.Should().BeNull();
+        Assert.Same(deserialized, deserialized.Left);
+        Assert.Null(deserialized.Right);
 
         root.Right = root.Left;
         deserialized = (BinaryTreeNode)Deserialize(Serialize(root));
-        deserialized.Left.Should().BeSameAs(deserialized);
-        deserialized.Right.Should().BeSameAs(deserialized);
+        Assert.Same(deserialized, deserialized.Left);
+        Assert.Same(deserialized, deserialized.Right);
     }
 
     [Fact]
@@ -131,12 +131,12 @@ public abstract class CycleTests<T> : SerializationTest<T> where T : ISerializer
         root.Left = root;
 
         var deserialized = (BinaryTreeNodeISerializable)Deserialize(Serialize(root));
-        deserialized.Left.Should().BeSameAs(deserialized);
-        deserialized.Right.Should().BeNull();
+        Assert.Same(deserialized, deserialized.Left);
+        Assert.Null(deserialized.Right);
 
         root.Right = root.Left;
         deserialized = (BinaryTreeNodeISerializable)Deserialize(Serialize(root));
-        deserialized.Left.Should().BeSameAs(deserialized);
-        deserialized.Right.Should().BeSameAs(deserialized);
+        Assert.Same(deserialized, deserialized.Left);
+        Assert.Same(deserialized, deserialized.Right);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/EventOrderTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/EventOrderTests.cs
@@ -20,7 +20,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("roots", "rootp", "rooti");
+            Assert.Equal(["roots", "rootp", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -40,7 +40,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -57,7 +57,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("values", "roots", "valuep", "rootp", "valuei", "rooti");
+            Assert.Equal(["values", "roots", "valuep", "rootp", "valuei", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -74,7 +74,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("rootp", "rooti");
+            Assert.Equal(["rootp", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -93,7 +93,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             Stream stream = Serialize(root);
             Deserialize(stream, surrogateSelector: selector);
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("roots", "rootp", "rooti");
+            Assert.Equal(["roots", "rootp", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -113,7 +113,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -130,7 +130,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("values", "valuep", "rootp", "valuei", "rooti");
+            Assert.Equal(["values", "valuep", "rootp", "valuei", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -152,7 +152,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             Stream stream = Serialize(root);
             Deserialize(stream, surrogateSelector: selector);
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -171,7 +171,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             Stream stream = Serialize(root);
             Deserialize(stream, surrogateSelector: selector);
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("values", "roots", "valuep", "rootp", "valuei", "rooti");
+            Assert.Equal(["values", "roots", "valuep", "rootp", "valuei", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -194,7 +194,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -214,7 +214,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -231,7 +231,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("values", "roots", "valuep", "rootp", "valuei", "rooti");
+            Assert.Equal(["values", "roots", "valuep", "rootp", "valuei", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -249,7 +249,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("rootp", "rooti");
+            Assert.Equal(["rootp", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -275,7 +275,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             {
                 Deserialize(stream, surrogateSelector: selector);
                 List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-                deserializeOrder.Should().Equal("roots", "rootp", "rooti");
+                Assert.Equal(["roots", "rootp", "rooti"], deserializeOrder);
             }
         }
         finally
@@ -297,7 +297,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -315,7 +315,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal("values", "valuep", "rootp", "valuei", "rooti");
+            Assert.Equal(["values", "valuep", "rootp", "valuei", "rooti"], deserializeOrder);
         }
         finally
         {
@@ -340,7 +340,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -361,7 +361,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -382,7 +382,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -408,7 +408,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -429,7 +429,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -452,7 +452,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             Stream stream = Serialize(root);
             Deserialize(stream, surrogateSelector: selector);
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -473,7 +473,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -494,7 +494,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -518,7 +518,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -539,7 +539,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -560,7 +560,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -582,7 +582,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -603,14 +603,13 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             Stream stream = Serialize(root);
             if (IsBinaryFormatterDeserializer)
             {
-                Action action = () => Deserialize(stream, surrogateSelector: selector);
-                action.Should().Throw<SerializationException>();
+                Assert.Throws<SerializationException>(() => Deserialize(stream, surrogateSelector: selector));
             }
             else
             {
                 Deserialize(stream, surrogateSelector: selector);
                 List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-                deserializeOrder.Should().Equal("childs", "roots", "childp", "rootp", "childi", "rooti");
+                Assert.Equal(["childs", "roots", "childp", "rootp", "childi", "rooti"], deserializeOrder);
             }
         }
         finally
@@ -633,7 +632,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -655,7 +654,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -681,7 +680,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -703,7 +702,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -725,7 +724,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -752,7 +751,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -774,7 +773,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -798,7 +797,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             Stream stream = Serialize(root);
             Deserialize(stream, surrogateSelector: selector);
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -820,7 +819,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -842,7 +841,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -867,7 +866,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -889,7 +888,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -911,7 +910,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -934,7 +933,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -956,14 +955,13 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
             Stream stream = Serialize(root);
             if (IsBinaryFormatterDeserializer)
             {
-                Action action = () => Deserialize(stream, surrogateSelector: selector);
-                action.Should().Throw<SerializationException>();
+                Assert.Throws<SerializationException>(() => Deserialize(stream, surrogateSelector: selector));
             }
             else
             {
                 Deserialize(stream, surrogateSelector: selector);
                 List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-                deserializeOrder.Should().Equal("child2s", "child1s", "roots", "child2p", "child1p", "rootp", "child2i", "child1i", "rooti");
+                Assert.Equal(["child2s", "child1s", "roots", "child2p", "child1p", "rootp", "child2i", "child1i", "rooti"], deserializeOrder);
             }
         }
         finally
@@ -987,7 +985,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {
@@ -1010,7 +1008,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
         {
             Deserialize(Serialize(root));
             List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
-            deserializeOrder.Should().Equal(expected);
+            Assert.Equal(expected, deserializeOrder);
         }
         finally
         {

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/JaggedArrayTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/JaggedArrayTests.cs
@@ -13,7 +13,7 @@ public abstract class JaggedArrayTests<T> : SerializationTest<T> where T : ISeri
         Stream stream = Serialize(jaggedArray);
         object deserialized = Deserialize(stream);
 
-        deserialized.Should().BeEquivalentTo(jaggedArray);
+        Assert.Equal(jaggedArray, deserialized);
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public abstract class JaggedArrayTests<T> : SerializationTest<T> where T : ISeri
 
         Stream stream = Serialize(jaggedArray);
         object deserialized = Deserialize(stream);
-        deserialized.Should().BeEquivalentTo(jaggedArray);
+        Assert.Equal(jaggedArray, deserialized);
     }
 
     [Fact]
@@ -32,6 +32,6 @@ public abstract class JaggedArrayTests<T> : SerializationTest<T> where T : ISeri
         int[][] jaggedEmpty = new int[1][];
 
         object deserialized = Deserialize(Serialize(jaggedEmpty));
-        deserialized.Should().BeEquivalentTo(jaggedEmpty);
+        Assert.Equal(jaggedEmpty, deserialized);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/MultidimensionalArrayTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/MultidimensionalArrayTests.cs
@@ -21,7 +21,7 @@ public abstract class MultidimensionalArrayTests<T> : SerializationTest<T> where
         Stream stream = Serialize(twoDimensions);
 
         object deserialized = Deserialize(stream);
-        deserialized.Should().BeEquivalentTo(twoDimensions);
+        Assert.Equal(twoDimensions, deserialized);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public abstract class MultidimensionalArrayTests<T> : SerializationTest<T> where
         // Raw data will be 0, 1, 10, 11 in memory and in the binary stream
         object deserialized = Deserialize(Serialize(twoDimensions));
 
-        deserialized.Should().BeEquivalentTo(twoDimensions);
+        Assert.Equal(twoDimensions, deserialized);
 
         int[,,] threeDimensions = new int[2, 2, 2];
         threeDimensions[0, 0, 0] = 888;
@@ -49,7 +49,7 @@ public abstract class MultidimensionalArrayTests<T> : SerializationTest<T> where
         threeDimensions[1, 1, 1] = 111;
 
         deserialized = Deserialize(Serialize(threeDimensions));
-        deserialized.Should().BeEquivalentTo(threeDimensions);
+        Assert.Equal(threeDimensions, deserialized);
     }
 
     [Fact]
@@ -58,19 +58,19 @@ public abstract class MultidimensionalArrayTests<T> : SerializationTest<T> where
         // Didn't even know this was possible.
         int[,] twoDimensionOneEmpty = new int[1, 0];
         object deserialized = Deserialize(Serialize(twoDimensionOneEmpty));
-        deserialized.Should().BeEquivalentTo(twoDimensionOneEmpty);
+        Assert.Equal(twoDimensionOneEmpty, deserialized);
 
         int[,] twoDimensionEmptyOne = new int[0, 1];
         deserialized = Deserialize(Serialize(twoDimensionEmptyOne));
-        deserialized.Should().BeEquivalentTo(twoDimensionEmptyOne);
+        Assert.Equal(twoDimensionEmptyOne, deserialized);
 
         int[,] twoDimensionEmpty = new int[0, 0];
         deserialized = Deserialize(Serialize(twoDimensionEmpty));
-        deserialized.Should().BeEquivalentTo(twoDimensionEmpty);
+        Assert.Equal(twoDimensionEmpty, deserialized);
 
         int[,,] threeDimension = new int[1, 0, 1];
         deserialized = Deserialize(Serialize(threeDimension));
-        deserialized.Should().BeEquivalentTo(threeDimension);
+        Assert.Equal(threeDimension, deserialized);
     }
 
     [Theory]
@@ -82,7 +82,7 @@ public abstract class MultidimensionalArrayTests<T> : SerializationTest<T> where
         InitArray(array);
 
         Array deserialized = (Array)Deserialize(Serialize(array));
-        deserialized.Should().BeEquivalentTo(deserialized);
+        Assert.Equal(array, deserialized);
     }
 
     public static TheoryData<int[]> DimensionLengthsTestData { get; } = new()
@@ -108,7 +108,7 @@ public abstract class MultidimensionalArrayTests<T> : SerializationTest<T> where
         InitArray(array);
 
         Array deserialized = (Array)Deserialize(Serialize(array));
-        deserialized.Should().BeEquivalentTo(deserialized);
+        Assert.Equal(array, deserialized);
     }
 
     private static void InitArray(Array array)

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/ObjectReferenceTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/ObjectReferenceTests.cs
@@ -12,7 +12,7 @@ public abstract class ObjectReferenceTests<T> : SerializationTest<T> where T : I
     public void DBNull_Deserialize()
     {
         object deserialized = RoundTrip(DBNull.Value);
-        deserialized.Should().BeSameAs(DBNull.Value);
+        Assert.Same(DBNull.Value, deserialized);
     }
 
     [Theory]
@@ -20,7 +20,7 @@ public abstract class ObjectReferenceTests<T> : SerializationTest<T> where T : I
     public void SupportedTypes_Deserialize(object value)
     {
         object deserialized = RoundTrip(value);
-        deserialized.Should().NotBeNull();
+        Assert.NotNull(deserialized);
     }
 
     public static TheoryData<object> SupportedTypesTestData { get; } = new()
@@ -34,7 +34,7 @@ public abstract class ObjectReferenceTests<T> : SerializationTest<T> where T : I
     {
         // Representing singletons is the most common pattern for IObjectReference.
         object deserialized = RoundTrip(ObjectReferenceNoFields.Value);
-        deserialized.Should().BeSameAs(ObjectReferenceNoFields.Value);
+        Assert.Same(ObjectReferenceNoFields.Value, deserialized);
     }
 
     [Serializable]
@@ -51,7 +51,8 @@ public abstract class ObjectReferenceTests<T> : SerializationTest<T> where T : I
     public void NestedSurrogate_Deserialize()
     {
         object deserialized = RoundTrip(new SerializableWithNestedSurrogate { Message = "Hello" });
-        deserialized.Should().BeOfType<SerializableWithNestedSurrogate>().Which.Message.Should().Be("Hello");
+        Assert.IsType<SerializableWithNestedSurrogate>(deserialized);
+        Assert.Equal("Hello", ((SerializableWithNestedSurrogate)deserialized).Message);
     }
 
     [Serializable]
@@ -89,10 +90,12 @@ public abstract class ObjectReferenceTests<T> : SerializationTest<T> where T : I
     public void NestedSurrogate_NullableEnum_Deserialize()
     {
         object deserialized = RoundTrip(new SerializableWithNestedSurrogate_NullableEnum());
-        deserialized.Should().BeOfType<SerializableWithNestedSurrogate_NullableEnum>().Which.Day.Should().BeNull();
+        Assert.IsType<SerializableWithNestedSurrogate_NullableEnum>(deserialized);
+        Assert.Null(((SerializableWithNestedSurrogate_NullableEnum)deserialized).Day);
 
         deserialized = RoundTrip(new SerializableWithNestedSurrogate_NullableEnum { Day = DayOfWeek.Monday });
-        deserialized.Should().BeOfType<SerializableWithNestedSurrogate_NullableEnum>().Which.Day.Should().Be(DayOfWeek.Monday);
+        Assert.IsType<SerializableWithNestedSurrogate_NullableEnum>(deserialized);
+        Assert.Equal(DayOfWeek.Monday, ((SerializableWithNestedSurrogate_NullableEnum)deserialized).Day);
     }
 
     [Serializable]

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/StressTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/StressTests.cs
@@ -23,7 +23,7 @@ public abstract class StressTests<T> : SerializationTest<T> where T : ISerialize
         }
 
         SimpleNode deserialized = (SimpleNode)Deserialize(Serialize(root));
-        deserialized.Next.Should().NotBeNull();
-        deserialized.Next.Should().NotBeSameAs(deserialized);
+        Assert.NotNull(deserialized.Next);
+        Assert.NotSame(deserialized, deserialized.Next);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/SurrogateTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/SurrogateTests.cs
@@ -36,7 +36,7 @@ public abstract class SurrogateTests<T> : SerializationTest<T> where T : ISerial
         SurrogateSelector selector = CreateSurrogateSelector<Point>(new PointSerializationSurrogate(refUnbox: true));
 
         Point deserialized = (Point)Deserialize(stream, surrogateSelector: selector);
-        deserialized.Should().Be(point);
+        Assert.Equal(point, deserialized);
     }
 
     public class PointSerializationSurrogate : ISerializationSurrogate
@@ -76,8 +76,8 @@ public abstract class SurrogateTests<T> : SerializationTest<T> where T : ISerial
         SurrogateSelector selector = CreateSurrogateSelector<Point>(new NullSurrogate());
         Point deserialized = (Point)Deserialize(stream, surrogateSelector: selector);
 
-        deserialized.X.Should().Be(0);
-        deserialized.Y.Should().Be(0);
+        Assert.Equal(0, deserialized.X);
+        Assert.Equal(0, deserialized.Y);
     }
 
     public class NullSurrogate : ISerializationSurrogate
@@ -104,15 +104,14 @@ public abstract class SurrogateTests<T> : SerializationTest<T> where T : ISerial
     public void SerializeNonSerializableTypeWithSurrogate()
     {
         NonSerializablePair<int, string> pair = new() { Value1 = 1, Value2 = "2" };
-        pair.GetType().IsSerializable.Should().BeFalse();
-        Action action = () => Serialize(pair);
-        action.Should().Throw<SerializationException>();
+        Assert.False(pair.GetType().IsSerializable);
+        Assert.Throws<SerializationException>(() => Serialize(pair));
 
         SurrogateSelector selector = CreateSurrogateSelector<NonSerializablePair<int, string>>(new NonSerializablePairSurrogate());
 
         var deserialized = RoundTrip(pair, surrogateSelector: selector);
-        deserialized.Should().NotBeSameAs(pair);
-        deserialized.Value1.Should().Be(pair.Value1);
-        deserialized.Value2.Should().Be(pair.Value2);
+        Assert.NotSame(pair, deserialized);
+        Assert.Equal(pair.Value1, deserialized.Value1);
+        Assert.Equal(pair.Value2, deserialized.Value2);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/SystemDrawingTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/Common/SystemDrawingTests.cs
@@ -18,7 +18,7 @@ public abstract class SystemDrawingTests<T> : SerializationTest<T> where T : ISe
     {
         using Bitmap bitmap = new(10, 10);
         using var deserialized = RoundTrip(bitmap, typeStyle: typeStyle, assemblyMatching: assemblyMatching);
-        deserialized.Size.Should().Be(bitmap.Size);
+        Assert.Equal(bitmap.Size, deserialized.Size);
     }
 
     [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.SupportsComInterop))]
@@ -29,7 +29,7 @@ public abstract class SystemDrawingTests<T> : SerializationTest<T> where T : ISe
         byte[] rawInlineImageBytes = Convert.FromBase64String(TestResources.TestPng);
         using Bitmap bitmap = new(new MemoryStream(rawInlineImageBytes));
         using var deserialized = RoundTrip(bitmap, typeStyle: typeStyle, assemblyMatching: assemblyMatching);
-        deserialized.Size.Should().Be(bitmap.Size);
-        deserialized.RawFormat.Should().Be(bitmap.RawFormat);
+        Assert.Equal(bitmap.Size, deserialized.Size);
+        Assert.Equal(bitmap.RawFormat, deserialized.RawFormat);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/ArrayTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/ArrayTests.cs
@@ -12,8 +12,7 @@ public class ArrayTests : Common.ArrayTests<FormattedObjectSerializer>
 {
     public override void Roundtrip_ArrayContainingArrayAtNonZeroLowerBound()
     {
-        Action action = base.Roundtrip_ArrayContainingArrayAtNonZeroLowerBound;
-        action.Should().Throw<NotSupportedException>();
+        Assert.Throws<NotSupportedException>(base.Roundtrip_ArrayContainingArrayAtNonZeroLowerBound);
     }
 
     [Theory]
@@ -22,7 +21,7 @@ public class ArrayTests : Common.ArrayTests<FormattedObjectSerializer>
     {
         BinaryFormattedObject format = new(Serialize(strings));
         var arrayRecord = (SZArrayRecord<string>)format.RootRecord;
-        arrayRecord.GetArray().Should().BeEquivalentTo(strings);
+        Assert.Equal(strings, arrayRecord.GetArray());
     }
 
     public static TheoryData<string?[]> StringArray_Parse_Data => new()
@@ -38,7 +37,7 @@ public class ArrayTests : Common.ArrayTests<FormattedObjectSerializer>
     {
         BinaryFormattedObject format = new(Serialize(array));
         var arrayRecord = (ArrayRecord)format.RootRecord;
-        arrayRecord.GetArray(expectedArrayType: array.GetType()).Should().BeEquivalentTo(array);
+        Assert.Equal(array, arrayRecord.GetArray(expectedArrayType: array.GetType()));
     }
 
     public static TheoryData<Array> PrimitiveArray_Parse_Data => new()

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/BasicObjectTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/BasicObjectTests.cs
@@ -37,6 +37,6 @@ public class BasicObjectTests : Common.BasicObjectTests<FormattedObjectSerialize
         serialized.Position = 0;
 
         // Now compare the two streams to ensure they are identical
-        deserializedSerialized.Length.Should().Be(serialized.Length);
+        Assert.Equal(serialized.Length, deserializedSerialized.Length);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/BinaryFormattedObjectTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/BinaryFormattedObjectTests.cs
@@ -15,8 +15,8 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
     public void ReadHeader()
     {
         BinaryFormattedObject format = new(Serialize("Hello World."));
-        format.RootRecord.Id.Should().NotBe(default);
-        format[format.RootRecord.Id].Should().Be(format.RootRecord);
+        Assert.NotEqual(default, format.RootRecord.Id);
+        Assert.Equal(format.RootRecord, format[format.RootRecord.Id]);
     }
 
     [Theory]
@@ -27,7 +27,7 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
     {
         BinaryFormattedObject format = new(Serialize(testString));
         PrimitiveTypeRecord<string> stringRecord = (PrimitiveTypeRecord<string>)format[format.RootRecord.Id];
-        stringRecord.Value.Should().Be(testString);
+        Assert.Equal(testString, stringRecord.Value);
     }
 
     [Fact]
@@ -39,16 +39,16 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         VerifyHashTable(systemClass, expectedVersion: 0, expectedHashSize: 3);
 
         SZArrayRecord<object> keys = (SZArrayRecord<object>)systemClass.GetSerializationRecord("Keys")!;
-        keys.Length.Should().Be(0);
+        Assert.Equal(0, keys.Length);
         SZArrayRecord<object> values = (SZArrayRecord<object>)systemClass.GetSerializationRecord("Values")!;
-        values.Length.Should().Be(0);
+        Assert.Equal(0, values.Length);
     }
 
     private static void VerifyHashTable(ClassRecord systemClass, int expectedVersion, int expectedHashSize)
     {
-        systemClass.RecordType.Should().Be(SerializationRecordType.SystemClassWithMembersAndTypes);
-        systemClass.TypeName.FullName.Should().Be("System.Collections.Hashtable");
-        systemClass.MemberNames.Should().BeEquivalentTo(
+        Assert.Equal(SerializationRecordType.SystemClassWithMembersAndTypes, systemClass.RecordType);
+        Assert.Equal("System.Collections.Hashtable", systemClass.TypeName.FullName);
+        Assert.Equal(
         [
             "LoadFactor",
             "Version",
@@ -57,13 +57,13 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
             "HashSize",
             "Keys",
             "Values"
-        ]);
+        ], systemClass.MemberNames);
 
-        systemClass.GetSingle("LoadFactor").Should().Be(0.72f);
-        systemClass.GetInt32("Version").Should().Be(expectedVersion);
-        systemClass.GetRawValue("Comparer").Should().BeNull();
-        systemClass.GetRawValue("HashCodeProvider").Should().BeNull();
-        systemClass.GetInt32("HashSize").Should().Be(expectedHashSize);
+        Assert.Equal(0.72f, systemClass.GetSingle("LoadFactor"));
+        Assert.Equal(expectedVersion, systemClass.GetInt32("Version"));
+        Assert.Null(systemClass.GetRawValue("Comparer"));
+        Assert.Null(systemClass.GetRawValue("HashCodeProvider"));
+        Assert.Equal(expectedHashSize, systemClass.GetInt32("HashSize"));
     }
 
     [Fact]
@@ -78,11 +78,11 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         VerifyHashTable(systemClass, expectedVersion: 1, expectedHashSize: 3);
 
         SZArrayRecord<object> keys = (SZArrayRecord<object>)format[systemClass.GetArrayRecord("Keys").Id];
-        keys.Length.Should().Be(1);
-        keys.GetArray().Single().Should().Be("This");
+        Assert.Equal(1, keys.Length);
+        Assert.Equal("This", keys.GetArray().Single());
         SZArrayRecord<object> values = (SZArrayRecord<object>)format[systemClass.GetArrayRecord("Values").Id];
-        values.Length.Should().Be(1);
-        values.GetArray().Single().Should().Be("That");
+        Assert.Equal(1, values.Length);
+        Assert.Equal("That", values.GetArray().Single());
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         // The collections themselves get ids first before the strings do.
         // Everything in the second keys is a string reference.
         SZArrayRecord<object> array = (SZArrayRecord<object>)systemClass.GetSerializationRecord("Keys")!;
-        array.GetArray().Should().BeEquivalentTo(["This", "TheOther", "That"]);
+        Assert.Equivalent(new object[] { "TheOther", "That", "This" }, array.GetArray());
     }
 
     [Fact]
@@ -120,17 +120,17 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         // The collections themselves get ids first before the strings do.
         // Everything in the second keys is a string reference.
         SZArrayRecord<object> keys = (SZArrayRecord<object>)systemClass.GetSerializationRecord("Keys")!;
-        keys.GetArray().Should().BeEquivalentTo(new object[] { "Yowza", "Youza", "Meeza" });
+        Assert.Equivalent(new object[] { "Yowza", "Youza", "Meeza" }, keys.GetArray());
 
         SZArrayRecord<object?> values = (SZArrayRecord<object?>)systemClass.GetSerializationRecord("Values")!;
-        values.GetArray().Should().BeEquivalentTo(new object?[] { null, null, null });
+        Assert.Equal(new object?[] { null, null, null }, values.GetArray());
     }
 
     [Fact]
     public void ReadObject()
     {
         BinaryFormattedObject format = new(Serialize(new object()));
-        format[format.RootRecord.Id].RecordType.Should().Be(SerializationRecordType.SystemClassWithMembersAndTypes);
+        Assert.Equal(SerializationRecordType.SystemClassWithMembersAndTypes, format[format.RootRecord.Id].RecordType);
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
     {
         ValueTuple<int> tuple = new(355);
         BinaryFormattedObject format = new(Serialize(tuple));
-        format[format.RootRecord.Id].RecordType.Should().Be(SerializationRecordType.SystemClassWithMembersAndTypes);
+        Assert.Equal(SerializationRecordType.SystemClassWithMembersAndTypes, format[format.RootRecord.Id].RecordType);
     }
 
     [Fact]
@@ -147,10 +147,10 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(new SimpleSerializableObject()));
 
         ClassRecord @class = (ClassRecord)format.RootRecord;
-        @class.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
-        @class.TypeName.FullName.Should().Be(typeof(SimpleSerializableObject).FullName);
-        @class.TypeName.AssemblyName!.FullName.Should().Be(typeof(SimpleSerializableObject).Assembly.FullName);
-        @class.MemberNames.Should().BeEmpty();
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, @class.RecordType);
+        Assert.Equal(typeof(SimpleSerializableObject).FullName, @class.TypeName.FullName);
+        Assert.Equal(typeof(SimpleSerializableObject).Assembly.FullName, @class.TypeName.AssemblyName!.FullName);
+        Assert.Empty(@class.MemberNames);
     }
 
     [Fact]
@@ -159,12 +159,12 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(new NestedSerializableObject()));
 
         ClassRecord @class = (ClassRecord)format.RootRecord;
-        @class.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
-        @class.TypeName.FullName.Should().Be(typeof(NestedSerializableObject).FullName);
-        @class.TypeName.AssemblyName!.FullName.Should().Be(typeof(NestedSerializableObject).Assembly.FullName);
-        @class.MemberNames.Should().BeEquivalentTo(["_object", "_meaning"]);
-        @class.GetRawValue("_object").Should().NotBeNull();
-        @class.GetInt32("_meaning").Should().Be(42);
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, @class.RecordType);
+        Assert.Equal(typeof(NestedSerializableObject).FullName, @class.TypeName.FullName);
+        Assert.Equal(typeof(NestedSerializableObject).Assembly.FullName, @class.TypeName.AssemblyName!.FullName);
+        Assert.Equal(["_object", "_meaning"], @class.MemberNames);
+        Assert.NotNull(@class.GetRawValue("_object"));
+        Assert.Equal(42, @class.GetInt32("_meaning"));
     }
 
     [Fact]
@@ -173,12 +173,12 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(new TwoIntSerializableObject()));
 
         ClassRecord @class = (ClassRecord)format.RootRecord;
-        @class.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
-        @class.TypeName.FullName.Should().Be(typeof(TwoIntSerializableObject).FullName);
-        @class.TypeName.AssemblyName!.FullName.Should().Be(typeof(TwoIntSerializableObject).Assembly.FullName);
-        @class.MemberNames.Should().BeEquivalentTo(["_value", "_meaning"]);
-        @class.GetRawValue("_value").Should().Be(1970);
-        @class.GetInt32("_meaning").Should().Be(42);
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, @class.RecordType);
+        Assert.Equal(typeof(TwoIntSerializableObject).FullName, @class.TypeName.FullName);
+        Assert.Equal(typeof(TwoIntSerializableObject).Assembly.FullName, @class.TypeName.AssemblyName!.FullName);
+        Assert.Equal(["_value", "_meaning"], @class.MemberNames);
+        Assert.Equal(1970, @class.GetRawValue("_value"));
+        Assert.Equal(42, @class.GetInt32("_meaning"));
     }
 
     [Fact]
@@ -187,11 +187,11 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(new RepeatedNestedSerializableObject()));
         ClassRecord classRecord = (ClassRecord)format.RootRecord;
         ClassRecord firstClass = classRecord.GetClassRecord("_first");
-        firstClass.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, firstClass.RecordType);
         ClassRecord classWithId = classRecord.GetClassRecord("_second");
-        classWithId.RecordType.Should().Be(SerializationRecordType.ClassWithId);
-        classWithId.GetRawValue("_value").Should().Be(1970);
-        classWithId.GetInt32("_meaning").Should().Be(42);
+        Assert.Equal(SerializationRecordType.ClassWithId, classWithId.RecordType);
+        Assert.Equal(1970, classWithId.GetRawValue("_value"));
+        Assert.Equal(42, classWithId.GetInt32("_meaning"));
     }
 
     [Fact]
@@ -202,8 +202,7 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(input));
 
         SZArrayRecord<int> array = (SZArrayRecord<int>)format[format.RootRecord.Id];
-        array.Length.Should().Be(4);
-        array.GetArray().Should().BeEquivalentTo(input);
+        Assert.Equal(input, array.GetArray());
     }
 
     [Fact]
@@ -214,9 +213,8 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(input));
 
         SZArrayRecord<string> array = (SZArrayRecord<string>)format[format.RootRecord.Id];
-        array.Length.Should().Be(3);
-        array.GetArray().Should().BeEquivalentTo(input);
-        format.RecordMap.Count.Should().Be(4);
+        Assert.Equal(input, array.GetArray());
+        Assert.Equal(4, format.RecordMap.Count);
     }
 
     [Fact]
@@ -227,8 +225,7 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(input));
 
         SZArrayRecord<string?> array = (SZArrayRecord<string?>)format[format.RootRecord.Id];
-        array.Length.Should().Be(6);
-        array.GetArray().Should().BeEquivalentTo(input);
+        Assert.Equal(input, array.GetArray());
     }
 
     [Fact]
@@ -239,9 +236,8 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(input));
 
         SZArrayRecord<string> array = (SZArrayRecord<string>)format[format.RootRecord.Id];
-        array.Length.Should().Be(3);
-        array.GetArray().Should().BeEquivalentTo(input);
-        format.RecordMap.Count.Should().Be(3);
+        Assert.Equal(input, array.GetArray());
+        Assert.Equal(3, format.RecordMap.Count);
     }
 
     [Fact]
@@ -249,8 +245,8 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
     {
         BinaryFormattedObject format = new(Serialize(new ObjectWithNullableObjects()));
         ClassRecord classRecord = (ClassRecord)format.RootRecord;
-        classRecord.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
-        classRecord.TypeName.AssemblyName!.FullName.Should().Be(typeof(ObjectWithNullableObjects).Assembly.FullName);
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, classRecord.RecordType);
+        Assert.Equal(typeof(ObjectWithNullableObjects).Assembly.FullName, classRecord.TypeName.AssemblyName!.FullName);
     }
 
     [Fact]
@@ -258,8 +254,8 @@ public class BinaryFormattedObjectTests : SerializationTest<FormattedObjectSeria
     {
         BinaryFormattedObject format = new(Serialize(new NestedObjectWithNullableObjects()));
         ClassRecord classRecord = (ClassRecord)format.RootRecord;
-        classRecord.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
-        classRecord.TypeName.AssemblyName!.FullName.Should().Be(typeof(NestedObjectWithNullableObjects).Assembly.FullName);
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, classRecord.RecordType);
+        Assert.Equal(typeof(NestedObjectWithNullableObjects).Assembly.FullName, classRecord.TypeName.AssemblyName!.FullName);
     }
 
     [Serializable]

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/ExceptionTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/ExceptionTests.cs
@@ -14,8 +14,8 @@ public class ExceptionTests : SerializationTest<FormattedObjectSerializer>
     {
         BinaryFormattedObject format = new(Serialize(new NotSupportedException()));
         var systemClass = (ClassRecord)format.RootRecord;
-        systemClass.TypeName.FullName.Should().Be(typeof(NotSupportedException).FullName);
-        systemClass.MemberNames.Should().BeEquivalentTo(
+        Assert.Equal(typeof(NotSupportedException).FullName, systemClass.TypeName.FullName);
+        Assert.Equal(
         [
             "ClassName",
             "Message",
@@ -29,19 +29,19 @@ public class ExceptionTests : SerializationTest<FormattedObjectSerializer>
             "HResult",
             "Source",
             "WatsonBuckets"
-        ]);
+        ], systemClass.MemberNames);
 
-        systemClass.GetString("ClassName").Should().Be("System.NotSupportedException");
-        systemClass.GetString("Message").Should().Be("Specified method is not supported.");
-        systemClass.GetRawValue("Data").Should().BeNull();
-        systemClass.GetRawValue("InnerException").Should().BeNull();
-        systemClass.GetRawValue("HelpURL").Should().BeNull();
-        systemClass.GetRawValue("StackTraceString").Should().BeNull();
-        systemClass.GetRawValue("RemoteStackTraceString").Should().BeNull();
-        systemClass.GetInt32("RemoteStackIndex").Should().Be(0);
-        systemClass.GetRawValue("ExceptionMethod").Should().BeNull();
-        systemClass.GetInt32("HResult").Should().Be(unchecked((int)0x80131515));
-        systemClass.GetRawValue("Source").Should().BeNull();
-        systemClass.GetRawValue("WatsonBuckets").Should().BeNull();
+        Assert.Equal("System.NotSupportedException", systemClass.GetString("ClassName"));
+        Assert.Equal("Specified method is not supported.", systemClass.GetString("Message"));
+        Assert.Null(systemClass.GetRawValue("Data"));
+        Assert.Null(systemClass.GetRawValue("InnerException"));
+        Assert.Null(systemClass.GetRawValue("HelpURL"));
+        Assert.Null(systemClass.GetRawValue("StackTraceString"));
+        Assert.Null(systemClass.GetRawValue("RemoteStackTraceString"));
+        Assert.Equal(0, systemClass.GetInt32("RemoteStackIndex"));
+        Assert.Null(systemClass.GetRawValue("ExceptionMethod"));
+        Assert.Equal(unchecked((int)0x80131515), systemClass.GetInt32("HResult"));
+        Assert.Null(systemClass.GetRawValue("Source"));
+        Assert.Null(systemClass.GetRawValue("WatsonBuckets"));
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/HashTableTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/HashTableTests.cs
@@ -25,37 +25,37 @@ public class HashtableTests : SerializationTest<FormattedObjectSerializer>
         // The converter isn't used for this scenario and can be a no-op.
         SerializationInfo info = new(typeof(Hashtable), FormatterConverterStub.Instance);
         hashtable.GetObjectData(info, default);
-        info.MemberCount.Should().Be(7);
+        Assert.Equal(7, info.MemberCount);
 
         var enumerator = info.GetEnumerator();
 
-        enumerator.MoveNext().Should().BeTrue();
-        enumerator.Current.Name.Should().Be("LoadFactor");
-        enumerator.Current.Value.Should().Be(0.72f);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("LoadFactor", enumerator.Current.Name);
+        Assert.Equal(0.72f, enumerator.Current.Value);
 
-        enumerator.MoveNext().Should().BeTrue();
-        enumerator.Current.Name.Should().Be("Version");
-        enumerator.Current.Value.Should().Be(1);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("Version", enumerator.Current.Name);
+        Assert.Equal(1, enumerator.Current.Value);
 
-        enumerator.MoveNext().Should().BeTrue();
-        enumerator.Current.Name.Should().Be("Comparer");
-        enumerator.Current.Value.Should().BeNull();
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("Comparer", enumerator.Current.Name);
+        Assert.Null(enumerator.Current.Value);
 
-        enumerator.MoveNext().Should().BeTrue();
-        enumerator.Current.Name.Should().Be("HashCodeProvider");
-        enumerator.Current.Value.Should().BeNull();
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("HashCodeProvider", enumerator.Current.Name);
+        Assert.Null(enumerator.Current.Value);
 
-        enumerator.MoveNext().Should().BeTrue();
-        enumerator.Current.Name.Should().Be("HashSize");
-        enumerator.Current.Value.Should().Be(3);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("HashSize", enumerator.Current.Name);
+        Assert.Equal(3, enumerator.Current.Value);
 
-        enumerator.MoveNext().Should().BeTrue();
-        enumerator.Current.Name.Should().Be("Keys");
-        enumerator.Current.Value.Should().BeEquivalentTo(new object[] { "This" });
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("Keys", enumerator.Current.Name);
+        Assert.Equal(new object[] { "This" }, enumerator.Current.Value);
 
-        enumerator.MoveNext().Should().BeTrue();
-        enumerator.Current.Name.Should().Be("Values");
-        enumerator.Current.Value.Should().BeEquivalentTo(new object[] { "That" });
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal("Values", enumerator.Current.Name);
+        Assert.Equal(new object[] { "That" }, enumerator.Current.Value);
     }
 
     [Fact]
@@ -68,12 +68,12 @@ public class HashtableTests : SerializationTest<FormattedObjectSerializer>
 
         BinaryFormattedObject format = new(Serialize(hashtable));
         ClassRecord systemClass = (ClassRecord)format.RootRecord;
-        systemClass.RecordType.Should().Be(SerializationRecordType.SystemClassWithMembersAndTypes);
-        systemClass.TypeName.FullName.Should().Be("System.Collections.Hashtable");
-        systemClass.GetSerializationRecord("Comparer")!.Should().BeAssignableTo<ClassRecord>().Which.TypeName.FullName.Should().Be("System.OrdinalComparer");
-        systemClass.GetSerializationRecord("HashCodeProvider")!.Should().BeAssignableTo<ClassRecord>().Which.TypeName.FullName.Should().Be("System.Resources.Extensions.Tests.FormattedObject.HashtableTests+CustomHashCodeProvider");
-        systemClass.GetSerializationRecord("Keys")!.Should().BeAssignableTo<SZArrayRecord<object>>();
-        systemClass.GetSerializationRecord("Values")!.Should().BeAssignableTo<SZArrayRecord<object>>();
+        Assert.Equal(SerializationRecordType.SystemClassWithMembersAndTypes, systemClass.RecordType);
+        Assert.Equal("System.Collections.Hashtable", systemClass.TypeName.FullName);
+        Assert.Equal("System.OrdinalComparer", systemClass.GetClassRecord("Comparer")!.TypeName.FullName);
+        Assert.Equal("System.Resources.Extensions.Tests.FormattedObject.HashtableTests+CustomHashCodeProvider", systemClass.GetClassRecord("HashCodeProvider")!.TypeName.FullName);
+        Assert.True(systemClass.GetSerializationRecord("Keys") is SZArrayRecord<object>);
+        Assert.True(systemClass.GetSerializationRecord("Values") is SZArrayRecord<object>);
     }
 
     [Serializable]

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/ListTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/ListTests.cs
@@ -19,16 +19,16 @@ public class ListTests : SerializationTest<FormattedObjectSerializer>
 
         VerifyArrayList((ClassRecord)format[format.RootRecord.Id]);
 
-        format[((ClassRecord)format.RootRecord).GetArrayRecord("_items").Id].Should().BeAssignableTo<SZArrayRecord<object>>();
+        Assert.True(format[((ClassRecord)format.RootRecord).GetArrayRecord("_items").Id] is SZArrayRecord<object>);
     }
 
     private static void VerifyArrayList(ClassRecord systemClass)
     {
-        systemClass.RecordType.Should().Be(SerializationRecordType.SystemClassWithMembersAndTypes);
+        Assert.Equal(SerializationRecordType.SystemClassWithMembersAndTypes, systemClass.RecordType);
 
-        systemClass.TypeName.FullName.Should().Be(typeof(ArrayList).FullName);
-        systemClass.MemberNames.Should().BeEquivalentTo(["_items", "_size", "_version"]);
-        systemClass.GetSerializationRecord("_items").Should().BeAssignableTo<SZArrayRecord<object>>();
+        Assert.Equal(typeof(ArrayList).FullName, systemClass.TypeName.FullName);
+        Assert.Equal(["_items", "_size", "_version"], systemClass.MemberNames);
+        Assert.True(systemClass.GetSerializationRecord("_items") is SZArrayRecord<object>);
     }
 
     [Theory]
@@ -45,7 +45,7 @@ public class ListTests : SerializationTest<FormattedObjectSerializer>
 
         SZArrayRecord<object> array = (SZArrayRecord<object>)format[listRecord.GetArrayRecord("_items").Id];
 
-        array.GetArray().Take(listRecord.GetInt32("_size")).Should().BeEquivalentTo(new[] { value });
+        Assert.Equal(new[] { value }, array.GetArray().Take(listRecord.GetInt32("_size")));
     }
 
     [Fact]
@@ -60,8 +60,7 @@ public class ListTests : SerializationTest<FormattedObjectSerializer>
         VerifyArrayList(listRecord);
 
         SZArrayRecord<object> array = (SZArrayRecord<object>)format[listRecord.GetArrayRecord("_items").Id];
-
-        array.GetArray().Take(listRecord.GetInt32("_size")).ToArray().Should().BeEquivalentTo(new object[] { "JarJar" });
+        Assert.Equal(new object[] { "JarJar" }, array.GetArray().Take(listRecord.GetInt32("_size")));
     }
 
     public static TheoryData<object> ArrayList_Primitive_Data => new()
@@ -126,13 +125,12 @@ public class ListTests : SerializationTest<FormattedObjectSerializer>
     {
         BinaryFormattedObject format = new(Serialize(new List<int>()));
         ClassRecord classInfo = (ClassRecord)format[format.RootRecord.Id];
-        classInfo.RecordType.Should().Be(SerializationRecordType.SystemClassWithMembersAndTypes);
+        Assert.Equal(SerializationRecordType.SystemClassWithMembersAndTypes, classInfo.RecordType);
 
         // Note that T types are serialized as the mscorlib type.
-        classInfo.TypeName.FullName.Should().Be(
-            "System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]");
+        Assert.Equal("System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", classInfo.TypeName.FullName);
 
-        classInfo.MemberNames.Should().BeEquivalentTo(
+        Assert.Equal(
         [
             "_items",
             // This is something that wouldn't be needed if List<T> implemented ISerializable. If we format
@@ -141,14 +139,14 @@ public class ListTests : SerializationTest<FormattedObjectSerializer>
             // It is a bit silly that _version gets serialized, it's only use is as a check to see if
             // the collection is modified while it is being enumerated.
             "_version"
-        ]);
+        ], classInfo.MemberNames);
 
-        classInfo.GetSerializationRecord("_items").Should().BeAssignableTo<SZArrayRecord<int>>();
-        classInfo.GetInt32("_size").Should().Be(0);
-        classInfo.GetInt32("_version").Should().Be(0);
+        Assert.True(classInfo.GetSerializationRecord("_items") is SZArrayRecord<int>);
+        Assert.Equal(0, classInfo.GetInt32("_size"));
+        Assert.Equal(0, classInfo.GetInt32("_version"));
 
         SZArrayRecord<int> array = (SZArrayRecord<int>)format[classInfo.GetArrayRecord("_items").Id];
-        array.Length.Should().Be(0);
+        Assert.Equal(0, array.Length);
     }
 
     [Fact]
@@ -157,12 +155,12 @@ public class ListTests : SerializationTest<FormattedObjectSerializer>
         BinaryFormattedObject format = new(Serialize(new List<string>()));
 
         ClassRecord classInfo = (ClassRecord)format[format.RootRecord.Id];
-        classInfo.RecordType.Should().Be(SerializationRecordType.SystemClassWithMembersAndTypes);
-        classInfo.TypeName.FullName.Should().StartWith("System.Collections.Generic.List`1[[System.String,");
-        classInfo.GetSerializationRecord("_items").Should().BeAssignableTo<SZArrayRecord<string>>();
+        Assert.Equal(SerializationRecordType.SystemClassWithMembersAndTypes, classInfo.RecordType);
+        Assert.StartsWith("System.Collections.Generic.List`1[[System.String,", classInfo.TypeName.FullName);
+        Assert.True(classInfo.GetSerializationRecord("_items") is SZArrayRecord<string>);
 
         SZArrayRecord<string> array = (SZArrayRecord<string>)format[classInfo.GetArrayRecord("_items").Id];
-        array.Length.Should().Be(0);
+        Assert.Equal(0, array.Length);
     }
 
     public static TheoryData<IList> Lists_UnsupportedTestData => new()

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/PrimitiveTypeTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/PrimitiveTypeTests.cs
@@ -79,7 +79,7 @@ public class PrimitiveTypeTests : SerializationTest<FormattedObjectSerializer>
     public void BinaryFormattedObject_ReadPrimitive(object value)
     {
         BinaryFormattedObject formattedObject = new(Serialize(value));
-        ((PrimitiveTypeRecord)formattedObject.RootRecord).Value.Should().Be(value);
+        Assert.Equal(value, ((PrimitiveTypeRecord)formattedObject.RootRecord).Value);
     }
 
     public static TheoryData<object> Primitive_Data => new()
@@ -117,7 +117,7 @@ public class PrimitiveTypeTests : SerializationTest<FormattedObjectSerializer>
 
     private static void VerifyGeneric<T>(T value, SerializationRecord record) where T : unmanaged
     {
-        record.As<PrimitiveTypeRecord>().Value.Should().Be(value);
-        record.As<PrimitiveTypeRecord<T>>().Value.Should().Be(value);
+        Assert.Equal(value, ((PrimitiveTypeRecord)record).Value);
+        Assert.Equal(value, ((PrimitiveTypeRecord<T>)record).Value);
     }
 }

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/SystemDrawingTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/SystemDrawingTests.cs
@@ -16,14 +16,14 @@ public class SystemDrawingTests : Common.SystemDrawingTests<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(input));
 
         ClassRecord classInfo = (ClassRecord)format.RootRecord;
-        classInfo.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
-        classInfo.Id.Should().NotBe(default);
-        format[format.RootRecord.Id].Should().Be(classInfo);
-        classInfo.TypeName.FullName.Should().Be("System.Drawing.PointF");
-        classInfo.TypeName.AssemblyName!.FullName.Should().Be("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-        classInfo.MemberNames.Should().BeEquivalentTo(["x", "y"]);
-        classInfo.GetSingle("x").Should().Be(input.X);
-        classInfo.GetSingle("y").Should().Be(input.Y);
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, classInfo.RecordType);
+        Assert.NotEqual(default, classInfo.Id);
+        Assert.Same(classInfo, format[format.RootRecord.Id]);
+        Assert.Equal("System.Drawing.PointF", classInfo.TypeName.FullName);
+        Assert.Equal("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", classInfo.TypeName.AssemblyName!.FullName);
+        Assert.Equal(["x", "y"], classInfo.MemberNames);
+        Assert.Equal(input.X, classInfo.GetSingle("x"));
+        Assert.Equal(input.Y, classInfo.GetSingle("y"));
     }
 
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported))]
@@ -33,15 +33,15 @@ public class SystemDrawingTests : Common.SystemDrawingTests<FormattedObjectSeria
         BinaryFormattedObject format = new(Serialize(input));
 
         ClassRecord classInfo = (ClassRecord)format.RootRecord;
-        classInfo.RecordType.Should().Be(SerializationRecordType.ClassWithMembersAndTypes);
-        classInfo.Id.Should().NotBe(default);
-        format[format.RootRecord.Id].Should().Be(classInfo);
-        classInfo.TypeName.FullName.Should().Be("System.Drawing.RectangleF");
-        classInfo.MemberNames.Should().BeEquivalentTo(["x", "y", "width", "height"]);
-        classInfo.GetSingle("x").Should().Be(input.X);
-        classInfo.GetSingle("y").Should().Be(input.Y);
-        classInfo.GetSingle("width").Should().Be(input.Width);
-        classInfo.GetSingle("height").Should().Be(input.Height);
+        Assert.Equal(SerializationRecordType.ClassWithMembersAndTypes, classInfo.RecordType);
+        Assert.NotEqual(default, classInfo.Id);
+        Assert.Same(classInfo, format[format.RootRecord.Id]);
+        Assert.Equal("System.Drawing.RectangleF", classInfo.TypeName.FullName);
+        Assert.Equal(["x", "y", "width", "height"], classInfo.MemberNames);
+        Assert.Equal(input.X, classInfo.GetSingle("x"));
+        Assert.Equal(input.Y, classInfo.GetSingle("y"));
+        Assert.Equal(input.Width, classInfo.GetSingle("width"));
+        Assert.Equal(input.Height, classInfo.GetSingle("height"));
     }
 
     public static TheoryData<object> SystemDrawing_TestData => new()

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/GlobalUsings.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/GlobalUsings.cs
@@ -6,4 +6,3 @@ global using System.Collections.Generic;
 global using System.Diagnostics;
 global using System.IO;
 global using Xunit;
-global using FluentAssertions;

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/System.Resources.Extensions.BinaryFormat.Tests.csproj
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/System.Resources.Extensions.BinaryFormat.Tests.csproj
@@ -35,7 +35,6 @@
   
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <ProjectReference Include="..\..\src\System.Resources.Extensions.csproj" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersVersion)" />


### PR DESCRIPTION
fixes #103278