### PR TITLE
Disable failing System.Net.Security.Tests.SslStreamNetworkStreamTest.SslStream_RandomSizeWrites_OK test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -935,7 +935,7 @@ namespace System.Net.Security.Tests
                 TargetHost = "localhost",
             };
             clientOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
-            clientOptions.ClientCertificateContext = SslStreamCertificateContext.Create(clientCertificate, useTrust ? null : clientChain, offline:true, trust);
+            clientOptions.ClientCertificateContext = SslStreamCertificateContext.Create(clientCertificate, useTrust ? null : clientChain, offline: true, trust);
 
             await SslStream_ClientSendsChain_Core(clientOptions, clientChain);
 
@@ -989,6 +989,7 @@ namespace System.Net.Security.Tests
         [InlineData(16384 * 100, 4096, 1024, true)]
         [InlineData(16384 * 100, 1024 * 20, 1024, true)]
         [InlineData(16384, 3, 3, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/104605")]
         public async Task SslStream_RandomSizeWrites_OK(int bufferSize, int readBufferSize, int writeBufferSize, bool useAsync)
         {
             byte[] dataToCopy = RandomNumberGenerator.GetBytes(bufferSize);


### PR DESCRIPTION
The investigation takes longer than expected, temporarily disabling test to unblock CI