### PR TITLE
[browser] host should not forward env variables

### DIFF
--- a/src/mono/wasm/host/BrowserHost.cs
+++ b/src/mono/wasm/host/BrowserHost.cs
@@ -61,12 +61,6 @@ internal sealed class BrowserHost
                 envVars[kvp.Key] = kvp.Value;
         }
 
-        foreach (DictionaryEntry de in Environment.GetEnvironmentVariables())
-        {
-            if (de.Key is not null && de.Value is not null)
-                envVars[(string)de.Key] = (string)de.Value;
-        }
-
         var runArgsJson = new RunArgumentsJson(applicationArguments: _args.AppArgs,
                                                runtimeArguments: _args.CommonConfig.RuntimeArguments,
                                                environmentVariables: envVars,


### PR DESCRIPTION
`dotnet` host should not forward all OS env variables to browser