### PR TITLE
Make build.ps1 default to the OS architecture

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -31,7 +31,7 @@ function Get-Help() {
   Write-Host "Common settings:"
   Write-Host "  -arch (-a)                     Target platform: x86, x64, arm, arm64, or wasm."
   Write-Host "                                 Pass a comma-separated list to build for multiple architectures."
-  Write-Host ("                                 [Default: {0} (the OS architecture.)]" -f [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant())
+  Write-Host "                                 [Default: Your machine's architecture.]"
   Write-Host "  -binaryLog (-bl)               Output binary log."
   Write-Host "  -configuration (-c)            Build configuration: Debug, Release or Checked."
   Write-Host "                                 Checked is exclusive to the CLR subset. It is the same as Debug, except code is"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -11,7 +11,7 @@ Param(
   [switch]$coverage,
   [string]$testscope,
   [switch]$testnobuild,
-  [ValidateSet("x86","x64","arm","arm64","wasm")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
+  [ValidateSet("x86","x64","arm","arm64","wasm")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()),
   [switch]$cross = $false,
   [string][Alias('s')]$subset,
   [ValidateSet("Debug","Release","Checked")][string][Alias('rc')]$runtimeConfiguration,
@@ -31,7 +31,7 @@ function Get-Help() {
   Write-Host "Common settings:"
   Write-Host "  -arch (-a)                     Target platform: x86, x64, arm, arm64, or wasm."
   Write-Host "                                 Pass a comma-separated list to build for multiple architectures."
-  Write-Host ("                                 [Default: {0} (Depends on your console's architecture.)]" -f [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())
+  Write-Host ("                                 [Default: {0} (the OS architecture.)]" -f [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant())
   Write-Host "  -binaryLog (-bl)               Output binary log."
   Write-Host "  -configuration (-c)            Build configuration: Debug, Release or Checked."
   Write-Host "                                 Checked is exclusive to the CLR subset. It is the same as Debug, except code is"


### PR DESCRIPTION
Following up on #104763, this PR makes the `-arch` parameter default to the OS architecture. I am not sure why we currently default to the current process architecture, but if I were to make a guess it's probably stemming from restrictions in older versions of Windows ARM when running emulated processes. In any case, I think we should change it because:

1. It creates a footgun for ARM machine development where the default architecture can be unpredictable.
2. Defaulting to the OS architecture makes windows builds [consistent with UNIX builds](https://github.com/dotnet/runtime/blob/61f08d36ac9d92a2c93a5478bf22f3fc82a0b7e8/eng/build.sh#L21).
