### PR TITLE
Emulate shell exit code behavior for signals in PAL

### DIFF
--- a/src/coreclr/pal/src/synchmgr/synchmanager.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchmanager.cpp
@@ -4495,7 +4495,7 @@ namespace CorUnix
                     *pfIsActualExitCode = true;
                     TRACE("Exit code was %d\n", *pdwExitCode);
                 }
-                else if ( WIFSIGNALED( iStatus ) )
+                else if (WIFSIGNALED(iStatus))
                 {
                     *pdwExitCode = 128 + WTERMSIG(iStatus);
                     *pfIsActualExitCode = true;

--- a/src/coreclr/pal/src/synchmgr/synchmanager.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchmanager.cpp
@@ -4495,6 +4495,12 @@ namespace CorUnix
                     *pfIsActualExitCode = true;
                     TRACE("Exit code was %d\n", *pdwExitCode);
                 }
+                else if ( WIFSIGNALED( iStatus ) )
+                {
+                    *pdwExitCode = 128 + WTERMSIG(iStatus);
+                    *pfIsActualExitCode = true;
+                    TRACE("Exited by signal %d = exit code %d\n", WTERMSIG(iStatus), *pdwExitCode);
+                }
                 else
                 {
                     WARN("Process terminated without exiting; can't get exit "

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3368,6 +3368,11 @@ PROCGetProcessStatus(
                 *pdwExitCode = WEXITSTATUS(status);
                 TRACE("Exit code was %d\n", *pdwExitCode);
             }
+            else if ( WIFSIGNALED( status ) )
+            {
+                *pdwExitCode = 128 + WTERMSIG(status);
+                TRACE("Exit code was signal %d = exit code %d\n", WTERMSIG(iStatus), *pdwExitCode);
+            }
             else
             {
                 WARN("process terminated without exiting; can't get exit "

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3371,7 +3371,7 @@ PROCGetProcessStatus(
             else if ( WIFSIGNALED( status ) )
             {
                 *pdwExitCode = 128 + WTERMSIG(status);
-                TRACE("Exit code was signal %d = exit code %d\n", WTERMSIG(iStatus), *pdwExitCode);
+                TRACE("Exit code was signal %d = exit code %d\n", WTERMSIG(status), *pdwExitCode);
             }
             else
             {


### PR DESCRIPTION
The PAL versions of `GetExitCodeProcess` and `WaitForMultipleObjects` currently just fake up an exit code using `EXIT_FAILURE` (usually 1) whenever a child process is terminated by a signal. This PR changes the logic to instead behave the same as most shells and `SystemNative_WaitPidExitedNoHang`, where the exit code becomes 128 + signal number.