### PR TITLE
JIT: Skip switch recognition for handles

### DIFF
--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -86,7 +86,7 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
             }
 
             // We're looking for "X EQ/NE CNS" or "CNS EQ/NE X" pattern
-            if (op1->IsCnsIntOrI() ^ op2->IsCnsIntOrI())
+            if ((op1->IsCnsIntOrI() && !op1->IsIconHandle()) ^ (op2->IsCnsIntOrI() && !op2->IsIconHandle()))
             {
                 // TODO: relax this to support any side-effect free expression
                 if (!op1->OperIs(GT_LCL_VAR) && !op2->OperIs(GT_LCL_VAR))


### PR DESCRIPTION
Recognizing a series of handle compares as a switch is not legal since those handles may change values.

I hit this issue in #104603 where the switch recognition managed to turn the following assert into a switch:
https://github.com/dotnet/runtime/blob/7f5ce1e2bb5b7589281a713dc379671cc0b99ea6/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs#L415

Baseline codegen was:
```asm
G_M9579_IG02:  ;; offset=0x0012
       test     rbx, rbx
       je       SHORT G_M9579_IG04
						;; size=5 bbWeight=1 PerfScore 1.25
G_M9579_IG03:  ;; offset=0x0017
       mov      rdi, qword ptr [rbx]
       lea      rcx, [(reloc 0x4000000000423520)]      ; System.Byte
       cmp      rdi, rcx
       je       G_M9579_IG10
       lea      rcx, [(reloc 0x4000000000423530)]      ; System.UInt16
       cmp      rdi, rcx
       je       G_M9579_IG10
       lea      rcx, [(reloc 0x4000000000423538)]      ; System.UInt32
       cmp      rdi, rcx
       je       SHORT G_M9579_IG10
       lea      rcx, [(reloc 0x4000000000423540)]      ; System.UInt64
       cmp      rdi, rcx
       je       SHORT G_M9579_IG10
						;; size=59 bbWeight=0.25 PerfScore 2.25
G_M9579_IG04:  ;; offset=0x0052
       lea      rcx, gword ptr [(reloc 0x40000000004206d8)]      ; '""'
       lea      rdx, gword ptr [(reloc 0x40000000004206d8)]      ; '""'
       call     System.Diagnostics.Debug:Fail(System.String,System.String)
       test     rbx, rbx
       jne      SHORT G_M9579_IG10
```

With the switch recognition, we were ending up with:
```asm
G_M9579_IG02:  ;; offset=0x0012
       test     rbx, rbx
       je       SHORT G_M9579_IG05
						;; size=5 bbWeight=1 PerfScore 1.25
G_M9579_IG03:  ;; offset=0x0017
       mov      rdi, qword ptr [rbx]
       lea      rcx, [(reloc 0x4000000000423578)]      ; System.Byte
       cmp      rdi, rcx
       je       G_M9579_IG11
       mov      rcx, 0x4000000000423588
       sub      rdi, rcx
       cmp      rdi, 16
       ja       SHORT G_M9579_IG05
						;; size=38 bbWeight=0.25 PerfScore 1.38
G_M9579_IG04:  ;; offset=0x003D
       mov      eax, 0x10101
       bt       eax, edi
       jb       SHORT G_M9579_IG11
						;; size=10 bbWeight=0.25 PerfScore 0.43
```

This PR puts us back at the baseline.