### PR TITLE
SPMI: Add a buffer to `FileWriter` and add a `--parallelism` option to superpmi.py

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -278,6 +278,7 @@ superpmi_common_parser.add_argument("--break_on_assert", action="store_true", he
 superpmi_common_parser.add_argument("--break_on_error", action="store_true", help=break_on_error_help)
 superpmi_common_parser.add_argument("--skip_cleanup", action="store_true", help=skip_cleanup_help)
 superpmi_common_parser.add_argument("--sequential", action="store_true", help="Run SuperPMI in sequential mode. Default is to run in parallel for faster runs.")
+superpmi_common_parser.add_argument("--parallelism", help="Specify amount of parallelism")
 superpmi_common_parser.add_argument("-spmi_log_file", help=spmi_log_file_help)
 superpmi_common_parser.add_argument("-jit_name", help="Specify the filename of the jit to use, e.g., 'clrjit_universal_arm64_x64.dll'. Default is clrjit.dll/libclrjit.so")
 superpmi_common_parser.add_argument("--altjit", action="store_true", help="Set the altjit variables on replay.")
@@ -1666,7 +1667,10 @@ class SuperPMIReplay:
                 repro_flags += [ "-target", self.coreclr_args.target_arch ]
 
             if not self.coreclr_args.sequential and not self.coreclr_args.compile:
-                common_flags += [ "-p" ]
+                if not self.coreclr_args.parallelism:
+                    common_flags += [ "-p" ]
+                else:
+                    common_flags += [ "-p", self.coreclr_args.parallelism ]
 
             if self.coreclr_args.break_on_assert:
                 common_flags += [ "-boa" ]
@@ -2171,7 +2175,10 @@ class SuperPMIReplayAsmDiffs:
                 flags += diff_option_flags
 
                 if not self.coreclr_args.sequential and not self.coreclr_args.compile:
-                    flags += [ "-p" ]
+                    if not self.coreclr_args.parallelism:
+                        flags += [ "-p" ]
+                    else:
+                        flags += [ "-p", self.coreclr_args.parallelism ]
 
                 if self.coreclr_args.break_on_assert:
                     flags += [ "-boa" ]
@@ -2981,7 +2988,10 @@ class SuperPMIReplayThroughputDiff:
                 flags += diff_option_flags
 
                 if not self.coreclr_args.sequential and not self.coreclr_args.compile:
-                    flags += [ "-p" ]
+                    if not self.coreclr_args.parallelism:
+                        flags += [ "-p" ]
+                    else:
+                        flags += [ "-p", self.coreclr_args.parallelism ]
 
                 if self.coreclr_args.break_on_assert:
                     flags += [ "-boa" ]
@@ -4448,6 +4458,11 @@ def setup_args(args):
                             "sequential",
                             lambda unused: True,
                             "Unable to set sequential.")
+
+        coreclr_args.verify(args,
+                            "parallelism",
+                            lambda unused: True,
+                            "Unable to set parallelism.")
 
         coreclr_args.verify(args,
                             "error_limit",


### PR DESCRIPTION
This helps a bit on SPMI tpdiff time. E.g. before:
```
❯ Measure-Command { py .\src\coreclr\scripts\superpmi.py tpdiff --parallelism 16 -base_jit_path C:\dev\dotnet\runtime3\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root_base\clrjit.dll -f realworld | Out-Default }
  : 0
Hours             : 0
Minutes           : 0
Seconds           : 26
Milliseconds      : 306
Ticks             : 263069051
TotalDays         : 0.000304478068287037
TotalHours        : 0.00730747363888889
TotalMinutes      : 0.438448418333333
TotalSeconds      : 26.3069051
TotalMilliseconds : 26306.9051
```

After:
```
❯ Measure-Command { py .\src\coreclr\scripts\superpmi.py tpdiff --parallelism 16 -base_jit_path C:\dev\dotnet\runtime3\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root_base\clrjit.dll -f realworld | Out-Default }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 22
Milliseconds      : 194
Ticks             : 221947019
TotalDays         : 0.000256883123842593
TotalHours        : 0.00616519497222222
TotalMinutes      : 0.369911698333333
TotalSeconds      : 22.1947019
TotalMilliseconds : 22194.7019
```

I'm hoping that it might help even more in CI.

Also added a `--parallelism` option to SPMI as it seems 16 parallelism is better than the default 32 for tpdiff on my CPU.