### PR TITLE
Add toolchain instructions for Fedora

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -20,9 +20,8 @@ Below are the requirements for toolchain setup, depending on your environment. P
 
 Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs ([dotnet/runtime#4069](https://github.com/dotnet/runtime/issues/4069)).
 
-### Toolchain Setup
 
-#### Debian-based / Ubuntu
+### Debian-based / Ubuntu
 
 These instructions are written assuming the current Ubuntu LTS.
 
@@ -64,7 +63,7 @@ For the _Kitware APT feed_, follow its [instructions here](https://apt.kitware.c
 
 You now have all the required components.
 
-##### Additional Requirements for Cross-Building
+#### Additional Requirements for Cross-Building
 
 If you are planning to use your Linux environment to do cross-building for other architectures (e.g. Arm32, Arm64) and/or other operating systems (e.g. Alpine, FreeBSD), you need to install these additional dependencies:
 
@@ -75,7 +74,7 @@ If you are planning to use your Linux environment to do cross-building for other
 
 **NOTE**: These dependencies are used to build the `crossrootfs`, not the runtime itself.
 
-#### Fedora
+### Fedora
 
 These instructions are written assuming Fedora 40.
 
@@ -101,7 +100,7 @@ sudo dnf install -y cmake llvm lld lldb clang python curl git libicu-devel opens
 krb5-devel zlib-devel lttng-ust-devel ninja-build
 ```
 
-#### Gentoo
+### Gentoo
 
 In case you have Gentoo you can run following command:
 

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -16,11 +16,41 @@ Install Docker. For further installation instructions, see [here](https://docs.d
 
 ## Environment
 
-These instructions are written assuming the current Ubuntu LTS. Pull Requests are welcome to address other environments.
+Below are the requirements for toolchain setup, depending on your environment. Pull Requests are welcome to address other environments.
 
 Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs ([dotnet/runtime#4069](https://github.com/dotnet/runtime/issues/4069)).
 
 ### Toolchain Setup
+
+#### Fedora
+
+These instructions are written assuming Fedora 40.
+
+Install the following packages for the toolchain:
+
+* cmake
+* llvm
+* lld
+* lldb
+* clang
+* python
+* curl
+* git
+* libicu-devel
+* openssl-devel
+* krb5-devel
+* zlib-devel
+* lttng-ust-devel
+* ninja-build (optional, enables building native code with ninja instead of make)
+
+```bash
+sudo dnf install -y cmake llvm lld lldb clang python curl git libicu-devel openssl-devel \
+krb5-devel zlib-devel lttng-ust-devel ninja-build
+```
+
+#### Debian-based / Ubuntu
+
+These instructions are written assuming the current Ubuntu LTS.
 
 Install the following packages for the toolchain:
 
@@ -60,7 +90,7 @@ For the _Kitware APT feed_, follow its [instructions here](https://apt.kitware.c
 
 You now have all the required components.
 
-#### Additional Requirements for Cross-Building
+##### Additional Requirements for Cross-Building
 
 If you are planning to use your Linux environment to do cross-building for other architectures (e.g. Arm32, Arm64) and/or other operating systems (e.g. Alpine, FreeBSD), you need to install these additional dependencies:
 

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -22,32 +22,6 @@ Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs (
 
 ### Toolchain Setup
 
-#### Fedora
-
-These instructions are written assuming Fedora 40.
-
-Install the following packages for the toolchain:
-
-* cmake
-* llvm
-* lld
-* lldb
-* clang
-* python
-* curl
-* git
-* libicu-devel
-* openssl-devel
-* krb5-devel
-* zlib-devel
-* lttng-ust-devel
-* ninja-build (optional, enables building native code with ninja instead of make)
-
-```bash
-sudo dnf install -y cmake llvm lld lldb clang python curl git libicu-devel openssl-devel \
-krb5-devel zlib-devel lttng-ust-devel ninja-build
-```
-
 #### Debian-based / Ubuntu
 
 These instructions are written assuming the current Ubuntu LTS.
@@ -100,6 +74,32 @@ If you are planning to use your Linux environment to do cross-building for other
 * debootstrap
 
 **NOTE**: These dependencies are used to build the `crossrootfs`, not the runtime itself.
+
+#### Fedora
+
+These instructions are written assuming Fedora 40.
+
+Install the following packages for the toolchain:
+
+* cmake
+* llvm
+* lld
+* lldb
+* clang
+* python
+* curl
+* git
+* libicu-devel
+* openssl-devel
+* krb5-devel
+* zlib-devel
+* lttng-ust-devel
+* ninja-build (optional, enables building native code with ninja instead of make)
+
+```bash
+sudo dnf install -y cmake llvm lld lldb clang python curl git libicu-devel openssl-devel \
+krb5-devel zlib-devel lttng-ust-devel ninja-build
+```
 
 ### Gentoo Special Case
 

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -2,9 +2,10 @@
 
 * [Docker](#docker)
 * [Environment](#environment)
-  * [Toolchain Setup](#toolchain-setup)
+  * [Debian-based / Ubuntu](#debian-based--ubuntu)
     * [Additional Requirements for Cross-Building](#additional-requirements-for-cross-building)
-  * [Gentoo Special Case](#gentoo-special-case)
+  * [Fedora](#fedora)
+  * [Gentoo](#gentoo)
 
 This guide will walk you through the requirements to build _dotnet/runtime_ on Linux. Before building there is environment setup that needs to happen to pull in all the dependencies required by the build.
 

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -101,7 +101,7 @@ sudo dnf install -y cmake llvm lld lldb clang python curl git libicu-devel opens
 krb5-devel zlib-devel lttng-ust-devel ninja-build
 ```
 
-### Gentoo Special Case
+#### Gentoo
 
 In case you have Gentoo you can run following command:
 


### PR DESCRIPTION
Fedora-based distributions use a different convention for package names, and differ enough from Debian-systems that I always need to go back to my notes to remember the exact names of build dependencies for Fedora.

/cc @tmds and @omajid for any feedback.