### PR TITLE
Condition DurationHistogram_HasBucketSizeHints on RemoteExecutor

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
@@ -41,7 +41,7 @@ namespace System.Net.NameResolution.Tests
             }).DisposeAsync();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static async Task DurationHistogram_HasBucketSizeHints()
         {
             await RemoteExecutor.Invoke(async () =>


### PR DESCRIPTION
This is breaking all outerloop legs that don't have RemoteExecutor support.