### PR TITLE
Replace more Unsafe.SizeOf<T> with sizeof(T)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -388,7 +388,7 @@
     <Features>strict;nullablePublicOnly</Features>
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
     <!-- Warnings to always disable -->
-    <NoWarn>$(NoWarn),CS8969</NoWarn>
+    <NoWarn>$(NoWarn);CS8500;CS8969</NoWarn>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</KeepNativeSymbols>

--- a/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -58,7 +58,6 @@ namespace System
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ArgIterator_Init2")]
         private static partial void Init(ArgIterator* thisPtr, IntPtr cookie, void* ptr);
 
-#pragma warning disable CS8500 // Takes a pointer to a managed type
         // Fetch an argument as a typed referece, advance the iterator.
         // Throws an exception if past end of argument list
         [CLSCompliant(false)]

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -790,9 +790,7 @@ namespace System
                 // for debug builds we always want to call AllocateNewArray to detect AllocateNewArray bugs
 #if !DEBUG
                 // small arrays are allocated using `new[]` as that is generally faster.
-#pragma warning disable 8500 // sizeof of managed types
                 if (length < 2048 / sizeof(T))
-#pragma warning restore 8500
                 {
                     return new T[length];
                 }
@@ -892,9 +890,7 @@ namespace System
                 Configurations = new Dictionary<string, object>()
             };
 
-#pragma warning disable CS8500 // takes address of managed type
             _EnumerateConfigurationValues(&context, &ConfigCallback);
-#pragma warning restore CS8500
             return context.Configurations!;
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
@@ -93,9 +93,7 @@ namespace System.Reflection
                 throw new ArgumentException(SR.Arg_TypedReference_Null);
 
             // Passing TypedReference by reference is easier to make correct in native code
-#pragma warning disable CS8500 // Takes a pointer to a managed type
             return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType?)DeclaringType);
-#pragma warning restore CS8500
         }
 
         [DebuggerStepThrough]
@@ -111,9 +109,7 @@ namespace System.Reflection
                 throw new ArgumentException(SR.Arg_TypedReference_Null);
 
             // Passing TypedReference by reference is easier to make correct in native code
-#pragma warning disable CS8500 // Takes a pointer to a managed type
             RuntimeFieldHandle.SetValueDirect(this, (RuntimeType)FieldType, &obj, value, (RuntimeType?)DeclaringType);
-#pragma warning restore CS8500
         }
 
         public override RuntimeFieldHandle FieldHandle => new RuntimeFieldHandle(this);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/DependentHandle.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/DependentHandle.cs
@@ -253,9 +253,7 @@ namespace System.Runtime
         // This optimization is the same that is used in GCHandle in RELEASE mode.
         // This is not used in DEBUG builds as the runtime performs additional checks.
         // The logic below is the inlined copy of ObjectFromHandle in the unmanaged runtime.
-#pragma warning disable 8500 // address of managed types
         private static unsafe object? InternalGetTarget(IntPtr dependentHandle) => *(object*)dependentHandle;
-#pragma warning restore 8500
 #endif
 
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/InternalCalls.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/InternalCalls.cs
@@ -23,7 +23,6 @@ namespace System.Runtime.ExceptionServices
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ResumeAtInterceptionLocation")]
         internal static unsafe partial void ResumeAtInterceptionLocation(void* pvRegDisplay);
 
-#pragma warning disable CS8500
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "CallCatchFunclet")]
         internal static unsafe partial IntPtr RhpCallCatchFunclet(
             ObjectHandleOnStack exceptionObj, byte* pHandlerIP, void* pvRegDisplay, EH.ExInfo* exInfo);
@@ -38,7 +37,6 @@ namespace System.Runtime.ExceptionServices
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AppendExceptionStackFrame")]
         internal static unsafe partial void RhpAppendExceptionStackFrame(ObjectHandleOnStack exceptionObj, IntPtr ip, UIntPtr sp, int flags, EH.ExInfo* exInfo);
-#pragma warning restore CS8500
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EHEnumInitFromStackFrameIterator")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.CoreCLR.cs
@@ -46,9 +46,7 @@ namespace System.Runtime.InteropServices
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern object? InternalGet(IntPtr handle);
 #else
-#pragma warning disable 8500 // address of managed types
         internal static unsafe object? InternalGet(IntPtr handle) => *(object*)handle;
-#pragma warning restore 8500
 #endif
 
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -206,7 +206,6 @@ namespace Internal.Runtime.CompilerHelpers
                 nint blockAddr = MethodTable.SupportsRelativePointers ? (nint)ReadRelPtr32(pBlock) : *pBlock;
                 if ((blockAddr & GCStaticRegionConstants.Uninitialized) == GCStaticRegionConstants.Uninitialized)
                 {
-#pragma warning disable CS8500 // takes address of managed type
                     object? obj = null;
                     RuntimeImports.RhAllocateNewObject(
                         new IntPtr(blockAddr & ~GCStaticRegionConstants.Mask),
@@ -234,7 +233,6 @@ namespace Internal.Runtime.CompilerHelpers
 
                     // Update the base pointer to point to the pinned object
                     *pBlock = *(IntPtr*)&obj;
-#pragma warning restore CS8500
                 }
 
                 currentBase++;

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
@@ -15,9 +15,7 @@ namespace System.Runtime
         private static unsafe IntPtr RhpCidResolve(IntPtr callerTransitionBlockParam, IntPtr pCell)
         {
             IntPtr locationOfThisPointer = callerTransitionBlockParam + TransitionBlock.GetThisOffset();
-#pragma warning disable 8500 // address of managed types
             object pObject = *(object*)locationOfThisPointer;
-#pragma warning restore 8500
             IntPtr dispatchResolveTarget = RhpCidResolve_Worker(pObject, pCell);
             return dispatchResolveTarget;
         }

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -279,12 +279,11 @@ namespace System.Runtime
                 isFirstFrame = false;
             }
 #else
-#pragma warning disable CS8500
             fixed (EH.ExInfo* pExInfo = &exInfo)
             {
                 InternalCalls.RhpAppendExceptionStackFrame(ObjectHandleOnStack.Create(ref exception), ip, sp, flags, pExInfo);
             }
-#pragma warning restore CS8500
+
             // Clear flags only if we called the function
             isFirstRethrowFrame = false;
             isFirstFrame = false;
@@ -686,13 +685,11 @@ namespace System.Runtime
             if (unwoundReversePInvoke)
             {
                 object exceptionObj = exInfo.ThrownException;
-#pragma warning disable CS8500
                 fixed (EH.ExInfo* pExInfo = &exInfo)
                 {
                     InternalCalls.RhpCallCatchFunclet(
                         ObjectHandleOnStack.Create(ref exceptionObj), null, exInfo._frameIter.RegisterSet, pExInfo);
                 }
-#pragma warning restore CS8500
             }
             else
             {
@@ -922,13 +919,11 @@ namespace System.Runtime
             InternalCalls.RhpCallCatchFunclet(
                 exceptionObj, pCatchHandler, frameIter.RegisterSet, ref exInfo);
 #else // NATIVEAOT
-#pragma warning disable CS8500
             fixed (EH.ExInfo* pExInfo = &exInfo)
             {
                 InternalCalls.RhpCallCatchFunclet(
                     ObjectHandleOnStack.Create(ref exceptionObj), pCatchHandler, frameIter.RegisterSet, pExInfo);
             }
-#pragma warning restore CS8500
 #endif // NATIVEAOT
             // currently, RhpCallCatchFunclet will resume after the catch
             Debug.Assert(false, "unreachable");
@@ -1209,12 +1204,10 @@ namespace System.Runtime
 #if NATIVEAOT
                 InternalCalls.RhpCallFinallyFunclet(pFinallyHandler, exInfo._frameIter.RegisterSet);
 #else // NATIVEAOT
-#pragma warning disable CS8500
                 fixed (EH.ExInfo* pExInfo = &exInfo)
                 {
                     InternalCalls.RhpCallFinallyFunclet(pFinallyHandler, exInfo._frameIter.RegisterSet, pExInfo);
                 }
-#pragma warning restore CS8500
 #endif // NATIVEAOT
                 exInfo._idxCurClause = MaxTryRegionIdx;
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
@@ -695,9 +695,7 @@ namespace System
                 Configurations = new Dictionary<string, object>()
             };
 
-#pragma warning disable CS8500 // takes address of managed type
             RuntimeImports.RhEnumerateConfigurationValues(&context, &ConfigCallback);
-#pragma warning restore CS8500
             return context.Configurations!;
         }
 
@@ -810,9 +808,7 @@ namespace System
                 // for debug builds we always want to call AllocateNewArray to detect AllocateNewArray bugs
 #if !DEBUG
                 // small arrays are allocated using `new[]` as that is generally faster.
-#pragma warning disable 8500 // sizeof of managed types
                 if (length < 2048 / sizeof(T))
-#pragma warning restore 8500
                 {
                     return new T[length];
                 }
@@ -832,9 +828,7 @@ namespace System
                     throw new OverflowException();
 
                 T[]? array = null;
-#pragma warning disable CS8500 // takes address of managed type
                 RuntimeImports.RhAllocateNewArray(MethodTable.Of<T[]>(), (uint)length, (uint)flags, &array);
-#pragma warning restore CS8500
                 if (array == null)
                     throw new OutOfMemoryException();
 
@@ -861,9 +855,7 @@ namespace System
                 throw new OverflowException();
 
             T[]? array = null;
-#pragma warning disable CS8500 // takes address of managed type
             RuntimeImports.RhAllocateNewArray(MethodTable.Of<T[]>(), (uint)length, (uint)flags, &array);
-#pragma warning restore CS8500
             if (array == null)
                 throw new OutOfMemoryException();
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
@@ -365,9 +365,7 @@ namespace System.Reflection
             else if (argCount == 1)
             {
                 ByReference br = ByReference.Create(ref parameters[0]);
-#pragma warning disable CS8500
                 void* pByrefStorage = &br;
-#pragma warning restore CS8500
 
                 // Since no copy of args is required, pass 'parameters' for both arguments.
                 CheckArguments(parameters, pByrefStorage, parameters);
@@ -410,9 +408,7 @@ namespace System.Reflection
             IntPtr* pStorage = stackalloc IntPtr[2 * argCount];
             NativeMemory.Clear(pStorage, (nuint)(2 * argCount) * (nuint)sizeof(IntPtr));
 
-#pragma warning disable 8500
             void* pByRefStorage = (ByReference*)(pStorage + argCount);
-#pragma warning restore 8500
 
             GCFrameRegistration regArgStorage = new((void**)pStorage, (uint)argCount, areByRefs: false);
             GCFrameRegistration regByRefStorage = new((void**)pByRefStorage, (uint)argCount, areByRefs: true);
@@ -461,9 +457,7 @@ namespace System.Reflection
             IntPtr* pStorage = stackalloc IntPtr[2 * argCount];
             NativeMemory.Clear(pStorage, (nuint)(2 * argCount) * (nuint)sizeof(IntPtr));
 
-#pragma warning disable 8500
             void* pByRefStorage = (ByReference*)(pStorage + argCount);
-#pragma warning restore 8500
 
             GCFrameRegistration regArgStorage = new((void**)pStorage, (uint)argCount, areByRefs: false);
             GCFrameRegistration regByRefStorage = new((void**)pByRefStorage, (uint)argCount, areByRefs: true);
@@ -501,9 +495,7 @@ namespace System.Reflection
             StackAllocatedArguments argStorage = default;
             Span<object?> copyOfParameters = ((Span<object?>)argStorage._args).Slice(0, _argumentCount);
             StackAllocatedByRefs byrefStorage = default;
-#pragma warning disable CS8500
             void* pByRefStorage = (ByReference*)&byrefStorage;
-#pragma warning restore CS8500
 
             CheckArguments(copyOfParameters, pByRefStorage, parameters, binderBundle);
 
@@ -535,9 +527,7 @@ namespace System.Reflection
             StackAllocatedArguments argStorage = default;
             Span<object?> copyOfParameters = ((Span<object?>)argStorage._args).Slice(0, _argumentCount);
             StackAllocatedByRefs byrefStorage = default;
-#pragma warning disable CS8500
             void* pByRefStorage = (ByReference*)&byrefStorage;
-#pragma warning restore CS8500
 
             CheckArguments(copyOfParameters, pByRefStorage, parameters);
 
@@ -562,9 +552,7 @@ namespace System.Reflection
             Debug.Assert(_argumentCount <= MaxStackAllocArgCount);
 
             StackAllocatedByRefs byrefStorage = default;
-#pragma warning disable CS8500
             void* pByRefStorage = (ByReference*)&byrefStorage;
-#pragma warning restore CS8500
 
             // Since no copy of args is required, pass 'parameters' for both arguments.
             CheckArguments(parameters, pByRefStorage, parameters);
@@ -686,10 +674,10 @@ namespace System.Reflection
 
                 copyOfParameters[i] = arg!;
 
-#pragma warning disable 8500, 9094
+#pragma warning disable 9094
                 ((ByReference*)byrefParameters)[i] = new ByReference(ref (argumentInfo.Transform & Transform.Reference) != 0 ?
                     ref Unsafe.As<object?, byte>(ref copyOfParameters[i]) : ref arg.GetRawData());
-#pragma warning restore 8500, 9094
+#pragma warning restore 9094
             }
         }
 
