### PR TITLE
Expose the TarEntry start of the data stream

### DIFF
--- a/src/libraries/System.Formats.Tar/ref/System.Formats.Tar.cs
+++ b/src/libraries/System.Formats.Tar/ref/System.Formats.Tar.cs
@@ -46,6 +46,7 @@ namespace System.Formats.Tar
         public System.IO.UnixFileMode Mode { get { throw null; } set { } }
         public System.DateTimeOffset ModificationTime { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
+        public long DataOffset { get { throw null; } }
         public int Uid { get { throw null; } set { } }
         public void ExtractToFile(string destinationFileName, bool overwrite) { }
         public System.Threading.Tasks.Task ExtractToFileAsync(string destinationFileName, bool overwrite, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -286,6 +286,7 @@ namespace System.Formats.Tar
         /// </summary>
         /// <remarks>
         /// If the entry does not come from an archive stream or if the archive stream is not seekable, returns -1.
+        /// The position value returned by this property is relative to the absolute start of the archive stream, independently of where the tar archive beging.
         /// </remarks>
         public long DataOffset => _header._dataOffset;
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -286,7 +286,7 @@ namespace System.Formats.Tar
         /// </summary>
         /// <remarks>
         /// If the entry does not come from an archive stream or if the archive stream is not seekable, returns -1.
-        /// The position value returned by this property is relative to the absolute start of the archive stream, independently of where the tar archive beging.
+        /// The position value returned by this property is relative to the absolute start of the archive stream, independent of where the tar archive begins.
         /// </remarks>
         public long DataOffset => _header._dataOffset;
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -282,6 +282,12 @@ namespace System.Formats.Tar
         }
 
         /// <summary>
+        /// The starting position of the data stream respective to the archive stream.
+        /// If the entry does not come from an archive stream, or the archive stream is unseekable, returns -1.
+        /// </summary>
+        public long DataOffset => _header._dataOffset;
+
+        /// <summary>
         /// A string that represents the current entry.
         /// </summary>
         /// <returns>The <see cref="Name"/> of the current entry.</returns>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -282,9 +282,11 @@ namespace System.Formats.Tar
         }
 
         /// <summary>
-        /// The starting position of the data stream respective to the archive stream.
-        /// If the entry does not come from an archive stream, or the archive stream is unseekable, returns -1.
+        /// Gets the starting position of the data stream respective to the archive stream.
         /// </summary>
+        /// <remarks>
+        /// If the entry does not come from an archive stream or if the archive stream is not seekable, returns -1.
+        /// </remarks>
         public long DataOffset => _header._dataOffset;
 
         /// <summary>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -84,7 +84,7 @@ namespace System.Formats.Tar
             long dataStartPosition = headerStartPosition + dataLocation;
 
             // Before writing, update the offset field now that the entry belongs to an archive
-            _dataOffset = dataStartPosition + 1;
+            _dataOffset = dataStartPosition;
 
             // Move to the data start location and write the data
             destinationStream.Seek(dataLocation, SeekOrigin.Current);
@@ -136,7 +136,7 @@ namespace System.Formats.Tar
             long dataStartPosition = headerStartPosition + dataLocation;
 
             // Before writing, update the offset field now that the entry belongs to an archive
-            _dataOffset = dataStartPosition + 1;
+            _dataOffset = dataStartPosition;
 
             // Move to the data start location and write the data
             destinationStream.Seek(dataLocation, SeekOrigin.Current);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -83,6 +83,9 @@ namespace System.Formats.Tar
             // We know the exact location where the data starts depending on the format
             long dataStartPosition = headerStartPosition + dataLocation;
 
+            // Before writing, update the offset field now that the entry belongs to an archive
+            _dataOffset = dataStartPosition + 1;
+
             // Move to the data start location and write the data
             destinationStream.Seek(dataLocation, SeekOrigin.Current);
             _dataStream.CopyTo(destinationStream); // The data gets copied from the current position
@@ -131,6 +134,9 @@ namespace System.Formats.Tar
 
             // We know the exact location where the data starts depending on the format
             long dataStartPosition = headerStartPosition + dataLocation;
+
+            // Before writing, update the offset field now that the entry belongs to an archive
+            _dataOffset = dataStartPosition + 1;
 
             // Move to the data start location and write the data
             destinationStream.Seek(dataLocation, SeekOrigin.Current);
@@ -758,6 +764,9 @@ namespace System.Formats.Tar
         // Writes the current header's data stream into the archive stream.
         private void WriteData(Stream archiveStream, Stream dataStream)
         {
+            // Before writing, update the offset field now that the entry belongs to an archive
+            SetDataOffset(this, archiveStream);
+
             dataStream.CopyTo(archiveStream); // The data gets copied from the current position
             WriteEmptyPadding(archiveStream);
         }
@@ -797,6 +806,9 @@ namespace System.Formats.Tar
         private async Task WriteDataAsync(Stream archiveStream, Stream dataStream, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            // Before writing, update the offset field now that the entry belongs to an archive
+            SetDataOffset(this, archiveStream);
 
             await dataStream.CopyToAsync(archiveStream, cancellationToken).ConfigureAwait(false); // The data gets copied from the current position
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -157,7 +157,7 @@ namespace System.Formats.Tar
         private static void SetDataOffset(TarHeader header, Stream archiveStream) => header._dataOffset =
             archiveStream.CanSeek
             // Add one because the last byte read is still part of the header
-            ? archiveStream.Position + 1
+            ? archiveStream.Position
             : -1;
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -154,10 +154,7 @@ namespace System.Formats.Tar
 
         // Stores the archive stream's position where we know the current entry's data section begins,
         // if the archive stream is seekable. Otherwise, -1.
-        private static void SetDataOffset(TarHeader header, Stream archiveStream) => header._dataOffset =
-            archiveStream.CanSeek
-            // Add one because the last byte read is still part of the header
-            ? archiveStream.Position
-            : -1;
+        private static void SetDataOffset(TarHeader header, Stream archiveStream) =>
+            header._dataOffset = archiveStream.CanSeek ? archiveStream.Position : -1;
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -40,6 +40,7 @@ namespace System.Formats.Tar
         private const string PaxEaDevMinor = "devminor";
 
         internal Stream? _dataStream;
+        internal long _dataOffset;
 
         // Position in the stream where the data ends in this header.
         internal long _endOfHeaderAndDataAndBlockAlignment;
@@ -95,6 +96,7 @@ namespace System.Formats.Tar
             _typeFlag = typeFlag;
             _magic = GetMagicForFormat(format);
             _version = GetVersionForFormat(format);
+            _dataOffset = -1;
         }
 
         // Constructor called when creating an entry using the common fields from another entry.
