### PR TITLE
Use OverloadResolutionPriority with Debug/Trace.Assert(string)

### DIFF
--- a/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
@@ -119,9 +119,10 @@ namespace System.Diagnostics
         public static System.Diagnostics.TraceListenerCollection Listeners { get { throw null; } }
         public static bool UseGlobalLock { get { throw null; } set { } }
         [System.Diagnostics.ConditionalAttribute("TRACE")]
+        [System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute(-1)]
         public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition) { }
         [System.Diagnostics.ConditionalAttribute("TRACE")]
-        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, string? message) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("condition")] string? message = null) { }
         [System.Diagnostics.ConditionalAttribute("TRACE")]
         public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, string? message, string? detailMessage) { }
         [System.Diagnostics.ConditionalAttribute("TRACE")]

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
@@ -3,6 +3,7 @@
 
 #define TRACE
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Diagnostics
@@ -114,6 +115,7 @@ namespace System.Diagnostics
         ///       is <see langword='false'/>.</para>
         /// </devdoc>
         [Conditional("TRACE")]
+        [OverloadResolutionPriority(-1)] // lower priority than (bool, string) overload so that the compiler prefers using CallerArgumentExpression
         public static void Assert([DoesNotReturnIf(false)] bool condition)
         {
             TraceInternal.Assert(condition);
@@ -124,7 +126,7 @@ namespace System.Diagnostics
         ///    <see langword='false'/>. </para>
         /// </devdoc>
         [Conditional("TRACE")]
-        public static void Assert([DoesNotReturnIf(false)] bool condition, string? message)
+        public static void Assert([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression(nameof(condition))] string? message = null)
         {
             TraceInternal.Assert(condition, message);
         }

--- a/src/libraries/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests/TraceClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/System.Diagnostics.TraceSource.Tests/TraceClassTests.cs
@@ -122,15 +122,19 @@ namespace System.Diagnostics.TraceSourceTests
             Trace.Listeners.Clear();
             Trace.Listeners.Add(listener);
             Trace.Listeners.Add(text);
-            Trace.Assert(true, "Message");
+            bool someSuccessfulCondition = true;
+            Trace.Assert(someSuccessfulCondition, "Message");
             Assert.Equal(0, listener.GetCallCount(Method.WriteLine));
             Assert.Equal(0, listener.GetCallCount(Method.Fail));
             text.Flush();
             Assert.DoesNotContain("Message", text.Output);
-            Trace.Assert(false, "Message");
+            bool someFailureCondition = false;
+            Trace.Assert(someFailureCondition);
+            Trace.Assert(someFailureCondition, "Message");
             Assert.Equal(0, listener.GetCallCount(Method.WriteLine));
-            Assert.Equal(1, listener.GetCallCount(Method.Fail));
+            Assert.Equal(2, listener.GetCallCount(Method.Fail));
             text.Flush();
+            Assert.Contains("someFailureCondition", text.Output);
             Assert.Contains("Message", text.Output);
         }
 
@@ -384,7 +388,13 @@ namespace System.Diagnostics.TraceSourceTests
             Trace.WriteLine("Message end.");
             textTL.Flush();
             newLine = Environment.NewLine;
-            var expected = "Message start." + newLine + "    This message should be indented.This should not be indented." + newLine + "      " + fail + "This failure is reported with a detailed message" + newLine + "      " + fail + newLine + "      " + fail + "This assert is reported" + newLine + "Message end." + newLine;
+            var expected =
+                "Message start." + newLine +
+                "    This message should be indented.This should not be indented." + newLine +
+                "      " + fail + "This failure is reported with a detailed message" + newLine +
+                "      " + fail + "false" + newLine +
+                "      " + fail + "This assert is reported" + newLine +
+                "Message end." + newLine;
             Assert.Equal(expected, textTL.Output);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
@@ -78,11 +78,12 @@ namespace System.Diagnostics
             WriteLine(string.Format(null, format, args));
 
         [Conditional("DEBUG")]
