### PR TITLE
[RISC-V] Turn off "V" in zlib-ng compilation

### DIFF
--- a/src/native/external/zlib-ng.cmake
+++ b/src/native/external/zlib-ng.cmake
@@ -9,6 +9,9 @@ set(ZLIB_ENABLE_TESTS OFF)
 set(ZLIBNG_ENABLE_TESTS OFF)
 set(Z_PREFIX ON)
 
+# TODO: Turn back on when Linux kernels with proper RISC-V extension detection (>= 6.5) are more commonplace
+set(WITH_RVV OFF)
+
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,Clang,AppleClang>:-Wno-unused-command-line-argument>) # clang : error : argument unused during compilation: '-fno-semantic-interposition'
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,Clang,AppleClang>:-Wno-logical-op-parentheses>) # place parentheses around the '&&' expression to silence this warning
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,MSVC>:/wd4127>) # warning C4127: conditional expression is constant


### PR DESCRIPTION
Our target ISA is rv64gc, not gcv. If kernel can't detect RISC-V extensions, zlib-ng defaults has_rvv to true, which crashes on hardware without vector instructions like VisionFive 2.

Part of #84834, cc @dotnet/samsung