### PR TITLE
[NativeAOT] Optimize multicast delegate thunk

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -323,11 +323,11 @@ namespace Internal.IL.Stubs
 
             // ldarg.0 (this pointer)
             // ldfld Delegate._helperObject
-            // castclass Delegate.Wrapper[]
+            // castclass Delegate.Wrapper[] (omitted - generate unsafe cast assuming the delegate is well-formed)
             // stloc delegateArrayLocal
             codeStream.EmitLdArg(0);
             codeStream.Emit(ILOpcode.ldfld, emitter.NewToken(HelperObjectField));
-            codeStream.Emit(ILOpcode.castclass, emitter.NewToken(invocationListArrayType));
+            // codeStream.Emit(ILOpcode.castclass, emitter.NewToken(invocationListArrayType));
             codeStream.EmitStLoc(delegateArrayLocal);
 
             // Fill in invocationCountLocal

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -436,8 +436,12 @@ namespace ILCompiler
                     return false;
 
                 // Delegate invocation never needs fat calls
-                if (owningType.IsDelegate && containingMethod.Name == "Invoke")
-                    return false;
+                if (owningType.IsDelegate)
+                {
+                    string methodName = containingMethod.Name;
+                    if (methodName == "Invoke" || methodName == "InvokeMulticastThunk")
+                        return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
- Use RawCalli
- Use Unsafe cast of invocation list

These changes make the codegen of multicast delegate thunk to be more similar to CoreCLR w/ JIT.