### PR TITLE
[mono] Fix aot compiler crash when checking for method signature

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12948,13 +12948,21 @@ should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_ty
 	MonoGenericParam *gen_param = NULL;
 	unsigned int gen_param_count;
 
+	ERROR_DECL (error);
+
 	if (method->is_generic && mono_class_is_gtd (method->klass)) {
 		// TODO: This is rarely encountered and would increase the complexity of covering such cases.
 		// For now always generate extra methods.
 		return TRUE;
 	} else if (method->is_generic) {
+		MonoMethodSignature* sig = mono_method_signature_checked(method, error);
+
+		if (!is_ok(error)) {
+			return FALSE;
+		}
+
 		gen_container = mono_method_get_generic_container (method);
-		gen_param_count = mono_method_signature_internal (method)->generic_param_count;
+		gen_param_count = sig->generic_param_count;
 	} else if (mono_class_is_gtd (method->klass)) {
 		gen_container = mono_class_get_generic_container (method->klass);
 		gen_param_count = gen_container->type_argc;

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12942,13 +12942,11 @@ emit_unwind_info_sections_win32 (MonoAotCompile *acfg, const char *function_star
  * Returns: TRUE - extra method should be generated, otherwise FALSE
  */
 static gboolean
-should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_type)
+should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_type, MonoError *error)
 {
 	MonoGenericContainer *gen_container = NULL;
 	MonoGenericParam *gen_param = NULL;
 	unsigned int gen_param_count;
-
-	ERROR_DECL (error);
 
 	if (method->is_generic && mono_class_is_gtd (method->klass)) {
 		// TODO: This is rarely encountered and would increase the complexity of covering such cases.
@@ -12957,7 +12955,7 @@ should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_ty
 	} else if (method->is_generic) {
 		MonoMethodSignature* sig = mono_method_signature_checked(method, error);
 
-		if (!is_ok(error)) {
+		if (!is_ok (error)) {
 			return FALSE;
 		}
 
@@ -12984,7 +12982,7 @@ should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_ty
 }
 
 static gboolean
-should_emit_gsharedvt_method (MonoAotCompile *acfg, MonoMethod *method)
+should_emit_gsharedvt_method (MonoAotCompile *acfg, MonoMethod *method, MonoError* error)
 {
 #ifdef TARGET_WASM
 	if (acfg->image == mono_get_corlib () && !strcmp (m_class_get_name (method->klass), "Vector`1"))
@@ -12994,7 +12992,7 @@ should_emit_gsharedvt_method (MonoAotCompile *acfg, MonoMethod *method)
 	if (acfg->image == mono_get_corlib () && !strcmp (m_class_get_name (method->klass), "Volatile"))
 		/* Read<T>/Write<T> are not needed and cause JIT failures */
 		return FALSE;
-	return should_emit_extra_method_for_generics (method, FALSE);
+	return should_emit_extra_method_for_generics (method, FALSE, error);
 }
 
 static gboolean
@@ -13055,15 +13053,16 @@ collect_methods (MonoAotCompile *acfg)
 		}
 		*/
 
-		if (should_emit_extra_method_for_generics (method, TRUE)) {
+		if (should_emit_extra_method_for_generics (method, TRUE, error)) {
 			/* Compile the ref shared version instead */
 			method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
-			if (!method) {
-				aot_printerrf (acfg, "Failed to load method 0x%x from '%s' due to %s.\n", token, image->name, mono_error_get_message (error));
-				aot_printerrf (acfg, "Run with MONO_LOG_LEVEL=debug for more information.\n");
-				mono_error_cleanup (error);
-				return FALSE;
-			}
+		}
+
+		if (!is_ok (error) || !method) {
+			aot_printerrf (acfg, "Failed to load method 0x%x from '%s' due to %s.\n", token, image->name, mono_error_get_message (error));
+			aot_printerrf (acfg, "Run with MONO_LOG_LEVEL=debug for more information.\n");
+			mono_error_cleanup (error);
+			return FALSE;
 		}
 
 		/* Since we add the normal methods first, their index will be equal to their zero based token index */
@@ -13098,7 +13097,7 @@ collect_methods (MonoAotCompile *acfg)
 			}
 		}
 
-		if ((method->is_generic || mono_class_is_gtd (method->klass)) && should_emit_gsharedvt_method (acfg, method)) {
+		if ((method->is_generic || mono_class_is_gtd (method->klass)) && should_emit_gsharedvt_method (acfg, method, error)) {
 			MonoMethod *gshared;
 
 			gshared = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);


### PR DESCRIPTION
This fixes a problem with the aot compiler where it tries to get a generic parameter count from a method, but instead crashes because the reference is null.

The problem stemmed from loading an assembly that had references to other assemblies that were not found. The aot compiler eventually figures out it can't do anything and exits. The crash occurred in between the validation process.

Fixes https://github.com/dotnet/runtime/issues/103901