### PR TITLE
JIT: defer creating throw helper code until we know it's needed

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5321,6 +5321,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Set stack levels and analyze throw helper usage.
     StackLevelSetter stackLevelSetter(this);
     stackLevelSetter.Run();
+    m_pLowering->FinalizeOutgoingArgSpace();
 
     // We can not add any new tracked variables after this point.
     lvaTrackedFixed = true;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6740,6 +6740,7 @@ private:
     void fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind);
     PhaseStatus fgCreateThrowHelperBlocks();
 
+
 public:
     AddCodeDsc* fgFindExcptnTarget(SpecialCodeKind kind, unsigned refData);
 
@@ -6749,6 +6750,8 @@ public:
     {
         return fgAddCodeList;
     }
+
+    void fgCreateThrowHelperBlockCode(AddCodeDsc* add);
 
 private:
     bool fgIsThrowHlpBlk(BasicBlock* block);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7,6 +7,8 @@
 #pragma hdrstop
 #endif
 
+#include "lower.h" // for LowerRange()
+
 // Flowgraph Miscellany
 
 //------------------------------------------------------------------------
@@ -3608,7 +3610,9 @@ void Compiler::fgCreateThrowHelperBlockCode(AddCodeDsc* add)
     }
     else
     {
-        LIR::AsRange(block).InsertAtEnd(LIR::SeqTree(this, tree));
+        LIR::AsRange(block).InsertAtEnd(tree);
+        LIR::ReadOnlyRange range(tree, tree);
+        m_pLowering->LowerRange(block, range);
     }
 }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7690,8 +7690,6 @@ PhaseStatus Lowering::DoPhase()
     }
 #endif
 
-    FinalizeOutgoingArgSpace();
-
     // Recompute local var ref counts before potentially sorting for liveness.
     // Note this does minimal work in cases where we are not going to sort.
     const bool isRecompute    = true;

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -44,6 +44,8 @@ public:
         lowerer.LowerRange(range);
     }
 
+    void FinalizeOutgoingArgSpace();
+
 private:
     // LowerRange handles new code that is introduced by or after Lowering.
     void LowerRange(LIR::ReadOnlyRange& range)
@@ -602,7 +604,6 @@ private:
     }
 
     void RequireOutgoingArgSpace(GenTree* node, unsigned numBytes);
-    void FinalizeOutgoingArgSpace();
 
     LinearScan*           m_lsra;
     unsigned              vtableCallTemp;       // local variable we use as a temp for vtable calls


### PR DESCRIPTION
Defer creation of throw helper code until the stack level setter analysis has determined the throw helper is needed. Defer finalizing the outgoing arg size as well.

The throw helper support now goes through the steps:
* early on phases can request that a throw helper block get created
* we create the blocks (but not the code) before final block layout so they get proper placement
* lowering adds references to throw helpers that are actually needed
* stack level setter then materializes code for the needed helpers, and removes the blocks for the unneeded ones
* we can then finalize the outgoing arg space size

Closes #104658.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=739624&view=ms.vss-build-web.run-extensions-tab)