### PR TITLE
Arm64/Sve: Enable Sve only if vector length is 128

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -80,9 +80,7 @@
 
 ;; uint64_t GetSveLengthFromOS(void);
     LEAF_ENTRY GetSveLengthFromOS
-        ;; TODO-SVE: Remove the hardcoded value 128 and uncomment once CI machines are updated to use MASM 14.4 or later
-        ;; rdvl    x0, 1
-        mov     x0, #128
+        rdvl    x0, 1
         ret     lr
     LEAF_END
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1514,8 +1514,8 @@ void EEJitManager::SetCpuInfo()
         uint32_t maxVectorTLength = (maxVectorTBitWidth / 8);
         uint64_t sveLengthFromOS = GetSveLengthFromOS();
 
-        // Do not enable SVE when the user specified vector length is smaller than the one offered by underlying OS.
-        if ((maxVectorTLength >= sveLengthFromOS) || (maxVectorTBitWidth == 0))
+        // Do not enable SVE when the system vector length is not 128-bits
+        if (sveLengthFromOS == 128)
         {
             CPUCompileFlags.Set(InstructionSet_Sve);
         }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1514,8 +1514,10 @@ void EEJitManager::SetCpuInfo()
         uint32_t maxVectorTLength = (maxVectorTBitWidth / 8);
         uint64_t sveLengthFromOS = GetSveLengthFromOS();
 
-        // Do not enable SVE when the system vector length is not 128-bits
+        // For now, enable only SVE when the system vector length is 128-bits
+        // TODO: https://github.com/dotnet/runtime/issues/101477
         if (sveLengthFromOS == 128)
+        // if ((maxVectorTLength >= sveLengthFromOS) || (maxVectorTBitWidth == 0))
         {
             CPUCompileFlags.Set(InstructionSet_Sve);
         }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1514,7 +1514,7 @@ void EEJitManager::SetCpuInfo()
         uint32_t maxVectorTLength = (maxVectorTBitWidth / 8);
         uint64_t sveLengthFromOS = GetSveLengthFromOS();
 
-        // For now, enable only SVE when the system vector length is 128-bits
+        // For now, enable SVE only when the system vector length is 128-bits
         // TODO: https://github.com/dotnet/runtime/issues/101477
         if (sveLengthFromOS == 128)
         // if ((maxVectorTLength >= sveLengthFromOS) || (maxVectorTBitWidth == 0))


### PR DESCRIPTION
In .NET 9, we will only support SVE if the system vector length of 128-bits. For supporting higher vector length, needs more work that will be done in future release.

References:
- https://github.com/dotnet/runtime/issues/101477 captures list of things need to be done to support higher vector length
- https://github.com/dotnet/runtime/pull/104065 changes in LSRA just save/restore NEON registers which are 128-bits in length.
- In scenarios like https://github.com/dotnet/runtime/pull/103801#discussion_r1659175596, we do not want to crash.