### PR TITLE
Use `XmlResolverIsNetworkingEnabledByDefault` property in `AotCompilerCommon.props`

### DIFF
--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -7,12 +7,6 @@
     <ControlFlowGuard>Guard</ControlFlowGuard>
     <InvariantGlobalization>true</InvariantGlobalization>
     <StripSymbols Condition="'$(KeepNativeSymbols)' == 'true'">false</StripSymbols>
+    <XmlResolverIsNetworkingEnabledByDefault>false</XmlResolverIsNetworkingEnabledByDefault>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Replace this line with the documented property once https://github.com/dotnet/runtime/issues/83495 is fixed -->
-    <RuntimeHostConfigurationOption Include="System.Xml.XmlResolver.IsNetworkingEnabledByDefault"
-                                    Value="false"
-                                    Trim="true" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Follow-up https://github.com/dotnet/runtime/issues/83495