### PR TITLE
[Loader][tests] Add more logging to pinpoint BinderTracingTests hang

### DIFF
--- a/src/tests/Loader/binding/tracing/BinderEventListener.cs
+++ b/src/tests/Loader/binding/tracing/BinderEventListener.cs
@@ -190,6 +190,7 @@ namespace BinderTracingTests
                     }
                 }
 
+                Console.WriteLine($"Waiting for bind events for {assemblyName.Name} ({timeWaitedInMs}ms waited) Sleeping for {waitIntervalInMs}ms");
                 Thread.Sleep(waitIntervalInMs);
                 timeWaitedInMs += waitIntervalInMs;
 

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.cs
@@ -172,6 +172,7 @@ namespace BinderTracingTests
                 Func<BindOperation> func = (Func<BindOperation>)method.CreateDelegate(typeof(Func<BindOperation>));
                 using (var listener = new BinderEventListener(loadsToTrack))
                 {
+                    Console.WriteLine($"[{DateTime.Now:T}] Invoking {method.Name}...");
                     BindOperation expected = func();
                     ValidateSingleBind(listener, expected.AssemblyName, expected);
                 }
@@ -182,6 +183,7 @@ namespace BinderTracingTests
                 return false;
             }
 
+            Console.WriteLine($"Test {method.Name} finished.");
             return true;
         }
 
