### PR TITLE
[mono][swift-interop] Support for Swift struct lowering in callback returns

### DIFF
--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -8435,9 +8435,9 @@ MONO_RESTORE_WARNING
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 			if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL) && sig->pinvoke &&
 	    		cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED && 
-	    		cfg->arch.cinfo->need_swift_return_buffer) {
+	    		cfg->arch.cinfo->need_swift_return_buffer && cinfo->ret.reg == AMD64_R10) {
 				// Save the return buffer passed by the Swift caller
-				amd64_mov_membase_reg (code, cfg->vret_addr->inst_basereg, cfg->vret_addr->inst_offset, SWIFT_RETURN_BUFFER_REG, sizeof (target_mgreg_t));
+				amd64_mov_membase_reg (code, cfg->vret_addr->inst_basereg, cfg->vret_addr->inst_offset, SWIFT_RETURN_BUFFER_REG, 8);
 			} else
 #endif
 			{
@@ -8449,8 +8449,7 @@ MONO_RESTORE_WARNING
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL) && 
 	    cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED && 
-	    cfg->arch.cinfo->need_swift_return_buffer &&
-		cfg->arch.cinfo->ret.storage != ArgValuetypeAddrInIReg) {
+	    cfg->arch.cinfo->need_swift_return_buffer) {
 		amd64_mov_reg_reg (code, AMD64_R10, SWIFT_RETURN_BUFFER_REG, 8);
 	}
 #endif

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -8759,7 +8759,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 			ArgInfo *ainfo = &cinfo->ret;
 			MonoInst *ins = cfg->ret;
 
-			for (int i = 0; i < ainfo->nregs; i ++) {
+			for (int i = 0; i < ainfo->nregs; i++) {
 				switch (ainfo->pair_storage [i]) {
 				case ArgInIReg:
 					amd64_mov_reg_membase (code, ainfo->pair_regs [i], ins->inst_basereg, ins->inst_offset + ainfo->offsets [i], sizeof (target_mgreg_t));

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1322,15 +1322,15 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 			int storage_type = ainfo->pair_storage [k];
 			int reg_storage = ainfo->pair_regs [k];
 			switch (storage_type) {
-				case ArgInIReg:
-					ccontext->gregs [reg_storage] = *src_cast;
-					break;
-				case ArgInFloatSSEReg:
-				case ArgInDoubleSSEReg:
-					ccontext->fregs [reg_storage] = *(double*)src_cast;
-					break;
-				default:
-					g_assert_not_reached ();
+			case ArgInIReg:
+				ccontext->gregs [reg_storage] = *src_cast;
+				break;
+			case ArgInFloatSSEReg:
+			case ArgInDoubleSSEReg:
+				ccontext->fregs [reg_storage] = *(double*)src_cast;
+				break;
+			default:
+				g_assert_not_reached ();
 			}
 			src_cast++;
 		}

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -2401,7 +2401,7 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 		linfo->vret_arg_index = cinfo->vret_arg_index;
 		break;
 	case ArgSwiftValuetypeLoweredRet:
-		// LLVM compilation of P/Invoke wrappers is not supported
+		linfo->ret.storage = LLVMArgNone; // LLVM compilation of pinvoke wrappers is not supported, see emit_method_inner in mini-llvm.c
 		break;
 	default:
 		g_assert_not_reached ();
@@ -2470,7 +2470,7 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 			linfo->args [i].storage = LLVMArgVtypeAddr;
 			break;
 		case ArgSwiftError:
-			// LLVM compilation of P/Invoke wrappers is not supported
+			linfo->args [i].storage = LLVMArgNone; // LLVM compilation of pinvoke wrappers is not supported, see emit_method_inner in mini-llvm.c
 			break;
 		default:
 			cfg->exception_message = g_strdup ("ainfo->storage");

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -8751,6 +8751,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 				g_assert_not_reached ();
 			}
 		}
+		break;
 	}
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	case ArgSwiftValuetypeLoweredRet: {
@@ -8773,8 +8774,8 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 					NOT_IMPLEMENTED;
 				}
 			}
-			break;
 		}
+		break;
 	}
 #endif /* MONO_ARCH_HAVE_SWIFTCALL */
 	}

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -8771,7 +8771,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 					amd64_movsd_reg_membase (code, ainfo->pair_regs [i], ins->inst_basereg, ins->inst_offset + ainfo->offsets [i]);
 					break;
 				default:
