### PR TITLE
Disable flaky Credentials_ServerChallengesWithWindowsAuth_ClientSendsWindowsAuthHeader test at linux

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
@@ -659,6 +659,7 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalTheory(nameof(IsNtlmInstalled))]
         [InlineData("NTLM")]
         [InlineData("Negotiate")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/95156", TestPlatforms.Linux)]
         public async Task Credentials_ServerChallengesWithWindowsAuth_ClientSendsWindowsAuthHeader(string authScheme)
         {
             if (IsWinHttpHandler && UseVersion >= HttpVersion20.Value)


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/95156

/cc @carlossanlop @liveans

Customer Impact
Noisy test.

Regression
No

Testing
We are keeping this test as 8.0+ and if reapers there, we will take further actions.

Risk
LOW, only disabling one test