### PR TITLE
don't rely on error code returned on Windows Nano

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -1267,13 +1267,13 @@ namespace System.Diagnostics.Tests
                 FileName = tempFile
             };
 
-            int expected = ERROR_BAD_EXE_FORMAT;
-
-            // Windows Nano bug see https://github.com/dotnet/runtime/issues/17919
-            if (PlatformDetection.IsWindowsNanoServer)
-                expected = ERROR_SUCCESS;
-
-            Assert.Equal(expected, Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode);
+            int errorCode = Assert.Throws<Win32Exception>(() => Process.Start(info)).NativeErrorCode;
+            
+            if (!PlatformDetection.IsWindowsNanoServer)
+            {
+                // We can not rely on the error code returned on Windows Nano https://github.com/dotnet/runtime/issues/17919
+                Assert.Equal(ERROR_BAD_EXE_FORMAT, errorCode);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
For a long time, Windows Nano used to return `ERROR_SUCCESS` when we were starting a file that was not an executable ( https://github.com/dotnet/runtime/issues/17919)

Recently it started to return `ERROR_TOO_MANY_POSTS`: Too many posts were made to a semaphore.

Which does not make any sense to me. Since the most important thing is to ensure that `Win32Exception` is being thrown, I've modified the test to verify that for all Windows versions and check the error code for non-Nano versions.

fixes #104770