### PR TITLE
Issue 104700: Clarify error message for collection property with no getter

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -764,6 +764,9 @@
   <data name="JsonSchemaExporter_DepthTooLarge" xml:space="preserve">
     <value>The depth of the generated JSON schema exceeds the JsonSerializerOptions.MaxDepth setting.</value>
   </data>
+  <data name="JsonPropertyRequiredAndCollectionPropertyMissingGetter" xml:space="preserve">
+    <value>JsonPropertyInfo '{0}' defined in type '{1}' is marked required but is a collection property and does not specify a getter.</value>
+  </data>
   <!-- System.Collections polyfills -->
   <data name="Arg_WrongType" xml:space="preserve">
     <value>The value '{0}' is not of type '{1}' and cannot be used in this generic collection.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -276,6 +276,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_JsonPropertyRequiredAndCollectionPropertyMissingGetter(JsonPropertyInfo jsonPropertyInfo)
+        {
+            throw new InvalidOperationException(SR.Format(SR.JsonPropertyRequiredAndCollectionPropertyMissingGetter, jsonPropertyInfo.Name, jsonPropertyInfo.DeclaringType));
+        }
+
+        [DoesNotReturn]
         public static void ThrowInvalidOperationException_JsonPropertyRequiredAndNotDeserializable(JsonPropertyInfo jsonPropertyInfo)
         {
             throw new InvalidOperationException(SR.Format(SR.JsonPropertyRequiredAndNotDeserializable, jsonPropertyInfo.Name, jsonPropertyInfo.DeclaringType));

--- a/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
@@ -564,7 +564,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public async Task RequiredPropertyWithoutSetterThrows()
+        public async Task RequiredNonDeserializablePropertyThrows()
         {
             JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(static ti =>
             {

--- a/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
@@ -564,7 +564,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public async Task RequiredNonDeserializablePropertyThrows()
+        public async Task RequiredPropertyWithoutSetterThrows()
         {
             JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(static ti =>
             {
@@ -608,6 +608,23 @@ namespace System.Text.Json.Serialization.Tests
         {
             [JsonExtensionData]
             public required Dictionary<string, JsonElement>? TestExtensionData { get; set; }
+        }
+
+        [Fact]
+        public async Task RequiredCollectionPropertyWithoutGetterThrows()
+        {
+            string json = """{"Foo":"foo","Bar":"bar"}""";
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await Serializer.DeserializeWrapper<ClassWithRequiredCollectionPropertyWithoutGetter>(json));
+            Assert.Contains(nameof(ClassWithRequiredCollectionPropertyWithoutGetter.TestCollectionPropertyWithoutGetter), exception.Message);
+        }
+
+        public class ClassWithRequiredCollectionPropertyWithoutGetter
+        {
+            public required Dictionary<string, JsonElement>? TestCollectionPropertyWithoutGetter
+            {
+                set => TestCollectionPropertyWithoutGetter = value;
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/RequiredKeywordTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/RequiredKeywordTests.cs
@@ -30,6 +30,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ClassWithInitOnlyRequiredProperty))]
         [JsonSerializable(typeof(ClassWithRequiredField))]
         [JsonSerializable(typeof(ClassWithRequiredExtensionDataProperty))]
+        [JsonSerializable(typeof(ClassWithRequiredCollectionPropertyWithoutGetter))]
         [JsonSerializable(typeof(ClassWithRequiredKeywordAndJsonRequiredCustomAttribute))]
         [JsonSerializable(typeof(ClassWithCustomRequiredPropertyName))]
         [JsonSerializable(typeof(DerivedClassWithRequiredInitOnlyProperty))]


### PR DESCRIPTION
- Added verification to distinguish between different error types.
- Renamed existing test to more accurately reflect that it tests required properties without a setter.
- Added a new test to ensure that a collection property without a getter throws an InvalidOperationException.

Fixes #104700