### PR TITLE
Don't use SyncTextWriter on WASI either

### DIFF
--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -158,8 +158,8 @@ public class ReadAndWrite
                 Console.SetOut(sw);
                 TextWriter writer = Console.Out;
                 Assert.NotNull(writer);
-                // Browser bypasses SyncTextWriter for faster startup
-                if (!OperatingSystem.IsBrowser())
+                // single-threaded WASM bypasses SyncTextWriter for faster startup
+                if (!PlatformDetection.IsThreadingSupported)
                     Assert.NotEqual(writer, sw); // the writer we provide gets wrapped
 
                 // We just want to ensure none of these throw exceptions, we don't actually validate

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -159,8 +159,10 @@ public class ReadAndWrite
                 TextWriter writer = Console.Out;
                 Assert.NotNull(writer);
                 // single-threaded WASM bypasses SyncTextWriter for faster startup
-                if (!PlatformDetection.IsThreadingSupported)
+                if (PlatformDetection.IsThreadingSupported)
                     Assert.NotEqual(writer, sw); // the writer we provide gets wrapped
+                else
+                    Assert.Equal(writer, sw); // the writer we provide does not get wrapped
 
                 // We just want to ensure none of these throw exceptions, we don't actually validate
                 // what was written.

--- a/src/libraries/System.Console/tests/SyncTextWriter.cs
+++ b/src/libraries/System.Console/tests/SyncTextWriter.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 public class SyncTextWriter
 {
-    // Browser bypasses SyncTextWriter for faster startup
+    // single-threaded WASM bypasses SyncTextWriter for faster startup
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
     public void SyncTextWriterLockedOnThis()
     {

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -22,8 +22,6 @@
     <IsBigEndian Condition="'$(Platform)' == 's390x'">true</IsBigEndian>
     <Is64Bit Condition="'$(Platform)' == 'arm64' or '$(Platform)' == 'x64' or '$(Platform)' == 's390x' or '$(Platform)' == 'loongarch64' or '$(Platform)' == 'ppc64le' or '$(Platform)' == 'riscv64'">true</Is64Bit>
     <UseMinimalGlobalizationData Condition="'$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true'">true</UseMinimalGlobalizationData>
-    <FeatureWasmManagedThreads Condition="'$(WasmEnableThreads)' == 'true'">true</FeatureWasmManagedThreads>
-    <DefineConstants Condition="'$(FeatureWasmManagedThreads)' == 'true'">$(DefineConstants);FEATURE_WASM_MANAGED_THREADS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition="'$(IsBigEndian)' == 'true'">$(DefineConstants);BIGENDIAN</DefineConstants>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -759,7 +759,7 @@ namespace System.IO
         {
             ArgumentNullException.ThrowIfNull(writer);
 
-#if !TARGET_BROWSER || FEATURE_WASM_MANAGED_THREADS
+#if (!TARGET_BROWSER && !TARGET_WASI) || FEATURE_WASM_MANAGED_THREADS
             return writer is SyncTextWriter ? writer : new SyncTextWriter(writer);
 #else
             return writer;

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/StreamReader/StreamReader.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/StreamReader/StreamReader.cs
@@ -29,7 +29,7 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
 
-        // Browser bypasses SyncTextWriter for faster startup
+        // single-threaded WASM bypasses SyncTextWriter for faster startup
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Synchronized_NewObject()
         {

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/StreamWriter/StreamWriter.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/StreamWriter/StreamWriter.cs
@@ -7,7 +7,7 @@ namespace System.IO.Tests
 {
     public partial class WriteTests
     {
-        // Browser bypasses SyncTextWriter for faster startup
+        // single-threaded WASM bypasses SyncTextWriter for faster startup
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Synchronized_NewObject()
         {

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/TextWriter/TextWriterTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/TextWriter/TextWriterTests.cs
@@ -690,7 +690,7 @@ namespace System.IO.Tests
             Assert.Same(e, vt.AsTask().Exception.InnerException);
         }
 
-        // Browser bypasses SyncTextWriter for faster startup
+        // single-threaded WASM bypasses SyncTextWriter for faster startup
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task FlushAsync_Precanceled()
         {

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -13,8 +13,6 @@
     <Platforms>x64;x86;arm;armv6;arm64;riscv64;s390x;wasm;ppc64le</Platforms>
 
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <FeatureWasmManagedThreads Condition="'$(WasmEnableThreads)' == 'true'">true</FeatureWasmManagedThreads>
-    <DefineConstants Condition="'$(FeatureWasmManagedThreads)' == 'true'">$(DefineConstants);FEATURE_WASM_MANAGED_THREADS</DefineConstants>
   </PropertyGroup>
 
   <!-- Note that various places in SPCL depend on this resource name i.e. TplEventSource -->


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/101221 so we match behavior between single-threaded Browser and WASI.