+        [OverloadResolutionPriority(-1)] // lower priority than (bool, string) overload so that the compiler prefers using CallerArgumentExpression
         public static void Assert([DoesNotReturnIf(false)] bool condition) =>
             Assert(condition, string.Empty, string.Empty);
 
         [Conditional("DEBUG")]
-        public static void Assert([DoesNotReturnIf(false)] bool condition, string? message) =>
+        public static void Assert([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression(nameof(condition))] string? message = null) =>
             Assert(condition, message, string.Empty);
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8535,13 +8535,14 @@ namespace System.Diagnostics
         public static int IndentLevel { get { throw null; } set { } }
         public static int IndentSize { get { throw null; } set { } }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
+        [System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute(-1)]
         public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("condition")] ref System.Diagnostics.Debug.AssertInterpolatedStringHandler message) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("condition")] ref System.Diagnostics.Debug.AssertInterpolatedStringHandler message, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("condition")] ref System.Diagnostics.Debug.AssertInterpolatedStringHandler detailMessage) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, string? message) { }
+        public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("condition")] string? message = null) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition, string? message, string? detailMessage) { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]

--- a/src/libraries/System.Runtime/tests/System.Diagnostics.Debug.Tests/DebugTestsNoListeners.cs
+++ b/src/libraries/System.Runtime/tests/System.Diagnostics.Debug.Tests/DebugTestsNoListeners.cs
@@ -81,15 +81,17 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void Asserts()
         {
-            VerifyLogged(() => Debug.Assert(true), "");
-            VerifyLogged(() => Debug.Assert(true, "assert passed"), "");
-            VerifyLogged(() => Debug.Assert(true, "assert passed", "nothing is wrong"), "");
-            VerifyLogged(() => Debug.Assert(true, "assert passed", "nothing is wrong {0} {1}", 'a', 'b'), "");
+            bool someSuccessfulCondition = true;
+            VerifyLogged(() => Debug.Assert(someSuccessfulCondition), "");
+            VerifyLogged(() => Debug.Assert(someSuccessfulCondition, "assert passed"), "");
+            VerifyLogged(() => Debug.Assert(someSuccessfulCondition, "assert passed", "nothing is wrong"), "");
+            VerifyLogged(() => Debug.Assert(someSuccessfulCondition, "assert passed", "nothing is wrong {0} {1}", 'a', 'b'), "");
 
-            VerifyAssert(() => Debug.Assert(false), "");
-            VerifyAssert(() => Debug.Assert(false, "assert passed"), "assert passed");
-            VerifyAssert(() => Debug.Assert(false, "assert passed", "nothing is wrong"), "assert passed", "nothing is wrong");
-            VerifyAssert(() => Debug.Assert(false, "assert passed", "nothing is wrong {0} {1}", 'a', 'b'), "assert passed", "nothing is wrong a b");
+            bool someFailedCondition = false;
+            VerifyAssert(() => Debug.Assert(someFailedCondition), "someFailedCondition");
+            VerifyAssert(() => Debug.Assert(someFailedCondition, "assert passed"), "assert passed");
+            VerifyAssert(() => Debug.Assert(someFailedCondition, "assert passed", "nothing is wrong"), "assert passed", "nothing is wrong");
+            VerifyAssert(() => Debug.Assert(someFailedCondition, "assert passed", "nothing is wrong {0} {1}", 'a', 'b'), "assert passed", "nothing is wrong a b");
         }
 
         [Fact]


### PR DESCRIPTION
```C#
using System.Diagnostics;

SomeMethod(6, 10);

static void SomeMethod(int a, int b)
{
    Debug.Assert(a > 0);
    Debug.Assert(b > 0);
    Debug.Assert((a - 3) > (b / 2));
}
```

Before:
```
Process terminated. Assertion failed.
   at Program.<<Main>$>g__SomeMethod|0_0(Int32 a, Int32 b)
```

After:
```
Process terminated. Assertion failed.
(a - 3) > (b / 2)
   at Program.<<Main>$>g__SomeMethod|0_0(Int32 a, Int32 b)
```