### PR TITLE
Avoid unobserved task exceptions in Http tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
@@ -182,11 +182,13 @@ namespace System.Net.Http.Functional.Tests
             {
                 await LoopbackServer.CreateServerAsync(async (origServer, origUrl) =>
                 {
+                    Task redirectTask = null;
+
                     await LoopbackServer.CreateServerAsync(async (redirectServer, redirectUrl) =>
                     {
                         Task<HttpResponseMessage> getResponseTask = client.GetAsync(TestAsync, origUrl);
 
-                        Task redirectTask = redirectServer.AcceptConnectionSendResponseAndCloseAsync();
+                        redirectTask = redirectServer.AcceptConnectionSendResponseAndCloseAsync();
 
                         await TestHelper.WhenAllCompletedOrAnyFailed(
                             getResponseTask,
@@ -199,6 +201,8 @@ namespace System.Net.Http.Functional.Tests
                             Assert.False(redirectTask.IsCompleted, "Should not have redirected to Location");
                         }
                     });
+
+                    await IgnoreExceptions(redirectTask);
                 });
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -410,7 +410,9 @@ namespace System.Net.Http.Functional.Tests
                 () => client.GetAsync(TestAsync, InvalidUri, cancellationToken: cts.Token));
 
             // .NET Framework has bug where it doesn't propagate token information.
-            Assert.True(oce.CancellationToken.IsCancellationRequested);
+#if !NETFRAMEWORK
+            Assert.Equal(cts.Token, oce.CancellationToken);
+#endif
         }
 
         public static IEnumerable<object[]> PostAsync_Cancel_CancellationTokenPassedToContent_MemberData()

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -86,14 +86,7 @@ namespace System.Net.Http.Functional.Tests
                 }
             }, async server =>
             {
-                try
-                {
-                    await server.AcceptConnectionAsync(connection => serverRelease.Task);
-                }
-                catch (Exception ex)
-                {
-                    _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                }
+                await IgnoreExceptions(server.AcceptConnectionAsync(connection => serverRelease.Task));
             });
         }
 
@@ -142,15 +135,9 @@ namespace System.Net.Http.Functional.Tests
                         await getResponse;
                     });
 
-                    try
-                    {
-                        clientFinished.SetResult(true);
-                        await serverTask;
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    clientFinished.SetResult(true);
+
+                    await IgnoreExceptions(serverTask);
                 });
             }
         }
@@ -203,15 +190,9 @@ namespace System.Net.Http.Functional.Tests
                         await getResponse;
                     });
 
-                    try
-                    {
-                        clientFinished.SetResult(true);
-                        await serverTask;
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    clientFinished.SetResult(true);
+
+                    await IgnoreExceptions(serverTask);
                 });
             }
         }
@@ -279,15 +260,10 @@ namespace System.Net.Http.Functional.Tests
                         cts.Cancel();
                         await readTask;
                     }).WaitAsync(TimeSpan.FromSeconds(30));
-                    try
-                    {
-                        clientFinished.SetResult(true);
-                        await serverTask;
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+
+                    clientFinished.SetResult(true);
+
+                    await IgnoreExceptions(serverTask);
                 });
             }
         }
