### PR TITLE
Some more cleanup to regex NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
@@ -104,7 +104,9 @@ namespace System.Text.RegularExpressions.Symbolic
             }
             else
             {
-                int[] lookup = _intLookup!;
+                Debug.Assert(_intLookup is not null);
+
+                int[] lookup = _intLookup;
                 return (uint)c < (uint)lookup.Length ? lookup[c] : 0;
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
@@ -47,8 +47,11 @@ namespace System.Text.RegularExpressions.Symbolic
             // in order to size the lookup array to minimize steady-state memory consumption of the potentially
             // large lookup array. We prefer to use the byte[] _lookup when possible, in order to keep memory
             // consumption to a minimum; doing so accomodates up to 255 minterms, which is the vast majority case.
-            // However, when there are more than 255 minterms, we need to use int[] _intLookup.
-            (uint, uint)[][] charRangesPerMinterm = ArrayPool<(uint, uint)[]>.Shared.Rent(minterms.Length);
+            // However, when there are more than 255 minterms, we need to use int[] _intLookup. We rent an object[]
+            // rather than a (uint,uint)[][] to avoid the extra type pressure on the ArrayPool (object[]s are common,
+            // (uint,uint)[][]s much less so).
+            object[] arrayPoolArray = ArrayPool<object>.Shared.Rent(minterms.Length);
+            Span<object> charRangesPerMinterm = arrayPoolArray.AsSpan(0, minterms.Length);
 
             int maxChar = -1;
             for (int mintermId = 1; mintermId < minterms.Length; mintermId++)
@@ -70,17 +73,17 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             // Return the rented array. We clear it before returning it in order to avoid all the ranges arrays being kept alive.
-            Array.Clear(charRangesPerMinterm, 0, minterms.Length);
-            ArrayPool<(uint, uint)[]>.Shared.Return(charRangesPerMinterm);
+            charRangesPerMinterm.Clear();
+            ArrayPool<object>.Shared.Return(arrayPoolArray);
 
-            // Creates the lookup array.
-            static T[] CreateLookup<T>(BDD[] minterms, ReadOnlySpan<(uint, uint)[]> charRangesPerMinterm, int _maxChar) where T : IBinaryInteger<T>
+            // Creates the lookup array. charRangesPerMinterm needs to have already been populated with (uint, uint)[] instances.
+            static T[] CreateLookup<T>(BDD[] minterms, ReadOnlySpan<object> charRangesPerMinterm, int _maxChar) where T : IBinaryInteger<T>
             {
                 T[] lookup = new T[_maxChar + 1];
                 for (int mintermId = 1; mintermId < minterms.Length; mintermId++)
                 {
                     // Each minterm maps to a range of characters. Set each of the characters in those ranges to the corresponding minterm.
-                    foreach ((uint start, uint end) in charRangesPerMinterm[mintermId])
+                    foreach ((uint start, uint end) in ((uint, uint)[])charRangesPerMinterm[mintermId])
                     {
                         lookup.AsSpan((int)start, (int)(end + 1 - start)).Fill(T.CreateTruncating(mintermId));
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
@@ -117,12 +117,6 @@ namespace System.Text.RegularExpressions.Symbolic
         public byte[]? ByteLookup => _lookup;
 
         /// <summary>
-        /// Gets a mapping from char to minterm for the rare case when there are &gt;= 255 minterms.
-        /// Null in the common case where there are fewer than 255 minterms.
-        /// </summary>
-        public int[]? IntLookup => _intLookup;
-
-        /// <summary>
         /// Maximum ordinal character for a non-0 minterm, used to conserve memory
         /// </summary>
         public int MaxChar => (_lookup?.Length ?? _intLookup!.Length) - 1;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
@@ -355,9 +355,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         /// <summary>Gets or creates a new DFA transition.</summary>
         /// <remarks>This function locks the matcher for safe concurrent use of the <see cref="_builder"/></remarks>
-        private bool TryCreateNewTransition(
-            MatchingState<TSet> sourceState, int mintermId, int offset, bool checkThreshold, [NotNullWhen(true)] out MatchingState<TSet>? nextState,
-            long timeoutOccursAt = 0)
+        private bool TryCreateNewTransition(MatchingState<TSet> sourceState, int mintermId, int offset, bool checkThreshold, long timeoutOccursAt, [NotNullWhen(true)] out MatchingState<TSet>? nextState)
         {
             Debug.Assert(offset < _dfaDelta.Length);
             lock (this)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
@@ -120,8 +120,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// Pre-computed hot-loop version of nullability check
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool IsNullableWithContext(int stateId, int mintermId) =>
-            (_nullabilityArray[stateId] & (1 << (int)GetPositionKind(mintermId))) > 0;
+        private bool IsNullableWithContext(byte stateNullability, int mintermId) =>
+            (stateNullability & (1 << (int)GetPositionKind(mintermId))) != 0;
 
         /// <summary>Returns the span from <see cref="_dfaDelta"/> that may contain transitions for the given state</summary>
         private Span<int> GetDeltasFor(MatchingState<TSet> state)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Explore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Explore.cs
@@ -35,16 +35,22 @@ namespace System.Text.RegularExpressions.Symbolic
                     {
                         // Don't dequeue yet, because a transition might fail
                         MatchingState<TSet> state = toExplore.Peek();
+
                         // Include the special minterm for the last end-of-line if the state is sensitive to it
                         int maxMinterm = state.StartsWithLineAnchor ? _minterms!.Length : _minterms!.Length - 1;
+
                         // Explore successor states for each minterm
                         for (int mintermId = 0; mintermId <= maxMinterm; ++mintermId)
                         {
                             int offset = DeltaOffset(state.Id, mintermId);
-                            if (!TryCreateNewTransition(state, mintermId, offset, true, out MatchingState<TSet>? nextState))
+                            if (!TryCreateNewTransition(state, mintermId, offset, true, 0, out MatchingState<TSet>? nextState))
+                            {
                                 goto DfaLimitReached;
+                            }
+
                             EnqueueIfUnseen(nextState, seen, toExplore);
                         }
+
                         // Safe to dequeue now that the state has been completely handled
                         toExplore.Dequeue();
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -71,7 +71,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     NfaMatchingState states = new();
                     // Here one could also consider previous characters for example for \b, \B, and ^ anchors
                     // and initialize inputSoFar accordingly
-                    states.InitializeFrom(this, _initialStates[GetCharKind<DefaultInputReader>([], -1)]);
+                    states.InitializeFrom(this, _initialStates[GetCharKind([], -1)]);
                     CurrentState statesWrapper = new(states);
 
                     // Used for end suffixes

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -71,7 +71,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     NfaMatchingState states = new();
                     // Here one could also consider previous characters for example for \b, \B, and ^ anchors
                     // and initialize inputSoFar accordingly
-                    states.InitializeFrom(this, _initialStates[GetCharKind<FullInputReader>([], -1)]);
+                    states.InitializeFrom(this, _initialStates[GetCharKind<DefaultInputReader>([], -1)]);
                     CurrentState statesWrapper = new(states);
 
                     // Used for end suffixes

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -374,7 +374,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
             // The Z anchor and over 255 minterms are rare enough to consider them separate edge cases.
             int matchEnd;
-            if (!_containsEndZAnchor && _mintermClassifier.IntLookup is null)
+            if (!_containsEndZAnchor && _mintermClassifier.ByteLookup is not null)
             {
                 // Optimize processing for the common case of no Z anchor and <= 255 minterms. Specialize each call with different generic method arguments.
                 matchEnd = (_findOpts is not null, _containsAnyAnchor) switch

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -1300,7 +1300,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     return true;
                 }
 
-                if (matcher.TryCreateNewTransition(matcher.GetState(dfaStateId), mintermId, dfaOffset, checkThreshold: true, out MatchingState<TSet>? nextState))
+                if (matcher.TryCreateNewTransition(matcher.GetState(dfaStateId), mintermId, dfaOffset, checkThreshold: true, timeoutOccursAt: 0, out MatchingState<TSet>? nextState))
                 {
                     // We were able to create a new DFA transition to some state. Move to it and
                     // return that we're still operating as a DFA and can keep going.
@@ -1313,8 +1313,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
             /// <summary>Transition function that only considers DFA state id</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal static bool TryTakeDFATransition(SymbolicRegexMatcher<TSet> matcher, ref int state,
-                int mintermId, long timeoutOccursAt)
+            internal static bool TryTakeDFATransition(SymbolicRegexMatcher<TSet> matcher, ref int state, int mintermId, long timeoutOccursAt)
             {
                 Debug.Assert(state > 0, $"Expected {nameof(state)} {state} > 0");
 
@@ -1330,9 +1329,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     return true;
                 }
 
-                if (matcher.TryCreateNewTransition(matcher.GetState(state), mintermId,
-                    matcher.DeltaOffset(state, mintermId),
-                    checkThreshold: true, out MatchingState<TSet>? nextState, timeoutOccursAt))
+                if (matcher.TryCreateNewTransition(matcher.GetState(state), mintermId, matcher.DeltaOffset(state, mintermId), checkThreshold: true, timeoutOccursAt, out MatchingState<TSet>? nextState))
                 {
                     // We were able to create a new DFA transition to some state. Move to it and
                     // return that we're still operating as a DFA and can keep going.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -514,7 +514,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     // NFA fallback check, assume \Z and full nullability for NFA since it's already extremely rare to get here and it's not worth special-casing.
                     const int NfaCharsPerTimeoutCheck = 1_000;
                     innerLoopLength = _checkTimeout && input.Length - pos > NfaCharsPerTimeoutCheck ? pos + NfaCharsPerTimeoutCheck : input.Length;
-                    done = FindEndPositionDeltasNFA<NfaStateHandler, NoOptimizationsInitialStateHandler, DefaultNullabilityHandler>(
+                    done = FindEndPositionDeltasNFA<NfaStateHandler, DefaultNullabilityHandler>(
                         input, innerLoopLength, mode, timeoutOccursAt, ref pos,
                         ref currentState, ref endPos, ref initialStatePosCandidate, ref initialStatePosCandidate);
                 }
@@ -590,7 +590,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     // NFA fallback check, assume \Z and full nullability for NFA since it's already extremely rare to get here.
                     const int NfaCharsPerTimeoutCheck = 1_000;
                     innerLoopLength = _checkTimeout && input.Length - pos > NfaCharsPerTimeoutCheck ? pos + NfaCharsPerTimeoutCheck : input.Length;
-                    done = FindEndPositionDeltasNFA<NfaStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(
+                    done = FindEndPositionDeltasNFA<NfaStateHandler, TNullabilityHandler>(
                         input, innerLoopLength, mode, timeoutOccursAt, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePosCandidate);
                 }
 
@@ -836,11 +836,10 @@ namespace System.Text.RegularExpressions.Symbolic
         /// 0 if iteration completed because we reached an initial state.
         /// A negative value if iteration completed because we ran out of input or we failed to transition.
         /// </returns>
-        private bool FindEndPositionDeltasNFA<TStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(
+        private bool FindEndPositionDeltasNFA<TStateHandler, TNullabilityHandler>(
                 ReadOnlySpan<char> input, int length, RegexRunnerMode mode, long timeoutOccursAt,
                 ref int posRef, ref CurrentState state, ref int endPosRef, ref int initialStatePosRef, ref int initialStatePosCandidateRef)
             where TStateHandler : struct, IStateHandler
-            where TFindOptimizationsHandler : struct, IInitialStateHandler
             where TNullabilityHandler : struct, INullabilityHandler
         {
             // To avoid frequent reads/writes to ref and out values, make and operate on local copies, which we then copy back once before returning.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -920,12 +920,13 @@ namespace System.Text.RegularExpressions.Symbolic
         /// lazily building out the graph as needed.
         /// </summary>
         private bool FindStartPositionDeltasDFA<TInputReader, TNullabilityHandler>(
-            ReadOnlySpan<char> input, ref int i, int startThreshold, ref CurrentState state, ref int lastStart)
+            ReadOnlySpan<char> input, ref int i, int startThreshold, ref CurrentState stateRef, ref int lastStart)
             where TInputReader : struct, IInputReader
             where TNullabilityHandler : struct, INullabilityHandler
         {
             // To avoid frequent reads/writes to ref values, make and operate on local copies, which we then copy back once before returning.
             int pos = i;
+            CurrentState state = stateRef;
             try
             {
                 // Loop backwards through each character in the input, transitioning from state to state for each.
@@ -963,6 +964,7 @@ namespace System.Text.RegularExpressions.Symbolic
             finally
             {
                 // Write back the local copies of the ref values.
+                stateRef = state;
                 i = pos;
             }
         }


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/102655.

Some of this is cleanup of things introduced in that PR, some is cleanup to things pre-existing.

@veanes, @ieviev, I'd appreciate help reviewing. Probably easiest to go commit by commit.