### PR TITLE
Add some helper functions for getting the intrinsic ID to use for a given oper

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2603,6 +2603,7 @@ class Compiler
     friend class FlowGraphNaturalLoop;
 
 #ifdef FEATURE_HW_INTRINSICS
+    friend struct GenTreeHWIntrinsic;
     friend struct HWIntrinsicInfo;
     friend struct SimdAsHWIntrinsicInfo;
 #endif // FEATURE_HW_INTRINSICS
@@ -9577,6 +9578,21 @@ private:
     // F+CD+DQ+BW+VL (such as VBMI) and should appear with a corresponding query around AVX512*_VL (i.e. AVX512_VBMI_VL)
 
 #ifdef DEBUG
+    //------------------------------------------------------------------------
+    // IsBaselineVector256IsaSupportedDebugOnly - Does isa support exist for Vector256.
+    //
+    // Returns:
+    //    `true` if AVX.
+    //
+    bool IsBaselineVector256IsaSupportedDebugOnly() const
+    {
+#ifdef TARGET_XARCH
+        return compIsaSupportedDebugOnly(InstructionSet_AVX);
+#else
+        return false;
+#endif
+    }
+
     //------------------------------------------------------------------------
     // IsBaselineVector512IsaSupportedDebugOnly - Does isa support exist for Vector512.
     //

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20867,6 +20867,11 @@ GenTree* Compiler::gtNewSimdBinOpNode(
             break;
         }
 #endif // TARGET_XARCH
