### PR TITLE
Fix arm64 MacOS and Linux Managed Debugging

### DIFF
--- a/src/coreclr/debug/inc/common.h
+++ b/src/coreclr/debug/inc/common.h
@@ -92,14 +92,12 @@ ULONG32 ContextSizeForFlags(ULONG32 flags)
     else
 #endif // TARGET_X86
     {
-#if !defined(CROSS_COMPILE) && !defined(TARGET_WINDOWS)
-    #if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+#if !defined(CROSS_COMPILE) && !defined(TARGET_WINDOWS) && (defined(TARGET_AMD64) || defined(TARGET_ARM64))
         if ((flags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
         {
             return sizeof(T_CONTEXT);
         }
         return offsetof(T_CONTEXT, XStateFeaturesMask);
-    #endif
 #else
         return sizeof(T_CONTEXT);
 #endif

--- a/src/coreclr/debug/inc/common.h
+++ b/src/coreclr/debug/inc/common.h
@@ -92,12 +92,14 @@ ULONG32 ContextSizeForFlags(ULONG32 flags)
     else
 #endif // TARGET_X86
     {
-#if !defined(CROSS_COMPILE) && !defined(TARGET_WINDOWS) && defined(TARGET_AMD64)
+#if !defined(CROSS_COMPILE) && !defined(TARGET_WINDOWS)
+    #if defined(TARGET_AMD64) || defined(TARGET_ARM64)
         if ((flags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
         {
             return sizeof(T_CONTEXT);
         }
         return offsetof(T_CONTEXT, XStateFeaturesMask);
+    #endif
 #else
         return sizeof(T_CONTEXT);
 #endif


### PR DESCRIPTION
A recent change to the size of T_CONTEXT broke managed debugging. This adds ARM64 to a check for the extended register state to unblock managed debugging. Fixes #104816 