### PR TITLE
[Apple] Disable EmptyStructs tests for apple mobile due to missing support for native libraries

### DIFF
--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.csproj
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.csproj
@@ -3,6 +3,8 @@
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/92129 -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/104430
Fyi: @tomeksowi 