### PR TITLE
Ensure that the correct VC++ toolset is selected in all build environments

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -976,27 +976,13 @@ endif()
 
 # Ensure other tools are present
 if (CLR_CMAKE_HOST_WIN32)
-    if(CLR_CMAKE_HOST_ARCH_ARM)
-
-      # Explicitly specify the assembler to be used for Arm32 compile
-      file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\HostX86\\arm\\armasm.exe" CMAKE_ASM_COMPILER)
-
-      set(CMAKE_ASM_MASM_COMPILER ${CMAKE_ASM_COMPILER})
-      message("CMAKE_ASM_MASM_COMPILER explicitly set to: ${CMAKE_ASM_MASM_COMPILER}")
-
-      # Enable generic assembly compilation to avoid CMake generate VS proj files that explicitly
-      # use ml[64].exe as the assembler.
-      enable_language(ASM)
-      set(CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreaded         "")
-      set(CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL      "")
-      set(CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDebug    "")
-      set(CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDebugDLL "")
-      set(CMAKE_ASM_COMPILE_OBJECT "<CMAKE_ASM_COMPILER> -g <INCLUDES> <FLAGS> -o <OBJECT> <SOURCE>")
-
-    elseif(CLR_CMAKE_HOST_ARCH_ARM64)
-
+    if(CLR_CMAKE_HOST_ARCH_ARM64)
       # Explicitly specify the assembler to be used for Arm64 compile
-      file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\HostX86\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+      if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+        file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\Hostarm64\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+      else()
+        file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\HostX64\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+      endif()
 
       set(CMAKE_ASM_MASM_COMPILER ${CMAKE_ASM_COMPILER})
       message("CMAKE_ASM_MASM_COMPILER explicitly set to: ${CMAKE_ASM_MASM_COMPILER}")

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -5,10 +5,9 @@
 
 set "__VCBuildArch="
 if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
+    set __VCBuildArch=arm64
     if /i "%~1" == "x64"   ( set __VCBuildArch=arm64_amd64 )
     if /i "%~1" == "x86"   ( set __VCBuildArch=arm64_x86 )
-    if /i "%~1" == "arm64" ( set __VCBuildArch=arm64 )
-    if /i "%~1" == "wasm"  ( set __VCBuildArch=arm64 )
 ) else (
     if /i "%~1" == "x64"   ( set __VCBuildArch=amd64 )
     if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -4,10 +4,22 @@
 :: as an argument, it also initializes VC++ build environment and CMakePath.
 
 set "__VCBuildArch="
-if /i "%~1" == "x86"   (set __VCBuildArch=x86)
-if /i "%~1" == "x64"   (set __VCBuildArch=x86_amd64)
-if /i "%~1" == "arm64" (if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (set __VCBuildArch=arm64) else (set __VCBuildArch=x86_arm64))
-if /i "%~1" == "wasm" (if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (set __VCBuildArch=arm64) else (set __VCBuildArch=x86_amd64))
+if /i "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
+    if /i "%~1" == "x64"   ( set __VCBuildArch=amd64 )
+    if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )
+    if /i "%~1" == "arm64" ( set __VCBuildArch=amd64_arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=amd64 )
+) else if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
+    if /i "%~1" == "x64"   ( set __VCBuildArch=arm64_amd64 )
+    if /i "%~1" == "x86"   ( set __VCBuildArch=arm64_x86 )
+    if /i "%~1" == "arm64" ( set __VCBuildArch=arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=arm64 )
+) else (
+    if /i "%~1" == "x64"   ( set __VCBuildArch=x86_amd64 )
+    if /i "%~1" == "x86"   ( set __VCBuildArch=x86 )
+    if /i "%~1" == "arm64" ( set __VCBuildArch=x86_arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=x86 )
+)
 
 :: Default to highest Visual Studio version available that has Visual C++ tools.
 ::

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -10,9 +10,10 @@ if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
     if /i "%~1" == "arm64" ( set __VCBuildArch=arm64 )
     if /i "%~1" == "wasm"  ( set __VCBuildArch=arm64 )
 ) else (
-    set __VCBuildArch=amd64
+    if /i "%~1" == "x64"   ( set __VCBuildArch=amd64 )
     if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )
     if /i "%~1" == "arm64" ( set __VCBuildArch=amd64_arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=amd64 )
 )
 
 :: Default to highest Visual Studio version available that has Visual C++ tools.

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -4,21 +4,16 @@
 :: as an argument, it also initializes VC++ build environment and CMakePath.
 
 set "__VCBuildArch="
