### PR TITLE
Lower GetElement on arm64 to the correct access sequence

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -1649,6 +1649,10 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             case NI_Vector128_GetElement:
             {
                 assert(intrin.numOperands == 2);
+                assert(!intrin.op1->isContained());
+
+                assert(intrin.op2->OperIsConst());
+                assert(intrin.op2->isContained());
 
                 var_types simdType = Compiler::getSIMDTypeForSize(node->GetSimdSize());
 
@@ -1658,109 +1662,22 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                     simdType = TYP_SIMD16;
                 }
 
-                if (!intrin.op2->OperIsConst())
-                {
-                    assert(!intrin.op2->isContained());
+                ssize_t ival = intrin.op2->AsIntCon()->IconValue();
 
-                    emitAttr baseTypeSize  = emitTypeSize(intrin.baseType);
-                    unsigned baseTypeScale = genLog2(EA_SIZE_IN_BYTES(baseTypeSize));
-
-                    regNumber baseReg;
-                    regNumber indexReg = op2Reg;
-
-                    // Optimize the case of op1 is in memory and trying to access i'th element.
-                    if (!intrin.op1->isUsedFromReg())
-                    {
-                        assert(intrin.op1->isContained());
-
-                        if (intrin.op1->OperIsLocal())
-                        {
-                            unsigned varNum = intrin.op1->AsLclVarCommon()->GetLclNum();
-                            baseReg         = internalRegisters.Extract(node);
-
-                            // Load the address of varNum
-                            GetEmitter()->emitIns_R_S(INS_lea, EA_PTRSIZE, baseReg, varNum, 0);
-                        }
-                        else
-                        {
-                            // Require GT_IND addr to be not contained.
-                            assert(intrin.op1->OperIs(GT_IND));
-
-                            GenTree* addr = intrin.op1->AsIndir()->Addr();
-                            assert(!addr->isContained());
-                            baseReg = addr->GetRegNum();
-                        }
-                    }
-                    else
-                    {
-                        unsigned simdInitTempVarNum = compiler->lvaSIMDInitTempVarNum;
-                        noway_assert(simdInitTempVarNum != BAD_VAR_NUM);
-
-                        baseReg = internalRegisters.Extract(node);
-
-                        // Load the address of simdInitTempVarNum
-                        GetEmitter()->emitIns_R_S(INS_lea, EA_PTRSIZE, baseReg, simdInitTempVarNum, 0);
-
-                        // Store the vector to simdInitTempVarNum
-                        GetEmitter()->emitIns_R_R(INS_str, emitTypeSize(simdType), op1Reg, baseReg);
-                    }
-
-                    assert(genIsValidIntReg(indexReg));
-                    assert(genIsValidIntReg(baseReg));
-                    assert(baseReg != indexReg);
-
-                    // Load item at baseReg[index]
-                    GetEmitter()->emitIns_R_R_R_Ext(ins_Load(intrin.baseType), baseTypeSize, targetReg, baseReg,
-                                                    indexReg, INS_OPTS_LSL, baseTypeScale);
-                }
-                else if (!GetEmitter()->isValidVectorIndex(emitTypeSize(simdType), emitTypeSize(intrin.baseType),
-                                                           intrin.op2->AsIntCon()->IconValue()))
+                if (!GetEmitter()->isValidVectorIndex(emitTypeSize(simdType), emitTypeSize(intrin.baseType), ival))
                 {
                     // We only need to generate code for the get if the index is valid
                     // If the index is invalid, previously generated for the range check will throw
+                    break;
                 }
