### PR TITLE
JIT: Refine post-dominance check in strength reduction

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2232,6 +2232,8 @@ public:
 
     bool MayExecuteBlockMultipleTimesPerIteration(BasicBlock* block);
 
+    bool IsPostDominatedOnLoopIteration(BasicBlock* block, BasicBlock* postDominator);
+
 #ifdef DEBUG
     static void Dump(FlowGraphNaturalLoop* loop);
 #endif // DEBUG

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5818,14 +5818,14 @@ bool FlowGraphNaturalLoop::IsPostDominatedOnLoopIteration(BasicBlock* block, Bas
     assert(ContainsBlock(block) && ContainsBlock(postDominator));
 
     unsigned index;
-    bool gotIndex = TryGetLoopBlockBitVecIndex(block, &index);
+    bool     gotIndex = TryGetLoopBlockBitVecIndex(block, &index);
     assert(gotIndex);
 
-    Compiler* comp = m_dfsTree->GetCompiler();
+    Compiler*               comp = m_dfsTree->GetCompiler();
     ArrayStack<BasicBlock*> stack(comp->getAllocator(CMK_Loops));
 
     BitVecTraits traits = LoopBlockTraits();
-    BitVec visited(BitVecOps::MakeEmpty(&traits));
+    BitVec       visited(BitVecOps::MakeEmpty(&traits));
 
     stack.Push(block);
     BitVecOps::AddElemD(&traits, visited, index);
@@ -5852,7 +5852,7 @@ bool FlowGraphNaturalLoop::IsPostDominatedOnLoopIteration(BasicBlock* block, Bas
 
         stack.Push(succ);
         return BasicBlockVisit::Continue;
-        };
+    };
 
     while (stack.Height() > 0)
     {

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1853,16 +1853,8 @@ BasicBlock* StrengthReductionContext::FindUpdateInsertionPoint(ArrayStack<Cursor
         }
         else
         {
-            if (m_comp->optReachable(cursor.Block, m_loop->GetHeader(), insertionPoint))
+            if (!m_loop->IsPostDominatedOnLoopIteration(cursor.Block, insertionPoint))
             {
-                // Header is reachable without going through the insertion
-                // point, meaning that the insertion point does not
-                // post-dominate the use of an IV we want to replace.
-                //
-                // TODO-CQ: We only need to check whether the header is
-                // reachable from inside the loop, which is both cheaper and
-                // less conservative to check.
-                //
                 return nullptr;
             }
         }

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -2224,12 +2224,10 @@ bool Compiler::optReachable(BasicBlock* const fromBlock, BasicBlock* const toBlo
                 return BasicBlockVisit::Abort;
             }
 
-            if (BitVecOps::IsMember(optReachableBitVecTraits, optReachableBitVec, succ->bbNum))
+            if (!BitVecOps::TryAddElemD(optReachableBitVecTraits, optReachableBitVec, succ->bbNum))
             {
                 return BasicBlockVisit::Continue;
             }
-
-            BitVecOps::AddElemD(optReachableBitVecTraits, optReachableBitVec, succ->bbNum);
 
             stack.Push(succ);
             return BasicBlockVisit::Continue;


### PR DESCRIPTION
When strength reduction has to find an insertion point for the new primary IV update it needs to find a block that post-dominates all the users of the IV. This was using `optReachable` before, but that is conservative since it finds paths that may exit the loop. This implements a more precise check.