@@ -149,5 +151,13 @@ namespace System.Formats.Tar
             TarEntryFormat.Gnu => GnuVersion,
             _ => string.Empty,
         };
+
+        // Stores the archive stream's position where we know the current entry's data section begins,
+        // if the archive stream is seekable. Otherwise, -1.
+        private static void SetDataOffset(TarHeader header, Stream archiveStream) => header._dataOffset =
+            archiveStream.CanSeek
+            // Add one because the last byte read is still part of the header
+            ? archiveStream.Position + 1
+            : -1;
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -100,6 +100,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public void DataOffset_RegularFile(bool canSeek)
         {
+            byte expectedData = 5;
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
             {
@@ -120,8 +121,15 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 2560.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 513 : -1;
+            long expectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+            if (canSeek)
+            {
+                ms.Position = actualEntry.DataOffset;
+                byte actualData = (byte)ms.ReadByte();
+                Assert.Equal(expectedData, actualData);
+            }
         }
 
         [Theory]
@@ -129,6 +137,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public async Task DataOffset_RegularFile_Async(bool canSeek)
         {
+            byte expectedData = 5;
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
@@ -149,8 +158,15 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 2560.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 513 : -1;
+            long expectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+            if (canSeek)
+            {
+                ms.Position = actualEntry.DataOffset;
+                byte actualData = (byte)ms.ReadByte();
+                Assert.Equal(expectedData, actualData);
+            }
         }
 
         [Theory]
@@ -183,7 +199,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 2560.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2561 : -1;
+            long expectedDataOffset = canSeek ? 2560 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
 
@@ -217,7 +233,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 2560.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2561 : -1;
+            long expectedDataOffset = canSeek ? 2560 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
 
@@ -248,7 +264,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 2560.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2561 : -1;
+            long expectedDataOffset = canSeek ? 2560 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
         [Theory]
@@ -278,7 +294,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 2560.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2561 : -1;
+            long expectedDataOffset = canSeek ? 2560 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
 
@@ -313,7 +329,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 4608.
             // The data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 4609 : -1;
+            long expectedDataOffset = canSeek ? 4608 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
         
@@ -348,7 +364,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 4608.
             // The data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 4609 : -1;
+            long expectedDataOffset = canSeek ? 4608 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
 
@@ -363,7 +379,7 @@ namespace System.Formats.Tar.Tests
             using MemoryStream ms = new();
             using TarWriter writer = new(ms);
             writer.WriteEntry(entry);
-            Assert.Equal(513, entry.DataOffset);
+            Assert.Equal(512, entry.DataOffset);
         }
         
         [Fact]
@@ -378,7 +394,7 @@ namespace System.Formats.Tar.Tests
             await using MemoryStream ms = new();
             await using TarWriter writer = new(ms);
             await writer.WriteEntryAsync(entry);
-            Assert.Equal(513, entry.DataOffset);
+            Assert.Equal(512, entry.DataOffset);
         }
 
         [Fact]
@@ -404,7 +420,7 @@ namespace System.Formats.Tar.Tests
             TarEntry actualEntry = reader.GetNextEntry();
             Assert.NotNull(actualEntry);
             // Gnu header length is 512, data starts in the next position
-            Assert.Equal(513, actualEntry.DataOffset);
+            Assert.Equal(512, actualEntry.DataOffset);
         }
 
         [Fact]
@@ -430,7 +446,7 @@ namespace System.Formats.Tar.Tests
             TarEntry actualEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(actualEntry);
             // Gnu header length is 512, data starts in the next position
-            Assert.Equal(513, actualEntry.DataOffset);
+            Assert.Equal(512, actualEntry.DataOffset);
         }
         
         [Theory]
@@ -469,14 +485,14 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 4608.
             // The regular file data section starts on the next byte.
-            long firstExpectedDataOffset = canSeek ? 4609 : -1;
+            long firstExpectedDataOffset = canSeek ? 4608 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
             
             TarEntry secondEntry = reader.GetNextEntry();
             Assert.NotNull(secondEntry);
             // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
-            // Second entry (including its long link and long path entries) data section starts at 4608 + 4608 = 9216 + 1
-            long secondExpectedDataOffset = canSeek ? 9217 : -1;
+            // Second entry (including its long link and long path entries) data section starts one byte after 4608 + 4608 = 9216
+            long secondExpectedDataOffset = canSeek ? 9216 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
         
@@ -516,14 +532,14 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 4608.
             // The regular file data section starts on the next byte.
-            long firstExpectedDataOffset = canSeek ? 4609 : -1;
+            long firstExpectedDataOffset = canSeek ? 4608 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
             
             TarEntry secondEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(secondEntry);
             // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
-            // Second entry (including its long link and long path entries) data section starts at 4608 + 4608 = 9216 + 1
-            long secondExpectedDataOffset = canSeek ? 9217 : -1;
+            // Second entry (including its long link and long path entries) data section starts one byte after 4608 + 4608 = 9216
+            long secondExpectedDataOffset = canSeek ? 9216 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -100,13 +100,12 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public void DataOffset_RegularFile(bool canSeek)
         {
-            byte expectedData = 5;
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(5);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 writer.WriteEntry(entry);
             }
@@ -128,7 +127,7 @@ namespace System.Formats.Tar.Tests
             {
                 ms.Position = actualEntry.DataOffset;
                 byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(expectedData, actualData);
+                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
             }
         }
 
@@ -137,13 +136,12 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public async Task DataOffset_RegularFile_Async(bool canSeek)
         {
-            byte expectedData = 5;
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(5);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry);
             }
@@ -165,7 +163,7 @@ namespace System.Formats.Tar.Tests
             {
                 ms.Position = actualEntry.DataOffset;
                 byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(expectedData, actualData);
+                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
             }
         }
 
@@ -180,7 +178,7 @@ namespace System.Formats.Tar.Tests
                 string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, veryLongName);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(5);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 writer.WriteEntry(entry);
             }
@@ -214,7 +212,7 @@ namespace System.Formats.Tar.Tests
                 string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, veryLongName);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(5);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry);
             }
@@ -374,7 +372,7 @@ namespace System.Formats.Tar.Tests
             GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
             Assert.Equal(-1, entry.DataOffset);
             entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(5);
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
             entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             using MemoryStream ms = new();
@@ -397,7 +395,7 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(-1, entry.DataOffset);
 
             entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(5);
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
             entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             await using MemoryStream ms = new();
@@ -423,7 +421,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(-1, entry.DataOffset);
 
                 using MemoryStream dataStream = new();
-                dataStream.WriteByte(5);
+                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 dataStream.Position = 0;
                 using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
                 entry.DataStream = wds;
@@ -449,7 +447,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(-1, entry.DataOffset);
 
                 await using MemoryStream dataStream = new();