-					NOT_IMPLEMENTED;
+					g_assert_not_reached ();
 				}
 			}
 		}

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -2067,7 +2067,7 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 	case ArgSwiftVtypeLoweredRet: {
 		int gr = 0, fr = 0; // We can start from 0 since we are handling only returns
 		char *storage = (char*)src;
-		for (int k = 0; k< ainfo->nregs; ++k) {
+		for (int k = 0; k< ainfo->nregs; k++) {
 			switch (ainfo->struct_storage [k]) {
 			case ArgInIReg:
 				ccontext->gregs [gr++] = *(gsize*)(storage + ainfo->offsets [k]);
@@ -2081,9 +2081,7 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 			default:
 				g_assert_not_reached ();
 			}
-
 		}	
-
 		break;
 	}
 #endif /* MONO_ARCH_HAVE_SWIFTCALL */

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -2024,22 +2024,21 @@ arg_get_val (CallContext *ccontext, ArgInfo *ainfo, gpointer dest)
 	}
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	case ArgSwiftVtypeLoweredRet: {
-		int i;
 		int gr = 0, fr = 0; // We can start from 0 since we are handling only returns
 		char *storage = (char*)dest;
-		for (i = 0; i < ainfo->nregs; ++i) {
-			switch (ainfo->struct_storage [i]) {
-				case ArgInIReg:
-					*(gsize*)(storage + ainfo->offsets [i]) = ccontext->gregs [gr++];
-					break;
-				case ArgInFReg:
-					*(double*)(storage + ainfo->offsets [i]) = ccontext->fregs [fr++];
-					break;
-				case ArgInFRegR4:
-					*(float*)(storage + ainfo->offsets [i]) = *(float*)&ccontext->fregs [fr++];
-					break;
-				default:
-					g_assert_not_reached ();
+		for (int k = 0; k < ainfo->nregs; ++k) {
+			switch (ainfo->struct_storage [k]) {
+			case ArgInIReg:
+				*(gsize*)(storage + ainfo->offsets [k]) = ccontext->gregs [gr++];
+				break;
+			case ArgInFReg:
+				*(double*)(storage + ainfo->offsets [k]) = ccontext->fregs [fr++];
+				break;
+			case ArgInFRegR4:
+				*(float*)(storage + ainfo->offsets [k]) = *(float*)&ccontext->fregs [fr++];
+				break;
+			default:
+				g_assert_not_reached ();
 			}
 		}
 		break;
@@ -2055,10 +2054,41 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 {
 	g_assert (arg_need_temp (ainfo));
 
-	float *src_float = (float*)src;
-	for (int k = 0; k < ainfo->nregs; k++) {
-		*(float*)&ccontext->fregs [ainfo->reg + k] = *src_float;
-		src_float++;
+	switch (ainfo->storage) {
+	case ArgHFA: {
+		float *src_float = (float*)src;
+		for (int k = 0; k < ainfo->nregs; k++) {
+			*(float*)&ccontext->fregs [ainfo->reg + k] = *src_float;
+			src_float++;
+		}
+		break;
+	}
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	case ArgSwiftVtypeLoweredRet: {
+		int gr = 0, fr = 0; // We can start from 0 since we are handling only returns
+		char *storage = (char*)src;
+		for (int k = 0; k< ainfo->nregs; ++k) {
+			switch (ainfo->struct_storage [k]) {
+			case ArgInIReg:
+				ccontext->gregs [gr++] = *(gsize*)(storage + ainfo->offsets [k]);
+				break;
+			case ArgInFReg:
+				ccontext->fregs [fr++] = *(double*)(storage + ainfo->offsets [k]);
+				break;
+			case ArgInFRegR4:
+				*(float*)&ccontext->fregs [fr++] = *(float*)(storage + ainfo->offsets [k]);
+				break;
+			default:
+				g_assert_not_reached ();
+			}
+
+		}	
+
+		break;
+	}
+#endif /* MONO_ARCH_HAVE_SWIFTCALL */
+	default:
+		g_assert_not_reached ();
 	}
 }
 
@@ -6486,6 +6516,30 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 		}
 		break;
 	}
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	case ArgSwiftVtypeLoweredRet: {
+		if (cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED) {
+			MonoInst *ins = cfg->ret;
+			int gr = 0, fr = 0; // We can start from 0 since we are handling only returns
+			for (int i = 0; i < cinfo->ret.nregs; ++i) {
+				switch (cinfo->ret.struct_storage [i]) {
+				case ArgInIReg:
+					code = emit_ldrx (code, gr++, ins->inst_basereg, GTMREG_TO_INT (ins->inst_offset + cinfo->ret.offsets [i]));
+					break;
+				case ArgInFRegR4:
+					code = emit_ldrfpw (code, fr++, ins->inst_basereg, GTMREG_TO_INT (ins->inst_offset + cinfo->ret.offsets [i]));
+					break;
+				case ArgInFReg:
+					code = emit_ldrfpx (code, fr++, ins->inst_basereg, GTMREG_TO_INT (ins->inst_offset + cinfo->ret.offsets [i]));
+					break;
+				default:
+					g_assert_not_reached ();
+				}
+			}
+		}
+		break;
+	}
+#endif /* MONO_ARCH_HAVE_SWIFTCALL */
 	default:
 		break;
 	}

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -3121,7 +3121,7 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 		linfo->ret.esize = cinfo->ret.esize;
 		break;
 	case ArgSwiftVtypeLoweredRet:
-		// LLVM compilation of P/Invoke wrappers is not supported
+		linfo->ret.storage = LLVMArgNone; // LLVM compilation of pinvoke wrappers is not supported, see emit_method_inner in mini-llvm.c
 		break;
 	default:
 		g_assert_not_reached ();
@@ -3188,7 +3188,7 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 			lainfo->storage = LLVMArgVtypeInSIMDReg;
 			break;
 		case ArgSwiftError:
-			// LLVM compilation of P/Invoke wrappers is not supported
+			lainfo->storage = LLVMArgNone; // LLVM compilation of pinvoke wrappers is not supported, see emit_method_inner in mini-llvm.c
 			break;
 		default:
 			g_assert_not_reached ();

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -2067,7 +2067,7 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 	case ArgSwiftVtypeLoweredRet: {
 		int gr = 0, fr = 0; // We can start from 0 since we are handling only returns
 		char *storage = (char*)src;
-		for (int k = 0; k< ainfo->nregs; k++) {
+		for (int k = 0; k < ainfo->nregs; k++) {
 			switch (ainfo->struct_storage [k]) {
 			case ArgInIReg:
 				ccontext->gregs [gr++] = *(gsize*)(storage + ainfo->offsets [k]);

--- a/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.cs
+++ b/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.cs
@@ -375,7 +375,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc3()
     {
         Console.Write("Running SwiftCallbackFunc3: ");
@@ -461,7 +460,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc4()
     {
         Console.Write("Running SwiftCallbackFunc4: ");
@@ -590,7 +588,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc5()
     {
         Console.Write("Running SwiftCallbackFunc5: ");
@@ -715,7 +712,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc6()
     {
         Console.Write("Running SwiftCallbackFunc6: ");
@@ -870,7 +866,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc8()
     {
         Console.Write("Running SwiftCallbackFunc8: ");
@@ -1066,7 +1061,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc10()
     {
         Console.Write("Running SwiftCallbackFunc10: ");
@@ -1175,7 +1169,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc11()
     {
         Console.Write("Running SwiftCallbackFunc11: ");
@@ -1258,7 +1251,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc12()
     {
         Console.Write("Running SwiftCallbackFunc12: ");
@@ -1750,7 +1742,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc18()
     {
         Console.Write("Running SwiftCallbackFunc18: ");
@@ -1864,7 +1855,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc19()
     {
         Console.Write("Running SwiftCallbackFunc19: ");
@@ -1970,7 +1960,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc20()
     {
         Console.Write("Running SwiftCallbackFunc20: ");
@@ -2045,7 +2034,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc21()
     {
         Console.Write("Running SwiftCallbackFunc21: ");
@@ -2169,7 +2157,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc22()
     {
         Console.Write("Running SwiftCallbackFunc22: ");
@@ -2428,7 +2415,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc25()
     {
         Console.Write("Running SwiftCallbackFunc25: ");
@@ -2525,7 +2511,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc26()
     {
         Console.Write("Running SwiftCallbackFunc26: ");
@@ -2716,7 +2701,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc28()
     {
         Console.Write("Running SwiftCallbackFunc28: ");
@@ -2844,7 +2828,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc29()
     {
         Console.Write("Running SwiftCallbackFunc29: ");
@@ -2998,7 +2981,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc31()
     {
         Console.Write("Running SwiftCallbackFunc31: ");
@@ -3052,7 +3034,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc32()
     {
         Console.Write("Running SwiftCallbackFunc32: ");
@@ -3432,7 +3413,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc37()
     {
         Console.Write("Running SwiftCallbackFunc37: ");
@@ -3750,7 +3730,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc41()
     {
         Console.Write("Running SwiftCallbackFunc41: ");
@@ -3869,7 +3848,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc43()
     {
         Console.Write("Running SwiftCallbackFunc43: ");
@@ -3974,7 +3952,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc44()
     {
         Console.Write("Running SwiftCallbackFunc44: ");
@@ -4059,7 +4036,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc45()
     {
         Console.Write("Running SwiftCallbackFunc45: ");
@@ -4119,7 +4095,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc46()
     {
         Console.Write("Running SwiftCallbackFunc46: ");
@@ -4236,7 +4211,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc47()
     {
         Console.Write("Running SwiftCallbackFunc47: ");
@@ -4380,7 +4354,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc49()
     {
         Console.Write("Running SwiftCallbackFunc49: ");
@@ -4558,7 +4531,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc51()
     {
         Console.Write("Running SwiftCallbackFunc51: ");
@@ -4632,7 +4604,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc52()
     {
         Console.Write("Running SwiftCallbackFunc52: ");
@@ -4792,7 +4763,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc53()
     {
         Console.Write("Running SwiftCallbackFunc53: ");
@@ -4912,7 +4882,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc54()
     {
         Console.Write("Running SwiftCallbackFunc54: ");
@@ -5011,7 +4980,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc55()
     {
         Console.Write("Running SwiftCallbackFunc55: ");
@@ -5146,7 +5114,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc57()
     {
         Console.Write("Running SwiftCallbackFunc57: ");
@@ -5467,7 +5434,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc62()
     {
         Console.Write("Running SwiftCallbackFunc62: ");
@@ -5594,7 +5560,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc64()
     {
         Console.Write("Running SwiftCallbackFunc64: ");
@@ -5694,7 +5659,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc65()
     {
         Console.Write("Running SwiftCallbackFunc65: ");
@@ -5762,7 +5726,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc66()
     {
         Console.Write("Running SwiftCallbackFunc66: ");
@@ -5970,7 +5933,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc68()
     {
         Console.Write("Running SwiftCallbackFunc68: ");
@@ -6070,7 +6032,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc69()
     {
         Console.Write("Running SwiftCallbackFunc69: ");
@@ -6187,7 +6148,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc70()
     {
         Console.Write("Running SwiftCallbackFunc70: ");
@@ -6300,7 +6260,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc72()
     {
         Console.Write("Running SwiftCallbackFunc72: ");
@@ -6552,7 +6511,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc75()
     {
         Console.Write("Running SwiftCallbackFunc75: ");
@@ -6751,7 +6709,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc77()
     {
         Console.Write("Running SwiftCallbackFunc77: ");
@@ -6910,7 +6867,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc79()
     {
         Console.Write("Running SwiftCallbackFunc79: ");
@@ -7051,7 +7007,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc81()
     {
         Console.Write("Running SwiftCallbackFunc81: ");
@@ -7201,7 +7156,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc83()
     {
         Console.Write("Running SwiftCallbackFunc83: ");
@@ -7428,7 +7382,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc85()
     {
         Console.Write("Running SwiftCallbackFunc85: ");
@@ -7533,7 +7486,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc86()
     {
         Console.Write("Running SwiftCallbackFunc86: ");
@@ -7682,7 +7634,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc88()
     {
         Console.Write("Running SwiftCallbackFunc88: ");
@@ -7752,7 +7703,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc89()
     {
         Console.Write("Running SwiftCallbackFunc89: ");
@@ -7861,7 +7811,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc90()
     {
         Console.Write("Running SwiftCallbackFunc90: ");
@@ -7982,7 +7931,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc91()
     {
         Console.Write("Running SwiftCallbackFunc91: ");
@@ -8076,7 +8024,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc92()
     {
         Console.Write("Running SwiftCallbackFunc92: ");
@@ -8140,7 +8087,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc93()
     {
         Console.Write("Running SwiftCallbackFunc93: ");
@@ -8250,7 +8196,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc94()
     {
         Console.Write("Running SwiftCallbackFunc94: ");
@@ -8340,7 +8285,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc95()
     {
         Console.Write("Running SwiftCallbackFunc95: ");
@@ -8504,7 +8448,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [SkipOnMono("Struct lowering for reverse pinvokes returns not supported on Mono")]
     public static void TestSwiftCallbackFunc97()
     {
         Console.Write("Running SwiftCallbackFunc97: ");


### PR DESCRIPTION
## Description
This PR adds support in Mono runtime for Swift `@frozen` struct lowering in function returns in reverse P/Invoke scenario. These changes are a follow-up to https://github.com/dotnet/runtime/pull/104389 which introduced support for direct P/Invoke scenario and contains detailed description of the problem.

## Implementation
The key implementation part was done in https://github.com/dotnet/runtime/pull/104389. Same as in direct P/Invokes, the struct can be returned as a lowered sequence of primitives or by reference.

1. Returned by lowered sequence:
    - The struct is disassembled inside `mono_arch_emit_epilog` where the lowered sequence of primitives is stored into dedicated return registers.

2. Returned by reference:
    - On arm64, handled as regular `ArgVtypeByRef` with no extra changes.
    - On x64, handled as `ArgValuetypeAddrInIReg` with specific handling where we need to load the return buffer address passed by Swift caller from `RAX` reg. into `vret_addr` inside the `mono_arch_emit_prolog`

## Verification
The changes are verified using the Interop/Swift/SwiftCallbackAbiStress runtime tests. The extended set of 2500 test cases was used locally to further verify the lowering support. The fullAOT functionality was only verified in local settings due to missing coverage on CI.

---

Contributes to https://github.com/dotnet/runtime/issues/102077