### PR TITLE
[release/8.0] Use latest .NET version in HttpStress runs

### DIFF
--- a/eng/docker/libraries-sdk.linux.Dockerfile
+++ b/eng/docker/libraries-sdk.linux.Dockerfile
@@ -1,6 +1,6 @@
 # Builds and copies library artifacts into target dotnet sdk image
 ARG BUILD_BASE_IMAGE=mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:8.0-bullseye-slim
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:7.0-bullseye-slim
 
 FROM $BUILD_BASE_IMAGE as corefxbuild
 

--- a/eng/docker/libraries-sdk.linux.Dockerfile
+++ b/eng/docker/libraries-sdk.linux.Dockerfile
@@ -1,6 +1,6 @@
 # Builds and copies library artifacts into target dotnet sdk image
 ARG BUILD_BASE_IMAGE=mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:7.0-bullseye-slim
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:8.0-bullseye-slim
 
 FROM $BUILD_BASE_IMAGE as corefxbuild
 
@@ -14,7 +14,7 @@ FROM $SDK_BASE_IMAGE as target
 
 ARG VERSION=8.0
 ARG CONFIGURATION=Release
-ENV _DOTNET_INSTALL_CHANNEL="$VERSION.1xx"
+ENV _DOTNET_INSTALL_CHANNEL=$VERSION
 
 # Install latest daily SDK:
 RUN wget https://dot.net/v1/dotnet-install.sh

--- a/eng/docker/libraries-sdk.windows.Dockerfile
+++ b/eng/docker/libraries-sdk.windows.Dockerfile
@@ -1,12 +1,12 @@
 # escape=`
 # Simple Dockerfile which copies clr and library build artifacts into target dotnet sdk image
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:7.0-nanoserver-ltsc2022
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:8.0-nanoserver-ltsc2022
 FROM $SDK_BASE_IMAGE as target
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG VERSION=8.0
-ENV _DOTNET_INSTALL_CHANNEL="$VERSION.1xx"
+ENV _DOTNET_INSTALL_CHANNEL=$VERSION
 ARG CONFIGURATION=Release
 
 USER ContainerAdministrator

--- a/eng/docker/libraries-sdk.windows.Dockerfile
+++ b/eng/docker/libraries-sdk.windows.Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 # Simple Dockerfile which copies clr and library build artifacts into target dotnet sdk image
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:8.0-nanoserver-ltsc2022
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:7.0-nanoserver-ltsc2022
 FROM $SDK_BASE_IMAGE as target
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
@@ -34,7 +34,7 @@ if (-not (Test-Path -Path $DailyDotnetRoot)) {
     Write-Host "Downloading daily SDK to: $DailyDotnetRoot"
     New-Item -ItemType Directory -Path $DailyDotnetRoot
     Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile "$DailyDotnetRoot\dotnet-install.ps1"
-    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel "$Version.1xx" -Quality daily -InstallDir $DailyDotnetRoot
+    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel $Version -Quality daily -InstallDir $DailyDotnetRoot
 } else {
     Write-Host "Daily SDK found in $DailyDotnetRoot"
 }

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
@@ -37,7 +37,7 @@ if [[ ! -d $daily_dotnet_root ]]; then
     echo "Downloading daily SDK to $daily_dotnet_root"
     mkdir $daily_dotnet_root
     wget https://dot.net/v1/dotnet-install.sh -O $daily_dotnet_root/dotnet-install.sh
-    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version.1xx --quality daily --install-dir $daily_dotnet_root
+    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version --quality daily --install-dir $daily_dotnet_root
 else
     echo "Daily SDK found in $daily_dotnet_root"
 fi

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Build-Local.ps1
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Build-Local.ps1
@@ -38,7 +38,7 @@ if (-not (Test-Path -Path $DailyDotnetRoot)) {
     Write-Host "Downloading daily SDK to: $DailyDotnetRoot"
     New-Item -ItemType Directory -Path $DailyDotnetRoot
     Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile "$DailyDotnetRoot\dotnet-install.ps1"
-    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel "$Version.1xx" -Quality daily -InstallDir $DailyDotnetRoot
+    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel $Version -Quality daily -InstallDir $DailyDotnetRoot
 } else {
     Write-Host "Daily SDK found in $DailyDotnetRoot"
 }

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
@@ -39,7 +39,7 @@ if [[ ! -d $daily_dotnet_root ]]; then
     echo "Downloading daily SDK to $daily_dotnet_root"
     mkdir $daily_dotnet_root
     wget https://dot.net/v1/dotnet-install.sh -O $daily_dotnet_root/dotnet-install.sh
-    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version.1xx --quality daily --install-dir $daily_dotnet_root
+    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version --quality daily --install-dir $daily_dotnet_root
 else
     echo "Daily SDK found in $daily_dotnet_root"
 fi


### PR DESCRIPTION
The current runs seem to be stuck using 8.0.5, removing the 1xx suffix from dotnet-install -Version parameter seems to get the latest one (8.0.7).

## Customer Impact

None, test-only change to make sure we consume the latest .NET 8 release in stress tests to pick up ASP.NET fixes.

## Regression

No

## Testing

Stress pipeline run as part of this PR.

## Risk

Low, test-only change.

