### PR TITLE
[GC] Fix freelist crash - don't modify during check-only operation

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -21507,10 +21507,13 @@ int gc_heap::generation_to_condemn (int n_initial,
     }
 
 #ifdef USE_REGIONS
-    if (!try_get_new_free_region())
+    if (!check_only_p)
     {
-        dprintf (GTC_LOG, ("can't get an empty region -> full compacting"));
-        last_gc_before_oom = TRUE;
+        if (!try_get_new_free_region())
+        {
+            dprintf (GTC_LOG, ("can't get an empty region -> full compacting"));
+            last_gc_before_oom = TRUE;
+        }
     }
 #endif //USE_REGIONS
 


### PR DESCRIPTION
`RegisterForFullGCNotification` sets `gc_heap::fgn_maxgen_percent`, which guards calls to `check_for_full_gc` to determine if a notification should be sent.  `gc_heap::generation_to_condemn`.  One part of `check_for_full_gc` calls `generation_to_condemn` with the parameter `check_only_p` set to `TRUE`.  `generation_to_condemn` calls `try_get_new_free_region`, which ensures that a free region is available.  It checks the freelist, but if none are found it creates a new one and adds it to the freelist.  `check_for_full_gc` does not (and should not) contain the necessary synchronization to make this safe.  This can lead to corruption of the basic region freelist, often ending up with `nullptr` links between nodes.

This caused crashed in production and the cause was determined by using a custom GC build with additional runtime checks.  The fix is to simply honor the `check_only_p` parameter and not call `try_get_new_free_region` when it is set.  The problem can be reproed by changing `try_get_new_free_region` to always create a new region.  This fix handles that repro.

This fix does not impact normal GC operation.  It can cause `check_for_full_gc` to no longer detect that full collection is going to occur, but only if the failure to create or initialize a new region is the only reason why that full collection is going to occur.  However, those cases are open to the race condition that can cause the freelist corruption is possible.