### PR TITLE
[HTTP/2] Throw meaningful exception if we get GOAWAY while reading response body

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -418,11 +418,11 @@ namespace System.Net.Http
                         }
                         else if (_incomingBuffer.ActiveLength == 0)
                         {
-                            ThrowMissingFrameException();
+                            ThrowMissingFrame();
                         }
                         else
                         {
-                            ThrowPrematureEOFException(FrameHeader.Size);
+                            ThrowPrematureEOF(FrameHeader.Size);
                         }
                     }
                 }
@@ -455,7 +455,7 @@ namespace System.Net.Http
 
                     int bytesRead = await _stream.ReadAsync(_incomingBuffer.AvailableMemory).ConfigureAwait(false);
                     _incomingBuffer.Commit(bytesRead);
-                    if (bytesRead == 0) ThrowPrematureEOFException(frameHeader.PayloadLength);
+                    if (bytesRead == 0) ThrowPrematureEOF(frameHeader.PayloadLength);
                 }
                 while (_incomingBuffer.ActiveLength < frameHeader.PayloadLength);
             }
@@ -463,10 +463,10 @@ namespace System.Net.Http
             // Return the read frame header.
             return frameHeader;
 
-            void ThrowPrematureEOFException(int requiredBytes) =>
+            void ThrowPrematureEOF(int requiredBytes) =>
                 throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, requiredBytes - _incomingBuffer.ActiveLength));
 
-            void ThrowMissingFrameException() =>
+            void ThrowMissingFrame() =>
                 throw new HttpIOException(HttpRequestError.ResponseEnded, SR.net_http_invalid_response_missing_frame);
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -413,7 +413,7 @@ namespace System.Net.Http
                     if (bytesRead == 0)
                     {
                         HttpIOException exception = _incomingBuffer.ActiveLength == 0 ?
-                            ThrowMissingFrame() : ThrowPrematureEOF(FrameHeader.Size);
+                            GetMissingFrameException() : GetPrematureEOFException(FrameHeader.Size);
                         throw _goAwayErrorCode is not null ?
                             new HttpProtocolException((long)_goAwayErrorCode, exception.Message, exception) : exception;
                     }
@@ -447,7 +447,7 @@ namespace System.Net.Http
 
                     int bytesRead = await _stream.ReadAsync(_incomingBuffer.AvailableMemory).ConfigureAwait(false);
                     _incomingBuffer.Commit(bytesRead);
-                    if (bytesRead == 0) throw ThrowPrematureEOF(frameHeader.PayloadLength);
+                    if (bytesRead == 0) throw GetPrematureEOFException(frameHeader.PayloadLength);
                 }
                 while (_incomingBuffer.ActiveLength < frameHeader.PayloadLength);
             }
@@ -455,10 +455,10 @@ namespace System.Net.Http
             // Return the read frame header.
             return frameHeader;
 
-            HttpIOException ThrowPrematureEOF(int requiredBytes) =>
+            HttpIOException GetPrematureEOFException(int requiredBytes) =>
                 new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, requiredBytes - _incomingBuffer.ActiveLength));
 
-            HttpIOException ThrowMissingFrame() =>
+            HttpIOException GetMissingFrameException() =>
                 new HttpIOException(HttpRequestError.ResponseEnded, SR.net_http_invalid_response_missing_frame);
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1054,7 +1054,6 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(nameof(SupportsAlpn))]
         public async Task GoAwayFrame_RequestServerDisconnects_ThrowsHttpProtocolExceptionWithProperErrorCode()
         {
-            _output.WriteLine("Started!");
             await Http2LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
                 // Client starts an HTTP/2 request and awaits response headers
@@ -1073,7 +1072,7 @@ namespace System.Net.Http.Functional.Tests
             async server =>
             {
                 // Server returns response headers
-                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+                await using Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
                 int streamId = await connection.ReadRequestHeaderAsync();
                 await connection.SendDefaultResponseHeadersAsync(streamId);
                 _output.WriteLine("Server sent response headers!");
@@ -1081,7 +1080,7 @@ namespace System.Net.Http.Functional.Tests
                 await connection.SendGoAway(streamId, ProtocolErrors.ENHANCE_YOUR_CALM);
                 _output.WriteLine("Server sent GOAWAY!");
                 connection.ShutdownSend();
-            }).WaitAsync(TimeSpan.FromSeconds(10));
+            });
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]


### PR DESCRIPTION
Fixes #97128

Not sure if this is the correct way to fix this.