### PR TITLE
Fix EH stacktrace keepalive array copy size

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -2975,7 +2975,7 @@ void StackTraceInfo::EnsureKeepAliveArray(PTRARRAYREF *ppKeepAliveArray, size_t 
         {
             memmoveGCRefs(pNewKeepAliveArray->GetDataPtr(),
                           (*ppKeepAliveArray)->GetDataPtr(),
-                          neededSize * sizeof(Object *));        
+                          (*ppKeepAliveArray)->GetNumComponents() * sizeof(Object *));
         }
         // Update the keepAlive array
         *ppKeepAliveArray = pNewKeepAliveArray;


### PR DESCRIPTION
When the stacktrace keepalive array is grown, we were incorrectly copying extra item from the original keepalive array to the new one. In some cases, it ended up adding garbage to the array and GC object verification has hickuped on it. In the CI, it was only hit by GCStress-Extra tests that set DOTNET_HeapVerify=1 so far.

This fixes the copied size to be the source array's number of elements.

Close #104878