### PR TITLE
Add libicu74 as a known ICU version

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <LinuxPackageDependency Include="libc6;libgcc1;libgssapi-krb5-2;libstdc++6;zlib1g"/>
     <LinuxPackageDependency Include="libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3" />
-    <KnownLibIcuVersion Include="72;71;70;69;68;67;66;65;63;60;57;55;52" />
+    <KnownLibIcuVersion Include="74;72;71;70;69;68;67;66;65;63;60;57;55;52" />
     <LibIcuPackageDependency Include="libicu" Dependencies="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />
     <LinuxPackageDependency
       Include="@(LibIcuPackageDependency->Metadata('Dependencies'))" />


### PR DESCRIPTION
Ubuntu 24.04 ships ICU v74 as the libicu74 package, so we need to add it as a known version.

Contributes to https://github.com/dotnet/sdk/issues/40506

This does not affect source-build. Canonical defines their own deb packages and they do not use the runtime-deps package.