### PR TITLE
Add missing cancellation throw in SendPingAsync path

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -342,7 +342,7 @@ namespace System.Net.NetworkInformation
                 // to the echo request we just sent. We need to filter such messages out, and continue reading until our timeout.
                 // For example, when pinging the local host, we need to filter out our own echo requests that the socket reads.
                 long startingTimestamp = Stopwatch.GetTimestamp();
-                while (!timeoutOrCancellationToken.IsCancellationRequested)
+                while (true)
                 {
                     SocketReceiveFromResult receiveResult = await socket.ReceiveFromAsync(
                         receiveBuffer.AsMemory(),


### PR DESCRIPTION
Fixes #104574 
Currently OSX using RawSocket to send ICMP request for ping. Looks like if we're getting cancellation after `ReceiveFromAsync` call completed, it can return `TimedOut` ping reply because we can break the loop if cancellation is requested without throwing.