@@ -763,10 +751,10 @@ namespace System.Reflection
 
                 copyOfParameters[i] = arg;
 
-#pragma warning disable 8500, 9094
+#pragma warning disable 9094
                 ((ByReference*)byrefParameters)[i] = new ByReference(ref (argumentInfo.Transform & Transform.Reference) != 0 ?
                     ref Unsafe.As<object?, byte>(ref copyOfParameters[i]) : ref arg.GetRawData());
-#pragma warning restore 8500, 9094
+#pragma warning restore 9094
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
@@ -9,8 +9,6 @@ using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Reflection
 {
     public abstract class EnumInfo

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -429,10 +429,8 @@ namespace System.Runtime.InteropServices
             private static bool IsRootedCallback(IntPtr pObj)
             {
                 // We are paused in the GC, so this is safe.
-#pragma warning disable CS8500 // Takes a pointer to a managed type
                 ManagedObjectWrapperHolder* holder = (ManagedObjectWrapperHolder*)&pObj;
                 return holder->_wrapper->IsRooted;
-#pragma warning restore CS8500
             }
 
             private readonly ManagedObjectWrapper* _wrapper;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
@@ -260,9 +260,7 @@ namespace System.Runtime.InteropServices
 
             // Compat note: CLR wouldn't bother with a range check. If someone does this,
             // they're likely taking dependency on some CLR implementation detail quirk.
-#pragma warning disable 8500 // sizeof of managed types
             ArgumentOutOfRangeException.ThrowIfGreaterThan(checked(ofs + sizeof(T)), size, nameof(ofs));
-#pragma warning restore 8500
 
             IntPtr nativeBytes = AllocCoTaskMem(size);
             NativeMemory.Clear((void*)nativeBytes, (nuint)size);
@@ -340,9 +338,7 @@ namespace System.Runtime.InteropServices
 
             // Compat note: CLR wouldn't bother with a range check. If someone does this,
             // they're likely taking dependency on some CLR implementation detail quirk.
-#pragma warning disable 8500 // sizeof of managed types
             ArgumentOutOfRangeException.ThrowIfGreaterThan(checked(ofs + sizeof(T)), size, nameof(ofs));
-#pragma warning restore 8500
 
             IntPtr nativeBytes = AllocCoTaskMem(size);
             NativeMemory.Clear((void*)nativeBytes, (nuint)size);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -350,11 +350,9 @@ namespace Internal.JitInterface
             IntPtr exception;
             IntPtr nativeEntry;
             uint codeSize;
-#pragma warning disable CS8500 // takes address of managed type
             var result = JitCompileMethod(out exception,
                     _jit, (IntPtr)(&_this), _unmanagedCallbacks,
                     ref methodInfo, (uint)CorJitFlag.CORJIT_FLAG_CALL_GETJITFLAGS, out nativeEntry, out codeSize);
-#pragma warning restore CS8500
             if (exception != IntPtr.Zero)
             {
                 if (_lastException != null)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
@@ -10,7 +10,7 @@
     <!-- ILSpy requires this assembly to target netstandard2.0 -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
-    <NoWarn>8002,NU1701</NoWarn>
+    <NoWarn>$(NoWarn);8002;NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <OutputPath>$(RuntimeBinDir)</OutputPath>
     <Platforms>AnyCPU;x64</Platforms>

--- a/src/coreclr/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/tools/r2rdump/R2RDump.csproj
@@ -9,7 +9,7 @@
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
-    <NoWarn>8002,NU1701</NoWarn>
+    <NoWarn>$(NoWarn);8002;NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <OutputPath>$(RuntimeBinDir)/R2RDump</OutputPath>
     <RunAnalyzers>false</RunAnalyzers>

--- a/src/coreclr/tools/r2rtest/R2RTest.csproj
+++ b/src/coreclr/tools/r2rtest/R2RTest.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
-    <NoWarn>8002,NU1701</NoWarn>
+    <NoWarn>$(NoWarn);8002;NU1701</NoWarn>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>$(RuntimeBinDir)\R2RTest</OutputPath>
     <RunAnalyzers>false</RunAnalyzers>

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.cs
@@ -7,8 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // takes address of managed type
-
 internal static partial class Interop
 {
     internal static partial class Sys

--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -193,10 +193,8 @@ namespace System
             }
             return result.ToString();
 #else
-#pragma warning disable CS8500 // takes address of managed type
             return string.Create(bytes.Length * 2, (RosPtr: (IntPtr)(&bytes), casing), static (chars, args) =>
                 EncodeToUtf16(*(ReadOnlySpan<byte>*)args.RosPtr, chars, args.casing));
-#pragma warning restore CS8500
 #endif
         }
 

--- a/src/libraries/Common/src/System/IO/Archiving.Utils.Windows.cs
+++ b/src/libraries/Common/src/System/IO/Archiving.Utils.Windows.cs
@@ -69,7 +69,6 @@ namespace System.IO
                     string.Empty;
             }
 
-#pragma warning disable CS8500 // takes address of managed type
             ReadOnlySpan<char> tmpPath = path; // avoid address exposing the span and impacting the other code in the method that uses it
             return string.Create(appendPathSeparator ? tmpPath.Length + 1 : tmpPath.Length, (appendPathSeparator, RosPtr: (IntPtr)(&tmpPath)), static (dest, state) =>
             {
@@ -84,7 +83,6 @@ namespace System.IO
                 // all slashes should be forward slashes.
                 dest.Replace('\\', '/');
             });
-#pragma warning restore CS8500
         }
     }
 }

--- a/src/libraries/Fuzzing/DotnetFuzzing/DotnetFuzzing.csproj
+++ b/src/libraries/Fuzzing/DotnetFuzzing/DotnetFuzzing.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <NoWarn>CA2252</NoWarn>
+    <NoWarn>$(NoWarn);CA2252</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
@@ -569,9 +569,7 @@ namespace Microsoft.Extensions.Logging.EventSource
             else
             {
                 eventData.DataPointer = (IntPtr)Unsafe.AsPointer(ref value);
-#pragma warning disable 8500 // sizeof of managed types
                 eventData.Size = sizeof(T);
-#pragma warning restore 8500
             }
         }
     }

--- a/src/libraries/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/libraries/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NoWarn>0436</NoWarn>
+    <NoWarn>$(NoWarn);0436</NoWarn>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and ('$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi')">true</DebuggerSupport>
   </PropertyGroup>

--- a/src/libraries/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
@@ -11,12 +11,10 @@ namespace System.Buffers
 
         public sealed override unsafe IMemoryOwner<T> Rent(int minimumBufferSize = -1)
         {
-#pragma warning disable 8500 // sizeof of managed types
             if (minimumBufferSize == -1)
                 minimumBufferSize = 1 + (4095 / sizeof(T));
             else if (((uint)minimumBufferSize) > Array.MaxLength)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumBufferSize);
-#pragma warning restore 8500
 
             return new ArrayMemoryPoolBuffer(minimumBufferSize);
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4GlobalStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4GlobalStatistics.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
-#pragma warning disable 8500 // taking address of managed types
-
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIPv4GlobalStatistics : IPGlobalStatistics

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceProperties.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
-#pragma warning disable 8500 // taking address of managed types
-
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIpInterfaceProperties : UnixIPInterfaceProperties

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdNetworkInterface.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // taking address of managed types
-
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdNetworkInterface : UnixNetworkInterface

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
@@ -8,8 +8,6 @@ using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
-#pragma warning disable 8500 // taking address of managed types
-
 namespace System.Net.NetworkInformation
 {
     internal abstract class UnixIPGlobalProperties : IPGlobalProperties

--- a/src/libraries/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/libraries/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>169,649</NoWarn>
+    <NoWarn>$(NoWarn);169;649</NoWarn>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser</TargetFrameworks>
   </PropertyGroup>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -63,7 +63,7 @@ namespace System.Net.Security
             SSPIWrapper.GetVerifyPackageInfo(GlobalSSPI.SSPISecureChannel, SecurityPackage, true);
         }
 
-        private static void SetAlpn(ref InputSecurityBuffers inputBuffers, List<SslApplicationProtocol> alpn, Span<byte> localBuffer)
+        private static unsafe void SetAlpn(ref InputSecurityBuffers inputBuffers, List<SslApplicationProtocol> alpn, Span<byte> localBuffer)
         {
             if (alpn.Count == 1 && alpn[0] == SslApplicationProtocol.Http11)
             {
@@ -84,7 +84,7 @@ namespace System.Net.Security
             else
             {
                 int protocolLength = Interop.Sec_Application_Protocols.GetProtocolLength(alpn);
-                int bufferLength = Unsafe.SizeOf<Interop.Sec_Application_Protocols>() + protocolLength;
+                int bufferLength = sizeof(Interop.Sec_Application_Protocols) + protocolLength;
 
                 Span<byte> alpnBuffer = bufferLength <= localBuffer.Length ? localBuffer : new byte[bufferLength];
                 Interop.Sec_Application_Protocols.SetProtocols(alpnBuffer, alpn, protocolLength);

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -7,7 +7,7 @@
       Dependencies are broken via Fakes. Since we are referencing netstandard, the real types can conflict with the ones
       imported. We are disabling the "Type conflicts with the imported type CS0436 warning" for these types of projects.
     -->
-    <NoWarn>436</NoWarn>
+    <NoWarn>$(NoWarn);436</NoWarn>
     <!-- Disable: CLSCompliant attribute is not needed -->
     <NoWarn>$(NoWarn);3021;SYSLIB0057</NoWarn>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-android</TargetFrameworks>

--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
@@ -4,8 +4,6 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-#pragma warning disable 8500 // address / sizeof of managed types
-
 namespace System.Buffers
 {
     public readonly partial struct NIndex : System.IEquatable<System.Buffers.NIndex>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Helpers.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     /// <summary>Performs primitive tensor operations over spans of memory.</summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IAggregationOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IAggregationOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives
@@ -2278,28 +2276,28 @@ namespace System.Numerics.Tensors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<T> CreateAlignmentMaskVector128<T>(int count)
         {
-            if (Unsafe.SizeOf<T>() == 1)
+            if (sizeof(T) == 1)
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<byte, T>(ref MemoryMarshal.GetReference(AlignmentByteMask_64x65)),
                     (uint)(count * 64));
             }
 
-            if (Unsafe.SizeOf<T>() == 2)
+            if (sizeof(T) == 2)
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<ushort, T>(ref MemoryMarshal.GetReference(AlignmentUInt16Mask_32x33)),
                     (uint)(count * 32));
             }
 
-            if (Unsafe.SizeOf<T>() == 4)
+            if (sizeof(T) == 4)
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<uint, T>(ref MemoryMarshal.GetReference(AlignmentUInt32Mask_16x17)),
                     (uint)(count * 16));
             }
 
