### PR TITLE
[QUIC] Fixed some tests leaking unobserved exceptions

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
@@ -49,7 +49,7 @@ namespace System.Net.Quic.Tests
         [Theory]
         [InlineData(new TlsCipherSuite[] { })]
         [InlineData(new[] { TlsCipherSuite.TLS_AES_128_CCM_8_SHA256 })]
-        public async void NoSupportedCiphers_ThrowsArgumentException(TlsCipherSuite[] ciphers)
+        public async Task NoSupportedCiphers_ThrowsArgumentException(TlsCipherSuite[] ciphers)
         {
             CipherSuitesPolicy policy = new CipherSuitesPolicy(ciphers);
             var listenerOptions = new QuicListenerOptions()
@@ -65,10 +65,12 @@ namespace System.Net.Quic.Tests
             };
             await using var listener = await CreateQuicListener(listenerOptions);
 
+            // Creating a connection with incompatible ciphers.
             var clientOptions = CreateQuicClientOptions(listener.LocalEndPoint);
             clientOptions.ClientAuthenticationOptions.CipherSuitesPolicy = policy;
             await Assert.ThrowsAsync<ArgumentException>(async () => await CreateQuicConnection(clientOptions));
 
+            // Creating a connection to a server configured with incompatible ciphers.
             await Assert.ThrowsAsync<AuthenticationException>(async () => await CreateQuicConnection(listener.LocalEndPoint));
             await Assert.ThrowsAsync<ArgumentException>(async () => await listener.AcceptConnectionAsync());
         }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -48,7 +49,7 @@ namespace System.Net.Quic.Tests
         [Theory]
         [InlineData(new TlsCipherSuite[] { })]
         [InlineData(new[] { TlsCipherSuite.TLS_AES_128_CCM_8_SHA256 })]
-        public void NoSupportedCiphers_ThrowsArgumentException(TlsCipherSuite[] ciphers)
+        public async void NoSupportedCiphers_ThrowsArgumentException(TlsCipherSuite[] ciphers)
         {
             CipherSuitesPolicy policy = new CipherSuitesPolicy(ciphers);
             var listenerOptions = new QuicListenerOptions()
@@ -62,11 +63,14 @@ namespace System.Net.Quic.Tests
                     return ValueTask.FromResult(serverOptions);
                 }
             };
-            Assert.ThrowsAsync<ArgumentException>(async () => await CreateQuicListener(listenerOptions));
+            await using var listener = await CreateQuicListener(listenerOptions);
 
-            var clientOptions = CreateQuicClientOptions(new IPEndPoint(IPAddress.Loopback, 5000));
+            var clientOptions = CreateQuicClientOptions(listener.LocalEndPoint);
             clientOptions.ClientAuthenticationOptions.CipherSuitesPolicy = policy;
-            Assert.ThrowsAsync<ArgumentException>(async () => await CreateQuicConnection(clientOptions));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await CreateQuicConnection(clientOptions));
+
+            await Assert.ThrowsAsync<AuthenticationException>(async () => await CreateQuicConnection(listener.LocalEndPoint));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await listener.AcceptConnectionAsync());
         }
 
         [Fact]

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -73,6 +73,7 @@ namespace System.Net.Quic.Tests
 
             ValueTask<QuicConnection> connectTask = CreateQuicConnection(listener.LocalEndPoint);
             await Assert.ThrowsAnyAsync<ArgumentException>(async () => await listener.AcceptConnectionAsync());
+            await connectTask;
         }
 
         [Fact]

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -73,7 +73,7 @@ namespace System.Net.Quic.Tests
 
             ValueTask<QuicConnection> connectTask = CreateQuicConnection(listener.LocalEndPoint);
             await Assert.ThrowsAnyAsync<ArgumentException>(async () => await listener.AcceptConnectionAsync());
-            await connectTask;
+            await Assert.ThrowsAnyAsync<AuthenticationException>(async () => await connectTask);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -1550,7 +1550,7 @@ namespace System.Net.Quic.Tests
 
                     // Dispose will abort reading from this side.
                     await stream.DisposeAsync();
-                    var readEx = await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, () => stream.ReadsClosed);
+                    await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, () => stream.ReadsClosed);
                 }
             }
         }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -1452,7 +1452,7 @@ namespace System.Net.Quic.Tests
                     }
                     else
                     {
-                        await WaitingSide(stream, tcs.Task, DefaultStreamErrorCodeClient);
+                        await WaitingSide(stream, tcs.Task, true);
                     }
                 },
                 clientFunction: async connection =>
