### PR TITLE
Define equals manually for Swift JitInterface InlineArray types.

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1547,7 +1547,7 @@ namespace Internal.JitInterface
                 return true;
             }
 
-            return LoweredElements.Slice(0, (int)numLoweredElements).SequenceEqual(other.LoweredElements).Slice(0, (int)other.numLoweredElements)
+            return LoweredElements.Slice(0, (int)numLoweredElements).SequenceEqual(other.LoweredElements.Slice(0, (int)other.numLoweredElements);
                 && Offsets.Slice(0, (int)numLoweredElements).SequenceEqual(other.Offsets).Slice(0, (int)other.numLoweredElements);
         }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1547,8 +1547,8 @@ namespace Internal.JitInterface
                 return true;
             }
 
-            return LoweredElements.Slice(0, (int)numLoweredElements).SequenceEqual(other.LoweredElements).Slice(0, (int)other.numLoweredElements)
-                && Offsets.Slice(0, (int)numLoweredElements).SequenceEqual(other.Offsets).Slice(0, (int)other.numLoweredElements);
+            return LoweredElements.Slice(0, (int)numLoweredElements).SequenceEqual(other.LoweredElements.Slice(0, (int)other.numLoweredElements))
+                && Offsets.Slice(0, (int)numLoweredElements).SequenceEqual(other.Offsets.Slice(0, (int)other.numLoweredElements));
         }
 
         public override int GetHashCode()

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1509,12 +1509,52 @@ namespace Internal.JitInterface
         private struct SwiftLoweredTypes
         {
             public CorInfoType type;
+
+            public override bool Equals(object other)
+            {
+                if (other is SwiftLoweredTypes otherType)
+                {
+                    ReadOnlySpan<CorInfoType> self = this;
+                    return self.SequenceEqual(otherType);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                var code = new HashCode();
+                foreach (var item in this)
+                {
+                    code.Add(item);
+                }
+                return code.ToHashCode();
+            }
         }
 
         [InlineArray(4)]
         private struct LoweredOffsets
         {
             public uint offset;
+            
+            public override bool Equals(object other)
+            {
+                if (other is LoweredOffsets otherType)
+                {
+                    ReadOnlySpan<uint> self = this;
+                    return self.SequenceEqual(otherType);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                var code = new HashCode();
+                foreach (var item in this)
+                {
+                    code.Add(item);
+                }
+                return code.ToHashCode();
+            }
         }
 
         private SwiftLoweredTypes _loweredElements;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1500,7 +1500,7 @@ namespace Internal.JitInterface
         public bool hasSignificantPadding { get => _hasSignificantPadding != 0; set => _hasSignificantPadding = value ? (byte)1 : (byte)0; }
     }
 
-    public struct CORINFO_SWIFT_LOWERING
+    public struct CORINFO_SWIFT_LOWERING : IEquatable<CORINFO_SWIFT_LOWERING>
     {
         private byte _byReference;
         public bool byReference { get => _byReference != 0; set => _byReference = value ? (byte)1 : (byte)0; }
@@ -1531,11 +1531,11 @@ namespace Internal.JitInterface
 
         public override bool Equals(object obj)
         {
-            if (obj is not CORINFO_SWIFT_LOWERING other)
-            {
-                return false;
-            }
+            return obj is CORINFO_SWIFT_LOWERING other && Equals(other);
+        }
 
+        public bool Equals(CORINFO_SWIFT_LOWERING other)
+        {
             if (byReference != other.byReference)
             {
                 return false;
@@ -1553,7 +1553,7 @@ namespace Internal.JitInterface
 
         public override int GetHashCode()
         {
-            HashCode code = new HashCode();
+            HashCode code = default;
             code.Add(byReference);
 
             if (byReference)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1547,8 +1547,8 @@ namespace Internal.JitInterface
                 return true;
             }
 
-            return LoweredElements.Slice(0, numLoweredElements).SequenceEqual(other.LoweredElements).Slice(0, other.numLoweredElements)
-                && Offsets.Slice(0, numLoweredElements).SequenceEqual(other.Offsets).Slice(0, other.numLoweredElements);
+            return LoweredElements.Slice(0, (int)numLoweredElements).SequenceEqual(other.LoweredElements).Slice(0, (int)other.numLoweredElements)
+                && Offsets.Slice(0, (int)numLoweredElements).SequenceEqual(other.Offsets).Slice(0, (int)other.numLoweredElements);
         }
 
         public override int GetHashCode()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/SwiftLoweringTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/SwiftLoweringTests.cs
@@ -88,6 +88,10 @@ namespace ILCompiler.Compiler.Tests
                                 {
                                     expected.Offsets[i] = (uint)naturalOffset.AlignUp(size);
                                 }
+                                else
+                                {
+                                    expected.Offsets[i] = (uint)naturalOffset;
+                                }
                                 naturalOffset += size;
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/104765