### PR TITLE
Emit More EventSource Data For Metrics Measurements

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -49,6 +49,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="System\Diagnostics\DsesSamplerBuilder.cs" />
     <Compile Include="System\Diagnostics\DistributedContextPropagator.cs" />
     <Compile Include="System\Diagnostics\DsesFilterAndTransform.cs" />
+    <Compile Include="System\Diagnostics\Helpers.cs" />
     <Compile Include="System\Diagnostics\LegacyPropagator.cs" />
     <Compile Include="System\Diagnostics\NoOutputPropagator.cs" />
     <Compile Include="System\Diagnostics\PassThroughPropagator.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Helpers.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Helpers.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Diagnostics
+{
+    internal static class Helpers
+    {
+        internal static string FormatTags(IEnumerable<KeyValuePair<string, object?>>? tags)
+        {
+            if (tags is null)
+            {
+                return string.Empty;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            bool first = true;
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    sb.Append(',');
+                }
+
+                sb.Append(tag.Key).Append('=');
+
+                if (tag.Value is not null)
+                {
+                    sb.Append(tag.Value.ToString());
+                }
+            }
+            return sb.ToString();
+        }
+
+        internal static string FormatTags(KeyValuePair<string, string>[] labels)
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < labels.Length; i++)
+            {
+                sb.Append(labels[i].Key).Append('=').Append(labels[i].Value);
+                if (i != labels.Length - 1)
+                {
+                    sb.Append(',');
+                }
+            }
+            return sb.ToString();
+        }
+
+        internal static string FormatObjectHash(object? obj) =>
+            obj is null ? string.Empty : RuntimeHelpers.GetHashCode(obj).ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Helpers.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Helpers.cs
@@ -37,6 +37,11 @@ namespace System.Diagnostics
 
         internal static string FormatTags(KeyValuePair<string, string>[] labels)
         {
+            if (labels is null || labels.Length == 0)
+            {
+                return string.Empty;
+            }
+
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < labels.Length; i++)
             {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Helpers.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Helpers.cs
@@ -30,12 +30,7 @@ namespace System.Diagnostics
                     sb.Append(',');
                 }
 
-                sb.Append(tag.Key).Append('=');
-
-                if (tag.Value is not null)
-                {
-                    sb.Append(tag.Value.ToString());
-                }
+                sb.Append(tag.Key).Append('=').Append(tag.Value);
             }
             return sb.ToString();
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -32,12 +32,12 @@ namespace System.Diagnostics.Metrics
         private readonly MeterListener _listener;
         private int _currentTimeSeries;
         private int _currentHistograms;
-        private readonly Action<Instrument, LabeledAggregationStatistics> _collectMeasurement;
+        private readonly Action<Instrument, LabeledAggregationStatistics, InstrumentState?> _collectMeasurement;
         private readonly Action<DateTime, DateTime> _beginCollection;
         private readonly Action<DateTime, DateTime> _endCollection;
-        private readonly Action<Instrument> _beginInstrumentMeasurements;
-        private readonly Action<Instrument> _endInstrumentMeasurements;
-        private readonly Action<Instrument> _instrumentPublished;
+        private readonly Action<Instrument, InstrumentState> _beginInstrumentMeasurements;
+        private readonly Action<Instrument, InstrumentState> _endInstrumentMeasurements;
+        private readonly Action<Instrument, InstrumentState?> _instrumentPublished;
         private readonly Action _initialInstrumentEnumerationComplete;
         private readonly Action<Exception> _collectionError;
         private readonly Action _timeSeriesLimitReached;
@@ -47,12 +47,12 @@ namespace System.Diagnostics.Metrics
         public AggregationManager(
             int maxTimeSeries,
             int maxHistograms,
-            Action<Instrument, LabeledAggregationStatistics> collectMeasurement,
+            Action<Instrument, LabeledAggregationStatistics, InstrumentState?> collectMeasurement,
             Action<DateTime, DateTime> beginCollection,
             Action<DateTime, DateTime> endCollection,
-            Action<Instrument> beginInstrumentMeasurements,
-            Action<Instrument> endInstrumentMeasurements,
-            Action<Instrument> instrumentPublished,
+            Action<Instrument, InstrumentState> beginInstrumentMeasurements,
+            Action<Instrument, InstrumentState> endInstrumentMeasurements,
+            Action<Instrument, InstrumentState?> instrumentPublished,
             Action initialInstrumentEnumerationComplete,
             Action<Exception> collectionError,
             Action timeSeriesLimitReached,
@@ -118,17 +118,18 @@ namespace System.Diagnostics.Metrics
         private void CompletedMeasurements(Instrument instrument, object? cookie)
         {
             _instruments.Remove(instrument);
-            _endInstrumentMeasurements(instrument);
+            Debug.Assert(cookie is not null);
+            _endInstrumentMeasurements(instrument, (InstrumentState)cookie);
             RemoveInstrumentState(instrument);
         }
 
         private void PublishedInstrument(Instrument instrument, MeterListener _)
         {
-            _instrumentPublished(instrument);
             InstrumentState? state = GetInstrumentState(instrument);
+            _instrumentPublished(instrument, state);
             if (state != null)
             {
-                _beginInstrumentMeasurements(instrument);
+                _beginInstrumentMeasurements(instrument, state);
 #pragma warning disable CA1864 // Prefer the 'IDictionary.TryAdd(TKey, TValue)' method. IDictionary.TryAdd() is not available in one of the builds
                 if (!_instruments.ContainsKey(instrument))
 #pragma warning restore CA1864
@@ -418,7 +419,7 @@ namespace System.Diagnostics.Metrics
             {
                 kv.Value.Collect(kv.Key, (LabeledAggregationStatistics labeledAggStats) =>
                 {
-                    _collectMeasurement(kv.Key, labeledAggStats);
+                    _collectMeasurement(kv.Key, labeledAggStats, kv.Value);
                 });
             }
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
@@ -13,8 +13,6 @@ namespace System.Diagnostics.Metrics
     {
         internal static KeyValuePair<string, object?>[] EmptyTags => Array.Empty<KeyValuePair<string, object?>>();
 
-        private string? _formattedTags;
-
         // The SyncObject is used to synchronize the following operations:
         //  - Instrument.Publish()
         //  - Meter constructor
@@ -144,8 +142,6 @@ namespace System.Diagnostics.Metrics
         /// A property tells if the instrument is an observable instrument.
         /// </summary>
         public virtual bool IsObservable => false;
-
-        internal string FormattedTags => _formattedTags ??= Helpers.FormatTags(Tags);
 
         // NotifyForUnpublishedInstrument is called from Meter.Dispose()
         internal void NotifyForUnpublishedInstrument()

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
@@ -13,6 +13,9 @@ namespace System.Diagnostics.Metrics
     {
         internal static KeyValuePair<string, object?>[] EmptyTags => Array.Empty<KeyValuePair<string, object?>>();
 
+        private string? _formattedTags;
+        private string? _formattedHash;
+
         // The SyncObject is used to synchronize the following operations:
         //  - Instrument.Publish()
         //  - Meter constructor
@@ -142,6 +145,9 @@ namespace System.Diagnostics.Metrics
         /// A property tells if the instrument is an observable instrument.
         /// </summary>
         public virtual bool IsObservable => false;
+
+        internal string FormattedTags => _formattedTags ??= Helpers.FormatTags(Tags);
+        internal string FormattedHash => _formattedHash ??= Helpers.FormatObjectHash(this);
 
         // NotifyForUnpublishedInstrument is called from Meter.Dispose()
         internal void NotifyForUnpublishedInstrument()

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
@@ -14,7 +14,6 @@ namespace System.Diagnostics.Metrics
         internal static KeyValuePair<string, object?>[] EmptyTags => Array.Empty<KeyValuePair<string, object?>>();
 
         private string? _formattedTags;
-        private string? _formattedHash;
 
         // The SyncObject is used to synchronize the following operations:
         //  - Instrument.Publish()
@@ -147,7 +146,6 @@ namespace System.Diagnostics.Metrics
         public virtual bool IsObservable => false;
 
         internal string FormattedTags => _formattedTags ??= Helpers.FormatTags(Tags);
-        internal string FormattedHash => _formattedHash ??= Helpers.FormatObjectHash(this);
 
         // NotifyForUnpublishedInstrument is called from Meter.Dispose()
         internal void NotifyForUnpublishedInstrument()

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/InstrumentState.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/InstrumentState.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Security;
+using System.Threading;
 
 namespace System.Diagnostics.Metrics
 {
@@ -14,16 +15,19 @@ namespace System.Diagnostics.Metrics
 
         // This can be called concurrently with Update()
         public abstract void Collect(Instrument instrument, Action<LabeledAggregationStatistics> aggregationVisitFunc);
-    }
 
+        public abstract int ID { get; }
+    }
 
     internal sealed class InstrumentState<TAggregator> : InstrumentState
         where TAggregator : Aggregator
     {
         private AggregatorStore<TAggregator> _aggregatorStore;
+        private static int s_idCounter;
 
         public InstrumentState(Func<TAggregator?> createAggregatorFunc)
         {
+            ID = Interlocked.Increment(ref s_idCounter);
             _aggregatorStore = new AggregatorStore<TAggregator>(createAggregatorFunc);
         }
 
@@ -38,5 +42,7 @@ namespace System.Diagnostics.Metrics
             TAggregator? aggregator = _aggregatorStore.GetAggregator(labels);
             aggregator?.Update(measurement);
         }
+
+        public override int ID { get; }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
@@ -20,7 +20,6 @@ namespace System.Diagnostics.Metrics
 
         private string? _formattedTags;
         private string? _formattedScopeHash;
-        private string? _formattedHash;
 
         internal bool Disposed { get; private set; }
 
@@ -28,7 +27,6 @@ namespace System.Diagnostics.Metrics
 
         internal string FormattedTags => _formattedTags ??= Helpers.FormatTags(Tags);
         internal string FormattedScopeHash => _formattedScopeHash ??= Helpers.FormatObjectHash(Scope);
-        internal string FormattedHash => _formattedHash ??= Helpers.FormatObjectHash(this);
 
         private static bool InitializeIsSupported() =>
             AppContext.TryGetSwitch("System.Diagnostics.Metrics.Meter.IsSupported", out bool isSupported) ? isSupported : true;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
@@ -17,9 +17,18 @@ namespace System.Diagnostics.Metrics
         private static readonly List<Meter> s_allMeters = new List<Meter>();
         private List<Instrument> _instruments = new List<Instrument>();
         private Dictionary<string, List<Instrument>> _nonObservableInstrumentsCache = new();
+
+        private string? _formattedTags;
+        private string? _formattedScopeHash;
+        private string? _formattedHash;
+
         internal bool Disposed { get; private set; }
 
         internal static bool IsSupported { get; } = InitializeIsSupported();
+
+        internal string FormattedTags => _formattedTags ??= Helpers.FormatTags(Tags);
+        internal string FormattedScopeHash => _formattedScopeHash ??= Helpers.FormatObjectHash(Scope);
+        internal string FormattedHash => _formattedHash ??= Helpers.FormatObjectHash(this);
 
         private static bool InitializeIsSupported() =>
             AppContext.TryGetSwitch("System.Diagnostics.Metrics.Meter.IsSupported", out bool isSupported) ? isSupported : true;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
@@ -18,15 +18,9 @@ namespace System.Diagnostics.Metrics
         private List<Instrument> _instruments = new List<Instrument>();
         private Dictionary<string, List<Instrument>> _nonObservableInstrumentsCache = new();
 
-        private string? _formattedTags;
-        private string? _formattedScopeHash;
-
         internal bool Disposed { get; private set; }
 
         internal static bool IsSupported { get; } = InitializeIsSupported();
-
-        internal string FormattedTags => _formattedTags ??= Helpers.FormatTags(Tags);
-        internal string FormattedScopeHash => _formattedScopeHash ??= Helpers.FormatObjectHash(Scope);
 
         private static bool InitializeIsSupported() =>
             AppContext.TryGetSwitch("System.Diagnostics.Metrics.Meter.IsSupported", out bool isSupported) ? isSupported : true;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -120,10 +120,9 @@ namespace System.Diagnostics.Metrics
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
-                                    string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
+        public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value, int instrumentId)
         {
-            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
+            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentId);
         }
 
         [Event(5, Keywords = Keywords.TimeSeriesValues, Version = 2)]
@@ -131,10 +130,9 @@ namespace System.Diagnostics.Metrics
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void GaugeValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string lastValue,
-                                    string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
+        public void GaugeValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string lastValue, int instrumentId)
         {
-            WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
+            WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue, instrumentId);
         }
 
         [Event(6, Keywords = Keywords.TimeSeriesValues, Version = 2)]