@@ -425,39 +401,16 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task SendAsync_Cancel_CancellationTokenPropagates()
         {
-            TaskCompletionSource<bool> clientCanceled = new TaskCompletionSource<bool>();
-            await LoopbackServerFactory.CreateClientAndServerAsync(
-                async uri =>
-                {
-                    var cts = new CancellationTokenSource();
-                    cts.Cancel();
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
 
-                    using (HttpClient client = CreateHttpClient())
-                    {
-                        OperationCanceledException ex = null;
-                        try
-                        {
-                            await client.GetAsync(uri, cts.Token);
-                        }
-                        catch (OperationCanceledException e)
-                        {
-                            ex = e;
-                        }
-                        Assert.True(ex != null, "Expected OperationCancelledException, but no exception was thrown.");
+            using HttpClient client = CreateHttpClient();
 
-                        Assert.True(cts.Token.IsCancellationRequested, "cts token IsCancellationRequested");
+            OperationCanceledException oce = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => client.GetAsync(TestAsync, InvalidUri, cancellationToken: cts.Token));
 
-                        // .NET Framework has bug where it doesn't propagate token information.
-                        Assert.True(ex.CancellationToken.IsCancellationRequested, "exception token IsCancellationRequested");
-
-                        clientCanceled.SetResult(true);
-                    }
-                },
-                async server =>
-                {
-                    Task serverTask = server.HandleRequestAsync();
-                    await clientCanceled.Task;
-                });
+            // .NET Framework has bug where it doesn't propagate token information.
+            Assert.True(oce.CancellationToken.IsCancellationRequested);
         }
 
         public static IEnumerable<object[]> PostAsync_Cancel_CancellationTokenPassedToContent_MemberData()

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -573,14 +573,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient(handler))
                 {
                     handler.Proxy = new WebProxy(proxyUri);
-                    try
-                    {
-                        await client.GetAsync(uri);
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    await IgnoreExceptions(client.GetAsync(uri));
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {
@@ -613,14 +606,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient(handler))
                 {
                     handler.Proxy = new WebProxy(proxyUri);
-                    try
-                    {
-                        await client.GetAsync(addressUri);
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    await IgnoreExceptions(client.GetAsync(addressUri));
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {
@@ -647,14 +633,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient(handler))
                 {
                     handler.Proxy = new WebProxy(proxyUri);
-                    try
-                    {
-                        await client.GetAsync(addressUri);
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    await IgnoreExceptions(client.GetAsync(addressUri));
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -16,6 +16,8 @@ namespace System.Net.Http.Functional.Tests
 
     public abstract partial class HttpClientHandlerTestBase : FileCleanupTestBase
     {
+        protected static readonly Uri InvalidUri = new("http://nosuchhost.invalid");
+
         // This file is shared with the WinHttpHandler implementation, which supports .NET Framework
         // So, define this so derived tests can use it.
         public static readonly Version HttpVersion30 = new Version(3, 0);
@@ -30,6 +32,20 @@ namespace System.Net.Http.Functional.Tests
         {
             _output = output;
         }
+
+        protected async Task IgnoreExceptions(Func<Task> func)
+        {
+            try
+            {
+                await func();
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
+            }
+        }
+
+        protected Task IgnoreExceptions(Task task) => IgnoreExceptions(() => task);
 
         protected virtual HttpClient CreateHttpClient() => CreateHttpClient(CreateHttpClientHandler());
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -496,6 +496,7 @@ namespace System.Net.Http
                 catch (HttpProtocolException e)
                 {
                     InitialSettingsReceived.TrySetException(e);
+                    LogExceptions(InitialSettingsReceived.Task);
                     throw;
                 }
                 catch (Exception e)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -26,8 +26,6 @@ namespace System.Net.Http.Functional.Tests
         private static bool EnableActivityPropagationEnvironmentVariableIsNotSetAndRemoteExecutorSupported =>
             string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnableActivityPropagationEnvironmentVariableSettingName)) && RemoteExecutor.IsSupported;
 
-        private static readonly Uri InvalidUri = new("http://nosuchhost.invalid");
-
         public DiagnosticsTest(ITestOutputHelper output) : base(output) { }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3276,15 +3276,11 @@ namespace System.Net.Http.Functional.Tests
                 // We should not reach retry limit without failing.
                 Assert.NotEqual(0, maxCount);
 
-                try
+                await IgnoreExceptions(async () =>
                 {
                     await connection.SendGoAway(streamId);
                     await connection.WaitForConnectionShutdownAsync();
-                }
-                catch (Exception ex)
-                {
-                    _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                }
+                });
             });
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
@@ -702,14 +702,7 @@ namespace System.Net.Http.Functional.Tests
                 },
                 async server =>
                 {
-                    try
-                    {
-                        await server.AcceptConnectionSendResponseAndCloseAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    await IgnoreExceptions(server.AcceptConnectionSendResponseAndCloseAsync());
                 });
         }
 
