### PR TITLE
[release/8.0-staging] [Mono] Fix the race condition issue of aot_module loading

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -815,7 +815,7 @@ get_module_event_data (
 		module_data->module_flags = MODULE_FLAGS_MANIFEST_MODULE;
 		if (image && image->dynamic)
 			module_data->module_flags |= MODULE_FLAGS_DYNAMIC_MODULE;
-		if (image && image->aot_module)
+		if (image && image->aot_module && (image->aot_module != AOT_MODULE_NOT_FOUND))
 			module_data->module_flags |= MODULE_FLAGS_NATIVE_MODULE;
 
 		module_data->module_il_path = NULL;
@@ -905,7 +905,7 @@ fire_assembly_events (
 	if (assembly->dynamic)
 		assembly_flags |= ASSEMBLY_FLAGS_DYNAMIC_ASSEMBLY;
 
-	if (assembly->image && assembly->image->aot_module) {
+	if (assembly->image && assembly->image->aot_module && (assembly->image->aot_module != AOT_MODULE_NOT_FOUND)) {
 		assembly_flags |= ASSEMBLY_FLAGS_NATIVE_ASSEMBLY;
 	}
 
@@ -2154,7 +2154,7 @@ get_assembly_event_data (
 		if (assembly->dynamic)
 			assembly_data->assembly_flags |= ASSEMBLY_FLAGS_DYNAMIC_ASSEMBLY;
 
-		if (assembly->image && assembly->image->aot_module)
+		if (assembly->image && assembly->image->aot_module && (assembly->image->aot_module != AOT_MODULE_NOT_FOUND))
 			assembly_data->assembly_flags |= ASSEMBLY_FLAGS_NATIVE_ASSEMBLY;
 
 		assembly_data->assembly_name = mono_stringify_assembly_name (&assembly->aname);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1231,7 +1231,8 @@ mono_interp_jit_call_supported (MonoMethod *method, MonoMethodSignature *sig)
 	if (!interp_jit_call_can_be_supported (method, sig, mono_llvm_only))
 		return FALSE;
 
-	if (mono_aot_only && m_class_get_image (method->klass)->aot_module && !(method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)) {
+	MonoAotModule *amodule = m_class_get_image (method->klass)->aot_module;
+	if (mono_aot_only && amodule && (amodule != AOT_MODULE_NOT_FOUND) && !(method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)) {
 		ERROR_DECL (error);
 		mono_class_init_internal (method->klass);
 		gpointer addr = mono_aot_get_method (method, error);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3034,7 +3034,8 @@ emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJitICallId ji
 
 				MonoMethod* const method = call->method;
 
-				if (m_class_get_image (method->klass)->aot_module)
+				MonoAotModule *amodule = m_class_get_image (method->klass)->aot_module;
+				if (amodule && (amodule != AOT_MODULE_NOT_FOUND))
 					/* The callee might be an AOT method */
 					near_call = FALSE;
 				if (method->dynamic)

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -423,6 +423,8 @@ struct MonoSpillInfo {
 	int offset;
 };
 
+#define AOT_MODULE_NOT_FOUND GINT_TO_POINTER (-1)
+
 /*
  * Information about a call site for the GC map creation code
  */


### PR DESCRIPTION
Backport of #103975 to release/8.0

/cc @fanyang-mono

## Customer Impact
Prior to this change, Maui Android customer's app would run into `Invalid IL code` error when setting `AndroidStripILAfterAOT=true`. The customer's app would either hit `InvalidProgramException` or crash completely. The customers reported the issue via https://github.com/dotnet/runtime/issues/103782 and https://github.com/dotnet/runtime/issues/104156

When setting `AndroidStripILAfterAOT=true`, the IL code for the AOT'ed methods would be removed. As a result, JIT would fail with an error like `Invalid IL code`, if the runtime attempts to do so. Usually, when a method was AOT compiled, Mono runtime would use it instead of attempting to JIT it. What happened to this customer reported scenario was that `mono_aot_get_method` raced with `load_aot_module` - one thread attemptted to read `MonoImage:aot_module` while the other thread was still loading the aot module. `MonoImage:aot_module` contained the information of where the AOT'ed code lives. When it wasn't fully loaded, Mono runtime thought it didn't exist. However, this race condition only happened when two threads were trying to invoke methods from the same assembly, which also happened to be not loaded yet. It is often related to the usage of reflection.

Before this PR, there wasn't a way to tell if an aot module was loaded but not found or wasn't loaded at all. This PR introduced a way to differentiate it. Now when `mono_aot_get_method` sees that the aot module wasn't loaded yet, it will wait a little bit and try again.

## Testing
Manually validated the problematic maui Android app reported in the original issue (https://github.com/dotnet/runtime/issues/103782). It works correctly now.

## Risk
Moderate risk. The race condition that this PR is fixing happens very rarely. So far it only happened to a handful of Maui Android customers. This PR doesn't change the behavior when there isn't a race condition, which is the majority of the case. Additionally, we had monitored microbenchmarks results for two weeks and didn't see any performance regressions caused by this change.

