### PR TITLE
[RISC-V] Fix passing float and uint arguments in VM

### DIFF
--- a/src/coreclr/vm/argdestination.h
+++ b/src/coreclr/vm/argdestination.h
@@ -187,7 +187,7 @@ public:
         else
         {
             // When a single float is passed according to integer calling convention
-            // (in integer register or on stack), the upper bits are not speciifed.
+            // (in integer register or on stack), the upper bits are not specified.
             *(UINT32*)dest = value;
         }
     }

--- a/src/coreclr/vm/argdestination.h
+++ b/src/coreclr/vm/argdestination.h
@@ -173,6 +173,26 @@ public:
             _ASSERTE(!"---------UNReachable-------LoongArch64/RISC-V64!!!");
         }
     }
+
+#ifdef TARGET_RISCV64
+    void CopySingleFloatToRegister(void* src)
+    {
+        void* dest = GetDestinationAddress();
+        UINT32 value = *(UINT32*)src;
+        if (TransitionBlock::IsFloatArgumentRegisterOffset(m_offset))
+        {
+            // NaN-box the floating register value or single-float instructions will treat it as NaN
+            *(UINT64*)dest = 0xffffffff00000000L | value;
+        }
+        else
+        {
+            // When a single float is passed according to integer calling convention
+            // (in integer register or on stack), the upper bits are not speciifed.
+            *(UINT32*)dest = value;
+        }
+    }
+#endif // TARGET_RISCV64
+
 #endif // !DACCESS_COMPILE
 
     PTR_VOID GetStructGenRegDestinationAddress()
@@ -182,7 +202,6 @@ public:
         return dac_cast<PTR_VOID>(dac_cast<TADDR>(m_base) + argOfs);
     }
 #endif // defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-
 #if defined(UNIX_AMD64_ABI)
 
     // Returns true if the ArgDestination represents a struct passed in registers.

--- a/src/coreclr/vm/argdestination.h
+++ b/src/coreclr/vm/argdestination.h
@@ -202,6 +202,7 @@ public:
         return dac_cast<PTR_VOID>(dac_cast<TADDR>(m_base) + argOfs);
     }
 #endif // defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+
 #if defined(UNIX_AMD64_ABI)
 
     // Returns true if the ArgDestination represents a struct passed in registers.

--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -474,10 +474,15 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
                             *((INT64*)pDest) = (INT16)pArguments[arg];
                         break;
                     case 4:
+#ifdef TARGET_RISCV64
+                        // RISC-V integer calling convention requires to sign-extend `uint` arguments as well
+                        *((INT64*)pDest) = (INT32)pArguments[arg];
+#else // TARGET_LOONGARCH64
                         if (m_argIt.GetArgType() == ELEMENT_TYPE_U4)
                             *((INT64*)pDest) = (UINT32)pArguments[arg];
                         else
                             *((INT64*)pDest) = (INT32)pArguments[arg];
+#endif // TARGET_RISCV64
                         break;
 #else
                     case 1:

--- a/src/tests/JIT/Directed/PrimitiveABI/CMakeLists.txt
+++ b/src/tests/JIT/Directed/PrimitiveABI/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (PrimitiveABI)
+project (PrimitiveABINative)
 include_directories(${INC_PLATFORM_DIR})
 
 if(CLR_CMAKE_HOST_WIN32)
@@ -7,6 +7,6 @@ else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Oz")
 endif()
 
-add_library (PrimitiveABI SHARED PrimitiveABI.c)
+add_library (PrimitiveABINative SHARED PrimitiveABI.c)
 
-install (TARGETS PrimitiveABI DESTINATION bin)
+install (TARGETS PrimitiveABINative DESTINATION bin)

--- a/src/tests/JIT/Directed/PrimitiveABI/CMakeLists.txt
+++ b/src/tests/JIT/Directed/PrimitiveABI/CMakeLists.txt
@@ -1,0 +1,12 @@
+project (PrimitiveABI)
+include_directories(${INC_PLATFORM_DIR})
+
+if(CLR_CMAKE_HOST_WIN32)
+    set_source_files_properties(PrimitiveABI.c PROPERTIES COMPILE_OPTIONS /TC) # compile as C
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Oz")
+endif()
+
+add_library (PrimitiveABI SHARED PrimitiveABI.c)
+
+install (TARGETS PrimitiveABI DESTINATION bin)

--- a/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.c
+++ b/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.c
@@ -1,0 +1,41 @@
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef _MSC_VER
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT __attribute__((visibility("default")))
+#endif // _MSC_VER
+
+DLLEXPORT int64_t Echo_ExtendedUint_RiscV(int a0, uint32_t a1)
+{
+	return (int32_t)a1;
+}
+
+DLLEXPORT int64_t Echo_ExtendedUint_OnStack_RiscV(
+	int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, uint32_t stack0)
+{
+	return (int32_t)stack0;
+}
+
+DLLEXPORT double Echo_Float_RiscV(float fa0, float fa1)
+{
+	return fa1 + fa0;
+}
+
+DLLEXPORT double Echo_Float_InIntegerReg_RiscV(
+	float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7,
+	float a0)
+{
+	return a0 + fa7;
+}
+
+DLLEXPORT double Echo_Float_OnStack_RiscV(
+	float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7,
+	int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, float stack0)
+{
+	return stack0 + fa7;
+}

--- a/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.cs
+++ b/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.cs
@@ -9,7 +9,7 @@ using Xunit;
 public static class Program
 {
 #region ExtendedUint_RiscVTests
-	[DllImport("PrimitiveABI")]
+	[DllImport("PrimitiveABINative")]
 	public static extern long Echo_ExtendedUint_RiscV(int a0, uint a1);
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
@@ -41,7 +41,7 @@ public static class Program
 		Assert.Equal(ret, native);
 	}
 
-	[DllImport("PrimitiveABI")]
+	[DllImport("PrimitiveABINative")]
 	public static extern long Echo_ExtendedUint_OnStack_RiscV(
 		int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, uint stack0);
 
@@ -77,7 +77,7 @@ public static class Program
 #endregion
 
 #region Float_RiscVTests
-	[DllImport("PrimitiveABI")]
+	[DllImport("PrimitiveABINative")]
 	public static extern double Echo_Float_RiscV(float fa0, float fa1);
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
@@ -109,7 +109,7 @@ public static class Program
 		Assert.Equal(ret, native);
 	}
 
-	[DllImport("PrimitiveABI")]
+	[DllImport("PrimitiveABINative")]
 	public static extern double Echo_Float_InIntegerReg_RiscV(
 		float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7, float a0);
 
@@ -143,7 +143,7 @@ public static class Program
 		Assert.Equal(ret, native);
 	}
 
-	[DllImport("PrimitiveABI")]
+	[DllImport("PrimitiveABINative")]
 	public static extern double Echo_Float_OnStack_RiscV(
 		float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7,
 		int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, float stack0);

--- a/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.cs
+++ b/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Program
+{
+#region ExtendedUint_RiscVTests
+	[DllImport("PrimitiveABI")]
+	public static extern long Echo_ExtendedUint_RiscV(int a0, uint a1);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static long Echo_ExtendedUint_RiscV_Managed(int a0, uint a1) => unchecked((int)a1);
+
+	[Fact]
+	public static void Test_ExtendedUint_RiscV()
+	{
+		const uint arg = 0xB1ED0C1Eu;
+		const long ret = unchecked((int)arg);
+		long managed = Echo_ExtendedUint_RiscV_Managed(0, arg);
+		long native = Echo_ExtendedUint_RiscV(0, arg);
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[Fact]
+	public static void Test_ExtendedUint_ByReflection_RiscV()
+	{
+		const uint arg = 0xB1ED0C1Eu;
+		const long ret = unchecked((int)arg);
+		long managed = (long)typeof(Program).GetMethod("Echo_ExtendedUint_RiscV_Managed").Invoke(
+			null, new object[] {0, arg});
+		long native = (long)typeof(Program).GetMethod("Echo_ExtendedUint_RiscV").Invoke(
+			null, new object[] {0, arg});
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[DllImport("PrimitiveABI")]
+	public static extern long Echo_ExtendedUint_OnStack_RiscV(
+		int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, uint stack0);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static long Echo_ExtendedUint_OnStack_RiscV_Managed(
+		int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, uint stack0) => unchecked((int)stack0);
+
+	[Fact]
+	public static void Test_ExtendedUint_OnStack_RiscV()
+	{
+		const uint arg = 0xB1ED0C1Eu;
+		const long ret = unchecked((int)arg);
+		long managed = Echo_ExtendedUint_OnStack_RiscV_Managed(0, 0, 0, 0, 0, 0, 0, 0, arg);
+		long native = Echo_ExtendedUint_OnStack_RiscV(0, 0, 0, 0, 0, 0, 0, 0, arg);
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[Fact]
+	public static void Test_ExtendedUint_OnStack_ByReflection_RiscV()
+	{
+		const uint arg = 0xB1ED0C1Eu;
+		const long ret = unchecked((int)arg);
+		long managed = (long)typeof(Program).GetMethod("Echo_ExtendedUint_OnStack_RiscV_Managed").Invoke(
+			null, new object[] {0, 0, 0, 0, 0, 0, 0, 0, arg});
+		long native = (long)typeof(Program).GetMethod("Echo_ExtendedUint_OnStack_RiscV").Invoke(
+			null, new object[] {0, 0, 0, 0, 0, 0, 0, 0, arg});
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+#endregion
+
+#region Float_RiscVTests
+	[DllImport("PrimitiveABI")]
+	public static extern double Echo_Float_RiscV(float fa0, float fa1);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static double Echo_Float_RiscV_Managed(float fa0, float fa1) => fa1;
+
+	[Fact]
+	public static void Test_Float_RiscV()
+	{
+		const float arg = 3.14159f;
+		const double ret = 3.14159f;
+		double managed = Echo_Float_RiscV_Managed(0f, arg);
+		double native = Echo_Float_RiscV(0f, arg);
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[Fact]
+	public static void Test_Float_ByReflection_RiscV()
+	{
+		const float arg = 3.14159f;
+		const double ret = 3.14159f;
+		double managed = (double)typeof(Program).GetMethod("Echo_Float_RiscV_Managed").Invoke(
+			null, new object[] {0f, arg});
+		double native = (double)typeof(Program).GetMethod("Echo_Float_RiscV").Invoke(
+			null, new object[] {0f, arg});
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[DllImport("PrimitiveABI")]
+	public static extern double Echo_Float_InIntegerReg_RiscV(
+		float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7, float a0);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static double Echo_Float_InIntegerReg_RiscV_Managed(
+		float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7, float a0) => a0;
+
+	[Fact]
+	public static void Test_Float_InIntegerReg_RiscV()
+	{
+		const float arg = 3.14159f;
+		const double ret = 3.14159f;
+		double managed = Echo_Float_InIntegerReg_RiscV_Managed(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, arg);
+		double native = Echo_Float_InIntegerReg_RiscV(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, arg);
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[Fact]
+	public static void Test_Float_InIntegerReg_ByReflection_RiscV()
+	{
+		const float arg = 3.14159f;
+		const double ret = 3.14159f;
+		double managed = (double)typeof(Program).GetMethod("Echo_Float_InIntegerReg_RiscV_Managed").Invoke(
+			null, new object[] {0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, arg});
+		double native = (double)typeof(Program).GetMethod("Echo_Float_InIntegerReg_RiscV").Invoke(
+			null, new object[] {0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, arg});
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[DllImport("PrimitiveABI")]
+	public static extern double Echo_Float_OnStack_RiscV(
+		float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7,
+		int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, float stack0);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static double Echo_Float_OnStack_RiscV_Managed(
+		float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6, float fa7,
+		int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, float stack0) => stack0;
+
+	[Fact]
+	public static void Test_Float_OnStack_RiscV()
+	{
+		const float arg = 3.14159f;
+		const double ret = 3.14159f;
+		double managed = Echo_Float_OnStack_RiscV_Managed(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0, 0, 0, 0, 0, 0, 0, 0, arg);
+		double native = Echo_Float_OnStack_RiscV(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0, 0, 0, 0, 0, 0, 0, 0, arg);
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+
+	[Fact]
+	public static void Test_Float_OnStack_ByReflection_RiscV()
+	{
+		const float arg = 3.14159f;
+		const double ret = 3.14159f;
+		double managed = (double)typeof(Program).GetMethod("Echo_Float_OnStack_RiscV_Managed").Invoke(
+			null, new object[] {0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0, 0, 0, 0, 0, 0, 0, 0, arg});
+		double native = (double)typeof(Program).GetMethod("Echo_Float_OnStack_RiscV").Invoke(
+			null, new object[] {0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0, 0, 0, 0, 0, 0, 0, 0, arg});
+
+		Assert.Equal(ret, managed);
+		Assert.Equal(ret, native);
+	}
+#endregion
+}

--- a/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.csproj
+++ b/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'riscv64'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.csproj
+++ b/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="PrimitiveABI.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.csproj
+++ b/src/tests/JIT/Directed/PrimitiveABI/PrimitiveABI.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'riscv64'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Follow the RISC-V ABI closer, see code comments for explanation.

The tests pass also without the fix because currently we're zero-extending `uint`s before use. I left them because they can be useful later when we start optimizing out the unnecessary type-extending instructions.

Part of #84834, cc @dotnet/samsung