### PR TITLE
Use exec_attr to gain proc_lock_memory priv on illumos

### DIFF
--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -76,16 +76,11 @@ int CacheLineSize;
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <kvm.h>
-#elif defined(__sun)
-#ifndef _KERNEL
-#define _KERNEL
-#define UNDEF_KERNEL
-#endif
-#include <sys/procfs.h>
-#ifdef UNDEF_KERNEL
-#undef _KERNEL
-#endif
-#endif
+#endif // __NetBSD__
+
+#ifdef __sun
+#include <procfs.h>
+#endif // __sun
 
 #ifdef __FreeBSD__
 #include <sys/user.h>


### PR DESCRIPTION
On Solaris and illumos, calling `mlock(2)` requires `proc_lock_memory` privilege.
Without that privilege, `mlock()` returns EPERM.

We can use fine-grained `privileges(7)` on these systems to grant this privilege.
See the comments in the code on how one sets that up.

This is helpful until we find a way to get rid of the `mlock()` page strategy,
either implementing somethings like `membarrier(2)` or something else.
Investigation of that is underway but may take a while.

While I'm here, fix the procfs.h include. Applications should use <procfs.h> not <sys/procfs.h>
That's why the temporary `#define _KERNEL` mess was there.  With that fix, the mess is cleaned up.
