### PR TITLE
Fix ISOSDACInterface::GetThreadData reading the GC alloc context.

### DIFF
--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -8068,6 +8068,12 @@ Thread::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     }
 
     //
+    // Add the thread local variables like alloc_context, etc.
+    //
+
+    m_pRuntimeThreadLocals.EnumMem();
+
+    //
     // Try and do a stack trace and save information
     // for each part of the stack.  This is very vulnerable
     // to memory problems so ignore all exceptions here.

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -8071,7 +8071,10 @@ Thread::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     // Add the thread local variables like alloc_context, etc.
     //
 
-    m_pRuntimeThreadLocals.EnumMem();
+    if (m_pRuntimeThreadLocals.IsValid())
+    {
+        m_pRuntimeThreadLocals.EnumMem();
+    }
 
     //
     // Try and do a stack trace and save information


### PR DESCRIPTION
The RuntimeThreadLocals struct that the gc_alloc_context is in wasn't being added to dump in Thread::EnumMemoryRegions.

It is failing to read memory [here](https://github.com/dotnet/runtime/blob/cae3aec80d32316026d85228e12a94dd4887d57f/src/coreclr/debug/daccess/request.cpp#L825) in the DAC GetThreadData() before this change.