### PR TITLE
Fix the ExposedLocalsNumbering test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -11,9 +11,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/finalization/CriticalFinalizer/*">
             <Issue>https://github.com/dotnet/runtime/issues/76041</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/ValueNumbering/ExposedLocalsNumbering/**">
-            <Issue>https://github.com/dotnet/runtime/issues/80184</Issue>
-        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/SSA/MemorySsa/**">
             <Issue>https://github.com/dotnet/runtime/issues/86112</Issue>
         </ExcludeList>


### PR DESCRIPTION
Should fix https://github.com/dotnet/runtime/issues/80184. See the first commit message for the description of the bug.