### PR TITLE
Fix access to hoisted variables from reductions

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -100,7 +100,7 @@ namespace System.Linq.Expressions.Compiler
                     // User-created blocks will never hit this case; only our
                     // internally reduced nodes will.
                     //
-                    scope = new CompilerScope(node, false) { NeedsClosure = _scope.NeedsClosure };
+                    scope = new CompilerScope(node, false) { NeedsClosure = true };
                 }
 
                 _scope = scope.Enter(this, _scope);

--- a/src/libraries/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -196,6 +196,24 @@ namespace System.Linq.Expressions.Tests
             Assert.False(isNullOfType());
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void TypeEqualConstantWithAccessToLambdaHoistedVariables(bool useInterpreter)
+        {
+            ParameterExpression arg0 = Expression.Parameter(typeof(object), "value");
+
+            // f1 = () => value;
+            Expression<Func<object>> expr1 = Expression.Lambda<Func<object>>(arg0);
+
+            // f0 = (object value) => (() => value) is int;
+            Expression<Func<object, bool>> expr0 = Expression.Lambda<Func<object, bool>>(
+                Expression.TypeEqual(
+                    expr1,
+                    typeof(int)),
+                parameters: new[] { arg0 });
+            Func<object, bool> f0 = expr0.Compile(useInterpreter);
+            Assert.False(f0(null));
+        }
+
         [Fact]
         public void ToStringTest()
         {


### PR DESCRIPTION
LambdaCompiler compiles several types of expressions by reducing them. Reductions may contain BlockExpressions not processed by VariableBinder, and in that case a scope is created for them on the fly during compilation. In particular, SwitchExpression and TypeBinaryExpression compilation can create a BlockExpression with a scope.

If such a BlockExpression is an immediate child of a LambdaExpression, it lost access to lambda parameters that were hoisted due to the propagation of the NeedsClosure flag for its scope from the lambda.

Always set the flag for such scopes to true, so that it always gets access to hoisted variables from the parent scope.

Fix #56262