@@ -142,10 +140,9 @@ namespace System.Diagnostics.Metrics
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles, int count, double sum,
-                                        string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
+        public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles, int count, double sum, int instrumentId)
         {
-            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
+            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum, instrumentId);
         }
 
         // Sent when we begin to monitor the value of a instrument, either because new session filter arguments changed subscriptions
@@ -167,11 +164,10 @@ namespace System.Diagnostics.Metrics
                         string instrumentTags,
                         string meterTags,
                         string meterScopeHash,
-                        int instrumentHash,
-                        int meterHash)
+                        int instrumentId)
         {
             WriteEvent(7, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
-                    instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
+                    instrumentTags, meterTags, meterScopeHash, instrumentId);
         }
 
         // Sent when we stop monitoring the value of a instrument, either because new session filter arguments changed subscriptions
@@ -192,11 +188,10 @@ namespace System.Diagnostics.Metrics
                         string instrumentTags,
                         string meterTags,
                         string meterScopeHash,
-                        int instrumentHash,
-                        int meterHash)
+                        int instrumentId)
         {
             WriteEvent(8, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
-                    instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
+                    instrumentTags, meterTags, meterScopeHash, instrumentId);
         }
 
         [Event(9, Keywords = Keywords.TimeSeriesValues | Keywords.Messages | Keywords.InstrumentPublishing)]
@@ -227,11 +222,10 @@ namespace System.Diagnostics.Metrics
                         string instrumentTags,
                         string meterTags,
                         string meterScopeHash,
-                        int instrumentHash,
-                        int meterHash)
+                        int instrumentId)
         {
             WriteEvent(11, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
-                    instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
+                    instrumentTags, meterTags, meterScopeHash, instrumentId);
         }
 
         [Event(12, Keywords = Keywords.TimeSeriesValues)]
@@ -263,10 +257,9 @@ namespace System.Diagnostics.Metrics
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
-                                    string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
+        public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value, int instrumentId)
         {
-            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
+            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentId);
         }
 
         [Event(17, Keywords = Keywords.TimeSeriesValues)]
@@ -442,22 +435,22 @@ namespace System.Diagnostics.Metrics
 
                         string sessionId = _sessionId;
                         _aggregationManager = new AggregationManager(
-                            maxTimeSeries,
-                            maxHistograms,
-                            (i, s) => TransmitMetricValue(i, s, sessionId),
-                            (startIntervalTime, endIntervalTime) => Parent.CollectionStart(sessionId, startIntervalTime, endIntervalTime),
-                            (startIntervalTime, endIntervalTime) => Parent.CollectionStop(sessionId, startIntervalTime, endIntervalTime),
-                            i => Parent.BeginInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, RuntimeHelpers.GetHashCode(i), RuntimeHelpers.GetHashCode(i.Meter)),
-                            i => Parent.EndInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, RuntimeHelpers.GetHashCode(i), RuntimeHelpers.GetHashCode(i.Meter)),
-                            i => Parent.InstrumentPublished(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, RuntimeHelpers.GetHashCode(i), RuntimeHelpers.GetHashCode(i.Meter)),
-                            () => Parent.InitialInstrumentEnumerationComplete(sessionId),
-                            e => Parent.Error(sessionId, e.ToString()),
-                            () => Parent.TimeSeriesLimitReached(sessionId),
-                            () => Parent.HistogramLimitReached(sessionId),
-                            e => Parent.ObservableInstrumentCallbackError(sessionId, e.ToString()));
+                            maxTimeSeries: maxTimeSeries,
+                            maxHistograms: maxHistograms,
+                            collectMeasurement: (i, s, state) => TransmitMetricValue(i, s, sessionId, state),
+                            beginCollection: (startIntervalTime, endIntervalTime) => Parent.CollectionStart(sessionId, startIntervalTime, endIntervalTime),
+                            endCollection: (startIntervalTime, endIntervalTime) => Parent.CollectionStop(sessionId, startIntervalTime, endIntervalTime),
+                            beginInstrumentMeasurements: (i, state) => Parent.BeginInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
+                                    Helpers.FormatTags(i.Tags), Helpers.FormatTags(i.Meter.Tags), Helpers.FormatObjectHash(i.Meter.Scope), state.ID),
+                            endInstrumentMeasurements: (i, state) => Parent.EndInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
+                                    Helpers.FormatTags(i.Tags), Helpers.FormatTags(i.Meter.Tags), Helpers.FormatObjectHash(i.Meter.Scope), state.ID),
+                            instrumentPublished: (i, state) => Parent.InstrumentPublished(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
+                                    Helpers.FormatTags(i.Tags), Helpers.FormatTags(i.Meter.Tags), Helpers.FormatObjectHash(i.Meter.Scope), state is null ? 0 : state.ID),
+                            initialInstrumentEnumerationComplete: () => Parent.InitialInstrumentEnumerationComplete(sessionId),
+                            collectionError: e => Parent.Error(sessionId, e.ToString()),
+                            timeSeriesLimitReached: () => Parent.TimeSeriesLimitReached(sessionId),
+                            histogramLimitReached: () => Parent.HistogramLimitReached(sessionId),
+                            observableInstrumentCallbackError: e => Parent.ObservableInstrumentCallbackError(sessionId, e.ToString()));
 
                         _aggregationManager.SetCollectionPeriod(TimeSpan.FromSeconds(refreshIntervalSecs));
 
@@ -667,33 +660,31 @@ namespace System.Diagnostics.Metrics
                 }
             }
 
-            private static void TransmitMetricValue(Instrument instrument, LabeledAggregationStatistics stats, string sessionId)
+            private static void TransmitMetricValue(Instrument instrument, LabeledAggregationStatistics stats, string sessionId, InstrumentState? instrumentState)
             {
+                int instrumentId = instrumentState?.ID ?? 0;
                 if (stats.AggregationStatistics is CounterStatistics rateStats)
                 {
                     if (rateStats.IsMonotonic)
                     {
                         Log.CounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
-                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture),
-                            instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
+                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture), instrumentId);
                     }
                     else
                     {
                         Log.UpDownCounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
-                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture),
-                            instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
+                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture), instrumentId);
                     }
                 }
                 else if (stats.AggregationStatistics is LastValueStatistics lastValueStats)
                 {
                     Log.GaugeValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
-                        lastValueStats.LastValue.HasValue ? lastValueStats.LastValue.Value.ToString(CultureInfo.InvariantCulture) : "",
-                        instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
+                        lastValueStats.LastValue.HasValue ? lastValueStats.LastValue.Value.ToString(CultureInfo.InvariantCulture) : "", instrumentId);
                 }
                 else if (stats.AggregationStatistics is HistogramStatistics histogramStats)
                 {
                     Log.HistogramValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels), FormatQuantiles(histogramStats.Quantiles),
-                        histogramStats.Count, histogramStats.Sum, instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
+                        histogramStats.Count, histogramStats.Sum, instrumentId);
                 }
             }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -115,40 +115,43 @@ namespace System.Diagnostics.Metrics
             WriteEvent(3, sessionId, intervalStartTime, intervalEndTime);
         }
 
-        [Event(4, Keywords = Keywords.TimeSeriesValues, Version = 1)]
+        [Event(4, Keywords = Keywords.TimeSeriesValues, Version = 2)]
 #if !NET8_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value)
+        public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
+                                    string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
         {
-            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value);
+            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
         }
 
-        [Event(5, Keywords = Keywords.TimeSeriesValues)]
+        [Event(5, Keywords = Keywords.TimeSeriesValues, Version = 2)]
 #if !NET8_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void GaugeValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string lastValue)
+        public void GaugeValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string lastValue,
+                                    string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
         {
-            WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue);
+            WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
         }
 
-        [Event(6, Keywords = Keywords.TimeSeriesValues, Version = 1)]
+        [Event(6, Keywords = Keywords.TimeSeriesValues, Version = 2)]
 #if !NET8_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles, int count, double sum)
+        public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles, int count, double sum,
+                                        string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
         {
-            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum);
+            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
         }
 
         // Sent when we begin to monitor the value of a instrument, either because new session filter arguments changed subscriptions
         // or because an instrument matching the pre-existing filter has just been created. This event precedes all *MetricPublished events
         // for the same named instrument.
-        [Event(7, Keywords = Keywords.TimeSeriesValues, Version = 1)]
+        [Event(7, Keywords = Keywords.TimeSeriesValues, Version = 2)]
 #if !NET8_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
@@ -163,15 +166,17 @@ namespace System.Diagnostics.Metrics
                         string? description,
                         string instrumentTags,
                         string meterTags,
-                        string meterScopeHash)
+                        string meterScopeHash,
+                        string instrumentHash,
+                        string meterHash)
         {
             WriteEvent(7, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
-                    instrumentTags, meterTags, meterScopeHash);
+                    instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
         }
 
         // Sent when we stop monitoring the value of a instrument, either because new session filter arguments changed subscriptions
         // or because the Meter has been disposed.
-        [Event(8, Keywords = Keywords.TimeSeriesValues, Version = 1)]
+        [Event(8, Keywords = Keywords.TimeSeriesValues, Version = 2)]
 #if !NET8_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
@@ -186,10 +191,12 @@ namespace System.Diagnostics.Metrics
                         string? description,
                         string instrumentTags,
                         string meterTags,
-                        string meterScopeHash)
+                        string meterScopeHash,
+                        string instrumentHash,
+                        string meterHash)
         {
             WriteEvent(8, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
-                    instrumentTags, meterTags, meterScopeHash);
+                    instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
         }
 
         [Event(9, Keywords = Keywords.TimeSeriesValues | Keywords.Messages | Keywords.InstrumentPublishing)]
@@ -204,7 +211,7 @@ namespace System.Diagnostics.Metrics
             WriteEvent(10, sessionId);
         }
 
-        [Event(11, Keywords = Keywords.InstrumentPublishing, Version = 1)]
+        [Event(11, Keywords = Keywords.InstrumentPublishing, Version = 2)]
 #if !NET8_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
@@ -219,10 +226,12 @@ namespace System.Diagnostics.Metrics
                         string? description,
                         string instrumentTags,
                         string meterTags,
-                        string meterScopeHash)
+                        string meterScopeHash,
+                        string instrumentHash,
+                        string meterHash)
         {
             WriteEvent(11, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
-                    instrumentTags, meterTags, meterScopeHash);
+                    instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
         }
 
         [Event(12, Keywords = Keywords.TimeSeriesValues)]
@@ -249,14 +258,15 @@ namespace System.Diagnostics.Metrics
             WriteEvent(15, runningSessionId);
         }
 
-        [Event(16, Keywords = Keywords.TimeSeriesValues, Version = 1)]
+        [Event(16, Keywords = Keywords.TimeSeriesValues, Version = 2)]
 #if !NET8_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
-        public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value)
+        public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
+                                    string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
         {
-            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value);
+            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
         }
 
         [Event(17, Keywords = Keywords.TimeSeriesValues)]
@@ -413,8 +423,8 @@ namespace System.Diagnostics.Metrics
                             }
                         }
                     }
-                    if ((command.Command == EventCommand.Update || command.Command == EventCommand.Enable) &&
-                        command.Arguments != null)
+
+                    if ((command.Command == EventCommand.Update || command.Command == EventCommand.Enable) && command.Arguments != null)
                     {
                         IncrementRefCount(commandSessionId, command);
 
@@ -438,11 +448,11 @@ namespace System.Diagnostics.Metrics
                             (startIntervalTime, endIntervalTime) => Parent.CollectionStart(sessionId, startIntervalTime, endIntervalTime),
                             (startIntervalTime, endIntervalTime) => Parent.CollectionStop(sessionId, startIntervalTime, endIntervalTime),
                             i => Parent.BeginInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    FormatTags(i.Tags), FormatTags(i.Meter.Tags), FormatScopeHash(i.Meter.Scope)),
+                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, i.FormattedHash, i.Meter.FormattedHash),
                             i => Parent.EndInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    FormatTags(i.Tags), FormatTags(i.Meter.Tags), FormatScopeHash(i.Meter.Scope)),
+                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, i.FormattedHash, i.Meter.FormattedHash),
                             i => Parent.InstrumentPublished(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    FormatTags(i.Tags), FormatTags(i.Meter.Tags), FormatScopeHash(i.Meter.Scope)),
+                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, i.FormattedHash, i.Meter.FormattedHash),
                             () => Parent.InitialInstrumentEnumerationComplete(sessionId),
                             e => Parent.Error(sessionId, e.ToString()),
                             () => Parent.TimeSeriesLimitReached(sessionId),
