### PR TITLE
Fix SSP restoring in edge cases

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -72,7 +72,7 @@ class AsmOffsets
     public const int OFFSETOF__REGDISPLAY__SP = 0x1a70;
     public const int OFFSETOF__REGDISPLAY__ControlPC = 0x1a78;
 #else // TARGET_UNIX
-    public const int SIZEOF__REGDISPLAY = 0xbe0;
+    public const int SIZEOF__REGDISPLAY = 0xbf0;
     public const int OFFSETOF__REGDISPLAY__SP = 0xbd0;
     public const int OFFSETOF__REGDISPLAY__ControlPC = 0xbd8;
 #endif // TARGET_UNIX

--- a/src/coreclr/inc/regdisp.h
+++ b/src/coreclr/inc/regdisp.h
@@ -45,6 +45,10 @@ struct REGDISPLAY_BASE {
 
     TADDR SP;
     TADDR ControlPC; // LOONGARCH: use RA for PC
+
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+    TADDR SSP;
+#endif
 };
 
 inline PCODE GetControlPC(const REGDISPLAY_BASE *pRD) {
@@ -509,6 +513,12 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
 
     // This will setup the PC and SP
     SyncRegDisplayToCurrentContext(pRD);
+
+#if !defined(DACCESS_COMPILE)
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+    pRD->SSP = GetSSP(pctx);
+#endif
+#endif // !DACCESS_COMPILE
 
     if (fLightUnwind)
         return;

--- a/src/coreclr/vm/amd64/Context.S
+++ b/src/coreclr/vm/amd64/Context.S
@@ -44,7 +44,14 @@ NESTED_ENTRY ClrRestoreNonvolatileContextWorker, _TEXT, NoHandler
         rdsspq  rax
         sub     r11, rax
         shr     r11, 3
-        incsspq r11
+        ; the incsspq instruction uses only the lowest 8 bits of the argument, so we need to loop in case the increment is larger than 255
+        mov     rax, 255
+    Update_Loop:
+        cmp     r11, rax
+        cmovb   rax, r11
+        incsspq rax
+        sub     r11, rax
+        ja      Update_Loop
     No_Ssp_Update:
 
         // When user-mode shadow stacks are enabled, and for example the intent is to continue execution in managed code after

--- a/src/coreclr/vm/amd64/Context.S
+++ b/src/coreclr/vm/amd64/Context.S
@@ -44,7 +44,7 @@ NESTED_ENTRY ClrRestoreNonvolatileContextWorker, _TEXT, NoHandler
         rdsspq  rax
         sub     r11, rax
         shr     r11, 3
-        ; the incsspq instruction uses only the lowest 8 bits of the argument, so we need to loop in case the increment is larger than 255
+        // the incsspq instruction uses only the lowest 8 bits of the argument, so we need to loop in case the increment is larger than 255
         mov     rax, 255
     Update_Loop:
         cmp     r11, rax

--- a/src/coreclr/vm/amd64/Context.asm
+++ b/src/coreclr/vm/amd64/Context.asm
@@ -53,7 +53,14 @@ NESTED_ENTRY ClrRestoreNonvolatileContextWorker, _TEXT
         rdsspq  rax
         sub     r11, rax
         shr     r11, 3
-        incsspq r11
+        ; the incsspq instruction uses only the lowest 8 bits of the argument, so we need to loop in case the increment is larger than 255
+        mov     rax, 255
+    Update_Loop:
+        cmp     r11, rax
+        cmovb   rax, r11
+        incsspq rax
+        sub     r11, rax
+        ja      Update_Loop
     No_Ssp_Update:
 
         ; When user-mode shadow stacks are enabled, and for example the intent is to continue execution in managed code after

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1561,7 +1561,7 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
     *pRD->pCurrentContextPointers = *pOtherRD->pCurrentContextPointers;
     SetIP(pRD->pCurrentContext, GetIP(pOtherRD->pCurrentContext));
     SetSP(pRD->pCurrentContext, GetSP(pOtherRD->pCurrentContext));
-#ifdef TARGET_AMD64
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
     pRD->SSP = pOtherRD->SSP;
 #endif
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -524,6 +524,12 @@ UINT_PTR Thread::VirtualUnwindCallFrame(PREGDISPLAY pRD, EECodeInfo* pCodeInfo /
         VirtualUnwindCallFrame(pRD->pCurrentContext, pRD->pCurrentContextPointers, pCodeInfo);
     }
 
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+    if (pRD->SSP != 0)
+    {
+        pRD->SSP += 8;
+    }
+#endif // TARGET_AMD64 && TARGET_WINDOWS
     SyncRegDisplayToCurrentContext(pRD);
     pRD->IsCallerContextValid = FALSE;
     pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.
@@ -1555,6 +1561,9 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
     *pRD->pCurrentContextPointers = *pOtherRD->pCurrentContextPointers;
     SetIP(pRD->pCurrentContext, GetIP(pOtherRD->pCurrentContext));
     SetSP(pRD->pCurrentContext, GetSP(pOtherRD->pCurrentContext));
+#ifdef TARGET_AMD64
+    pRD->SSP = pOtherRD->SSP;
+#endif
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = (pRD->pCurrentContextPointers->regname == NULL) ? pOtherRD->pCurrentContext->regname : *pRD->pCurrentContextPointers->regname;
     ENUM_CALLEE_SAVED_REGISTERS();

--- a/src/tests/Regressions/coreclr/GitHub_104820/test104820.cs
+++ b/src/tests/Regressions/coreclr/GitHub_104820/test104820.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Test104820
+{
+    // Test that SSP is updated properly when resuming after catch when the shadow stack
+    // contains the instruction pointer of the resume frame multiple times and the SSP needs
+    // to be restored to the location of one that's not the first one found on the shadow
+    // stack.
+    // This test fails with stack overflow of the shadow stack if the SSP is updated incorrectly.
+    static void ShadowStackPointerUpdateTest(int depth)
+    {
+        if (depth == 0)
+        {
+            throw new Exception();
+        }
+
+        for (int i = 0; i < 1000; i++)
+        {
+            try
+            {
+                try
+                {
+                    ShadowStackPointerUpdateTest(depth - 1);
+                }
+                catch (Exception)
+                {
+                    throw new Exception();
+                }
+            }
+            catch (Exception) when (depth == 100)
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+	ShadowStackPointerUpdateTest(100);
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_104820/test104820.cs
+++ b/src/tests/Regressions/coreclr/GitHub_104820/test104820.cs
@@ -40,6 +40,6 @@ public class Test104820
     [Fact]
     public static void TestEntryPoint()
     {
-	ShadowStackPointerUpdateTest(100);
+        ShadowStackPointerUpdateTest(100);
     }
 }

--- a/src/tests/Regressions/coreclr/GitHub_104820/test104820.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_104820/test104820.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test104820.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There are edge cases when the SSP restoring for continuation after a catch handler completes doesn't work correctly. The problem is caused by the fact that we scan for the Rip of the frame handling the exception on the shadow stack to find where to restore it, and in those edge cases, the same address can be there multiple times and the first occurence is not the right one. For example, when an exception is thrown from a catch handler, it escapes the handler and the handler for the escaped exception is in the same method as the one that invoked the handler.

This change fixes it by finding the SSP of the first managed frame where we search for the handler and then updating the SSP with every unwind. The SSP is stored in the REGDISPLAY. So when we reach the CallCatchFunclet, the REGDISPLAY contains the SSP to restore.

There was also one more issue with restoring the SSP. I turned out that the incsspq instruction uses only the lowest 8 bits of the argument to increment the SSP, so the ClrRestoreNonVolatileContextWorker needs to have a loop that repeats that instruction in case we need to move it by more than 255 slots.