### PR TITLE
Fix frame boundary detection in SslStream

### DIFF
--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -455,7 +455,7 @@
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />
-    <Reference Include="System.Console" Condition="'$(Configuration)' == 'Debug'" />
+    <Reference Include="System.Console" />
     <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.Linq" />
     <Reference Include="System.Memory" />

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -455,7 +455,7 @@
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />
-    <Reference Include="System.Console" />
+    <Reference Include="System.Console" Condition="'$(Configuration)' == 'Debug'" />
     <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.Linq" />
     <Reference Include="System.Memory" />

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -470,7 +470,7 @@ namespace System.Net.Security
             {
                 TlsFrameHeader nextHeader = default;
 
-                if (!TlsFrameHelper.TryGetFrameHeader(_buffer.EncryptedReadOnlySpan.Slice(chunkSize), ref nextHeader))
+                if (!TlsFrameHelper.TryGetFrameHeader(availableData.Slice(chunkSize), ref nextHeader))
                 {
                     break;
                 }
@@ -479,7 +479,7 @@ namespace System.Net.Security
 
                 // Can process more handshake frames in single step or during TLS1.3 post-handshake auth, but we should
                 // avoid processing too much so as to preserve API boundary between handshake and I/O.
-                if ((nextHeader.Type != TlsContentType.Handshake && nextHeader.Type != TlsContentType.ChangeCipherSpec) && !_isRenego || frameSize > _buffer.EncryptedLength)
+                if ((nextHeader.Type != TlsContentType.Handshake && nextHeader.Type != TlsContentType.ChangeCipherSpec) && !_isRenego || frameSize > availableData.Length - chunkSize)
                 {
                     // We don't have full frame left or we already have app data which needs to be processed by decrypt.
                     break;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -461,7 +461,6 @@ namespace System.Net.Security
         private ProtocolToken ProcessTlsFrame(int frameSize)
         {
             int chunkSize = frameSize;
-            int initFrameSize = frameSize;
 
             ReadOnlySpan<byte> availableData = _buffer.EncryptedReadOnlySpan;
 
@@ -488,20 +487,9 @@ namespace System.Net.Security
                 chunkSize += frameSize;
             }
 
-            try
-            {
-                ProtocolToken token = NextMessage(availableData.Slice(0, chunkSize), out int consumed);
-                _buffer.DiscardEncrypted(consumed);
-                return token;
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                System.Console.WriteLine($"FrameSize: {initFrameSize}, {frameSize}");
-                System.Console.WriteLine($"AvailableData: {availableData.Length}, ChunkSize: {chunkSize}");
-                System.Console.WriteLine($"Disposed: {ReferenceEquals(_exception, s_disposedSentinel)}");
-
-                throw;
-            }
+            ProtocolToken token = NextMessage(availableData.Slice(0, chunkSize), out int consumed);
+            _buffer.DiscardEncrypted(consumed);
+            return token;
         }
 
         //

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamFramingTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamFramingTest.cs
@@ -39,10 +39,10 @@ namespace System.Net.Security.Tests
             // 1 byte reads
             ByteByByte,
 
-            // Receive at most 257 B in one read, targets specifically receiving
+            // Receive data at chunks, not necessarily respecting frame boundaries
             Chunked,
 
-            // coalesce reads to biggest chunks possible
+            // Coalesce reads to biggest chunks possible
             Coalescing
         }
 
@@ -78,7 +78,6 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(HandshakeScenarioData))]
-        // [InlineData(FramingType.Prime257, SslProtocols.Tls12, ClientCertScenario.None)]
         public async Task Handshake_Success(FramingType framingType, SslProtocols sslProtocol, ClientCertScenario clientCertScenario)
         {
             (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/104605.
Fixes https://github.com/dotnet/runtime/issues/104682.