-                dataStream.WriteByte(5);
+                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 dataStream.Position = 0;
                 await using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
                 entry.DataStream = wds;

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -260,7 +260,7 @@ namespace System.Formats.Tar.Tests
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
-                entry.LinkName = new string('a', 1234); // Forces using a GNU LongLink entry
+                entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
                 await writer.WriteEntryAsync(entry);
             }
             ms.Position = 0;
@@ -285,14 +285,14 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void DataOffset_RegularFile_LongLin_LongPath(bool canSeek)
+        public void DataOffset_RegularFile_LongLink_LongPath(bool canSeek)
         {
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongName);
-                entry.LinkName = new string('a', 1234); // Forces using a GNU LongLink entry
+                entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
                 writer.WriteEntry(entry);
             }
             ms.Position = 0;
@@ -309,10 +309,10 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular long path tar header
             // * 1234 bytes for the data section containing the full long path
             // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
+            // Then it writes the actual entry, containing:
             // * 512 bytes of the regular tar header
             // Totalling 4608.
-            // The regular file data section starts on the next byte.
+            // The data section starts on the next byte.
             long expectedDataOffset = canSeek ? 4609 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
@@ -320,14 +320,14 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task DataOffset_RegularFile_LongLin_LongPath_Async(bool canSeek)
+        public async Task DataOffset_RegularFile_LongLink_LongPath_Async(bool canSeek)
         {
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongName);
-                entry.LinkName = new string('a', 1234); // Forces using a GNU LongLink entry
+                entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
                 await writer.WriteEntryAsync(entry);
             }
             ms.Position = 0;
@@ -344,10 +344,10 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular long path tar header
             // * 1234 bytes for the data section containing the full long path
             // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
+            // Then it writes the actual entry, containing:
             // * 512 bytes of the regular tar header
             // Totalling 4608.
-            // The regular file data section starts on the next byte.
+            // The data section starts on the next byte.
             long expectedDataOffset = canSeek ? 4609 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
@@ -431,6 +431,100 @@ namespace System.Formats.Tar.Tests
             Assert.NotNull(actualEntry);
             // Gnu header length is 512, data starts in the next position
             Assert.Equal(513, actualEntry.DataOffset);
+        }
+        
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DataOffset_LongPath_LongLink_SecondEntry(bool canSeek)
+        {
+            string veryLongPathName = new string('a', 1234); // Forces using a GNU LongPath entry
+            string veryLongLinkName = new string('b', 1234); // Forces using a GNU LongLink entry
+
+            using MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+                entry1.LinkName = veryLongLinkName;
+                writer.WriteEntry(entry1);
+                
+                GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+                entry2.LinkName = veryLongLinkName;
+                writer.WriteEntry(entry2);
+            }
+            ms.Position = 0;
+
+            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            using TarReader reader = new(streamToRead);
+            TarEntry firstEntry = reader.GetNextEntry();
+            Assert.NotNull(firstEntry);
+            // GNU first writes the long link and long path entries, containing:
+            // * 512 bytes of the regular long link tar header
+            // * 1234 bytes for the data section containing the full long link
+            // * 302 bytes of padding
+            // * 512 bytes of the regular long path tar header
+            // * 1234 bytes for the data section containing the full long path
+            // * 302 bytes of padding
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 4608.
+            // The regular file data section starts on the next byte.
+            long firstExpectedDataOffset = canSeek ? 4609 : -1;
+            Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
+            
+            TarEntry secondEntry = reader.GetNextEntry();
+            Assert.NotNull(secondEntry);
+            // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
+            // Second entry (including its long link and long path entries) data section starts at 4608 + 4608 = 9216 + 1
+            long secondExpectedDataOffset = canSeek ? 9217 : -1;
+            Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
+        }
+        
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DataOffset_LongPath_LongLink_SecondEntry_Async(bool canSeek)
+        {
+            string veryLongPathName = new string('a', 1234); // Forces using a GNU LongPath entry
+            string veryLongLinkName = new string('b', 1234); // Forces using a GNU LongLink entry
+
+            await using MemoryStream ms = new();
+            await using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+                entry1.LinkName = veryLongLinkName;
+                await writer.WriteEntryAsync(entry1);
+                
+                GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+                entry2.LinkName = veryLongLinkName;
+                await writer.WriteEntryAsync(entry2);
+            }
+            ms.Position = 0;
+
+            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            await using TarReader reader = new(streamToRead);
+            TarEntry firstEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(firstEntry);
+            // GNU first writes the long link and long path entries, containing:
+            // * 512 bytes of the regular long link tar header
+            // * 1234 bytes for the data section containing the full long link
+            // * 302 bytes of padding
+            // * 512 bytes of the regular long path tar header
+            // * 1234 bytes for the data section containing the full long path
+            // * 302 bytes of padding
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 4608.
+            // The regular file data section starts on the next byte.
+            long firstExpectedDataOffset = canSeek ? 4609 : -1;
+            Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
+            
+            TarEntry secondEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(secondEntry);
+            // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
+            // Second entry (including its long link and long path entries) data section starts at 4608 + 4608 = 9216 + 1
+            long secondExpectedDataOffset = canSeek ? 9217 : -1;
+            Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -375,11 +375,19 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(-1, entry.DataOffset);
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             using MemoryStream ms = new();
             using TarWriter writer = new(ms);
             writer.WriteEntry(entry);
             Assert.Equal(512, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 512 (header) + 1 (data) + 511 (padding)
+            // Second entry 512 (header)
+            // 512 + 512 + 512 = 1536
+            writer.WriteEntry(entry);
+            Assert.Equal(1536, entry.DataOffset);
         }
         
         [Fact]
