### PR TITLE
[QUIC&H/3] QuicConnection handshake timeout

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -33,6 +33,8 @@ namespace System.Net.Test.Common
         public const long H3_CONNECT_ERROR = 0x10f;
         public const long H3_VERSION_FALLBACK = 0x110;
 
+        public static TimeSpan HandshakeTimeout => TimeSpan.FromSeconds(30);
+
         private readonly QuicConnection _connection;
 
         // Queue for holding streams we accepted before we managed to accept the control stream

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
@@ -48,7 +48,8 @@ namespace System.Net.Test.Common
                             },
                             ServerCertificate = _cert,
                             ClientCertificateRequired = false
-                        }
+                        },
+                        HandshakeTimeout = Http3LoopbackConnection.HandshakeTimeout
                     };
                     return ValueTask.FromResult(serverOptions);
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -112,7 +112,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
         [SupportedOSPlatform("windows")]
-        public static async ValueTask<QuicConnection> ConnectQuicAsync(HttpRequestMessage request, DnsEndPoint endPoint, TimeSpan idleTimeout, SslClientAuthenticationOptions clientAuthenticationOptions, Action<QuicConnection, QuicStreamCapacityChangedArgs> streamCapacityCallback, CancellationToken cancellationToken)
+        public static async ValueTask<QuicConnection> ConnectQuicAsync(HttpRequestMessage request, DnsEndPoint endPoint, TimeSpan idleTimeout, TimeSpan handshakeTimeout, SslClientAuthenticationOptions clientAuthenticationOptions, Action<QuicConnection, QuicStreamCapacityChangedArgs> streamCapacityCallback, CancellationToken cancellationToken)
         {
             clientAuthenticationOptions = SetUpRemoteCertificateValidationCallback(clientAuthenticationOptions, request);
 
@@ -123,6 +123,7 @@ namespace System.Net.Http
                     MaxInboundBidirectionalStreams = 0, // Client doesn't support inbound streams: https://www.rfc-editor.org/rfc/rfc9114.html#name-bidirectional-streams. An extension might change this.
                     MaxInboundUnidirectionalStreams = 5, // Minimum is 3: https://www.rfc-editor.org/rfc/rfc9114.html#unidirectional-streams (1x control stream + 2x QPACK). Set to 100 if/when support for PUSH streams is added.
                     IdleTimeout = idleTimeout,
+                    HandshakeTimeout = handshakeTimeout,
                     DefaultStreamErrorCode = (long)Http3ErrorCode.RequestCancelled,
                     DefaultCloseErrorCode = (long)Http3ErrorCode.NoError,
                     RemoteEndPoint = endPoint,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -252,7 +252,7 @@ namespace System.Net.Http
                     // If the authority was sent as an option through alt-svc then include alt-used header.
                     connection = new Http3Connection(this, authority, includeAltUsedHeader: _http3Authority == authority);
 
-                    QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(queueItem.Request, new DnsEndPoint(authority.IdnHost, authority.Port), _poolManager.Settings._pooledConnectionIdleTimeout, _sslOptionsHttp3!, connection.StreamCapacityCallback, cts.Token).ConfigureAwait(false);
+                    QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(queueItem.Request, new DnsEndPoint(authority.IdnHost, authority.Port), _poolManager.Settings._pooledConnectionIdleTimeout, _poolManager.Settings._connectTimeout, _sslOptionsHttp3!, connection.StreamCapacityCallback, cts.Token).ConfigureAwait(false);
                     if (quicConnection.NegotiatedApplicationProtocol != SslApplicationProtocol.Http3)
                     {
                         await quicConnection.DisposeAsync().ConfigureAwait(false);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -715,7 +715,8 @@ namespace System.Net.Quic.Tests
                 DefaultStreamErrorCode = DefaultStreamErrorCodeClient,
                 DefaultCloseErrorCode = DefaultCloseErrorCodeClient,
                 RemoteEndPoint = new DnsEndPoint(name, 10000),
-                ClientAuthenticationOptions = GetSslClientAuthenticationOptions(sameTargetHost ? name : "localhost")
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions(sameTargetHost ? name : "localhost"),
+                HandshakeTimeout = HandshakeTimeout
             };
 
             SocketException ex = await Assert.ThrowsAsync<SocketException>(() => QuicConnection.ConnectAsync(options).AsTask());
@@ -729,7 +730,8 @@ namespace System.Net.Quic.Tests
             {
                 DefaultStreamErrorCode = DefaultStreamErrorCodeClient,
                 DefaultCloseErrorCode = DefaultCloseErrorCodeClient,
-                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions(),
+                HandshakeTimeout = HandshakeTimeout
             };
 
             Assert.Throws<ArgumentNullException>(() => QuicConnection.ConnectAsync(options));
@@ -741,7 +743,8 @@ namespace System.Net.Quic.Tests
             var options = new QuicClientConnectionOptions()
             {
                 RemoteEndPoint = new DnsEndPoint("localhost", 10000),
-                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions(),
+                HandshakeTimeout = HandshakeTimeout
             };
 
             Assert.Throws<ArgumentOutOfRangeException>(() => QuicConnection.ConnectAsync(options));

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -68,7 +68,10 @@ namespace System.Net.Quic.Tests
         {
             QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
             // Do not set any options, which should throw an argument exception from accept.
-            listenerOptions.ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(new QuicServerConnectionOptions());
+            listenerOptions.ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(new QuicServerConnectionOptions()
+            {
+                HandshakeTimeout = HandshakeTimeout
+            });
             await using QuicListener listener = await CreateQuicListener(listenerOptions);
 
             ValueTask<QuicConnection> connectTask = CreateQuicConnection(listener.LocalEndPoint);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -69,7 +69,8 @@ namespace System.Net.Quic.Tests
                 {
                     DefaultStreamErrorCode = QuicTestBase.DefaultStreamErrorCodeServer,
                     DefaultCloseErrorCode = QuicTestBase.DefaultCloseErrorCodeServer,
-                    ServerAuthenticationOptions = GetSslServerAuthenticationOptions()
+                    ServerAuthenticationOptions = GetSslServerAuthenticationOptions(),
+                    HandshakeTimeout = QuicTestBase.HandshakeTimeout
                 })
             });
 
