### PR TITLE
Fix WinHttp SlowServerRespondsAfterDefaultReceiveTimeout_ThrowsHttpRequestException

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -116,7 +116,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.SendResponseAsync($"HTTP/1.1 200 OK\r\nDate: {DateTimeOffset.UtcNow:R)}\r\nContent-Length: 1000\r\n\r\n");
+                    await connection.SendResponseAsync(LoopbackServer.GetHttpResponseHeaders(contentLength: 1000));
                     await tcs.Task;
                 });
             });


### PR DESCRIPTION
Fixes #96481 

Looks like issue is already fixed (Date response header was missing) with #104400, this PR makes it less error-prone.