### PR TITLE
Fix name of zlib that the linker needs

### DIFF
--- a/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
+++ b/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
@@ -13,7 +13,7 @@ macro(append_extra_compression_libs NativeLibsExtra)
       find_package(ZLIB REQUIRED)
       list(APPEND ZLIB_LIBRARIES m)
   else()
-    list(APPEND ZLIB_LIBRARIES zlib)
+    list(APPEND ZLIB_LIBRARIES z)
   endif ()
   list(APPEND ${NativeLibsExtra} ${ZLIB_LIBRARIES})
 

--- a/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
+++ b/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
@@ -3,9 +3,6 @@ macro(append_extra_compression_libs NativeLibsExtra)
   # TODO: remove the mono-style HOST_ variable checks once Mono is using eng/native/configureplatform.cmake to define the CLR_CMAKE_TARGET_ defines
   if (CLR_CMAKE_TARGET_BROWSER OR HOST_BROWSER OR CLR_CMAKE_TARGET_WASI OR HOST_WASI)
       # nothing special to link
-  elseif (CLR_CMAKE_TARGET_ANDROID OR HOST_ANDROID)
-      # need special case here since we want to link against libz.so but find_package() would resolve libz.a
-      list(APPEND ZLIB_LIBRARIES z)
   elseif (CLR_CMAKE_HOST_ARCH_ARMV6)
       find_package(ZLIB REQUIRED)
       list(APPEND ZLIB_LIBRARIES z)
@@ -13,6 +10,12 @@ macro(append_extra_compression_libs NativeLibsExtra)
       find_package(ZLIB REQUIRED)
       list(APPEND ZLIB_LIBRARIES m)
   else()
+    # 'z' is used in:
+    # - Platforms that set CMAKE_USE_SYSTEM_ZLIB to true, like Android.
+    # - When it is set to true via CLI using --cmakeargs.
+    # 'zlib' represents our in-tree zlib, and is used in all other platforms
+    # that don't meet any of the previous special requirements, like most
+    # regular Unix and Windows builds.
     list(APPEND ZLIB_LIBRARIES $<IF:$<BOOL:CLR_CMAKE_USE_SYSTEM_ZLIB>,z,zlib>)
   endif ()
   list(APPEND ${NativeLibsExtra} ${ZLIB_LIBRARIES})

--- a/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
+++ b/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
@@ -13,7 +13,7 @@ macro(append_extra_compression_libs NativeLibsExtra)
       find_package(ZLIB REQUIRED)
       list(APPEND ZLIB_LIBRARIES m)
   else()
-    list(APPEND ZLIB_LIBRARIES z)
+    list(APPEND ZLIB_LIBRARIES $<IF:$<BOOL:CLR_CMAKE_USE_SYSTEM_ZLIB>,z,zlib>)
   endif ()
   list(APPEND ${NativeLibsExtra} ${ZLIB_LIBRARIES})
 


### PR DESCRIPTION
It needs to be `z` so the linker argument becomes `-lz`. Otherwise the linker sees `-lzlib` which fails on Linux.

To reproduce the error, I used:

    $ ./build.sh --cmakeargs -DCLR_CMAKE_USE_SYSTEM_ZLIB=true