### PR TITLE
Throw ObjectDisposedException instead of NullReferenceException

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
@@ -18,6 +18,11 @@ namespace System
 
         public bool MoveNext()
         {
+            if (_str == null)
+            {
+                throw new ObjectDisposedException(null);
+            }
+        
             int index = _index + 1;
             int length = _str.Length;
 


### PR DESCRIPTION
Calling MoveNext after Dispose should throw an ObjectDisposedException. This was mentioned in #5480. The NullReferenceException (caused by _str.Length) indicates a bug in the code that throws it. This causes confusion during debugging because it looks like this:
![grafik](https://github.com/user-attachments/assets/eb2e9647-e352-49ec-a581-78fb7461cf81)
It looks like `a` is null, as opposed to some code inside MoveNext unexpectedly throwing a NullReferenceException. And it's extremely rare for framework-internal code to throw NullReferenceExceptions.
