### PR TITLE
[release/8.0-staging][browser] Fix WBT timeout (30000ms exceeded)

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -117,7 +117,7 @@ internal class BrowserRunner : IAsyncDisposable
         if (modifyBrowserUrl != null)
             browserUrl = modifyBrowserUrl(browserUrl);
 
-        IPage page = await Browser.NewPageAsync();
+        IPage page = await Browser!.NewPageAsync();
         if (onConsoleMessage is not null)
             page.Console += (_, msg) => onConsoleMessage(msg);
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/104481.

Fixes https://github.com/dotnet/runtime/issues/104830.

Risk:
Low
This PR changes only the test infrastructure. Instead of trying to launch browser once for 3s, with this PR we try 3 times, 1s each.