### PR TITLE
Optimize BOX+UNBOX for "T? -> T" and "T -> T?"

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8229,6 +8229,7 @@ public:
 
     bool eeIsValueClass(CORINFO_CLASS_HANDLE clsHnd);
     bool eeIsByrefLike(CORINFO_CLASS_HANDLE clsHnd);
+    bool eeIsSharedInst(CORINFO_CLASS_HANDLE clsHnd);
     bool eeIsIntrinsic(CORINFO_METHOD_HANDLE ftn);
     bool eeIsFieldStatic(CORINFO_FIELD_HANDLE fldHnd);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3455,7 +3455,7 @@ public:
 
     GenTree* gtNewMustThrowException(unsigned helper, var_types type, CORINFO_CLASS_HANDLE clsHnd);
 
-    GenTreeLclFld* gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset);
+    GenTreeLclFld* gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset, ClassLayout* layout = nullptr);
     GenTreeRetExpr* gtNewInlineCandidateReturnExpr(GenTreeCall* inlineCandidate, var_types type);
 
     GenTreeFieldAddr* gtNewFieldAddrNode(var_types            type,

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4499,6 +4499,10 @@ protected:
         MakeInlineObservation = 2,
     };
 
+    GenTree* impStoreNullableFields(CORINFO_CLASS_HANDLE nullableCls,
+        GenTree* value);
+    void impLoadNullableFields(GenTree* nullableObj, CORINFO_CLASS_HANDLE nullableCls, GenTree** hasValueFld, GenTree** valueFld);
+
     int impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                            const BYTE*             codeAddr,
                            const BYTE*             codeEndp,

--- a/src/coreclr/jit/ee_il_dll.hpp
+++ b/src/coreclr/jit/ee_il_dll.hpp
@@ -60,6 +60,12 @@ bool Compiler::eeIsByrefLike(CORINFO_CLASS_HANDLE clsHnd)
 }
 
 FORCEINLINE
+bool Compiler::eeIsSharedInst(CORINFO_CLASS_HANDLE clsHnd)
+{
+    return (info.compCompHnd->getClassAttribs(clsHnd) & CORINFO_FLG_SHAREDINST) != 0;
+}
+
+FORCEINLINE
 bool Compiler::eeIsIntrinsic(CORINFO_METHOD_HANDLE ftn)
 {
     return info.compCompHnd->isIntrinsic(ftn);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15037,8 +15037,7 @@ GenTree* Compiler::gtOptimizeEnumHasFlag(GenTree* thisOp, GenTree* flagOp)
 
     // If we have a shared type instance we can't safely check type
     // equality, so bail.
-    DWORD classAttribs = info.compCompHnd->getClassAttribs(thisHnd);
-    if (classAttribs & CORINFO_FLG_SHAREDINST)
+    if (eeIsSharedInst(thisHnd))
     {
         JITDUMP("bailing, have shared instance type\n");
         return nullptr;
@@ -18840,8 +18839,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                 // processing the call, but we could/should apply
                 // similar sharpening to the argument and local types
                 // of the inlinee.
-                const unsigned retClassFlags = info.compCompHnd->getClassAttribs(objClass);
-                if (retClassFlags & CORINFO_FLG_SHAREDINST)
+                if (eeIsSharedInst(objClass))
                 {
                     CORINFO_CONTEXT_HANDLE context = inlInfo->exactContextHnd;
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8300,9 +8300,9 @@ GenTreeConditional* Compiler::gtNewConditionalNode(
     return node;
 }
 
-GenTreeLclFld* Compiler::gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset)
+GenTreeLclFld* Compiler::gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset, ClassLayout* layout)
 {
-    GenTreeLclFld* node = new (this, GT_LCL_FLD) GenTreeLclFld(GT_LCL_FLD, type, lnum, offset, nullptr);
+    GenTreeLclFld* node = new (this, GT_LCL_FLD) GenTreeLclFld(GT_LCL_FLD, type, lnum, offset, layout);
     return node;
 }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11710,7 +11710,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     {
                         JITDUMP("IND(obj) is actually a class handle for %s\n", eeGetClassName(handle));
                         // Filter out all shared generic instantiations
-                        if ((info.compCompHnd->getClassAttribs(handle) & CORINFO_FLG_SHAREDINST) == 0)
+                        if (!eeIsSharedInst(handle))
                         {
                             void* pEmbedClsHnd;
                             void* embedClsHnd = (void*)info.compCompHnd->embedClassHandle(handle, &pEmbedClsHnd);


### PR DESCRIPTION
Remove heap allocations for such box+unbox patterns when nullable is involved.

```cs
TTo Test<TFrom, TTo>(TFrom o) => (TTo)(object)o;
```
Current codegen for `Test<int?, int>` and `Test<int, int?>`:
```asm
; Assembly listing for Test<int?, int>
G_M61296_IG01:
       push     rbx
       sub      rsp, 48
       mov      ebx, ecx
G_M61296_IG02:
       mov      rcx, 0x7FF8348774D0
       call     CORINFO_HELP_NEWSFAST     <-------------- heap allocation!
       mov      dword ptr [rax+0x08], ebx
       mov      r8, rax
       lea      rcx, [rsp+0x28]
       mov      rdx, 0x7FF834B4B750
       call     CORINFO_HELP_UNBOX_NULLABLE
       mov      rax, qword ptr [rsp+0x28]
G_M61296_IG03:
       add      rsp, 48
       pop      rbx
       ret      
; Total bytes of code 59


; Assembly listing for Test<int, int?>
G_M21085_IG01:
       sub      rsp, 40
       mov      qword ptr [rsp+0x30], rcx
G_M21085_IG02:
       lea      rdx, [rsp+0x30]
       mov      rcx, 0x7FF83614B750
       call     CORINFO_HELP_BOX_NULLABLE     <-------------- heap allocation!
       mov      eax, dword ptr [rax+0x08]
G_M21085_IG03:
       add      rsp, 40
       ret      
; Total bytes of code 37
```

New codegen for `Test<int?, int>` and `Test<int, int?>`:
```asm
; Assembly listing for Test<int?, int>
G_M61296_IG01:
       push     rax
G_M61296_IG02:
       mov      byte  ptr [rsp], 1
       mov      dword ptr [rsp+0x04], ecx
       mov      rax, qword ptr [rsp]
G_M61296_IG03:
       add      rsp, 8
       ret      
; Total bytes of code 18


; Assembly listing for Test<int, int?>
G_M21085_IG01:
       sub      rsp, 40
       mov      qword ptr [rsp+0x30], rcx
G_M21085_IG02:
       cmp      byte  ptr [rsp+0x30], 0
       je       SHORT G_M21085_IG04
       mov      eax, dword ptr [rsp+0x34]
G_M21085_IG03:
       add      rsp, 40
       ret      
G_M21085_IG04:
       call     CORINFO_HELP_THROWNULLREF
       int3     
; Total bytes of code 31
```