### PR TITLE
Avoid UnobservedTaskExceptions from `HttpConnection.PrepareForReuse`

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -169,7 +169,15 @@ namespace System.Net.Http
                     _readAheadTask = _stream.ReadAsync(_readBuffer.AvailableMemory);
 #pragma warning restore CA2012
 
-                    return !_readAheadTask.IsCompleted;
+                    // If the read-ahead task already completed, we can't reuse the connection.
+                    // We're still responsible for observing potential exceptions thrown by the read-ahead task to avoid leaking unobserved exceptions.
+                    if (_readAheadTask.IsCompleted)
+                    {
+                        LogExceptions(_readAheadTask.AsTask());
+                        return false;
+                    }
+
+                    return true;
                 }
                 catch (Exception error)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -181,24 +181,6 @@ namespace System.Net.Http
             return 100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0');
         }
 
-        /// <summary>Awaits a task, ignoring any resulting exceptions.</summary>
-        internal static void IgnoreExceptions(ValueTask<int> task)
-        {
-            // Avoid TaskScheduler.UnobservedTaskException firing for any exceptions.
-            if (task.IsCompleted)
-            {
-                if (task.IsFaulted)
-                {
-                    _ = task.AsTask().Exception;
-                }
-            }
-            else
-            {
-                task.AsTask().ContinueWith(static t => _ = t.Exception,
-                    CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-            }
-        }
-
         /// <summary>Awaits a task, logging any resulting exceptions (which are otherwise ignored).</summary>
         internal void LogExceptions(Task task)
         {


### PR DESCRIPTION
Fixes #104324

We have two places where we set `_readAheadTask`:
- In `CheckUsabilityOnScavenge` (zero-byte read + fancy synchronization around `_readAheadTaskStatus`)
- In `PrepareForReuse` (simple `ReadAsync(readBuffer)` right before we start writing a request to an existing connection)

#80214 fixed leaking unobserved exceptions with the former while reintroducing a similar issue with the latter.

In `PrepareForReuse`, the contract is that the caller will either:
- Immediately start using the connection and write something to it if `PrepareForReuse` returned `true`
- Immediately dispose the connection if it returned `false`

In the case where the task completed immediately, we would dispose the connection, but we weren't observing the potential exception from the read-ahead task.