@@ -663,73 +673,28 @@ namespace System.Diagnostics.Metrics
                 {
                     if (rateStats.IsMonotonic)
                     {
-                        Log.CounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels),
-                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "",
-                            rateStats.Value.ToString(CultureInfo.InvariantCulture));
+                        Log.CounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
+                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture),
+                            instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
                     }
                     else
                     {
-                        Log.UpDownCounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels),
-                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "",
-                            rateStats.Value.ToString(CultureInfo.InvariantCulture));
+                        Log.UpDownCounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
+                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture),
+                            instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
                     }
                 }
                 else if (stats.AggregationStatistics is LastValueStatistics lastValueStats)
                 {
-                    Log.GaugeValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels),
-                        lastValueStats.LastValue.HasValue ? lastValueStats.LastValue.Value.ToString(CultureInfo.InvariantCulture) : "");
+                    Log.GaugeValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
+                        lastValueStats.LastValue.HasValue ? lastValueStats.LastValue.Value.ToString(CultureInfo.InvariantCulture) : "",
+                        instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
                 }
                 else if (stats.AggregationStatistics is HistogramStatistics histogramStats)
                 {
-                    Log.HistogramValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels), FormatQuantiles(histogramStats.Quantiles), histogramStats.Count, histogramStats.Sum);
+                    Log.HistogramValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels), FormatQuantiles(histogramStats.Quantiles),
+                        histogramStats.Count, histogramStats.Sum, instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
                 }
-            }
-
-            private static string FormatScopeHash(object? scope) =>
-                scope is null ? string.Empty : RuntimeHelpers.GetHashCode(scope).ToString(CultureInfo.InvariantCulture);
-
-            private static string FormatTags(IEnumerable<KeyValuePair<string, object?>>? tags)
-            {
-                if (tags is null)
-                {
-                    return string.Empty;
-                }
-
-                StringBuilder sb = new StringBuilder();
-                bool first = true;
-                foreach (KeyValuePair<string, object?> tag in tags)
-                {
-                    if (first)
-                    {
-                        first = false;
-                    }
-                    else
-                    {
-                        sb.Append(',');
-                    }
-
-                    sb.Append(tag.Key).Append('=');
-
-                    if (tag.Value is not null)
-                    {
-                        sb.Append(tag.Value.ToString());
-                    }
-                }
-                return sb.ToString();
-            }
-
-            private static string FormatTags(KeyValuePair<string, string>[] labels)
-            {
-                StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < labels.Length; i++)
-                {
-                    sb.Append(labels[i].Key).Append('=').Append(labels[i].Value);
-                    if (i != labels.Length - 1)
-                    {
-                        sb.Append(',');
-                    }
-                }
-                return sb.ToString();
             }
 
             private static string FormatQuantiles(QuantileValue[] quantiles)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -121,7 +121,7 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
-                                    string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
+                                    string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
         {
             WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
@@ -132,7 +132,7 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void GaugeValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string lastValue,
-                                    string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
+                                    string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
         {
             WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
@@ -143,7 +143,7 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles, int count, double sum,
-                                        string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
+                                        string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
         {
             WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
@@ -167,8 +167,8 @@ namespace System.Diagnostics.Metrics
                         string instrumentTags,
                         string meterTags,
                         string meterScopeHash,
-                        string instrumentHash,
-                        string meterHash)
+                        int instrumentHash,
+                        int meterHash)
         {
             WriteEvent(7, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
                     instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
@@ -192,8 +192,8 @@ namespace System.Diagnostics.Metrics
                         string instrumentTags,
                         string meterTags,
                         string meterScopeHash,
-                        string instrumentHash,
-                        string meterHash)
+                        int instrumentHash,
+                        int meterHash)
         {
             WriteEvent(8, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
                     instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
@@ -227,8 +227,8 @@ namespace System.Diagnostics.Metrics
                         string instrumentTags,
                         string meterTags,
                         string meterScopeHash,
-                        string instrumentHash,
-                        string meterHash)
+                        int instrumentHash,
+                        int meterHash)
         {
             WriteEvent(11, sessionId, meterName, meterVersion ?? "", instrumentName, instrumentType, unit ?? "", description ?? "",
                     instrumentTags, meterTags, meterScopeHash, instrumentHash, meterHash);
@@ -264,7 +264,7 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
-                                    string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
+                                    string instrumentTags, int instrumentHash, string meterTags, int meterHash, string scopeHash)
         {
             WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
@@ -448,11 +448,11 @@ namespace System.Diagnostics.Metrics
                             (startIntervalTime, endIntervalTime) => Parent.CollectionStart(sessionId, startIntervalTime, endIntervalTime),
                             (startIntervalTime, endIntervalTime) => Parent.CollectionStop(sessionId, startIntervalTime, endIntervalTime),
                             i => Parent.BeginInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, i.FormattedHash, i.Meter.FormattedHash),
+                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, RuntimeHelpers.GetHashCode(i), RuntimeHelpers.GetHashCode(i.Meter)),
                             i => Parent.EndInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, i.FormattedHash, i.Meter.FormattedHash),
+                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, RuntimeHelpers.GetHashCode(i), RuntimeHelpers.GetHashCode(i.Meter)),
                             i => Parent.InstrumentPublished(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description,
-                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, i.FormattedHash, i.Meter.FormattedHash),
+                                    i.FormattedTags, i.Meter.FormattedTags, i.Meter.FormattedScopeHash, RuntimeHelpers.GetHashCode(i), RuntimeHelpers.GetHashCode(i.Meter)),
                             () => Parent.InitialInstrumentEnumerationComplete(sessionId),
                             e => Parent.Error(sessionId, e.ToString()),
                             () => Parent.TimeSeriesLimitReached(sessionId),
@@ -675,25 +675,25 @@ namespace System.Diagnostics.Metrics
                     {
                         Log.CounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
                             rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture),
-                            instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
+                            instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
                     }
                     else
                     {
                         Log.UpDownCounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
                             rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "", rateStats.Value.ToString(CultureInfo.InvariantCulture),
-                            instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
+                            instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
                     }
                 }
                 else if (stats.AggregationStatistics is LastValueStatistics lastValueStats)
                 {
                     Log.GaugeValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels),
                         lastValueStats.LastValue.HasValue ? lastValueStats.LastValue.Value.ToString(CultureInfo.InvariantCulture) : "",
-                        instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
+                        instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
                 }
                 else if (stats.AggregationStatistics is HistogramStatistics histogramStats)
                 {
                     Log.HistogramValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, Helpers.FormatTags(stats.Labels), FormatQuantiles(histogramStats.Quantiles),
-                        histogramStats.Count, histogramStats.Sum, instrument.FormattedTags, instrument.FormattedHash, instrument.Meter.FormattedTags, instrument.Meter.FormattedHash, instrument.Meter.FormattedScopeHash);
+                        histogramStats.Count, histogramStats.Sum, instrument.FormattedTags, RuntimeHelpers.GetHashCode(instrument), instrument.Meter.FormattedTags, RuntimeHelpers.GetHashCode(instrument.Meter), instrument.Meter.FormattedScopeHash);
                 }
             }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -121,9 +121,9 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
-                                    string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
+                                    string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
         {
-            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
+            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
 
         [Event(5, Keywords = Keywords.TimeSeriesValues, Version = 2)]
@@ -132,9 +132,9 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void GaugeValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string lastValue,
-                                    string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
+                                    string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
         {
-            WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
+            WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
 
         [Event(6, Keywords = Keywords.TimeSeriesValues, Version = 2)]
@@ -143,9 +143,9 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles, int count, double sum,
-                                        string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
+                                        string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
         {
-            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
+            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
 
         // Sent when we begin to monitor the value of a instrument, either because new session filter arguments changed subscriptions
@@ -264,9 +264,9 @@ namespace System.Diagnostics.Metrics
                                       Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
 #endif
         public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value,
-                                    string instrumentFormattedTags, string instrumentHash, string meterFormattedTags, string meterHash, string formattedScopeHash)
+                                    string instrumentTags, string instrumentHash, string meterTags, string meterHash, string scopeHash)
         {
-            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentFormattedTags, instrumentHash, meterFormattedTags, meterHash, formattedScopeHash);
+            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value, instrumentTags, instrumentHash, meterTags, meterHash, scopeHash);
         }
 
         [Event(17, Keywords = Keywords.TimeSeriesValues)]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -1645,14 +1645,14 @@ namespace System.Diagnostics.Metrics.Tests
                     Rate = e.Payload[6].ToString(),
                     Value = e.Payload[7].ToString(),
                     InstrumentFormattedTags = e.Payload[8].ToString(),
-                    InstrumentFormattedHash = e.Payload[9].ToString(),
+                    InstrumentHash = (int)(e.Payload[9]),
                     MeterFormattedTags = e.Payload[10].ToString(),
-                    MeterFormattedHash = e.Payload[11].ToString(),
+                    MeterHash = (int)(e.Payload[11]),
                     MeterScopeHash = e.Payload[12].ToString()
                 }).ToArray();
 
-            var counter1Events = counterEvents.Where(e => e.InstrumentFormattedHash == Helpers.FormatObjectHash(data.Counter1)).ToArray();
-            var counter2Events = counterEvents.Where(e => e.InstrumentFormattedHash == Helpers.FormatObjectHash(data.Counter2)).ToArray();
+            var counter1Events = counterEvents.Where(e => e.InstrumentHash == RuntimeHelpers.GetHashCode(data.Counter1)).ToArray();
+            var counter2Events = counterEvents.Where(e => e.InstrumentHash == RuntimeHelpers.GetHashCode(data.Counter2)).ToArray();
 
             var instrument1Event = counter1Events[0];
             var instrument2Event = counter2Events[0];
@@ -1660,17 +1660,17 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(counter1Events.Length, counter2Events.Length);
             Assert.Equal(1, counter1Events.Length);
             Assert.Equal(1, counter2Events.Length);
-            Assert.Equal(counter1Events[0].InstrumentFormattedHash, Helpers.FormatObjectHash(data.Counter1));
+            Assert.Equal(counter1Events[0].InstrumentHash, RuntimeHelpers.GetHashCode(data.Counter1));
 
             if (data.SameInstrumentInstances || (data.SameMeterInstances && data.SameInstrumentNames && data.SameInstrumentTags))
             {
-                Assert.Equal(counter1Events[0].InstrumentFormattedHash, counter2Events[0].InstrumentFormattedHash);
-                Assert.Equal(counter1Events[0].InstrumentFormattedHash, Helpers.FormatObjectHash(data.Counter2));
+                Assert.Equal(counter1Events[0].InstrumentHash, counter2Events[0].InstrumentHash);
+                Assert.Equal(counter1Events[0].InstrumentHash, RuntimeHelpers.GetHashCode(data.Counter2));
                 Assert.Equal("2", instrument1Event.Value);
             }
             else
             {
-                Assert.Equal(counter2Events[0].InstrumentFormattedHash, Helpers.FormatObjectHash(data.Counter2));
+                Assert.Equal(counter2Events[0].InstrumentHash, RuntimeHelpers.GetHashCode(data.Counter2));
                 Assert.Equal("1", instrument1Event.Value);
                 Assert.Equal("1", instrument2Event.Value);
             }
@@ -1680,7 +1680,7 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(data.SameMeterVersion, instrument1Event.MeterVersion == instrument2Event.MeterVersion);
             Assert.Equal(data.SameMeterTags, instrument1Event.MeterFormattedTags == instrument2Event.MeterFormattedTags);
             Assert.Equal(data.SameScopeInstances, instrument1Event.MeterScopeHash == instrument2Event.MeterScopeHash);
-            Assert.Equal(data.SameMeterInstances, instrument1Event.MeterFormattedHash == instrument2Event.MeterFormattedHash);
+            Assert.Equal(data.SameMeterInstances, instrument1Event.MeterHash == instrument2Event.MeterHash);
             Assert.Equal(data.SameInstrumentNames, instrument1Event.InstrumentName == instrument2Event.InstrumentName);
         }
 
@@ -1832,17 +1832,17 @@ namespace System.Diagnostics.Metrics.Tests
                     Rate = e.Payload[6].ToString(),
                     Value = e.Payload[7].ToString(),
                     InstrumentFormattedTags = e.Payload[8].ToString(),
-                    InstrumentFormattedHash = e.Payload[9].ToString(),
+                    InstrumentHash = (int)(e.Payload[9]),
                     MeterFormattedTags = e.Payload[10].ToString(),
-                    MeterFormattedHash = e.Payload[11].ToString(),
+                    MeterHash = (int)(e.Payload[11]),
                     MeterScopeHash = e.Payload[12].ToString()
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentFormattedHash == Helpers.FormatObjectHash(instrument)).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentHash == RuntimeHelpers.GetHashCode(instrument)).ToArray();
             Assert.True(filteredEvents.Length >= expected.Length);
 
             string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
             string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