-if /i "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
-    if /i "%~1" == "x64"   ( set __VCBuildArch=amd64 )
-    if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )
-    if /i "%~1" == "arm64" ( set __VCBuildArch=amd64_arm64 )
-    if /i "%~1" == "wasm"  ( set __VCBuildArch=amd64 )
-) else if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
+if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
     if /i "%~1" == "x64"   ( set __VCBuildArch=arm64_amd64 )
     if /i "%~1" == "x86"   ( set __VCBuildArch=arm64_x86 )
     if /i "%~1" == "arm64" ( set __VCBuildArch=arm64 )
     if /i "%~1" == "wasm"  ( set __VCBuildArch=arm64 )
 ) else (
-    if /i "%~1" == "x64"   ( set __VCBuildArch=x86_amd64 )
-    if /i "%~1" == "x86"   ( set __VCBuildArch=x86 )
-    if /i "%~1" == "arm64" ( set __VCBuildArch=x86_arm64 )
-    if /i "%~1" == "wasm"  ( set __VCBuildArch=x86 )
+    if /i "%~1" == "x64"   ( set __VCBuildArch=amd64 )
+    if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )
+    if /i "%~1" == "arm64" ( set __VCBuildArch=amd64_arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=amd64 )
 )
 
 :: Default to highest Visual Studio version available that has Visual C++ tools.

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -9,10 +9,9 @@ if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
     if /i "%~1" == "x64"   ( set __VCBuildArch=arm64_amd64 )
     if /i "%~1" == "x86"   ( set __VCBuildArch=arm64_x86 )
 ) else (
-    if /i "%~1" == "x64"   ( set __VCBuildArch=amd64 )
+    set __VCBuildArch=amd64
     if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )
     if /i "%~1" == "arm64" ( set __VCBuildArch=amd64_arm64 )
-    if /i "%~1" == "wasm"  ( set __VCBuildArch=amd64 )
 )
 
 :: Default to highest Visual Studio version available that has Visual C++ tools.

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -5,9 +5,10 @@
 
 set "__VCBuildArch="
 if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
-    set __VCBuildArch=arm64
     if /i "%~1" == "x64"   ( set __VCBuildArch=arm64_amd64 )
     if /i "%~1" == "x86"   ( set __VCBuildArch=arm64_x86 )