@@ -197,6 +199,7 @@ namespace BinderTracingTests
             Console.WriteLine($"[{DateTime.Now:T}] Launching process for {method.Name}...");
             using (Process p = Process.Start(startInfo))
             {
+                Console.WriteLine($"Started subprocess {p.Id} for {method.Name}...");
                 p.OutputDataReceived += (_, args) => Console.WriteLine(args.Data);
                 p.BeginOutputReadLine();
 
@@ -210,6 +213,7 @@ namespace BinderTracingTests
 
         private static void ValidateSingleBind(BinderEventListener listener, AssemblyName assemblyName, BindOperation expected)
         {
+            Console.WriteLine($"[{DateTime.Now:T}] Validating bind operation for {assemblyName}...");
             BindOperation[] binds = listener.WaitAndGetEventsForAssembly(assemblyName);
             Assert.True(binds.Length == 1, $"Bind event count for {assemblyName} - expected: 1, actual: {binds.Length}");
             BindOperation actual = binds[0];

--- a/src/tests/Loader/binding/tracing/Helpers.cs
+++ b/src/tests/Loader/binding/tracing/Helpers.cs
@@ -17,6 +17,7 @@ namespace BinderTracingTests
     {
         public static void ValidateBindOperation(BindOperation expected, BindOperation actual)
         {
+            Console.WriteLine("ValidateBindOperation Started");
             ValidateAssemblyName(expected.AssemblyName, actual.AssemblyName, nameof(BindOperation.AssemblyName));
             Assert.Equal(expected.AssemblyPath ?? string.Empty, actual.AssemblyPath);
             Assert.Equal(expected.AssemblyLoadContext, actual.AssemblyLoadContext);
@@ -37,6 +38,7 @@ namespace BinderTracingTests
             ValidateProbedPaths(expected.ProbedPaths, actual.ProbedPaths);
 
             ValidateNestedBinds(expected.NestedBinds, actual.NestedBinds);
+            Console.WriteLine("ValidateBindOperation Finished");
         }
 
         public static string GetAssemblyInAppPath(string assemblyName)


### PR DESCRIPTION
BinderTracingTests has experienced flakey test hangs https://github.com/dotnet/runtime/issues/104670 https://github.com/dotnet/runtime/issues/97735 and https://github.com/dotnet/runtime/issues/94390

The exact cause of the hang has been elusive due to insufficient diagnostics.
Given the console log from the test
```
 "C:\h\w\B101091F\p\corerun.exe" -p "System.Reflection.Metadata.MetadataUpdater.IsSupported=false" -p "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true"  BinderTracingTest.ResolutionFlow.dll 
[10:04:40 AM] Running AssemblyLoadContextResolving_ReturnNull...
[10:04:42 AM] Running AssemblyLoadContextResolving_LoadAssembly...
[10:04:42 AM] Running AssemblyLoadContextResolving_NameMismatch...
[10:04:42 AM] Running AssemblyLoadContextResolving_MultipleHandlers...
[10:04:42 AM] Running AppDomainAssemblyResolve_ReturnNull...
[10:04:43 AM] Running AppDomainAssemblyResolve_LoadAssembly...
[10:04:43 AM] Running AppDomainAssemblyResolve_NameMismatch...
[10:04:43 AM] Running AppDomainAssemblyResolve_MultipleHandlers...
[10:04:43 AM] Launching process for AssemblyLoadFromResolveHandler_LoadDependency...
[10:04:45 AM] Running AssemblyLoadFromResolveHandler_LoadDependency...

[10:04:47 AM] Launching process for AssemblyLoadFromResolveHandler_NotTracked...
[10:04:48 AM] Running AssemblyLoadFromResolveHandler_NotTracked...

cmdLine:C:\h\w\B101091F\w\A251091E\e\Loader\Loader\../binding/tracing/BinderTracingTest.ResolutionFlow/BinderTracingTest.ResolutionFlow.cmd Timed Out (timeout in milliseconds: 600000 from variable __TestTimeout, start: 7/10/2024 10:04:38 AM, end: 7/10/2024 10:14:38 AM)
```
coupled with the native stack trace from the dump 
```
0:000> !clrstack -f -all
OS Thread Id: 0x23ec
Child SP       IP Call Site
0097E0EC 77B3F3EC ntdll!NtWaitForMultipleObjects + 12
0097E284 72246A85 coreclr!Thread::DoAppropriateAptStateWait + 199
0097E308 72246FB3 coreclr!Thread::DoAppropriateWaitWorker + 998
0097E464 7224D4AD coreclr!`Thread::DoAppropriateWait'::`9'::__Body::Run + 90
0097E4B8 72246B3C coreclr!Thread::DoAppropriateWait + 149
0097E51C 722BEC16 coreclr!WaitHandleNative::CorWaitOneNative + 294
0097E560          [HelperMethodFrame: 0097e560] System.Private.CoreLib.dll!System.Threading.WaitHandle.WaitOneCore(IntPtr, Int32, Boolean)
0097E5F4 71022A5C System_Private_CoreLib!System.Boolean System.Threading.WaitHandle::WaitOneNoCheck(System.Int32, System.Boolean, System.Object, System.Diagnostics.Tracing.NativeRuntimeEventSource+WaitHandleWaitSourceMap)$##6003CB2 + 188
0097E5F8 71022A5C System.Private.CoreLib.dll!System.Threading.WaitHandle.WaitOneNoCheck(Int32, Boolean, System.Object, WaitHandleWaitSourceMap) + 188
0097E630 71022984 System_Private_CoreLib!System.Boolean System.Threading.WaitHandle::WaitOne(System.Int32)$##6003CB1 + 20
0097E63C 71022984 System.Private.CoreLib.dll!System.Threading.WaitHandle.WaitOne(Int32) + 20
0097E644 094C5B7B system.diagnostics.process.dll!System.Diagnostics.Process.WaitForExitCore(Int32) + 123
0097E67C 094C0800 BinderTracingTest.ResolutionFlow.dll!BinderTracingTests.BinderTracingTest.RunTestInSeparateProcess(System.Reflection.MethodInfo) + 816
0097E6DC 0817237E BinderTracingTest.ResolutionFlow.dll!BinderTracingTests.BinderTracingTest.RunAllTests() + 446
0097E704 0817204F BinderTracingTest.ResolutionFlow.dll!BinderTracingTests.BinderTracingTest.Main(System.String[]) + 39
```

The most recent flakey test hang occurred while waiting for the test running in an isolated subprocess, and it's not clear whether the subprocess hit a race condition, if the subprocess exited and its signal never made it back to [`p.WaitForExit()`](https://github.com/dotnet/runtime/blob/ad25cd0126a8d4a060f2039f987bd58e7ca56a1d/src/tests/Loader/binding/tracing/BinderTracingTest.cs#L206), or something else.

To note, there was only dump collected despite the hang occurring during a test that spins up a subprocess. We would expect the subprocess to have a dump collected as well given that https://github.com/dotnet/runtime/blob/d710379da9b2699bba0a8f26d65d3a6e8549f26a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs#L792 would create dumps for the main test process and subprocesses.

------------

This PR aims to add slightly more logging to help pinpoint where the test hang occurs, with the expectation that the next time the test suite flakes (if at all), we can have more information to work with.