### PR TITLE
Use latest released SDK for HttpStress.

### DIFF
--- a/eng/docker/libraries-sdk.linux.Dockerfile
+++ b/eng/docker/libraries-sdk.linux.Dockerfile
@@ -14,7 +14,7 @@ FROM $SDK_BASE_IMAGE as target
 
 ARG VERSION=9.0
 ARG CONFIGURATION=Release
-ENV _DOTNET_INSTALL_CHANNEL="$VERSION.1xx"
+ENV _DOTNET_INSTALL_CHANNEL=$VERSION
 
 # Install latest daily SDK:
 RUN wget https://dot.net/v1/dotnet-install.sh

--- a/eng/docker/libraries-sdk.windows.Dockerfile
+++ b/eng/docker/libraries-sdk.windows.Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_BASE_IMAGE as target
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG VERSION=9.0
-ENV _DOTNET_INSTALL_CHANNEL="$VERSION.1xx"
+ENV _DOTNET_INSTALL_CHANNEL=$VERSION
 ARG CONFIGURATION=Release
 
 USER ContainerAdministrator

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
@@ -34,7 +34,7 @@ if (-not (Test-Path -Path $DailyDotnetRoot)) {
     Write-Host "Downloading daily SDK to: $DailyDotnetRoot"
     New-Item -ItemType Directory -Path $DailyDotnetRoot
     Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile "$DailyDotnetRoot\dotnet-install.ps1"
-    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel "$Version.1xx" -Quality daily -InstallDir $DailyDotnetRoot
+    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel $Version -Quality daily -InstallDir $DailyDotnetRoot
 } else {
     Write-Host "Daily SDK found in $DailyDotnetRoot"
 }

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
@@ -37,7 +37,7 @@ if [[ ! -d $daily_dotnet_root ]]; then
     echo "Downloading daily SDK to $daily_dotnet_root"
     mkdir $daily_dotnet_root
     wget https://dot.net/v1/dotnet-install.sh -O $daily_dotnet_root/dotnet-install.sh
-    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version.1xx --quality daily --install-dir $daily_dotnet_root
+    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version --quality daily --install-dir $daily_dotnet_root
 else
     echo "Daily SDK found in $daily_dotnet_root"
 fi

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Build-Local.ps1
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Build-Local.ps1
@@ -38,7 +38,7 @@ if (-not (Test-Path -Path $DailyDotnetRoot)) {
     Write-Host "Downloading daily SDK to: $DailyDotnetRoot"
     New-Item -ItemType Directory -Path $DailyDotnetRoot
     Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile "$DailyDotnetRoot\dotnet-install.ps1"
-    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel "$Version.1xx" -Quality daily -InstallDir $DailyDotnetRoot
+    & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel $Version -Quality daily -InstallDir $DailyDotnetRoot
 } else {
     Write-Host "Daily SDK found in $DailyDotnetRoot"
 }

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
@@ -40,7 +40,7 @@ if [[ ! -d $daily_dotnet_root ]]; then
     echo "Downloading daily SDK to $daily_dotnet_root"
     mkdir $daily_dotnet_root
     wget https://dot.net/v1/dotnet-install.sh -O $daily_dotnet_root/dotnet-install.sh
-    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version.1xx --quality daily --install-dir $daily_dotnet_root
+    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version --quality daily --install-dir $daily_dotnet_root
 else
     echo "Daily SDK found in $daily_dotnet_root"
 fi


### PR DESCRIPTION
This PR removes the .1xx suffix on the channel of the installed SDK to allow installing more recent SDKs.