### PR TITLE
Ignore type resolution failures when checking for attributes in `StackTrace.ToString`.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1647,9 +1647,12 @@ namespace System.Reflection
                 // Resolve attribute type from ctor parent token found in decorated decoratedModule scope
                 attributeType = (decoratedModule.ResolveType(scope.GetParentToken(caCtorToken), null, null) as RuntimeType)!;
             }
-            catch
+            catch when (attributeFilterType.IsSealed)
             {
-                // Skip attributes whose type cannot be resolved.
+                // If the type of one of the attributes cannot be resolved and the filter type is sealed, we can ignore
+                // the error and return false. We can do this only when looking for sealed attribute types because otherwise,
+                // that type that failed to be resolved could have been a subclass of the filter type, and by ignoring the
+                // error we are potentially returning false information.
                 attributeType = null;
                 return false;
             }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1516,7 +1516,7 @@ namespace System.Reflection
                 if (!FilterCustomAttributeRecord(caRecord.tkCtor, in scope,
                                                  decoratedModule, decoratedMetadataToken, attributeFilterType!, mustBeInheritable,
                                                  ref derivedAttributes,
-                                                 out RuntimeType? attributeType, out IRuntimeMethodInfo? ctorWithParameters, out bool isVarArg))
+                                                 out RuntimeType attributeType, out IRuntimeMethodInfo? ctorWithParameters, out bool isVarArg))
                 {
                     continue;
                 }
@@ -1635,27 +1635,15 @@ namespace System.Reflection
             RuntimeType attributeFilterType,
             bool mustBeInheritable,
             ref RuntimeType.ListBuilder<object> derivedAttributes,
-            [NotNullWhen(true)] out RuntimeType? attributeType,
+            out RuntimeType attributeType,
             out IRuntimeMethodInfo? ctorWithParameters,
             out bool isVarArg)
         {
             ctorWithParameters = null;
             isVarArg = false;
 
-            try
-            {
-                // Resolve attribute type from ctor parent token found in decorated decoratedModule scope
-                attributeType = (decoratedModule.ResolveType(scope.GetParentToken(caCtorToken), null, null) as RuntimeType)!;
-            }
-            catch when (attributeFilterType.IsSealed)
-            {
-                // If the type of one of the attributes cannot be resolved and the filter type is sealed, we can ignore
-                // the error and return false. We can do this only when looking for sealed attribute types because otherwise,
-                // that type that failed to be resolved could have been a subclass of the filter type, and by ignoring the
-                // error we are potentially returning false information.
-                attributeType = null;
-                return false;
-            }
+            // Resolve attribute type from ctor parent token found in decorated decoratedModule scope
+            attributeType = (decoratedModule.ResolveType(scope.GetParentToken(caCtorToken), null, null) as RuntimeType)!;
 
             // Test attribute type against user provided attribute type filter
             if (!MatchesTypeFilter(attributeType, attributeFilterType))

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1516,7 +1516,7 @@ namespace System.Reflection
                 if (!FilterCustomAttributeRecord(caRecord.tkCtor, in scope,
                                                  decoratedModule, decoratedMetadataToken, attributeFilterType!, mustBeInheritable,
                                                  ref derivedAttributes,
-                                                 out RuntimeType attributeType, out IRuntimeMethodInfo? ctorWithParameters, out bool isVarArg))
+                                                 out RuntimeType? attributeType, out IRuntimeMethodInfo? ctorWithParameters, out bool isVarArg))
                 {
                     continue;
                 }
@@ -1635,7 +1635,7 @@ namespace System.Reflection
             RuntimeType attributeFilterType,
             bool mustBeInheritable,
             ref RuntimeType.ListBuilder<object> derivedAttributes,
-            [MaybeNullWhen(false)] out RuntimeType attributeType,
+            [NotNullWhen(true)] out RuntimeType? attributeType,
             out IRuntimeMethodInfo? ctorWithParameters,
             out bool isVarArg)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1635,15 +1635,24 @@ namespace System.Reflection
             RuntimeType attributeFilterType,
             bool mustBeInheritable,
             ref RuntimeType.ListBuilder<object> derivedAttributes,