-            string formattedMeterHash = Helpers.FormatObjectHash(instrument.Meter);
+            int meterHash = RuntimeHelpers.GetHashCode(instrument.Meter);
             string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
 
             for (int i = 0; i < expected.Length; i++)
@@ -1853,7 +1853,7 @@ namespace System.Diagnostics.Metrics.Tests
 
                 Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
                 Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
-                Assert.Equal(formattedMeterHash, filteredEvents[i].MeterFormattedHash);
+                Assert.Equal(meterHash, filteredEvents[i].MeterHash);
                 Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
             }
         }
@@ -1885,17 +1885,17 @@ namespace System.Diagnostics.Metrics.Tests
                     Tags = e.Payload[5].ToString(),
                     Value = e.Payload[6].ToString(),
                     InstrumentFormattedTags = e.Payload[7].ToString(),
-                    InstrumentFormattedHash = e.Payload[8].ToString(),
+                    InstrumentHash = (int)(e.Payload[8]),
                     MeterFormattedTags = e.Payload[9].ToString(),
-                    MeterFormattedHash = e.Payload[10].ToString(),
+                    MeterHash = (int)(e.Payload[10]),
                     MeterScopeHash = e.Payload[11].ToString(),
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentFormattedHash == Helpers.FormatObjectHash(instrument)).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentHash == RuntimeHelpers.GetHashCode(instrument)).ToArray();
             Assert.True(filteredEvents.Length >= expectedValues.Length);
 
             string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
             string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
-            string formattedMeterHash = Helpers.FormatObjectHash(instrument.Meter);
+            int meterHash = RuntimeHelpers.GetHashCode(instrument.Meter);
             string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
 
             for (int i = 0; i < expectedValues.Length; i++)
@@ -1905,7 +1905,7 @@ namespace System.Diagnostics.Metrics.Tests
 
                 Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
                 Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
-                Assert.Equal(formattedMeterHash, filteredEvents[i].MeterFormattedHash);
+                Assert.Equal(meterHash, filteredEvents[i].MeterHash);
                 Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
             }
         }
@@ -1925,17 +1925,17 @@ namespace System.Diagnostics.Metrics.Tests
                     Count = e.Payload[7].ToString(),
                     Sum = e.Payload[8].ToString(),
                     InstrumentFormattedTags = e.Payload[9].ToString(),
-                    InstrumentFormattedHash = e.Payload[10].ToString(),
+                    InstrumentHash = (int)(e.Payload[10]),
                     MeterFormattedTags = e.Payload[11].ToString(),
-                    MeterFormattedHash = e.Payload[12].ToString(),
+                    MeterHash = (int)(e.Payload[12]),
                     MeterScopeHash = e.Payload[13].ToString()
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentFormattedHash == Helpers.FormatObjectHash(instrument)).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentHash == RuntimeHelpers.GetHashCode(instrument)).ToArray();
             Assert.True(filteredEvents.Length >= expected.Length);
 
             string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
             string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
-            string formattedMeterHash = Helpers.FormatObjectHash(instrument.Meter);
+            int meterHash = RuntimeHelpers.GetHashCode(instrument.Meter);
             string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
 
             for (int i = 0; i < expected.Length; i++)
@@ -1947,7 +1947,7 @@ namespace System.Diagnostics.Metrics.Tests
 
                 Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
                 Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
-                Assert.Equal(formattedMeterHash, filteredEvents[i].MeterFormattedHash);
+                Assert.Equal(meterHash, filteredEvents[i].MeterHash);
                 Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
             }
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -59,12 +59,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
 
@@ -103,13 +103,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter.Name, c.Name, c, "", "", ("0", "17"), ("6", "23"), ("13", "36"));
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter.Name, c.Name, "", "", ("0", "17"), ("6", "23"), ("13", "36"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
 
@@ -152,12 +152,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("6", "23"), ("13", "36"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("6", "23"), ("13", "36"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 9);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
 
@@ -201,17 +201,17 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 2);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("6", "6"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("6", "6"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 2);
 
             AssertBeginInstrumentReportingEventsPresent(events3, c, c2, c3);
             AssertInitialEnumerationCompleteEventPresent(events3);
-            AssertCounterEventsPresent(events3, meter3.Name, c3.Name, c3, "", "", ("7", "7"));
+            AssertCounterEventsPresent(events3, meter3.Name, c3.Name, "", "", ("7", "7"));
             AssertCollectStartStopEventsPresent(events3, IntervalSecs, 2);
         }
 
@@ -246,10 +246,10 @@ namespace System.Diagnostics.Metrics.Tests
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events, meter2.Name, c2.Name, c2, "", "", ("6", "6"), ("13", "19"));
-            AssertCounterEventsPresent(events2, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("6", "6"), ("13", "19"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter2.Name, c2.Name, "", "", ("6", "6"), ("13", "19"));
+            AssertCounterEventsPresent(events2, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("6", "6"), ("13", "19"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
@@ -292,13 +292,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "-10", "9");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "-10", "9");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -343,13 +343,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "-1", "32");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "-1", "32");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -393,13 +393,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "100", "-70");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "100", "-70");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -432,7 +432,7 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
         }
 
@@ -465,7 +465,7 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
         }
 
@@ -512,13 +512,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "5", "10");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "5", "10");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -571,13 +571,13 @@ namespace System.Diagnostics.Metrics.Tests
             AssertBeginInstrumentReportingEventsPresent(events2, h);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events, meterA.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meterA.Name, g.Name, g, "", g.Unit, "-100", "100");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meterA.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meterB.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meterA.Name, g.Name, "", g.Unit, "-100", "100");
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc, g);
         }
@@ -635,13 +635,13 @@ namespace System.Diagnostics.Metrics.Tests
             AssertBeginInstrumentReportingEventsPresent(events2, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events, meterA.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meterA.Name, g.Name, g, "", g.Unit, "-10", "9");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meterA.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meterB.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meterA.Name, g.Name, "", g.Unit, "-10", "9");
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc, h, g);
             AssertEndInstrumentReportingEventsPresent(events2, c, oc, og, udc, oudc, g);
@@ -723,13 +723,13 @@ namespace System.Diagnostics.Metrics.Tests
 
                 AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
                 AssertInitialEnumerationCompleteEventPresent(events);
-                AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "200", "-200");
-                AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
-                AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("-33", "-33"), ("-40", "-73"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "-11"), ("-11", "-22"));
+                AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "200", "-200");
+                AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
+                AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
                 AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             }).Dispose();
         }
@@ -776,13 +776,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "77", "-177");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "77", "-177");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -837,13 +837,13 @@ namespace System.Diagnostics.Metrics.Tests
 
                 AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
                 AssertInitialEnumerationCompleteEventPresent(events);
-                AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "1", "-1");
-                AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
-                AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("40", "73"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "-11"), ("-11", "-22"));
+                AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "1", "-1");
+                AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
+                AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
                 AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             }
             finally
@@ -898,13 +898,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-1000", "2000");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("-33", "-33"), ("-40", "-73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "11"), ("11", "22"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-1000", "2000");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -977,20 +977,20 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=red", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=blue", "", ("6", "6"), ("13", "19"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "Color=black", "", "1", "3");
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "Color=white", "", "2", "4");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "Color=red,Size=19", "", ("", "10"), ("7", "17"));
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "Color=blue,Size=4", "", ("", "20"), ("14", "34"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "Color=red,Size=19", "", "9", "18");
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "Color=blue,Size=4", "", "18", "36");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Size=123", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Size=124", "", ("0.5=20;0.95=20;0.99=20", "1", "20"), ("0.5=27;0.95=27;0.99=27", "1", "27"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "Color=red", "", ("-33", "-33"), ("40", "7"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "Color=blue", "", ("-34", "-34"), ("41", "7"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "Color=red,Size=19", "", ("", "-11"), ("-11", "-22"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "Color=blue,Size=4", "", ("", "-22"), ("-22", "-44"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", ("6", "6"), ("13", "19"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "Color=black", "", "1", "3");
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "Color=white", "", "2", "4");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", ("", "10"), ("7", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", ("", "20"), ("14", "34"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=red,Size=19", "", "9", "18");
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=blue,Size=4", "", "18", "36");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=123", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=124", "", ("0.5=20;0.95=20;0.99=20", "1", "20"), ("0.5=27;0.95=27;0.99=27", "1", "27"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=red", "", ("-33", "-33"), ("40", "7"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", ("-34", "-34"), ("41", "7"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", ("", "-11"), ("-11", "-22"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", ("", "-22"), ("-22", "-44"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -1046,12 +1046,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c3a, c1b, c2b, c3b, c2c, c3c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meterA.Name, c3a.Name, c3a, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterB.Name, c1b.Name, c1b, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterB.Name, c2b.Name, c2b, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterB.Name, c3b.Name, c3b, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, c3c, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, c3c, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterA.Name, c3a.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c1b.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c2b.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c3b.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", ("1", "1"), ("2", "3"));
             AssertCounterEventsNotPresent(events, meterA.Name, c1a.Name, "");
             AssertCounterEventsNotPresent(events, meterA.Name, c2a.Name, "");
             AssertCounterEventsNotPresent(events, meterC.Name, c1c.Name, "");
@@ -1140,13 +1140,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("0", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-123", "", "123", "");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("",  "17"), ("0", "17"), ("14", "31"), ("0", "31"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "18", "", "36", "");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("", "0", "0"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("", "0", "0"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("0", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "22"), ("0", "22"), ("22", "44"), ("0", "44"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("0", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-123", "", "123", "");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("",  "17"), ("0", "17"), ("14", "31"), ("0", "31"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "18", "", "36", "");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("", "0", "0"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("", "0", "0"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("0", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "22"), ("0", "22"), ("22", "44"), ("0", "44"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 5);
         }
 
@@ -1193,13 +1193,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meterA.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meterA.Name, g.Name, g, "", g.Unit, "9", "90");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meterA.Name, og.Name, og, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meterB.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meterA.Name, g.Name, "", g.Unit, "9", "90");
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc, g);
         }
@@ -1292,13 +1292,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, i, s, b, l, dec, f, d);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, i.Name, i, "", "", ("1234568", "1234568"), ("1234568", "2469136"));
-            AssertCounterEventsPresent(events, meter.Name, s.Name, s, "", "", ("21433", "21433"), ("21433", "42866"));
-            AssertCounterEventsPresent(events, meter.Name, b.Name, b, "", "", ("2", "2"), ("2", "4"));
-            AssertCounterEventsPresent(events, meter.Name, l.Name, l, "", "", ("123456789013", "123456789013"), ("123456789013", "246913578026"));
-            AssertCounterEventsPresent(events, meter.Name, dec.Name, dec, "", "", ("123456789012346", "123456789012346"), ("123456789012346", "246913578024692"));
-            AssertCounterEventsPresent(events, meter.Name, f.Name, f, "", "", ("123457.7890625", "123457.7890625"), ("123457.7890625", "246915.578125"));
-            AssertCounterEventsPresent(events, meter.Name, d.Name, d, "", "", ("6.25", "6.25"), ("6.25", "12.5"));
+            AssertCounterEventsPresent(events, meter.Name, i.Name, "", "", ("1234568", "1234568"), ("1234568", "2469136"));
+            AssertCounterEventsPresent(events, meter.Name, s.Name, "", "", ("21433", "21433"), ("21433", "42866"));
+            AssertCounterEventsPresent(events, meter.Name, b.Name, "", "", ("2", "2"), ("2", "4"));
+            AssertCounterEventsPresent(events, meter.Name, l.Name, "", "", ("123456789013", "123456789013"), ("123456789013", "246913578026"));
+            AssertCounterEventsPresent(events, meter.Name, dec.Name, "", "", ("123456789012346", "123456789012346"), ("123456789012346", "246913578024692"));
+            AssertCounterEventsPresent(events, meter.Name, f.Name, "", "", ("123457.7890625", "123457.7890625"), ("123457.7890625", "246915.578125"));
+            AssertCounterEventsPresent(events, meter.Name, d.Name, "", "", ("6.25", "6.25"), ("6.25", "12.5"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -1330,8 +1330,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=red", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=blue", "", ("6", "6"), ("13", "19"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", ("6", "6"), ("13", "19"));
             AssertTimeSeriesLimitPresent(events);
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=green");
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=yellow");
@@ -1367,8 +1367,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, h);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
             AssertHistogramLimitPresent(events);
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=green");
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=yellow");
@@ -1397,7 +1397,7 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertObservableCallbackErrorPresent(events);
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
@@ -1437,13 +1437,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-10", "10");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "11"), ("11", "22"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-10", "10");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             // Now create a new listener and do everything a 2nd time. Because the listener above has been disposed the source should be
@@ -1467,13 +1467,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-10", "10");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "31"), ("7", "38"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "36", "45");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "44"), ("11", "55"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-10", "10");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "31"), ("7", "38"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "36", "45");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "44"), ("11", "55"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -1507,8 +1507,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, h);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
             AssertHistogramLimitPresent(events);
             AssertTimeSeriesLimitNotPresent(events);
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=green");
@@ -1516,120 +1516,42 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
-        public class MeterInstrumentContainer
-        {
-            public Counter<int> Counter1 { get; set; }
-            public Counter<int> Counter2 { get; set; }
-            public bool SameInstrumentNames { get; set; }
-            public bool SameInstrumentTags { get; set; }
-            public bool SameInstrumentInstances { get; set; }
-            public bool SameMeterNames { get; set; }
-            public bool SameMeterVersion { get; set; }
-            public bool SameMeterTags { get; set; }
-            public bool SameMeterInstances { get; set; }
-            public bool SameScopeInstances { get; set; }
-        }
-
         public static IEnumerable<object[]> DifferentMetersAndInstrumentsData()
         {
-            // Different counters and different meters
-            yield return new object[] {
-                new MeterInstrumentContainer {
-                    Counter1 = new Meter("M1").CreateCounter<int>("C1"),
-                    Counter2 = new Meter("M1").CreateCounter<int>("C1"),
-                    SameInstrumentNames = true,
-                    SameInstrumentTags = true,
-                    SameInstrumentInstances = false,
-                    SameMeterNames = true,
-                    SameMeterVersion = true,
-                    SameMeterTags = true,
-                    SameMeterInstances = false,
-                    SameScopeInstances = true,
-                }
-            };
+            yield return new object[] { new Meter("M1").CreateCounter<int>("C1"), new Meter("M1").CreateCounter<int>("C1"), false};
 
-            // Same counters and same meters
             var counter = new Meter("M1").CreateCounter<int>("C1");
-            yield return new object[] {
-                new MeterInstrumentContainer {
-                    Counter1 = counter,
-                    Counter2 = counter.Meter.CreateCounter<int>("C1"),
-                    SameInstrumentNames = true,
-                    SameInstrumentTags = true,
-                    SameInstrumentInstances = true,
-                    SameMeterNames = true,
-                    SameMeterVersion = true,
-                    SameMeterTags = true,
-                    SameMeterInstances = true,
-                    SameScopeInstances = true,
-                }
-            };
+            yield return new object[] { counter, counter.Meter.CreateCounter<int>("C1"), false };
 
-            // Different counters and different meters but with exact same data
+            // Same counters
+            counter = new Meter("M1").CreateCounter<int>("C1");
+            yield return new object[] { counter, counter, true };
+
             var scope = new object();
-            yield return new object[] {
-                new MeterInstrumentContainer {
-                    Counter1 = new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope).CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
-                    Counter2 = new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope).CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
-                    SameInstrumentNames = true,
-                    SameInstrumentTags = true,
-                    SameInstrumentInstances = false,
-                    SameMeterNames = true,
-                    SameMeterVersion = true,
-                    SameMeterTags = true,
-                    SameMeterInstances = false,
-                    SameScopeInstances = true,
-                }
+            yield return new object[]
+            {
+                new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope).CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
+                new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope).CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
+                false, // Same Instrument
             };
 
