### PR TITLE
Ensure rented array is always returned in `Measurement`

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
@@ -115,7 +115,10 @@ namespace System.Diagnostics.Metrics
             }
 
             if (count == 0)
+            {
+                ArrayPool<KeyValuePair<string, object?>>.Shared.Return(array);
                 return Instrument.EmptyTags;
+            }
 
             result = new KeyValuePair<string, object?>[count];
             array.AsSpan().Slice(0, count).CopyTo(result.AsSpan());


### PR DESCRIPTION
This fixes a small logic bug I missed when removing the `finally` block in the prior PR.

cc/ @tarekgh 