### PR TITLE
JIT: Improve strength reduction's prediction of loop reversal

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7616,6 +7616,7 @@ public:
                                          FlowGraphNaturalLoop*   loop,
                                          BasicBlock*             exiting,
                                          LoopLocalOccurrences*   loopLocals);
+    bool optCanAndShouldChangeExitTest(GenTree* cond, bool dump);
     bool optPrimaryIVHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);
     bool optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
                            unsigned              lclNum,

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7616,6 +7616,7 @@ public:
                                          FlowGraphNaturalLoop*   loop,
                                          BasicBlock*             exiting,
                                          LoopLocalOccurrences*   loopLocals);
+    bool optPrimaryIVHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);
     bool optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
                            unsigned              lclNum,
                            ScevAddRec*           addRec,

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1158,6 +1158,18 @@ bool Compiler::optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevConte
     return true;
 }
 
+//------------------------------------------------------------------------
+// optCanAndShouldChangeExitTest:
+//   Check if the exit test can be rephrased to a downwards counted exit test
+//   (being compared to zero).
+//
+// Parameters:
+//   cond - The exit test
+//   dump - Whether to JITDUMP the reason for the decisions
+//
+// Returns:
+//   True if the exit test can be changed.
+//
 bool Compiler::optCanAndShouldChangeExitTest(GenTree* cond, bool dump)
 {
     if ((cond->gtFlags & GTF_SIDE_EFFECT) != 0)
@@ -1185,7 +1197,7 @@ bool Compiler::optCanAndShouldChangeExitTest(GenTree* cond, bool dump)
 }
 
 //------------------------------------------------------------------------
-// optPrimaryIVIsLoopScoped:
+// optPrimaryIVHasNonLoopUses:
 //   Check if a primary IV may have uses of the primary IV that we do not
 //   reason about.
 //

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1179,7 +1179,10 @@ bool Compiler::optCanAndShouldChangeExitTest(GenTree* cond, bool dump)
         // to be never analyzable for us even if we tried to do that, so just
         // do the easy check here.
         if (dump)
+        {
             JITDUMP("  No; exit node has side effects\n");
+        }
+
         return false;
     }
 
@@ -1189,7 +1192,10 @@ bool Compiler::optCanAndShouldChangeExitTest(GenTree* cond, bool dump)
         (cond->gtGetOp1()->IsIntegralConst(0) || cond->gtGetOp2()->IsIntegralConst(0)))
     {
         if (dump)
+        {
             JITDUMP("  No; operand of condition [%06u] is already 0\n", dspTreeID(cond));
+        }
+
         return false;
     }
 

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1010,12 +1010,12 @@ bool Compiler::optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevConte
         }
 
         bool hasUseInTest      = false;
-        auto checkRemovableUse = [=, &hasUseInTest](BasicBlock* block, Statement* stmt, GenTree* tree) {
+        auto checkRemovableUse = [=, &hasUseInTest](BasicBlock* block, Statement* stmt) {
             if (stmt == jtrueStmt)
             {
                 hasUseInTest = true;
                 // Use is inside the loop test that we know we can change (from
-                // calling optCanChangeExitTest above)
+                // calling optCanAndShouldChangeExitTest above)
                 return true;
             }
 
@@ -1044,7 +1044,7 @@ bool Compiler::optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevConte
             return true;
         };
 
-        if (!loopLocals->VisitOccurrences(loop, candidateLclNum, checkRemovableUse))
+        if (!loopLocals->VisitStatementsWithOccurrences(loop, candidateLclNum, checkRemovableUse))
         {
             // Aborted means we found a non-removable use
             continue;


### PR DESCRIPTION
The current goal is to make sure strength reduction does not introduce new primary IVs. To do so we rely on the downwards-loop transformation to get rid of uses of the primary IV in the loop test.
This PR refines the checks that strength reduction was using to predict whether a use of the primary IV in a loop test will be removed. It should now be the exact same checks as the downwards-transformation uses.

Additionally, it means we can remove `CursorInfo::IsInsideExitTest`; we now just avoid creating the cursor in the first place if we know the use will be removable.