-            // Same meters and different counters with same data
             Meter meter = new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope);
-            yield return new object[] {
-                new MeterInstrumentContainer {
-                    Counter1 = meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
-                    Counter2 = meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
-                    SameInstrumentNames = true,
-                    SameInstrumentTags = true,
-                    SameInstrumentInstances = false,
-                    SameMeterNames = true,
-                    SameMeterVersion = true,
-                    SameMeterTags = true,
-                    SameMeterInstances = true,
-                    SameScopeInstances = true,
-                }
-            };
-
-            // different meters and different counters with different data
-            var scope1 = new object();
-            Meter meter1 = new Meter("M2", "v2", new TagList { { "k3", "v3" } }, scope1);
-            yield return new object[] {
-                new MeterInstrumentContainer {
-                    Counter1 = meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
-                    Counter2 = meter1.CreateCounter<int>("C2", "u2", "d2", new TagList { { "k4", "v4" } } ),
-                    SameInstrumentNames = false,
-                    SameInstrumentTags = false,
-                    SameInstrumentInstances = false,
-                    SameMeterNames = false,
-                    SameMeterVersion = false,
-                    SameMeterTags = false,
-                    SameMeterInstances = false,
-                    SameScopeInstances = false,
-                }
-            };
+            yield return new object[] { meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ), meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ), false };
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         [OuterLoop("Slow and has lots of console spew")]
         [MemberData(nameof(DifferentMetersAndInstrumentsData))]
-        public void TestDifferentMetersAndInstruments(MeterInstrumentContainer data)
+        public void TestDifferentMetersAndInstruments(Counter<int> counter1, Counter<int> counter2, bool isSameCounters)
         {
-            EventWrittenEventArgs[] events;
+            Assert.Equal(object.ReferenceEquals(counter1, counter2), isSameCounters);
 
-            using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, isShared: true, IntervalSecs, data.Counter1.Meter.Name, data.Counter2.Meter.Name))
+            EventWrittenEventArgs[] events;
+            using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, isShared: true, IntervalSecs, counter1.Meter.Name, counter2.Meter.Name))
             {
                 listener.WaitForCollectionStop(s_waitForEventTimeout, 1);
-                data.Counter1.Add(1);
-                data.Counter2.Add(1);
+                counter1.Add(1);
+                counter2.Add(1);
                 listener.WaitForCollectionStop(s_waitForEventTimeout, 2);
                 events = listener.Events.ToArray();
             }
@@ -1644,44 +1566,18 @@ namespace System.Diagnostics.Metrics.Tests
                     Tags = e.Payload[5].ToString(),
                     Rate = e.Payload[6].ToString(),
                     Value = e.Payload[7].ToString(),
-                    InstrumentFormattedTags = e.Payload[8].ToString(),
-                    InstrumentHash = (int)(e.Payload[9]),
-                    MeterFormattedTags = e.Payload[10].ToString(),
-                    MeterHash = (int)(e.Payload[11]),
-                    MeterScopeHash = e.Payload[12].ToString()
+                    InstrumentId = (int)(e.Payload[8])
                 }).ToArray();
 
-            var counter1Events = counterEvents.Where(e => e.InstrumentHash == RuntimeHelpers.GetHashCode(data.Counter1)).ToArray();
-            var counter2Events = counterEvents.Where(e => e.InstrumentHash == RuntimeHelpers.GetHashCode(data.Counter2)).ToArray();
-
-            var instrument1Event = counter1Events[0];
-            var instrument2Event = counter2Events[0];
-
-            Assert.Equal(counter1Events.Length, counter2Events.Length);
-            Assert.Equal(1, counter1Events.Length);
-            Assert.Equal(1, counter2Events.Length);
-            Assert.Equal(counter1Events[0].InstrumentHash, RuntimeHelpers.GetHashCode(data.Counter1));
-
-            if (data.SameInstrumentInstances || (data.SameMeterInstances && data.SameInstrumentNames && data.SameInstrumentTags))
+            if (isSameCounters)
             {
-                Assert.Equal(counter1Events[0].InstrumentHash, counter2Events[0].InstrumentHash);
-                Assert.Equal(counter1Events[0].InstrumentHash, RuntimeHelpers.GetHashCode(data.Counter2));
-                Assert.Equal("2", instrument1Event.Value);
+                Assert.Equal(1, counterEvents.Length);
             }
             else
             {
-                Assert.Equal(counter2Events[0].InstrumentHash, RuntimeHelpers.GetHashCode(data.Counter2));
-                Assert.Equal("1", instrument1Event.Value);
-                Assert.Equal("1", instrument2Event.Value);
+                Assert.Equal(2, counterEvents.Length);
+                Assert.NotEqual(counterEvents[0].InstrumentId, counterEvents[1].InstrumentId);
             }
-
-            Assert.Equal(data.SameInstrumentTags, instrument1Event.InstrumentFormattedTags == instrument2Event.InstrumentFormattedTags);
-            Assert.Equal(data.SameMeterNames, instrument1Event.MeterName == instrument2Event.MeterName);
-            Assert.Equal(data.SameMeterVersion, instrument1Event.MeterVersion == instrument2Event.MeterVersion);
-            Assert.Equal(data.SameMeterTags, instrument1Event.MeterFormattedTags == instrument2Event.MeterFormattedTags);
-            Assert.Equal(data.SameScopeInstances, instrument1Event.MeterScopeHash == instrument2Event.MeterScopeHash);
-            Assert.Equal(data.SameMeterInstances, instrument1Event.MeterHash == instrument2Event.MeterHash);
-            Assert.Equal(data.SameInstrumentNames, instrument1Event.InstrumentName == instrument2Event.InstrumentName);
         }
 
         private static void AssertBeginInstrumentReportingEventsPresent(EventWrittenEventArgs[] events, params Instrument[] expectedInstruments)
@@ -1698,13 +1594,12 @@ namespace System.Diagnostics.Metrics.Tests
                     InstrumentTags = e.Payload[7].ToString(),
                     MeterTags = e.Payload[8].ToString(),
                     ScopeHash = e.Payload[9].ToString(),
-                    InstrumentHash = e.Payload[10].ToString(),
-                    MeterHash = e.Payload[11].ToString(),
+                    InstrumentId = (int)(e.Payload[10]),
                 }).ToArray();
 
             foreach(Instrument i in expectedInstruments)
             {
-                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name && ev.InstrumentHash == Helpers.FormatObjectHash(i) && ev.MeterHash == Helpers.FormatObjectHash(i.Meter)).FirstOrDefault();
+                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name).FirstOrDefault();
                 Assert.True(e != null, "Expected to find a BeginInstrumentReporting event for " + i.Meter.Name + "\\" + i.Name);
                 Assert.Equal(i.Meter.Version ?? "", e.MeterVersion);
                 Assert.Equal(i.GetType().Name, e.InstrumentType);
@@ -1713,6 +1608,7 @@ namespace System.Diagnostics.Metrics.Tests
                 Assert.Equal(Helpers.FormatTags(i.Tags), e.InstrumentTags);
                 Assert.Equal(Helpers.FormatTags(i.Meter.Tags), e.MeterTags);
                 Assert.Equal(Helpers.FormatObjectHash(i.Meter.Scope), e.ScopeHash);
+                Assert.True(e.InstrumentId > 0);
             }
 
             Assert.Equal(expectedInstruments.Length, beginReportEvents.Length);
@@ -1732,13 +1628,12 @@ namespace System.Diagnostics.Metrics.Tests
                     InstrumentTags = e.Payload[7].ToString(),
                     MeterTags = e.Payload[8].ToString(),
                     ScopeHash = e.Payload[9].ToString(),
-                    InstrumentHash = e.Payload[10].ToString(),
-                    MeterHash = e.Payload[11].ToString(),
+                    InstrumentId = (int)(e.Payload[10]),
                 }).ToArray();
 
             foreach (Instrument i in expectedInstruments)
             {
-                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name && ev.InstrumentHash == Helpers.FormatObjectHash(i) && ev.MeterHash == Helpers.FormatObjectHash(i.Meter)).FirstOrDefault();
+                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name).FirstOrDefault();
                 Assert.True(e != null, "Expected to find a EndInstrumentReporting event for " + i.Meter.Name + "\\" + i.Name);
                 Assert.Equal(i.Meter.Version ?? "", e.MeterVersion);
                 Assert.Equal(i.GetType().Name, e.InstrumentType);
@@ -1747,6 +1642,7 @@ namespace System.Diagnostics.Metrics.Tests
                 Assert.Equal(Helpers.FormatTags(i.Tags), e.InstrumentTags);
                 Assert.Equal(Helpers.FormatTags(i.Meter.Tags), e.MeterTags);
                 Assert.Equal(Helpers.FormatObjectHash(i.Meter.Scope), e.ScopeHash);
+                Assert.True(e.InstrumentId > 0);
             }
 
             Assert.Equal(expectedInstruments.Length, beginReportEvents.Length);
@@ -1786,13 +1682,12 @@ namespace System.Diagnostics.Metrics.Tests
                     InstrumentTags = e.Payload[7].ToString(),
                     MeterTags = e.Payload[8].ToString(),
                     ScopeHash = e.Payload[9].ToString(),
-                    InstrumentHash = e.Payload[10].ToString(),
-                    MeterHash = e.Payload[11].ToString(),
+                    InstrumentId = (int)(e.Payload[10]),
                 }).ToArray();
 
             foreach (Instrument i in expectedInstruments)
             {
-                var e = publishEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name && ev.InstrumentHash == Helpers.FormatObjectHash(i) && ev.MeterHash == Helpers.FormatObjectHash(i.Meter)).FirstOrDefault();
+                var e = publishEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name).FirstOrDefault();
                 Assert.True(e != null, "Expected to find a InstrumentPublished event for " + i.Meter.Name + "\\" + i.Name);
                 Assert.Equal(i.Meter.Version ?? "", e.MeterVersion);
                 Assert.Equal(i.GetType().Name, e.InstrumentType);
