### PR TITLE
JIT: Prove some cases where strength reducing to GC pointers is ok

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4848,6 +4848,52 @@ AssertionIndex Compiler::optAssertionIsNonNullInternal(GenTree*                 
     return NO_ASSERTION_INDEX;
 }
 
+//------------------------------------------------------------------------
+// optAssertionVNIsNonNull: See if we can prove that the value of a VN is
+// non-null using assertions.
+//
+// Arguments:
+//   vn         - VN to check
+//   assertions - set of live assertions
+//
+// Return Value:
+//   True if the VN could be proven non-null.
+//
+bool Compiler::optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions)
+{
+    if (vnStore->IsKnownNonNull(vn))
+    {
+        return true;
+    }
+
+    // Check each assertion to find if we have a vn != null assertion.
+    //
+    BitVecOps::Iter iter(apTraits, assertions);
+    unsigned        index = 0;
+    while (iter.NextElem(&index))
+    {
+        AssertionIndex assertionIndex = GetAssertionIndex(index);
+        if (assertionIndex > optAssertionCount)
+        {
+            break;
+        }
+        AssertionDsc* curAssertion = optGetAssertion(assertionIndex);
+        if (!curAssertion->CanPropNonNull())
+        {
+            continue;
+        }
+
+        if (curAssertion->op1.vn != vn)
+        {
+            continue;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
 /*****************************************************************************
  *
  *  Given a tree consisting of a call and a set of available assertions, we

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8025,6 +8025,7 @@ public:
     AssertionIndex optAssertionIsSubrange(GenTree* tree, IntegralRange range, ASSERT_VALARG_TP assertions);
     AssertionIndex optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions);
     AssertionIndex optAssertionIsNonNullInternal(GenTree* op, ASSERT_VALARG_TP assertions DEBUGARG(bool* pVnBased));
+    bool           optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions);
     bool           optAssertionIsNonNull(GenTree*                    op,
                                          ASSERT_VALARG_TP assertions DEBUGARG(bool* pVnBased) DEBUGARG(AssertionIndex* pIndex));
 

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1783,7 +1783,7 @@ bool StrengthReductionContext::StaysWithinManagedObject(ArrayStack<CursorInfo>* 
     // TODO: We could also use assertions on the length of the array. E.g. if
     // we know the length of the array is > 3, then we can allow the add rec to
     // have a later start. Maybe range check can be used?
-    if ((offset < 0) || (offset > OFFSETOF__CORINFO_Array__data))
+    if ((offset < 0) || (offset > (int64_t)OFFSETOF__CORINFO_Array__data))
     {
         return false;
     }

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -75,6 +75,8 @@ struct Scev
 
     bool IsInvariant();
 
+    Scev* PeelAdditions(int64_t* offset);
+
     static bool Equals(Scev* left, Scev* right);
 };
 


### PR DESCRIPTION
For loops iterating over arrays we often have bounds that allow us to
prove that an add recurrence formed by strength reduction will stay
within that array. In these cases we know that forming the byrefs
eagerly is ok.

For example, when strength reduction is enabled, this changes the
codegen of

```csharp
private struct S
{
    public int A, B, C;
}

[MethodImpl(MethodImplOptions.NoInlining)]
private static float Sum(S[] ss)
{
    int sum = 0;
    for (int i = 0; i < ss.Length; i++)
    {
        S v = ss[i];
        sum += v.A;
        sum += v.B;
        sum += v.C;
    }

    return sum;
}
```
in the following way:
```diff
 G_M63518_IG03:
-       mov      r11d, 16
+       add      rcx, 16
 						;; size=4 bbWeight=0.25 PerfScore 0.06
 G_M63518_IG04:
-       lea      r8, bword ptr [rcx+r11]
+       mov      r8, rcx
        mov      r10d, dword ptr [r8]
        mov      r9d, dword ptr [r8+0x04]
        mov      r8d, dword ptr [r8+0x08]
        add      eax, r10d
        add      eax, r9d
        add      eax, r8d
-       add      r11, 12
+       add      rcx, 12
        dec      edx
        jne      SHORT G_M63518_IG04
 						;; size=31 bbWeight=4 PerfScore 34.00
```
which removes a live loop-carried value.