### PR TITLE
Remove `virtual` modifier from `Calendar.CurrentEraValue`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
@@ -100,7 +100,7 @@ namespace System.Globalization
         /// <summary>
         /// This is used to convert CurrentEra(0) to an appropriate era value.
         /// </summary>
-        internal virtual int CurrentEraValue
+        internal int CurrentEraValue
         {
             get
             {


### PR DESCRIPTION
This change enables inlining of the `CurrentEraValue` property.

https://github.com/MihuBot/runtime-utils/issues/475#issuecomment-2209548714