-                else if (!intrin.op1->isUsedFromReg())
+
+                if ((varTypeIsFloating(intrin.baseType) && (targetReg == op1Reg) && (ival == 0)))
                 {
-                    assert(intrin.op1->isContained());
-                    assert(intrin.op2->IsCnsIntOrI());
-
-                    int         offset = (int)intrin.op2->AsIntCon()->IconValue() * genTypeSize(intrin.baseType);
-                    instruction ins    = ins_Load(intrin.baseType);
-
-                    assert(!intrin.op1->isUsedFromReg());
-
-                    if (intrin.op1->OperIsLocal())
-                    {
-                        unsigned varNum = intrin.op1->AsLclVarCommon()->GetLclNum();
-                        GetEmitter()->emitIns_R_S(ins, emitActualTypeSize(intrin.baseType), targetReg, varNum, offset);
-                    }
-                    else
-                    {
-                        assert(intrin.op1->OperIs(GT_IND));
-
-                        GenTree* addr = intrin.op1->AsIndir()->Addr();
-                        assert(!addr->isContained());
-                        regNumber baseReg = addr->GetRegNum();
-
-                        // ldr targetReg, [baseReg, #offset]
-                        GetEmitter()->emitIns_R_R_I(ins, emitActualTypeSize(intrin.baseType), targetReg, baseReg,
-                                                    offset);
-                    }
-                }
-                else
-                {
-                    assert(intrin.op2->IsCnsIntOrI());
-                    ssize_t indexValue = intrin.op2->AsIntCon()->IconValue();
-
                     // no-op if vector is float/double, targetReg == op1Reg and fetching for 0th index.
-                    if ((varTypeIsFloating(intrin.baseType) && (targetReg == op1Reg) && (indexValue == 0)))
-                    {
-                        break;
-                    }
-
-                    GetEmitter()->emitIns_R_R_I(ins, emitTypeSize(intrin.baseType), targetReg, op1Reg, indexValue,
-                                                INS_OPTS_NONE);
+                    break;
                 }
+
+                GetEmitter()->emitIns_R_R_I(ins, emitTypeSize(intrin.baseType), targetReg, op1Reg, ival, INS_OPTS_NONE);
                 break;
             }
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1324,20 +1324,21 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
                 }
                 else
                 {
-                    // We have a non-constant index, so scale it up via mul
+                    // We have a non-constant index, so scale it up via mul but
+                    // don't lower the GT_MUL node since the indir will
+                    // try to create an addressing mode and will do folding itself
 
                     GenTreeIntConCommon* scale = comp->gtNewIconNode(genTypeSize(simdBaseType));
                     BlockRange().InsertBefore(node, scale);
-                    LowerNode(scale);
 
                     offset = comp->gtNewOperNode(GT_MUL, op2->TypeGet(), op2, scale);
                     BlockRange().InsertBefore(node, offset);
-                    LowerNode(offset);
                 }
 
+                // Add the offset, don't lower the GT_ADD node since the indir will
+                // try to create an addressing mode and will do folding itself
                 GenTree* addr = comp->gtNewOperNode(GT_ADD, op1->TypeGet(), op1, offset);
                 BlockRange().InsertBefore(node, addr);
-                LowerNode(addr);
 
                 // Finally we can indirect the memory address to get the actual value
                 GenTreeIndir* indir = comp->gtNewIndir(simdBaseType, addr);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1349,6 +1349,10 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
                     addr = comp->gtNewOperNode(GT_ADD, addr->TypeGet(), addr, offset);
                     BlockRange().InsertBefore(node, addr);
                 }
+                else
+                {
+                    BlockRange().Remove(offset);
+                }
 
                 // Finally we can indirect the memory address to get the actual value
                 GenTreeIndir* indir = comp->gtNewIndir(simdBaseType, addr);

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1917,7 +1917,6 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
             srcCount += BuildDelayFreeUses(intrin.op3, embOp2Node->Op(1));
         }
     }
