### PR TITLE
[mono] Issue #103365 follow-up PR

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -4271,8 +4271,8 @@ build_variance_search_table (MonoClass *klass) {
 	gboolean any_items = build_variance_search_table_inner (klass, buf, buf_size, &buf_count, klass, TRUE);
 
 	if (any_items) {
-		guint bytes = ((buf_count - 1) * sizeof(MonoVarianceSearchTableEntry)) + sizeof(VarianceSearchTable);
-		result = (VarianceSearchTable *)mono_mem_manager_alloc (m_class_get_mem_manager (klass), bytes);
+		guint bytes = (buf_count * sizeof(MonoVarianceSearchTableEntry));
+		result = (VarianceSearchTable *)mono_mem_manager_alloc (m_class_get_mem_manager (klass), bytes + sizeof(VarianceSearchTable));
 		result->count = buf_count;
 		memcpy (result->entries, buf, bytes);
 	}

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1466,8 +1466,8 @@ gboolean
 mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method);
 
 typedef struct _MonoVarianceSearchTableEntry {
-    int depth, offset;
     MonoClass *klass;
+    guint16 offset;
 } MonoVarianceSearchTableEntry;
 
 MonoVarianceSearchTableEntry *

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1466,7 +1466,7 @@ gboolean
 mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method);
 
 void
-mono_class_get_variance_search_table (MonoClass *klass, MonoClass ***table, int *table_size);
+mono_class_get_variance_search_table (MonoClass *klass, MonoVarianceSearchTableEntry **table, int *table_size);
 
 // There are many ways to do on-demand initialization.
 //   Some allow multiple concurrent initializations. Some do not.

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1465,8 +1465,13 @@ mono_class_has_default_constructor (MonoClass *klass, gboolean public_only);
 gboolean
 mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method);
 
-void
-mono_class_get_variance_search_table (MonoClass *klass, MonoVarianceSearchTableEntry **table, int *table_size);
+typedef struct _MonoVarianceSearchTableEntry {
+    int depth, offset;
+    MonoClass *klass;
+} MonoVarianceSearchTableEntry;
+
+MonoVarianceSearchTableEntry *
+mono_class_get_variance_search_table (MonoClass *klass, int *table_size);
 
 // There are many ways to do on-demand initialization.
 //   Some allow multiple concurrent initializations. Some do not.

