### PR TITLE
ProcessThreadTests.TestStartTimeProperty - Get spawned thread by ID from Process.Threads to avoid mismatch

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.Unix.cs
@@ -32,7 +32,23 @@ namespace System.Diagnostics.Tests
             Assert.Throws<PlatformNotSupportedException>(() => thread.PriorityLevel = level);
         }
 
-        private static int GetCurrentThreadId() => syscall(186); // SYS_gettid
+        private static int GetCurrentThreadId()
+        {
+            // The magic values come from https://github.com/torvalds/linux.
+            int SYS_gettid = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.Arm => 224,
+                Architecture.Arm64 => 178,
+                Architecture.X86 => 224,
+                Architecture.X64 => 186,
+                Architecture.S390x => 236,
+                Architecture.Ppc64le => 207,
+                Architecture.RiscV64 => 178,
+                _ => 178,
+            };
+
+            return syscall(SYS_gettid);
+        }
 
         [DllImport("libc")]
         private static extern int syscall(int nr);

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.Unix.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -30,5 +31,10 @@ namespace System.Diagnostics.Tests
 
             Assert.Throws<PlatformNotSupportedException>(() => thread.PriorityLevel = level);
         }
+
+        private static int GetCurrentThreadId() => syscall(186); // SYS_gettid
+
+        [DllImport("libc")]
+        private static extern int syscall(int nr);
     }
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -150,7 +150,7 @@ namespace System.Diagnostics.Tests
                 {
                     p.Refresh();
 
-                    int newThreadId = OperatingSystem.IsWindows() ? GetCurrentThreadId() : gettid();
+                    int newThreadId = GetCurrentThreadId();
 
                     ProcessThread[] processThreads = p.Threads.Cast<ProcessThread>().ToArray();
                     ProcessThread newThread = Assert.Single(processThreads, thread => thread.Id == newThreadId);
@@ -158,13 +158,6 @@ namespace System.Diagnostics.Tests
                     Assert.InRange(newThread.StartTime.ToUniversalTime(), curTime - allowedWindow, DateTime.Now.ToUniversalTime() + allowedWindow);
                 }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
-
-            [DllImport("libc")]
-            static extern int gettid();
-
-            [DllImport("kernel32.dll")]
-            [SuppressGCTransition]
-            static extern int GetCurrentThreadId();
         }
 
         [Fact]

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -108,7 +108,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Windows)] // OSX and FreeBSD throw PNSE from StartTime
         public async Task TestStartTimeProperty()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -112,9 +112,7 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Windows)] // OSX and FreeBSD throw PNSE from StartTime
         public async Task TestStartTimeProperty()
         {
-            TimeSpan allowedWindow = PlatformDetection.IsMonoRuntime
-                ? TimeSpan.FromSeconds(15)
-                : TimeSpan.FromSeconds(2);
+            TimeSpan allowedWindow = TimeSpan.FromSeconds(2);
 
             using (Process p = Process.GetCurrentProcess())
             {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -111,7 +111,9 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Linux|TestPlatforms.Windows)] // OSX and FreeBSD throw PNSE from StartTime
         public async Task TestStartTimeProperty()
         {
-            TimeSpan allowedWindow = TimeSpan.FromSeconds(2);
+            TimeSpan allowedWindow = PlatformDetection.IsMonoRuntime
+                ? TimeSpan.FromSeconds(15)
+                : TimeSpan.FromSeconds(2);
 
             using (Process p = Process.GetCurrentProcess())
             {


### PR DESCRIPTION
fixes #103448