### PR TITLE
SPMI: Increase helix timeout for superpmi-diffs job

### DIFF
--- a/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
@@ -122,7 +122,7 @@ jobs:
         helixType: 'build/tests/'
         helixQueues: ${{ join(',', parameters.helixQueues) }}
         creator: dotnet-bot
-        WorkItemTimeout: 3:00 # 3 hours
+        WorkItemTimeout: 5:00 # 5 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'
         helixProjectArguments: '$(Build.SourcesDirectory)/src/coreclr/scripts/superpmi-diffs.proj'

--- a/src/coreclr/scripts/superpmi-diffs.proj
+++ b/src/coreclr/scripts/superpmi-diffs.proj
@@ -57,7 +57,7 @@
 
   <PropertyGroup>
     <WorkItemCommand>$(Python) $(ProductDirectory)/superpmi_diffs.py -type $(SuperPmiDiffType) -base_jit_directory $(ProductDirectory)/base -diff_jit_directory $(ProductDirectory)/diff $(SuperPmiBaseJitOptionsArg) $(SuperPmiDiffJitOptionsArg) -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
-    <WorkItemTimeout>3:00</WorkItemTimeout>
+    <WorkItemTimeout>5:00</WorkItemTimeout>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
win-x86 tpdiff is hitting this timeout right towards the end of the last collection it needs to run over. Up the limit by 2 hours like we did for the pipeline itself in a33eb5c.

Ideally we would parallelize this better...