### PR TITLE
Don't attempt to `EnsureInitializedToManagedFrame` under `USE_PORTABLE_HELPERS`

### DIFF
--- a/src/coreclr/nativeaot/Runtime/StackFrameIterator.cpp
+++ b/src/coreclr/nativeaot/Runtime/StackFrameIterator.cpp
@@ -323,10 +323,9 @@ void StackFrameIterator::InternalInit(Thread * pThreadToWalk, PInvokeTransitionF
 
 #endif // TARGET_ARM
 
-#endif // defined(USE_PORTABLE_HELPERS)
-
     // adjust for thunks, if needed
     EnsureInitializedToManagedFrame();
+#endif // !defined(USE_PORTABLE_HELPERS)
 
     STRESS_LOG1(LF_STACKWALK, LL_INFO10000, "   %p\n", m_ControlPC);
 }


### PR DESCRIPTION
This is just downstream->upstream code syncing from https://github.com/dotnet/runtimelab/pull/2632.