### PR TITLE
Fix WinHttp StreamingTest backward compat Version

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -25,6 +25,7 @@ namespace System
         public static bool IsWindows8xOrLater => IsWindowsVersionOrLater(6, 2);
         public static bool IsWindows10OrLater => IsWindowsVersionOrLater(10, 0);
         public static bool IsWindowsServer2019 => IsWindows && IsNotWindowsNanoServer && GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildVersion() == 17763;
+        public static bool IsWindowsServer2022 => IsWindows && IsNotWindowsNanoServer && GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildVersion() == 20348;
         public static bool IsWindowsNanoServer => IsWindows && (IsNotWindowsIoTCore && GetWindowsInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         public static bool IsWindowsServerCore => IsWindows && GetWindowsInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase);
         public static int WindowsVersion => IsWindows ? (int)GetWindowsVersion() : -1;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         // Build number suggested by the WinHttp team.
         // It can be reduced if bidirectional streaming is backported.
         public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0)
-            || Environment.OSVersion.Version == new Version(10, 0, 20348, 0); // This is required for WS2022
+            || PlatformDetection.IsWindowsServer2022; // This is required
                                                                               // because WINHTTP_FLAG_AUTOMATIC_CHUNKING is backported to WS2022.
 
         public static bool TestsEnabled => OsSupportsWinHttpBidirectionalStreaming && PlatformDetection.SupportsAlpn;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -22,7 +22,9 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
         // Build number suggested by the WinHttp team.
         // It can be reduced if bidirectional streaming is backported.
-        public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0);
+        public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0)
+            || Environment.OSVersion.Version == new Version(10, 0, 20348, 0); // This is required for WS2022
+                                                                              // because WINHTTP_FLAG_AUTOMATIC_CHUNKING is backported to WS2022.
 
         public static bool TestsEnabled => OsSupportsWinHttpBidirectionalStreaming && PlatformDetection.SupportsAlpn;
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -326,7 +326,6 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         }
 
         [ConditionalFact(nameof(TestsBackwardsCompatibilityEnabled))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/103754")]
         public async Task BackwardsCompatibility_DowngradeToHttp11()
         {
             TaskCompletionSource<object> completeStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Fixes #103754 
Server 2022 WinHttp supports the automatic chunking in HTTP/2 now, so our requests are going as `HTTP/2` requests instead of falling back to HTTP/1.1.

OSVersion doesn't report revision (reports it as 0) and build version will be 20348 for WS2022. 
