### PR TITLE
Improve build error on systems that have a 32-bit time_t

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -233,9 +233,9 @@ void InitializeOpenSSLShim(void)
     }
 
 #if defined(TARGET_ARM) && defined(TARGET_LINUX)
-    // This value will represent a time in year 2038 if 64-bit time is used,
-    // or 1901 if the lower 32 bits are interpreted as a 32-bit time_t value.
-    time_t timeVal = (time_t)((unsigned long)INT_MAX + 1u);
+    // This value will represent a time in year 2038 if 64-bit time_t is used,
+    // or 1901 if the conversion overflowed.
+    time_t timeVal = (time_t)0x80000000U;
     struct tm tmVal = { 0 };
 
     // Detect whether openssl is using 32-bit or 64-bit time_t.

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -235,7 +235,7 @@ void InitializeOpenSSLShim(void)
 #if defined(TARGET_ARM) && defined(TARGET_LINUX)
     // This value will represent a time in year 2038 if 64-bit time is used,
     // or 1901 if the lower 32 bits are interpreted as a 32-bit time_t value.
-    time_t timeVal = (time_t)INT_MAX + 1u;
+    time_t timeVal = (time_t)((unsigned long)INT_MAX + 1u);
     struct tm tmVal = { 0 };
 
     // Detect whether openssl is using 32-bit or 64-bit time_t.

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -235,7 +235,7 @@ void InitializeOpenSSLShim(void)
 #if defined(TARGET_ARM) && defined(TARGET_LINUX)
     // This value will represent a time in year 2038 if 64-bit time is used,
     // or 1901 if the lower 32 bits are interpreted as a 32-bit time_t value.
-    time_t timeVal = (time_t)INT_MAX + 1;
+    time_t timeVal = (time_t)INT_MAX + 1u;
     struct tm tmVal = { 0 };
 
     // Detect whether openssl is using 32-bit or 64-bit time_t.

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -233,8 +233,10 @@ void InitializeOpenSSLShim(void)
     }
 
 #if defined(TARGET_ARM) && defined(TARGET_LINUX)
-    // This value will represent a time in year 2038 if 64-bit time_t is used,
-    // or 1901 if the conversion overflowed.
+    c_static_assert_msg(sizeof(time_t) == 8, "Build requires 64-bit time_t.");
+    
+    // This value will represent a time in year 2038 if 64-bit time is used,
+    // or 1901 if the lower 32 bits are interpreted as a 32-bit time_t value.
     time_t timeVal = (time_t)0x80000000U;
     struct tm tmVal = { 0 };
 


### PR DESCRIPTION
We now require a 64-bit time_t, even on ARM32. This adds a static_assert to ensure time_t is 64-bit, and if not, produce a compile time error.

This also uses a constant instead of `(time_t)INT_MAX + 1` since, if that overflows, it is UB because time_t is a signed type.

Contributes to #104333