+
+        default:
+        {
+            break;
+        }
     }
 
     if (needsReverseOps)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -27620,7 +27620,7 @@ NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForUnOp(
         case GT_NEG:
         {
 #if defined(TARGET_ARM64)
-            assert(varTypeIsSigned(simdBaseType));
+            assert(varTypeIsSigned(simdBaseType) || varTypeIsFloating(simdBaseType));
 
             if (varTypeIsLong(simdBaseType))
             {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20813,7 +20813,7 @@ GenTree* Compiler::gtNewSimdBinOpNode(
 #if defined(TARGET_ARM64)
                 if (!varTypeIsByte(simdBaseType))
                 {
-                    // MultiplyByScalar requires the scalar op to be op2
+                    // MultiplyByScalar requires the scalar op to be op2fGetHWIntrinsicIdForBinOp
                     needsReverseOps = true;
                 }
 #endif // TARGET_ARM64
@@ -20845,17 +20845,20 @@ GenTree* Compiler::gtNewSimdBinOpNode(
         case GT_OR:
         case GT_XOR:
         {
-            if (varTypeIsIntegral(simdBaseType) && !compOpportunisticallyDependsOn(InstructionSet_AVX2))
+            if (simdSize == 32)
             {
-                if (varTypeIsLong(simdBaseType))
+                if (varTypeIsIntegral(simdBaseType) && !compOpportunisticallyDependsOn(InstructionSet_AVX2))
                 {
-                    simdBaseJitType = CORINFO_TYPE_DOUBLE;
-                    simdBaseType    = TYP_DOUBLE;
-                }
-                else
-                {
-                    simdBaseJitType = CORINFO_TYPE_FLOAT;
-                    simdBaseType    = TYP_FLOAT;
+                    if (varTypeIsLong(simdBaseType))
+                    {
+                        simdBaseJitType = CORINFO_TYPE_DOUBLE;
+                        simdBaseType    = TYP_DOUBLE;
+                    }
+                    else
+                    {
+                        simdBaseJitType = CORINFO_TYPE_FLOAT;
+                        simdBaseType    = TYP_FLOAT;
+                    }
                 }
             }
 
@@ -28226,7 +28229,7 @@ NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForBinOp(Compiler*  comp,
                 if (simdSize == 32)
                 {
                     assert(comp->compIsaSupportedDebugOnly(InstructionSet_AVX2));
-                    id = varTypeIsInt(op2) ? NI_AVX2_ShiftRightLogical : NI_AVX2_ShiftRightLogicalVariable;
+                    id = varTypeIsInt(op2) ? NI_AVX2_ShiftRightArithmetic : NI_AVX2_ShiftRightArithmeticVariable;
                 }
                 else if (varTypeIsInt(op2))
                 {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -21764,14 +21764,14 @@ GenTree* Compiler::gtNewSimdCmpOpNode(
         case GT_GE:
         case GT_LE:
         {
-            needsConvertMaskToVector = (simdSize == 64) || (canUseEvexEncoding() && !varTypeIsFloating(simdBaseType));
+            needsConvertMaskToVector = (simdSize == 64) || (varTypeIsIntegral(simdBaseType) && canUseEvexEncoding());
             break;
         }
 
         case GT_GT:
         case GT_LT:
         {
-            needsConvertMaskToVector = (simdSize == 64) || (canUseEvexEncoding() && varTypeIsUnsigned(simdBaseType));
+            needsConvertMaskToVector = (simdSize == 64) || (varTypeIsUnsigned(simdBaseType) && canUseEvexEncoding());
             break;
         }
 
@@ -28585,13 +28585,13 @@ NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(Compiler*  comp,
             assert(op2->TypeIs(simdType));
 
 #if defined(TARGET_XARCH)
-            if (varTypeIsIntegral(simdBaseType))
+            if (simdSize == 64)
             {
-                if (comp->canUseEvexEncoding())
-                {
-                    id = NI_EVEX_CompareGreaterThanMask;
-                }
-                else if (varTypeIsSigned(simdBaseType))
+                id = NI_EVEX_CompareGreaterThanMask;
+            }
+            else if (varTypeIsIntegral(simdBaseType))
+            {
+                if (varTypeIsSigned(simdBaseType))
                 {
                     if (simdSize == 32)
                     {
@@ -28611,10 +28611,10 @@ NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(Compiler*  comp,
                         id = NI_SSE2_CompareGreaterThan;
                     }
                 }
-            }
-            else if (simdSize == 64)
-            {
-                id = NI_EVEX_CompareGreaterThanMask;
+                else if (comp->canUseEvexEncoding())
+                {
+                    id = NI_EVEX_CompareGreaterThanMask;
+                }
             }
             else if (simdSize == 32)
             {
@@ -28690,13 +28690,13 @@ NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(Compiler*  comp,
             assert(op2->TypeIs(simdType));
 
 #if defined(TARGET_XARCH)
-            if (varTypeIsIntegral(simdBaseType))
+            if (simdSize == 64)
             {
-                if (comp->canUseEvexEncoding())
-                {
-                    id = NI_EVEX_CompareLessThanMask;
-                }
-                else if (varTypeIsSigned(simdBaseType))
+                id = NI_EVEX_CompareLessThanMask;
+            }
+            else if (varTypeIsIntegral(simdBaseType))
+            {
+                if (varTypeIsSigned(simdBaseType))
                 {
                     if (simdSize == 32)
                     {
@@ -28716,10 +28716,10 @@ NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(Compiler*  comp,
                         id = NI_SSE2_CompareLessThan;
                     }
                 }
-            }
-            else if (simdSize == 64)
-            {
-                id = NI_EVEX_CompareLessThanMask;
+                else if (comp->canUseEvexEncoding())
+                {
+                    id = NI_EVEX_CompareLessThanMask;
+                }
             }
             else if (simdSize == 32)
             {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20890,7 +20890,7 @@ GenTree* Compiler::gtNewSimdBinOpNode(
     }
 
     NamedIntrinsic intrinsic =
-        GenTreeHWIntrinsic::HWIdGetForBinOp(this, op, op1, op2ForLookup, simdBaseType, simdSize, false);
+        GenTreeHWIntrinsic::GetHWIntrinsicIdForBinOp(this, op, op1, op2ForLookup, simdBaseType, simdSize, false);
 
     if (intrinsic != NI_Illegal)
     {
@@ -20906,9 +20906,9 @@ GenTree* Compiler::gtNewSimdBinOpNode(
             // by shifting 32-bit values and masking off the bits that should be zeroed.
 
             assert(varTypeIsByte(simdBaseType));
-            assert(simdSize != 64);
 
-            intrinsic = GenTreeHWIntrinsic::HWIdGetForBinOp(this, op, op1, op2ForLookup, TYP_INT, simdSize, false);
+            intrinsic =
+                GenTreeHWIntrinsic::GetHWIntrinsicIdForBinOp(this, op, op1, op2ForLookup, TYP_INT, simdSize, false);
             assert(intrinsic != NI_Illegal);
 
             GenTree* maskAmountOp;
@@ -21127,8 +21127,6 @@ GenTree* Compiler::gtNewSimdBinOpNode(
             }
             else if (varTypeIsInt(simdBaseType))
             {
-                assert(!compIsaSupportedDebugOnly(InstructionSet_SSE41));
-
                 // op1Dup = op1
                 GenTree* op1Dup = fgMakeMultiUse(&op1);
 
@@ -21784,7 +21782,8 @@ GenTree* Compiler::gtNewSimdCmpOpNode(
     }
 #endif // TARGET_XARCH
 
-    NamedIntrinsic intrinsic = GenTreeHWIntrinsic::HWIdGetForCmpOp(this, op, op1, op2, simdBaseType, simdSize, false);
+    NamedIntrinsic intrinsic =
+        GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(this, op, op1, op2, simdBaseType, simdSize, false);
 
     if (intrinsic != NI_Illegal)
     {
@@ -21805,7 +21804,6 @@ GenTree* Compiler::gtNewSimdCmpOpNode(
         {
             assert(varTypeIsLong(simdBaseType));
             assert(simdSize == 16);
-            assert(!compIsaSupportedDebugOnly(InstructionSet_SSE41));
 
             // There is no direct SSE2 support for comparing TYP_LONG vectors.
             // These have to be implemented in terms of TYP_INT vector comparison operations.
@@ -21980,7 +21978,6 @@ GenTree* Compiler::gtNewSimdCmpOpNode(
             {
                 assert(varTypeIsLong(simdBaseType));
                 assert(simdSize == 16);
-                assert(!compIsaSupportedDebugOnly(InstructionSet_SSE42));
 
                 // There is no direct SSE2 support for comparing TYP_LONG vectors.
                 // These have to be implemented in terms of TYP_INT vector comparison operations.
@@ -25471,7 +25468,8 @@ GenTree* Compiler::gtNewSimdUnOpNode(
     }
 #endif // TARGET_ARM64
 
-    NamedIntrinsic intrinsic = GenTreeHWIntrinsic::HWIdGetForUnOp(this, op, op1, simdBaseType, simdSize, false);
+    NamedIntrinsic intrinsic =
+        GenTreeHWIntrinsic::GetHWIntrinsicIdForUnOp(this, op, op1, simdBaseType, simdSize, false);
 
     if (intrinsic != NI_Illegal)
     {
@@ -26642,7 +26640,7 @@ bool GenTreeHWIntrinsic::OperIsBitwiseHWIntrinsic(genTreeOps oper)
 bool GenTreeHWIntrinsic::OperIsBitwiseHWIntrinsic() const
 {
     bool       isScalar = false;
-    genTreeOps oper     = HWOperGet(&isScalar);
+    genTreeOps oper     = GetOperForHWIntrinsicId(&isScalar);
     return OperIsBitwiseHWIntrinsic(oper);
 }
 
@@ -27007,7 +27005,7 @@ void GenTreeHWIntrinsic::Initialize(NamedIntrinsic intrinsicId)
 }
 
 //------------------------------------------------------------------------------
-// HWOperGet: Returns oper based on the intrinsic ID and base type
+// GetOperForHWIntrinsicId: Returns oper based on the intrinsic ID and base type
 //
 // Arguments:
 //    id           - The intrinsic ID for which to get the oper
@@ -27017,7 +27015,7 @@ void GenTreeHWIntrinsic::Initialize(NamedIntrinsic intrinsicId)
 // Returns:
 //    The oper based on the intrinsic ID and base type
 //
-genTreeOps GenTreeHWIntrinsic::HWOperGet(NamedIntrinsic id, var_types simdBaseType, bool* isScalar)
+genTreeOps GenTreeHWIntrinsic::GetOperForHWIntrinsicId(NamedIntrinsic id, var_types simdBaseType, bool* isScalar)
 {
     *isScalar = false;
 
@@ -27569,7 +27567,7 @@ genTreeOps GenTreeHWIntrinsic::HWOperGet(NamedIntrinsic id, var_types simdBaseTy
 }
 
 //------------------------------------------------------------------------------
-// HWIdGetForUnOp: Returns intrinsic ID based on the oper, base type, and simd size
+// GetHWIntrinsicIdForUnOp: Returns intrinsic ID based on the oper, base type, and simd size
 //
 // Arguments:
 //    comp         - The compiler instance
@@ -27582,7 +27580,7 @@ genTreeOps GenTreeHWIntrinsic::HWOperGet(NamedIntrinsic id, var_types simdBaseTy
 // Returns:
 //    The intrinsic ID based on the oper, base type, and simd size
 //
-NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForUnOp(
+NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForUnOp(
     Compiler* comp, genTreeOps oper, GenTree* op1, var_types simdBaseType, unsigned simdSize, bool isScalar)
 {
     var_types simdType = comp->getSIMDTypeForSize(simdSize);
@@ -27662,7 +27660,7 @@ NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForUnOp(
 }
 
 //------------------------------------------------------------------------------
-// HWIdGetForBinOp: Returns intrinsic ID based on the oper, base type, and simd size
+// GetHWIntrinsicIdForBinOp: Returns intrinsic ID based on the oper, base type, and simd size
 //
 // Arguments:
 //    comp         - The compiler instance
@@ -27676,13 +27674,13 @@ NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForUnOp(
 // Returns:
 //    The intrinsic ID based on the oper, base type, and simd size
 //
-NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForBinOp(Compiler*  comp,
-                                                   genTreeOps oper,
-                                                   GenTree*   op1,
-                                                   GenTree*   op2,
-                                                   var_types  simdBaseType,
-                                                   unsigned   simdSize,
-                                                   bool       isScalar)
+NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForBinOp(Compiler*  comp,
+                                                            genTreeOps oper,
+                                                            GenTree*   op1,
+                                                            GenTree*   op2,
+                                                            var_types  simdBaseType,
+                                                            unsigned   simdSize,
+                                                            bool       isScalar)
 {
     var_types simdType = comp->getSIMDTypeForSize(simdSize);
 
@@ -28035,8 +28033,6 @@ NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForBinOp(Compiler*  comp,
                 id = NI_SSE2_MultiplyLow;
             }
 #elif defined(TARGET_ARM64)
-            assert(op2->TypeIs(simdType) || op2->TypeIs(simdBaseType));
-
             if ((simdSize == 8) && (isScalar || (simdBaseType == TYP_DOUBLE)))
             {
                 id = NI_AdvSimd_MultiplyScalar;
@@ -28436,7 +28432,7 @@ NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForBinOp(Compiler*  comp,
 }
 
 //------------------------------------------------------------------------------
-// HWIdGetForCmpOp: Returns intrinsic ID based on the oper, base type, and simd size
+// GetHWIntrinsicIdForCmpOp: Returns intrinsic ID based on the oper, base type, and simd size
 //
 // Arguments:
 //    comp         - The compiler instance
@@ -28450,13 +28446,13 @@ NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForBinOp(Compiler*  comp,
 // Returns:
 //    The intrinsic ID based on the oper, base type, and simd size
 //
-NamedIntrinsic GenTreeHWIntrinsic::HWIdGetForCmpOp(Compiler*  comp,
-                                                   genTreeOps oper,
-                                                   GenTree*   op1,
-                                                   GenTree*   op2,
-                                                   var_types  simdBaseType,
-                                                   unsigned   simdSize,
-                                                   bool       isScalar)
+NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(Compiler*  comp,
+                                                            genTreeOps oper,
+                                                            GenTree*   op1,
+                                                            GenTree*   op2,
+                                                            var_types  simdBaseType,
+                                                            unsigned   simdSize,
+                                                            bool       isScalar)
 {
     var_types simdType = comp->getSIMDTypeForSize(simdSize);
 
@@ -29716,10 +29712,10 @@ uint8_t GenTreeHWIntrinsic::GetTernaryControlByte(GenTreeHWIntrinsic* second) co
 
     bool isScalar = false;
 
-    genTreeOps firstOper = HWOperGet(&isScalar);
+    genTreeOps firstOper = GetOperForHWIntrinsicId(&isScalar);
     assert(!isScalar);
 
-    genTreeOps secondOper = second->HWOperGet(&isScalar);
+    genTreeOps secondOper = second->GetOperForHWIntrinsicId(&isScalar);
     assert(!isScalar);
 
     uint8_t AB  = 0;
@@ -29842,7 +29838,7 @@ bool GenTree::IsVectorPerElementMask(var_types simdBaseType, unsigned simdSize) 
         }
 
         bool       isScalar = false;
-        genTreeOps oper     = intrinsic->HWOperGet(&isScalar);
+        genTreeOps oper     = intrinsic->GetOperForHWIntrinsicId(&isScalar);
 
         switch (oper)
         {
@@ -30154,7 +30150,7 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
     }
 
     bool       isScalar = false;
-    genTreeOps oper     = tree->HWOperGet(&isScalar);
+    genTreeOps oper     = tree->GetOperForHWIntrinsicId(&isScalar);
 
 #if defined(TARGET_XARCH)
     if (oper == GT_AND_NOT)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6624,7 +6624,28 @@ struct GenTreeHWIntrinsic : public GenTreeJitIntrinsic
 
     static bool Equals(GenTreeHWIntrinsic* op1, GenTreeHWIntrinsic* op2);
 
-    genTreeOps HWOperGet(bool* isScalar) const;
+    static NamedIntrinsic HWIdGetForUnOp(
+        Compiler* comp, genTreeOps oper, GenTree* op1, var_types simdBaseType, unsigned simdSize, bool isScalar);
+    static NamedIntrinsic HWIdGetForBinOp(Compiler*  comp,
+                                          genTreeOps oper,
+                                          GenTree*   op1,
+                                          GenTree*   op2,
+                                          var_types  simdBaseType,
+                                          unsigned   simdSize,
+                                          bool       isScalar);
+    static NamedIntrinsic HWIdGetForCmpOp(Compiler*  comp,
+                                          genTreeOps oper,
+                                          GenTree*   op1,
+                                          GenTree*   op2,
+                                          var_types  simdBaseType,
+                                          unsigned   simdSize,
+                                          bool       isScalar);
+    static genTreeOps     HWOperGet(NamedIntrinsic id, var_types simdBaseType, bool* isScalar);
+
+    genTreeOps HWOperGet(bool* isScalar) const
+    {
+        return HWOperGet(GetHWIntrinsicId(), GetSimdBaseType(), isScalar);
+    }
 
     bool ShouldConstantProp(GenTree* operand, GenTreeVecCon* vecCon);
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6624,27 +6624,27 @@ struct GenTreeHWIntrinsic : public GenTreeJitIntrinsic
 
     static bool Equals(GenTreeHWIntrinsic* op1, GenTreeHWIntrinsic* op2);
 
-    static NamedIntrinsic HWIdGetForUnOp(
+    static NamedIntrinsic GetHWIntrinsicIdForUnOp(
         Compiler* comp, genTreeOps oper, GenTree* op1, var_types simdBaseType, unsigned simdSize, bool isScalar);
-    static NamedIntrinsic HWIdGetForBinOp(Compiler*  comp,
-                                          genTreeOps oper,
-                                          GenTree*   op1,
-                                          GenTree*   op2,
-                                          var_types  simdBaseType,
-                                          unsigned   simdSize,
-                                          bool       isScalar);
-    static NamedIntrinsic HWIdGetForCmpOp(Compiler*  comp,
-                                          genTreeOps oper,
-                                          GenTree*   op1,
-                                          GenTree*   op2,
-                                          var_types  simdBaseType,
-                                          unsigned   simdSize,
-                                          bool       isScalar);
-    static genTreeOps     HWOperGet(NamedIntrinsic id, var_types simdBaseType, bool* isScalar);
+    static NamedIntrinsic GetHWIntrinsicIdForBinOp(Compiler*  comp,
+                                                   genTreeOps oper,
+                                                   GenTree*   op1,
+                                                   GenTree*   op2,
+                                                   var_types  simdBaseType,
+                                                   unsigned   simdSize,
+                                                   bool       isScalar);
+    static NamedIntrinsic GetHWIntrinsicIdForCmpOp(Compiler*  comp,
+                                                   genTreeOps oper,
+                                                   GenTree*   op1,
+                                                   GenTree*   op2,
+                                                   var_types  simdBaseType,
+                                                   unsigned   simdSize,
+                                                   bool       isScalar);
+    static genTreeOps     GetOperForHWIntrinsicId(NamedIntrinsic id, var_types simdBaseType, bool* isScalar);
 
-    genTreeOps HWOperGet(bool* isScalar) const
+    genTreeOps GetOperForHWIntrinsicId(bool* isScalar) const
     {
-        return HWOperGet(GetHWIntrinsicId(), GetSimdBaseType(), isScalar);
+        return GetOperForHWIntrinsicId(GetHWIntrinsicId(), GetSimdBaseType(), isScalar);
     }
 
     bool ShouldConstantProp(GenTree* operand, GenTreeVecCon* vecCon);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -1416,7 +1416,7 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
     }
 
     bool       isScalar = false;
-    genTreeOps oper     = node->HWOperGet(&isScalar);
+    genTreeOps oper     = node->GetOperForHWIntrinsicId(&isScalar);
 
     switch (oper)
     {
@@ -1452,7 +1452,7 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
                 }
 
                 bool       nestedIsScalar = false;
-                genTreeOps nestedOper     = second->AsHWIntrinsic()->HWOperGet(&isScalar);
+                genTreeOps nestedOper     = second->AsHWIntrinsic()->GetOperForHWIntrinsicId(&isScalar);
 
                 if (nestedOper == GT_NONE)
                 {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9968,7 +9968,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
         default:
         {
             bool       isScalar   = false;
-            genTreeOps actualOper = node->HWOperGet(&isScalar);
+            genTreeOps actualOper = node->GetOperForHWIntrinsicId(&isScalar);
             genTreeOps oper       = actualOper;
 
             if (GenTreeHWIntrinsic::OperIsBitwiseHWIntrinsic(oper))
@@ -10125,7 +10125,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
     }
 
     bool       isScalar = false;
-    genTreeOps oper     = node->HWOperGet(&isScalar);
+    genTreeOps oper     = node->GetOperForHWIntrinsicId(&isScalar);
 
     if (isScalar)
     {
@@ -10148,7 +10148,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
             {
                 // Try handle: ~op1 & op2
                 GenTreeHWIntrinsic* hw     = op1->AsHWIntrinsic();
-                genTreeOps          hwOper = hw->HWOperGet(&isScalar);
+                genTreeOps          hwOper = hw->GetOperForHWIntrinsicId(&isScalar);
 
                 if (isScalar)
                 {
@@ -10174,7 +10174,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
             {
                 // Try handle: op1 & ~op2
                 GenTreeHWIntrinsic* hw     = op2->AsHWIntrinsic();
-                genTreeOps          hwOper = hw->HWOperGet(&isScalar);
+                genTreeOps          hwOper = hw->GetOperForHWIntrinsicId(&isScalar);
 
                 if (isScalar)
                 {
@@ -10229,7 +10229,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
             if (op1->OperIsHWIntrinsic())
             {
                 GenTreeHWIntrinsic* hw     = op1->AsHWIntrinsic();
-                genTreeOps          hwOper = hw->HWOperGet(&isScalar);
+                genTreeOps          hwOper = hw->GetOperForHWIntrinsicId(&isScalar);
 
                 if (isScalar)
                 {
@@ -10266,7 +10266,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
             if (op1->OperIsHWIntrinsic())
             {
                 GenTreeHWIntrinsic* hw     = op1->AsHWIntrinsic();
-                genTreeOps          hwOper = hw->HWOperGet(&isScalar);
+                genTreeOps          hwOper = hw->GetOperForHWIntrinsicId(&isScalar);
 
                 if (isScalar)
                 {
@@ -10308,7 +10308,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
                 if (op2->OperIsHWIntrinsic())
                 {
                     GenTreeHWIntrinsic* hw             = op2->AsHWIntrinsic();
-                    genTreeOps          hwOper         = hw->HWOperGet(&isScalar);
+                    genTreeOps          hwOper         = hw->GetOperForHWIntrinsicId(&isScalar);
                     var_types           hwSimdBaseType = hw->GetSimdBaseType();
 
                     if (isScalar)
@@ -10414,7 +10414,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsicAssociative(GenTreeHWIntrinsic* tree)
     }
 
     bool       isScalar              = false;
-    genTreeOps oper                  = tree->HWOperGet(&isScalar);
+    genTreeOps oper                  = tree->GetOperForHWIntrinsicId(&isScalar);
     bool       needsMatchingBaseType = false;
 
     switch (oper)
@@ -10457,7 +10457,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsicAssociative(GenTreeHWIntrinsic* tree)
     GenTreeHWIntrinsic* intrinOp1 = effectiveOp1->AsHWIntrinsic();
 
     bool       op1IsScalar = false;
-    genTreeOps op1Oper     = intrinOp1->HWOperGet(&op1IsScalar);
+    genTreeOps op1Oper     = intrinOp1->GetOperForHWIntrinsicId(&op1IsScalar);
 
     if ((op1Oper != oper) || (op1IsScalar != isScalar))
     {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7563,7 +7563,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunUnary(
     if (IsVNConstant(arg0VN))
     {
         bool       isScalar = false;
-        genTreeOps oper     = tree->HWOperGet(&isScalar);
+        genTreeOps oper     = tree->GetOperForHWIntrinsicId(&isScalar);
 
         if (oper != GT_NONE)
         {
@@ -7915,7 +7915,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(GenTreeHWIntrinsic* tree,
         assert(IsVNConstant(arg0VN) && IsVNConstant(arg1VN));
 
         bool       isScalar = false;
-        genTreeOps oper     = tree->HWOperGet(&isScalar);
+        genTreeOps oper     = tree->GetOperForHWIntrinsicId(&isScalar);
 
         if (oper != GT_NONE)
         {
@@ -8045,7 +8045,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(GenTreeHWIntrinsic* tree,
     else if (cnsVN != NoVN)
     {
         bool       isScalar = false;
-        genTreeOps oper     = tree->HWOperGet(&isScalar);
+        genTreeOps oper     = tree->GetOperForHWIntrinsicId(&isScalar);
 
         if (isScalar)
         {
@@ -8395,7 +8395,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(GenTreeHWIntrinsic* tree,
     else if (arg0VN == arg1VN)
     {
         bool       isScalar = false;
-        genTreeOps oper     = tree->HWOperGet(&isScalar);
+        genTreeOps oper     = tree->GetOperForHWIntrinsicId(&isScalar);
 
         if (isScalar)
         {


### PR DESCRIPTION
This is purely a refactoring, it extracts some of the logic that mapped a `genTreeOper` to the corresponding `NamedIntrinsic` into a helper so that it could be used from locations other than import.

This makes it easier for lowering or morph to do transformations without requiring a new node to be allocated.