@@ -1801,24 +1696,25 @@ namespace System.Diagnostics.Metrics.Tests
                 Assert.Equal(Helpers.FormatTags(i.Tags), e.InstrumentTags);
                 Assert.Equal(Helpers.FormatTags(i.Meter.Tags), e.MeterTags);
                 Assert.Equal(Helpers.FormatObjectHash(i.Meter.Scope), e.ScopeHash);
+                Assert.True(e.InstrumentId > 0);
             }
 
             Assert.Equal(expectedInstruments.Length, publishEvents.Length);
         }
 
-        private static void AssertCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
+        private static void AssertCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params (string, string)[] expected)
         {
-            AssertGenericCounterEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, instrument, tags, expectedUnit, expected);
+            AssertGenericCounterEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expected);
         }
 
-        private static void AssertUpDownCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
+        private static void AssertUpDownCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params (string, string)[] expected)
         {
-            AssertGenericCounterEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, instrument, tags, expectedUnit, expected);
+            AssertGenericCounterEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expected);
         }
 
-        private static void AssertGenericCounterEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
+        private static void AssertGenericCounterEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params (string, string)[] expected)
         {
             var counterEvents = events.Where(e => e.EventName == eventName).Select(e =>
@@ -1831,30 +1727,17 @@ namespace System.Diagnostics.Metrics.Tests
                     Tags = e.Payload[5].ToString(),
                     Rate = e.Payload[6].ToString(),
                     Value = e.Payload[7].ToString(),
-                    InstrumentFormattedTags = e.Payload[8].ToString(),
-                    InstrumentHash = (int)(e.Payload[9]),
-                    MeterFormattedTags = e.Payload[10].ToString(),
-                    MeterHash = (int)(e.Payload[11]),
-                    MeterScopeHash = e.Payload[12].ToString()
+                    InstrumentId = (int)(e.Payload[7]),
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentHash == RuntimeHelpers.GetHashCode(instrument)).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
             Assert.True(filteredEvents.Length >= expected.Length);
-
-            string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
-            string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
-            int meterHash = RuntimeHelpers.GetHashCode(instrument.Meter);
-            string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
 
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(expectedUnit, filteredEvents[i].Unit);
                 Assert.Equal(expected[i].Item1, filteredEvents[i].Rate);
                 Assert.Equal(expected[i].Item2, filteredEvents[i].Value);
-
-                Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
-                Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
-                Assert.Equal(meterHash, filteredEvents[i].MeterHash);
-                Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
+                Assert.True(filteredEvents[i].InstrumentId > 0);
             }
         }
 
@@ -1872,7 +1755,7 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(0, filteredEvents.Length);
         }
 
-        private static void AssertGaugeEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
+        private static void AssertGaugeEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params string[] expectedValues)
         {
             var counterEvents = events.Where(e => e.EventName == "GaugeValuePublished").Select(e =>
@@ -1884,33 +1767,20 @@ namespace System.Diagnostics.Metrics.Tests
                     Unit = e.Payload[4].ToString(),
                     Tags = e.Payload[5].ToString(),
                     Value = e.Payload[6].ToString(),
-                    InstrumentFormattedTags = e.Payload[7].ToString(),
-                    InstrumentHash = (int)(e.Payload[8]),
-                    MeterFormattedTags = e.Payload[9].ToString(),
-                    MeterHash = (int)(e.Payload[10]),
-                    MeterScopeHash = e.Payload[11].ToString(),
+                    InstrumentId = (int)(e.Payload[7]),
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentHash == RuntimeHelpers.GetHashCode(instrument)).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
             Assert.True(filteredEvents.Length >= expectedValues.Length);
-
-            string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
-            string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
-            int meterHash = RuntimeHelpers.GetHashCode(instrument.Meter);
-            string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
 
             for (int i = 0; i < expectedValues.Length; i++)
             {
                 Assert.Equal(expectedUnit, filteredEvents[i].Unit);
                 Assert.Equal(expectedValues[i], filteredEvents[i].Value);
-
-                Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
-                Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
-                Assert.Equal(meterHash, filteredEvents[i].MeterHash);
-                Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
+                Assert.True(filteredEvents[i].InstrumentId > 0);
             }
         }
 
-        private static void AssertHistogramEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
+        private static void AssertHistogramEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params (string, string, string)[] expected)
         {
             var counterEvents = events.Where(e => e.EventName == "HistogramValuePublished").Select(e =>
@@ -1924,19 +1794,10 @@ namespace System.Diagnostics.Metrics.Tests
                     Quantiles = (string)e.Payload[6],
                     Count = e.Payload[7].ToString(),
                     Sum = e.Payload[8].ToString(),
-                    InstrumentFormattedTags = e.Payload[9].ToString(),
-                    InstrumentHash = (int)(e.Payload[10]),
-                    MeterFormattedTags = e.Payload[11].ToString(),
-                    MeterHash = (int)(e.Payload[12]),
-                    MeterScopeHash = e.Payload[13].ToString()
+                    InstrumentId = (int)(e.Payload[9])
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentHash == RuntimeHelpers.GetHashCode(instrument)).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
             Assert.True(filteredEvents.Length >= expected.Length);
-
-            string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
-            string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
-            int meterHash = RuntimeHelpers.GetHashCode(instrument.Meter);
-            string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
 
             for (int i = 0; i < expected.Length; i++)
             {
@@ -1944,11 +1805,7 @@ namespace System.Diagnostics.Metrics.Tests
                 Assert.Equal(expected[i].Item1, filteredEvents[i].Quantiles);
                 Assert.Equal(expected[i].Item2, filteredEvents[i].Count);
                 Assert.Equal(expected[i].Item3, filteredEvents[i].Sum);
-
-                Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
-                Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
-                Assert.Equal(meterHash, filteredEvents[i].MeterHash);
-                Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
+                Assert.True(filteredEvents[i].InstrumentId > 0);
             }
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -59,12 +59,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
 
@@ -103,13 +103,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter.Name, c.Name, "", "", ("0", "17"), ("6", "23"), ("13", "36"));
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter.Name, c.Name, c, "", "", ("0", "17"), ("6", "23"), ("13", "36"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
 
@@ -152,12 +152,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("6", "23"), ("13", "36"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("0", "17"), ("6", "23"), ("13", "36"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 9);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("5", "5"), ("12", "17"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
 
@@ -201,17 +201,17 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 2);
 
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("6", "6"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("6", "6"));
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 2);
 
             AssertBeginInstrumentReportingEventsPresent(events3, c, c2, c3);
             AssertInitialEnumerationCompleteEventPresent(events3);
-            AssertCounterEventsPresent(events3, meter3.Name, c3.Name, "", "", ("7", "7"));
+            AssertCounterEventsPresent(events3, meter3.Name, c3.Name, c3, "", "", ("7", "7"));
             AssertCollectStartStopEventsPresent(events3, IntervalSecs, 2);
         }
 
@@ -246,10 +246,10 @@ namespace System.Diagnostics.Metrics.Tests
             AssertBeginInstrumentReportingEventsPresent(events2, c, c2);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events, meter2.Name, c2.Name, "", "", ("6", "6"), ("13", "19"));
-            AssertCounterEventsPresent(events2, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, "", "", ("6", "6"), ("13", "19"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter2.Name, c2.Name, c2, "", "", ("6", "6"), ("13", "19"));
+            AssertCounterEventsPresent(events2, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events2, meter2.Name, c2.Name, c2, "", "", ("6", "6"), ("13", "19"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             AssertCollectStartStopEventsPresent(events2, IntervalSecs, 3);
         }
@@ -292,13 +292,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "-10", "9");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "-10", "9");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -343,13 +343,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "-1", "32");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "-1", "32");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -393,13 +393,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "100", "-70");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "100", "-70");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -432,7 +432,7 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
         }
 
@@ -465,7 +465,7 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"), ("19", "36"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
         }
 
@@ -512,13 +512,13 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "5", "10");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "5", "10");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -571,13 +571,13 @@ namespace System.Diagnostics.Metrics.Tests
             AssertBeginInstrumentReportingEventsPresent(events2, h);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meterA.Name, g.Name, "", g.Unit, "-100", "100");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meterA.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meterA.Name, g.Name, g, "", g.Unit, "-100", "100");
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meterA.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meterB.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc, g);
         }
@@ -635,13 +635,13 @@ namespace System.Diagnostics.Metrics.Tests
             AssertBeginInstrumentReportingEventsPresent(events2, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events, 2);
             AssertInitialEnumerationCompleteEventPresent(events2);
-            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meterA.Name, g.Name, "", g.Unit, "-10", "9");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meterA.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meterA.Name, g.Name, g, "", g.Unit, "-10", "9");
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meterA.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meterB.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc, h, g);
             AssertEndInstrumentReportingEventsPresent(events2, c, oc, og, udc, oudc, g);
@@ -723,13 +723,13 @@ namespace System.Diagnostics.Metrics.Tests
 
                 AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
                 AssertInitialEnumerationCompleteEventPresent(events);
-                AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "200", "-200");
-                AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-                AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
+                AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "200", "-200");
+                AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
+                AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("-33", "-33"), ("-40", "-73"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "-11"), ("-11", "-22"));
                 AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             }).Dispose();
         }
@@ -776,13 +776,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", g.Unit, "77", "-177");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", g.Unit, "77", "-177");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -837,13 +837,13 @@ namespace System.Diagnostics.Metrics.Tests
 
                 AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
                 AssertInitialEnumerationCompleteEventPresent(events);
-                AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "1", "-1");
-                AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
-                AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-                AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
-                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
+                AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "1", "-1");
+                AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
+                AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
+                AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("40", "73"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "-11"), ("-11", "-22"));
                 AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             }
             finally
