### PR TITLE
Use IndexOfAnyExcept in BigInteger.IsPowerOfTwo

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -637,15 +637,10 @@ namespace System.Numerics
 
                 if (_sign != 1)
                     return false;
+
                 int iu = _bits.Length - 1;
-                if (!BitOperations.IsPow2(_bits[iu]))
-                    return false;
-                while (--iu >= 0)
-                {
-                    if (_bits[iu] != 0)
-                        return false;
-                }
-                return true;
+
+                return BitOperations.IsPow2(_bits[iu]) && _bits.AsSpan().IndexOfAnyExcept(0u) == iu;
             }
         }
 

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -640,7 +640,7 @@ namespace System.Numerics
 
                 int iu = _bits.Length - 1;
 
-                return BitOperations.IsPow2(_bits[iu]) && _bits.AsSpan().IndexOfAnyExcept(0u) == iu;
+                return BitOperations.IsPow2(_bits[iu]) && !_bits.AsSpan(0, iu).ContainsAnyExcept(0u);
             }
         }
 


### PR DESCRIPTION
This path is taken once we know the most significant uint is itself a power of two, and we just need to check the rest are zero. The benchmarks are an attempt to show the worst-case:

|             Method |        Job |      Mean |     Error |    StdDev | Ratio | RatioSD |
|------------------- |----------- |----------:|----------:|----------:|------:|--------:|
|    SmallPowerOfTwo | main |  1.436 ns | 0.0010 ns | 0.0009 ns |  1.00 |    0.00 |
|    SmallPowerOfTwo | PR |  2.503 ns | 0.0469 ns | 0.0392 ns |  1.74 |    0.03 |
|                    |            |           |           |           |       |         |
| SmallNotPowerOfTwo | main |  1.117 ns | 0.0012 ns | 0.0011 ns |  1.00 |    0.00 |
| SmallNotPowerOfTwo | PR |  2.464 ns | 0.0063 ns | 0.0059 ns |  2.21 |    0.01 |
|                    |            |           |           |           |       |         |
|    LargePowerOfTwo | main | 31.979 ns | 0.0081 ns | 0.0072 ns |  1.00 |    0.00 |
|    LargePowerOfTwo | PR |  5.711 ns | 0.0028 ns | 0.0025 ns |  0.18 |    0.00 |
|                    |            |           |           |           |       |         |
| LargeNotPowerOfTwo | main |  1.119 ns | 0.0011 ns | 0.0009 ns |  1.00 |    0.00 |
| LargeNotPowerOfTwo | PR |  2.919 ns | 0.0011 ns | 0.0009 ns |  2.61 |    0.00 |

```c#
public class Benchmarks
{
    private BigInteger _smallPowerOfTwo;
    private BigInteger _smallNotPowerOfTwo;
    private BigInteger _largePowerOfTwo;
    private BigInteger _largeNotPowerOfTwo;

    [GlobalSetup]
    public void GlobalSetup()
    {
        _smallPowerOfTwo    = BigInteger.Parse("0000000000000001000000000000000000000000000000000000000000000000", NumberStyles.BinaryNumber);
        _smallNotPowerOfTwo = BigInteger.Parse("0000000000000001000000000000000001110011011011000010100011101111", NumberStyles.BinaryNumber);

        Random rnd = new Random(123456);
        
        var bytes = new byte[1 + 256];
        bytes[0] = 1;
        
        _largePowerOfTwo = new BigInteger(bytes, isBigEndian: true);
        
        rnd.NextBytes(bytes.AsSpan(1));

        _largeNotPowerOfTwo = new BigInteger(bytes, isBigEndian: true);
    }

    [Benchmark]
    public bool SmallPowerOfTwo() => _smallPowerOfTwo.IsPowerOfTwo;
    
    [Benchmark]
    public bool SmallNotPowerOfTwo() => _smallNotPowerOfTwo.IsPowerOfTwo;
    
    [Benchmark]
    public bool LargePowerOfTwo() => _largePowerOfTwo.IsPowerOfTwo;
    
    [Benchmark]
    public bool LargeNotPowerOfTwo() => _largeNotPowerOfTwo.IsPowerOfTwo;
}
```