@@ -94,7 +95,8 @@ namespace System.Net.Quic.Tests
                                 DefaultStreamErrorCode = QuicTestBase.DefaultStreamErrorCodeClient,
                                 DefaultCloseErrorCode = QuicTestBase.DefaultCloseErrorCodeClient,
                                 RemoteEndPoint = listener.LocalEndPoint,
-                                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+                                ClientAuthenticationOptions = GetSslClientAuthenticationOptions(),
+                                HandshakeTimeout = QuicTestBase.HandshakeTimeout
                             });
                             stream2 = await connection2.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
                             // OpenBidirectionalStream only allocates ID. We will force stream opening

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -43,6 +43,7 @@ namespace System.Net.Quic.Tests
         public ITestOutputHelper _output;
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
         public static TimeSpan PassingTestTimeout => TimeSpan.FromMilliseconds(PassingTestTimeoutMilliseconds);
+        public static TimeSpan HandshakeTimeout => TimeSpan.FromSeconds(30);
 
         public QuicTestBase(ITestOutputHelper output)
         {
@@ -75,7 +76,8 @@ namespace System.Net.Quic.Tests
             {
                 DefaultStreamErrorCode = DefaultStreamErrorCodeServer,
                 DefaultCloseErrorCode = DefaultCloseErrorCodeServer,
-                ServerAuthenticationOptions = GetSslServerAuthenticationOptions()
+                ServerAuthenticationOptions = GetSslServerAuthenticationOptions(),
+                HandshakeTimeout = HandshakeTimeout
             };
         }
 
@@ -105,7 +107,8 @@ namespace System.Net.Quic.Tests
                 DefaultStreamErrorCode = DefaultStreamErrorCodeClient,
                 DefaultCloseErrorCode = DefaultCloseErrorCodeClient,
                 RemoteEndPoint = endpoint,
-                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions(),
+                HandshakeTimeout = HandshakeTimeout
             };
         }
 


### PR DESCRIPTION
Increased `QuicConnection` handshake timeout in tests.

Optional: propagated `SocketsHttpHandler.ConnectTimeout` to `QuicConnectionOptions.HandshakeTimeout`. Note that since the default is "infinite", this might lead to hanging connection establishment. So if there are any concerns, I'll revert this part of the change.