@@ -390,11 +398,19 @@ namespace System.Formats.Tar.Tests
 
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             await using MemoryStream ms = new();
             await using TarWriter writer = new(ms);
             await writer.WriteEntryAsync(entry);
             Assert.Equal(512, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 512 (header) + 1 (data) + 511 (padding)
+            // Second entry 512 (header)
+            // 512 + 512 + 512 = 1536
+            await writer.WriteEntryAsync(entry);
+            Assert.Equal(1536, entry.DataOffset);
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
@@ -122,6 +122,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public void DataOffset_RegularFile(bool canSeek)
         {
+            byte expectedData = 5;
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
             {
@@ -146,8 +147,15 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 1537 : -1;
+            long expectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+            if (canSeek)
+            {
+                ms.Position = actualEntry.DataOffset;
+                byte actualData = (byte)ms.ReadByte();
+                Assert.Equal(expectedData, actualData);
+            }
         }
 
         [Theory]
@@ -155,6 +163,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public async Task DataOffset_RegularFile_Async(bool canSeek)
         {
+            byte expectedData = 5;
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
@@ -179,8 +188,15 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 1537 : -1;
+            long expectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+            if (canSeek)
+            {
+                ms.Position = actualEntry.DataOffset;
+                byte actualData = (byte)ms.ReadByte();
+                Assert.Equal(expectedData, actualData);
+            }
         }
 
         [Theory]
@@ -203,7 +219,7 @@ namespace System.Formats.Tar.Tests
             Assert.NotNull(actualEntry);
             Assert.Equal(TarEntryType.GlobalExtendedAttributes, actualEntry.EntryType);
             // The PAX global extended attributes header length is 512, data starts in the next position
-            long expectedDataOffset = canSeek ? 513 : -1;
+            long expectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
 
@@ -227,7 +243,7 @@ namespace System.Formats.Tar.Tests
             Assert.NotNull(actualEntry);
             Assert.Equal(TarEntryType.GlobalExtendedAttributes, actualEntry.EntryType);
             // The PAX global extended attributes header length is 512, data starts in the next position
-            long expectedDataOffset = canSeek ? 513 : -1;
+            long expectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
         
@@ -251,7 +267,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            Assert.Equal(1537, entry.DataOffset);
+            Assert.Equal(1536, entry.DataOffset);
         }
         
         [Fact]
@@ -274,7 +290,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            Assert.Equal(1537, entry.DataOffset);
+            Assert.Equal(1536, entry.DataOffset);
         }
 
         [Fact]
@@ -307,7 +323,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            Assert.Equal(1537, actualEntry.DataOffset);
+            Assert.Equal(1536, actualEntry.DataOffset);
         }
 
         [Fact]
@@ -340,7 +356,7 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            Assert.Equal(1537, actualEntry.DataOffset);
+            Assert.Equal(1536, actualEntry.DataOffset);
         }
         
         [Theory]
@@ -379,14 +395,14 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            long firstExpectedDataOffset = canSeek ? 1537 : -1;
+            long firstExpectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
             
             TarEntry secondEntry = reader.GetNextEntry();
             Assert.NotNull(secondEntry);
-            // The first entry (including its extended attribute entry) end at 1536 + 5 (data) + 507 (padding) = 2048
-            // Second entry's data also starts 1536 bytes after the beginning of its header, so 2048 + 1536 = 3584 + 1
-            long secondExpectedDataOffset = canSeek ? 3585 : -1;
+            // The first entry (including its extended attribute entry) end at 1536 + 1 (data) + 511 (padding) = 2048
+            // Second entry's data also starts one byte after the 1536 bytes after the beginning of its header, so 2048 + 1536 = 3584
+            long secondExpectedDataOffset = canSeek ? 3584 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
 
@@ -426,14 +442,14 @@ namespace System.Formats.Tar.Tests
             // * 512 bytes of the regular tar header
             // Totalling 1536.
             // The regular file data section starts on the next byte.
-            long firstExpectedDataOffset = canSeek ? 1537 : -1;
+            long firstExpectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
             
             TarEntry secondEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(secondEntry);
-            // The first entry (including its extended attribute entry) end at 1536 + 5 (data) + 507 (padding) = 2048
-            // Second entry's data also starts 1536 bytes after the beginning of its header, so 2048 + 1536 = 3584 + 1
-            long secondExpectedDataOffset = canSeek ? 3585 : -1;
+            // The first entry (including its extended attribute entry) end at 1536 + 1 (data) + 511 (padding) = 2048
+            // Second entry's data also starts one byte after the 1536 bytes after the beginning of its header, so 2048 + 1536 = 3584
+            long secondExpectedDataOffset = canSeek ? 3584 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
@@ -255,6 +255,7 @@ namespace System.Formats.Tar.Tests
 
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             using MemoryStream ms = new();
             using TarWriter writer = new(ms);
@@ -268,6 +269,13 @@ namespace System.Formats.Tar.Tests
             // Totalling 1536.
             // The regular file data section starts on the next byte.
             Assert.Equal(1536, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 1536 + 1 (data) + 511 (padding) = 2048
+            // Second entry 1536
+            // 2048 + 1536 = 3584
+            writer.WriteEntry(entry);
+            Assert.Equal(3584, entry.DataOffset);
         }
         
         [Fact]
@@ -278,6 +286,7 @@ namespace System.Formats.Tar.Tests
 
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             await using MemoryStream ms = new();
             await using TarWriter writer = new(ms);
