### PR TITLE
Copy prop equivalent phis

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1433,6 +1433,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             }
         }
     }
+
     //
     // Are we making an IsType assertion?
     //
@@ -2318,14 +2319,10 @@ AssertionIndex Compiler::optAssertionGenPhiDefn(GenTree* tree)
     }
 
     // Try to find if all phi arguments are known to be non-null.
-    //
     bool isNonNull = true;
     for (GenTreePhi::Use& use : tree->AsLclVar()->Data()->AsPhi()->Uses())
     {
-        GenTreePhiArg* const treePhiArg = use.GetNode()->AsPhiArg();
-        ValueNum             treePhiArgVN =
-            lvaGetDesc(treePhiArg)->GetPerSsaData(treePhiArg->GetSsaNum())->m_vnPair.GetConservative();
-        if (!vnStore->IsKnownNonNull(treePhiArgVN))
+        if (!vnStore->IsKnownNonNull(use.GetNode()->gtVNPair.GetConservative()))
         {
             isNonNull = false;
             break;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1184,28 +1184,6 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
         assertion.op2.SetIconFlag(GTF_EMPTY);
     }
     //
-    // Are two phi defs are equivalent?
-    //
-    else if (op1->IsPhiDefn() && op2->IsPhiDefn())
-    {
-        GenTreeLclVarCommon* const op1Lcl = op1->AsLclVar();
-        GenTreeLclVarCommon* const op2Lcl = op2->AsLclVar();
-        GenTreePhi* const          op1Phi = op1Lcl->Data()->AsPhi();
-        GenTreePhi* const          op2Phi = op2Lcl->Data()->AsPhi();
-
-        assertion.op1.kind       = O1K_LCLVAR;
-        assertion.op1.lcl.lclNum = op1Lcl->GetLclNum();
-        assertion.op1.lcl.ssaNum = op1Lcl->GetSsaNum();
-        assertion.op1.vn         = optConservativeNormalVN(op1Phi);
-
-        assertion.op2.kind       = O2K_LCLVAR_COPY;
-        assertion.op2.lcl.lclNum = op2Lcl->GetLclNum();
-        assertion.op2.lcl.ssaNum = op2Lcl->GetSsaNum();
-        assertion.op2.vn         = optConservativeNormalVN(op2Phi);
-
-        assertion.assertionKind = assertionKind;
-    }
-    //
     // Are we making an assertion about a local variable?
     //
     else if (op1->OperIsScalarLocal())
@@ -2339,101 +2317,11 @@ AssertionIndex Compiler::optAssertionGenPhiDefn(GenTree* tree)
         return NO_ASSERTION_INDEX;
     }
 
