### PR TITLE
Reduce allocations in Quic/HTTP3

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs
@@ -318,7 +318,6 @@ internal sealed class ResettableValueTaskSource : IValueTaskSource
                 }
 
                 _finalTaskSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
                 if (!_isCompleted)
                 {
                     GCHandle handle = GCHandle.Alloc(keepAlive);


### PR DESCRIPTION
As of #104035 we're now waiting for `WritesClosed` on every request, and paying for the allocations backing that `Task`. This PR attempts to claw that perf back.

This does a couple of things:
- if the `ResettableValueTaskSource`'s final task was already signaled by the time someone first asked for the `Task`, avoid allocating the intermediate `TaskCompletionSource` and its `Task`.
- Move the waiting on `WritesClosed` later on in Http3's `SendAsync` (after receiving the response) to make it more likely that `WritesClosed` will have been completed by the time we check, thus avoiding the allocations.
- Honors the `cancellationToken` while waiting for `WritesClosed` -- @ManickaP I'm guessing that's desirable here?
- Avoids the state machine allocation in `FlushSendBufferAsync`