@@ -291,6 +300,13 @@ namespace System.Formats.Tar.Tests
             // Totalling 1536.
             // The regular file data section starts on the next byte.
             Assert.Equal(1536, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 1536 + 1 (data) + 511 (padding) = 2048
+            // Second entry 1536
+            // 2048 + 1536 = 3584
+            await writer.WriteEntryAsync(entry);
+            Assert.Equal(3584, entry.DataOffset);
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -113,6 +115,232 @@ namespace System.Formats.Tar.Tests
             PaxTarEntry fifo = new PaxTarEntry(TarEntryType.Fifo, InitialEntryName);
             SetFifo(fifo);
             VerifyFifo(fifo);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DataOffset_RegularFile(bool canSeek)
+        {
+            using MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+                entry.DataStream = new MemoryStream();
+                entry.DataStream.WriteByte(5);
+                entry.DataStream.Position = 0;
+                writer.WriteEntry(entry);
+            }
+            ms.Position = 0;
+
+            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            using TarReader reader = new(streamToRead);
+            TarEntry actualEntry = reader.GetNextEntry();
+            Assert.NotNull(actualEntry);
+            // PAX first writes the extended attributes entry, containing:
+            // * 512 bytes of the regular tar header
+            // * 113 bytes of the default extended attributes in the data section (mdata)
+            // * 399 bytes of padding after the data
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 1536.
+            // The regular file data section starts on the next byte.
+            long expectedDataOffset = canSeek ? 1537 : -1;
+            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DataOffset_RegularFile_Async(bool canSeek)
+        {
+            await using MemoryStream ms = new();
+            await using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+                entry.DataStream = new MemoryStream();
+                entry.DataStream.WriteByte(5);
+                entry.DataStream.Position = 0;
+                await writer.WriteEntryAsync(entry);
+            }
+            ms.Position = 0;
+
+            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            await using TarReader reader = new(streamToRead);
+            TarEntry actualEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(actualEntry);
+            // PAX first writes the extended attributes entry, containing:
+            // * 512 bytes of the regular tar header
+            // * 113 bytes of the default extended attributes in the data section (mdata)
+            // * 399 bytes of padding after the data
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 1536.
+            // The regular file data section starts on the next byte.
+            long expectedDataOffset = canSeek ? 1537 : -1;
+            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DataOffset_GlobalExtendedAttributes(bool canSeek)
+        {
+            using MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                PaxGlobalExtendedAttributesTarEntry entry =  new PaxGlobalExtendedAttributesTarEntry(new Dictionary<string, string>());
+                Assert.Equal(-1, entry.DataOffset);
+                writer.WriteEntry(entry);
+            }
+            ms.Position = 0;
+
+            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            using TarReader reader = new(streamToRead);
+            TarEntry actualEntry = reader.GetNextEntry();
+            Assert.NotNull(actualEntry);
+            Assert.Equal(TarEntryType.GlobalExtendedAttributes, actualEntry.EntryType);
+            // The PAX global extended attributes header length is 512, data starts in the next position
+            long expectedDataOffset = canSeek ? 513 : -1;
+            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DataOffset_GlobalExtendedAttributes_Async(bool canSeek)
+        {
+            await using MemoryStream ms = new();
+            await using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                PaxGlobalExtendedAttributesTarEntry entry =  new PaxGlobalExtendedAttributesTarEntry(new Dictionary<string, string>());
+                Assert.Equal(-1, entry.DataOffset);
+                await writer.WriteEntryAsync(entry);
+            }
+            ms.Position = 0;
+
+            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            await using TarReader reader = new(streamToRead);
+            TarEntry actualEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(actualEntry);
+            Assert.Equal(TarEntryType.GlobalExtendedAttributes, actualEntry.EntryType);
+            // The PAX global extended attributes header length is 512, data starts in the next position
+            long expectedDataOffset = canSeek ? 513 : -1;
+            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+        }
+        
+        [Fact]
+        public void DataOffset_BeforeAndAfterArchive()
+        {
+            PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            Assert.Equal(-1, entry.DataOffset);
+
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(5);
+
+            using MemoryStream ms = new();
+            using TarWriter writer = new(ms);
+            writer.WriteEntry(entry);
+            // PAX first writes the extended attributes entry, containing:
+            // * 512 bytes of the regular tar header
+            // * 113 bytes of the default extended attributes in the data section (mdata)
+            // * 399 bytes of padding after the data
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 1536.
+            // The regular file data section starts on the next byte.
+            Assert.Equal(1537, entry.DataOffset);
+        }
+        
+        [Fact]
+        public async Task DataOffset_BeforeAndAfterArchive_Async()
+        {
+            PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            Assert.Equal(-1, entry.DataOffset);
+
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(5);
+
+            await using MemoryStream ms = new();
+            await using TarWriter writer = new(ms);
+            await writer.WriteEntryAsync(entry);
+            // PAX first writes the extended attributes entry, containing:
+            // * 512 bytes of the regular tar header
+            // * 113 bytes of the default extended attributes in the data section (mdata)
+            // * 399 bytes of padding after the data
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 1536.
+            // The regular file data section starts on the next byte.
+            Assert.Equal(1537, entry.DataOffset);
+        }
+
+        [Fact]
+        public void DataOffset_UnseekableDataStream()
+        {
+            using MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+
+                using MemoryStream dataStream = new();
+                dataStream.WriteByte(5);
+                dataStream.Position = 0;
+                using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
+                entry.DataStream = wds;
+
+                writer.WriteEntry(entry);
+            }
+            ms.Position = 0;
+
+            using TarReader reader = new(ms);
+            TarEntry actualEntry = reader.GetNextEntry();
+            Assert.NotNull(actualEntry);
+            // PAX first writes the extended attributes entry, containing:
+            // * 512 bytes of the regular tar header
+            // * 113 bytes of the default extended attributes in the data section (mdata)
+            // * 399 bytes of padding after the data
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 1536.
+            // The regular file data section starts on the next byte.
+            Assert.Equal(1537, actualEntry.DataOffset);
+        }
+
+        [Fact]
+        public async Task DataOffset_UnseekableDataStream_Async()
+        {
+            await using MemoryStream ms = new();
+            await using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+
+                await using MemoryStream dataStream = new();
+                dataStream.WriteByte(5);
+                dataStream.Position = 0;
+                await using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
+                entry.DataStream = wds;
+
+                await writer.WriteEntryAsync(entry);
+            }
+            ms.Position = 0;
+
+            await using TarReader reader = new(ms);
+            TarEntry actualEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(actualEntry);
+            // PAX first writes the extended attributes entry, containing:
+            // * 512 bytes of the regular tar header
+            // * 113 bytes of the default extended attributes in the data section (mdata)
+            // * 399 bytes of padding after the data
+            // Then it writes the actual regular file entry, containing:
+            // * 512 bytes of the regular tar header
+            // Totalling 1536.
+            // The regular file data section starts on the next byte.
+            Assert.Equal(1537, actualEntry.DataOffset);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
@@ -167,11 +167,19 @@ namespace System.Formats.Tar.Tests
 
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             using MemoryStream ms = new();
             using TarWriter writer = new(ms);
             writer.WriteEntry(entry);
             Assert.Equal(512, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 512 (header) + 1 (data) + 511 (padding)
+            // Second entry 512 (header)
+            // 512 + 512 + 512 = 1536
+            writer.WriteEntry(entry);
+            Assert.Equal(1536, entry.DataOffset);
         }
 
         [Fact]
@@ -182,11 +190,19 @@ namespace System.Formats.Tar.Tests
 
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             await using MemoryStream ms = new();
             await using TarWriter writer = new(ms);
             await writer.WriteEntryAsync(entry);
             Assert.Equal(512, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 512 (header) + 1 (data) + 511 (padding)
+            // Second entry 512 (header)
+            // 512 + 512 + 512 = 1536
+            await writer.WriteEntryAsync(entry);
+            Assert.Equal(1536, entry.DataOffset);
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
@@ -96,6 +96,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public void DataOffset_RegularFile(bool canSeek)
         {
+            byte expectedData = 5;
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
             {
@@ -113,8 +114,15 @@ namespace System.Formats.Tar.Tests
             TarEntry actualEntry = reader.GetNextEntry();
             Assert.NotNull(actualEntry);
             // Ustar header length is 512, data starts in the next position
-            long expectedDataOffset = canSeek ? 513 : -1;
+            long expectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+            if (canSeek)
+            {
+                ms.Position = actualEntry.DataOffset;
+                byte actualData = (byte)ms.ReadByte();
+                Assert.Equal(expectedData, actualData);
+            }
         }
 
         [Theory]
@@ -122,6 +130,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public async Task DataOffset_RegularFile_Async(bool canSeek)
         {
+            byte expectedData = 5;
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
@@ -139,8 +148,15 @@ namespace System.Formats.Tar.Tests
             TarEntry actualEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(actualEntry);
             // Ustar header length is 512, data starts in the next position
-            long expectedDataOffset = canSeek ? 513 : -1;
+            long expectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+            if (canSeek)
+            {
+                ms.Position = actualEntry.DataOffset;
+                byte actualData = (byte)ms.ReadByte();
+                Assert.Equal(expectedData, actualData);
+            }
         }
 
         [Fact]
@@ -155,7 +171,7 @@ namespace System.Formats.Tar.Tests
             using MemoryStream ms = new();
             using TarWriter writer = new(ms);
             writer.WriteEntry(entry);
-            Assert.Equal(513, entry.DataOffset);
+            Assert.Equal(512, entry.DataOffset);
         }
 
         [Fact]
@@ -170,7 +186,7 @@ namespace System.Formats.Tar.Tests
             await using MemoryStream ms = new();
             await using TarWriter writer = new(ms);
             await writer.WriteEntryAsync(entry);
-            Assert.Equal(513, entry.DataOffset);
+            Assert.Equal(512, entry.DataOffset);
         }
 
         [Fact]
