### PR TITLE
Enable fixed disabled System.Text.Json tests

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/ImmutableCollectionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/ImmutableCollectionsTests.cs
@@ -394,7 +394,7 @@ namespace System.Text.Json.Tests
             });
 
             string json = JsonSerializer.Serialize(data, s_indentedOption);
-            Assert.Equal(@"{
+            JsonTestHelper.AssertJsonEqual(@"{
   ""1"": ""One"",
   ""2"": ""II"",
   ""3"": ""3""

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/ImmutableCollectionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/ImmutableCollectionsTests.cs
@@ -329,7 +329,6 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region Dictionary
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/30524")]
         [Fact]
         public void SerializeDictionary()
         {
@@ -348,7 +347,6 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", (string)a[3]);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/30524")]
         [Fact]
         public void DeserializeDictionary()
         {
@@ -366,7 +364,6 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", data[3]);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/30524")]
         [Fact]
         public void DeserializeDictionaryInterface()
         {
@@ -386,7 +383,6 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region SortedDictionary
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/30524")]
         [Fact]
         public void SerializeSortedDictionary()
         {
@@ -405,7 +401,6 @@ namespace System.Text.Json.Tests
 }", json);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/30524")]
         [Fact]
         public void DeserializeSortedDictionary()
         {


### PR DESCRIPTION
I noticed some disabled tests linked to dotnet/runtime#30524 which was fixed and closed in 2020 and I couldn't find a reason for them being still disabled.

I enabled them and ran the tests locally and the tests passed so I assume it would be fine to re-enable them.

I also looked at other tests for System.Text.Json which were linked to an issue and I couldn't find any other tests in the same situation.