@@ -898,13 +898,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-1000", "2000");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-1000", "2000");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("-33", "-33"), ("-40", "-73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -977,20 +977,20 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", ("6", "6"), ("13", "19"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "Color=black", "", "1", "3");
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "Color=white", "", "2", "4");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", ("", "10"), ("7", "17"));
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", ("", "20"), ("14", "34"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=red,Size=19", "", "9", "18");
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=blue,Size=4", "", "18", "36");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=123", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=124", "", ("0.5=20;0.95=20;0.99=20", "1", "20"), ("0.5=27;0.95=27;0.99=27", "1", "27"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=red", "", ("-33", "-33"), ("40", "7"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", ("-34", "-34"), ("41", "7"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", ("", "-11"), ("-11", "-22"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", ("", "-22"), ("-22", "-44"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=red", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=blue", "", ("6", "6"), ("13", "19"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "Color=black", "", "1", "3");
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "Color=white", "", "2", "4");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "Color=red,Size=19", "", ("", "10"), ("7", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "Color=blue,Size=4", "", ("", "20"), ("14", "34"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "Color=red,Size=19", "", "9", "18");
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "Color=blue,Size=4", "", "18", "36");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Size=123", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Size=124", "", ("0.5=20;0.95=20;0.99=20", "1", "20"), ("0.5=27;0.95=27;0.99=27", "1", "27"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "Color=red", "", ("-33", "-33"), ("40", "7"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "Color=blue", "", ("-34", "-34"), ("41", "7"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "Color=red,Size=19", "", ("", "-11"), ("-11", "-22"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "Color=blue,Size=4", "", ("", "-22"), ("-22", "-44"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -1046,12 +1046,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c3a, c1b, c2b, c3b, c2c, c3c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meterA.Name, c3a.Name, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterB.Name, c1b.Name, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterB.Name, c2b.Name, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterB.Name, c3b.Name, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", ("1", "1"), ("2", "3"));
-            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterA.Name, c3a.Name, c3a, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c1b.Name, c1b, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c2b.Name, c2b, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c3b.Name, c3b, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, c3c, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, c3c, "", "", ("1", "1"), ("2", "3"));
             AssertCounterEventsNotPresent(events, meterA.Name, c1a.Name, "");
             AssertCounterEventsNotPresent(events, meterA.Name, c2a.Name, "");
             AssertCounterEventsNotPresent(events, meterC.Name, c1c.Name, "");
@@ -1140,13 +1140,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("0", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-123", "", "123", "");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("",  "17"), ("0", "17"), ("14", "31"), ("0", "31"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "18", "", "36", "");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("", "0", "0"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("", "0", "0"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("0", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "22"), ("0", "22"), ("22", "44"), ("0", "44"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("0", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-123", "", "123", "");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("",  "17"), ("0", "17"), ("14", "31"), ("0", "31"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "18", "", "36", "");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("", "0", "0"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("", "0", "0"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("0", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "22"), ("0", "22"), ("22", "44"), ("0", "44"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 5);
         }
 
@@ -1193,13 +1193,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meterA.Name, g.Name, "", g.Unit, "9", "90");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
-            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
+            AssertCounterEventsPresent(events, meterA.Name, c.Name, c, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meterA.Name, g.Name, g, "", g.Unit, "9", "90");
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, oc, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
+            AssertGaugeEventsPresent(events, meterA.Name, og.Name, og, "", og.Unit, "9", "18", "27");
+            AssertHistogramEventsPresent(events, meterB.Name, h.Name, h, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, udc, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, oudc, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc, g);
         }
@@ -1292,13 +1292,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, i, s, b, l, dec, f, d);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, i.Name, "", "", ("1234568", "1234568"), ("1234568", "2469136"));
-            AssertCounterEventsPresent(events, meter.Name, s.Name, "", "", ("21433", "21433"), ("21433", "42866"));
-            AssertCounterEventsPresent(events, meter.Name, b.Name, "", "", ("2", "2"), ("2", "4"));
-            AssertCounterEventsPresent(events, meter.Name, l.Name, "", "", ("123456789013", "123456789013"), ("123456789013", "246913578026"));
-            AssertCounterEventsPresent(events, meter.Name, dec.Name, "", "", ("123456789012346", "123456789012346"), ("123456789012346", "246913578024692"));
-            AssertCounterEventsPresent(events, meter.Name, f.Name, "", "", ("123457.7890625", "123457.7890625"), ("123457.7890625", "246915.578125"));
-            AssertCounterEventsPresent(events, meter.Name, d.Name, "", "", ("6.25", "6.25"), ("6.25", "12.5"));
+            AssertCounterEventsPresent(events, meter.Name, i.Name, i, "", "", ("1234568", "1234568"), ("1234568", "2469136"));
+            AssertCounterEventsPresent(events, meter.Name, s.Name, s, "", "", ("21433", "21433"), ("21433", "42866"));
+            AssertCounterEventsPresent(events, meter.Name, b.Name, b, "", "", ("2", "2"), ("2", "4"));
+            AssertCounterEventsPresent(events, meter.Name, l.Name, l, "", "", ("123456789013", "123456789013"), ("123456789013", "246913578026"));
+            AssertCounterEventsPresent(events, meter.Name, dec.Name, dec, "", "", ("123456789012346", "123456789012346"), ("123456789012346", "246913578024692"));
+            AssertCounterEventsPresent(events, meter.Name, f.Name, f, "", "", ("123457.7890625", "123457.7890625"), ("123457.7890625", "246915.578125"));
+            AssertCounterEventsPresent(events, meter.Name, d.Name, d, "", "", ("6.25", "6.25"), ("6.25", "12.5"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -1330,8 +1330,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", ("5", "5"), ("12", "17"));
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", ("6", "6"), ("13", "19"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=red", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "Color=blue", "", ("6", "6"), ("13", "19"));
             AssertTimeSeriesLimitPresent(events);
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=green");
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=yellow");
@@ -1367,8 +1367,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, h);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
             AssertHistogramLimitPresent(events);
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=green");
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=yellow");
@@ -1397,7 +1397,7 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
             AssertObservableCallbackErrorPresent(events);
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
@@ -1437,13 +1437,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-10", "10");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-10", "10");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "10"), ("7", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "9", "18");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             // Now create a new listener and do everything a 2nd time. Because the listener above has been disposed the source should be
@@ -1467,13 +1467,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc, g);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
-            AssertGaugeEventsPresent(events, meter.Name, g.Name, "", "", "-10", "10");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "31"), ("7", "38"));
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "36", "45");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "44"), ("11", "55"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, c, "", "", ("5", "5"), ("12", "17"));
+            AssertGaugeEventsPresent(events, meter.Name, g.Name, g, "", "", "-10", "10");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, oc, "", "", ("", "31"), ("7", "38"));
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, og, "", "", "36", "45");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, udc, "", "", ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, oudc, "", "", ("", "44"), ("11", "55"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -1507,8 +1507,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, h);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, h, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
             AssertHistogramLimitPresent(events);
             AssertTimeSeriesLimitNotPresent(events);
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=green");
@@ -1516,37 +1516,172 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
-        private static string FormatScopeHash(object? scope) =>
-            scope is null ? string.Empty : RuntimeHelpers.GetHashCode(scope).ToString(CultureInfo.InvariantCulture);
-
-        private static string FormatTags(IEnumerable<KeyValuePair<string, object?>>? tags)
+        public class MeterInstrumentContainer
         {
-            if (tags is null)
+            public Counter<int> Counter1 { get; set; }
+            public Counter<int> Counter2 { get; set; }
+            public bool SameInstrumentNames { get; set; }
+            public bool SameInstrumentTags { get; set; }
+            public bool SameInstrumentInstances { get; set; }
+            public bool SameMeterNames { get; set; }
+            public bool SameMeterVersion { get; set; }
+            public bool SameMeterTags { get; set; }
+            public bool SameMeterInstances { get; set; }
+            public bool SameScopeInstances { get; set; }
+        }
+
+        public static IEnumerable<object[]> DifferentMetersAndInstrumentsData()
+        {
+            // Different counters and different meters
+            yield return new object[] {
+                new MeterInstrumentContainer {
+                    Counter1 = new Meter("M1").CreateCounter<int>("C1"),
+                    Counter2 = new Meter("M1").CreateCounter<int>("C1"),
+                    SameInstrumentNames = true,
+                    SameInstrumentTags = true,
+                    SameInstrumentInstances = false,
+                    SameMeterNames = true,
+                    SameMeterVersion = true,
+                    SameMeterTags = true,
+                    SameMeterInstances = false,
+                    SameScopeInstances = true,
+                }
+            };
+
+            // Same counters and same meters
+            var counter = new Meter("M1").CreateCounter<int>("C1");
+            yield return new object[] {
+                new MeterInstrumentContainer {
+                    Counter1 = counter,
+                    Counter2 = counter.Meter.CreateCounter<int>("C1"),
+                    SameInstrumentNames = true,
+                    SameInstrumentTags = true,
+                    SameInstrumentInstances = true,
+                    SameMeterNames = true,
+                    SameMeterVersion = true,
+                    SameMeterTags = true,
+                    SameMeterInstances = true,
+                    SameScopeInstances = true,
+                }
+            };
+
+            // Different counters and different meters but with exact same data
+            var scope = new object();
+            yield return new object[] {
+                new MeterInstrumentContainer {
+                    Counter1 = new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope).CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
+                    Counter2 = new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope).CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
+                    SameInstrumentNames = true,
+                    SameInstrumentTags = true,
+                    SameInstrumentInstances = false,
+                    SameMeterNames = true,
+                    SameMeterVersion = true,
+                    SameMeterTags = true,
+                    SameMeterInstances = false,
+                    SameScopeInstances = true,
+                }
+            };
+
+            // Same meters and different counters with same data
+            Meter meter = new Meter("M1", "v1", new TagList { { "k1", "v1" } }, scope);
+            yield return new object[] {
+                new MeterInstrumentContainer {
+                    Counter1 = meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
+                    Counter2 = meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
+                    SameInstrumentNames = true,
+                    SameInstrumentTags = true,
+                    SameInstrumentInstances = false,
+                    SameMeterNames = true,
+                    SameMeterVersion = true,
+                    SameMeterTags = true,
+                    SameMeterInstances = true,
+                    SameScopeInstances = true,
+                }
+            };
+
+            // different meters and different counters with different data
+            var scope1 = new object();
+            Meter meter1 = new Meter("M2", "v2", new TagList { { "k3", "v3" } }, scope1);
+            yield return new object[] {
+                new MeterInstrumentContainer {
+                    Counter1 = meter.CreateCounter<int>("C1", "u1", "d1", new TagList { { "k2", "v2" } } ),
+                    Counter2 = meter1.CreateCounter<int>("C2", "u2", "d2", new TagList { { "k4", "v4" } } ),
+                    SameInstrumentNames = false,
+                    SameInstrumentTags = false,
+                    SameInstrumentInstances = false,
+                    SameMeterNames = false,
+                    SameMeterVersion = false,
+                    SameMeterTags = false,
+                    SameMeterInstances = false,
+                    SameScopeInstances = false,
+                }
+            };
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        [OuterLoop("Slow and has lots of console spew")]
+        [MemberData(nameof(DifferentMetersAndInstrumentsData))]
+        public void TestDifferentMetersAndInstruments(MeterInstrumentContainer data)
+        {
+            EventWrittenEventArgs[] events;
+
+            using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, isShared: true, IntervalSecs, data.Counter1.Meter.Name, data.Counter2.Meter.Name))
             {
-                return string.Empty;
+                listener.WaitForCollectionStop(s_waitForEventTimeout, 1);
+                data.Counter1.Add(1);
+                data.Counter2.Add(1);
+                listener.WaitForCollectionStop(s_waitForEventTimeout, 2);
+                events = listener.Events.ToArray();
             }
 
-            StringBuilder sb = new StringBuilder();
-            bool first = true;
-            foreach (KeyValuePair<string, object?> tag in tags)
+            var counterEvents = events.Where(e => e.EventName == "CounterRateValuePublished").Select(e =>
+                new
+                {
+                    MeterName = e.Payload[1].ToString(),
+                    MeterVersion = e.Payload[2].ToString(),
+                    InstrumentName = e.Payload[3].ToString(),
+                    Unit = e.Payload[4].ToString(),
+                    Tags = e.Payload[5].ToString(),
+                    Rate = e.Payload[6].ToString(),
+                    Value = e.Payload[7].ToString(),
+                    InstrumentFormattedTags = e.Payload[8].ToString(),
+                    InstrumentFormattedHash = e.Payload[9].ToString(),
+                    MeterFormattedTags = e.Payload[10].ToString(),
+                    MeterFormattedHash = e.Payload[11].ToString(),
+                    MeterScopeHash = e.Payload[12].ToString()
+                }).ToArray();
+
+            var counter1Events = counterEvents.Where(e => e.InstrumentFormattedHash == Helpers.FormatObjectHash(data.Counter1)).ToArray();
+            var counter2Events = counterEvents.Where(e => e.InstrumentFormattedHash == Helpers.FormatObjectHash(data.Counter2)).ToArray();
+
+            var instrument1Event = counter1Events[0];
+            var instrument2Event = counter2Events[0];
+
+            Assert.Equal(counter1Events.Length, counter2Events.Length);
+            Assert.Equal(1, counter1Events.Length);
+            Assert.Equal(1, counter2Events.Length);
+            Assert.Equal(counter1Events[0].InstrumentFormattedHash, Helpers.FormatObjectHash(data.Counter1));
+
+            if (data.SameInstrumentInstances || (data.SameMeterInstances && data.SameInstrumentNames && data.SameInstrumentTags))
             {
-                if (first)
-                {
-                    first = false;
-                }
-                else
-                {
-                    sb.Append(',');
-                }
-
-                sb.Append(tag.Key).Append('=');
-
-                if (tag.Value is not null)
-                {
-                    sb.Append(tag.Value.ToString());
-                }
+                Assert.Equal(counter1Events[0].InstrumentFormattedHash, counter2Events[0].InstrumentFormattedHash);
+                Assert.Equal(counter1Events[0].InstrumentFormattedHash, Helpers.FormatObjectHash(data.Counter2));
+                Assert.Equal("2", instrument1Event.Value);
             }
-            return sb.ToString();
+            else
+            {
+                Assert.Equal(counter2Events[0].InstrumentFormattedHash, Helpers.FormatObjectHash(data.Counter2));
+                Assert.Equal("1", instrument1Event.Value);
+                Assert.Equal("1", instrument2Event.Value);
+            }
+
+            Assert.Equal(data.SameInstrumentTags, instrument1Event.InstrumentFormattedTags == instrument2Event.InstrumentFormattedTags);
+            Assert.Equal(data.SameMeterNames, instrument1Event.MeterName == instrument2Event.MeterName);
+            Assert.Equal(data.SameMeterVersion, instrument1Event.MeterVersion == instrument2Event.MeterVersion);
+            Assert.Equal(data.SameMeterTags, instrument1Event.MeterFormattedTags == instrument2Event.MeterFormattedTags);
+            Assert.Equal(data.SameScopeInstances, instrument1Event.MeterScopeHash == instrument2Event.MeterScopeHash);
+            Assert.Equal(data.SameMeterInstances, instrument1Event.MeterFormattedHash == instrument2Event.MeterFormattedHash);
+            Assert.Equal(data.SameInstrumentNames, instrument1Event.InstrumentName == instrument2Event.InstrumentName);
         }
 
         private static void AssertBeginInstrumentReportingEventsPresent(EventWrittenEventArgs[] events, params Instrument[] expectedInstruments)
