### PR TITLE
[iOS][HybridGlobalization] Disable CultureName_Set_Invalid_ThrowsCultureNotFoundException test

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyNameTests.cs
@@ -222,6 +222,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/95338", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnApplePlatform))]
         public void CultureName_Set_Invalid_ThrowsCultureNotFoundException()
         {
             var assemblyName = new AssemblyName("Test");


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/104071 by mistake I enabled `CultureName_Set_Invalid_ThrowsCultureNotFoundException`.
Disabling it in this PR.
Further investigation will be done in https://github.com/dotnet/runtime/issues/95338

Fixes https://github.com/dotnet/runtime/issues/104346.