### PR TITLE
[mono][swift-interop] Enable SwiftInvalidCallConv tests on Mono runtime

### DIFF
--- a/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.csproj
+++ b/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.csproj
@@ -5,8 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Swift interop is supported on Apple platforms only -->
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsAppleMobile)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/93631 -->
-    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'mono'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
The `SwiftInvalidCallConv` tests were disabled but are passing locally, let's enable them.

x64 miniJIT CI result:
```
10:55:52.539 Running test: Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv/SwiftInvalidCallConv.cmd

Return code:      0
Raw output file:      /tmp/helix/working/A38F08F5/w/BA040A13/uploads/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv/output.txt
Raw output:
BEGIN EXECUTION
/tmp/helix/working/A38F08F5/p/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true SwiftInvalidCallConv.dll ''
Expected: 100
Actual: 100
END EXECUTION - PASSED
Test Harness Exitcode is : 0
To run the test:
Set up CORE_ROOT and run.
> /private/tmp/helix/working/A38F08F5/w/BA040A13/e/Interop/Interop/../Swift/SwiftInvalidCallConv/SwiftInvalidCallConv/SwiftInvalidCallConv.sh
10:55:52.722 Passed test: Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv/SwiftInvalidCallConv.cmd
```