-            Debug.Assert(Unsafe.SizeOf<T>() == 8);
+            Debug.Assert(sizeof(T) == 8);
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<ulong, T>(ref MemoryMarshal.GetReference(AlignmentUInt64Mask_8x9)),
@@ -2314,28 +2312,28 @@ namespace System.Numerics.Tensors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector256<T> CreateAlignmentMaskVector256<T>(int count)
         {
-            if (Unsafe.SizeOf<T>() == 1)
+            if (sizeof(T) == 1)
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<byte, T>(ref MemoryMarshal.GetReference(AlignmentByteMask_64x65)),
                     (uint)(count * 64));
             }
 
-            if (Unsafe.SizeOf<T>() == 2)
+            if (sizeof(T) == 2)
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<ushort, T>(ref MemoryMarshal.GetReference(AlignmentUInt16Mask_32x33)),
                     (uint)(count * 32));
             }
 
-            if (Unsafe.SizeOf<T>() == 4)
+            if (sizeof(T) == 4)
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<uint, T>(ref MemoryMarshal.GetReference(AlignmentUInt32Mask_16x17)),
                     (uint)(count * 16));
             }
 
-            Debug.Assert(Unsafe.SizeOf<T>() == 8);
+            Debug.Assert(sizeof(T) == 8);
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<ulong, T>(ref MemoryMarshal.GetReference(AlignmentUInt64Mask_8x9)),
@@ -2350,28 +2348,28 @@ namespace System.Numerics.Tensors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector512<T> CreateAlignmentMaskVector512<T>(int count)
         {
-            if (Unsafe.SizeOf<T>() == 1)
+            if (sizeof(T) == 1)
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<byte, T>(ref MemoryMarshal.GetReference(AlignmentByteMask_64x65)),
                     (uint)(count * 64));
             }
 
-            if (Unsafe.SizeOf<T>() == 2)
+            if (sizeof(T) == 2)
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<ushort, T>(ref MemoryMarshal.GetReference(AlignmentUInt16Mask_32x33)),
                     (uint)(count * 32));
             }
 
-            if (Unsafe.SizeOf<T>() == 4)
+            if (sizeof(T) == 4)
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<uint, T>(ref MemoryMarshal.GetReference(AlignmentUInt32Mask_16x17)),
                     (uint)(count * 16));
             }
 
-            Debug.Assert(Unsafe.SizeOf<T>() == 8);
+            Debug.Assert(sizeof(T) == 8);
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<ulong, T>(ref MemoryMarshal.GetReference(AlignmentUInt64Mask_8x9)),
@@ -2386,28 +2384,28 @@ namespace System.Numerics.Tensors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<T> CreateRemainderMaskVector128<T>(int count)
         {
-            if (Unsafe.SizeOf<T>() == 1)
+            if (sizeof(T) == 1)
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<byte, T>(ref MemoryMarshal.GetReference(RemainderByteMask_64x65)),
                     (uint)(count * 64) + 48); // last 16 bytes in the row
             }
 
-            if (Unsafe.SizeOf<T>() == 2)
+            if (sizeof(T) == 2)
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<ushort, T>(ref MemoryMarshal.GetReference(RemainderUInt16Mask_32x33)),
                     (uint)(count * 32) + 24); // last 8 shorts in the row
             }
 
-            if (Unsafe.SizeOf<T>() == 4)
+            if (sizeof(T) == 4)
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<uint, T>(ref MemoryMarshal.GetReference(RemainderUInt32Mask_16x17)),
                     (uint)(count * 16) + 12); // last 4 ints in the row
             }
 
-            Debug.Assert(Unsafe.SizeOf<T>() == 8);
+            Debug.Assert(sizeof(T) == 8);
             {
                 return Vector128.LoadUnsafe(
                     ref Unsafe.As<ulong, T>(ref MemoryMarshal.GetReference(RemainderUInt64Mask_8x9)),
@@ -2422,28 +2420,28 @@ namespace System.Numerics.Tensors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector256<T> CreateRemainderMaskVector256<T>(int count)
         {
-            if (Unsafe.SizeOf<T>() == 1)
+            if (sizeof(T) == 1)
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<byte, T>(ref MemoryMarshal.GetReference(RemainderByteMask_64x65)),
                     (uint)(count * 64) + 32); // last 32 bytes in the row
             }
 
-            if (Unsafe.SizeOf<T>() == 2)
+            if (sizeof(T) == 2)
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<ushort, T>(ref MemoryMarshal.GetReference(RemainderUInt16Mask_32x33)),
                     (uint)(count * 32) + 16); // last 16 shorts in the row
             }
 
-            if (Unsafe.SizeOf<T>() == 4)
+            if (sizeof(T) == 4)
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<uint, T>(ref MemoryMarshal.GetReference(RemainderUInt32Mask_16x17)),
                     (uint)(count * 16) + 8); // last 8 ints in the row
             }
 
-            Debug.Assert(Unsafe.SizeOf<T>() == 8);
+            Debug.Assert(sizeof(T) == 8);
             {
                 return Vector256.LoadUnsafe(
                     ref Unsafe.As<ulong, T>(ref MemoryMarshal.GetReference(RemainderUInt64Mask_8x9)),
@@ -2458,28 +2456,28 @@ namespace System.Numerics.Tensors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector512<T> CreateRemainderMaskVector512<T>(int count)
         {
-            if (Unsafe.SizeOf<T>() == 1)
+            if (sizeof(T) == 1)
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<byte, T>(ref MemoryMarshal.GetReference(RemainderByteMask_64x65)),
                     (uint)(count * 64));
             }
 
-            if (Unsafe.SizeOf<T>() == 2)
+            if (sizeof(T) == 2)
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<ushort, T>(ref MemoryMarshal.GetReference(RemainderUInt16Mask_32x33)),
                     (uint)(count * 32));
             }
 
-            if (Unsafe.SizeOf<T>() == 4)
+            if (sizeof(T) == 4)
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<uint, T>(ref MemoryMarshal.GetReference(RemainderUInt32Mask_16x17)),
                     (uint)(count * 16));
             }
 
-            Debug.Assert(Unsafe.SizeOf<T>() == 8);
+            Debug.Assert(sizeof(T) == 8);
             {
                 return Vector512.LoadUnsafe(
                     ref Unsafe.As<ulong, T>(ref MemoryMarshal.GetReference(RemainderUInt64Mask_8x9)),

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IBinaryOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IBinaryOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives
@@ -2740,27 +2738,27 @@ namespace System.Numerics.Tensors
         {
             // We need to do log2(count) operations to compute the total sum
 
-            if (Unsafe.SizeOf<T>() == 1)
+            if (sizeof(T) == 1)
             {
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsByte(), Vector128.Create((byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7)).As<byte, T>());
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsByte(), Vector128.Create((byte)4, 5, 6, 7, 0, 1, 2, 3, 8, 9, 10, 11, 12, 13, 14, 15)).As<byte, T>());
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsByte(), Vector128.Create((byte)2, 3, 0, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)).As<byte, T>());
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsByte(), Vector128.Create((byte)1, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)).As<byte, T>());
             }
-            else if (Unsafe.SizeOf<T>() == 2)
+            else if (sizeof(T) == 2)
             {
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsInt16(), Vector128.Create(4, 5, 6, 7, 0, 1, 2, 3)).As<short, T>());
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsInt16(), Vector128.Create(2, 3, 0, 1, 4, 5, 6, 7)).As<short, T>());
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsInt16(), Vector128.Create(1, 0, 2, 3, 4, 5, 6, 7)).As<short, T>());
             }
-            else if (Unsafe.SizeOf<T>() == 4)
+            else if (sizeof(T) == 4)
             {
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsInt32(), Vector128.Create(2, 3, 0, 1)).As<int, T>());
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsInt32(), Vector128.Create(1, 0, 3, 2)).As<int, T>());
             }
             else
             {
-                Debug.Assert(Unsafe.SizeOf<T>() == 8);
+                Debug.Assert(sizeof(T) == 8);
                 x = TAggregate.Invoke(x, Vector128.Shuffle(x.AsInt64(), Vector128.Create(1, 0)).As<long, T>());
             }
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IIndexOfOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IIndexOfOperator.cs
@@ -5,8 +5,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IStatefulUnaryOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IStatefulUnaryOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.ITernaryOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.ITernaryOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToFourOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToFourOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToTwoOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOneToTwoOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives
@@ -90,7 +88,7 @@ namespace System.Numerics.Tensors
 
             nuint remainder = (uint)x.Length;
 
