### PR TITLE
Swap MetricsHandler and DiagnosticsHandler

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.InvokeNativeHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.InvokeNativeHandler.cs
@@ -176,7 +176,7 @@ namespace System.Net.Http
 
             try
             {
-                return method!.Invoke(_nativeHandler, parameters)!;
+                return method!.Invoke(_nativeUnderlyingHandler, parameters)!;
             }
             catch (TargetInvocationException e)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -22,9 +22,9 @@ namespace System.Net.Http
     {
         private static readonly ConcurrentDictionary<string, MethodInfo?> s_cachedMethods = new();
 
-        private readonly HttpMessageHandler? _nativeHandler;
+        private readonly HttpMessageHandler? _nativeUnderlyingHandler;
         private IMeterFactory? _nativeMeterFactory;
-        private MetricsHandler? _nativeMetricsHandler;
+        private HttpMessageHandler? _nativeFirstHandler; // DiagnosticsHandler or MetricsHandler, depending on global configuration.
 
         private readonly SocketsHttpHandler? _socketHandler;
 
@@ -38,23 +38,24 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    if (_nativeMetricsHandler is null)
+                    if (_nativeFirstHandler is null)
                     {
                         // We only setup these handlers for the native handler. SocketsHttpHandler already does this internally.
-                        HttpMessageHandler handler = _nativeHandler!;
+                        HttpMessageHandler handler = _nativeUnderlyingHandler!;
 
+                        // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
+                        // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
+                        handler = new MetricsHandler(handler, _nativeMeterFactory, out _);
                         if (DiagnosticsHandler.IsGloballyEnabled())
                         {
                             handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current);
                         }
 
-                        MetricsHandler metricsHandler = new MetricsHandler(handler, _nativeMeterFactory, out _);
-
                         // Ensure a single handler is used for all requests.
-                        Interlocked.CompareExchange(ref _nativeMetricsHandler, metricsHandler, null);
+                        Interlocked.CompareExchange(ref _nativeFirstHandler, handler, null);
                     }
 
-                    return _nativeMetricsHandler;
+                    return _nativeFirstHandler;
                 }
                 else
                 {
@@ -67,7 +68,7 @@ namespace System.Net.Http
         {
             if (IsNativeHandlerEnabled)
             {
-                _nativeHandler = CreateNativeHandler();
+                _nativeUnderlyingHandler = CreateNativeHandler();
             }
             else
             {
@@ -115,7 +116,7 @@ namespace System.Net.Http
 
                 if (IsNativeHandlerEnabled)
                 {
-                    if (_nativeMetricsHandler is not null)
+                    if (_nativeFirstHandler is not null)
                     {
                         throw new InvalidOperationException(SR.net_http_operation_started);
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -529,6 +529,8 @@ namespace System.Net.Http
                 handler = new HttpAuthenticatedConnectionHandler(poolManager);
             }
 
+            // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
+            // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
             handler = new MetricsHandler(handler, settings._meterFactory, out Meter meter);
             settings._metrics = new SocketsHttpHandlerMetrics(meter);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -529,15 +529,14 @@ namespace System.Net.Http
                 handler = new HttpAuthenticatedConnectionHandler(poolManager);
             }
 
+            handler = new MetricsHandler(handler, settings._meterFactory, out Meter meter);
+            settings._metrics = new SocketsHttpHandlerMetrics(meter);
+
             // DiagnosticsHandler is inserted before RedirectHandler so that trace propagation is done on redirects as well
             if (DiagnosticsHandler.IsGloballyEnabled() && settings._activityHeadersPropagator is DistributedContextPropagator propagator)
             {
                 handler = new DiagnosticsHandler(handler, propagator, settings._allowAutoRedirect);
             }
-
-            handler = new MetricsHandler(handler, settings._meterFactory, out Meter meter);
-
-            settings._metrics = new SocketsHttpHandlerMetrics(meter);
 
             if (settings._allowAutoRedirect)
             {


### PR DESCRIPTION
To support [Exemplars](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/metrics/exemplars/README.md), `http.request.duration` must be recorded before stopping the HTTP request Activity.

Fixes #103893.