### PR TITLE
Throw InvalidOperationException on RuntimeMethodHandle.GetFunctionPointer() for generic methods

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2013,8 +2013,7 @@ PCODE MethodDesc::TryGetMultiCallableAddrOfCode(CORINFO_ACCESS_FLAGS accessFlags
 
     if (IsGenericMethodDefinition())
     {
-        _ASSERTE(!"Cannot take the address of an uninstantiated generic method.");
-        COMPlusThrow(kInvalidProgramException);
+        COMPlusThrow(kInvalidOperationException, IDS_EE_CODEEXECUTION_CONTAINSGENERICVAR);
     }
 
     if (accessFlags & CORINFO_ACCESS_LDFTN)

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2011,7 +2011,7 @@ PCODE MethodDesc::TryGetMultiCallableAddrOfCode(CORINFO_ACCESS_FLAGS accessFlags
     }
     CONTRACTL_END
 
-    if (IsGenericMethodDefinition() || ContainsGenericVariables())
+    if (ContainsGenericVariables())
     {
         COMPlusThrow(kInvalidOperationException, IDS_EE_CODEEXECUTION_CONTAINSGENERICVAR);
     }

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2011,7 +2011,7 @@ PCODE MethodDesc::TryGetMultiCallableAddrOfCode(CORINFO_ACCESS_FLAGS accessFlags
     }
     CONTRACTL_END
 
-    if (IsGenericMethodDefinition())
+    if (IsGenericMethodDefinition() || ContainsGenericVariables())
     {
         COMPlusThrow(kInvalidOperationException, IDS_EE_CODEEXECUTION_CONTAINSGENERICVAR);
     }

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
@@ -307,6 +307,13 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public void GetFunctionPointerFromUninstantiatedGenericMethod()
+        {
+            RuntimeMethodHandle handle = typeof(MI_SubClass).GetMethod(nameof(MI_SubClass.StaticGenericMethod))!.MethodHandle;
+            Assert.Throws<InvalidOperationException>(() => handle.GetFunctionPointer());
+        }
+
+        [Fact]
         public void GetHashCodeTest()
         {
             MethodInfo methodInfo = GetMethod(typeof(MI_SubClass), "VoidMethodReturningInt");

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
@@ -307,9 +307,35 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public void InvokeUninstantiatedGenericType_GenericMethod()
+        {
+            Assert.Throws<InvalidOperationException>(() => GetMethod(typeof(MI_GenericClass<>), "GenericMethod4").Invoke(null, [null]));
+        }
+
+        [Fact]
+        public void InvokeUninstantiatedGenericType_NonGenericMethod()
+        {
+            Assert.Throws<InvalidOperationException>(() => GetMethod(typeof(MI_GenericClass<>), "NonGenericMethod").Invoke(null, [null]));
+        }
+
+        [Fact]
         public void GetFunctionPointerFromUninstantiatedGenericMethod()
         {
             RuntimeMethodHandle handle = typeof(MI_SubClass).GetMethod(nameof(MI_SubClass.StaticGenericMethod))!.MethodHandle;
+            Assert.Throws<InvalidOperationException>(() => handle.GetFunctionPointer());
+        }
+
+        [Fact]
+        public void GetFunctionPointerOnUninstantiatedGenericType_GenericMethod()
+        {
+            RuntimeMethodHandle handle = typeof(MI_GenericClass<>).GetMethod("GenericMethod4")!.MethodHandle;
+            Assert.Throws<InvalidOperationException>(() => handle.GetFunctionPointer());
+        }
+
+        [Fact]
+        public void GetFunctionPointerOnUninstantiatedGenericType_NonGenericMethod()
+        {
+            RuntimeMethodHandle handle = typeof(MI_GenericClass<>).GetMethod("NonGenericMethod")!.MethodHandle;
             Assert.Throws<InvalidOperationException>(() => handle.GetFunctionPointer());
         }
 
@@ -806,6 +832,8 @@ namespace System.Reflection.Tests
         public T GenericMethod1(T t) => t;
         public T GenericMethod2<S>(S s1, T t, string s2) => t;
         public static S GenericMethod3<S>(S s) => s;
+        public static T GenericMethod4(T s) => s;
+        public static void NonGenericMethod() { }
     }
 
     public interface MethodInfoBaseDefinitionInterface

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7474,6 +7474,11 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 			MonoMethod *local_cmethod = LOCAL_VAR (ip [2], MonoMethod*);
 
+			if (local_cmethod->is_generic || mono_class_is_gtd (local_cmethod->klass)) {
+				MonoException *ex = mono_exception_from_name_msg (mono_defaults.corlib, "System", "InvalidOperationException", "");
+				THROW_EX (ex, ip);
+			}			
+
 			// FIXME push/pop LMF
 			if (G_UNLIKELY (mono_method_has_unmanaged_callers_only_attribute (local_cmethod))) {
 				local_cmethod = mono_marshal_get_managed_wrapper  (local_cmethod, NULL, (MonoGCHandle)0, error);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2938,6 +2938,11 @@ mono_jit_compile_method_jit_only (MonoMethod *method, MonoError *error)
 static gpointer
 get_ftnptr_for_method (MonoMethod *method, gboolean need_unbox, MonoError *error)
 {
+	if (method->is_generic) {
+		mono_error_set_generic_error (error, "System", "InvalidOperationException", "");
+		return NULL;
+	}
+
 	if (!mono_llvm_only) {
 		gpointer res = mono_jit_compile_method (method, error);
 		res = mini_add_method_trampoline (method, res, mono_method_needs_static_rgctx_invoke (method, TRUE), need_unbox);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2938,7 +2938,7 @@ mono_jit_compile_method_jit_only (MonoMethod *method, MonoError *error)
 static gpointer
 get_ftnptr_for_method (MonoMethod *method, gboolean need_unbox, MonoError *error)
 {
-	if (method->is_generic) {
+	if (method->is_generic || mono_class_is_gtd (method->klass)) {
 		mono_error_set_generic_error (error, "System", "InvalidOperationException", "");
 		return NULL;
 	}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/101664

On CoreClr, the previous exception was InvalidProgramException. On Mono, the call caused a crash.
