### PR TITLE
Remove `virtual` modifier from `GetDatePart`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
@@ -432,7 +432,7 @@ namespace System.Globalization
         /// Returns a given date part of this DateTime. This method is used
         /// to compute the year, day-of-year, month, or day part.
         /// </summary>
-        private int GetDatePart(long ticks, int part)
+        private static int GetDatePart(long ticks, int part)
         {
             // The Gregorian year, month, day value for ticks.
             int hebrewYearType;                // lunar year type

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
@@ -432,7 +432,7 @@ namespace System.Globalization
         /// Returns a given date part of this DateTime. This method is used
         /// to compute the year, day-of-year, month, or day part.
         /// </summary>
-        internal virtual int GetDatePart(long ticks, int part)
+        private int GetDatePart(long ticks, int part)
         {
             // The Gregorian year, month, day value for ticks.
             int hebrewYearType;                // lunar year type

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/HijriCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/HijriCalendar.cs
@@ -192,7 +192,7 @@ namespace System.Globalization
         /// In order to get the exact Hijri year, we compare the exact absolute date for HijriYear and (HijriYear + 1).
         /// From here, we can get the correct Hijri year.
         /// </summary>
-        internal virtual int GetDatePart(long ticks, int part)
+        private int GetDatePart(long ticks, int part)
         {
             CheckTicksRange(ticks);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/JulianCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/JulianCalendar.cs
@@ -111,7 +111,7 @@ namespace System.Globalization
         /// Returns a given date part of this DateTime. This method is used
         /// to compute the year, day-of-year, month, or day part.
         /// </summary>
-        internal static int GetDatePart(long ticks, int part)
+        private static int GetDatePart(long ticks, int part)
         {
             // Gregorian 1/1/0001 is Julian 1/3/0001. Remember DateTime(0) is referred to Gregorian 1/1/0001.
             // The following line convert Gregorian ticks to Julian ticks.

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/PersianCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/PersianCalendar.cs
@@ -141,7 +141,7 @@ namespace System.Globalization
             return DaysToMonth[month];
         }
 
-        internal int GetDatePart(long ticks, int part)
+        private int GetDatePart(long ticks, int part)
         {
             CheckTicksRange(ticks);
 


### PR DESCRIPTION
The `GetDatePart` method in derived classes of `System.Globalization.Calendar` has no overrides therefore the `virtual` modifier is unnecessary.

Additionally make these methods `private`, and `static` where possible.