### PR TITLE
Do more DSA parameter sanity checking up front

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
@@ -151,6 +151,7 @@ namespace System.Security.Cryptography
                 _ => false,
             };
         }
+
         private static bool IsValidQLength(long qBitLength)
         {
             // FIPS 186-1/186-2 only allows 160

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
@@ -25,16 +25,6 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
-            DssParms parms = DssParms.Decode(algId.Parameters.Value, AsnEncodingRules.BER);
-
-            ret = new DSAParameters
-            {
-                P = parms.P.ToByteArray(isUnsigned: true, isBigEndian: true),
-                Q = parms.Q.ToByteArray(isUnsigned: true, isBigEndian: true),
-            };
-
-            ret.G = parms.G.ExportKeyParameter(ret.P.Length);
-
             BigInteger x;
 
             try
@@ -57,6 +47,33 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
             }
 
+            DssParms parms = DssParms.Decode(algId.Parameters.Value, AsnEncodingRules.BER);
+
+            // Sanity checks from FIPS 186-4 4.1/4.2.  Since FIPS 186-5 withdrew DSA/DSS
+            // these will never change again.
+            //
+            // This technically allows a non-standard combination of 1024-bit P and 256-bit Q,
+            // but that will get filtered out by the underlying provider.
+            // These checks just prevent obviously bad data from wasting work on reinterpretation.
+            if (parms.P.Sign < 0 ||
+                parms.Q.Sign < 0 ||
+                !IsValidPLength(parms.P.GetBitLength()) ||
+                !IsValidQLength(parms.Q.GetBitLength()) ||
+                parms.G <= 1 ||
+                parms.G >= parms.P ||
+                x <= 1 ||
+                x >= parms.Q)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            ret = new DSAParameters
+            {
+                P = parms.P.ToByteArray(isUnsigned: true, isBigEndian: true),
+                Q = parms.Q.ToByteArray(isUnsigned: true, isBigEndian: true),
+            };
+
+            ret.G = parms.G.ExportKeyParameter(ret.P.Length);
             ret.X = x.ExportKeyParameter(ret.Q.Length);
 
             // The public key is not contained within the format, calculate it.
@@ -69,6 +86,11 @@ namespace System.Security.Cryptography
             in AlgorithmIdentifierAsn algId,
             out DSAParameters ret)
         {
+            if (!algId.Parameters.HasValue)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
             BigInteger y;
 
             try
@@ -88,12 +110,25 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
             }
 
-            if (!algId.Parameters.HasValue)
+            DssParms parms = DssParms.Decode(algId.Parameters.Value, AsnEncodingRules.BER);
+
+            // Sanity checks from FIPS 186-4 4.1/4.2.  Since FIPS 186-5 withdrew DSA/DSS
+            // these will never change again.
+            //
+            // This technically allows a non-standard combination of 1024-bit P and 256-bit Q,
+            // but that will get filtered out by the underlying provider.
+            // These checks just prevent obviously bad data from wasting work on reinterpretation.
+            if (parms.P.Sign < 0 ||
+                parms.Q.Sign < 0 ||
+                !IsValidPLength(parms.P.GetBitLength()) ||
+                !IsValidQLength(parms.Q.GetBitLength()) ||
+                parms.G <= 1 ||
+                parms.G >= parms.P ||
+                y <= 1 ||
+                y >= parms.P)
             {
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
-
-            DssParms parms = DssParms.Decode(algId.Parameters.Value, AsnEncodingRules.BER);
 
             ret = new DSAParameters
             {
@@ -103,6 +138,24 @@ namespace System.Security.Cryptography
 
             ret.G = parms.G.ExportKeyParameter(ret.P.Length);
             ret.Y = y.ExportKeyParameter(ret.P.Length);
+        }
+
+        private static bool IsValidPLength(long pBitLength)
+        {
+            return pBitLength switch
+            {
+                // FIPS 186-3/186-4
+                1024 or 2048 or 3072 => true,
+                // FIPS 186-1/186-2
+                >= 512 and < 1024 => pBitLength % 64 == 0,
+                _ => false,
+            };
+        }
+        private static bool IsValidQLength(long qBitLength)
+        {
+            // FIPS 186-1/186-2 only allows 160
+            // FIPS 186-3/186-4 allow 160/224/256
+            return qBitLength is 160 or 224 or 256;
         }
 
         internal static void ReadSubjectPublicKeyInfo(


### PR DESCRIPTION
DSA parameters have a very rigid structure.  We can do some checks before we create a lot of `byte[]` to package the data to pack into a different buffer to send to the OS library.

Checking primality and any other actual value coherency is left to the underlying cryptographic library, these just filter egregious errors.