### PR TITLE
Extend usage of GC_ALLOC_ALIGN8

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49370,7 +49370,6 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
     }                                                                                       \
 } while (false)
 
-#ifdef FEATURE_64BIT_ALIGNMENT
 // Allocate small object with an alignment requirement of 8-bytes.
 Object* AllocAlign8(alloc_context* acontext, gc_heap* hp, size_t size, uint32_t flags)
 {
@@ -49436,7 +49435,6 @@ Object* AllocAlign8(alloc_context* acontext, gc_heap* hp, size_t size, uint32_t 
 
     return newAlloc;
 }
-#endif // FEATURE_64BIT_ALIGNMENT
 
 Object*
 GCHeap::Alloc(gc_alloc_context* context, size_t size, uint32_t flags REQD_ALIGN_DCL)
@@ -49497,15 +49495,11 @@ GCHeap::Alloc(gc_alloc_context* context, size_t size, uint32_t flags REQD_ALIGN_
     }
     else
     {
-#ifdef FEATURE_64BIT_ALIGNMENT
         if (flags & GC_ALLOC_ALIGN8)
         {
             newAlloc = AllocAlign8 (acontext, hp, size, flags);
         }
         else
-#else
-        assert ((flags & GC_ALLOC_ALIGN8) == 0);
-#endif
         {
             newAlloc = (Object*) hp->allocate (size + ComputeMaxStructAlignPad(requiredAlignment), acontext, flags);
         }

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -1046,7 +1046,9 @@ enum GC_ALLOC_FLAGS
     GC_ALLOC_FINALIZE           = 1,
     GC_ALLOC_CONTAINS_REF       = 2,
     GC_ALLOC_ALIGN8_BIAS        = 4,
-    GC_ALLOC_ALIGN8             = 8,
+    GC_ALLOC_ALIGN8             = 8, // Only implies the initial allocation is 8 byte aligned.
+                                     // Preserving the alignment across relocation depends on
+                                     // RESPECT_LARGE_ALIGNMENT also being defined.
     GC_ALLOC_ZEROING_OPTIONAL   = 16,
     GC_ALLOC_LARGE_OBJECT_HEAP  = 32,
     GC_ALLOC_PINNED_OBJECT_HEAP = 64,

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1465,9 +1465,7 @@ class gc_heap
     friend struct ::alloc_context;
     friend void ProfScanRootsHelper(Object** object, ScanContext *pSC, uint32_t dwFlags);
     friend void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForEtw, BOOL fShouldWalkHeapObjectsForEtw);
-#ifdef FEATURE_64BIT_ALIGNMENT
     friend Object* AllocAlign8(alloc_context* acontext, gc_heap* hp, size_t size, uint32_t flags);
-#endif //FEATURE_64BIT_ALIGNMENT
     friend class t_join;
     friend class gc_mechanisms;
     friend class seg_free_spaces;


### PR DESCRIPTION
In the past we added FEATURE_64BIT_ALIGNMENT to support 8 byte alignment requirements on ARM, but for performance we also like to 8 byte align double arrays on other architectures. The GC has a GC_ALLOC_ALIGN8 flag that does that but it was only being used in the ARM case and we had a more complicated workaround being used elsewhere. This change expands GC_ALLOC_ALIGN8 so it is supported on all architectures and converges all our aligned double arrays to use that approach.

This change is also present in https://github.com/dotnet/runtime/pull/100356 but extracting it out in a separate PR to make it easy to get it reviewed and merged.

@Maoni0 @jkotas @AaronRobinsonMSFT @davidwrighton 