-
     else if (intrin.op2 != nullptr)
     {
         // RMW intrinsic operands doesn't have to be delayFree when they can be assigned the same register as op1Reg
@@ -1928,28 +1927,8 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
         bool             forceOp2DelayFree   = false;
         SingleTypeRegSet lowVectorCandidates = RBM_NONE;
         size_t           lowVectorOperandNum = 0;
-        if ((intrin.id == NI_Vector64_GetElement) || (intrin.id == NI_Vector128_GetElement))
-        {
-            if (!intrin.op2->IsCnsIntOrI() && (!intrin.op1->isContained() || intrin.op1->OperIsLocal()))
-            {
-                // If the index is not a constant and the object is not contained or is a local
-                // we will need a general purpose register to calculate the address
-                // internal register must not clobber input index
-                // TODO-Cleanup: An internal register will never clobber a source; this code actually
-                // ensures that the index (op2) doesn't interfere with the target.
-                buildInternalIntRegisterDefForNode(intrinsicTree);
-                forceOp2DelayFree = true;
-            }
 
-            if (!intrin.op2->IsCnsIntOrI() && !intrin.op1->isContained())
-            {
-                // If the index is not a constant or op1 is in register,
-                // we will use the SIMD temp location to store the vector.
-                var_types requiredSimdTempType = (intrin.id == NI_Vector64_GetElement) ? TYP_SIMD8 : TYP_SIMD16;
-                compiler->getSIMDInitTempVarNum(requiredSimdTempType);
-            }
-        }
-        else if (HWIntrinsicInfo::IsLowVectorOperation(intrin.id))
+        if (HWIntrinsicInfo::IsLowVectorOperation(intrin.id))
         {
             getLowVectorOperandAndCandidates(intrin, &lowVectorOperandNum, &lowVectorCandidates);
         }

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -117,8 +117,12 @@ unsigned Compiler::getSIMDInitTempVarNum(var_types simdType)
     if (lvaSIMDInitTempVarNum == BAD_VAR_NUM)
     {
         JITDUMP("Allocating SIMDInitTempVar as %s\n", varTypeName(simdType));
+
         lvaSIMDInitTempVarNum                  = lvaGrabTempWithImplicitUse(false DEBUGARG("SIMDInitTempVar"));
         lvaTable[lvaSIMDInitTempVarNum].lvType = simdType;
+
+        // Ensure we mark it as do-not-enregister
+        lvaTable[lvaSIMDInitTempVarNum].lvDoNotEnregister = true;
     }
     else if (genTypeSize(lvaTable[lvaSIMDInitTempVarNum].lvType) < genTypeSize(simdType))
     {

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -117,12 +117,8 @@ unsigned Compiler::getSIMDInitTempVarNum(var_types simdType)
     if (lvaSIMDInitTempVarNum == BAD_VAR_NUM)
     {
         JITDUMP("Allocating SIMDInitTempVar as %s\n", varTypeName(simdType));
-
         lvaSIMDInitTempVarNum                  = lvaGrabTempWithImplicitUse(false DEBUGARG("SIMDInitTempVar"));
         lvaTable[lvaSIMDInitTempVarNum].lvType = simdType;
-
-        // Ensure we mark it as do-not-enregister
-        lvaSetVarDoNotEnregister(lvaSIMDInitTempVarNum DEBUGARG(DoNotEnregisterReason::LclAddrNode));
     }
     else if (genTypeSize(lvaTable[lvaSIMDInitTempVarNum].lvType) < genTypeSize(simdType))
     {

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -122,7 +122,7 @@ unsigned Compiler::getSIMDInitTempVarNum(var_types simdType)
         lvaTable[lvaSIMDInitTempVarNum].lvType = simdType;
 
         // Ensure we mark it as do-not-enregister
-        lvaTable[lvaSIMDInitTempVarNum].lvDoNotEnregister = true;
+        lvaSetVarDoNotEnregister(lvaSIMDInitTempVarNum DEBUGARG(DoNotEnregisterReason::LclAddrNode));
     }
     else if (genTypeSize(lvaTable[lvaSIMDInitTempVarNum].lvType) < genTypeSize(simdType))
     {


### PR DESCRIPTION
Unlike xarch where this could be handled a bit more trivially in codegen, Arm64 isn't as flexible and so we get better and more correct codegen by explicitly lowering to the correct sequence instead.