### PR TITLE
Don't dispose timers if we're in our UnhandledException handler.

### DIFF
--- a/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddXamarinPlaceholderFilesToPackage>true</AddXamarinPlaceholderFilesToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -40,6 +40,7 @@ namespace System.Runtime.Caching
         private bool _throwOnDisposed;
         private EventHandler _onAppDomainUnload;
         private UnhandledExceptionEventHandler _onUnhandledException;
+        private int _inUnhandledExceptionHandler;
 #if NETCOREAPP
         [UnsupportedOSPlatformGuard("browser")]
         private static bool _countersSupported => !OperatingSystem.IsBrowser();
@@ -238,14 +239,19 @@ namespace System.Runtime.Caching
             Dispose();
         }
 
+        internal bool InUnhandledExceptionHandler => _inUnhandledExceptionHandler > 0;
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
         {
+            Interlocked.Increment(ref _inUnhandledExceptionHandler);
+
             // if the CLR is terminating, dispose the cache.
             // This will dispose the perf counters
             if (eventArgs.IsTerminating)
             {
                 Dispose();
             }
+
+            Interlocked.Decrement(ref _inUnhandledExceptionHandler);
         }
 
         private static void ValidatePolicy(CacheItemPolicy policy)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
@@ -340,8 +340,19 @@ namespace System.Runtime.Caching
                     GCHandleRef<Timer> timerHandleRef = _timerHandleRef;
                     if (timerHandleRef != null && Interlocked.CompareExchange(ref _timerHandleRef, null, timerHandleRef) == timerHandleRef)
                     {
-                        timerHandleRef.Dispose();
-                        Dbg.Trace("MemoryCacheStats", "Stopped CacheMemoryTimers");
+                        // If inside an unhandled exception handler, Timers may be succeptible to deadlocks. Use a safer approach.
+                        if (_memoryCache.InUnhandledExceptionHandler)
+                        {
+                            // This does not stop/dispose the timer. But the callback on the timer is protected by _disposed, which we have already
+                            // set above.
+                            timerHandleRef.FreeHandle();
+                            Dbg.Trace("MemoryCacheStats", "Freed CacheMemoryTimers");
+                        }
+                        else
+                        {
+                            timerHandleRef.Dispose();
+                            Dbg.Trace("MemoryCacheStats", "Stopped CacheMemoryTimers");
+                        }
                     }
                 }
                 while (_inCacheManagerThread != 0)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/SRef.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/SRef.cs
@@ -59,6 +59,11 @@ namespace System.Runtime.Caching
         public void Dispose()
         {
             Target.Dispose();
+            FreeHandle();
+        }
+
+        internal void FreeHandle()
+        {
             // Safe to call Dispose more than once but not thread-safe
             if (_handle.IsAllocated)
             {


### PR DESCRIPTION
- **Description** - 
Timer was updated in 5.0 to improve performance, but is prone to deadlocks when manipulated in an unhandled exception handler. Which MemoryCache does. And MemoryCache is probably more likely to witness unhandled exceptions like OOM than typical code.
- **Customer Impact** - The deadlock is preventing a first-party team (Exchange/Substrate) from migrating to .Net 6 and 8.
- **Regression?** - From NetFx, yes.
- **Risk** Low.

Original Issue: #64115 (and #102666)
.Net 9.0 PR: #103937

System.Runtime.Caching is an OOB package that ships alongside the runtime.