### PR TITLE
Remove `virtual` modifier from `InternalFallback`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/DecoderFallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/DecoderFallback.cs
@@ -104,7 +104,7 @@ namespace System.Text
         // Right now this has both bytes and bytes[], since we might have extra bytes, hence the
         // array, and we might need the index, hence the byte*
         // Don't touch ref chars unless we succeed
-        internal virtual unsafe bool InternalFallback(byte[] bytes, byte* pBytes, ref char* chars)
+        internal unsafe bool InternalFallback(byte[] bytes, byte* pBytes, ref char* chars)
         {
             Debug.Assert(byteStart != null, "[DecoderFallback.InternalFallback]Used InternalFallback without calling InternalInitialize");
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncoderFallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncoderFallback.cs
@@ -293,7 +293,7 @@ namespace System.Text
         // Note that this could also change the contents of this.encoder, which is the same
         // object that the caller is using, so the caller could mess up the encoder for us
         // if they aren't careful.
-        internal virtual unsafe bool InternalFallback(char ch, ref char* chars)
+        internal unsafe bool InternalFallback(char ch, ref char* chars)
         {
             // Shouldn't have null charStart
             Debug.Assert(charStart != null,


### PR DESCRIPTION
* `System.Text.DecoderFallbackBuffer`
* `System.Text.EncoderFallbackBuffer`

These `internal` methods have no overrides therefore the `virtual` modifier is unnecessary.