### PR TITLE
ILLink: Rebuild override info after custom step runs

### DIFF
--- a/src/tools/illink/src/linker/CompatibilitySuppressions.xml
+++ b/src/tools/illink/src/linker/CompatibilitySuppressions.xml
@@ -1534,6 +1534,12 @@
     <Target>T:Mono.Linker.MessageOrigin</Target>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Mono.Linker.OverrideInformation</Target>
+    <Left>ref/net9.0/illink.dll</Left>
+    <Right>lib/net9.0/illink.dll</Right>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0009</DiagnosticId>
     <Target>T:Mono.Linker.AnnotationStore</Target>
   </Suppression>

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -2012,8 +2012,13 @@ namespace Mono.Linker.Steps
 
 			var typeOrigin = new MessageOrigin (type);
 
-			foreach (Action<TypeDefinition> handleMarkType in MarkContext.MarkTypeActions)
-				handleMarkType (type);
+			if (MarkContext.MarkTypeActions.Count > 0) {
+				foreach (Action<TypeDefinition> handleMarkType in MarkContext.MarkTypeActions)
+					handleMarkType (type);
+
+				// Rebuild type info for the type in case a mark action added new methods.
+				Annotations.TypeMapInfo.MapType (type);
+			}
 
 			MarkType (type.BaseType, new DependencyInfo (DependencyKind.BaseType, type), typeOrigin);
 

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -2016,8 +2016,10 @@ namespace Mono.Linker.Steps
 				foreach (Action<TypeDefinition> handleMarkType in MarkContext.MarkTypeActions)
 					handleMarkType (type);
 
-				// Rebuild type info for the type in case a mark action added new methods.
-				Annotations.TypeMapInfo.MapType (type);
+				if (Context.HasCustomMarkHandler) {
+					// Rebuild type info for the type in case a mark action added new methods.
+					Annotations.TypeMapInfo.MapType (type);
+				}
 			}
 
 			MarkType (type.BaseType, new DependencyInfo (DependencyKind.BaseType, type), typeOrigin);

--- a/src/tools/illink/src/linker/Linker/DictionaryExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/DictionaryExtensions.cs
@@ -2,19 +2,26 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Mono.Linker
 {
 	internal static class DictionaryExtensions
 	{
-		public static void AddToList<TKey, TElement> (this Dictionary<TKey, List<TElement>> me, TKey key, TElement value)
+		public static void AddToSet<TKey, TElement> (this Dictionary<TKey, HashSet<TElement>> me, TKey key, TElement value)
 			where TKey : notnull
 		{
-			if (!me.TryGetValue (key, out List<TElement>? valueList)) {
-				valueList = new ();
-				me[key] = valueList;
+			if (!me.TryGetValue (key, out HashSet<TElement>? valueSet)) {
+				valueSet = new ();
+				me[key] = valueSet;
 			}
-			valueList.Add (value);
+			if (valueSet.ToList().Count == 1) {
+
+				var b = valueSet.ToList()[0]?.Equals (value);
+				Debug.WriteLine(b);
+			}
+			valueSet.Add (value);
 		}
 	}
 }

--- a/src/tools/illink/src/linker/Linker/InterfaceImplementor.cs
+++ b/src/tools/illink/src/linker/Linker/InterfaceImplementor.cs
@@ -9,7 +9,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	public class InterfaceImplementor
+	public class InterfaceImplementor : IEquatable<InterfaceImplementor>
 	{
 		/// <summary>
 		/// The type that implements <see cref="InterfaceImplementor.InterfaceType"/>.
@@ -55,5 +55,20 @@ namespace Mono.Linker
 			}
 			throw new InvalidOperationException ($"Type '{implementor.FullName}' does not implement interface '{interfaceType.FullName}' directly or through any interfaces");
 		}
+
+		public bool Equals (InterfaceImplementor? other)
+		{
+			if (other is null)
+				return false;
+
+			if (ReferenceEquals (this, other))
+				return true;
+
+			return Implementor == other.Implementor && InterfaceImplementation == other.InterfaceImplementation && InterfaceType == other.InterfaceType;
+		}
+
+		public override bool Equals (object? obj) => obj is InterfaceImplementor other && Equals (other);
+
+		public override int GetHashCode () => HashCode.Combine (Implementor, InterfaceImplementation, InterfaceType);
 	}
 }

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -184,6 +184,8 @@ namespace Mono.Linker
 
 		public string? AssemblyListFile { get; set; }
 
