### PR TITLE
Skip calling not implemented PEAssembly::GetDisplayName in DAC

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2142,32 +2142,7 @@ ClrDataAccess::GetPEFileName(CLRDATA_ADDRESS moduleAddr, unsigned int count, _In
     }
     else if (!pPEAssembly->IsReflectionEmit())
     {
-        StackSString displayName;
-        pPEAssembly->GetDisplayName(displayName, 0);
-
-        if (displayName.IsEmpty())
-        {
-            if (fileName)
-                fileName[0] = 0;
-
-            if (pNeeded)
-                *pNeeded = 1;
-        }
-        else
-        {
-            unsigned int len = displayName.GetCount()+1;
-
-            if (fileName)
-            {
-                wcsncpy_s(fileName, count, displayName.GetUnicode(), _TRUNCATE);
-
-                if (count < len)
-                    len = count;
-            }
-
-            if (pNeeded)
-                *pNeeded = len;
-        }
+        hr = E_NOTIMPL;
     }
     else
     {
@@ -2711,19 +2686,7 @@ ClrDataAccess::GetAssemblyName(CLRDATA_ADDRESS assembly, unsigned int count, _In
     }
     else if (!pAssembly->GetPEAssembly()->IsReflectionEmit())
     {
-        StackSString displayName;
-        pAssembly->GetPEAssembly()->GetDisplayName(displayName, 0);
-
-        const WCHAR *val = displayName.GetUnicode();
-
-        if (pNeeded)
-            *pNeeded = displayName.GetCount() + 1;
-
-        if (name && count)
-        {
-            wcsncpy_s(name, count, val, _TRUNCATE);
-            name[count-1] = 0;
-        }
+        hr = E_NOTIMPL;
     }
     else
     {

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -715,6 +715,7 @@ inline BOOL PEAssembly::IsPtrInPEImage(PTR_CVOID data)
 // ------------------------------------------------------------
 // Descriptive strings
 // ------------------------------------------------------------
+#ifndef DACCESS_COMPILE
 inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
 {
     CONTRACTL
@@ -726,14 +727,11 @@ inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
     }
     CONTRACTL_END;
 
-#ifndef DACCESS_COMPILE
     AssemblySpec spec;
     spec.InitializeSpec(this);
     spec.GetDisplayName(flags, result);
-#else
-    DacNotImpl();
-#endif //DACCESS_COMPILE
 }
+#endif //DACCESS_COMPILE
 
 // ------------------------------------------------------------
 // Metadata access


### PR DESCRIPTION
`PEAssembly::GetDisplayName` just throws E_NOTIMPL in the DAC. Just make the current callers directly return E_NOTIMPL.

cc @dotnet/dotnet-diag @lambdageek 