-            if (Vector512.IsHardwareAccelerated && Vector512<TInput>.IsSupported && Vector512<TOutput>.IsSupported && TUnaryOperator.Vectorizable && Unsafe.SizeOf<TInput>() == Unsafe.SizeOf<TOutput>())
+            if (Vector512.IsHardwareAccelerated && Vector512<TInput>.IsSupported && Vector512<TOutput>.IsSupported && TUnaryOperator.Vectorizable && sizeof(TInput) == sizeof(TOutput))
             {
                 if (remainder >= (uint)Vector512<TInput>.Count)
                 {
@@ -108,7 +106,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector256.IsHardwareAccelerated && Vector256<TInput>.IsSupported && Vector256<TOutput>.IsSupported && TUnaryOperator.Vectorizable && Unsafe.SizeOf<TInput>() == Unsafe.SizeOf<TOutput>())
+            if (Vector256.IsHardwareAccelerated && Vector256<TInput>.IsSupported && Vector256<TOutput>.IsSupported && TUnaryOperator.Vectorizable && sizeof(TInput) == sizeof(TOutput))
             {
                 if (remainder >= (uint)Vector256<TInput>.Count)
                 {
@@ -126,7 +124,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector128.IsHardwareAccelerated && Vector128<TInput>.IsSupported && Vector128<TOutput>.IsSupported && TUnaryOperator.Vectorizable && Unsafe.SizeOf<TInput>() == Unsafe.SizeOf<TOutput>())
+            if (Vector128.IsHardwareAccelerated && Vector128<TInput>.IsSupported && Vector128<TOutput>.IsSupported && TUnaryOperator.Vectorizable && sizeof(TInput) == sizeof(TOutput))
             {
                 if (remainder >= (uint)Vector128<TInput>.Count)
                 {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryTwoToOneOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryTwoToOneOperator.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static unsafe partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -12,7 +12,6 @@ using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
 #pragma warning disable 0809  //warning CS0809: Obsolete member 'ReadOnlyTensorSpan<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System.Numerics.Tensors
 {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualBasic;
 
 #pragma warning disable CS8601 // Possible null reference assignment.
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System.Numerics.Tensors
 {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -14,7 +14,6 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 
 #pragma warning disable CS8601 // Possible null reference assignment.
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System.Numerics.Tensors
 {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -14,7 +14,6 @@ using System.Runtime.Serialization;
 
 #pragma warning disable CS8601 // Possible null reference assignment.
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System.Numerics.Tensors
 {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ConvertHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ConvertHelpers.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.IndexOfMax.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.IndexOfMax.cs
@@ -7,8 +7,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LeadingZeroCount.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LeadingZeroCount.cs
@@ -7,8 +7,6 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.PopCount.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.PopCount.cs
@@ -7,8 +7,6 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Rotate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Rotate.cs
@@ -3,8 +3,6 @@
 
 using System.Runtime.Intrinsics;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TrailingZeroCount.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TrailingZeroCount.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Numerics.Tensors
 {
     public static partial class TensorPrimitives

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
@@ -12,7 +12,6 @@ using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
 #pragma warning disable 0809  //warning CS0809: Obsolete member 'TensorSpan<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System.Numerics.Tensors
 {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.T.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.T.cs
@@ -4,9 +4,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System.Numerics.Tensors
 {
     internal static partial class TensorSpanHelpers // .T

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System.Numerics.Tensors
 {
     internal static partial class TensorSpanHelpers

--- a/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
+++ b/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
@@ -321,14 +321,12 @@ namespace System.Numerics
         public static bool LessThanOrEqualAny<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) { throw null; }
         public static System.Numerics.Vector<T> LessThanOrEqual<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) { throw null; }
         public static System.Numerics.Vector<T> LessThan<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Numerics.Vector<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Numerics.Vector<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Numerics.Vector<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static System.Numerics.Vector<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.Numerics.Vector<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
@@ -407,14 +405,12 @@ namespace System.Numerics
         [System.CLSCompliantAttribute(false)]
         public static System.Numerics.Vector<System.UInt64> ShiftRightLogical(System.Numerics.Vector<System.UInt64> value, int shiftCount) { throw null; }
         public static System.Numerics.Vector<T> SquareRoot<T>(System.Numerics.Vector<T> value) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe void Store<T>(this System.Numerics.Vector<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAligned<T>(this System.Numerics.Vector<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Numerics.Vector<T> source, T* destination) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static void StoreUnsafe<T>(this System.Numerics.Vector<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static void StoreUnsafe<T>(this System.Numerics.Vector<T> source, ref T destination, nuint elementOffset) { throw null; }

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -12,8 +12,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Internal.Runtime;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System
 {
     [Serializable]

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -150,7 +150,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void Memmove<T>(ref T destination, ref T source, nuint elementCount)
         {
-#pragma warning disable 8500 // sizeof of managed types
             if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 // Blittable memmove
@@ -167,7 +166,6 @@ namespace System
                     ref Unsafe.As<T, byte>(ref source),
                     elementCount * (nuint)sizeof(T));
             }
-#pragma warning restore 8500
         }
 
         // The maximum block size to for __BulkMoveWithWriteBarrier FCall. This is required to avoid GC starvation.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
@@ -154,14 +154,12 @@ namespace System.Buffers.Text
 #if NET
             int encodedLength = GetEncodedLength(source.Length);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
             return string.Create(encodedLength, (IntPtr)(&source), static (buffer, spanPtr) =>
             {
                 ReadOnlySpan<byte> source = *(ReadOnlySpan<byte>*)spanPtr;
                 EncodeToChars(source, buffer, out _, out int charsWritten);
                 Debug.Assert(buffer.Length == charsWritten, $"The source length: {source.Length}, bytes written: {charsWritten}");
             });
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
 #else
             char[] destination = new char[GetEncodedLength(source.Length)];
             EncodeToChars(source, destination, out _, out int charsWritten);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -500,9 +500,8 @@ namespace System.Collections.Generic
             {
                 Swap(ref leftRef, ref nextToLastRef);
             }
-#pragma warning disable 8500 // sizeof of managed types
+
             return (int)((nint)Unsafe.ByteOffset(ref zeroRef, ref leftRef) / sizeof(T));
-#pragma warning restore 8500
         }
 
         private static void HeapSort(Span<T> keys)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1121,12 +1121,7 @@ namespace System.Diagnostics.Tracing
         }
 
         // Returns the object as a IntPtr - safe when only used for logging
-        internal static unsafe nint ObjectIDForEvents(object? o)
-        {
-#pragma warning disable CS8500 // takes address of managed type
-            return *(nint*)&o;
-#pragma warning restore CS8500
-        }
+        internal static unsafe nint ObjectIDForEvents(object? o) => *(nint*)&o;
 
 #pragma warning restore 1591
 

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
@@ -5,8 +5,6 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System
 {
     public abstract partial class Enum

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Icu.cs
@@ -144,9 +144,7 @@ namespace System.Globalization
             IcuEnumCalendarsData callbackContext = default;
             callbackContext.Results = new List<string>();
             callbackContext.DisallowDuplicates = true;
-#pragma warning disable CS8500 // takes address of managed type
             bool result = EnumCalendarInfo(localeName, calendarId, dataType, &callbackContext);
-#pragma warning restore CS8500
             if (result)
             {
                 List<string> datePatternsList = callbackContext.Results;
@@ -372,9 +370,7 @@ namespace System.Globalization
 
             IcuEnumCalendarsData callbackContext = default;
             callbackContext.Results = new List<string>();
-#pragma warning disable CS8500 // takes address of managed type
             bool result = EnumCalendarInfo(localeName, calendarId, dataType, &callbackContext);
-#pragma warning restore CS8500
             if (result)
             {
                 // the month-name arrays are expected to have 13 elements.  If ICU only returns 12, add an
@@ -422,9 +418,7 @@ namespace System.Globalization
 
             IcuEnumCalendarsData callbackContext = default;
             callbackContext.Results = new List<string>();
-#pragma warning disable CS8500 // takes address of managed type
             bool result = EnumCalendarInfo(localeName, calendarId, dataType, &callbackContext);
-#pragma warning restore CS8500
             if (result)
             {
                 calendarData = callbackContext.Results.ToArray();
@@ -433,7 +427,6 @@ namespace System.Globalization
             return result;
         }
 
-#pragma warning disable CS8500 // takes address of managed type
         private static unsafe bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, IcuEnumCalendarsData* callbackContext)
         {
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
@@ -443,7 +436,6 @@ namespace System.Globalization
             return Interop.Globalization.EnumCalendarInfo(&EnumCalendarInfoCallback, localeName, calendarId, dataType, (IntPtr)callbackContext);
 #endif
         }
-#pragma warning restore CS8500
 
         [UnmanagedCallersOnly]
         private static unsafe void EnumCalendarInfoCallback(char* calendarStringPtr, IntPtr context)
@@ -451,9 +443,7 @@ namespace System.Globalization
             try
             {
                 ReadOnlySpan<char> calendarStringSpan = MemoryMarshal.CreateReadOnlySpanFromNullTerminated(calendarStringPtr);
-#pragma warning disable 8500
                 IcuEnumCalendarsData* callbackContext = (IcuEnumCalendarsData*)context;
-#pragma warning restore 8500
 
                 if (callbackContext->DisallowDuplicates)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // taking address of managed type
-
 namespace System.Globalization
 {
     internal sealed partial class CalendarData

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable 8500 // taking address of managed type
-
 namespace System.Globalization
 {
     internal sealed partial class CalendarData

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
@@ -8,8 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
-#pragma warning disable 8500 // taking address of managed type
-
 namespace System.Globalization
 {
     internal sealed partial class CultureData

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -731,7 +731,6 @@ namespace System.IO
         {
             Debug.Assert(first.Length > 0 && second.Length > 0 && third.Length > 0 && fourth.Length > 0, "should have dealt with empty paths");
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
             var state = new JoinInternalState
             {
                 ReadOnlySpanPtr1 = (IntPtr)(&first),
@@ -782,7 +781,6 @@ namespace System.IO
                     Debug.Assert(fourth.Length == destination.Length);
                     fourth.CopyTo(destination);
                 });
-#pragma warning restore CS8500
         }
 
         private struct JoinInternalState // used to avoid rooting ValueTuple`7

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -11,8 +11,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Text;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System
 {
     /// <summary>
@@ -3986,32 +3984,32 @@ namespace System
         /// <param name="value">The value for which to search.</param>
         /// <returns>The number of times <paramref name="value"/> was found in the <paramref name="span"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Count<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>?
+        public static unsafe int Count<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>?
         {
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
-                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                if (sizeof(T) == sizeof(byte))
                 {
                     return SpanHelpers.CountValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, byte>(value),
                         span.Length);
                 }
-                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                else if (sizeof(T) == sizeof(short))
                 {
                     return SpanHelpers.CountValueType(
                         ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, short>(value),
                         span.Length);
                 }
-                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                else if (sizeof(T) == sizeof(int))
                 {
                     return SpanHelpers.CountValueType(
                         ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, int>(value),
                         span.Length);
                 }
-                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                else if (sizeof(T) == sizeof(long))
                 {
                     return SpanHelpers.CountValueType(
                         ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
@@ -1501,7 +1501,6 @@ namespace System.Numerics
             return false;
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The source from which the vector will be loaded.</param>
@@ -1540,7 +1539,6 @@ namespace System.Numerics
         [Intrinsic]
         [CLSCompliant(false)]
         public static Vector<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -2444,7 +2442,6 @@ namespace System.Numerics
             return result;
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The vector that will be stored.</param>
@@ -2483,7 +2480,6 @@ namespace System.Numerics
         [Intrinsic]
         [CLSCompliant(false)]
         public static void StoreAlignedNonTemporal<T>(this Vector<T> source, T* destination) => source.StoreAligned(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
@@ -136,7 +136,6 @@ namespace System.Numerics
             get => Vector.Create(Scalar<T>.AllBitsSet);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Gets the number of <typeparamref name="T" /> that are in a <see cref="Vector{T}" />.</summary>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public static int Count
@@ -148,7 +147,6 @@ namespace System.Numerics
                 return sizeof(Vector<T>) / sizeof(T);
             }
         }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Gets a new <see cref="Vector{T}" /> with the elements set to their index.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
@@ -931,7 +929,6 @@ namespace System.Numerics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LessThanOrEqualAny(TSelf, TSelf)" />
         static bool ISimdVector<Vector<T>, T>.LessThanOrEqualAny(Vector<T> left, Vector<T> right) => Vector.LessThanOrEqualAny(left, right);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         static Vector<T> ISimdVector<Vector<T>, T>.Load(T* source) => Vector.Load(source);
 
@@ -940,7 +937,6 @@ namespace System.Numerics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         static Vector<T> ISimdVector<Vector<T>, T>.LoadAlignedNonTemporal(T* source) => Vector.LoadAlignedNonTemporal(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
         static Vector<T> ISimdVector<Vector<T>, T>.LoadUnsafe(ref readonly T source) => Vector.LoadUnsafe(in source);
@@ -1008,7 +1004,6 @@ namespace System.Numerics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Sqrt(TSelf)" />
         static Vector<T> ISimdVector<Vector<T>, T>.Sqrt(Vector<T> vector) => Vector.SquareRoot(vector);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         static void ISimdVector<Vector<T>, T>.Store(Vector<T> source, T* destination) => source.Store(destination);
 
@@ -1017,7 +1012,6 @@ namespace System.Numerics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         static void ISimdVector<Vector<T>, T>.StoreAlignedNonTemporal(Vector<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />
         static void ISimdVector<Vector<T>, T>.StoreUnsafe(Vector<T> vector, ref T destination) => vector.StoreUnsafe(ref destination);

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -11,7 +11,6 @@ using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
 #pragma warning disable 0809 // Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -290,15 +290,11 @@ namespace System.Reflection
             }
 
             StackAllocatedByRefs byrefs = default;
-#pragma warning disable CS8500
             IntPtr* pByRefFixedStorage = (IntPtr*)&byrefs;
-#pragma warning restore CS8500
 
             for (int i = 0; i < _argCount; i++)
             {
-#pragma warning disable CS8500
                 *(ByReference*)(pByRefFixedStorage + i) = (_invokerArgFlags[i] & InvokerArgFlags.IsValueType) != 0 ?
-#pragma warning restore CS8500
                     ByReference.Create(ref copyOfArgs[i]!.GetRawData()) :
                     ByReference.Create(ref copyOfArgs[i]);
             }
@@ -370,9 +366,7 @@ namespace System.Reflection
                         object? arg = arguments[i];
                         shouldCopyBack[i] = CheckArgument(ref arg, i);
                         copyOfArgs[i] = arg;
-    #pragma warning disable CS8500
                         *(ByReference*)(pByRefStorage + i) = (_invokerArgFlags[i] & InvokerArgFlags.IsValueType) != 0 ?
-    #pragma warning restore CS8500
                             ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i).GetRawData()) :
                             ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i));
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.Constructor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.Constructor.cs
@@ -40,9 +40,7 @@ namespace System.Reflection
 
                 for (int i = 0; i < argCount; i++)
                 {
-#pragma warning disable CS8500
                     *(ByReference*)(pByRefStorage + i) = (_invokerArgFlags[i] & InvokerArgFlags.IsValueType) != 0 ?
-#pragma warning restore CS8500
                         ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i).GetRawData()) :
                         ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i));
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
@@ -160,15 +160,11 @@ namespace System.Reflection
             }
 
             StackAllocatedByRefs byrefs = default;
-#pragma warning disable CS8500
             IntPtr* pByRefFixedStorage = (IntPtr*)&byrefs;
-#pragma warning restore CS8500
 
             for (int i = 0; i < _argCount; i++)
             {
-#pragma warning disable CS8500
                 *(ByReference*)(pByRefFixedStorage + i) = (_invokerArgFlags[i] & InvokerArgFlags.IsValueType) != 0 ?
-#pragma warning restore CS8500
                     ByReference.Create(ref copyOfArgs[i]!.GetRawData()) :
                     ByReference.Create(ref copyOfArgs[i]);
             }
@@ -256,9 +252,7 @@ namespace System.Reflection
 
                     for (int i = 0; i < _argCount; i++)
                     {
-    #pragma warning disable CS8500
                         *(ByReference*)(pByRefStorage + i) = (_invokerArgFlags[i] & InvokerArgFlags.IsValueType) != 0 ?
-    #pragma warning restore CS8500
                             ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i).GetRawData()) :
                             ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i));
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
@@ -343,15 +343,11 @@ namespace System.Reflection
             }
 
             StackAllocatedByRefs byrefs = default;
-#pragma warning disable CS8500
             IntPtr* pByRefFixedStorage = (IntPtr*)&byrefs;
-#pragma warning restore CS8500
 
             for (int i = 0; i < _argCount; i++)
             {
-#pragma warning disable CS8500
                 *(ByReference*)(pByRefFixedStorage + i) = (_invokerArgFlags[i] & InvokerArgFlags.IsValueType) != 0 ?
-#pragma warning restore CS8500
                     ByReference.Create(ref copyOfArgs[i]!.GetRawData()) :
                     ByReference.Create(ref copyOfArgs[i]);
             }
@@ -423,9 +419,7 @@ namespace System.Reflection
                         object? arg = arguments[i];
                         shouldCopyBack[i] = CheckArgument(ref arg, i);
                         copyOfArgs[i] = arg;
-    #pragma warning disable CS8500
                         *(ByReference*)(pByRefStorage + i) = (_invokerArgFlags[i] & InvokerArgFlags.IsValueType) != 0 ?
-    #pragma warning restore CS8500
                             ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i).GetRawData()) :
                             ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i));
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -7,13 +7,9 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 
-//
 // The implementations of most the methods in this file are provided as intrinsics.
 // In CoreCLR, the body of the functions are replaced by the EE with unsafe code. See see getILIntrinsicImplementationForUnsafe for details.
 // In AOT compilers, see Internal.IL.Stubs.UnsafeIntrinsics for details.
-//
-
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System.Runtime.CompilerServices
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -176,9 +176,7 @@ namespace System.Runtime.InteropServices
 
             // Unsafe.AsPointer is safe since array must be pinned
             void* pRawData = Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(arr));
