### PR TITLE
[browser] Extension agnostic lazy assembly loading

### DIFF
--- a/src/mono/browser/runtime/lazyLoading.ts
+++ b/src/mono/browser/runtime/lazyLoading.ts
@@ -7,7 +7,6 @@ import { AssetEntry } from "./types";
 
 export async function loadLazyAssembly (assemblyNameToLoad: string): Promise<boolean> {
     const resources = loaderHelpers.config.resources!;
-    const originalAssemblyName = assemblyNameToLoad;
     const lazyAssemblies = resources.lazyAssembly;
     if (!lazyAssemblies) {
         throw new Error("No assemblies have been marked as lazy-loadable. Use the 'BlazorWebAssemblyLazyLoad' item group in your project file to enable lazy loading an assembly.");
@@ -52,7 +51,7 @@ export async function loadLazyAssembly (assemblyNameToLoad: string): Promise<boo
         return false;
     }
 
-    let pdbNameToLoad = changeExtension(originalAssemblyName, ".pdb");
+    let pdbNameToLoad = assemblyNameWithoutExtension + ".pdb";
     let shouldLoadPdb = false;
     if (loaderHelpers.config.debugLevel != 0 && loaderHelpers.isDebuggingSupported()) {
         shouldLoadPdb = Object.prototype.hasOwnProperty.call(lazyAssemblies, pdbNameToLoad);
@@ -94,13 +93,4 @@ export async function loadLazyAssembly (assemblyNameToLoad: string): Promise<boo
 
     load_lazy_assembly(dll, pdb);
     return true;
-}
-
-function changeExtension (filename: string, newExtensionWithLeadingDot: string) {
-    const lastDotIndex = filename.lastIndexOf(".");
-    if (lastDotIndex < 0) {
-        throw new Error(`No extension to replace in '${filename}'`);
-    }
-
-    return filename.substring(0, lastDotIndex) + newExtensionWithLeadingDot;
 }

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/LazyLoadingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/LazyLoadingTests.cs
@@ -20,16 +20,32 @@ public class LazyLoadingTests : AppTestBase
     {
     }
 
-    [Fact, TestCategory("no-fingerprinting")]
-    public async Task LoadLazyAssemblyBeforeItIsNeeded()
+    public static IEnumerable<object?[]> LoadLazyAssemblyBeforeItIsNeededData()
+    {
+        string[] data = ["wasm", "dll", "NoExtension"];
+        return data.Select(d => new object[] { d, data });
+    }
+
+    [Theory, TestCategory("no-fingerprinting")]
+    [MemberData(nameof(LoadLazyAssemblyBeforeItIsNeededData))]
+    public async Task LoadLazyAssemblyBeforeItIsNeeded(string lazyLoadingTestExtension, string[] allLazyLoadingTestExtensions)
     {
         CopyTestAsset("WasmBasicTestApp", "LazyLoadingTests", "App");
-        BuildProject("Debug");
+        BuildProject("Debug", extraArgs: $"-p:LazyLoadingTestExtension={lazyLoadingTestExtension}");
 
-        var result = await RunSdkStyleAppForBuild(new(Configuration: "Debug", TestScenario: "LazyLoadingTest"));
+        // We are running the app and passing all possible lazy extensions to test matrix of all possibilities.
+        // We don't need to rebuild the application to test how client is trying to load the assembly.
+        foreach (var clientLazyLoadingTestExtension in allLazyLoadingTestExtensions)
+        {
+            var result = await RunSdkStyleAppForBuild(new(
+                Configuration: "Debug", 
+                TestScenario: "LazyLoadingTest", 
+                BrowserQueryString: new Dictionary<string, string> { ["lazyLoadingTestExtension"] = clientLazyLoadingTestExtension }
+            ));
 
-        Assert.True(result.TestOutput.Any(m => m.Contains("FirstName")), "The lazy loading test didn't emit expected message with JSON");
-        Assert.True(result.ConsoleOutput.Any(m => m.Contains("Attempting to download") && m.Contains("_framework/Json.") && m.Contains(".pdb")), "The lazy loading test didn't load PDB");
+            Assert.True(result.TestOutput.Any(m => m.Contains("FirstName")), "The lazy loading test didn't emit expected message with JSON");
+            Assert.True(result.ConsoleOutput.Any(m => m.Contains("Attempting to download") && m.Contains("_framework/Json.") && m.Contains(".pdb")), "The lazy loading test didn't load PDB");
+        }
     }
 
     [Fact]

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/WasmBasicTestApp.csproj
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/WasmBasicTestApp.csproj
@@ -6,11 +6,19 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <!-- Lazy loading test various extensions -->
+  <PropertyGroup>
+    <LazyAssemblyExtension Condition="'$(LazyLoadingTestExtension)' == 'dll'">.dll</LazyAssemblyExtension>
+    <LazyAssemblyExtension Condition="'$(LazyLoadingTestExtension)' == 'wasm'">.wasm</LazyAssemblyExtension>
+    <LazyAssemblyExtension Condition="'$(LazyLoadingTestExtension)' == 'NoExtension'"></LazyAssemblyExtension>
+    <LazyAssemblyExtension Condition="'$(LazyLoadingTestExtension)' == ''">$(WasmAssemblyExtension)</LazyAssemblyExtension>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Library\Json.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <BlazorWebAssemblyLazyLoad Include="Json.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Json$(LazyAssemblyExtension)" />
   </ItemGroup>
 </Project>

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/WasmBasicTestApp.csproj
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/WasmBasicTestApp.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <BlazorWebAssemblyLazyLoad Include="Json$(WasmAssemblyExtension)" />
+    <BlazorWebAssemblyLazyLoad Include="Json.dll" />
   </ItemGroup>
 </Project>

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -138,7 +138,23 @@ try {
             break;
         case "LazyLoadingTest":
             if (params.get("loadRequiredAssembly") !== "false") {
-                await INTERNAL.loadLazyAssembly(`Json${assemblyExtension}`);
+                let lazyAssemblyExtension = assemblyExtension;
+                switch (params.get("lazyLoadingTestExtension")) {
+                    case "wasm":
+                        lazyAssemblyExtension = ".wasm";
+                        break;
+                    case "dll":
+                        lazyAssemblyExtension = ".dll";
+                        break;
+                    case "NoExtension":
+                        lazyAssemblyExtension = "";
+                        break;
+                    default:
+                        lazyAssemblyExtension = assemblyExtension;
+                        break;
+                }
+
+                await INTERNAL.loadLazyAssembly(`Json${lazyAssemblyExtension}`);
             }
             exports.LazyLoadingTest.Run();
             exit(0);

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -176,7 +176,7 @@ public class GenerateWasmBootJson : Task
         {
             var endpointByAsset = Endpoints.ToDictionary(e => e.GetMetadata("AssetFile"));
 
-            var lazyLoadAssembliesWithoutExtension = LazyLoadedAssemblies.ToDictionary(l =>
+            var lazyLoadAssembliesWithoutExtension = (LazyLoadedAssemblies ?? Array.Empty<ITaskItem>()).ToDictionary(l =>
             {
                 var extension = Path.GetExtension(l.ItemSpec);
                 if (extension == ".dll" || extension == Utils.WebcilInWasmExtension)

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -176,6 +176,15 @@ public class GenerateWasmBootJson : Task
         {
             var endpointByAsset = Endpoints.ToDictionary(e => e.GetMetadata("AssetFile"));
 
+            var lazyLoadAssembliesWithoutExtension = LazyLoadedAssemblies.ToDictionary(l =>
+            {
+                var extension = Path.GetExtension(l.ItemSpec);
+                if (extension == ".dll" || extension == Utils.WebcilInWasmExtension)
+                    return Path.GetFileNameWithoutExtension(l.ItemSpec);
+
+                return l.ItemSpec;
+            });
+
             var remainingLazyLoadAssemblies = new List<ITaskItem>(LazyLoadedAssemblies ?? Array.Empty<ITaskItem>());
             var resourceData = result.resources;
 
@@ -194,7 +203,7 @@ public class GenerateWasmBootJson : Task
                 var resourceName = Path.GetFileName(resource.GetMetadata("OriginalItemSpec"));
                 var resourceRoute = Path.GetFileName(endpointByAsset[resource.ItemSpec].ItemSpec);
 
-                if (TryGetLazyLoadedAssembly(resourceName, out var lazyLoad))
+                if (TryGetLazyLoadedAssembly(lazyLoadAssembliesWithoutExtension, resourceName, out var lazyLoad))
                 {
                     MapFingerprintedAsset(resourceData, resourceRoute, resourceName);
                     Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as a lazy loaded assembly.", resource.ItemSpec);
@@ -220,7 +229,7 @@ public class GenerateWasmBootJson : Task
                 else if (string.Equals("symbol", assetTraitValue, StringComparison.OrdinalIgnoreCase))
                 {
                     MapFingerprintedAsset(resourceData, resourceRoute, resourceName);
-                    if (TryGetLazyLoadedAssembly($"{fileName}.dll", out _) || TryGetLazyLoadedAssembly($"{fileName}{Utils.WebcilInWasmExtension}", out _))
+                    if (TryGetLazyLoadedAssembly(lazyLoadAssembliesWithoutExtension, fileName, out _))
                     {
                         Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as a lazy loaded symbols file.", resource.ItemSpec);
                         resourceData.lazyAssembly ??= new ResourceHashesByNameDictionary();
@@ -463,9 +472,13 @@ public class GenerateWasmBootJson : Task
         }
     }
 
-    private bool TryGetLazyLoadedAssembly(string fileName, out ITaskItem lazyLoadedAssembly)
+    private static bool TryGetLazyLoadedAssembly(Dictionary<string, ITaskItem> lazyLoadAssembliesNoExtension, string fileName, out ITaskItem lazyLoadedAssembly)
     {
-        return (lazyLoadedAssembly = LazyLoadedAssemblies?.SingleOrDefault(a => a.ItemSpec == fileName)) != null;
+        var extension = Path.GetExtension(fileName);
+        if (extension == ".dll" || extension == Utils.WebcilInWasmExtension)
+            fileName = Path.GetFileNameWithoutExtension(fileName);
+
+        return lazyLoadAssembliesNoExtension.TryGetValue(fileName, out lazyLoadedAssembly);
     }
 
     private Version? parsedTargetFrameworkVersion;


### PR DESCRIPTION
- Allow to pass extension less assembly name when loading lazy assembly
- Tests cover matrix of all possibilities (build with wasm, dll, no-extension X load with wasm, dll, no-extension)
- Depends on https://github.com/dotnet/runtime/pull/103755

Fixes https://github.com/dotnet/runtime/issues/94132