### PR TITLE
Optimize BigInteger.ToString for large decimal string 

### DIFF
--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Tests;
-using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Numerics.Tests
@@ -497,7 +496,7 @@ namespace System.Numerics.Tests
         {
             Assert.Throws<OverflowException>(() => BigInteger.Parse(testingValue, NumberStyles.AllowExponent));
         }
-        
+
         [Fact]
         public static void ToString_InvalidFormat_ThrowsFormatException()
         {
@@ -540,7 +539,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        public void RunPowerOf1E9ToStringTests()
+        public static void RunPowerOf1E9ToStringTests()
         {
             foreach (var test in new[]
             {
@@ -2093,6 +2092,39 @@ namespace System.Numerics.Tests
             nfi.PositiveSign = ">>";
 
             return nfi;
+        }
+    }
+
+
+    [Collection(nameof(DisableParallelization))]
+    public class ToStringTestThreshold
+    {
+        [Fact]
+        public static void RunSimpleToStringTests()
+        {
+            BigIntTools.Utils.RunWithFakeThreshold(Number.ToStringNaiveThreshold, 4, () =>
+            {
+                ToStringTest.RunSimpleToStringTests();
+            });
+        }
+
+        [Fact]
+        public void RunPowerOf1E9ToStringTests()
+        {
+            BigIntTools.Utils.RunWithFakeThreshold(Number.ToStringNaiveThreshold, 4, () =>
+            {
+                ToStringTest.RunPowerOf1E9ToStringTests();
+            });
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void RunRepeatedCharsToStringTests()
+        {
+            BigIntTools.Utils.RunWithFakeThreshold(Number.ToStringNaiveThreshold, 4, () =>
+            {
+                ToStringTest.RunRepeatedCharsToStringTests();
+            });
         }
     }
 }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -539,6 +539,38 @@ namespace System.Numerics.Tests
             b.ToString("G00000999999999"); // Should not throw
         }
 
+        [Fact]
+        public void RunPowerOf1E9ToStringTests()
+        {
+            foreach (var test in new[]
+            {
+                new string('9', 9* (1<<10))+new string('9', 9* (1<<10)),
+                "1"+new string('0', 9* (1<<10))+new string('9', 9* (1<<10)),
+                "1"+new string('0', 9* (1<<10)-1)+"1"+new string('9', 9* (1<<10)),
+                "1"+new string('0', 9* (1<<11)),
+                "1"+new string('0', 9* (1<<11)-1)+"1",
+            })
+            {
+                VerifyToString(test, test);
+            }
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void RunRepeatedCharsToStringTests()
+        {
+            string test;
+
+            for (int length = 1; length < 1300; length++)
+            {
+                test = new string('1', length);
+                VerifyToString(test, test);
+
+                test = new string('9', length);
+                VerifyToString(test, test);
+            }
+        }
+
         private static void RunSimpleProviderToStringTests(Random random, string format, NumberFormatInfo provider, int precision, StringFormatter formatter)
         {
             string test;


### PR DESCRIPTION
This PR is a counterpart to #55121. [divide-and-conquer algorithm](http://www.numberworld.org/y-cruncher/internals/radix-conversion.html)

Number.FormatBigInteger() can run in $D(n)log(N)$ time using the Divide and Conquer algorithm, where $D(n)$ represents the computational complexity of BigInteger division.

The computational complexity of division will be improved by #96895. Once 96895 is merged, I will add a benchmark and set the PR to "ready for review."