@@ -1465,7 +1465,7 @@ namespace System.Net.Quic.Tests
 
                     if (disposeServer)
                     {
-                        await WaitingSide(stream, tcs.Task, DefaultStreamErrorCodeServer);
+                        await WaitingSide(stream, tcs.Task, false);
                     }
                     else
                     {
@@ -1493,10 +1493,6 @@ namespace System.Net.Quic.Tests
 
                 await stream.DisposeAsync();
 
-                // Reads should be aborted as we didn't consume the data.
-                var readEx = await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, () => stream.ReadsClosed);
-                Assert.Null(readEx.ApplicationErrorCode);
-
                 // Writes should be aborted as we aborted them.
                 if (abortCode.HasValue)
                 {
@@ -1509,29 +1505,21 @@ namespace System.Net.Quic.Tests
                     Assert.True(stream.WritesClosed.IsCompletedSuccessfully);
                 }
 
+                // Reads should be aborted as we didn't consume the data.
+                var readEx = await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, () => stream.ReadsClosed);
+                Assert.Null(readEx.ApplicationErrorCode);
+
                 tcs.SetResult(abortCode);
             }
-            async ValueTask WaitingSide(QuicStream stream, Task<long?> task, long errorCode)
+            async ValueTask WaitingSide(QuicStream stream, Task<long?> task, bool server)
             {
                 long? abortCode = await task;
-
-                // Reads will be aborted by the peer as we didn't consume them all.
-                if (abortCode.HasValue)
-                {
-                    var readEx = await AssertThrowsQuicExceptionAsync(QuicError.StreamAborted, () => stream.ReadsClosed);
-                    Assert.Equal(abortCode.Value, readEx.ApplicationErrorCode);
-                }
-                // Reads should be still open as the peer closed gracefully and we are keeping the data in buffer.
-                else
-                {
-                    Assert.False(stream.ReadsClosed.IsCompleted);
-                }
 
                 if (!completeWrites)
                 {
                     // Writes must be aborted by the peer as we didn't complete them.
                     var writeEx = await AssertThrowsQuicExceptionAsync(QuicError.StreamAborted, () => stream.WritesClosed);
-                    Assert.Equal(errorCode, writeEx.ApplicationErrorCode);
+                    Assert.Equal(server ? DefaultStreamErrorCodeClient : DefaultStreamErrorCodeServer, writeEx.ApplicationErrorCode);
                 }
                 else
                 {
@@ -1545,8 +1533,24 @@ namespace System.Net.Quic.Tests
                     {
                         QuicException qe = Assert.IsType<QuicException>(ex);
                         Assert.Equal(QuicError.StreamAborted, qe.QuicError);
-                        Assert.Equal(errorCode, qe.ApplicationErrorCode);
+                        Assert.Equal(server ? DefaultStreamErrorCodeClient : DefaultStreamErrorCodeServer, qe.ApplicationErrorCode);
                     }
+                }
+
+                // Reads will be aborted by the peer as we didn't consume them all.
+                if (abortCode.HasValue)
+                {
+                    var readEx = await AssertThrowsQuicExceptionAsync(QuicError.StreamAborted, () => stream.ReadsClosed);
+                    Assert.Equal(abortCode.Value, readEx.ApplicationErrorCode);
+                }
+                // Reads should be still open as the peer closed gracefully and we are keeping the data in buffer.
+                else
+                {
+                    Assert.False(stream.ReadsClosed.IsCompleted);
+
+                    // Dispose will abort reading from this side.
+                    await stream.DisposeAsync();
+                    var readEx = await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, () => stream.ReadsClosed);
                 }
             }
         }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -45,14 +45,7 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
             lock (s_unobservedExceptions)
             {
                 string text = e.Exception.ToString();
-                if (!s_unobservedExceptions.ContainsKey(text))
-                {
-                    s_unobservedExceptions[text] = 1;
-                }
-                else
-                {
-                    s_unobservedExceptions[text] += 1;
-                }
+                s_unobservedExceptions[text] = s_unobservedExceptions.GetValueOrDefault(text) + 1;
             }
         };
         TaskScheduler.UnobservedTaskException += eventHandler;


### PR DESCRIPTION
Fixes leaking unobserved exceptions from S.N.Quic tests. 
Adds print out for the leaking exceptions - I can remove it if it's considered spam.

The remaining issue comes from `QuicConnection._connectionCloseTcs` but the fix is a bit more involved, I'll do it in separate PR.

Contributes to https://github.com/dotnet/runtime/issues/80111