+		internal bool HasCustomMarkHandler { get; set; }
+
 		public List<IMarkHandler> MarkHandlers { get; }
 
 		public Dictionary<string, bool> SingleWarn { get; set; }

--- a/src/tools/illink/src/linker/Linker/OverrideInformation.cs
+++ b/src/tools/illink/src/linker/Linker/OverrideInformation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics;
 using Mono.Cecil;
 using System.Diagnostics.CodeAnalysis;
@@ -8,7 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Mono.Linker
 {
 	[DebuggerDisplay ("{Override}")]
-	public class OverrideInformation
+	public class OverrideInformation : IEquatable<OverrideInformation>
 	{
 		public MethodDefinition Base { get; }
 
@@ -37,5 +38,26 @@ namespace Mono.Linker
 		[MemberNotNullWhen (true, nameof (InterfaceImplementor), nameof (MatchingInterfaceImplementation))]
 		public bool IsOverrideOfInterfaceMember
 			=> InterfaceImplementor != null;
+
+		public bool Equals (OverrideInformation? other)
+		{
+			if (other is null)
+				return false;
+
+			if (ReferenceEquals (this, other))
+				return true;
+
+			if (Base != other.Base || Override != other.Override)
+				return false;
+
+			if (InterfaceImplementor == null)
+				return other.InterfaceImplementor == null;
+
+			return InterfaceImplementor.Equals (other.InterfaceImplementor);
+		}
+
+		public override bool Equals (object? obj) => obj is OverrideInformation other && Equals (other);
+
+		public override int GetHashCode () => HashCode.Combine (Base, Override, InterfaceImplementor);
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepCanFixAbstractMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepCanFixAbstractMethods.cs
@@ -29,7 +29,6 @@ namespace Mono.Linker.Tests.Cases.Extensibility
 			// to be created through reflection instead of a direct call to the constructor, otherwise we build the
 			// TypeMapInfo cache too early for the custom step.
 
-			// var type = typeof (InterfaceImplementation);
 			var type = typeof (InterfaceImplementationInOtherAssembly);
 			InterfaceType instance = (InterfaceType) System.Activator.CreateInstance (type);
 			InterfaceType.UseInstance (instance);
@@ -46,7 +45,7 @@ namespace Mono.Linker.Tests.Cases.Extensibility
 		[Kept]
 		[KeptMember (".ctor()")]
 		[KeptInterface (typeof (InterfaceType))]
-		// [CreatedMember ("AbstractMethod()")] // https://github.com/dotnet/runtime/issues/104266
+		[CreatedMember ("AbstractMethod()")]
 		class InterfaceImplementationAccessedViaReflection : InterfaceType
 		{
 		}
@@ -61,7 +60,7 @@ namespace Mono.Linker.Tests.Cases.Extensibility
 		[Kept]
 		[KeptMember (".ctor()")]
 		[KeptInterface (typeof (InterfaceType))]
-		// [CreatedMember ("AbstractMethod()")] // https://github.com/dotnet/runtime/issues/104266
+		[CreatedMember ("AbstractMethod()")]
 		class InterfaceImplementation : InterfaceType
 		{
 		}


### PR DESCRIPTION
This modifies the tracking of overrides in TypeMapInfo to allow additional overrides to be discovered on a subsequent call to MapType. Then after a custom step runs for a marked type, we build the type info again to ensure that any additional overrides introduced by the custom step are taken into account.

Fixes https://github.com/dotnet/runtime/issues/104266. However, note that there are still many kinds of modifications that a custom step could make which are not guaranteed to be taken into account, and there's no guarantee about the order in which different types in an assembly are processed by the custom step. However, the modifications done in FixAbstractMethodsStep should work.

We should be able to reintroduce the dependency analysis framework with this, but I will make that change in a separate PR.