### PR TITLE
[RISC-V] Increase timeout for tracing/eventcounter/runtimecounters

### DIFF
--- a/src/tests/tracing/eventcounter/runtimecounters.cs
+++ b/src/tests/tracing/eventcounter/runtimecounters.cs
@@ -104,17 +104,19 @@ namespace RuntimeEventCounterTests
             // Create an EventListener.
             using (RuntimeCounterListener myListener = new RuntimeCounterListener())
             {
-                Thread.Sleep(60000);
-                if (myListener.Verify())
+                // Wait max 60 seconds
+                for (int i = 0; i < 60; i++)
                 {
-                    Console.WriteLine("Test passed");
-                    return 100;
+                    Thread.Sleep(1000);
+                    if (myListener.Verify())
+                    {
+                        Console.WriteLine("Test passed");
+                        return 100;
+                    }
                 }
-                else
-                {
-                    Console.WriteLine($"Test Failed - did not see one or more of the expected runtime counters.");
-                    return 1;
-                }
+
+                Console.WriteLine($"Test Failed - did not see one or more of the expected runtime counters.");
+                return 1;
             }
         }
     }

--- a/src/tests/tracing/eventcounter/runtimecounters.cs
+++ b/src/tests/tracing/eventcounter/runtimecounters.cs
@@ -104,7 +104,7 @@ namespace RuntimeEventCounterTests
             // Create an EventListener.
             using (RuntimeCounterListener myListener = new RuntimeCounterListener())
             {
-                Thread.Sleep(3000);
+                Thread.Sleep(60000);
                 if (myListener.Verify())
                 {
                     Console.WriteLine("Test passed");


### PR DESCRIPTION
This test expects that all runtime counters are already prepared when timeout has passed, however, it might be untrue for debug/checked builds (specifically, debug/checked build on VisionFive2 riscv64).

```
               Saw cpu-usage
               Unhandled exception. System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
                  at System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator.MoveNext() in src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs:line 1631
                  at RuntimeEventCounterTests.RuntimeCounterListener.Verify()
                  at RuntimeEventCounterTests.TestRuntimeEventCounter.Main()

```

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung