### PR TITLE
JIT: Check return value of `InitializeCursors`

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1339,7 +1339,10 @@ bool StrengthReductionContext::TryStrengthReduce()
 
         ScevAddRec* primaryIV = static_cast<ScevAddRec*>(candidate);
 
-        InitializeCursors(primaryIVLcl, primaryIV);
+        if (!InitializeCursors(primaryIVLcl, primaryIV))
+        {
+            continue;
+        }
 
         ArrayStack<CursorInfo>* cursors     = &m_cursors1;
         ArrayStack<CursorInfo>* nextCursors = &m_cursors2;
@@ -1517,7 +1520,7 @@ bool StrengthReductionContext::InitializeCursors(GenTreeLclVarCommon* primaryIVL
 
     if (!m_loopLocals.VisitOccurrences(m_loop, primaryIVLcl->GetLclNum(), visitor) || (m_cursors1.Height() <= 0))
     {
-        JITDUMP("  Could not create cursors for all loop uses of primary IV");
+        JITDUMP("  Could not create cursors for all loop uses of primary IV\n");
         return false;
     }
 


### PR DESCRIPTION
We were missing checking the return value of `InitializeCursors`. Typically this would just cause us to end up with an empty set of cursors as we abort the search as soon as we fail to create one cursor, and the cursor we would typically fail to create is always the first one. Running the next logic with an empty set of cursors causes no ill effects, so this has no diffs.