@@ -196,7 +212,7 @@ namespace System.Formats.Tar.Tests
             TarEntry actualEntry = reader.GetNextEntry();
             Assert.NotNull(actualEntry);
             // Ustar header length is 512, data starts in the next position
-            Assert.Equal(513, actualEntry.DataOffset);
+            Assert.Equal(512, actualEntry.DataOffset);
         }
 
         [Fact]
@@ -222,7 +238,7 @@ namespace System.Formats.Tar.Tests
             TarEntry actualEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(actualEntry);
             // Ustar header length is 512, data starts in the next position
-            Assert.Equal(513, actualEntry.DataOffset);
+            Assert.Equal(512, actualEntry.DataOffset);
         }
         
         [Theory]
@@ -254,14 +270,14 @@ namespace System.Formats.Tar.Tests
             TarEntry firstEntry = reader.GetNextEntry();
             Assert.NotNull(firstEntry);
             // Ustar header length is 512, data starts in the next position
-            long firstExpectedDataOffset = canSeek ? 513 : -1;
+            long firstExpectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
             
             TarEntry secondEntry = reader.GetNextEntry();
             Assert.NotNull(secondEntry);
-            // First entry ends at 512 (header) + 5 (data) + 507 (padding) = 1024
-            // Second entry also has 512 header, so data starts at 1536 + 1
-            long secondExpectedDataOffset = canSeek ? 1537 : -1;
+            // First entry ends at 512 (header) + 1 (data) + 511 (padding) = 1024
+            // Second entry also has 512 header, so data starts one byte after 1536
+            long secondExpectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
         
@@ -294,14 +310,14 @@ namespace System.Formats.Tar.Tests
             TarEntry firstEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(firstEntry);
             // Ustar header length is 512, data starts in the next position
-            long firstExpectedDataOffset = canSeek ? 513 : -1;
+            long firstExpectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
             
             TarEntry secondEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(secondEntry);
-            // First entry ends at 512 (header) + 5 (data) + 507 (padding) = 1024
-            // Second entry also has 512 header, so data starts at 1536 + 1
-            long secondExpectedDataOffset = canSeek ? 1537 : -1;
+            // First entry ends at 512 (header) + 1 (data) + 511 (padding) = 1024
+            // Second entry also has 512 header, so data starts one byte after 1536
+            long secondExpectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
@@ -96,14 +96,13 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public void DataOffset_RegularFile(bool canSeek)
         {
-            byte expectedData = 5;
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry.DataOffset);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(5);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 writer.WriteEntry(entry);
             }
@@ -121,7 +120,7 @@ namespace System.Formats.Tar.Tests
             {
                 ms.Position = actualEntry.DataOffset;
                 byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(expectedData, actualData);
+                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
             }
         }
 
@@ -130,14 +129,13 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public async Task DataOffset_RegularFile_Async(bool canSeek)
         {
-            byte expectedData = 5;
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry.DataOffset);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(5);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry);
             }
@@ -155,7 +153,7 @@ namespace System.Formats.Tar.Tests
             {
                 ms.Position = actualEntry.DataOffset;
                 byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(expectedData, actualData);
+                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
             }
         }
 
@@ -166,7 +164,7 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(-1, entry.DataOffset);
 
             entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(5);
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
             entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             using MemoryStream ms = new();
@@ -189,7 +187,7 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(-1, entry.DataOffset);
 
             entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(5);
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
             entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             await using MemoryStream ms = new();
@@ -215,7 +213,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(-1, entry.DataOffset);
 
                 using MemoryStream dataStream = new();
-                dataStream.WriteByte(5);
+                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 dataStream.Position = 0;
                 using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
                 entry.DataStream = wds;
@@ -241,7 +239,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(-1, entry.DataOffset);
 
                 await using MemoryStream dataStream = new();
-                dataStream.WriteByte(5);
+                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 dataStream.Position = 0;
                 await using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
                 entry.DataStream = wds;
@@ -260,7 +258,7 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void DataOffset_RegularFile_SecondEntry(bool canSeek)
+        public void DataOffset_RegularFile_SecondEntry_MultiByte(bool canSeek)
         {
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
@@ -268,14 +266,14 @@ namespace System.Formats.Tar.Tests
                 UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry1.DataOffset);
                 entry1.DataStream = new MemoryStream();
-                entry1.DataStream.WriteByte(5);
+                entry1.DataStream.Write(ExpectedOffsetDataMultiByte);
                 entry1.DataStream.Position = 0;
                 writer.WriteEntry(entry1);
                 
                 UstarTarEntry entry2 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry2.DataOffset);
                 entry2.DataStream = new MemoryStream();
-                entry2.DataStream.WriteByte(5);
+                entry2.DataStream.Write(ExpectedOffsetDataMultiByte);
                 entry2.DataStream.Position = 0;
                 writer.WriteEntry(entry2);
             }
@@ -289,9 +287,18 @@ namespace System.Formats.Tar.Tests
             long firstExpectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
             
+            if (canSeek)
+            {
+                byte[] actualData = new byte[ExpectedOffsetDataMultiByte.Length];
+                ms.Position = firstEntry.DataOffset; // Reposition the archive stream to confirm the reader will autorestore its position later
+                ms.ReadExactly(actualData);
+                AssertExtensions.SequenceEqual(ExpectedOffsetDataMultiByte, actualData);
+            }
+
+            // If the archive stream is seekable, this should autorestore archive stream position internally
             TarEntry secondEntry = reader.GetNextEntry();
             Assert.NotNull(secondEntry);
-            // First entry ends at 512 (header) + 1 (data) + 511 (padding) = 1024
+            // First entry ends at 512 (header) + 4 (data) + 508 (padding) = 1024
             // Second entry also has 512 header, so data starts one byte after 1536
             long secondExpectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
