### PR TITLE
JIT: Fix "elaborated type specifier" for enum class in JIT

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4658,7 +4658,7 @@ struct NewCallArg
     // The class handle if SignatureType == TYP_STRUCT.
     CORINFO_CLASS_HANDLE SignatureClsHnd = NO_CLASS_HANDLE;
     // The type of well known arg
-    enum class WellKnownArg WellKnownArg = ::WellKnownArg::None;
+    enum WellKnownArg WellKnownArg = ::WellKnownArg::None;
 
     NewCallArg WellKnown(::WellKnownArg type) const
     {


### PR DESCRIPTION
It [appears](https://en.cppreference.com/w/cpp/language/elaborated_type_specifier) even scoped enums should just get the `enum` keyword in these cases.

Fix #104442