@@ -1562,20 +1697,22 @@ namespace System.Diagnostics.Metrics.Tests
                     Description = e.Payload[6].ToString(),
                     InstrumentTags = e.Payload[7].ToString(),
                     MeterTags = e.Payload[8].ToString(),
-                    ScopeHash = e.Payload[9].ToString()
+                    ScopeHash = e.Payload[9].ToString(),
+                    InstrumentHash = e.Payload[10].ToString(),
+                    MeterHash = e.Payload[11].ToString(),
                 }).ToArray();
 
             foreach(Instrument i in expectedInstruments)
             {
-                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name).FirstOrDefault();
+                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name && ev.InstrumentHash == Helpers.FormatObjectHash(i) && ev.MeterHash == Helpers.FormatObjectHash(i.Meter)).FirstOrDefault();
                 Assert.True(e != null, "Expected to find a BeginInstrumentReporting event for " + i.Meter.Name + "\\" + i.Name);
                 Assert.Equal(i.Meter.Version ?? "", e.MeterVersion);
                 Assert.Equal(i.GetType().Name, e.InstrumentType);
                 Assert.Equal(i.Unit ?? "", e.Unit);
                 Assert.Equal(i.Description ?? "", e.Description);
-                Assert.Equal(FormatTags(i.Tags), e.InstrumentTags);
-                Assert.Equal(FormatTags(i.Meter.Tags), e.MeterTags);
-                Assert.Equal(FormatScopeHash(i.Meter.Scope), e.ScopeHash);
+                Assert.Equal(Helpers.FormatTags(i.Tags), e.InstrumentTags);
+                Assert.Equal(Helpers.FormatTags(i.Meter.Tags), e.MeterTags);
+                Assert.Equal(Helpers.FormatObjectHash(i.Meter.Scope), e.ScopeHash);
             }
 
             Assert.Equal(expectedInstruments.Length, beginReportEvents.Length);
@@ -1594,20 +1731,22 @@ namespace System.Diagnostics.Metrics.Tests
                     Description = e.Payload[6].ToString(),
                     InstrumentTags = e.Payload[7].ToString(),
                     MeterTags = e.Payload[8].ToString(),
-                    ScopeHash = e.Payload[9].ToString()
+                    ScopeHash = e.Payload[9].ToString(),
+                    InstrumentHash = e.Payload[10].ToString(),
+                    MeterHash = e.Payload[11].ToString(),
                 }).ToArray();
 
             foreach (Instrument i in expectedInstruments)
             {
-                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name).FirstOrDefault();
+                var e = beginReportEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name && ev.InstrumentHash == Helpers.FormatObjectHash(i) && ev.MeterHash == Helpers.FormatObjectHash(i.Meter)).FirstOrDefault();
                 Assert.True(e != null, "Expected to find a EndInstrumentReporting event for " + i.Meter.Name + "\\" + i.Name);
                 Assert.Equal(i.Meter.Version ?? "", e.MeterVersion);
                 Assert.Equal(i.GetType().Name, e.InstrumentType);
                 Assert.Equal(i.Unit ?? "", e.Unit);
                 Assert.Equal(i.Description ?? "", e.Description);
-                Assert.Equal(FormatTags(i.Tags), e.InstrumentTags);
-                Assert.Equal(FormatTags(i.Meter.Tags), e.MeterTags);
-                Assert.Equal(FormatScopeHash(i.Meter.Scope), e.ScopeHash);
+                Assert.Equal(Helpers.FormatTags(i.Tags), e.InstrumentTags);
+                Assert.Equal(Helpers.FormatTags(i.Meter.Tags), e.MeterTags);
+                Assert.Equal(Helpers.FormatObjectHash(i.Meter.Scope), e.ScopeHash);
             }
 
             Assert.Equal(expectedInstruments.Length, beginReportEvents.Length);
@@ -1646,38 +1785,40 @@ namespace System.Diagnostics.Metrics.Tests
                     Description = e.Payload[6].ToString(),
                     InstrumentTags = e.Payload[7].ToString(),
                     MeterTags = e.Payload[8].ToString(),
-                    ScopeHash = e.Payload[9].ToString()
+                    ScopeHash = e.Payload[9].ToString(),
+                    InstrumentHash = e.Payload[10].ToString(),
+                    MeterHash = e.Payload[11].ToString(),
                 }).ToArray();
 
             foreach (Instrument i in expectedInstruments)
             {
-                var e = publishEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name).FirstOrDefault();
+                var e = publishEvents.Where(ev => ev.InstrumentName == i.Name && ev.MeterName == i.Meter.Name && ev.InstrumentHash == Helpers.FormatObjectHash(i) && ev.MeterHash == Helpers.FormatObjectHash(i.Meter)).FirstOrDefault();
                 Assert.True(e != null, "Expected to find a InstrumentPublished event for " + i.Meter.Name + "\\" + i.Name);
                 Assert.Equal(i.Meter.Version ?? "", e.MeterVersion);
                 Assert.Equal(i.GetType().Name, e.InstrumentType);
                 Assert.Equal(i.Unit ?? "", e.Unit);
                 Assert.Equal(i.Description ?? "", e.Description);
-                Assert.Equal(FormatTags(i.Tags), e.InstrumentTags);
-                Assert.Equal(FormatTags(i.Meter.Tags), e.MeterTags);
-                Assert.Equal(FormatScopeHash(i.Meter.Scope), e.ScopeHash);
+                Assert.Equal(Helpers.FormatTags(i.Tags), e.InstrumentTags);
+                Assert.Equal(Helpers.FormatTags(i.Meter.Tags), e.MeterTags);
+                Assert.Equal(Helpers.FormatObjectHash(i.Meter.Scope), e.ScopeHash);
             }
 
             Assert.Equal(expectedInstruments.Length, publishEvents.Length);
         }
 
-        private static void AssertCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private static void AssertCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
             string expectedUnit, params (string, string)[] expected)
         {
-            AssertGenericCounterEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expected);
+            AssertGenericCounterEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, instrument, tags, expectedUnit, expected);
         }
 
-        private static void AssertUpDownCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private static void AssertUpDownCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
             string expectedUnit, params (string, string)[] expected)
         {
-            AssertGenericCounterEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expected);
+            AssertGenericCounterEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, instrument, tags, expectedUnit, expected);
         }
 
-        private static void AssertGenericCounterEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private static void AssertGenericCounterEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
             string expectedUnit, params (string, string)[] expected)
         {
             var counterEvents = events.Where(e => e.EventName == eventName).Select(e =>
@@ -1689,15 +1830,31 @@ namespace System.Diagnostics.Metrics.Tests
                     Unit = e.Payload[4].ToString(),
                     Tags = e.Payload[5].ToString(),
                     Rate = e.Payload[6].ToString(),
-                    Value = e.Payload[7].ToString()
+                    Value = e.Payload[7].ToString(),
+                    InstrumentFormattedTags = e.Payload[8].ToString(),
+                    InstrumentFormattedHash = e.Payload[9].ToString(),
+                    MeterFormattedTags = e.Payload[10].ToString(),
+                    MeterFormattedHash = e.Payload[11].ToString(),
+                    MeterScopeHash = e.Payload[12].ToString()
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentFormattedHash == Helpers.FormatObjectHash(instrument)).ToArray();
             Assert.True(filteredEvents.Length >= expected.Length);
+
+            string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
+            string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
+            string formattedMeterHash = Helpers.FormatObjectHash(instrument.Meter);
+            string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
+
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(expectedUnit, filteredEvents[i].Unit);
                 Assert.Equal(expected[i].Item1, filteredEvents[i].Rate);
                 Assert.Equal(expected[i].Item2, filteredEvents[i].Value);
+
+                Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
+                Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
+                Assert.Equal(formattedMeterHash, filteredEvents[i].MeterFormattedHash);
+                Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
             }
         }
 
@@ -1715,7 +1872,7 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(0, filteredEvents.Length);
         }
 
-        private static void AssertGaugeEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private static void AssertGaugeEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
             string expectedUnit, params string[] expectedValues)
         {
             var counterEvents = events.Where(e => e.EventName == "GaugeValuePublished").Select(e =>
@@ -1727,17 +1884,33 @@ namespace System.Diagnostics.Metrics.Tests
                     Unit = e.Payload[4].ToString(),
                     Tags = e.Payload[5].ToString(),
                     Value = e.Payload[6].ToString(),
+                    InstrumentFormattedTags = e.Payload[7].ToString(),
+                    InstrumentFormattedHash = e.Payload[8].ToString(),
+                    MeterFormattedTags = e.Payload[9].ToString(),
+                    MeterFormattedHash = e.Payload[10].ToString(),
+                    MeterScopeHash = e.Payload[11].ToString(),
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentFormattedHash == Helpers.FormatObjectHash(instrument)).ToArray();
             Assert.True(filteredEvents.Length >= expectedValues.Length);
+
+            string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
+            string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
+            string formattedMeterHash = Helpers.FormatObjectHash(instrument.Meter);
+            string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
+
             for (int i = 0; i < expectedValues.Length; i++)
             {
                 Assert.Equal(expectedUnit, filteredEvents[i].Unit);
                 Assert.Equal(expectedValues[i], filteredEvents[i].Value);
+
+                Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
+                Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
+                Assert.Equal(formattedMeterHash, filteredEvents[i].MeterFormattedHash);
+                Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
             }
         }
 
-        private static void AssertHistogramEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private static void AssertHistogramEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, Instrument instrument, string tags,
             string expectedUnit, params (string, string, string)[] expected)
         {
             var counterEvents = events.Where(e => e.EventName == "HistogramValuePublished").Select(e =>
@@ -1750,16 +1923,32 @@ namespace System.Diagnostics.Metrics.Tests
                     Tags = e.Payload[5].ToString(),
                     Quantiles = (string)e.Payload[6],
                     Count = e.Payload[7].ToString(),
-                    Sum = e.Payload[8].ToString()
+                    Sum = e.Payload[8].ToString(),
+                    InstrumentFormattedTags = e.Payload[9].ToString(),
+                    InstrumentFormattedHash = e.Payload[10].ToString(),
+                    MeterFormattedTags = e.Payload[11].ToString(),
+                    MeterFormattedHash = e.Payload[12].ToString(),
+                    MeterScopeHash = e.Payload[13].ToString()
                 }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags && e.InstrumentFormattedHash == Helpers.FormatObjectHash(instrument)).ToArray();
             Assert.True(filteredEvents.Length >= expected.Length);
+
+            string formattedInstrumentTags = Helpers.FormatTags(instrument.Tags);
+            string formattedMeterTags = Helpers.FormatTags(instrument.Meter.Tags);
+            string formattedMeterHash = Helpers.FormatObjectHash(instrument.Meter);
+            string formattedMeterScopeHash = Helpers.FormatObjectHash(instrument.Meter.Scope);
+
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(filteredEvents[i].Unit, expectedUnit);
                 Assert.Equal(expected[i].Item1, filteredEvents[i].Quantiles);
                 Assert.Equal(expected[i].Item2, filteredEvents[i].Count);
                 Assert.Equal(expected[i].Item3, filteredEvents[i].Sum);
+
+                Assert.Equal(formattedInstrumentTags, filteredEvents[i].InstrumentFormattedTags);
+                Assert.Equal(formattedMeterTags, filteredEvents[i].MeterFormattedTags);
+                Assert.Equal(formattedMeterHash, filteredEvents[i].MeterFormattedHash);
+                Assert.Equal(formattedMeterScopeHash, filteredEvents[i].MeterScopeHash);
             }
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\src\System\Diagnostics\DsesSamplerBuilder.cs" Link="DsesSamplerBuilder.cs" />
+    <Compile Include="..\src\System\Diagnostics\Helpers.cs" Link="Helpers.cs" />
     <Compile Include="..\src\System\Diagnostics\Metrics\Aggregator.cs" Link="Aggregator.cs" />
     <Compile Include="..\src\System\Diagnostics\Metrics\AggregatorStore.cs" Link="AggregatorStore.cs" />
     <Compile Include="..\src\System\Diagnostics\Metrics\ExponentialHistogramAggregator.cs" Link="ExponentialHistogramAggregator.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/93097 and https://github.com/dotnet/runtime/issues/93767

- https://github.com/dotnet/runtime/issues/93097 
- https://github.com/dotnet/runtime/issues/93767

This change enables the emission of additional metrics data during measurement publishing. Specifically, it will emit the instrument's formatted tags and hash, as well as the meter's formatted tags, scope hash, and meter hash. With this extra data, aggregators can easily differentiate between instruments created with identical parameters such as name, tags, and units. Similarly, it allows for distinguishing between meters created with the same parameters, such as meter name, version, tags, and scope.