@@ -300,7 +307,7 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task DataOffset_RegularFile_SecondEntryAsync(bool canSeek)
+        public async Task DataOffset_RegularFile_SecondEntry_MultiByte_Async(bool canSeek)
         {
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
@@ -308,14 +315,14 @@ namespace System.Formats.Tar.Tests
                 UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry1.DataOffset);
                 entry1.DataStream = new MemoryStream();
-                entry1.DataStream.WriteByte(5);
+                entry1.DataStream.Write(ExpectedOffsetDataMultiByte);
                 entry1.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry1);
                 
                 UstarTarEntry entry2 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry2.DataOffset);
                 entry2.DataStream = new MemoryStream();
-                entry2.DataStream.WriteByte(5);
+                entry2.DataStream.Write(ExpectedOffsetDataMultiByte);
                 entry2.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry2);
             }
@@ -328,10 +335,19 @@ namespace System.Formats.Tar.Tests
             // Ustar header length is 512, data starts in the next position
             long firstExpectedDataOffset = canSeek ? 512 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
-            
+
+            if (canSeek)
+            {
+                byte[] actualData = new byte[ExpectedOffsetDataMultiByte.Length];
+                ms.Position = firstEntry.DataOffset; // Reposition the archive stream to confirm the reader will autorestore its position later
+                await ms.ReadExactlyAsync(actualData);
+                AssertExtensions.SequenceEqual(ExpectedOffsetDataMultiByte, actualData);
+            }
+
+            // If the archive stream is seekable, this should autorestore archive stream position internally
             TarEntry secondEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(secondEntry);
-            // First entry ends at 512 (header) + 1 (data) + 511 (padding) = 1024
+            // First entry ends at 512 (header) + 4 (data) + 508 (padding) = 1024
             // Second entry also has 512 header, so data starts one byte after 1536
             long secondExpectedDataOffset = canSeek ? 1536 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Tests.cs
@@ -224,5 +224,85 @@ namespace System.Formats.Tar.Tests
             // Ustar header length is 512, data starts in the next position
             Assert.Equal(513, actualEntry.DataOffset);
         }
+        
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DataOffset_RegularFile_SecondEntry(bool canSeek)
+        {
+            using MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry1.DataOffset);
+                entry1.DataStream = new MemoryStream();
+                entry1.DataStream.WriteByte(5);
+                entry1.DataStream.Position = 0;
+                writer.WriteEntry(entry1);
+                
+                UstarTarEntry entry2 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry2.DataOffset);
+                entry2.DataStream = new MemoryStream();
+                entry2.DataStream.WriteByte(5);
+                entry2.DataStream.Position = 0;
+                writer.WriteEntry(entry2);
+            }
+            ms.Position = 0;
+
+            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            using TarReader reader = new(streamToRead);
+            TarEntry firstEntry = reader.GetNextEntry();
+            Assert.NotNull(firstEntry);
+            // Ustar header length is 512, data starts in the next position
+            long firstExpectedDataOffset = canSeek ? 513 : -1;
+            Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
+            
+            TarEntry secondEntry = reader.GetNextEntry();
+            Assert.NotNull(secondEntry);
+            // First entry ends at 512 (header) + 5 (data) + 507 (padding) = 1024
+            // Second entry also has 512 header, so data starts at 1536 + 1
+            long secondExpectedDataOffset = canSeek ? 1537 : -1;
+            Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
+        }
+        
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DataOffset_RegularFile_SecondEntryAsync(bool canSeek)
+        {
+            await using MemoryStream ms = new();
+            await using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry1.DataOffset);
+                entry1.DataStream = new MemoryStream();
+                entry1.DataStream.WriteByte(5);
+                entry1.DataStream.Position = 0;
+                await writer.WriteEntryAsync(entry1);
+                
+                UstarTarEntry entry2 = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry2.DataOffset);
+                entry2.DataStream = new MemoryStream();
+                entry2.DataStream.WriteByte(5);
+                entry2.DataStream.Position = 0;
+                await writer.WriteEntryAsync(entry2);
+            }
+            ms.Position = 0;
+
+            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            await using TarReader reader = new(streamToRead);
+            TarEntry firstEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(firstEntry);
+            // Ustar header length is 512, data starts in the next position
+            long firstExpectedDataOffset = canSeek ? 513 : -1;
+            Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
+            
+            TarEntry secondEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(secondEntry);
+            // First entry ends at 512 (header) + 5 (data) + 507 (padding) = 1024
+            // Second entry also has 512 header, so data starts at 1536 + 1
+            long secondExpectedDataOffset = canSeek ? 1537 : -1;
+            Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Tests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -68,6 +69,136 @@ namespace System.Formats.Tar.Tests
             V7TarEntry symbolicLink = new V7TarEntry(TarEntryType.SymbolicLink, InitialEntryName);
             SetSymbolicLink(symbolicLink);
             VerifySymbolicLink(symbolicLink);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void DataOffset_RegularFile(bool canSeek)
+        {
+            using MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+                entry.DataStream = new MemoryStream();
+                entry.DataStream.WriteByte(5);
+                entry.DataStream.Position = 0;
+                writer.WriteEntry(entry);
+            }
+            ms.Position = 0;
+
+            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            using TarReader reader = new(streamToRead);
+            TarEntry actualEntry = reader.GetNextEntry();
+            Assert.NotNull(actualEntry);
+            // V7 header length is 512, data starts in the next position
+            long expectedDataOffset = canSeek ? 513 : -1;
+            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DataOffset_RegularFile_Async(bool canSeek)
+        {
+            await using MemoryStream ms = new();
+            await using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+                entry.DataStream = new MemoryStream();
+                entry.DataStream.WriteByte(5);
+                entry.DataStream.Position = 0;
+                await writer.WriteEntryAsync(entry);
+            }
+            ms.Position = 0;
+
+            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+            await using TarReader reader = new(streamToRead);
+            TarEntry actualEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(actualEntry);
+            // V7 header length is 512, data starts in the next position
+            long expectedDataOffset = canSeek ? 513 : -1;
+            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+        }
+
+        [Fact]
+        public void DataOffset_BeforeAndAfterArchive()
+        {
+            V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
+            Assert.Equal(-1, entry.DataOffset);
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(5);
+
+            using MemoryStream ms = new();
+            using TarWriter writer = new(ms);
+            writer.WriteEntry(entry);
+            Assert.Equal(513, entry.DataOffset);
+        }
+        
+        [Fact]
+        public async Task DataOffset_BeforeAndAfterArchive_Async()
+        {
+            V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
+            Assert.Equal(-1, entry.DataOffset);
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(5);
+
+            await using MemoryStream ms = new();
+            await using TarWriter writer = new(ms);
+            await writer.WriteEntryAsync(entry);
+            Assert.Equal(513, entry.DataOffset);
+        }
+
+        [Fact]
+        public void DataOffset_UnseekableDataStream()
+        {
+            using MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+
+                using MemoryStream dataStream = new();
+                dataStream.WriteByte(5);
+                dataStream.Position = 0;
+                using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
+                entry.DataStream = wds;
+
+                writer.WriteEntry(entry);
+            }
+            ms.Position = 0;
+
+            using TarReader reader = new(ms);
+            TarEntry actualEntry = reader.GetNextEntry();
+            Assert.NotNull(actualEntry);
+        }
+
+        [Fact]
+        public async Task DataOffset_UnseekableDataStream_Async()
+        {
+            await using MemoryStream ms = new();
+            await using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
+                Assert.Equal(-1, entry.DataOffset);
+
+                await using MemoryStream dataStream = new();
+                dataStream.WriteByte(5);
+                dataStream.Position = 0;
+                await using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
+                entry.DataStream = wds;
+
+                await writer.WriteEntryAsync(entry);
+            }
+            ms.Position = 0;
+
+            await using TarReader reader = new(ms);
+            TarEntry actualEntry = await reader.GetNextEntryAsync();
+            Assert.NotNull(actualEntry);
+            // V7 header length is 512, data starts in the next position
+            Assert.Equal(513, actualEntry.DataOffset);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Tests.cs
@@ -76,14 +76,13 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public void DataOffset_RegularFile(bool canSeek)
         {
-            byte expectedData = 5;
             using MemoryStream ms = new();
             using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry.DataOffset);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(expectedData);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 writer.WriteEntry(entry);
             }
