### PR TITLE
Fix certificate test failures on iOS(-likes)

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CollectionTests.cs
@@ -800,6 +800,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
         public static void ExportMultiplePrivateKeys()
         {
             var collection = new X509Certificate2Collection();


### PR DESCRIPTION
While `new X509Certificate2(bytes)` could read both PEM and DER certs, `X509CertificateLoader.LoadCertificate(bytes)` could not.

Also, sprinkle a SkipOnPlatform attribute on a test that is failing, but I don't see any issue tracking.

Fixes #104161