### PR TITLE
Redact query from HttpTelemetry

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -41,7 +41,7 @@ namespace System.Net.Http
             if (!GlobalHttpSettings.DiagnosticsHandler.DisableUriRedaction)
             {
                 int queryIndex = pathAndQuery.IndexOf('?');
-                if (queryIndex >= 0)
+                if (queryIndex >= 0 && queryIndex < (pathAndQuery.Length - 1))
                 {
                     pathAndQuery = $"{pathAndQuery.AsSpan(0, queryIndex + 1)}*";
                 }
@@ -182,6 +182,25 @@ namespace System.Net.Http
         public void Redirect(string redirectUri)
         {
             WriteEvent(eventId: 16, redirectUri);
+        }
+
+        [NonEvent]
+        public void Redirect(Uri redirectUri)
+        {
+            if (!GlobalHttpSettings.DiagnosticsHandler.DisableUriRedaction)
+            {
+                string pathAndQuery = redirectUri.PathAndQuery;
+                int queryIndex = pathAndQuery.IndexOf('?');
+                if (queryIndex >= 0 && queryIndex < (pathAndQuery.Length - 1))
+                {
+                    UriBuilder uriBuilder = new UriBuilder(redirectUri)
+                    {
+                        Query = "*"
+                    };
+                    redirectUri = uriBuilder.Uri;
+                }
+            }
+            Redirect(redirectUri.AbsoluteUri);
         }
 
         [NonEvent]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -43,10 +43,7 @@ namespace System.Net.Http
                 int queryIndex = pathAndQuery.IndexOf('?');
                 if (queryIndex >= 0)
                 {
-                    using ValueStringBuilder str = queryIndex < 254 ? new ValueStringBuilder(stackalloc char[queryIndex + 2]) : new ValueStringBuilder(queryIndex + 2);
-                    str.Append(pathAndQuery.AsSpan(0, queryIndex + 1));
-                    str.Append('*');
-                    pathAndQuery = str.ToString();
+                    pathAndQuery = $"{pathAndQuery.AsSpan(0, queryIndex + 1)}*";
                 }
             }
             WriteEvent(eventId: 1, scheme, host, port, pathAndQuery, versionMajor, versionMinor, versionPolicy);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -55,7 +55,7 @@ namespace System.Net.Http
 
                 if (HttpTelemetry.Log.IsEnabled())
                 {
-                    HttpTelemetry.Log.Redirect(redirectUri.AbsoluteUri);
+                    HttpTelemetry.Log.Redirect(redirectUri);
                 }
                 if (NetEventSource.Log.IsEnabled())
                 {


### PR DESCRIPTION
Follow up on #103769

Redacts query string from the official HttpTelemetry (EventSource "System.Net.Http"). Uses the same opt out as distributed tracing (Activity) and `HttpClientFactory` logging. Doesn't touch private events (EventSource "Private.InternalDiagnostics.*").

Fixes #74340

cc @CarnaViire 