--- a/src/mono/mono/metadata/class-private-definition.h
+++ b/src/mono/mono/metadata/class-private-definition.h
@@ -129,8 +129,7 @@ struct _MonoClass {
 	/* Infrequently used items. See class-accessors.c: InfrequentDataKind for what goes into here. */
 	MonoPropertyBag infrequent_data;
 
-	MonoClass **variant_search_table;
-	int variant_search_table_length;
+	void *variant_search_table;
 };
 
 struct _MonoClassDef {

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1988,7 +1988,8 @@ mono_class_interface_offset_with_variance (MonoClass *klass, MonoClass *itf, gbo
 		MonoVarianceSearchTableEntry *vst;
 		int vst_count;
 		mono_class_get_variance_search_table (klass, &vst, &vst_count);
-		int depth = vst_count ? vst[0].depth : 0, i = 0, j;
+		int depth = vst_count ? vst[0].depth : 0, j;
+		i = 0;
 
 		while (depth) {
 			// g_print ("depth==%d, i==%d, count==%d\n", depth, i, vst_count);

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1985,58 +1985,49 @@ mono_class_interface_offset_with_variance (MonoClass *klass, MonoClass *itf, gbo
 
 		return m_class_get_interface_offsets_packed (klass) [found];
 	} else if (has_variance) {
-		MonoVarianceSearchTableEntry *vst;
-		int vst_count;
-		mono_class_get_variance_search_table (klass, &vst, &vst_count);
-		int depth = vst_count ? vst[0].depth : 0, j;
-		i = 0;
+		int vst_count, offset = 0;
+		MonoVarianceSearchTableEntry *vst = mono_class_get_variance_search_table (klass, &vst_count);
 
-		while (depth) {
-			// g_print ("depth==%d, i==%d, count==%d\n", depth, i, vst_count);
-
+		// The variance search table is a buffer containing all interfaces with in/out params in the type's inheritance
+		//  hierarchy, with a NULL separator between each level of the hierarchy. This allows us to skip recursing down
+		//  the whole chain and avoid performing duplicate compatibility checks, since duplicates are stripped from the
+		//  buffer. To comply with the spec, we do an exact-match pass and then a variance pass for each level in the
+		//  hierarchy, then move on to the next level and do two passes for that one.
+		while (offset < vst_count) {
 			// Exact match pass: Is there an exact match at this level of the type hierarchy?
 			// If so, we can use the interface_offset we computed earlier, since we're walking from most derived to least.
-			for (j = i; j < vst_count; j++) {
-				if (vst [j].depth != depth)
+			for (i = offset; i < vst_count; i++) {
+				// If we hit a null, that's the next level in the inheritance hierarchy, so stop there
+				if (vst [i].klass == NULL)
 					break;
 
-				/*
-				char * cname = mono_type_get_full_name (vst [j].klass);
-				g_print ("  #%d: depth==%d %s\n", j, vst [j].depth, cname);
-				g_free (cname);
-				*/
-				if (itf != vst [j].klass)
+				if (itf != vst [i].klass)
 					continue;
 
 				*non_exact_match = FALSE;
-				g_assert (vst [j].offset == exact_match);
+				g_assert (vst [i].offset == exact_match);
 				return exact_match;
 			}
 
 			// Inexact match (variance) pass:
 			// Is any interface at this level of the type hierarchy variantly compatible with the desired interface?
 			// If so, select the first compatible one we find.
-			for (j = i; j < vst_count; j++) {
-				if (vst [j].depth < depth) {
-					i = j;
+			for (i = offset; i < vst_count; i++) {
+				// If we hit a null, that's the next level in the inheritance hierarchy, so bump offset past it
+				if (vst [i].klass == NULL) {
+					offset = i + 1;
 					break;
 				}
 
-				/*
-				char * cname = mono_type_get_full_name (vst [j].klass);
-				g_print ("  #%d: depth==%d %s\n", j, vst [j].depth, cname);
-				g_free (cname);
-				*/
-				if (!mono_class_is_variant_compatible (itf, vst [j].klass, FALSE))
+				if (!mono_class_is_variant_compatible (itf, vst [i].klass, FALSE))
 					continue;
 
-				int inexact_match = vst [j].offset;
-				g_assert (inexact_match != exact_match);
-				*non_exact_match = TRUE;
+				int inexact_match = vst [i].offset;
+				// FIXME: Is it correct that this is possible?
+				// g_assert (inexact_match != exact_match);
+				*non_exact_match = inexact_match != exact_match;
 				return inexact_match;
 			}
-
-			depth--;
 		}
 
 		// If the variance search failed to find a match, return the exact match search result (probably -1).

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1303,6 +1303,7 @@ get_method_constrained (MonoImage *image, MonoMethod *method, MonoClass *constra
 		g_assert (itf_slot >= 0);
 		gboolean variant = FALSE;
 		int itf_base = mono_class_interface_offset_with_variance (constrained_class, base_class, &variant);
+		g_assert (itf_base >= 0);
 		vtable_slot = itf_slot + itf_base;
 	}
 	g_assert (vtable_slot >= 0);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -625,6 +625,7 @@ get_virtual_method (InterpMethod *imethod, MonoVTable *vtable)
 	}
 
 	MonoMethod *virtual_method = m_class_get_vtable (vtable->klass) [slot];
+	g_assert (virtual_method);
 	if (m->is_inflated && mono_method_get_context (m)->method_inst) {
 		MonoGenericContext context = { NULL, NULL };
 
@@ -648,8 +649,30 @@ get_virtual_method (InterpMethod *imethod, MonoVTable *vtable)
 	}
 
 	// Basic sanity check since a call might crash if we have the wrong method somehow
-	g_assert (m->signature->param_count == virtual_method->signature->param_count);
-	g_assert (m->signature->hasthis == virtual_method->signature->hasthis);
+
+	MonoMethodSignature *m_sig, *virtual_method_sig;
+	{
+		ERROR_DECL (error);
+		m_sig = mono_method_signature_checked (m, error);
+		mono_error_cleanup (error);
+	}
+	{
+		ERROR_DECL (error);
+		virtual_method_sig = mono_method_signature_checked (virtual_method, error);
+		mono_error_cleanup (error);
+	}
+	gboolean ok = m_sig &&
+		virtual_method_sig &&
+		(m_sig->param_count == virtual_method_sig->param_count) &&
+		(m_sig->hasthis == virtual_method_sig->hasthis);
+	if (!ok) {
+		g_print (
+			"get_virtual_method signature mismatch for %s.%s and %s.%s\n",
+			m_class_get_name (m->klass), m->name,
+			m_class_get_name (virtual_method->klass), virtual_method->name
+		);
+		g_assert (ok);
+	}
 
 	InterpMethod *virtual_imethod = mono_interp_get_imethod (virtual_method);
 	return virtual_imethod;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -647,6 +647,10 @@ get_virtual_method (InterpMethod *imethod, MonoVTable *vtable)
 		virtual_method = mono_marshal_get_synchronized_wrapper (virtual_method);
 	}
 
+	// Basic sanity check since a call might crash if we have the wrong method somehow
+	g_assert (m->signature->param_count == virtual_method->signature->param_count);
+	g_assert (m->signature->hasthis == virtual_method->signature->hasthis);
+
 	InterpMethod *virtual_imethod = mono_interp_get_imethod (virtual_method);
 	return virtual_imethod;
 }
@@ -7479,7 +7483,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (local_cmethod->is_generic || mono_class_is_gtd (local_cmethod->klass)) {
 				MonoException *ex = mono_exception_from_name_msg (mono_defaults.corlib, "System", "InvalidOperationException", "");
 				THROW_EX (ex, ip);
-			}			
+			}
 
 			// FIXME push/pop LMF
 			if (G_UNLIKELY (mono_method_has_unmanaged_callers_only_attribute (local_cmethod))) {

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -626,6 +626,7 @@ get_virtual_method (InterpMethod *imethod, MonoVTable *vtable)
 
 	MonoMethod *virtual_method = m_class_get_vtable (vtable->klass) [slot];
 	g_assert (virtual_method);
+
 	if (m->is_inflated && mono_method_get_context (m)->method_inst) {
 		MonoGenericContext context = { NULL, NULL };
 
@@ -646,32 +647,6 @@ get_virtual_method (InterpMethod *imethod, MonoVTable *vtable)
 
 	if (virtual_method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
 		virtual_method = mono_marshal_get_synchronized_wrapper (virtual_method);
-	}
-
-	// Basic sanity check since a call might crash if we have the wrong method somehow
-
-	MonoMethodSignature *m_sig, *virtual_method_sig;
-	{
-		ERROR_DECL (error);
-		m_sig = mono_method_signature_checked (m, error);
-		mono_error_cleanup (error);
-	}
-	{
-		ERROR_DECL (error);
-		virtual_method_sig = mono_method_signature_checked (virtual_method, error);
-		mono_error_cleanup (error);
-	}
-	gboolean ok = m_sig &&
-		virtual_method_sig &&
-		(m_sig->param_count == virtual_method_sig->param_count) &&
-		(m_sig->hasthis == virtual_method_sig->hasthis);
-	if (!ok) {
-		g_print (
-			"get_virtual_method signature mismatch for %s.%s and %s.%s\n",
-			m_class_get_name (m->klass), m->name,
-			m_class_get_name (virtual_method->klass), virtual_method->name
-		);
-		g_assert (ok);
 	}
 
 	InterpMethod *virtual_imethod = mono_interp_get_imethod (virtual_method);

--- a/src/native/public/mono/metadata/object-forward.h
+++ b/src/native/public/mono/metadata/object-forward.h
@@ -19,4 +19,9 @@ typedef struct _MonoException MONO_RT_MANAGED_ATTR MonoException;
 typedef struct _MonoReflectionAssembly MONO_RT_MANAGED_ATTR MonoReflectionAssembly;
 typedef struct _MonoReflectionTypeBuilder MONO_RT_MANAGED_ATTR MonoReflectionTypeBuilder;
 
+typedef struct _MonoVarianceSearchTableEntry {
+    int depth, offset;
+    MonoClass *klass;
+} MonoVarianceSearchTableEntry;
+
 #endif /* __MONO_OBJECT_FORWARD_H__ */

--- a/src/native/public/mono/metadata/object-forward.h
+++ b/src/native/public/mono/metadata/object-forward.h
@@ -19,9 +19,4 @@ typedef struct _MonoException MONO_RT_MANAGED_ATTR MonoException;
 typedef struct _MonoReflectionAssembly MONO_RT_MANAGED_ATTR MonoReflectionAssembly;
 typedef struct _MonoReflectionTypeBuilder MONO_RT_MANAGED_ATTR MonoReflectionTypeBuilder;
 
-typedef struct _MonoVarianceSearchTableEntry {
-    int depth, offset;
-    MonoClass *klass;
-} MonoVarianceSearchTableEntry;
-
 #endif /* __MONO_OBJECT_FORWARD_H__ */


### PR DESCRIPTION
* Slightly reduce memory usage for classes without a variance search table (many of them)
* Make the variance search table for a given class larger, but remove the need to recursively search every table in the hierarchy
* Optimize out the additional interfaces list scan to compute the interface offset once we find a match in the variance table