### PR TITLE
SPMI: Improve error handling in parallel mode

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1453,22 +1453,36 @@ class SuperPMICollect:
 # SuperPMI Replay helpers
 ################################################################################
 
-
-def print_superpmi_result(return_code, coreclr_args, base_metrics, diff_metrics):
-    """ Print a description of a superpmi return (error) code. If the return code is
-        zero, meaning success, don't print anything.
+def print_superpmi_error_result(return_code, coreclr_args):
+    """ Print a description of a superpmi return error code.
         Note that Python treats process return codes (at least on Windows) as
         unsigned integers, so compare against both signed and unsigned numbers for
         those return codes.
     """
+
     if return_code == 0:
-        logging.info("Clean SuperPMI {} ({} contexts processed)".format("replay" if diff_metrics is None else "diff", base_metrics["Overall"]["Successful compiles"]))
+        pass # Success
     elif return_code == -1 or return_code == 4294967295:
-        logging.error("General fatal error")
+        logging.error("General fatal error, please check the log for more details.")
     elif return_code == -2 or return_code == 4294967294:
-        logging.error("JIT failed to initialize")
+        logging.error("JIT failed to initialize, please check the log for more details.")
     elif return_code == 1:
         logging.warning("Compilation failures")
+    elif return_code == 2:
+        pass # Diffs
+    elif return_code == 3:
+        pass # Misses
+    elif return_code == 139 and coreclr_args.host_os != "windows":
+        logging.error("Fatal error, SuperPMI has returned SIGSEGV (segmentation fault), please check the log for more details.")
+    else:
+        logging.error("Unknown error code %s, please check the log for more details.", return_code)
+
+def print_superpmi_success_result(return_code, base_metrics, diff_metrics):
+    """ Print a description of a superpmi return success code.
+    """
+
+    if return_code == 0:
+        logging.info("Clean SuperPMI {} ({} contexts processed)".format("replay" if diff_metrics is None else "diff", base_metrics["Overall"]["Successful compiles"]))
     elif return_code == 2:
         logging.warning("Asm diffs found")
     elif return_code == 3:
@@ -1483,12 +1497,6 @@ def print_superpmi_result(return_code, coreclr_args, base_metrics, diff_metrics)
                 logging.warning("SuperPMI encountered missing data for {} out of {} contexts".format(missing_base, total_contexts))
             else:
                 logging.warning("SuperPMI encountered missing data. Missing with base JIT: {}. Missing with diff JIT: {}. Total contexts: {}.".format(missing_base, missing_diff, total_contexts))
-
-    elif return_code == 139 and coreclr_args.host_os != "windows":
-        logging.error("Fatal error, SuperPMI has returned SIGSEGV (segmentation fault)")
-    else:
-        logging.error("Unknown error code %s", return_code)
-
 
 def print_fail_mcl_file_method_numbers(fail_mcl_file):
     """ Given a SuperPMI ".mcl" file (containing a list of failure indices), print out the method numbers.
@@ -1722,9 +1730,10 @@ class SuperPMIReplay:
 
                 command = [self.superpmi_path] + flags + [self.jit_path, mch_file]
                 (return_code, replay_output) = run_and_log_return_output(command)
+                print_superpmi_error_result(return_code, self.coreclr_args)
 
                 replay_metrics = self.aggregate_replay_metrics(details_info_file)
-                print_superpmi_result(return_code, self.coreclr_args, replay_metrics, None)
+                print_superpmi_success_result(return_code, replay_metrics, None)
 
                 if return_code != 0:
                     # Don't report as replay failure missing data (return code 3).
@@ -2209,9 +2218,11 @@ class SuperPMIReplayAsmDiffs:
                     command = [self.superpmi_path] + flags + [self.base_jit_path, self.diff_jit_path, mch_file]
                     return_code = run_and_log(command)
 
-                (base_metrics, diff_metrics, diffs) = aggregate_diff_metrics(detailed_info_file)
+                print_superpmi_error_result(return_code, self.coreclr_args)
 
-                print_superpmi_result(return_code, self.coreclr_args, base_metrics, diff_metrics)
+                (base_metrics, diff_metrics, diffs) = aggregate_diff_metrics(detailed_info_file)
+                print_superpmi_success_result(return_code, base_metrics, diff_metrics)
+
                 artifacts_base_name = create_artifacts_base_name(self.coreclr_args, mch_file)
 
                 if return_code != 0:
@@ -2981,6 +2992,7 @@ class SuperPMIReplayThroughputDiff:
                 ]
                 flags = [
                     "-applyDiff",
+                    "-v", "ewi",
                     "-details", detailed_info_file,
                 ]
                 flags += target_flags
@@ -3015,11 +3027,10 @@ class SuperPMIReplayThroughputDiff:
                     command = [self.pin_path] + pin_options + ["--"] + [self.superpmi_path] + flags + [self.base_jit_path, self.diff_jit_path, mch_file]
                     return_code = run_and_log(command)
 
-                if return_code != 0:
-                    command_string = " ".join(command)
-                    logging.debug("'%s': Error return code: %s", command_string, return_code)
+                print_superpmi_error_result(return_code, self.coreclr_args)
 
                 (base_metrics, diff_metrics, _) = aggregate_diff_metrics(detailed_info_file)
