### PR TITLE
Implement new `TagsList` constructor on `Measurement`

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -437,7 +437,7 @@ namespace System.Diagnostics.Metrics
         public Measurement(T value, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? tags) { throw null; }
         public Measurement(T value, params System.Collections.Generic.KeyValuePair<string, object?>[]? tags) { throw null; }
         public Measurement(T value, params System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object?>> tags) { throw null; }
-        public Measurement(T value, in TagList tags) { throw null; }
+        public Measurement(T value, in System.Diagnostics.TagList tags) { throw null; }
         public ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
         public T Value { get { throw null; } }
     }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -437,6 +437,7 @@ namespace System.Diagnostics.Metrics
         public Measurement(T value, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? tags) { throw null; }
         public Measurement(T value, params System.Collections.Generic.KeyValuePair<string, object?>[]? tags) { throw null; }
         public Measurement(T value, params System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object?>> tags) { throw null; }
+        public Measurement(T value, in TagList tags) { throw null; }
         public ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
         public T Value { get { throw null; } }
     }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
@@ -8,17 +8,17 @@ using System.Runtime.CompilerServices;
 namespace System.Diagnostics.Metrics
 {
     /// <summary>
-    /// Measurement stores one observed metrics value and its associated tags. This type is used by Observable instruments' Observe() method when reporting current measurements.
-    /// with the associated tags.
+    /// <see cref="Measurement{T}"/> stores one observed value and its associated tags for a metric.
+    /// Observable instruments use this type when reporting current measurements from their <see cref="ObservableInstrument{T}.Observe()"/> implementation.
     /// </summary>
     public readonly struct Measurement<T> where T : struct
     {
         private readonly KeyValuePair<string, object?>[] _tags;
 
         /// <summary>
-        /// Initializes a new instance of the Measurement using the value and the list of tags.
+        /// Initializes a new instance of <see cref="Measurement{T}"/> with the provided <paramref name="value"/>.
         /// </summary>
-        /// <param name="value">The measurement value.</param>
+        /// <param name="value">The value of the measurement.</param>
         public Measurement(T value)
         {
             _tags = Instrument.EmptyTags;
@@ -26,10 +26,10 @@ namespace System.Diagnostics.Metrics
         }
 
         /// <summary>
-        /// Initializes a new instance of the Measurement using the value and the list of tags.
+        /// Initializes a new instance of Measurement with the provided <paramref name="value"/> and zero or more associated <paramref name="tags"/>.
         /// </summary>
-        /// <param name="value">The measurement value.</param>
-        /// <param name="tags">The measurement associated tags list.</param>
+        /// <param name="value">The value of the measurement.</param>
+        /// <param name="tags">The <see cref="KeyValuePair{TKey, TValue}"/> tags associated with the measurement.</param>
         public Measurement(T value, IEnumerable<KeyValuePair<string, object?>>? tags)
         {
             _tags = ToArray(tags);
@@ -37,10 +37,10 @@ namespace System.Diagnostics.Metrics
         }
 
         /// <summary>
-        /// Initializes a new instance of the Measurement using the value and the list of tags.
+        /// Initializes a new instance of Measurement with the provided <paramref name="value"/> and zero or more associated <paramref name="tags"/>.
         /// </summary>
-        /// <param name="value">The measurement value.</param>
-        /// <param name="tags">The measurement associated tags list.</param>
+        /// <param name="value">The value of the measurement.</param>
+        /// <param name="tags">The <see cref="KeyValuePair{TKey, TValue}"/> tags associated with the measurement.</param>
         public Measurement(T value, params KeyValuePair<string, object?>[]? tags)
         {
             if (tags is not null)
@@ -57,10 +57,11 @@ namespace System.Diagnostics.Metrics
         }
 
         /// <summary>
-        /// Initializes a new instance of the Measurement using the value and the list of tags.
+        /// Initializes a new instance of Measurement with the provided <paramref name="value"/> and a <see cref="ReadOnlySpan{T}"/> containing
+        /// zero or more associated <paramref name="tags"/>.
         /// </summary>
-        /// <param name="value">The measurement value.</param>
-        /// <param name="tags">The measurement associated tags list.</param>
+        /// <param name="value">The value of the measurement.</param>
+        /// <param name="tags">The <see cref="KeyValuePair{TKey, TValue}"/> tags associated with the measurement.</param>
         public Measurement(T value, params ReadOnlySpan<KeyValuePair<string, object?>> tags)
         {
             _tags = tags.ToArray();
@@ -68,10 +69,11 @@ namespace System.Diagnostics.Metrics
         }
 
         /// <summary>
-        /// Initializes a new instance of the Measurement using the value and a <see cref="TagList"/>.
+        /// Initializes a new instance of the Measurement with the provided <paramref name="value"/> and a <see cref="TagList"/> containing
+        /// zero or more associated <paramref name="tags"/>.
         /// </summary>
-        /// <param name="value">The measurement value.</param>
-        /// <param name="tags">A <see cref="TagList" /> containing key-value pair tags associated with the measurement.</param>
+        /// <param name="value">The value of the measurement.</param>
+        /// <param name="tags">A <see cref="TagList"/> containing the <see cref="KeyValuePair{TKey, TValue}"/> tags associated with the measurement.</param>
         public Measurement(T value, in TagList tags)
         {
             if (tags.Count > 0)
@@ -88,12 +90,12 @@ namespace System.Diagnostics.Metrics
         }
 
         /// <summary>
-        /// Gets the measurement tags list.
+        /// Gets the tags associated with the measurement.
         /// </summary>
         public ReadOnlySpan<KeyValuePair<string, object?>> Tags => _tags.AsSpan();
 
         /// <summary>
-        /// Gets the measurement value.
+        /// Gets the value of the measurement.
         /// </summary>
         public T Value { get; }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Measurement.cs
@@ -68,6 +68,26 @@ namespace System.Diagnostics.Metrics
         }
 
         /// <summary>
+        /// Initializes a new instance of the Measurement using the value and a <see cref="TagList"/>.
+        /// </summary>
+        /// <param name="value">The measurement value.</param>
+        /// <param name="tags">A <see cref="TagList" /> containing key-value pair tags associated with the measurement.</param>
+        public Measurement(T value, in TagList tags)
+        {
+            if (tags.Count > 0)
+            {
+                _tags = new KeyValuePair<string, object?>[tags.Count];
+                tags.CopyTo(_tags.AsSpan());
+            }
+            else
+            {
+                _tags = Instrument.EmptyTags;
+            }
+
+            Value = value;
+        }
+
+        /// <summary>
         /// Gets the measurement tags list.
         /// </summary>
         public ReadOnlySpan<KeyValuePair<string, object?>> Tags => _tags.AsSpan();


### PR DESCRIPTION
Closes #104015

Adds a new constructor, [as proposed](https://github.com/dotnet/runtime/issues/104015), to optimize the scenario where a `TagsList` is provided to construct a new `Measurement`. This avoids boxing allocations and reduces execution time.

```
| Method     | Size | Mean      | Error     | StdDev    | Ratio    | RatioSD | Gen0   | Allocated | Alloc Ratio |
|----------- |----- |----------:|----------:|----------:|---------:|--------:|-------:|----------:|------------:|
| TagList    | 1    | 20.746 ns | 0.3769 ns | 0.4033 ns | baseline |         | 0.0159 |     200 B |             |
| TagListNew | 1    |  7.627 ns | 0.1620 ns | 0.1516 ns |     -63% |    3.1% | 0.0032 |      40 B |        -80% |
|            |      |           |           |           |          |         |        |           |             |
| TagList    | 8    | 44.965 ns | 0.9227 ns | 1.1331 ns | baseline |         | 0.0249 |     312 B |             |
| TagListNew | 8    | 29.285 ns | 0.5105 ns | 0.4526 ns |     -35% |    2.7% | 0.0121 |     152 B |        -51% |
|            |      |           |           |           |          |         |        |           |             |
| TagList    | 20   | 31.073 ns | 0.6176 ns | 0.6066 ns | baseline |         | 0.0402 |     504 B |             |
| TagListNew | 20   | 18.474 ns | 0.3874 ns | 0.4757 ns |     -40% |    3.2% | 0.0274 |     344 B |        -32% |
```

I also took the chance to fix and clarify the XML doc comments.

cc @tarekgh 