### PR TITLE
Use `GetArrayDataReference` in `Vector*`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -597,7 +597,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[0]), this);
+            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetArrayDataReference(array)), this);
         }
 
         /// <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
@@ -625,7 +625,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[index]), this);
+            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (uint)index)), this);
         }
 
         /// <summary>Copies the vector to the given <see cref="Span{T}" />.The length of the destination span must be at least 2.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -630,7 +630,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[0]), this);
+            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetArrayDataReference(array)), this);
         }
 
         /// <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
@@ -658,7 +658,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[index]), this);
+            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (uint)index)), this);
         }
 
         /// <summary>Copies the vector to the given <see cref="Span{T}" />. The length of the destination span must be at least 3.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/VectorDebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/VectorDebugView_1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Numerics
 {
@@ -20,7 +21,7 @@ namespace System.Numerics
             get
             {
                 var items = new byte[Vector<byte>.Count];
-                Unsafe.WriteUnaligned(ref items[0], _value);
+                Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(items), _value);
                 return items;
             }
         }
@@ -30,7 +31,7 @@ namespace System.Numerics
             get
             {
                 var items = new double[Vector<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -40,7 +41,7 @@ namespace System.Numerics
             get
             {
                 var items = new short[Vector<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -50,7 +51,7 @@ namespace System.Numerics
             get
             {
                 var items = new int[Vector<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -60,7 +61,7 @@ namespace System.Numerics
             get
             {
                 var items = new long[Vector<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -70,7 +71,7 @@ namespace System.Numerics
             get
             {
                 var items = new nint[Vector<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -80,7 +81,7 @@ namespace System.Numerics
             get
             {
                 var items = new nuint[Vector<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -90,7 +91,7 @@ namespace System.Numerics
             get
             {
                 var items = new sbyte[Vector<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -100,7 +101,7 @@ namespace System.Numerics
             get
             {
                 var items = new float[Vector<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -110,7 +111,7 @@ namespace System.Numerics
             get
             {
                 var items = new ushort[Vector<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -120,7 +121,7 @@ namespace System.Numerics
             get
             {
                 var items = new uint[Vector<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -130,7 +131,7 @@ namespace System.Numerics
             get
             {
                 var items = new ulong[Vector<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
@@ -63,7 +63,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(values)));
         }
 
         /// <summary>Creates a new <see cref="Vector{T}" /> from a given array.</summary>
@@ -82,7 +82,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (uint)index)));
         }
 
         /// <summary>Creates a new <see cref="Vector{T}" /> from a given readonly span.</summary>
@@ -624,7 +624,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), this);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(destination)), this);
         }
 
         /// <summary>Copies a <see cref="Vector{T}" /> to a given array starting at the specified index.</summary>
@@ -648,7 +648,7 @@ namespace System.Numerics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), this);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), (uint)startIndex)), this);
         }
 
         /// <summary>Copies a <see cref="Vector{T}" /> to a given span.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -777,7 +777,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(destination)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector128{T}" /> to a given array starting at the specified index.</summary>
@@ -804,7 +804,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), (uint)startIndex)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector128{T}" /> to a given span.</summary>
@@ -940,7 +940,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(values)));
         }
 
         /// <summary>Creates a new <see cref="Vector128{T}" /> from a given array.</summary>
@@ -961,7 +961,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (uint)index)));
         }
 
         /// <summary>Creates a new <see cref="Vector128{T}" /> from a given readonly span.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128DebugView_1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Runtime.Intrinsics
 {
@@ -19,7 +20,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new byte[Vector128<byte>.Count];
-                Unsafe.WriteUnaligned(ref items[0], _value);
+                Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(items), _value);
                 return items;
             }
         }
@@ -29,7 +30,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector128<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -39,7 +40,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector128<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -49,7 +50,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector128<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -59,7 +60,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector128<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -69,7 +70,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector128<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -79,7 +80,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector128<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -89,7 +90,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector128<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -99,7 +100,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector128<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -109,7 +110,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector128<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -119,7 +120,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector128<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -129,7 +130,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector128<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -616,7 +616,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(destination)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector256{T}" /> to a given array starting at the specified index.</summary>
@@ -643,7 +643,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), (uint)startIndex)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector256{T}" /> to a given span.</summary>
@@ -779,7 +779,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(values)));
         }
 
         /// <summary>Creates a new <see cref="Vector256{T}" /> from a given array.</summary>