+                print_superpmi_success_result(return_code, base_metrics, diff_metrics)
 
                 if base_metrics is not None and diff_metrics is not None:
                     base_instructions = base_metrics["Overall"]["Diff executed instructions"]

--- a/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
@@ -308,6 +308,7 @@ struct PerWorkerData
     char* detailsPath = nullptr;
     char* stdOutputPath = nullptr;
     char* stdErrorPath = nullptr;
+    SpmiResult resultCode = SpmiResult::GeneralFailure;
 };
 
 static void MergeWorkerMCLs(char* mclFilename, PerWorkerData* workerData, int workerCount, char* PerWorkerData::*mclPath)
@@ -354,6 +355,19 @@ static void MergeWorkerCsvs(char* csvFilename, PerWorkerData* workerData, int wo
     bool hasHeader = false;
     for (int i = 0; i < workerCount; i++)
     {
+        switch (workerData[i].resultCode)
+        {
+            case SpmiResult::Success:
+            case SpmiResult::Diffs:
+            case SpmiResult::Misses:
+            case SpmiResult::Error:
+                break;
+
+            default:
+                LogWarning("Skipping merging CSV from child %d due to result code %d", i, (int)workerData[i].resultCode);
+                continue;
+        }
+
         FileLineReader reader;
         if (!FileLineReader::Open(workerData[i].*csvPath, &reader))
         {
@@ -645,29 +659,58 @@ int doParallelSuperPMI(CommandLine::Options& o)
         {
             DWORD      exitCodeTmp;
             BOOL       ok          = GetExitCodeProcess(hProcesses[i], &exitCodeTmp);
-            SpmiResult childResult = (SpmiResult)exitCodeTmp;
-            if (ok && (childResult != result))
+            if (ok)
             {
-                if (result == SpmiResult::Error || childResult == SpmiResult::Error)
+                SpmiResult childResult = (SpmiResult)exitCodeTmp;
+
+                switch (childResult)
                 {
-                    result = SpmiResult::Error;
+                case SpmiResult::Success:
+                case SpmiResult::Diffs:
+                case SpmiResult::Misses:
+                case SpmiResult::Error:
+                case SpmiResult::JitFailedToInit:
+                    break;
+
+                default:
+                    // We may get here for OOM-killed, for example.
+                    LogError("Child process %d exited with code %u", i, exitCodeTmp);
+                    childResult = SpmiResult::GeneralFailure;
+                    break;
                 }
-                else if (result == SpmiResult::Diffs || childResult == SpmiResult::Diffs)
+
+                perWorkerData[i].resultCode = childResult;
+
+                if (childResult != result)
                 {
-                    result = SpmiResult::Diffs;
+                    // In priority: first failures are more important to propagate
+                    if (result == SpmiResult::GeneralFailure || childResult == SpmiResult::GeneralFailure)
+                    {
+                        result = SpmiResult::GeneralFailure;
+                    }
+                    else if (result == SpmiResult::JitFailedToInit || childResult == SpmiResult::JitFailedToInit)
+                    {
+                        result = SpmiResult::JitFailedToInit;
+                    }
+                    else if (result == SpmiResult::Error || childResult == SpmiResult::Error)
+                    {
+                        result = SpmiResult::Error;
+                    }
+                    else if (result == SpmiResult::Diffs || childResult == SpmiResult::Diffs)
+                    {
+                        result = SpmiResult::Diffs;
+                    }
+                    else if (result == SpmiResult::Misses || childResult == SpmiResult::Misses)
+                    {
+                        result = SpmiResult::Misses;
+                    }
+                    // Keep success result
                 }
-                else if (result == SpmiResult::Misses || childResult == SpmiResult::Misses)
-                {
-                    result = SpmiResult::Misses;
-                }
-                else if (result == SpmiResult::JitFailedToInit || childResult == SpmiResult::JitFailedToInit)
-                {
-                    result = SpmiResult::JitFailedToInit;
-                }
-                else
-                {
-                    result = SpmiResult::GeneralFailure;
-                }
+            }
+            else
+            {
+                LogError("Could not get exit code for child process %d\n", i);
+                result = SpmiResult::GeneralFailure;
             }
         }
 


### PR DESCRIPTION
superpmi.py did not handle subprocess failures very well on linux. This makes a bunch of improvements around this scenario to make it easier to realize when something is wrong, and what is wrong.

- On failures, avoid merging the .csv files together of child processes that failed with "unknown" or general failure exit codes. Their csv files may be corrupted. In one particular case the sub process had been killed by the OOM-killer, so the .csv file was truncated.
- Split the printing of the superpmi error and success codes in superpmi.py. The printing of the error is done before we try parsing the .csv file, to ensure we get some reasonable output even if we end up failing while parsing the .csv file.
- Turn on some logging for tpdiff
- Log child exit code when it is a failure exit code. Otherwise this condition does not show up anywhere.

#104902 is also important to make the diagnosibility good. Before that change the PAL will return failure code 1 for any signal terminating the sub process (like OOM-killed). Exit code 1 coincides with `SpmiResult::Failure` that we use when we hit any JIT asserts, which is a more expected failure than e.g. a OOM-kill. 