### PR TITLE
Enable TLS on linux/arm64 only for static resolver

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -794,4 +794,18 @@ LEAF_ENTRY GetThreadStaticsVariableOffset, _TEXT
         EPILOG_RETURN
 LEAF_END GetThreadStaticsVariableOffset, _TEXT
 // ------------------------------------------------------------------
+
+// ------------------------------------------------------------------
+// size_t GetTLSResolverAddress()
+
+// Helper to get the TLS resolver address. This will be then used to determine if we have a static or dynamic resolver.
+LEAF_ENTRY GetTLSResolverAddress, _TEXT
+        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -32
+        adrp    x0,     :tlsdesc:t_ThreadStatics
+        ldr     x1,     [x0, #:tlsdesc_lo12:t_ThreadStatics]
+        mov     x0, x1
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+        EPILOG_RETURN
+LEAF_END GetTLSResolverAddress, _TEXT
+// ------------------------------------------------------------------
 #endif // !TARGET_OSX

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -784,7 +784,9 @@ void FreeTLSIndicesForLoaderAllocator(LoaderAllocator *pLoaderAllocator)
 
 static void* GetTlsIndexObjectAddress();
 
+#if !defined(TARGET_OSX) && defined(TARGET_UNIX) && defined(TARGET_ARM64)
 extern "C" size_t GetTLSResolverAddress();
+#endif // !TARGET_OSX && TARGET_UNIX && TARGET_ARM64
 
 bool CanJITOptimizeTLSAccess()
 {
@@ -801,7 +803,7 @@ bool CanJITOptimizeTLSAccess()
     // Optimization is disabled for FreeBSD/arm64
 #elif defined(FEATURE_INTERPRETER)
     // Optimization is disabled when interpreter may be used
-#elif defined(TARGET_UNIX) && defined(TARGET_ARM64)
+#elif !defined(TARGET_OSX) && defined(TARGET_UNIX) && defined(TARGET_ARM64)
     // Optimization is enabled for linux/arm64 only for static resolver.
     // For static resolver, the TP offset is same for all threads.
     // For dynamic resolver, TP offset returned is that of a JIT thread and


### PR DESCRIPTION
If the TLS is resolved by the dynamic resolver, the TP offset returned if for calling (JITting) thread and it is wrong to embed that information in the JIT code which will get executed by an execution thread. Doing that gets SEGFAULT. So detect what type of resolver it is and depending on that disable TLS if it is dynamic resolver.