### PR TITLE
InternalSetThreadPriority fails if raising priority on illumos

### DIFF
--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1183,7 +1183,7 @@ CorUnix::InternalSetThreadPriority(
     st = pthread_setschedparam(pTargetThread->GetPThreadSelf(), policy, &schedParam);
     if (st != 0)
     {
-#if SET_SCHEDPARAM_NEEDS_PRIVS
+#if SET_SCHEDPARAM_NEEDS_PRIVS || defined(__sun)
         if (EPERM == st)
         {
             // UNIXTODO: Should log a warning to the event log


### PR DESCRIPTION
Need SET_SCHEDPARAM_NEEDS_PRIVS behavior on illumos
Maybe could set this via configuration, but this way works too.