-            out RuntimeType attributeType,
+            [MaybeNullWhen(false)] out RuntimeType attributeType,
             out IRuntimeMethodInfo? ctorWithParameters,
             out bool isVarArg)
         {
             ctorWithParameters = null;
             isVarArg = false;
 
-            // Resolve attribute type from ctor parent token found in decorated decoratedModule scope
-            attributeType = (decoratedModule.ResolveType(scope.GetParentToken(caCtorToken), null, null) as RuntimeType)!;
+            try
+            {
+                // Resolve attribute type from ctor parent token found in decorated decoratedModule scope
+                attributeType = (decoratedModule.ResolveType(scope.GetParentToken(caCtorToken), null, null) as RuntimeType)!;
+            }
+            catch
+            {
+                // Skip attributes whose type cannot be resolved.
+                attributeType = null;
+                return false;
+            }
 
             // Test attribute type against user provided attribute type filter
             if (!MatchesTypeFilter(attributeType, attributeFilterType))

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -240,7 +240,7 @@ namespace System.Diagnostics
                     Type? declaringType = mb.DeclaringType;
                     string methodName = mb.Name;
                     bool methodChanged = false;
-                    if (declaringType != null && declaringType.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false))
+                    if (declaringType != null && IsDefinedSafe(declaringType, typeof(CompilerGeneratedAttribute), inherit: false))
                     {
                         isAsync = declaringType.IsAssignableTo(typeof(IAsyncStateMachine));
                         if (isAsync || declaringType.IsAssignableTo(typeof(IEnumerator)))
@@ -384,31 +384,37 @@ namespace System.Diagnostics
                 return false;
             }
 
-            try
+            if (IsDefinedSafe(mb, typeof(StackTraceHiddenAttribute), inherit: false))
             {
-                if (mb.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false))
-                {
-                    // Don't show where StackTraceHidden is applied to the method.
-                    return false;
-                }
-
-                Type? declaringType = mb.DeclaringType;
-                // Methods don't always have containing types, for example dynamic RefEmit generated methods.
-                if (declaringType != null &&
-                    declaringType.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false))
-                {
-                    // Don't show where StackTraceHidden is applied to the containing Type of the method.
-                    return false;
-                }
+                // Don't show where StackTraceHidden is applied to the method.
+                return false;
             }
-            catch
+
+            Type? declaringType = mb.DeclaringType;
+            // Methods don't always have containing types, for example dynamic RefEmit generated methods.
+            if (declaringType != null &&
+                IsDefinedSafe(declaringType, typeof(StackTraceHiddenAttribute), inherit: false))
             {
-                // Getting the StackTraceHiddenAttribute has failed, behave as if it was not present.
-                // One of the reasons can be that the method mb or its declaring type use attributes
-                // defined in an assembly that is missing.
+                // Don't show where StackTraceHidden is applied to the containing Type of the method.
+                return false;
             }
 
             return true;
+        }
+
+        private static bool IsDefinedSafe(MemberInfo memberInfo, Type attributeType bool inherit)
+        {
+            try
+            {
+                return memberInfo.IsDefined(attributeType, inherit);
+            }
+            catch
+            {
+                // Checking for the attribute has failed, behave as if it was not present. One of
+                // the reasons can be that the member has attributes defined in an assembly that
+                // is missing.
+                return false;
+            }
         }
 
         private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -402,7 +402,7 @@ namespace System.Diagnostics
             return true;
         }
 
-        private static bool IsDefinedSafe(MemberInfo memberInfo, Type attributeType bool inherit)
+        private static bool IsDefinedSafe(MemberInfo memberInfo, Type attributeType, bool inherit)
         {
             try
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -417,6 +417,20 @@ namespace System.Diagnostics
             }
         }
 
+        private static Attribute[] GetCustomAttributesSafe(MemberInfo memberInfo, Type attributeType, bool inherit)
+        {
+            try
+            {
+                return Attribute.GetCustomAttributes(memberInfo, attributeType, inherit);
+            }
+            catch
+            {
+                // Getting the attributes has failed, return an empty array. One of the reasons
+                // can be that the member has attributes defined in an assembly that is missing.
+                return [];
+            }
+        }
+
         private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
         {
             Debug.Assert(method != null);
@@ -444,7 +458,7 @@ namespace System.Diagnostics
 
             foreach (MethodInfo candidateMethod in methods)
             {
-                StateMachineAttribute[]? attributes = (StateMachineAttribute[])Attribute.GetCustomAttributes(candidateMethod, typeof(StateMachineAttribute), inherit: false);
+                StateMachineAttribute[]? attributes = (StateMachineAttribute[])GetCustomAttributesSafe(candidateMethod, typeof(StateMachineAttribute), inherit: false);
                 if (attributes == null)
                 {
                     continue;


### PR DESCRIPTION
Fixes #104528.

Similar to #48535, this PR makes `StackTrace.ToString` resilient to exceptions when performing some more custom attribute retrieving. We do this by introducing `***Safe` edition of reflection methods that perform the operation and return a negative result if an exception was thrown, and updating all uses of `IsDefined` and `GetCustomAttributes` in the `StackTrace` class.