### PR TITLE
[QUIC] fix unobserved exceptions

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -169,20 +169,17 @@ public sealed partial class QuicStream
         try
         {
             QUIC_HANDLE* handle;
-            int status = MsQuicApi.Api.StreamOpen(
+            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamOpen(
                 connectionHandle,
                 type == QuicStreamType.Unidirectional ? QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL : QUIC_STREAM_OPEN_FLAGS.NONE,
                 &NativeCallback,
                 (void*)GCHandle.ToIntPtr(context),
-                &handle);
-
-            if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? ex, streamWasSuccessfullyStarted: false, message: "StreamOpen failed"))
+                &handle),
+                "StreamOpen failed");
+            _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle)
             {
-                throw ex;
-            }
-
-            _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle);
-            _handle.Disposable = _sendBuffers;
+                Disposable = _sendBuffers
+            };
         }
         catch
         {
@@ -213,8 +210,10 @@ public sealed partial class QuicStream
         GCHandle context = GCHandle.Alloc(this, GCHandleType.Weak);
         try
         {
-            _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle);
-            _handle.Disposable = _sendBuffers;
+            _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle)
+            {
+                Disposable = _sendBuffers
+            };
             delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_STREAM_EVENT*, int> nativeCallback = &NativeCallback;
             MsQuicApi.Api.SetCallbackHandler(
                 _handle,
@@ -261,14 +260,12 @@ public sealed partial class QuicStream
             int status = MsQuicApi.Api.StreamStart(
                 _handle,
                 QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT);
-
-            if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception, streamWasSuccessfullyStarted: false))
+            if (StatusFailed(status))
             {
                 _decrementStreamCapacity = null;
-                _startedTcs.TrySetException(exception);
+                _startedTcs.TrySetException(ThrowHelper.GetExceptionForMsQuicStatus(status));
             }
         }
-
         return valueTask;
     }
 
@@ -637,7 +634,7 @@ public sealed partial class QuicStream
                 // It's local shutdown by app, this side called QuicConnection.CloseAsync, throw QuicError.OperationAborted.
                 (shutdownByApp: true, closedRemotely: false) => ThrowHelper.GetOperationAbortedException(),
                 // It's remote shutdown by transport, we received a CONNECTION_CLOSE frame with a QUIC transport error code, throw error based on the status.
-                (shutdownByApp: false, closedRemotely: true) => ThrowHelper.GetExceptionForMsQuicStatus(data.ConnectionCloseStatus, (long)data.ConnectionErrorCode, $"Shutdown by transport {data.ConnectionErrorCode}"),
+                (shutdownByApp: false, closedRemotely: true) => ThrowHelper.GetExceptionForMsQuicStatus(data.ConnectionCloseStatus, (long)data.ConnectionErrorCode),
                 // It's local shutdown by transport, most likely due to a timeout, throw error based on the status.
                 (shutdownByApp: false, closedRemotely: false) => ThrowHelper.GetExceptionForMsQuicStatus(data.ConnectionCloseStatus, (long)data.ConnectionErrorCode),
             };

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -580,7 +580,7 @@ namespace System.Net.Quic.Tests
                     return true;
                 };
 
-                await CreateQuicConnection(clientOptions);
+                await using QuicConnection connection = await CreateQuicConnection(clientOptions);
             }
             finally
             {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -117,6 +117,67 @@ namespace System.Net.Quic.Tests
                 });
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(null)]
+        public async Task CloseAsync_PendingOpenStream_Throws(bool? localClose)
+        {
+            byte[] data = new byte[10];
+
+            await using QuicListener listener = await CreateQuicListener(changeServerOptions: localClose is null ? options => options.IdleTimeout = TimeSpan.FromSeconds(10) : null);
+
+            // Allow client to accept a stream, one will be accepted and another will be pending while we close the server connection.
+            QuicClientConnectionOptions clientOptions = CreateQuicClientOptions(listener.LocalEndPoint);
+            clientOptions.MaxInboundBidirectionalStreams = 1;
+            await using QuicConnection clientConnection = await CreateQuicConnection(clientOptions);
+
+            await using QuicConnection serverConnection = await listener.AcceptConnectionAsync();
+
+            // Put one stream into server stream queue.
+            QuicStream queuedStream = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+            await queuedStream.WriteAsync(data.AsMemory(), completeWrites: true);
+
+            // Open one stream to the client that is allowed.
+            QuicStream firstStream = await serverConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+            await firstStream.WriteAsync(data.AsMemory(), completeWrites: true);
+
+            // Try to open another stream which should wait on capacity.
+            ValueTask<QuicStream> secondStreamTask = serverConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+            Assert.False(secondStreamTask.IsCompleted);
+
+            // Close the connection, second stream task should complete with appropriate error.
+            if (localClose is true)
+            {
+                await serverConnection.CloseAsync(123);
+                await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, async () => await secondStreamTask);
+
+                // Try to open yet another stream which should fail because of already closed connection.
+                await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, async () => await serverConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional));
+            }
+            else if (localClose is false)
+            {
+                await clientConnection.CloseAsync(456);
+                QuicException ex1 = await AssertThrowsQuicExceptionAsync(QuicError.ConnectionAborted, async () => await secondStreamTask);
+                Assert.Equal(456, ex1.ApplicationErrorCode);
+
+                // Try to open yet another stream which should fail because of already closed connection.
+                QuicException ex2 = await AssertThrowsQuicExceptionAsync(QuicError.ConnectionAborted, async () => await serverConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional));
+                Assert.Equal(456, ex2.ApplicationErrorCode);
+            }
+            else
+            {
+                await Task.Delay(TimeSpan.FromSeconds(15));
+
+                QuicException ex1 = await AssertThrowsQuicExceptionAsync(QuicError.ConnectionIdle, async () => await secondStreamTask);
+                Assert.Equal(1, ex1.TransportErrorCode);
+
+                // Try to open yet another stream which should fail because of already closed connection.
+                QuicException ex2 = await AssertThrowsQuicExceptionAsync(QuicError.ConnectionIdle, async () => await serverConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional));
+                Assert.Equal(1, ex2.TransportErrorCode);
+            }
+        }
+
         [Fact]
         public async Task Dispose_WithPendingAcceptAndConnect_PendingAndSubsequentThrowOperationAbortedException()
         {
@@ -228,6 +289,9 @@ namespace System.Net.Quic.Tests
             await streamsAvailableFired.WaitAsync();
             Assert.Equal(0, bidiIncrement);
             Assert.Equal(1, unidiIncrement);
+
+            await clientConnection.DisposeAsync();
+            await serverConnection.DisposeAsync();
         }
 
         [Theory]
