### PR TITLE
Use the maskBaseType when consuming a mask directly as part of KORTEST

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -2309,10 +2309,24 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
     GenTree*     op2    = node->Op(2);
     GenCondition cmpCnd = (cmpOp == GT_EQ) ? GenCondition::EQ : GenCondition::NE;
 
+    // We may need to change the base type to match the underlying mask size to ensure
+    // the right instruction variant is picked. If the op_Equality was for TYP_INT but
+    // the mask was for TYP_DOUBLE then we'd pick kortestw when we really want kortestb.
+    // Changing the size is fine in some scenarios, such as comparison against Zero or
+    // AllBitsSet, but not in other scenarios such as against an arbitrary mask.
+
+    CorInfoType maskBaseJitType = simdBaseJitType;
+    var_types   maskBaseType    = simdBaseType;
+
     if (op1Msk->OperIsHWIntrinsic(NI_EVEX_ConvertMaskToVector))
     {
-        op1Msk = op1Msk->AsHWIntrinsic()->Op(1);
+        GenTreeHWIntrinsic* cvtMaskToVector = op1Msk->AsHWIntrinsic();
+
+        op1Msk = cvtMaskToVector->Op(1);
         assert(varTypeIsMask(op1Msk));
+
+        maskBaseJitType = cvtMaskToVector->GetSimdBaseJitType();
+        maskBaseType    = cvtMaskToVector->GetSimdBaseType();
     }
 
     if (!varTypeIsFloating(simdBaseType) && (simdSize != 64) && op2->IsVectorZero() &&
@@ -2465,7 +2479,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
         GenTree* nextNode = node->gtNext;
 
         NamedIntrinsic maskIntrinsicId = NI_EVEX_CompareEqualMask;
-        uint32_t       count           = simdSize / genTypeSize(simdBaseType);
+        uint32_t       count           = simdSize / genTypeSize(maskBaseType);
 
         // KORTEST does a bitwise or on the result and sets ZF if it is zero and CF if it is all
         // bits set. Because of this, when we have at least 8 elements to compare we can use a
@@ -2650,14 +2664,14 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
                             GenTree* cnsNode;
 
                             maskNode = comp->gtNewSimdHWIntrinsicNode(TYP_MASK, maskNode, NI_EVEX_NotMask,
-                                                                      simdBaseJitType, simdSize);
+                                                                      maskBaseJitType, simdSize);
                             BlockRange().InsertBefore(node, maskNode);
 
                             cnsNode = comp->gtNewIconNode(8 - count);
                             BlockRange().InsertAfter(maskNode, cnsNode);
 
                             maskNode = comp->gtNewSimdHWIntrinsicNode(TYP_MASK, maskNode, cnsNode,
-                                                                      NI_EVEX_ShiftLeftMask, simdBaseJitType, simdSize);
+                                                                      NI_EVEX_ShiftLeftMask, maskBaseJitType, simdSize);
                             BlockRange().InsertAfter(cnsNode, maskNode);
                             LowerNode(maskNode);
 
@@ -2666,7 +2680,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
 
                             maskNode =
                                 comp->gtNewSimdHWIntrinsicNode(TYP_MASK, maskNode, cnsNode, NI_EVEX_ShiftRightMask,
-                                                               simdBaseJitType, simdSize);
+                                                               maskBaseJitType, simdSize);
                             BlockRange().InsertAfter(cnsNode, maskNode);
 
                             maskIntrinsicId = NI_EVEX_ShiftRightMask;
@@ -2791,6 +2805,11 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
         {
             assert(node == maskNode);
 
+            // We're not consuming the underlying mask directly, even if one exists,
+            // so ensure that we track the base type as the one we'll be producing
+            // via the vector comparison introduced here.
+            maskBaseJitType = simdBaseJitType;
+
             // We have `x == y` or `x != y` both of which where we want to find `AllBitsSet` in the mask since
             // we can directly do the relevant comparison. Given the above tables then when we have a full mask
             // we can simply check against `CF == 1` for `op_Equality` and `ZF == 0` for `op_Inequality`.
@@ -2830,7 +2849,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
         {
             GenTreeHWIntrinsic* cc;
 
-            cc = comp->gtNewSimdHWIntrinsicNode(simdType, maskNode, NI_EVEX_KORTEST, simdBaseJitType, simdSize);
+            cc = comp->gtNewSimdHWIntrinsicNode(simdType, maskNode, NI_EVEX_KORTEST, maskBaseJitType, simdSize);
             BlockRange().InsertBefore(nextNode, cc);
 
             use.ReplaceWith(cc);
@@ -3052,8 +3071,19 @@ GenTree* Lowering::LowerHWIntrinsicCndSel(GenTreeHWIntrinsic* node)
 
             if (isOp1CvtMaskToVector)
             {
-                maskNode = op1->AsHWIntrinsic()->Op(1);
+                GenTreeHWIntrinsic* cvtMaskToVector = op1->AsHWIntrinsic();
+
+                maskNode = cvtMaskToVector->Op(1);
                 BlockRange().Remove(op1);
+
+                // We need to change the base type to match the underlying mask size to ensure
+                // the right instruction variant is picked. If the CndSel was for TYP_INT but
+                // the mask was for TYP_DOUBLE then we'd generate vpblendmd when we really want
+                // vpblendmq. Changing the size is fine since CndSel itself is bitwise and the
+                // the mask is just representing entire elements at a given size.
+
+                CorInfoType maskBaseJitType = cvtMaskToVector->GetSimdBaseJitType();
+                node->SetSimdBaseJitType(maskBaseJitType);
             }
             else
             {


### PR DESCRIPTION
This resolves #104317.

The issue had been that we were eliding `ConvertMaskToVector` without accounting for the fact that there could have been a change of the `baseType` such as caused by using `value.AsInt32()`. We normally do take this into account, there was just an existing path in lowering that missed this and which was now being hit due to recent IR improvements.

An example of where this is problematic would be if we had a `TYP_LONG` mask of `0b10`, the `ConvertVectorToMask` would produce `[Zero, AllBitsSet]`, if that were then consumed by an operation taking a `TYP_INT` it would see it as `[Zero, Zero, AllBitsSet, AllBitsSet]`. However, if we consumed it directly as a mask we'd still have `10` when the API would've needed `0b1100` for parity.

However, some of the use sites we can still elide the `ConvertMaskToVector`, we just need to fixup the consumer to have the right base type. For example, if we're doing `op_Equality` against `Zero` or `AllBitsSet`, then the bitset expected never changes. The same applies for `CndSel` which is a bitwise operation.