### PR TITLE
Clean up procfs.h mess on sunos and illumos

### DIFF
--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -76,15 +76,10 @@ int CacheLineSize;
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <kvm.h>
-#elif defined(__sun)
-#ifndef _KERNEL
-#define _KERNEL
-#define UNDEF_KERNEL
 #endif
-#include <sys/procfs.h>
-#ifdef UNDEF_KERNEL
-#undef _KERNEL
-#endif
+
+#if defined(__sun)
+#include <procfs.h>
 #endif
 
 #ifdef __FreeBSD__

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -34,16 +34,11 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <kvm.h>
-#elif defined(__sun)
-#ifndef _KERNEL
-#define _KERNEL
-#define UNDEF_KERNEL
 #endif
-#include <sys/procfs.h>
+
+#if defined(__sun)
+#include <procfs.h>
 #include <fcntl.h>
-#ifdef UNDEF_KERNEL
-#undef _KERNEL
-#endif
 #endif
 
 #include <signal.h>
@@ -72,10 +67,6 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #endif
 #if HAVE_LWP_H
 #include <lwp.h>
-#endif
-// If we don't have sys/lwp.h but do expect to use _lwp_self, declare it to silence compiler warnings
-#if HAVE__LWP_SELF && !HAVE_SYS_LWP_H && !HAVE_LWP_H
-extern "C" int _lwp_self ();
 #endif
 
 #if HAVE_CPUSET_T

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -59,15 +59,10 @@
 // Somehow, AIX mangles the definition for this behind a C++ def
 // Redeclare it here
 extern int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
-#elif defined(TARGET_SUNOS)
-#ifndef _KERNEL
-#define _KERNEL
-#define UNDEF_KERNEL
 #endif
-#include <sys/procfs.h>
-#ifdef UNDEF_KERNEL
-#undef _KERNEL
-#endif
+
+#if defined(TARGET_SUNOS)
+#include <procfs.h>
 #endif
 
 #ifdef __linux__


### PR DESCRIPTION
Applications should include <procfs.h> not <sys/procfs.h> If there's actually some need to directly include sys/procfs.h then one should #define	_STRUCTURED_PROC	1
as explained in the procfs.h file

Can I add reviewers?  I don't see a button for that.  @am11 ? @jkoritzinsky ? @janvorli ?