@@ -298,6 +362,9 @@ namespace System.Net.Quic.Tests
             Assert.False(streamsAvailableFired.CurrentCount > 0);
             Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams * 3, bidiTotal);
             Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams * 3 : QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiTotal);
+
+            await clientConnection.DisposeAsync();
+            await serverConnection.DisposeAsync();
         }
 
         [Theory]
@@ -368,6 +435,9 @@ namespace System.Net.Quic.Tests
             Assert.False(streamsAvailableFired.CurrentCount > 0);
             Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams * 3, bidiTotal);
             Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams * 3 : QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiTotal);
+
+            await clientConnection.DisposeAsync();
+            await serverConnection.DisposeAsync();
         }
 
         [Fact]
@@ -434,6 +504,9 @@ namespace System.Net.Quic.Tests
 
             // by now, we opened and closed 2 * Limit, and expect a budget of 'Limit' more
             Assert.Equal(3 * Limit, maxStreamIndex);
+
+            await clientConnection.DisposeAsync();
+            await serverConnection.DisposeAsync();
         }
 
         [Fact]
@@ -634,6 +707,8 @@ namespace System.Net.Quic.Tests
 
             var accept1Exception = await Assert.ThrowsAsync<ObjectDisposedException>(async () => await acceptTask1);
             var accept2Exception = await Assert.ThrowsAsync<ObjectDisposedException>(async () => await acceptTask2);
+
+            await clientConnection.DisposeAsync();
         }
 
         [Theory]

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -120,30 +120,46 @@ namespace System.Net.Quic.Tests
             return QuicConnection.ConnectAsync(clientOptions);
         }
 
-        internal QuicListenerOptions CreateQuicListenerOptions(IPAddress address = null)
+        internal QuicListenerOptions CreateQuicListenerOptions(IPAddress address = null, Action<QuicServerConnectionOptions> changeServerOptions = null)
         {
             address ??= IPAddress.Loopback;
             return new QuicListenerOptions()
             {
                 ListenEndPoint = new IPEndPoint(address, 0),
                 ApplicationProtocols = new List<SslApplicationProtocol>() { ApplicationProtocol },
-                ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(CreateQuicServerOptions())
+                ConnectionOptionsCallback = (_, _, _) =>
+                {
+                    var options = CreateQuicServerOptions();
+                    if (changeServerOptions is not null)
+                    {
+                        changeServerOptions(options);
+                    }
+                    return ValueTask.FromResult(options);
+                }
             };
         }
 
-        internal ValueTask<QuicListener> CreateQuicListener(IPAddress address = null)
+        internal ValueTask<QuicListener> CreateQuicListener(IPAddress address = null, Action<QuicServerConnectionOptions> changeServerOptions = null)
         {
-            var options = CreateQuicListenerOptions(address);
+            var options = CreateQuicListenerOptions(address, changeServerOptions);
             return CreateQuicListener(options);
         }
 
-        internal ValueTask<QuicListener> CreateQuicListener(IPEndPoint endpoint)
+        internal ValueTask<QuicListener> CreateQuicListener(IPEndPoint endpoint, Action<QuicServerConnectionOptions> changeServerOptions = null)
         {
             var options = new QuicListenerOptions()
             {
                 ListenEndPoint = endpoint,
                 ApplicationProtocols = new List<SslApplicationProtocol>() { ApplicationProtocol },
-                ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(CreateQuicServerOptions())
+                ConnectionOptionsCallback = (_, _, _) =>
+                {
+                    var options = CreateQuicServerOptions();
+                    if (changeServerOptions is not null)
+                    {
+                        changeServerOptions(options);
+                    }
+                    return ValueTask.FromResult(options);
+                }
             };
             return CreateQuicListener(options);
         }


### PR DESCRIPTION
Addresses the last issue with unobserved exception leaking from `_connectionCloseTcs`.

Fixes #80111

---
**Testing**
I used Miha's trick from https://github.com/dotnet/runtime/issues/80111#issuecomment-2206037068 to manually check for unobserved exceptions from HTTP tests, but we don't have a collection fixture like `QuicTestCollection` to add similar print like:
https://github.com/dotnet/runtime/blob/9d24b13dadf84de72bce61ab50909fed5331cbd5/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs#L97
in HTTP. And adding it and annotating the whole test lib felt like out of the scope for this PR.

Also note that from xUnit 3 there should be [`Assembly Fixtures`](https://xunit.net/docs/shared-context) which wouldn't require annotating every single test class in an assembly.