### PR TITLE
Replace Ubuntu 18 images with Ubuntu 20 in ARM 64 runs

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -70,9 +70,9 @@ jobs:
     # Linux arm64
     - ${{ if eq(parameters.platform, 'linux_arm64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Ubuntu.2204.Arm64.Open)Ubuntu.2004.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8
+        - (Ubuntu.2004.Arm64.Open)Ubuntu.2004.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - (Ubuntu.2204.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8
+        - (Ubuntu.2004.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'linux_musl_x64') }}:

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -70,9 +70,9 @@ jobs:
     # Linux arm64
     - ${{ if eq(parameters.platform, 'linux_arm64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Ubuntu.1804.Arm64.Open)Ubuntu.2004.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8
+        - (Ubuntu.2004.Arm64.Open)Ubuntu.2004.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - (Ubuntu.1804.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8
+        - (Ubuntu.2004.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'linux_musl_x64') }}:

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -70,9 +70,9 @@ jobs:
     # Linux arm64
     - ${{ if eq(parameters.platform, 'linux_arm64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Ubuntu.2004.Arm64.Open)Ubuntu.2004.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8
+        - (Ubuntu.2204.Arm64.Open)Ubuntu.2004.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - (Ubuntu.2004.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-arm64v8
+        - (Ubuntu.2204.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'linux_musl_x64') }}:

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -18,7 +18,6 @@ namespace System
         public static bool IsOpenSUSE => IsDistroAndVersion("opensuse");
         public static bool IsUbuntu => IsDistroAndVersion("ubuntu");
         public static bool IsUbuntu2004 => IsDistroAndVersion("ubuntu", 20, 4);
-        public static bool IsUbuntu1804 => IsDistroAndVersion("ubuntu", 18, 4);
         public static bool IsDebian => IsDistroAndVersion("debian");
         public static bool IsAlpine => IsDistroAndVersion("alpine");
         public static bool IsRaspbian10 => IsDistroAndVersion("raspbian", 10);

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -18,6 +18,7 @@ namespace System
         public static bool IsOpenSUSE => IsDistroAndVersion("opensuse");
         public static bool IsUbuntu => IsDistroAndVersion("ubuntu");
         public static bool IsUbuntu2004 => IsDistroAndVersion("ubuntu", 20, 4);
+        public static bool IsUbuntu1804 => IsDistroAndVersion("ubuntu", 18, 4);
         public static bool IsDebian => IsDistroAndVersion("debian");
         public static bool IsAlpine => IsDistroAndVersion("alpine");
         public static bool IsRaspbian10 => IsDistroAndVersion("raspbian", 10);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
@@ -134,9 +134,10 @@ namespace System.Net.Security.Tests
             server.Dispose();
         }
 
-        [ConditionalTheory]
+        public static bool IsNotUbuntu1804OnArm => !(PlatformDetection.IsUbuntu1804 && PlatformDetection.IsArmOrArm64Process);
+
+        [ConditionalTheory(nameof(IsNotUbuntu1804OnArm))] // bug in OpenSSL on past-EOL Ubuntu 18.04 ARM
         [MemberData(nameof(SslProtocolsData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/103354", typeof(PlatformDetection), nameof(PlatformDetection.IsArmOrArm64Process))]
         public Task NoClientCert_DefaultValue_ResumeSucceeds(SslProtocols sslProtocol)
         {
             SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
@@ -189,9 +190,8 @@ namespace System.Net.Security.Tests
             return data;
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(nameof(IsNotUbuntu1804OnArm))] // bug in OpenSSL on past-EOL Ubuntu 18.04 ARM
         [MemberData(nameof(ClientCertTestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/103354", typeof(PlatformDetection), nameof(PlatformDetection.IsArmOrArm64Process))]
         public Task ClientCert_DefaultValue_ResumeSucceeds(SslProtocols sslProtocol, bool certificateRequired, ClientCertSource certSource)
         {
             SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
@@ -134,9 +134,7 @@ namespace System.Net.Security.Tests
             server.Dispose();
         }
 
-        public static bool IsNotUbuntu1804OnArm => !(PlatformDetection.IsUbuntu1804 && PlatformDetection.IsArmOrArm64Process);
-
-        [ConditionalTheory(nameof(IsNotUbuntu1804OnArm))] // bug in OpenSSL on past-EOL Ubuntu 18.04 ARM
+        [Theory]
         [MemberData(nameof(SslProtocolsData))]
         public Task NoClientCert_DefaultValue_ResumeSucceeds(SslProtocols sslProtocol)
         {
@@ -190,7 +188,7 @@ namespace System.Net.Security.Tests
             return data;
         }
 
-        [ConditionalTheory(nameof(IsNotUbuntu1804OnArm))] // bug in OpenSSL on past-EOL Ubuntu 18.04 ARM
+        [Theory]
         [MemberData(nameof(ClientCertTestData))]
         public Task ClientCert_DefaultValue_ResumeSucceeds(SslProtocols sslProtocol, bool certificateRequired, ClientCertSource certSource)
         {


### PR DESCRIPTION
Closes #103354.

TLS resumption does not work reliably with the OpenSSL version present on Ubuntu 18.04 distribution. Since the distro in question is past EOL, we should simply update the queues to more recent distro image.