### PR TITLE
Check the VL in bytes instead of bits

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1514,9 +1514,9 @@ void EEJitManager::SetCpuInfo()
         uint32_t maxVectorTLength = (maxVectorTBitWidth / 8);
         uint64_t sveLengthFromOS = GetSveLengthFromOS();
 
-        // For now, enable SVE only when the system vector length is 128-bits
+        // For now, enable SVE only when the system vector length is 16 bytes (128-bits)
         // TODO: https://github.com/dotnet/runtime/issues/101477
-        if (sveLengthFromOS == 128)
+        if (sveLengthFromOS == 16)
         // if ((maxVectorTLength >= sveLengthFromOS) || (maxVectorTBitWidth == 0))
         {
             CPUCompileFlags.Set(InstructionSet_Sve);


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/104174, I was checking the returned value of `rdvl` in bits instead of bytes. Fixed it.