-#pragma warning disable 8500 // sizeof of managed types
             return (IntPtr)((byte*)pRawData + (uint)index * (nuint)sizeof(T));
-#pragma warning restore 8500
         }
 
         public static IntPtr OffsetOf<T>(string fieldName) => OffsetOf(typeof(T), fieldName);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
@@ -379,7 +379,7 @@ namespace System.Runtime.InteropServices.Marshalling
         public static unsafe ComVariant CreateRaw<T>(VarEnum vt, T rawValue)
             where T : unmanaged
         {
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(Unsafe.SizeOf<T>(), sizeof(UnionTypes), nameof(T));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(sizeof(T), sizeof(UnionTypes), nameof(T));
             if (vt == VarEnum.VT_DECIMAL)
             {
                 throw new ArgumentException(SR.ComVariant_VT_DECIMAL_NotSupported_CreateRaw, nameof(vt));
@@ -571,7 +571,7 @@ namespace System.Runtime.InteropServices.Marshalling
         public unsafe ref T GetRawDataRef<T>()
             where T : unmanaged
         {
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(Unsafe.SizeOf<T>(), sizeof(UnionTypes), nameof(T));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(sizeof(T), sizeof(UnionTypes), nameof(T));
             if (typeof(T) == typeof(decimal))
             {
                 throw new ArgumentException(SR.ComVariant_VT_DECIMAL_NotSupported_RawDataRef, nameof(T));

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System.Runtime.InteropServices
 {
     /// <summary>
@@ -113,7 +111,7 @@ namespace System.Runtime.InteropServices
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Span<TTo> Cast<TFrom, TTo>(Span<TFrom> span)
+        public static unsafe Span<TTo> Cast<TFrom, TTo>(Span<TFrom> span)
             where TFrom : struct
             where TTo : struct
         {
@@ -124,8 +122,8 @@ namespace System.Runtime.InteropServices
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.
-            uint fromSize = (uint)Unsafe.SizeOf<TFrom>();
-            uint toSize = (uint)Unsafe.SizeOf<TTo>();
+            uint fromSize = (uint)sizeof(TFrom);
+            uint toSize = (uint)sizeof(TTo);
             uint fromLength = (uint)span.Length;
             int toLength;
             if (fromSize == toSize)
@@ -168,7 +166,7 @@ namespace System.Runtime.InteropServices
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<TTo> Cast<TFrom, TTo>(ReadOnlySpan<TFrom> span)
+        public static unsafe ReadOnlySpan<TTo> Cast<TFrom, TTo>(ReadOnlySpan<TFrom> span)
             where TFrom : struct
             where TTo : struct
         {
@@ -179,8 +177,8 @@ namespace System.Runtime.InteropServices
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.
-            uint fromSize = (uint)Unsafe.SizeOf<TFrom>();
-            uint toSize = (uint)Unsafe.SizeOf<TTo>();
+            uint fromSize = (uint)sizeof(TFrom);
+            uint toSize = (uint)sizeof(TTo);
             uint fromLength = (uint)span.Length;
             int toLength;
             if (fromSize == toSize)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -405,9 +405,7 @@ namespace System.Runtime.InteropServices
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 throw new ArgumentException(SR.Argument_NeedStructWithNoRefs);
 
-#pragma warning disable 8500 // sizeof of managed types
             return (uint)sizeof(T);
-#pragma warning restore 8500
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
@@ -399,7 +399,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the elements in the vector (<typeparamref name="T" />) is not supported.</exception>
         static abstract bool LessThanOrEqualAny(TSelf left, TSelf right);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Loads a vector from the given source.</summary>
         /// <param name="source">The source from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" />.</returns>
@@ -425,7 +424,6 @@ namespace System.Runtime.Intrinsics
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         static virtual TSelf LoadAlignedNonTemporal(T* source) => TSelf.LoadAligned(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Loads a vector from the given source.</summary>
         /// <param name="source">The source from which the vector will be loaded.</param>
@@ -584,7 +582,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="vector" /> (<typeparamref name="T" />) is not supported.</exception>
         static abstract TSelf Sqrt(TSelf vector);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Stores a vector at the given destination.</summary>
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The destination at which <paramref name="source" /> will be stored.</param>
@@ -610,7 +607,6 @@ namespace System.Runtime.Intrinsics
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         static virtual void StoreAlignedNonTemporal(TSelf source, T* destination) => TSelf.StoreAligned(source, destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Stores a vector at the given destination.</summary>
         /// <param name="vector">The vector that will be stored.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/SimdVectorExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/SimdVectorExtensions.cs
@@ -64,7 +64,6 @@ namespace System.Runtime.Intrinsics
             return TVector.GetElement(vector, index);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="TVector">The type of the vector.</typeparam>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -101,7 +100,6 @@ namespace System.Runtime.Intrinsics
         {
             TVector.StoreAlignedNonTemporal(source, destination);
         }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="TVector">The type of the vector.</typeparam>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -2077,7 +2077,6 @@ namespace System.Runtime.Intrinsics
                 || Vector64.LessThanOrEqualAny(left._upper, right._upper);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The source from which the vector will be loaded.</param>
@@ -2116,7 +2115,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static unsafe Vector128<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -3160,7 +3158,6 @@ namespace System.Runtime.Intrinsics
             );
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The vector that will be stored.</param>
@@ -3199,7 +3196,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this Vector128<T> source, T* destination) => source.StoreAligned(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>
         /// Stores to lower 64 bits of <paramref name="source"/> to memory destination of <paramref name="destination"/>[<paramref name="elementOffset"/>]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
@@ -42,7 +42,6 @@ namespace System.Runtime.Intrinsics
             get => Vector128.Create(Scalar<T>.AllBitsSet);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Gets the number of <typeparamref name="T" /> that are in a <see cref="Vector128{T}" />.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
         public static int Count
@@ -54,7 +53,6 @@ namespace System.Runtime.Intrinsics
                 return Vector128.Size / sizeof(T);
             }
         }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Gets a new <see cref="Vector128{T}" /> with the elements set to their index.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
@@ -578,7 +576,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LessThanOrEqualAny(TSelf, TSelf)" />
         static bool ISimdVector<Vector128<T>, T>.LessThanOrEqualAny(Vector128<T> left, Vector128<T> right) => Vector128.LessThanOrEqualAny(left, right);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         static Vector128<T> ISimdVector<Vector128<T>, T>.Load(T* source) => Vector128.Load(source);
 
@@ -587,7 +584,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         static Vector128<T> ISimdVector<Vector128<T>, T>.LoadAlignedNonTemporal(T* source) => Vector128.LoadAlignedNonTemporal(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
         static Vector128<T> ISimdVector<Vector128<T>, T>.LoadUnsafe(ref readonly T source) => Vector128.LoadUnsafe(in source);
@@ -655,7 +651,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Sqrt(TSelf)" />
         static Vector128<T> ISimdVector<Vector128<T>, T>.Sqrt(Vector128<T> vector) => Vector128.Sqrt(vector);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         static void ISimdVector<Vector128<T>, T>.Store(Vector128<T> source, T* destination) => source.Store(destination);
 
@@ -664,7 +659,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         static void ISimdVector<Vector128<T>, T>.StoreAlignedNonTemporal(Vector128<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />
         static void ISimdVector<Vector128<T>, T>.StoreUnsafe(Vector128<T> vector, ref T destination) => vector.StoreUnsafe(ref destination);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -1993,7 +1993,6 @@ namespace System.Runtime.Intrinsics
                 || Vector128.LessThanOrEqualAny(left._upper, right._upper);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The source from which the vector will be loaded.</param>
@@ -2032,7 +2031,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static Vector256<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -3044,7 +3042,6 @@ namespace System.Runtime.Intrinsics
             );
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The vector that will be stored.</param>
@@ -3083,7 +3080,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static void StoreAlignedNonTemporal<T>(this Vector256<T> source, T* destination) => source.StoreAligned(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
@@ -41,7 +41,6 @@ namespace System.Runtime.Intrinsics
             get => Vector256.Create(Scalar<T>.AllBitsSet);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Gets the number of <typeparamref name="T" /> that are in a <see cref="Vector256{T}" />.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
         public static int Count
@@ -53,7 +52,6 @@ namespace System.Runtime.Intrinsics
                 return Vector256.Size / sizeof(T);
             }
         }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Gets a new <see cref="Vector256{T}" /> with the elements set to their index.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
@@ -567,7 +565,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LessThanOrEqualAny(TSelf, TSelf)" />
         static bool ISimdVector<Vector256<T>, T>.LessThanOrEqualAny(Vector256<T> left, Vector256<T> right) => Vector256.LessThanOrEqualAny(left, right);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         static Vector256<T> ISimdVector<Vector256<T>, T>.Load(T* source) => Vector256.Load(source);
 
@@ -576,7 +573,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         static Vector256<T> ISimdVector<Vector256<T>, T>.LoadAlignedNonTemporal(T* source) => Vector256.LoadAlignedNonTemporal(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
         static Vector256<T> ISimdVector<Vector256<T>, T>.LoadUnsafe(ref readonly T source) => Vector256.LoadUnsafe(in source);
@@ -644,7 +640,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Sqrt(TSelf)" />
         static Vector256<T> ISimdVector<Vector256<T>, T>.Sqrt(Vector256<T> vector) => Vector256.Sqrt(vector);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         static void ISimdVector<Vector256<T>, T>.Store(Vector256<T> source, T* destination) => source.Store(destination);
 
@@ -653,7 +648,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         static void ISimdVector<Vector256<T>, T>.StoreAlignedNonTemporal(Vector256<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />
         static void ISimdVector<Vector256<T>, T>.StoreUnsafe(Vector256<T> vector, ref T destination) => vector.StoreUnsafe(ref destination);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -2056,7 +2056,6 @@ namespace System.Runtime.Intrinsics
                 || Vector256.LessThanOrEqualAny(left._upper, right._upper);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The source from which the vector will be loaded.</param>
@@ -2095,7 +2094,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static Vector512<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -3106,7 +3104,6 @@ namespace System.Runtime.Intrinsics
             );
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The vector that will be stored.</param>
@@ -3145,7 +3142,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static void StoreAlignedNonTemporal<T>(this Vector512<T> source, T* destination) => source.StoreAligned(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
@@ -41,7 +41,6 @@ namespace System.Runtime.Intrinsics
             get => Vector512.Create(Scalar<T>.AllBitsSet);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Gets the number of <typeparamref name="T" /> that are in a <see cref="Vector512{T}" />.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
         public static int Count
@@ -53,7 +52,6 @@ namespace System.Runtime.Intrinsics
                 return Vector512.Size / sizeof(T);
             }
         }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Gets a new <see cref="Vector512{T}" /> with the elements set to their index.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
@@ -567,7 +565,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LessThanOrEqualAny(TSelf, TSelf)" />
         static bool ISimdVector<Vector512<T>, T>.LessThanOrEqualAny(Vector512<T> left, Vector512<T> right) => Vector512.LessThanOrEqualAny(left, right);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         static Vector512<T> ISimdVector<Vector512<T>, T>.Load(T* source) => Vector512.Load(source);
 
@@ -576,7 +573,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         static Vector512<T> ISimdVector<Vector512<T>, T>.LoadAlignedNonTemporal(T* source) => Vector512.LoadAlignedNonTemporal(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
         static Vector512<T> ISimdVector<Vector512<T>, T>.LoadUnsafe(ref readonly T source) => Vector512.LoadUnsafe(in source);
@@ -644,7 +640,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Sqrt(TSelf)" />
         static Vector512<T> ISimdVector<Vector512<T>, T>.Sqrt(Vector512<T> vector) => Vector512.Sqrt(vector);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         static void ISimdVector<Vector512<T>, T>.Store(Vector512<T> source, T* destination) => source.Store(destination);
 
@@ -653,7 +648,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         static void ISimdVector<Vector512<T>, T>.StoreAlignedNonTemporal(Vector512<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />
         static void ISimdVector<Vector512<T>, T>.StoreUnsafe(Vector512<T> vector, ref T destination) => vector.StoreUnsafe(ref destination);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -1847,7 +1847,6 @@ namespace System.Runtime.Intrinsics
             return false;
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The source from which the vector will be loaded.</param>
@@ -1886,7 +1885,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static unsafe Vector64<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Loads a vector from the given source.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -3024,7 +3022,6 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="source">The vector that will be stored.</param>
@@ -3063,7 +3060,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this Vector64<T> source, T* destination) => source.StoreAligned(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Stores a vector at the given destination.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
@@ -41,7 +41,6 @@ namespace System.Runtime.Intrinsics
             get => Vector64.Create(Scalar<T>.AllBitsSet);
         }
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <summary>Gets the number of <typeparamref name="T" /> that are in a <see cref="Vector64{T}" />.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
         public static unsafe int Count
@@ -53,7 +52,6 @@ namespace System.Runtime.Intrinsics
                 return Vector64.Size / sizeof(T);
             }
         }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <summary>Gets a new <see cref="Vector64{T}" /> with the elements set to their index.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
@@ -635,7 +633,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LessThanOrEqualAny(TSelf, TSelf)" />
         static bool ISimdVector<Vector64<T>, T>.LessThanOrEqualAny(Vector64<T> left, Vector64<T> right) => Vector64.LessThanOrEqualAny(left, right);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         static Vector64<T> ISimdVector<Vector64<T>, T>.Load(T* source) => Vector64.Load(source);
 
@@ -644,7 +641,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         static Vector64<T> ISimdVector<Vector64<T>, T>.LoadAlignedNonTemporal(T* source) => Vector64.LoadAlignedNonTemporal(source);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
         static Vector64<T> ISimdVector<Vector64<T>, T>.LoadUnsafe(ref readonly T source) => Vector64.LoadUnsafe(in source);
@@ -712,7 +708,6 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Sqrt(TSelf)" />
         static Vector64<T> ISimdVector<Vector64<T>, T>.Sqrt(Vector64<T> vector) => Vector64.Sqrt(vector);
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         static void ISimdVector<Vector64<T>, T>.Store(Vector64<T> source, T* destination) => source.Store(destination);
 
@@ -721,7 +716,6 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         static void ISimdVector<Vector64<T>, T>.StoreAlignedNonTemporal(Vector64<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />
         static void ISimdVector<Vector64<T>, T>.StoreUnsafe(Vector64<T> vector, ref T destination) => vector.StoreUnsafe(ref destination);

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1SearchValues.cs
@@ -6,8 +6,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // address of managed types
-
 namespace System.Buffers
 {
     internal sealed class Any1SearchValues<T, TImpl> : SearchValues<T>
@@ -16,9 +14,9 @@ namespace System.Buffers
     {
         private readonly TImpl _e0;
 
-        public Any1SearchValues(ReadOnlySpan<TImpl> values)
+        public unsafe Any1SearchValues(ReadOnlySpan<TImpl> values)
         {
-            Debug.Assert(Unsafe.SizeOf<T>() == Unsafe.SizeOf<TImpl>());
+            Debug.Assert(sizeof(T) == sizeof(TImpl));
             Debug.Assert(values.Length == 1);
             _e0 = values[0];
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2SearchValues.cs
@@ -6,8 +6,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // address of managed types
-
 namespace System.Buffers
 {
     internal sealed class Any2SearchValues<T, TImpl> : SearchValues<T>
@@ -16,9 +14,9 @@ namespace System.Buffers
     {
         private readonly TImpl _e0, _e1;
 
-        public Any2SearchValues(ReadOnlySpan<TImpl> values)
+        public unsafe Any2SearchValues(ReadOnlySpan<TImpl> values)
         {
-            Debug.Assert(Unsafe.SizeOf<T>() == Unsafe.SizeOf<TImpl>());
+            Debug.Assert(sizeof(T) == sizeof(TImpl));
             Debug.Assert(values.Length == 2);
             (_e0, _e1) = (values[0], values[1]);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any3SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any3SearchValues.cs
@@ -6,8 +6,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // address of managed types
-
 namespace System.Buffers
 {
     internal sealed class Any3SearchValues<T, TImpl> : SearchValues<T>
@@ -16,9 +14,9 @@ namespace System.Buffers
     {
         private readonly TImpl _e0, _e1, _e2;
 
-        public Any3SearchValues(ReadOnlySpan<TImpl> values)
+        public unsafe Any3SearchValues(ReadOnlySpan<TImpl> values)
         {
-            Debug.Assert(Unsafe.SizeOf<T>() == Unsafe.SizeOf<TImpl>());
+            Debug.Assert(sizeof(T) == sizeof(TImpl));
             Debug.Assert(values.Length == 3);
             (_e0, _e1, _e2) = (values[0], values[1], values[2]);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any4SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any4SearchValues.cs
@@ -6,8 +6,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // address of managed types
-
 namespace System.Buffers
 {
     internal sealed class Any4SearchValues<T, TImpl> : SearchValues<T>
@@ -16,9 +14,9 @@ namespace System.Buffers
     {
         private readonly TImpl _e0, _e1, _e2, _e3;
 
-        public Any4SearchValues(ReadOnlySpan<TImpl> values)
+        public unsafe Any4SearchValues(ReadOnlySpan<TImpl> values)
         {
-            Debug.Assert(Unsafe.SizeOf<T>() == Unsafe.SizeOf<TImpl>());
+            Debug.Assert(sizeof(T) == sizeof(TImpl));
             Debug.Assert(values.Length == 4);
             (_e0, _e1, _e2, _e3) = (values[0], values[1], values[2], values[3]);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any5SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any5SearchValues.cs
@@ -6,8 +6,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 8500 // address of managed types
-
 namespace System.Buffers
 {
     internal sealed class Any5SearchValues<T, TImpl> : SearchValues<T>
@@ -16,9 +14,9 @@ namespace System.Buffers
     {
         private readonly TImpl _e0, _e1, _e2, _e3, _e4;
 
-        public Any5SearchValues(ReadOnlySpan<TImpl> values)
+        public unsafe Any5SearchValues(ReadOnlySpan<TImpl> values)
         {
-            Debug.Assert(Unsafe.SizeOf<T>() == Unsafe.SizeOf<TImpl>());
+            Debug.Assert(sizeof(T) == sizeof(TImpl));
             Debug.Assert(values.Length == 5);
             (_e0, _e1, _e2, _e3, _e4) = (values[0], values[1], values[2], values[3], values[4]);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -9,8 +9,6 @@ using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System.Buffers
 {
     internal static class IndexOfAnyAsciiSearcher

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -10,8 +10,6 @@ using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 
-#pragma warning disable CS8500 // Takes the address of a managed type
-
 namespace System.Buffers
 {
     /// <summary>Data structure used to optimize checks for whether a char is in a set of chars.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
@@ -8,8 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable CS8500 // Takes the address of a managed type
-
 namespace System.Buffers
 {
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -10,7 +10,6 @@ using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
 #pragma warning disable 0809 // Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
-#pragma warning disable 8500 // address / sizeof of managed types
 
 namespace System
 {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
@@ -7,8 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System
 {
     // This is a separate class instead of 'partial SpanHelpers' to hide the private helpers

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -7,8 +7,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System
 {
     internal static partial class SpanHelpers // .T
@@ -3775,7 +3773,7 @@ namespace System
             return count;
         }
 
-        public static int CountValueType<T>(ref T current, T value, int length) where T : struct, IEquatable<T>?
+        public static unsafe int CountValueType<T>(ref T current, T value, int length) where T : struct, IEquatable<T>?
         {
             int count = 0;
             ref T end = ref Unsafe.Add(ref current, length);
@@ -3794,7 +3792,7 @@ namespace System
 
                     // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
                     ulong mask = Vector512.Equals(Vector512.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
+                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)sizeof(T));
                     count += BitOperations.PopCount(mask);
                 }
                 else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
@@ -3809,7 +3807,7 @@ namespace System
 
                     // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
                     uint mask = Vector256.Equals(Vector256.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
+                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)sizeof(T));
                     count += BitOperations.PopCount(mask);
                 }
                 else
@@ -3824,7 +3822,7 @@ namespace System
 
                     // Count the last vector and mask off the elements that were already counted (number of elements between oneVectorAwayFromEnd and current).
                     uint mask = Vector128.Equals(Vector128.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
-                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)Unsafe.SizeOf<T>());
+                    mask >>= (int)((nuint)Unsafe.ByteOffset(ref oneVectorAwayFromEnd, ref current) / (uint)sizeof(T));
                     count += BitOperations.PopCount(mask);
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
-#pragma warning disable 8500 // sizeof of managed types
-
 namespace System
 {
     internal static partial class SpanHelpers

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5337,7 +5337,6 @@ namespace System.Threading.Tasks
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // method looks long, but for a given TResult it results in a relatively small amount of asm
         public static unsafe Task<TResult> FromResult<TResult>(TResult result)
         {
-#pragma warning disable 8500 // address of / sizeof of managed types
             // The goal of this function is to be give back a cached task if possible, or to otherwise give back a new task.
             // To give back a cached task, we need to be able to evaluate the incoming result value, and we need to avoid as
             // much overhead as possible when doing so, as this function is invoked as part of the return path from every async
@@ -5386,7 +5385,6 @@ namespace System.Threading.Tasks
 
             // No cached task is available.  Manufacture a new one for this result.
             return new Task<TResult>(result);
-#pragma warning restore 8500
         }
 
         /// <summary>Creates a <see cref="Task{TResult}"/> that's completed exceptionally with the specified exception.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TypedReference.cs
@@ -53,9 +53,7 @@ namespace System
             // reference to TypedReference is banned, so have to pass result as pointer
             unsafe
             {
-#pragma warning disable CS8500 // Takes a pointer to a managed type
                 InternalMakeTypedReference(&result, target, fields, targetType);
-#pragma warning restore CS8500
             }
             return result;
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -100,31 +100,31 @@ namespace System.Xml
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteTextNodeRaw<T>(XmlBinaryNodeType nodeType, T value)
+        private unsafe void WriteTextNodeRaw<T>(XmlBinaryNodeType nodeType, T value)
             where T : unmanaged
         {
-            // GetTextNodeBuffer performs bounds checks and ensures returned buffer has size of at least (1 + Unsafe.SizeOf<T>())
-            byte[] buffer = GetTextNodeBuffer(1 + Unsafe.SizeOf<T>(), out int offset);
+            // GetTextNodeBuffer performs bounds checks and ensures returned buffer has size of at least (1 + sizeof(T))
+            byte[] buffer = GetTextNodeBuffer(1 + sizeof(T), out int offset);
 
-            Debug.Assert(offset >= 0 && offset + 1 + Unsafe.SizeOf<T>() <= buffer.Length, "WriteTextNodeRaw");
+            Debug.Assert(offset >= 0 && offset + 1 + sizeof(T) <= buffer.Length, "WriteTextNodeRaw");
             ref byte bytePtr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(buffer), offset);
 
             bytePtr = (byte)nodeType;
             Unsafe.WriteUnaligned<T>(ref Unsafe.Add(ref bytePtr, 1), value);
-            Advance(1 + Unsafe.SizeOf<T>());
+            Advance(1 + sizeof(T));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteRaw<T>(T value)
+        private unsafe void WriteRaw<T>(T value)
             where T : unmanaged
         {
-            // GetBuffer performs bounds checks and ensures returned buffer has size of at least (Unsafe.SizeOf<T>())
-            byte[] buffer = GetBuffer(Unsafe.SizeOf<T>(), out int offset);
+            // GetBuffer performs bounds checks and ensures returned buffer has size of at least (sizeof(T))
+            byte[] buffer = GetBuffer(sizeof(T), out int offset);
 
-            Debug.Assert(offset >= 0 && offset + Unsafe.SizeOf<T>() <= buffer.Length, "WriteRaw");
+            Debug.Assert(offset >= 0 && offset + sizeof(T) <= buffer.Length, "WriteRaw");
             ref byte bytePtr = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(buffer), offset);
             Unsafe.WriteUnaligned<T>(ref bytePtr, value);
-            Advance(Unsafe.SizeOf<T>());
+            Advance(sizeof(T));
         }
 
         private void WriteTextNodeWithInt8(XmlBinaryNodeType nodeType, byte value)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -935,7 +935,6 @@ namespace System.Xml
             return (sbyte)GetByte(offset);
         }
 
-#pragma warning disable 8500 // sizeof of managed types
         private unsafe T ReadRawBytes<T>() where T : unmanaged
         {
             ReadOnlySpan<byte> buffer = GetBuffer(sizeof(T), out int offset)
@@ -948,7 +947,6 @@ namespace System.Xml
 
         private unsafe T ReadRawBytes<T>(int offset) where T : unmanaged
             => MemoryMarshal.Read<T>(_buffer.AsSpan(offset, sizeof(T)));
-#pragma warning restore 8500
 
         public int GetInt16(int offset)
             => BitConverter.IsLittleEndian ? ReadRawBytes<short>(offset) : BinaryPrimitives.ReverseEndianness(ReadRawBytes<short>(offset));

--- a/src/libraries/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
+++ b/src/libraries/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>436</NoWarn>
+    <NoWarn>$(NoWarn);436</NoWarn>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
@@ -8,7 +8,7 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <!-- Disable RS2008: Enable analyzer release tracking
          Diagnostics in runtime use a different mechanism (docs/project/list-of-diagnostics.md) -->
-    <NoWarn>RS2008;RS1038;$(NoWarn)</NoWarn>
+    <NoWarn>$(NoWarn);RS2008;RS1038</NoWarn>
     <DefineConstants>$(DefineConstants);JSIMPORTGENERATOR</DefineConstants>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.csproj
@@ -8,7 +8,7 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <!-- Disable RS2008: Enable analyzer release tracking
          Diagnostics in runtime use a different mechanism (docs/project/list-of-diagnostics.md) -->
-    <NoWarn>RS2008;RS1038;$(NoWarn)</NoWarn>
+    <NoWarn>$(NoWarn);RS2008;RS1038</NoWarn>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <DefineConstants>$(DefineConstants);MICROSOFT_INTEROP_COMINTERFACEGENERATOR</DefineConstants>
     <StringResourcesPath>../Common/Resources/Strings.resx</StringResourcesPath>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.csproj
@@ -8,7 +8,7 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <!-- Disable RS2008: Enable analyzer release tracking
          Diagnostics in runtime use a different mechanism (docs/project/list-of-diagnostics.md) -->
-    <NoWarn>RS2008;RS1038;$(NoWarn)</NoWarn>
+    <NoWarn>$(NoWarn);RS2008;RS1038</NoWarn>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <StringResourcesPath>../Common/Resources/Strings.resx</StringResourcesPath>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -202,14 +202,12 @@ namespace System.Runtime.Intrinsics
         public static bool LessThanOrEqualAny<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> LessThan<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector128<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector128<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector128<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static System.Runtime.Intrinsics.Vector128<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector128<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
@@ -302,14 +300,12 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector128<ulong> Shuffle(System.Runtime.Intrinsics.Vector128<ulong> vector, System.Runtime.Intrinsics.Vector128<ulong> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Shuffle(System.Runtime.Intrinsics.Vector128<double> vector, System.Runtime.Intrinsics.Vector128<long> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> Sqrt<T>(System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector128<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector128<T> source, ref T destination, nuint elementOffset) { throw null; }
@@ -579,14 +575,12 @@ namespace System.Runtime.Intrinsics
         public static bool LessThanOrEqualAny<T>(System.Runtime.Intrinsics.Vector256<T> left, System.Runtime.Intrinsics.Vector256<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector256<T> left, System.Runtime.Intrinsics.Vector256<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> LessThan<T>(System.Runtime.Intrinsics.Vector256<T> left, System.Runtime.Intrinsics.Vector256<T> right) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector256<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector256<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector256<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static System.Runtime.Intrinsics.Vector256<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector256<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
@@ -679,14 +673,12 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector256<ulong> Shuffle(System.Runtime.Intrinsics.Vector256<ulong> vector, System.Runtime.Intrinsics.Vector256<ulong> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Shuffle(System.Runtime.Intrinsics.Vector256<double> vector, System.Runtime.Intrinsics.Vector256<long> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> Sqrt<T>(System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector256<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector256<T> source, ref T destination, nuint elementOffset) { throw null; }
@@ -957,14 +949,12 @@ namespace System.Runtime.Intrinsics
         public static bool LessThanOrEqualAny<T>(System.Runtime.Intrinsics.Vector512<T> left, System.Runtime.Intrinsics.Vector512<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector512<T> left, System.Runtime.Intrinsics.Vector512<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> LessThan<T>(System.Runtime.Intrinsics.Vector512<T> left, System.Runtime.Intrinsics.Vector512<T> right) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector512<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector512<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector512<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static System.Runtime.Intrinsics.Vector512<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector512<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
@@ -1057,14 +1047,12 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector512<ulong> Shuffle(System.Runtime.Intrinsics.Vector512<ulong> vector, System.Runtime.Intrinsics.Vector512<ulong> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Shuffle(System.Runtime.Intrinsics.Vector512<double> vector, System.Runtime.Intrinsics.Vector512<long> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> Sqrt<T>(System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector512<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector512<T> source, ref T destination, nuint elementOffset) { throw null; }
@@ -1304,14 +1292,12 @@ namespace System.Runtime.Intrinsics
         public static bool LessThanOrEqualAny<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> LessThan<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector64<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector64<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector64<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static System.Runtime.Intrinsics.Vector64<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector64<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
@@ -1400,14 +1386,12 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector64<uint> Shuffle(System.Runtime.Intrinsics.Vector64<uint> vector, System.Runtime.Intrinsics.Vector64<uint> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<float> Shuffle(System.Runtime.Intrinsics.Vector64<float> vector, System.Runtime.Intrinsics.Vector64<int> indices) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> Sqrt<T>(System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         [System.CLSCompliantAttribute(false)]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
-#pragma warning restore CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('T')
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector64<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector64<T> source, ref T destination, nuint elementOffset) { throw null; }

--- a/src/libraries/System.Runtime/tests/System.Dynamic.Runtime.Tests/System.Dynamic.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Dynamic.Runtime.Tests/System.Dynamic.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>67,168,219,414,162,184,458,464,78,169,114,693,108,1981,649,109,1066,3021,3026,3002,3014,3022,660,661,429;xUnit1013</NoWarn>
+    <NoWarn>$(NoWarn);67;168;219;414;162;184;458;464;78;169;114;693;108;1981;649;109;1066;3021;3026;3002;3014;3022;660;661;429;xUnit1013</NoWarn>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-maccatalyst</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Runtime/tests/System.Runtime.CompilerServices.Unsafe.Tests/UnsafeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.CompilerServices.Unsafe.Tests/UnsafeTests.cs
@@ -6,8 +6,6 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using Xunit;
 
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
-
 namespace System.Runtime.CompilerServices
 {
     public class UnsafeTests

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
@@ -1097,7 +1097,7 @@ namespace System.Tests
 
             EmbeddedValueType<string>[] array = uninitialized ? GC.AllocateUninitializedArray<EmbeddedValueType<string>>(length, pinned: true) : GC.AllocateArray<EmbeddedValueType<string>>(length, pinned: true);
             byte* pointer = (byte*)Unsafe.AsPointer(ref array[0]); // Unsafe.AsPointer is safe since array is pinned
-            var size = Unsafe.SizeOf<EmbeddedValueType<string>>();
+            int size = sizeof(EmbeddedValueType<string>);
 
             GC.Collect();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/PemEncoding.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/PemEncoding.cs
@@ -525,7 +525,6 @@ namespace System.Security.Cryptography
 
             int encodedSize = GetEncodedSize(label.Length, data.Length);
 
-#pragma warning disable CS8500 // takes address of managed type
             return string.Create(
                 encodedSize,
                 (LabelPointer: (IntPtr)(&label), DataPointer: (IntPtr)(&data)),
@@ -542,7 +541,6 @@ namespace System.Security.Cryptography
                         throw new CryptographicException();
                     }
                 });
-#pragma warning restore CS8500
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -15,8 +15,6 @@ using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
 using X509VerifyStatusCodeUniversal = Interop.Crypto.X509VerifyStatusCodeUniversal;
 
-#pragma warning disable 8500 // taking address of managed type
-
 namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed class OpenSslX509ChainProcessor : IChainPal

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.AndroidKeyStore.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.AndroidKeyStore.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
-#pragma warning disable 8500 // taking address of managed type
-
 namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed partial class StorePal
@@ -129,9 +127,7 @@ namespace System.Security.Cryptography.X509Certificates
             [UnmanagedCallersOnly]
             private static unsafe void EnumCertificatesCallback(void* certPtr, void* privateKeyPtr, Interop.AndroidCrypto.PAL_KeyAlgorithm privateKeyAlgorithm, void* context)
             {
-#pragma warning disable 8500 // taking address of managed type
                 EnumCertificatesContext* callbackContext = (EnumCertificatesContext*)context;
-#pragma warning restore 8500
 
                 AndroidCertificatePal certPal;
                 var handle = new SafeX509Handle((IntPtr)certPtr);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.TrustedStore.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.TrustedStore.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
-#pragma warning disable 8500 // taking address of managed type
-
 namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed partial class StorePal

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -3,8 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-#pragma warning disable CS8500 // takes address of managed type
-
 namespace System.Text.RegularExpressions
 {
     // Callback class

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1591,7 +1591,6 @@ namespace System.Text.RegularExpressions
             }
 
             // Get the pointer/length of the span to be able to pass it into string.Create.
-#pragma warning disable CS8500 // takes address of managed type
             ReadOnlySpan<char> tmpChars = chars; // avoid address exposing the span and impacting the other code in the method that uses it
             return
 #if NET
@@ -1616,7 +1615,6 @@ namespace System.Text.RegularExpressions
                 }
                 Debug.Assert(i == span.Length);
             });
-#pragma warning restore CS8500
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable CS8500 // takes address of managed type
-
 namespace System.Text.RegularExpressions
 {
     /// <summary>

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs
@@ -106,7 +106,6 @@ namespace System.Threading.Tasks
                 typeof(T) == typeof(nint) ||
                 typeof(T) == typeof(nuint);
 
-#pragma warning disable CS8500
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static unsafe bool CompareExchange(ref T location, T value, T comparand) =>
                 sizeof(T) == sizeof(byte) ? Interlocked.CompareExchange(ref Unsafe.As<T, byte>(ref location), Unsafe.As<T, byte>(ref value), Unsafe.As<T, byte>(ref comparand)) == Unsafe.As<T, byte>(ref comparand) :
@@ -114,7 +113,6 @@ namespace System.Threading.Tasks
                 sizeof(T) == sizeof(uint) ? Interlocked.CompareExchange(ref Unsafe.As<T, uint>(ref location), Unsafe.As<T, uint>(ref value), Unsafe.As<T, uint>(ref comparand)) == Unsafe.As<T, uint>(ref comparand) :
                 sizeof(T) == sizeof(ulong) ? Interlocked.CompareExchange(ref Unsafe.As<T, ulong>(ref location), Unsafe.As<T, ulong>(ref value), Unsafe.As<T, ulong>(ref comparand)) == Unsafe.As<T, ulong>(ref comparand) :
                 throw new UnreachableException();
-#pragma warning restore CS8500
 
             // The worker body. Each worker will execute this same body.
             Func<object, Task> taskBody = static async o =>

--- a/src/mono/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/mono/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -63,9 +63,7 @@ namespace System
             TypedReference result = default;
             unsafe
             {
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 IntGetNextArg(&result);
-#pragma warning restore CS8500
             }
             return result;
         }
@@ -81,9 +79,7 @@ namespace System
             TypedReference result = default;
             unsafe
             {
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 IntGetNextArgWithType(&result, rth.Value);
-#pragma warning restore CS8500
             }
             return result;
         }

--- a/src/mono/System.Private.CoreLib/src/System/Buffer.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Buffer.Mono.cs
@@ -21,13 +21,11 @@ namespace System
         {
             if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-#pragma warning disable 8500 // sizeof of managed types
                 // Blittable memmove
                 SpanHelpers.Memmove(
                     ref Unsafe.As<T, byte>(ref destination),
                     ref Unsafe.As<T, byte>(ref source),
                     elementCount * (nuint)sizeof(T));
-#pragma warning restore 8500
             }
             else if (elementCount > 0)
             {

--- a/src/mono/System.Private.CoreLib/src/System/Enum.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Enum.Mono.cs
@@ -6,8 +6,6 @@ using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable 8500 // pointer to / sizeof managed types
-
 namespace System
 {
     public partial class Enum

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -111,9 +111,7 @@ namespace System.Reflection
             unsafe
             {
                 // Passing TypedReference by reference is easier to make correct in native code
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 RuntimeFieldHandle.SetValueDirect(this, (RuntimeType)FieldType, &obj, value, (RuntimeType?)DeclaringType);
-#pragma warning restore CS8500
             }
         }
 
@@ -127,9 +125,7 @@ namespace System.Reflection
             unsafe
             {
                 // Passing TypedReference by reference is easier to make correct in native code
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType?)DeclaringType);
-#pragma warning restore CS8500
             }
         }
 

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
@@ -109,7 +109,6 @@ namespace System.Runtime.InteropServices
 
         private static Dictionary<(Type, string), ICustomMarshaler>? MarshalerInstanceCache;
 
-#pragma warning disable 8500
 #pragma warning disable 9080
         private static unsafe void SetInvokeArgs(ref string cookie, IntPtr *params_byref)
         {
@@ -117,7 +116,6 @@ namespace System.Runtime.InteropServices
             *(ByReference*)params_byref = objRef;
         }
 #pragma warning restore 9080
-#pragma warning restore 8500
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Implementation detail of MarshalAs.CustomMarshaler")]

--- a/src/mono/System.Private.CoreLib/src/System/TypedReference.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/TypedReference.Mono.cs
@@ -18,9 +18,7 @@ namespace System
 
         public static unsafe object? ToObject(TypedReference value)
         {
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
             return InternalToObject(&value);
-#pragma warning restore CS8500
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/mono/browser/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -518,16 +518,14 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private unsafe T ReadBigEndian<T>() where T : struct
         {
-            Span<byte> data = stackalloc byte[Unsafe.SizeOf<T>()];
+            Span<byte> data = stackalloc byte[sizeof(T)];
             T ret = default;
             Read(data);
             if (BitConverter.IsLittleEndian)
             {
                 data.Reverse();
             }
-#pragma warning disable CS8500 // takes address of managed type
             data.CopyTo(new Span<byte>(&ret, data.Length));
-#pragma warning restore CS8500
             return ret;
         }
     }
@@ -547,10 +545,8 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private unsafe void WriteBigEndian<T>(T val) where T : struct
         {
-            Span<byte> data = stackalloc byte[Unsafe.SizeOf<T>()];
-#pragma warning disable CS8500 // takes address of managed type
+            Span<byte> data = stackalloc byte[sizeof(T)];
             new Span<byte>(&val, data.Length).CopyTo(data);
-#pragma warning restore CS8500
             if (BitConverter.IsLittleEndian)
             {
                 data.Reverse();

--- a/src/mono/browser/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/browser/debugger/tests/debugger-test/debugger-test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="WasmBuildApp">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>219</NoWarn>
+    <NoWarn>$(NoWarn);219</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzers>false</RunAnalyzers>
     <WasmBuildAppDependsOn>PrepareForWasmBuildApp;$(WasmBuildAppDependsOn)</WasmBuildAppDependsOn>

--- a/src/mono/wasm/testassets/WasmOnAspNetCore/AspNetCoreServer/AspNetCoreServer.csproj
+++ b/src/mono/wasm/testassets/WasmOnAspNetCore/AspNetCoreServer/AspNetCoreServer.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- configure await warnings -->
-    <NoWarn>CA2007</NoWarn>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/testassets/WasmOnAspNetCore/BlazorClient/BlazorClient.csproj
+++ b/src/mono/wasm/testassets/WasmOnAspNetCore/BlazorClient/BlazorClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <WasmEnableThreads>true</WasmEnableThreads>
     <!-- nullablility warning, async warning -->
-    <NoWarn>CS8604;CS4014</NoWarn>
+    <NoWarn>$(NoWarn);CS8604;CS4014</NoWarn>
     <StaticWebAssetBasePath>blazorclient</StaticWebAssetBasePath>
   </PropertyGroup>
 

--- a/src/mono/wasm/testassets/WasmOnAspNetCore/Shared/Shared.csproj
+++ b/src/mono/wasm/testassets/WasmOnAspNetCore/Shared/Shared.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <NoWarn>CA2007</NoWarn>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
   <!-- versions are pinned but when run from WBT level, it's taking in-tree runtime -->

--- a/src/mono/wasm/testassets/WasmOnAspNetCore/WasmBrowserClient/WasmBrowserClient.csproj
+++ b/src/mono/wasm/testassets/WasmOnAspNetCore/WasmBrowserClient/WasmBrowserClient.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <!-- declare types in namespaces; ConfigureAwait; Prefer 'static readonly' fields; trim warnings -->
-    <NoWarn>CA1050;CA2007;CA1861;IL2104</NoWarn>
+    <NoWarn>$(NoWarn);CA1050;CA2007;CA1861;IL2104</NoWarn>
     <WasmEnableThreads>true</WasmEnableThreads>
     <StaticWebAssetBasePath>wasmclient</StaticWebAssetBasePath>
   </PropertyGroup>

--- a/src/tests/FunctionalTests/Android/Device_Emulator/gRPC/Android.Device_Emulator.gRPC.Test.csproj
+++ b/src/tests/FunctionalTests/Android/Device_Emulator/gRPC/Android.Device_Emulator.gRPC.Test.csproj
@@ -18,7 +18,7 @@
     <Nullable>enable</Nullable>
     <!-- Disable CS8981 because the generated code from the protobuf files contains classes with lowercase names -->
     <!-- Disable SYSLIB0039 because the tests intentionally use TLS 1.0 and 1.1 -->
-    <NoWarn>CS8981;SYSLIB0039</NoWarn>
+    <NoWarn>$(NoWarn);CS8981;SYSLIB0039</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/FunctionalTests/Android/Device_Emulator/gRPC/grpc-dotnet/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/src/tests/FunctionalTests/Android/Device_Emulator/gRPC/grpc-dotnet/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Disable CS8981 because the generated code from the protobuf files contains classes with lowercase names -->
     <!-- Disable SYSLIB0039 because the tests intentionally use TLS 1.0 and 1.1 -->
-    <NoWarn>CS8981;SYSLIB0039</NoWarn>
+    <NoWarn>$(NoWarn);CS8981;SYSLIB0039</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup Condition="$(BuildingOutsideDiagnostics)">
     <DefineConstants>$(DefineConstants);DIAGNOSTICS_RUNTIME</DefineConstants>
-    <NoWarn>CS1591,CS8073,CS0162</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS8073;CS0162</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also suppress CS8500 broadly rather than in hundreds of files individually. We'd previously discussed doing so and decided to wait until we saw the need more broadly, which I believe is now.