### PR TITLE
[release/6.0] Fix WinHttp StreamingTest backward compat version

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -171,6 +171,7 @@ namespace System
 
         internal static uint GetWindowsVersion() => (uint)GetWindowsVersionObject().Major;
         internal static uint GetWindowsMinorVersion() => (uint)GetWindowsVersionObject().Minor;
+        internal static uint GetWindowsBuildVersion() => (uint)GetWindowsVersionObject().Build;
 
         internal static bool IsWindowsVersionOrLater(int major, int minor, int build = -1)
         {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -24,6 +24,7 @@ namespace System
         public static bool IsWindows8x => IsWindows && GetWindowsVersion() == 6 && (GetWindowsMinorVersion() == 2 || GetWindowsMinorVersion() == 3);
         public static bool IsWindows8xOrLater => IsWindowsVersionOrLater(6, 2);
         public static bool IsWindows10OrLater => IsWindowsVersionOrLater(10, 0);
+        public static bool IsWindowsServer2022 => IsWindows && IsNotWindowsNanoServer && GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildVersion() == 20348;
         public static bool IsWindowsNanoServer => IsWindows && (IsNotWindowsIoTCore && GetWindowsInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         public static bool IsWindowsServerCore => IsWindows && GetWindowsInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase);
         public static int WindowsVersion => IsWindows ? (int)GetWindowsVersion() : -1;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -22,9 +22,9 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
         // Build number suggested by the WinHttp team.
         // It can be reduced if bidirectional streaming is backported.
-        public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0);
+        public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0) && PlatformDetection.IsWindowsServer2022;
 
-        public static bool TestsEnabled => OsSupportsWinHttpBidirectionalStreaming && PlatformDetection.SupportsAlpn;
+        public static bool TestsEnabled => OsSupportsWinHttpBidirectionalStreaming && PlatformDetection.SupportsAlpn && !PlatformDetection.IsWindowsServer2022;
 
         public static bool TestsBackwardsCompatibilityEnabled => !OsSupportsWinHttpBidirectionalStreaming && PlatformDetection.SupportsAlpn;
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
         // Build number suggested by the WinHttp team.
         // It can be reduced if bidirectional streaming is backported.
-        public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0) && PlatformDetection.IsWindowsServer2022;
+        public static bool OsSupportsWinHttpBidirectionalStreaming => Environment.OSVersion.Version >= new Version(10, 0, 22357, 0) || PlatformDetection.IsWindowsServer2022;
 
         public static bool TestsEnabled => OsSupportsWinHttpBidirectionalStreaming && PlatformDetection.SupportsAlpn && !PlatformDetection.IsWindowsServer2022;
 


### PR DESCRIPTION
# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
Fixes #104390
and disables other tests in the same test suite, which can trigger assertion problem see below.
main PR #104722 which fixes the behavior, but in release branches we're disabling tests instead.

Recently, WS2022 got an update which backports AUTOMATIC_CHUNKING in WinHttp, and it affects our test in CI. Because, we were relying on it, now we're disabling tests because #104891 started to pop up with the backport in WS2022.
# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
No Customer Impact, test-only change.
# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No
# Testing

<!-- What kind of testing has been done with the fix. -->
CI
# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Test-only change, no risk.
# Package authoring signed off?

IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](../../docs/project/library-servicing.md) and gotten it explicitly reviewed.