### PR TITLE
Set GCStressIncompatible on GenericContext tests

### DIFF
--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/Generator/Program.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/Generator/Program.cs
@@ -801,6 +801,11 @@ namespace VirtualStaticInterfaceMethodTestGen
                 twOutputTest.WriteLine("    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (");
                 twOutputTest.WriteLine("        01 00 00 00");
                 twOutputTest.WriteLine("    )");
+                twOutputTest.WriteLine("    // [SkipOnCoreClr(\"GC Stress Incompatible\", RuntimeTestModes.AnyGCStress)]");
+                twOutputTest.WriteLine("    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = (");
+                twOutputTest.WriteLine("        01 00 16 47 43 20 53 74 72 65 73 73 20 49 6e 63");
+                twOutputTest.WriteLine("        6f 6d 70 61 74 69 62 6c 65 c0 00 00 00 00 00");
+	            twOutputTest.WriteLine("    )");
                 twOutputTest.WriteLine("    .entrypoint");
                 twOutputTest.WriteLine("    .locals init (class [System.Runtime]System.Exception V_0)");
                 twOutputTest.Write(swMainMethodBody.ToString());

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <!-- Needed for GCStressIncompatible -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenericContextCommonCs.cs" />

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenericContextCommonCs.cs" />

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <!-- Needed for GCStressIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTest/GenericContextTest.il
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTest/GenericContextTest.il
@@ -19969,6 +19969,11 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    // [SkipOnCoreClr("GC Stress Incompatible", RuntimeTestModes.AnyGCStress)]
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = (
+      01 00 16 47 43 20 53 74 72 65 73 73 20 49 6e 63
+      6f 6d 70 61 74 69 62 6c 65 c0 00 00 00 00 00
+	  )
     .entrypoint
     .locals init (class [System.Runtime]System.Exception V_0)
     .try {

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDICallDI/GenericContextTestDICallDI.il
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDICallDI/GenericContextTestDICallDI.il
@@ -19969,6 +19969,11 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    // [SkipOnCoreClr("GC Stress Incompatible", RuntimeTestModes.AnyGCStress)]
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = (
+      01 00 16 47 43 20 53 74 72 65 73 73 20 49 6e 63
+      6f 6d 70 61 74 69 62 6c 65 c0 00 00 00 00 00
+	  )
     .entrypoint
     .locals init (class [System.Runtime]System.Exception V_0)
     .try {

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDefaultImp/GenericContextTestDefaultImp.il
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDefaultImp/GenericContextTestDefaultImp.il
@@ -19969,6 +19969,11 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    // [SkipOnCoreClr("GC Stress Incompatible", RuntimeTestModes.AnyGCStress)]
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = (
+      01 00 16 47 43 20 53 74 72 65 73 73 20 49 6e 63
+      6f 6d 70 61 74 69 62 6c 65 c0 00 00 00 00 00
+	  )
     .entrypoint
     .locals init (class [System.Runtime]System.Exception V_0)
     .try {


### PR DESCRIPTION
As suggested in https://github.com/dotnet/runtime/issues/104633, this may help in reducing test timeouts.