@@ -717,6 +710,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task ReadAsStringAsync_Unbuffered_CanBeCanceled()
         {
             var cts = new CancellationTokenSource();
+            var observedCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await LoopbackServer.CreateClientAndServerAsync(
                 async uri =>
@@ -728,6 +722,7 @@ namespace System.Net.Http.Functional.Tests
                         HttpCompletionOption.ResponseHeadersRead);
 
                     await Assert.ThrowsAsync<TaskCanceledException>(() => response.Content.ReadAsStringAsync(cts.Token));
+                    observedCancellation.SetResult();
                 },
                 async server =>
                 {
@@ -735,17 +730,9 @@ namespace System.Net.Http.Functional.Tests
                     {
                         await connection.ReadRequestHeaderAsync();
                         await connection.SendResponseAsync(LoopbackServer.GetHttpResponseHeaders(contentLength: 100));
-                        await Task.Delay(250);
+                        await Task.Delay(10);
                         cts.Cancel();
-                        await Task.Delay(500);
-                        try
-                        {
-                            await connection.SendResponseAsync(new string('a', 100));
-                        }
-                        catch (Exception ex)
-                        {
-                            _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                        }
+                        await observedCancellation.Task.WaitAsync(TestHelper.PassingTestTimeout);
                     });
                 });
         }
@@ -797,14 +784,7 @@ namespace System.Net.Http.Functional.Tests
                 },
                 async server =>
                 {
-                    try
-                    {
-                        await server.AcceptConnectionSendResponseAndCloseAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    await IgnoreExceptions(server.AcceptConnectionSendResponseAndCloseAsync());
                 });
         }
 
@@ -812,6 +792,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task ReadAsByteArrayAsync_Unbuffered_CanBeCanceled()
         {
             var cts = new CancellationTokenSource();
+            var observedCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await LoopbackServer.CreateClientAndServerAsync(
                 async uri =>
@@ -823,6 +804,7 @@ namespace System.Net.Http.Functional.Tests
                         HttpCompletionOption.ResponseHeadersRead);
 
                     await Assert.ThrowsAsync<TaskCanceledException>(() => response.Content.ReadAsByteArrayAsync(cts.Token));
+                    observedCancellation.SetResult();
                 },
                 async server =>
                 {
@@ -830,17 +812,9 @@ namespace System.Net.Http.Functional.Tests
                     {
                         await connection.ReadRequestHeaderAsync();
                         await connection.SendResponseAsync(LoopbackServer.GetHttpResponseHeaders(contentLength: 100));
-                        await Task.Delay(250);
+                        await Task.Delay(10);
                         cts.Cancel();
-                        await Task.Delay(500);
-                        try
-                        {
-                            await connection.SendResponseAsync(new string('a', 100));
-                        }
-                        catch (Exception ex)
-                        {
-                            _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                        }
+                        await observedCancellation.Task.WaitAsync(TestHelper.PassingTestTimeout);
                     });
                 });
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
@@ -710,7 +710,6 @@ namespace System.Net.Http.Functional.Tests
         public async Task ReadAsStringAsync_Unbuffered_CanBeCanceled()
         {
             var cts = new CancellationTokenSource();
-            var observedCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await LoopbackServer.CreateClientAndServerAsync(
                 async uri =>
@@ -722,7 +721,6 @@ namespace System.Net.Http.Functional.Tests
                         HttpCompletionOption.ResponseHeadersRead);
 
                     await Assert.ThrowsAsync<TaskCanceledException>(() => response.Content.ReadAsStringAsync(cts.Token));
-                    observedCancellation.SetResult();
                 },
                 async server =>
                 {
@@ -730,9 +728,10 @@ namespace System.Net.Http.Functional.Tests
                     {
                         await connection.ReadRequestHeaderAsync();
                         await connection.SendResponseAsync(LoopbackServer.GetHttpResponseHeaders(contentLength: 100));
-                        await Task.Delay(10);
+                        await Task.Delay(250);
                         cts.Cancel();
-                        await observedCancellation.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        await Task.Delay(500);
+                        await IgnoreExceptions(connection.SendResponseAsync(new string('a', 100)));
                     });
                 });
         }
