### PR TITLE
Delete FEATURE_READYTORUN_COMPILER ifdef

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1904,18 +1904,11 @@ CEEInfo::getHeapClassSize(
     TypeHandle VMClsHnd(clsHnd);
     MethodTable* pMT = VMClsHnd.GetMethodTable();
     _ASSERTE(pMT);
+    _ASSERTE(!pMT->IsValueType());
     _ASSERTE(!pMT->HasComponentSize());
 
     // Add OBJECT_SIZE to account for method table pointer.
-    //
-    if (pMT->IsValueType())
-    {
-        result = VMClsHnd.GetSize() + OBJECT_SIZE;
-    }
-    else
-    {
-        result = pMT->GetNumInstanceFieldBytes() + OBJECT_SIZE;
-    }
+    result = pMT->GetNumInstanceFieldBytes() + OBJECT_SIZE;
 
     EE_TO_JIT_TRANSITION_LEAF();
     return result;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1906,10 +1906,6 @@ CEEInfo::getHeapClassSize(
     _ASSERTE(pMT);
     _ASSERTE(!pMT->HasComponentSize());
 
-#ifdef FEATURE_READYTORUN_COMPILER
-    _ASSERTE(!IsReadyToRunCompilation() || pMT->IsInheritanceChainLayoutFixedInCurrentVersionBubble());
-#endif
-
     // Add OBJECT_SIZE to account for method table pointer.
     //
     if (pMT->IsValueType())


### PR DESCRIPTION
#103361 resurrected this long-deleted ifdef (it's crossgen1-specific define).

I actually wonder if we should roll back _all_ changes to `getHeapClassSize` - @EgorBo's #104411 doesn't fix getHeapClassSize to work with valuetypes and we don't have any failing tests, so maybe it doesn't need to handle valuetypes?