### PR TITLE
Avoid boxing in System.ObjectModel.KeydCollection during startup

### DIFF
--- a/src/libraries/System.ObjectModel/src/System.ObjectModel.csproj
+++ b/src/libraries/System.ObjectModel/src/System.ObjectModel.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="System.ObjectModel.Forwards.cs" />
+    <Compile Include="System\ThrowHelper.cs" />
     <Compile Include="System\Collections\CollectionHelpers.cs" />
     <Compile Include="System\Collections\Generic\DebugView.cs" />
     <Compile Include="System\Collections\Specialized\INotifyCollectionChanged.cs" />

--- a/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
+++ b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
@@ -71,7 +71,10 @@ namespace System.Collections.ObjectModel
 
         public bool Contains(TKey key)
         {
-            ArgumentNullException.ThrowIfNull(key);
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(key));
+            }
 
             if (dict != null)
             {
@@ -91,7 +94,10 @@ namespace System.Collections.ObjectModel
 
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TItem item)
         {
-            ArgumentNullException.ThrowIfNull(key);
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(key));
+            }
 
             if (dict != null)
             {
@@ -131,7 +137,10 @@ namespace System.Collections.ObjectModel
 
         public bool Remove(TKey key)
         {
-            ArgumentNullException.ThrowIfNull(key);
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(key));
+            }
 
             if (dict != null)
             {

--- a/src/libraries/System.ObjectModel/src/System/ThrowHelper.cs
+++ b/src/libraries/System.ObjectModel/src/System/ThrowHelper.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System
+{
+    internal static class ThrowHelper
+    {
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string? paramName) =>
+            throw new ArgumentNullException(paramName);
+    }
+}


### PR DESCRIPTION
ArgumentNullException.ThrowIfNull can incur boxing when applied to argument of generic type. Tier-1 JIT optimizations are able to optimize this boxing in steady state, but Tier-0 JIT optimization are not. It can result into excessive allocations during startup. Switch KeyedCollection to use ThrowHelper that is pattern used by number of other collections.