-    // If this is a loop header (cycle entry), see if this phi-def
-    // is value equivalent to some other phi-def in the block. Note
-    // value numbering is a one-pass forward algorithm and doesn't
-    // know the value numbers for back edge phi args, so cycle entry
-    // phis will all have novel VNs.
-    //
-    // We walk "backwards" so that
-    // we don't generate the assertion too early...?
-    //
-    // Note we can create at most one assertion, hopefully they chain
-    // so if one phi-def is both non-null and equivalent to another,
-    // the first generates the non-null assertion, the second the eq assertion.
-    //
-    // Consider: compute hash of forward edge phi inputs during VN,
-    // so we can quickly rule out inequivalent cases.
-    //
-    // Consider: tap into reachability logic available to VN, and/or
-    // edit out PHIs from impossible preds, or mark the phi nodes
-    // in some way so we can ignore them here.
-    //
-    // Consider: might want to skip handler entries?
-    //
-    FlowGraphNaturalLoop* const loop = m_blockToLoop->GetLoop(compCurBB);
-    if ((loop != nullptr) && (loop->GetHeader() == compCurBB))
-    {
-        for (Statement* stmt = compCurBB->firstStmt(); stmt != compCurStmt; stmt = stmt->GetNextStmt())
-        {
-            // Consider: limit searching if there are lots of phi defs
-            //
-            GenTree* const otherTree = stmt->GetRootNode();
-            assert(otherTree->IsPhiDefn());
-
-            if (otherTree->TypeGet() != tree->TypeGet())
-            {
-                continue;
-            }
-
-            GenTreePhi* const       treePhi   = tree->AsLclVar()->Data()->AsPhi();
-            GenTreePhi* const       otherPhi  = otherTree->AsLclVar()->Data()->AsPhi();
-            GenTreePhi::UseIterator treeIter  = treePhi->Uses().begin();
-            GenTreePhi::UseIterator treeEnd   = treePhi->Uses().end();
-            GenTreePhi::UseIterator otherIter = otherPhi->Uses().begin();
-            GenTreePhi::UseIterator otherEnd  = otherPhi->Uses().end();
-
-            bool phiDefsAreEquivalent = true;
-
-            for (; (treeIter != treeEnd) && (otherIter != otherEnd); ++treeIter, ++otherIter)
-            {
-                GenTreePhiArg* const treePhiArg  = treeIter->GetNode()->AsPhiArg();
-                GenTreePhiArg* const otherPhiArg = otherIter->GetNode()->AsPhiArg();
-
-                // Consider: ignore phi if gtPredBB is unreachable.
-                // But we don't know that here.
-                //
-                assert(treePhiArg->gtPredBB == otherPhiArg->gtPredBB);
-
-                // Consult SSA defs always... in principle we could just do this for
-                // back edge PhiArgs and use the Phi Arg VNs for forward edges,
-                // but the loops are invalidated by RBO so we're not sure which is which.
-                // Possibly we could rely on DFS instead.
-                //
-                ValueNum treePhiArgVN =
-                    lvaGetDesc(treePhiArg)->GetPerSsaData(treePhiArg->GetSsaNum())->m_vnPair.GetConservative();
-                ValueNum otherPhiArgVN =
-                    lvaGetDesc(otherPhiArg)->GetPerSsaData(otherPhiArg->GetSsaNum())->m_vnPair.GetConservative();
-
-                // Consider: see if we already think these two VNs are equivalent..
-                //
-                if (treePhiArgVN != otherPhiArgVN)
-                {
-                    // Consider: in some cases we know hte PHIs can't be equivalent...
-                    phiDefsAreEquivalent = false;
-                    break;
-                }
-            }
-
-            // If we didn't verify all phi args we have failed to prove equivalence
-            //
-            phiDefsAreEquivalent &= (treeIter == treeEnd);
-            phiDefsAreEquivalent &= (otherIter == otherEnd);
-
-            if (phiDefsAreEquivalent)
-            {
-                JITDUMP("Found equivalent phi defs: [%06u] and [%06u]\n", dspTreeID(treePhi), dspTreeID(otherPhi));
-                return optCreateAssertion(tree, otherTree, OAK_EQUAL);
-            }
-        }
-    }
-
     // Try to find if all phi arguments are known to be non-null.
+    //
     bool isNonNull = true;
     for (GenTreePhi::Use& use : tree->AsLclVar()->Data()->AsPhi()->Uses())
     {
-        // Use same trick as above to get VNs for back edge phi args
-        //
         GenTreePhiArg* const treePhiArg = use.GetNode()->AsPhiArg();
         ValueNum             treePhiArgVN =
             lvaGetDesc(treePhiArg)->GetPerSsaData(treePhiArg->GetSsaNum())->m_vnPair.GetConservative();
@@ -6718,8 +6606,6 @@ PhaseStatus Compiler::optAssertionPropMain()
                 }
             }
 
-            compCurStmt = stmt;
-
             // Perform assertion gen for control flow based assertions.
             for (GenTree* const tree : stmt->TreeList())
             {
@@ -6803,10 +6689,7 @@ PhaseStatus Compiler::optAssertionPropMain()
         fgRemoveRestOfBlock = false;
 
         // Walk the statement trees in this basic block
-        // (remember if we generated equiv phi defs?
-        //
-        // Statement* stmt = block->FirstNonPhiDef();
-        Statement* stmt = block->firstStmt();
+        Statement* stmt = block->FirstNonPhiDef();
         while (stmt != nullptr)
         {
             // Propagation tells us to remove the rest of the block. Remove it.

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -487,12 +487,6 @@ void Compiler::optCopyPropPushDef(GenTree* defNode, GenTreeLclVarCommon* lclNode
     else if (lclNode->HasSsaName())
     {
         unsigned ssaNum = lclNode->GetSsaNum();
-        if ((defNode != nullptr) && defNode->IsPhiDefn())
-        {
-            // TODO-CQ: design better heuristics for propagation and remove this.
-            // ssaNum = SsaConfig::RESERVED_SSA_NUM;
-        }
-
         pushDef(lclNum, ssaNum);
     }
 }


### PR DESCRIPTION
VN doesn't always give PHI defs the best possible values (in particular if there are backedge phi args). Look for equivalent phis later, during copy prop.

Addresses the regression case noted in https://github.com/dotnet/runtime/issues/95645#issuecomment-2204089724 where cross-block morph's copy prop plus loop bottom testing has created some unnecessary loop-carried values.