### PR TITLE
Fix crash in DAC enum memory code that brings down createdump

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7954,13 +7954,16 @@ BOOL ExceptionTypeOverridesStackTraceGetter(PTR_MethodTable pMT)
     for (DWORD slot = g_pObjectClass->GetNumVirtuals(); slot < g_pExceptionClass->GetNumVirtuals(); slot++)
     {
         MethodDesc *pMD = g_pExceptionClass->GetMethodDescForSlot(slot);
-        LPCUTF8 name = pMD->GetName();
-
-        if (name != NULL && strcmp(name, "get_StackTrace") == 0)
+        if (pMD != nullptr)
         {
-            // see if the slot is overridden by pMT
-            MethodDesc *pDerivedMD = pMT->GetMethodDescForSlot(slot);
-            return (pDerivedMD != pMD);
+            LPCUTF8 name = pMD->GetName();
+
+            if (name != NULL && strcmp(name, "get_StackTrace") == 0)
+            {
+                // see if the slot is overridden by pMT
+                MethodDesc *pDerivedMD = pMT->GetMethodDescForSlot(slot);
+                return (pDerivedMD != pMD);
+            }
         }
     }
 

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7953,7 +7953,7 @@ BOOL ExceptionTypeOverridesStackTraceGetter(PTR_MethodTable pMT)
     // find the slot corresponding to get_StackTrace
     for (DWORD slot = g_pObjectClass->GetNumVirtuals(); slot < g_pExceptionClass->GetNumVirtuals(); slot++)
     {
-        MethodDesc *pMD = g_pExceptionClass->GetMethodDescForSlot(slot);
+        MethodDesc *pMD = g_pExceptionClass->GetMethodDescForSlot_NoThrow(slot);
         if (pMD != nullptr)
         {
             LPCUTF8 name = pMD->GetName();
@@ -7961,7 +7961,7 @@ BOOL ExceptionTypeOverridesStackTraceGetter(PTR_MethodTable pMT)
             if (name != NULL && strcmp(name, "get_StackTrace") == 0)
             {
                 // see if the slot is overridden by pMT
-                MethodDesc *pDerivedMD = pMT->GetMethodDescForSlot(slot);
+                MethodDesc *pDerivedMD = pMT->GetMethodDescForSlot_NoThrow(slot);
                 return (pDerivedMD != pMD);
             }
         }

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -415,6 +415,10 @@ inline MethodDesc* MethodTable::GetMethodDescForSlot(DWORD slot)
     CONTRACTL_END;
 
     PCODE pCode = GetRestoredSlot(slot);
+    if (pCode == (PCODE)NULL)
+    {
+        return nullptr;
+    }
 
     // This is an optimization that we can take advantage of if we're trying to get the MethodDesc
     // for an interface virtual, since their slots usually point to stub.

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -415,10 +415,6 @@ inline MethodDesc* MethodTable::GetMethodDescForSlot(DWORD slot)
     CONTRACTL_END;
 
     PCODE pCode = GetRestoredSlot(slot);
-    if (pCode == (PCODE)NULL)
-    {
-        return nullptr;
-    }
 
     // This is an optimization that we can take advantage of if we're trying to get the MethodDesc
     // for an interface virtual, since their slots usually point to stub.


### PR DESCRIPTION
Either a recent change in a MT's virtual method slot allocation or createdump is just getting unlucky now and the slot hasn't been filled in yet is causing this crash. The DAC EnumMemoryRegions API is calling ExceptionTypeOverridesStackTraceGetter() which enumerates all the virtual method slots in the ExceptionObject's MT looking for "get_StackTrace" and check if it has been overridden.  All the code involved hasn't change in a very long time.

GetMethodDescForSlot gets called for a slot that has no PCODE (GetRestoredSlot() returns null).  There is a comment in that function about slots not being filled in yet and code on the runtime side (ifdef'ed out in the DAC) that fills it in.

The stack trace of the crash:

```
* thread #1, name = 'createdump', stop reason = signal SIGSEGV: invalid address (fault address: 0x0)
  * frame #0: 0x00007fffc46fc6c0 0x00007f8568876eed libmscordaccore.so`Precode::GetType(this=0x0000000000000000) + 29 at precode.h:447
    frame #1: 0x00007fffc46fc6f0 0x00007f8568876dc9 libmscordaccore.so`Precode::GetPrecodeFromEntryPoint(addr=0, fSpeculative=YES) + 153 at precode.h:557
    frame #2: 0x00007fffc46fc750 0x00007f8568880074 libmscordaccore.so`MethodDesc::GetMethodDescFromStubAddr(addr=0, fSpeculative=NO) + 52 at method.cpp:2628
    frame #3: 0x00007fffc46fc7a0 0x00007f85688a692a libmscordaccore.so`MethodTable::GetMethodDescForSlotAddress(addr=0, fSpeculative=NO) + 90 at methodtable.cpp:6211
    frame #4: 0x00007fffc46fc7d0 0x00007f856887ba41 libmscordaccore.so`MethodTable::GetMethodDescForSlot(this=0x00007f8565d9f030, slot=11) + 161 at methodtable.inl:426
    frame #5: 0x00007fffc46fc810 0x00007f85688ccc93 libmscordaccore.so`ExceptionTypeOverridesStackTraceGetter(pMT=PTR_MethodTable @ 0x00007fffc46fcb50) + 259 at excep.cpp:7956
    frame #6: 0x00007fffc46fc870 0x00007f856899b6de libmscordaccore.so`ClrDataAccess::DumpManagedExcepObject(this=0x000055bc91c4d210, flags=CLRDATA_ENUM_MEM_TRIAGE, objRef=OBJECTREF @ 0x00007fffc46fd658) + 3422 at enummem.cpp:527
    frame #7: 0x00007fffc46fcef0 0x00007f8568996abd libmscordaccore.so`ClrDataAccess::EnumMemDumpAllThreadsStack(this=0x000055bc91c4d210, flags=CLRDATA_ENUM_MEM_TRIAGE) + 909 at enummem.cpp:1143
    frame #8: 0x00007fffc46fe360 0x00007f85689a1c28 libmscordaccore.so`ClrDataAccess::EnumMemoryRegionsWorkerMicroTriage(this=0x000055bc91c4d210, flags=CLRDATA_ENUM_MEM_TRIAGE) + 200 at enummem.cpp:1714
    frame #9: 0x00007fffc46fe830 0x00007f85689a7809 libmscordaccore.so`ClrDataAccess::EnumMemoryRegionsWrapper(this=0x000055bc91c4d210, flags=CLRDATA_ENUM_MEM_TRIAGE) + 329 at enummem.cpp:1920
    frame #10: 0x00007fffc46fe940 0x00007f85689a7f18 libmscordaccore.so`ClrDataAccess::EnumMemoryRegions(this=0x000055bc91c4d210, callback=0x000055bc91c2eae0, miniDumpFlags=1181100, flags=CLRDATA_ENUM_MEM_HEAP2) + 632 at enummem.cpp:2033
    frame #11: 0x00007fffc46fea70 0x000055bc8fdb2e20 createdump`CrashInfo::EnumerateMemoryRegionsWithDAC(this=0x000055bc91c2eae0, dumpType=Triage) + 352 at crashinfo.cpp:410
    frame #12: 0x00007fffc46fead0 0x000055bc8fda6f58 createdump`CreateDump(options=0x00007fffc4702cd0) + 1160 at createdumpunix.cpp:75
    frame #13: 0x00007fffc4702c30 0x000055bc8fda59b7 createdump`createdump_main(argc=11, argv=0x00007fffc4702ec0) + 2199 at createdumpmain.cpp:222
    frame #14: 0x00007fffc4702d30 0x000055bc8fda48e2 createdump`main(argc=11, argv=0x00007fffc4702e68) + 34 at main.cpp:20
    frame #15: 0x00007fffc4702d60 0x00007f8568c8ad90 libc.so.6`__libc_start_call_main(main=(createdump`main at main.cpp:19), argc=11, argv=0x00007fffc4702e68) + 128 at libc_start_call_main.h:58
    frame #16: 0x00007fffc4702e00 0x00007f8568c8ae40 libc.so.6`__libc_start_main_impl(main=(createdump`main at main.cpp:19), argc=11, argv=0x00007fffc4702e68, init=(_rtld_global), fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffc4702e58) + 128 at libc-start.c:392
    frame #17: 0x00007fffc4702e50 0x000055bc8fda47f5 createdump`_start + 37(lldb) k
```
