### PR TITLE
[release/6.0] Disable SslStress and HttpStress runs

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -11,7 +11,6 @@ schedules:
   branches:
     include:
     - main
-    - release/6.0
 
 variables:
   - template: ../variables.yml

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -11,7 +11,6 @@ schedules:
   branches:
     include:
     - main
-    - release/6.0
 
 variables:
   - template: ../variables.yml


### PR DESCRIPTION
Follow up from https://github.com/dotnet/runtime/pull/103572. Seems like the schedule must be disabled in the particular branch (see https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml)

## Customer Impact

None, test only change to disable scheduled runs of pipelines which have been reliably failing (in the build step) for many months.

## Regression

No

## Testing

N/A

## Risk

Low, test-only change.