@@ -800,7 +800,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (uint)index)));
         }
 
         /// <summary>Creates a new <see cref="Vector256{T}" /> from a given readonly span.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256DebugView_1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Runtime.Intrinsics
 {
@@ -19,7 +20,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new byte[Vector256<byte>.Count];
-                Unsafe.WriteUnaligned(ref items[0], _value);
+                Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(items), _value);
                 return items;
             }
         }
@@ -29,7 +30,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector256<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -39,7 +40,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector256<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -49,7 +50,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector256<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -59,7 +60,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector256<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -69,7 +70,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector256<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -79,7 +80,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector256<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -89,7 +90,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector256<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -99,7 +100,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector256<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -109,7 +110,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector256<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -119,7 +120,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector256<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -129,7 +130,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector256<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -544,7 +544,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(destination)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector512{T}" /> to a given array starting at the specified index.</summary>
@@ -570,7 +570,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), (uint)startIndex)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector512{T}" /> to a given span.</summary>
@@ -704,7 +704,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(values)));
         }
 
         /// <summary>Creates a new <see cref="Vector512{T}" /> from a given array.</summary>
@@ -724,7 +724,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (uint)index)));
         }
 
         /// <summary>Creates a new <see cref="Vector512{T}" /> from a given readonly span.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512DebugView_1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Runtime.Intrinsics
 {
@@ -19,7 +20,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new byte[Vector512<byte>.Count];
-                Unsafe.WriteUnaligned(ref items[0], _value);
+                Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(items), _value);
                 return items;
             }
         }
@@ -29,7 +30,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector512<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -39,7 +40,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector512<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -49,7 +50,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector512<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -59,7 +60,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector512<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -69,7 +70,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector512<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -79,7 +80,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector512<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -89,7 +90,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector512<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -99,7 +100,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector512<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -109,7 +110,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector512<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -119,7 +120,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector512<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -129,7 +130,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector512<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -560,7 +560,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(destination)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector64{T}" /> to a given array starting at the specified index.</summary>
@@ -587,7 +587,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), (uint)startIndex)), vector);
         }
 
         /// <summary>Copies a <see cref="Vector64{T}" /> to a given span.</summary>
@@ -725,7 +725,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetArrayDataReference(values)));
         }
 
         /// <summary>Creates a new <see cref="Vector64{T}" /> from a given array.</summary>
@@ -746,7 +746,7 @@ namespace System.Runtime.Intrinsics
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
 
-            return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (uint)index)));
         }
 
         /// <summary>Creates a new <see cref="Vector64{T}" /> from a given readonly span.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64DebugView_1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Runtime.Intrinsics
 {
@@ -19,7 +20,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new byte[Vector64<byte>.Count];
-                Unsafe.WriteUnaligned(ref items[0], _value);
+                Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(items), _value);
                 return items;
             }
         }
@@ -29,7 +30,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector64<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -39,7 +40,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector64<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -49,7 +50,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector64<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -59,7 +60,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector64<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -69,7 +70,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector64<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -79,7 +80,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector64<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -89,7 +90,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector64<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -99,7 +100,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector64<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -109,7 +110,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector64<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -119,7 +120,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector64<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }
@@ -129,7 +130,7 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector64<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref MemoryMarshal.GetArrayDataReference(items)), _value);
                 return items;
             }
         }


### PR DESCRIPTION
### ```(System.Numerics.Vector`1[double]:.ctor(double[]):this)```

```diff
-       mov      eax, dword ptr [rsi+0x08]
-       cmp      eax, 4
+       cmp      dword ptr [rsi+0x08], 4
        jl       SHORT G_M58252_IG04
        vmovups  ymm0, ymmword ptr [rsi+0x10]
        vmovups  ymmword ptr [rdi], ymm0
-						;; size=17 bbWeight=1 PerfScore 10.25
+						;; size=15 bbWeight=1 PerfScore 11.00
```