### PR TITLE
JIT: Propagate physical promotion liveness in post-order

### DIFF
--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -200,7 +200,6 @@ class PromotionLiveness
     unsigned*                                               m_structLclToTrackedIndex = nullptr;
     unsigned                                                m_numVars                 = 0;
     BasicBlockLiveness*                                     m_bbInfo                  = nullptr;
-    bool                                                    m_hasPossibleBackEdge     = false;
     BitVec                                                  m_liveIn;
     BitVec                                                  m_ehLiveVars;
     JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, BitVec> m_aggDeaths;


### PR DESCRIPTION
We now have a DFS tree available in physical promotion. This mean that like normal liveness (after #103809) we can maximize the information propagated on every iteration by running physical promotion's dataflow in post-order.