### PR TITLE
[eventpipe][tests] Reenable eventsourceerror non-arm32 unix platforms

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -92,9 +92,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">
             <Issue>https://github.com/dotnet/runtime/issues/46175</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
-            <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/typeequivalence/signatures/nopiatestil/*">
             <Issue>CoreCLR doesn't support type equivalence on Unix</Issue>
         </ExcludeList>
@@ -409,6 +406,9 @@
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TargetArchitecture)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(TargetsWindows)' != 'true' and '$(RuntimeFlavor)' == 'coreclr'">
         <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/nativeruntimeeventsource/*">
             <Issue>https://github.com/dotnet/runtime/issues/68690</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
+            <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/regress/vsw/373472/**">
             <Issue>Allocates large contiguous array that is not consistently available on 32-bit platforms</Issue>


### PR DESCRIPTION
Re-enables tracing/eventpipe/eventsourceerror that was disabled in https://github.com/dotnet/runtime/issues/80666 for non-arm32 unix platforms.

From the build https://github.com/dotnet/runtime/issues/80666#issuecomment-2196101795 where the latest crash occurred, the dump collected was investigated in https://github.com/dotnet/runtime/issues/80666#issuecomment-2233574376 and found to be partial and with insufficient information to easily pinpoint the problem. We suspect that the incomplete dump is due to the crash occurring on arm32, so this PR reenables the test for non-arm32 unix platforms in hopes that if the test flakes again, there will be a more complete dump that will be easier to investigate.