@@ -792,7 +791,6 @@ namespace System.Net.Http.Functional.Tests
         public async Task ReadAsByteArrayAsync_Unbuffered_CanBeCanceled()
         {
             var cts = new CancellationTokenSource();
-            var observedCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await LoopbackServer.CreateClientAndServerAsync(
                 async uri =>
@@ -804,7 +802,6 @@ namespace System.Net.Http.Functional.Tests
                         HttpCompletionOption.ResponseHeadersRead);
 
                     await Assert.ThrowsAsync<TaskCanceledException>(() => response.Content.ReadAsByteArrayAsync(cts.Token));
-                    observedCancellation.SetResult();
                 },
                 async server =>
                 {
@@ -812,9 +809,10 @@ namespace System.Net.Http.Functional.Tests
                     {
                         await connection.ReadRequestHeaderAsync();
                         await connection.SendResponseAsync(LoopbackServer.GetHttpResponseHeaders(contentLength: 100));
-                        await Task.Delay(10);
+                        await Task.Delay(250);
                         cts.Cancel();
-                        await observedCancellation.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        await Task.Delay(500);
+                        await IgnoreExceptions(connection.SendResponseAsync(new string('a', 100)));
                     });
                 });
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
@@ -127,17 +127,13 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                try
+                await IgnoreExceptions(async () =>
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         await clientCompleted.Task.WaitAsync(TestHelper.PassingTestTimeout);
                     });
-                }
-                catch (Exception ex)
-                {
-                    _output.WriteLine($"Ignoring exception {ex}");
-                }
+                });
             }, options: new GenericLoopbackOptions { UseSsl = useSsl });
         }
 
@@ -157,7 +153,7 @@ namespace System.Net.Http.Functional.Tests
 
             Task serverTask = Task.Run(async () =>
             {
-                try
+                await IgnoreExceptions(async () =>
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
@@ -170,11 +166,7 @@ namespace System.Net.Http.Functional.Tests
                             await clientCompleted.Task.WaitAsync(TestHelper.PassingTestTimeout);
                         }
                     });
