### PR TITLE
Don't call fcntl on an invalid file descriptor.

### DIFF
--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -333,7 +333,7 @@ intptr_t SystemNative_Open(const char* path, int32_t flags, int32_t mode)
     int result;
     while ((result = open(path, flags, (mode_t)mode)) < 0 && errno == EINTR);
 #if !HAVE_O_CLOEXEC
-    if (old_flags & PAL_O_CLOEXEC)
+    if (result != -1 && old_flags & PAL_O_CLOEXEC)
     {
         fcntl(result, F_SETFD, FD_CLOEXEC);
     }


### PR DESCRIPTION
I noticed the `fcntl` function will be called even if `open` fails. This could potentially overwrite `errno` and cause [downstream code to misclassify the failure](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs#L96-L121).

The systems I'm testing on have `O_CLOEXEC`, so I'm not sure how to test this change.