@@ -101,7 +100,7 @@ namespace System.Formats.Tar.Tests
             {
                 ms.Position = actualEntry.DataOffset;
                 byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(expectedData, actualData);
+                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
             }
         }
 
@@ -110,14 +109,13 @@ namespace System.Formats.Tar.Tests
         [InlineData(true)]
         public async Task DataOffset_RegularFile_Async(bool canSeek)
         {
-            byte expectedData = 5;
             await using MemoryStream ms = new();
             await using (TarWriter writer = new(ms, leaveOpen: true))
             {
                 V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry.DataOffset);
                 entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(expectedData);
+                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry);
             }
@@ -135,7 +133,7 @@ namespace System.Formats.Tar.Tests
             {
                 ms.Position = actualEntry.DataOffset;
                 byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(expectedData, actualData);
+                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
             }
         }
 
@@ -145,7 +143,7 @@ namespace System.Formats.Tar.Tests
             V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
             Assert.Equal(-1, entry.DataOffset);
             entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(5);
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
             entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             using MemoryStream ms = new();
@@ -167,7 +165,7 @@ namespace System.Formats.Tar.Tests
             V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
             Assert.Equal(-1, entry.DataOffset);
             entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(5);
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
             entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             await using MemoryStream ms = new();
@@ -193,7 +191,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(-1, entry.DataOffset);
 
                 using MemoryStream dataStream = new();
-                dataStream.WriteByte(5);
+                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 dataStream.Position = 0;
                 using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
                 entry.DataStream = wds;
@@ -217,7 +215,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(-1, entry.DataOffset);
 
                 await using MemoryStream dataStream = new();
-                dataStream.WriteByte(5);
+                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 dataStream.Position = 0;
                 await using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
                 entry.DataStream = wds;
@@ -244,14 +242,14 @@ namespace System.Formats.Tar.Tests
                 V7TarEntry entry1 = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry1.DataOffset);
                 entry1.DataStream = new MemoryStream();
-                entry1.DataStream.WriteByte(5);
+                entry1.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry1.DataStream.Position = 0;
                 writer.WriteEntry(entry1);
                 
                 V7TarEntry entry2 = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry2.DataOffset);
                 entry2.DataStream = new MemoryStream();
-                entry2.DataStream.WriteByte(5);
+                entry2.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry2.DataStream.Position = 0;
                 writer.WriteEntry(entry2);
             }
@@ -284,14 +282,14 @@ namespace System.Formats.Tar.Tests
                 V7TarEntry entry1 = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry1.DataOffset);
                 entry1.DataStream = new MemoryStream();
-                entry1.DataStream.WriteByte(5);
+                entry1.DataStream.Write(ExpectedOffsetDataMultiByte);
                 entry1.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry1);
                 
                 V7TarEntry entry2 = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
                 Assert.Equal(-1, entry2.DataOffset);
                 entry2.DataStream = new MemoryStream();
-                entry2.DataStream.WriteByte(5);
+                entry2.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
                 entry2.DataStream.Position = 0;
                 await writer.WriteEntryAsync(entry2);
             }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Tests.cs
@@ -146,11 +146,19 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(-1, entry.DataOffset);
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             using MemoryStream ms = new();
             using TarWriter writer = new(ms);
             writer.WriteEntry(entry);
             Assert.Equal(512, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 512 (header) + 1 (data) + 511 (padding)
+            // Second entry 512 (header)
+            // 512 + 512 + 512 = 1536
+            writer.WriteEntry(entry);
+            Assert.Equal(1536, entry.DataOffset);
         }
         
         [Fact]
@@ -160,11 +168,19 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(-1, entry.DataOffset);
             entry.DataStream = new MemoryStream();
             entry.DataStream.WriteByte(5);
+            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
 
             await using MemoryStream ms = new();
             await using TarWriter writer = new(ms);
             await writer.WriteEntryAsync(entry);
             Assert.Equal(512, entry.DataOffset);
+
+            // Write it again, the offset should now point to the second written entry
+            // First entry 512 (header) + 1 (data) + 511 (padding)
+            // Second entry 512 (header)
+            // 512 + 512 + 512 = 1536
+            await writer.WriteEntryAsync(entry);
+            Assert.Equal(1536, entry.DataOffset);
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -97,6 +97,8 @@ namespace System.Formats.Tar.Tests
         internal const char Separator = '/';
         internal const int MaxPathComponent = 255;
         internal const long LegacyMaxFileSize = (1L << 33) - 1; // Max value of 11 octal digits = 2^33 - 1 or 8 Gb.
+        internal const byte ExpectedOffsetDataSingleByte = 5;
+        internal readonly byte[] ExpectedOffsetDataMultiByte = [9, 8, 7, 6];
 
         private static readonly string[] V7TestCaseNames = new[]
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/101314

Implements the API below to allow users know where the entry's data first byte is located with respect to the parent archive stream.

```cs
namespace System.Formats.Tar;

public abstract partial class TarEntry
{
    public long DataOffset { get; }
}
```

cc @martinpf