+    if /i "%~1" == "arm64" ( set __VCBuildArch=arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=arm64 )
 ) else (
     set __VCBuildArch=amd64
     if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -359,18 +359,18 @@ if %__BuildNative% EQU 1 (
 
     REM Set the environment for the native build
     if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
-        set __VCTargetArch=arm64
-        if /i "%__HostArch%" == "x64" ( set __VCTargetArch=arm64_amd64 )
-        if /i "%__HostArch%" == "x86" ( set __VCTargetArch=arm64_x86 )
+        set __VCBuildArch=arm64
+        if /i "%__HostArch%" == "x64" ( set __VCBuildArch=arm64_amd64 )
+        if /i "%__HostArch%" == "x86" ( set __VCBuildArch=arm64_x86 )
     ) else (
-        set __VCTargetArch=amd64
-        if /i "%__HostArch%" == "x86" ( set __VCTargetArch=amd64_x86 )
-        if /i "%__HostArch%" == "arm64" ( set __VCTargetArch=amd64_arm64 )
+        set __VCBuildArch=amd64
+        if /i "%__HostArch%" == "x86" ( set __VCBuildArch=amd64_x86 )
+        if /i "%__HostArch%" == "arm64" ( set __VCBuildArch=amd64_arm64 )
     )
 
     if NOT DEFINED SkipVCEnvInit (
-        echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCTargetArch!
-        call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCTargetArch!
+        echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
+        call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
     )
     @if defined _echo @echo on
 

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -361,10 +361,18 @@ if %__BuildNative% EQU 1 (
     echo %__MsgPrefix%Commencing build of native components for %__TargetOS%.%__TargetArch%.%__BuildType%
 
     REM Set the environment for the native build
-    set __VCTargetArch=amd64
-    if /i "%__HostArch%" == "x86" ( set __VCTargetArch=x86 )
-    if /i "%__HostArch%" == "arm64" (
-        if /i "%__ProcessorArch%" == "ARM64" (set __VCTargetArch=arm64) else (set __VCTargetArch=x86_arm64)
+    if /i "%__ProcessorArch%" == "AMD64" (
+        set __VCTargetArch=amd64
+        if /i "%__TargetArch%" == "x86" ( set __VCTargetArch=amd64_x86 )
+        if /i "%__TargetArch%" == "arm64" ( set __VCTargetArch=amd64_arm64 )
+    ) else if /i "%__ProcessorArch%" == "ARM64" (
+        set __VCTargetArch=arm64
+        if /i "%__TargetArch%" == "x64" ( set __VCTargetArch=arm64_amd64 )
+        if /i "%__TargetArch%" == "x86" ( set __VCTargetArch=arm64_x86 )
+    ) else (
+        set __VCTargetArch=x86
+        if /i "%__TargetArch%" == "x64" ( set __VCTargetArch=x86_amd64 )
+        if /i "%__TargetArch%" == "arm64" ( set __VCTargetArch=x86_arm64 )
     )
 
     if NOT DEFINED SkipVCEnvInit (

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -174,9 +174,6 @@ if %__TotalSpecifiedTargetArch% GTR 1 (
     goto Usage
 )
 
-set __ProcessorArch=%PROCESSOR_ARCHITEW6432%
-if "%__ProcessorArch%"=="" set __ProcessorArch=%PROCESSOR_ARCHITECTURE%
-
 if %__TargetArchX64%==1   set __TargetArch=x64
 if %__TargetArchX86%==1   set __TargetArch=x86
 if %__TargetArchArm%==1   set __TargetArch=arm
@@ -361,18 +358,14 @@ if %__BuildNative% EQU 1 (
     echo %__MsgPrefix%Commencing build of native components for %__TargetOS%.%__TargetArch%.%__BuildType%
 
     REM Set the environment for the native build
-    if /i "%__ProcessorArch%" == "AMD64" (
-        set __VCTargetArch=amd64
-        if /i "%__TargetArch%" == "x86" ( set __VCTargetArch=amd64_x86 )
-        if /i "%__TargetArch%" == "arm64" ( set __VCTargetArch=amd64_arm64 )
-    ) else if /i "%__ProcessorArch%" == "ARM64" (
+    if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
         set __VCTargetArch=arm64
         if /i "%__TargetArch%" == "x64" ( set __VCTargetArch=arm64_amd64 )
         if /i "%__TargetArch%" == "x86" ( set __VCTargetArch=arm64_x86 )
-    ) else (
-        set __VCTargetArch=x86
-        if /i "%__TargetArch%" == "x64" ( set __VCTargetArch=x86_amd64 )
-        if /i "%__TargetArch%" == "arm64" ( set __VCTargetArch=x86_arm64 )
+    ) else
+        set __VCTargetArch=amd64
+        if /i "%__TargetArch%" == "x86" ( set __VCTargetArch=amd64_x86 )
+        if /i "%__TargetArch%" == "arm64" ( set __VCTargetArch=amd64_arm64 )
     )
 
     if NOT DEFINED SkipVCEnvInit (

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -360,12 +360,12 @@ if %__BuildNative% EQU 1 (
     REM Set the environment for the native build
     if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
         set __VCTargetArch=arm64
-        if /i "%__TargetArch%" == "x64" ( set __VCTargetArch=arm64_amd64 )
-        if /i "%__TargetArch%" == "x86" ( set __VCTargetArch=arm64_x86 )
-    ) else
+        if /i "%__HostArch%" == "x64" ( set __VCTargetArch=arm64_amd64 )
+        if /i "%__HostArch%" == "x86" ( set __VCTargetArch=arm64_x86 )
+    ) else (
         set __VCTargetArch=amd64
-        if /i "%__TargetArch%" == "x86" ( set __VCTargetArch=amd64_x86 )
-        if /i "%__TargetArch%" == "arm64" ( set __VCTargetArch=amd64_arm64 )
+        if /i "%__HostArch%" == "x86" ( set __VCTargetArch=amd64_x86 )
+        if /i "%__HostArch%" == "arm64" ( set __VCTargetArch=amd64_arm64 )
     )
 
     if NOT DEFINED SkipVCEnvInit (


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/runtime/pull/104695, this PR tries to set the correct build architectures for all configurations. The changes result in cross-compilation failing in the `gen-buildsys.cmd` stage, figured I'd post the PR for group troubleshooting.

Fix #104674. Fix #76516.