-                }
-                catch (Exception ex)
-                {
-                    _output.WriteLine($"Ignoring exception {ex}");
-                }
+                });
             });
 
             Task clientTask = Task.Run(async () =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -451,13 +451,13 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public void MaxResponseDrainSize_SetAfterUse_Throws()
+        public async Task MaxResponseDrainSize_SetAfterUse_Throws()
         {
             using (var handler = new SocketsHttpHandler())
             using (HttpClient client = CreateHttpClient(handler))
             {
                 handler.MaxResponseDrainSize = 1;
-                _ = client.GetAsync($"http://{Guid.NewGuid():N}"); // ignoring failure
+                await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync(InvalidUri));
                 Assert.Equal(1, handler.MaxResponseDrainSize);
                 Assert.Throws<InvalidOperationException>(() => handler.MaxResponseDrainSize = 1);
             }
@@ -494,13 +494,13 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public void ResponseDrainTimeout_SetAfterUse_Throws()
+        public async Task ResponseDrainTimeout_SetAfterUse_Throws()
         {
             using (var handler = new SocketsHttpHandler())
             using (HttpClient client = CreateHttpClient(handler))
             {
                 handler.ResponseDrainTimeout = TimeSpan.FromSeconds(42);
-                _ = client.GetAsync($"http://{Guid.NewGuid():N}"); // ignoring failure
+                await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync(InvalidUri));
                 Assert.Equal(TimeSpan.FromSeconds(42), handler.ResponseDrainTimeout);
                 Assert.Throws<InvalidOperationException>(() => handler.ResponseDrainTimeout = TimeSpan.FromSeconds(42));
             }
@@ -1343,13 +1343,13 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public void ConnectTimeout_SetAfterUse_Throws()
+        public async Task ConnectTimeout_SetAfterUse_Throws()
         {
             using (var handler = new SocketsHttpHandler())
             using (HttpClient client = CreateHttpClient(handler))
             {
                 handler.ConnectTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
-                _ = client.GetAsync($"http://{Guid.NewGuid():N}"); // ignoring failure
+                await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync(InvalidUri));
                 Assert.Equal(TimeSpan.FromMilliseconds(int.MaxValue), handler.ConnectTimeout);
                 Assert.Throws<InvalidOperationException>(() => handler.ConnectTimeout = TimeSpan.FromMilliseconds(1));
             }
@@ -1390,13 +1390,13 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public void Expect100ContinueTimeout_SetAfterUse_Throws()
+        public async Task Expect100ContinueTimeout_SetAfterUse_Throws()
         {
             using (var handler = new SocketsHttpHandler())
             using (HttpClient client = CreateHttpClient(handler))
             {
                 handler.Expect100ContinueTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
-                _ = client.GetAsync($"http://{Guid.NewGuid():N}"); // ignoring failure
+                await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync(InvalidUri));
                 Assert.Equal(TimeSpan.FromMilliseconds(int.MaxValue), handler.Expect100ContinueTimeout);
                 Assert.Throws<InvalidOperationException>(() => handler.Expect100ContinueTimeout = TimeSpan.FromMilliseconds(1));
             }
@@ -3880,14 +3880,7 @@ namespace System.Net.Http.Functional.Tests
                 },
                 async server =>
                 {
-                    try
-                    {
-                        await server.AcceptConnectionSendResponseAndCloseAsync(content: "foo");
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    await IgnoreExceptions(server.AcceptConnectionSendResponseAndCloseAsync(content: "foo"));
                 }, options: options);
         }
 
@@ -3917,14 +3910,7 @@ namespace System.Net.Http.Functional.Tests
                 },
                 async server =>
                 {
-                    try
-                    {
-                        await server.AcceptConnectionSendResponseAndCloseAsync(content: "foo");
-                    }
-                    catch (Exception ex)
-                    {
-                        _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                    }
+                    await IgnoreExceptions(server.AcceptConnectionSendResponseAndCloseAsync(content: "foo"));
                 }, options: options);
         }
     }
@@ -4269,14 +4255,7 @@ namespace System.Net.Http.Functional.Tests
             },
             async server =>
             {
-                try
-                {
-                    await server.HandleRequestAsync();
-                }
-                catch (Exception ex)
-                {
-                    _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-                }
+                await IgnoreExceptions(server.HandleRequestAsync());
 
                 // On HTTP/1.x, an exception being thrown while sending the request content will result in the connection being closed.
                 // This test is ensuring that a subsequent request can succeed on a new connection.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocksProxyTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocksProxyTest.cs
@@ -109,14 +109,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(exceptionMessage, innerException.Message);
             Assert.Equal("SocksException", innerException.GetType().Name);
 
-            try
-            {
-                await proxy.DisposeAsync();
-            }
-            catch (Exception ex)
-            {
-                _output.WriteLine($"Ignored exception:{Environment.NewLine}{ex}");
-            }
+            await IgnoreExceptions(proxy.DisposeAsync().AsTask());
         }
     }
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/80111#issuecomment-2206037068 by removing most unobserved non-Quic exceptions from our HTTP tests.

The only product change is the 1 added `LogExceptions` in `Http2Connection.cs`.