### PR TITLE
Use `Unsafe.BitCast` for `Int128` ↔`UInt128` operators

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -425,7 +425,7 @@ namespace System
         /// <param name="value">The value to convert.</param>
         /// <returns><paramref name="value" /> converted to a <see cref="UInt128" />.</returns>
         [CLSCompliant(false)]
-        public static explicit operator UInt128(Int128 value) => new UInt128(value._upper, value._lower);
+        public static explicit operator UInt128(Int128 value) => Unsafe.BitCast<Int128, UInt128>(value);
 
         /// <summary>Explicitly converts a 128-bit signed integer to a <see cref="UInt128" /> value, throwing an overflow exception for any values that fall outside the representable range.</summary>
         /// <param name="value">The value to convert.</param>
@@ -438,7 +438,7 @@ namespace System
             {
                 ThrowHelper.ThrowOverflowException();
             }
-            return new UInt128(value._upper, value._lower);
+            return Unsafe.BitCast<Int128, UInt128>(value);
         }
 
         /// <summary>Explicitly converts a 128-bit signed integer to a <see cref="UIntPtr" /> value.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -344,7 +344,7 @@ namespace System
         /// <param name="value">The value to convert.</param>
         /// <returns><paramref name="value" /> converted to a <see cref="Int128" />.</returns>
         [CLSCompliant(false)]
-        public static explicit operator Int128(UInt128 value) => new Int128(value._upper, value._lower);
+        public static explicit operator Int128(UInt128 value) => Unsafe.BitCast<UInt128, Int128>(value);
 
         /// <summary>Explicitly converts a 128-bit unsigned integer to a <see cref="Int128" /> value, throwing an overflow exception for any values that fall outside the representable range.</summary>
         /// <param name="value">The value to convert.</param>
@@ -357,7 +357,7 @@ namespace System
             {
                 ThrowHelper.ThrowOverflowException();
             }
-            return new Int128(value._upper, value._lower);
+            return Unsafe.BitCast<UInt128, Int128>(value);
         }
 
         /// <summary>Explicitly converts a 128-bit unsigned integer to a <see cref="IntPtr" /> value.</summary>


### PR DESCRIPTION
Diffs show increased inlining and tail calls.

https://github.com/MihuBot/runtime-utils/issues/478
https://github.com/MihuBot/runtime-utils/issues/479