### PR TITLE
[RISC-V] CLR test build fix

### DIFF
--- a/src/tests/Regressions/coreclr/103365/103365.cs
+++ b/src/tests/Regressions/coreclr/103365/103365.cs
@@ -39,13 +39,12 @@ public class BasicDerivedClass : BasicBaseClass, IBaseInterface<BasicDerivedClas
 public static class Test_Issue103365
 {
     [Fact]
-  	public static void Main ()
-	{
+    public static void Test()
+    {
         var instances = new IBaseInterface<BasicBaseClass>[2];
         instances[0] = new BasicBaseClass();
         instances[1] = new BasicDerivedClass();
         Assert.Equal("BasicBaseClass", instances[0].explicitDeclaration());
         Assert.Equal("BasicDerivedClass", instances[1].explicitDeclaration());
-  	}
+    }
 }
-


### PR DESCRIPTION
src/tests/Regressions/coreclr/103365/103365.cs(42,23): error XUW1001: Projects in merged tests group should not have entry points.

Part of #84834, cc @dotnet/samsung