### PR TITLE
Revert "Use generic math for floating point formatting" for Single and Double

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -354,33 +354,33 @@ namespace System
 
         public override string ToString()
         {
-            return Number.FormatFloat(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatDouble(m_value, null, NumberFormatInfo.CurrentInfo);
         }
 
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format)
         {
-            return Number.FormatFloat(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatDouble(m_value, format, NumberFormatInfo.CurrentInfo);
         }
 
         public string ToString(IFormatProvider? provider)
         {
-            return Number.FormatFloat(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatDouble(m_value, null, NumberFormatInfo.GetInstance(provider));
         }
 
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, IFormatProvider? provider)
         {
-            return Number.FormatFloat(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatDouble(m_value, format, NumberFormatInfo.GetInstance(provider));
         }
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatFloat(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatDouble(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatFloat(m_value, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
+            return Number.TryFormatDouble(m_value, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
         }
 
         public static double Parse(string s) => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider: null);
@@ -2334,10 +2334,6 @@ namespace System
         static double IBinaryFloatParseAndFormatInfo<double>.BitsToFloat(ulong bits) => BitConverter.UInt64BitsToDouble(bits);
 
         static ulong IBinaryFloatParseAndFormatInfo<double>.FloatToBits(double value) => BitConverter.DoubleToUInt64Bits(value);
-
-        static int IBinaryFloatParseAndFormatInfo<double>.MaxRoundTripDigits => 17;
-
-        static int IBinaryFloatParseAndFormatInfo<double>.MaxPrecisionCustomFormat => 15;
 
         //
         // Helpers

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -2335,6 +2335,10 @@ namespace System
 
         static ulong IBinaryFloatParseAndFormatInfo<double>.FloatToBits(double value) => BitConverter.DoubleToUInt64Bits(value);
 
+        static int IBinaryFloatParseAndFormatInfo<double>.MaxRoundTripDigits => 17;
+
+        static int IBinaryFloatParseAndFormatInfo<double>.MaxPrecisionCustomFormat => 15;
+
         //
         // Helpers
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -505,7 +505,7 @@ namespace System
         /// </summary>
         public override string ToString()
         {
-            return Number.FormatHalf(this, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatFloatingPoint(this, null, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace System
         /// </summary>
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format)
         {
-            return Number.FormatHalf(this, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatFloatingPoint(this, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -521,7 +521,7 @@ namespace System
         /// </summary>
         public string ToString(IFormatProvider? provider)
         {
-            return Number.FormatHalf(this, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatFloatingPoint(this, null, NumberFormatInfo.GetInstance(provider));
         }
 
         /// <summary>
@@ -529,7 +529,7 @@ namespace System
         /// </summary>
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, IFormatProvider? provider)
         {
-            return Number.FormatHalf(this, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatFloatingPoint(this, format, NumberFormatInfo.GetInstance(provider));
         }
 
         /// <summary>
@@ -542,13 +542,13 @@ namespace System
         /// <returns></returns>
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatHalf(this, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatFloatingPoint(this, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatHalf(this, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
+            return Number.TryFormatFloatingPoint(this, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
         }
 
         //
@@ -2373,5 +2373,9 @@ namespace System
         static Half IBinaryFloatParseAndFormatInfo<Half>.BitsToFloat(ulong bits) => BitConverter.UInt16BitsToHalf((ushort)(bits));
 
         static ulong IBinaryFloatParseAndFormatInfo<Half>.FloatToBits(Half value) => BitConverter.HalfToUInt16Bits(value);
+
+        static int IBinaryFloatParseAndFormatInfo<Half>.MaxRoundTripDigits => 5;
+
+        static int IBinaryFloatParseAndFormatInfo<Half>.MaxPrecisionCustomFormat => 5;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -505,7 +505,7 @@ namespace System
         /// </summary>
         public override string ToString()
         {
-            return Number.FormatFloat(this, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatHalf(this, null, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace System
         /// </summary>
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format)
         {
-            return Number.FormatFloat(this, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatHalf(this, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -521,7 +521,7 @@ namespace System
         /// </summary>
         public string ToString(IFormatProvider? provider)
         {
-            return Number.FormatFloat(this, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatHalf(this, null, NumberFormatInfo.GetInstance(provider));
         }
 
         /// <summary>
@@ -529,7 +529,7 @@ namespace System
         /// </summary>
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, IFormatProvider? provider)
         {
-            return Number.FormatFloat(this, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatHalf(this, format, NumberFormatInfo.GetInstance(provider));
         }
 
         /// <summary>
@@ -542,13 +542,13 @@ namespace System
         /// <returns></returns>
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatFloat(this, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatHalf(this, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatFloat(this, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
+            return Number.TryFormatHalf(this, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
         }
 
         //
@@ -2373,9 +2373,5 @@ namespace System
         static Half IBinaryFloatParseAndFormatInfo<Half>.BitsToFloat(ulong bits) => BitConverter.UInt16BitsToHalf((ushort)(bits));
 
         static ulong IBinaryFloatParseAndFormatInfo<Half>.FloatToBits(Half value) => BitConverter.HalfToUInt16Bits(value);
-
-        static int IBinaryFloatParseAndFormatInfo<Half>.MaxRoundTripDigits => 5;
-
-        static int IBinaryFloatParseAndFormatInfo<Half>.MaxPrecisionCustomFormat => 5;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Number.DiyFp.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.DiyFp.cs
@@ -19,7 +19,6 @@ namespace System
         {
             public const int DoubleImplicitBitIndex = 52;
             public const int SingleImplicitBitIndex = 23;
-            public const int HalfImplicitBitIndex = 10;
 
             public const int SignificandSize = 64;
 
@@ -61,10 +60,11 @@ namespace System
             //
             // Precondition:
             //  The value encoded by value must be greater than 0.
-            public static DiyFp CreateAndGetBoundaries(Half value, out DiyFp mMinus, out DiyFp mPlus)
+            public static DiyFp CreateAndGetBoundaries<TNumber>(TNumber value, out DiyFp mMinus, out DiyFp mPlus)
+                where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
             {
-                var result = new DiyFp(value);
-                result.GetBoundaries(HalfImplicitBitIndex, out mMinus, out mPlus);
+                DiyFp result = Create(value);
+                result.GetBoundaries(TNumber.DenormalMantissaBits, out mMinus, out mPlus);
                 return result;
             }
 
@@ -82,11 +82,13 @@ namespace System
                 f = ExtractFractionAndBiasedExponent(value, out e);
             }
 
-            public DiyFp(Half value)
+            public static DiyFp Create<TNumber>(TNumber value)
+                where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
             {
-                Debug.Assert(Half.IsFinite(value));
-                Debug.Assert((float)value > 0.0f);
-                f = ExtractFractionAndBiasedExponent(value, out e);
+                Debug.Assert(TNumber.IsFinite(value));
+                Debug.Assert(value > TNumber.Zero);
+                ulong f = ExtractFractionAndBiasedExponent(value, out int e);
+                return new DiyFp(f, e);
             }
 
             public DiyFp(ulong f, int e)

--- a/src/libraries/System.Private.CoreLib/src/System/Number.DiyFp.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.DiyFp.cs
@@ -17,6 +17,10 @@ namespace System
         // DiyFp are not designed to contain special doubles (NaN and Infinity).
         internal readonly ref struct DiyFp
         {
+            public const int DoubleImplicitBitIndex = 52;
+            public const int SingleImplicitBitIndex = 23;
+            public const int HalfImplicitBitIndex = 10;
+
             public const int SignificandSize = 64;
 
             public readonly ulong f;
@@ -29,21 +33,60 @@ namespace System
             //
             // Precondition:
             //  The value encoded by value must be greater than 0.
-            public static DiyFp CreateAndGetBoundaries<TNumber>(TNumber value, out DiyFp mMinus, out DiyFp mPlus)
-                where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
+            public static DiyFp CreateAndGetBoundaries(double value, out DiyFp mMinus, out DiyFp mPlus)
             {
-                var result = Create(value);
-                result.GetBoundaries(TNumber.DenormalMantissaBits, out mMinus, out mPlus);
+                var result = new DiyFp(value);
+                result.GetBoundaries(DoubleImplicitBitIndex, out mMinus, out mPlus);
                 return result;
             }
 
-            public static DiyFp Create<TNumber>(TNumber value)
-                where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
+            // Computes the two boundaries of value.
+            //
+            // The bigger boundary (mPlus) is normalized.
+            // The lower boundary has the same exponent as mPlus.
+            //
+            // Precondition:
+            //  The value encoded by value must be greater than 0.
+            public static DiyFp CreateAndGetBoundaries(float value, out DiyFp mMinus, out DiyFp mPlus)
             {
-                Debug.Assert(TNumber.IsFinite(value));
-                Debug.Assert(value > TNumber.Zero);
-                ulong f = ExtractFractionAndBiasedExponent(value, out int e);
-                return new DiyFp(f, e);
+                var result = new DiyFp(value);
+                result.GetBoundaries(SingleImplicitBitIndex, out mMinus, out mPlus);
+                return result;
+            }
+
+            // Computes the two boundaries of value.
+            //
+            // The bigger boundary (mPlus) is normalized.
+            // The lower boundary has the same exponent as mPlus.
+            //
+            // Precondition:
+            //  The value encoded by value must be greater than 0.
+            public static DiyFp CreateAndGetBoundaries(Half value, out DiyFp mMinus, out DiyFp mPlus)
+            {
+                var result = new DiyFp(value);
+                result.GetBoundaries(HalfImplicitBitIndex, out mMinus, out mPlus);
+                return result;
+            }
+
+            public DiyFp(double value)
+            {
+                Debug.Assert(double.IsFinite(value));
+                Debug.Assert(value > 0.0);
+                f = ExtractFractionAndBiasedExponent(value, out e);
+            }
+
+            public DiyFp(float value)
+            {
+                Debug.Assert(float.IsFinite(value));
+                Debug.Assert(value > 0.0f);
+                f = ExtractFractionAndBiasedExponent(value, out e);
+            }
+
+            public DiyFp(Half value)
+            {
+                Debug.Assert(Half.IsFinite(value));
+                Debug.Assert((float)value > 0.0f);
+                f = ExtractFractionAndBiasedExponent(value, out e);
             }
 
             public DiyFp(ulong f, int e)

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
@@ -40,36 +40,6 @@ namespace System
             number.DigitsCount = length;
         }
 
-        public static unsafe void Dragon4Half(Half value, int cutoffNumber, bool isSignificantDigits, ref NumberBuffer number)
-        {
-            Half v = Half.IsNegative(value) ? Half.Negate(value) : value;
-
-            Debug.Assert((double)v > 0.0);
-            Debug.Assert(Half.IsFinite(v));
-
-            ushort mantissa = ExtractFractionAndBiasedExponent(value, out int exponent);
-
-            uint mantissaHighBitIdx;
-            bool hasUnequalMargins = false;
-
-            if ((mantissa >> DiyFp.HalfImplicitBitIndex) != 0)
-            {
-                mantissaHighBitIdx = DiyFp.HalfImplicitBitIndex;
-                hasUnequalMargins = (mantissa == (1U << DiyFp.HalfImplicitBitIndex));
-            }
-            else
-            {
-                Debug.Assert(mantissa != 0);
-                mantissaHighBitIdx = (uint)BitOperations.Log2(mantissa);
-            }
-
-            int length = (int)(Dragon4(mantissa, exponent, mantissaHighBitIdx, hasUnequalMargins, cutoffNumber, isSignificantDigits, number.Digits, out int decimalExponent));
-
-            number.Scale = decimalExponent + 1;
-            number.Digits[length] = (byte)('\0');
-            number.DigitsCount = length;
-        }
-
         public static unsafe void Dragon4Single(float value, int cutoffNumber, bool isSignificantDigits, ref NumberBuffer number)
         {
             float v = float.IsNegative(value) ? -value : value;
@@ -86,6 +56,37 @@ namespace System
             {
                 mantissaHighBitIdx = DiyFp.SingleImplicitBitIndex;
                 hasUnequalMargins = (mantissa == (1U << DiyFp.SingleImplicitBitIndex));
+            }
+            else
+            {
+                Debug.Assert(mantissa != 0);
+                mantissaHighBitIdx = (uint)BitOperations.Log2(mantissa);
+            }
+
+            int length = (int)(Dragon4(mantissa, exponent, mantissaHighBitIdx, hasUnequalMargins, cutoffNumber, isSignificantDigits, number.Digits, out int decimalExponent));
+
+            number.Scale = decimalExponent + 1;
+            number.Digits[length] = (byte)('\0');
+            number.DigitsCount = length;
+        }
+
+        public static unsafe void Dragon4<TNumber>(TNumber value, int cutoffNumber, bool isSignificantDigits, ref NumberBuffer number)
+            where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
+        {
+            TNumber v = TNumber.IsNegative(value) ? -value : value;
+
+            Debug.Assert(v > TNumber.Zero);
+            Debug.Assert(TNumber.IsFinite(v));
+
+            ulong mantissa = ExtractFractionAndBiasedExponent(value, out int exponent);
+
+            uint mantissaHighBitIdx;
+            bool hasUnequalMargins = false;
+
+            if ((mantissa >> TNumber.DenormalMantissaBits) != 0)
+            {
+                mantissaHighBitIdx = TNumber.DenormalMantissaBits;
+                hasUnequalMargins = (mantissa == (1U << TNumber.DenormalMantissaBits));
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -252,6 +252,23 @@ namespace System
     {
         internal const int DecimalPrecision = 29; // Decimal.DecCalc also uses this value
 
+        // SinglePrecision and DoublePrecision represent the maximum number of digits required
+        // to guarantee that any given Single or Double can roundtrip. Some numbers may require
+        // less, but none will require more.
+        private const int HalfPrecision = 5;
+        private const int SinglePrecision = 9;
+        private const int DoublePrecision = 17;
+
+        // SinglePrecisionCustomFormat and DoublePrecisionCustomFormat are used to ensure that
+        // custom format strings return the same string as in previous releases when the format
+        // would return x digits or less (where x is the value of the corresponding constant).
+        // In order to support more digits, we would need to update ParseFormatSpecifier to pre-parse
+        // the format and determine exactly how many digits are being requested and whether they
+        // represent "significant digits" or "digits after the decimal point".
+        private const int HalfPrecisionCustomFormat = 5;
+        private const int SinglePrecisionCustomFormat = 7;
+        private const int DoublePrecisionCustomFormat = 15;
+
         /// <summary>The non-inclusive upper bound of <see cref="s_smallNumberCache"/>.</summary>
         /// <remarks>
         /// This is a semi-arbitrary bound. For mono, which is often used for more size-constrained workloads,
@@ -377,6 +394,28 @@ namespace System
             number.CheckConsistency();
         }
 
+        public static string FormatDouble(double value, string? format, NumberFormatInfo info)
+        {
+            var vlb = new ValueListBuilder<char>(stackalloc char[CharStackBufferSize]);
+            string result = FormatDouble(ref vlb, value, format, info) ?? vlb.AsSpan().ToString();
+            vlb.Dispose();
+            return result;
+        }
+
+        public static bool TryFormatDouble<TChar>(double value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        {
+            var vlb = new ValueListBuilder<TChar>(stackalloc TChar[CharStackBufferSize]);
+            string? s = FormatDouble(ref vlb, value, format, info);
+
+            Debug.Assert(s is null || typeof(TChar) == typeof(char));
+            bool success = s != null ?
+                TryCopyTo(s, destination, out charsWritten) :
+                vlb.TryCopyTo(destination, out charsWritten);
+
+            vlb.Dispose();
+            return success;
+        }
+
         private static int GetFloatingPointMaxDigitsAndPrecision(char fmt, ref int precision, NumberFormatInfo info, out bool isSignificantDigits)
         {
             if (fmt == 0)
@@ -498,23 +537,105 @@ namespace System
             return maxDigits;
         }
 
-        public static string FormatFloat<TNumber>(TNumber value, string? format, NumberFormatInfo info)
-            where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
+        /// <summary>Formats the specified value according to the specified format and info.</summary>
+        /// <returns>
+        /// Non-null if an existing string can be returned, in which case the builder will be unmodified.
+        /// Null if no existing string was returned, in which case the formatted output is in the builder.
+        /// </returns>
+        private static unsafe string? FormatDouble<TChar>(ref ValueListBuilder<TChar> vlb, double value, ReadOnlySpan<char> format, NumberFormatInfo info) where TChar : unmanaged, IUtfChar<TChar>
+        {
+            if (!double.IsFinite(value))
+            {
+                if (double.IsNaN(value))
+                {
+                    if (typeof(TChar) == typeof(char))
+                    {
+                        return info.NaNSymbol;
+                    }
+                    else
+                    {
+                        vlb.Append(info.NaNSymbolTChar<TChar>());
+                        return null;
+                    }
+                }
+
+                if (typeof(TChar) == typeof(char))
+                {
+                    return double.IsNegative(value) ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                }
+                else
+                {
+                    vlb.Append(double.IsNegative(value) ? info.NegativeInfinitySymbolTChar<TChar>() : info.PositiveInfinitySymbolTChar<TChar>());
+                    return null;
+                }
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int precision);
+            byte* pDigits = stackalloc byte[DoubleNumberBufferLength];
+
+            if (fmt == '\0')
+            {
+                // For back-compat we currently specially treat the precision for custom
+                // format specifiers. The constant has more details as to why.
+                precision = DoublePrecisionCustomFormat;
+            }
+
+            NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, DoubleNumberBufferLength);
+            number.IsNegative = double.IsNegative(value);
+
+            // We need to track the original precision requested since some formats
+            // accept values like 0 and others may require additional fixups.
+            int nMaxDigits = GetFloatingPointMaxDigitsAndPrecision(fmt, ref precision, info, out bool isSignificantDigits);
+
+            if ((value != 0.0) && (!isSignificantDigits || !Grisu3.TryRunDouble(value, precision, ref number)))
+            {
+                Dragon4Double(value, precision, isSignificantDigits, ref number);
+            }
+
+            number.CheckConsistency();
+
+            // When the number is known to be roundtrippable (either because we requested it be, or
+            // because we know we have enough digits to satisfy roundtrippability), we should validate
+            // that the number actually roundtrips back to the original result.
+
+            Debug.Assert(((precision != -1) && (precision < DoublePrecision)) || (BitConverter.DoubleToInt64Bits(value) == BitConverter.DoubleToInt64Bits(NumberToFloat<double>(ref number))));
+
+            if (fmt != 0)
+            {
+                if (precision == -1)
+                {
+                    Debug.Assert((fmt == 'G') || (fmt == 'g') || (fmt == 'R') || (fmt == 'r'));
+
+                    // For the roundtrip and general format specifiers, when returning the shortest roundtrippable
+                    // string, we need to update the maximum number of digits to be the greater of number.DigitsCount
+                    // or DoublePrecision. This ensures that we continue returning "pretty" strings for values with
+                    // less digits. One example this fixes is "-60", which would otherwise be formatted as "-6E+01"
+                    // since DigitsCount would be 1 and the formatter would almost immediately switch to scientific notation.
+
+                    nMaxDigits = Math.Max(number.DigitsCount, DoublePrecision);
+                }
+                NumberToString(ref vlb, ref number, fmt, nMaxDigits, info);
+            }
+            else
+            {
+                Debug.Assert(precision == DoublePrecisionCustomFormat);
+                NumberToStringFormat(ref vlb, ref number, format, info);
+            }
+            return null;
+        }
+
+        public static string FormatSingle(float value, string? format, NumberFormatInfo info)
         {
             var vlb = new ValueListBuilder<char>(stackalloc char[CharStackBufferSize]);
-            string result = FormatFloat(ref vlb, value, format, info) ?? vlb.AsSpan().ToString();
+            string result = FormatSingle(ref vlb, value, format, info) ?? vlb.AsSpan().ToString();
             vlb.Dispose();
             return result;
         }
 
-        public static bool TryFormatFloat<TNumber, TChar>(TNumber value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<TChar> destination, out int charsWritten)
-            where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
-            where TChar : unmanaged, IUtfChar<TChar>
+        public static bool TryFormatSingle<TChar>(float value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
-            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
-
             var vlb = new ValueListBuilder<TChar>(stackalloc TChar[CharStackBufferSize]);
-            string? s = FormatFloat(ref vlb, value, format, info);
+            string? s = FormatSingle(ref vlb, value, format, info);
 
             Debug.Assert(s is null || typeof(TChar) == typeof(char));
             bool success = s != null ?
@@ -530,15 +651,13 @@ namespace System
         /// Non-null if an existing string can be returned, in which case the builder will be unmodified.
         /// Null if no existing string was returned, in which case the formatted output is in the builder.
         /// </returns>
-        private static unsafe string? FormatFloat<TNumber, TChar>(ref ValueListBuilder<TChar> vlb, TNumber value, ReadOnlySpan<char> format, NumberFormatInfo info)
-            where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
-            where TChar : unmanaged, IUtfChar<TChar>
+        private static unsafe string? FormatSingle<TChar>(ref ValueListBuilder<TChar> vlb, float value, ReadOnlySpan<char> format, NumberFormatInfo info) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
 
-            if (!TNumber.IsFinite(value))
+            if (!float.IsFinite(value))
             {
-                if (TNumber.IsNaN(value))
+                if (float.IsNaN(value))
                 {
                     if (typeof(TChar) == typeof(char))
                     {
@@ -553,33 +672,35 @@ namespace System
 
                 if (typeof(TChar) == typeof(char))
                 {
-                    return TNumber.IsNegative(value) ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                    return float.IsNegative(value) ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
                 }
                 else
                 {
-                    vlb.Append(TNumber.IsNegative(value) ? info.NegativeInfinitySymbolTChar<TChar>() : info.PositiveInfinitySymbolTChar<TChar>());
+                    vlb.Append(float.IsNegative(value) ? info.NegativeInfinitySymbolTChar<TChar>() : info.PositiveInfinitySymbolTChar<TChar>());
                     return null;
                 }
             }
 
             char fmt = ParseFormatSpecifier(format, out int precision);
-            byte* pDigits = stackalloc byte[TNumber.NumberBufferLength];
+            byte* pDigits = stackalloc byte[SingleNumberBufferLength];
 
             if (fmt == '\0')
             {
-                precision = TNumber.MaxPrecisionCustomFormat;
+                // For back-compat we currently specially treat the precision for custom
+                // format specifiers. The constant has more details as to why.
+                precision = SinglePrecisionCustomFormat;
             }
 
-            NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, TNumber.NumberBufferLength);
-            number.IsNegative = TNumber.IsNegative(value);
+            NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, SingleNumberBufferLength);
+            number.IsNegative = float.IsNegative(value);
 
             // We need to track the original precision requested since some formats
             // accept values like 0 and others may require additional fixups.
             int nMaxDigits = GetFloatingPointMaxDigitsAndPrecision(fmt, ref precision, info, out bool isSignificantDigits);
 
-            if ((value != default) && (!isSignificantDigits || !Grisu3.TryRun(value, precision, ref number)))
+            if ((value != default) && (!isSignificantDigits || !Grisu3.TryRunSingle(value, precision, ref number)))
             {
-                Dragon4(value, precision, isSignificantDigits, ref number);
+                Dragon4Single(value, precision, isSignificantDigits, ref number);
             }
 
             number.CheckConsistency();
@@ -588,7 +709,7 @@ namespace System
             // because we know we have enough digits to satisfy roundtrippability), we should validate
             // that the number actually roundtrips back to the original result.
 
-            Debug.Assert(((precision != -1) && (precision < TNumber.MaxRoundTripDigits)) || (TNumber.FloatToBits(value) == TNumber.FloatToBits(NumberToFloat<TNumber>(ref number))));
+            Debug.Assert(((precision != -1) && (precision < SinglePrecision)) || (BitConverter.SingleToInt32Bits(value) == BitConverter.SingleToInt32Bits(NumberToFloat<float>(ref number))));
 
             if (fmt != 0)
             {
@@ -602,16 +723,127 @@ namespace System
                     // less digits. One example this fixes is "-60", which would otherwise be formatted as "-6E+01"
                     // since DigitsCount would be 1 and the formatter would almost immediately switch to scientific notation.
 
-                    nMaxDigits = Math.Max(number.DigitsCount, TNumber.MaxRoundTripDigits);
+                    nMaxDigits = Math.Max(number.DigitsCount, SinglePrecision);
                 }
                 NumberToString(ref vlb, ref number, fmt, nMaxDigits, info);
             }
             else
             {
-                Debug.Assert(precision == TNumber.MaxPrecisionCustomFormat);
+                Debug.Assert(precision == SinglePrecisionCustomFormat);
                 NumberToStringFormat(ref vlb, ref number, format, info);
             }
             return null;
+        }
+
+        public static string FormatHalf(Half value, string? format, NumberFormatInfo info)
+        {
+            var vlb = new ValueListBuilder<char>(stackalloc char[CharStackBufferSize]);
+            string result = FormatHalf(ref vlb, value, format, info) ?? vlb.AsSpan().ToString();
+            vlb.Dispose();
+            return result;
+        }
+
+        /// <summary>Formats the specified value according to the specified format and info.</summary>
+        /// <returns>
+        /// Non-null if an existing string can be returned, in which case the builder will be unmodified.
+        /// Null if no existing string was returned, in which case the formatted output is in the builder.
+        /// </returns>
+        private static unsafe string? FormatHalf<TChar>(ref ValueListBuilder<TChar> vlb, Half value, ReadOnlySpan<char> format, NumberFormatInfo info) where TChar : unmanaged, IUtfChar<TChar>
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (!Half.IsFinite(value))
+            {
+                if (Half.IsNaN(value))
+                {
+                    if (typeof(TChar) == typeof(char))
+                    {
+                        return info.NaNSymbol;
+                    }
+                    else
+                    {
+                        vlb.Append(info.NaNSymbolTChar<TChar>());
+                        return null;
+                    }
+                }
+
+                if (typeof(TChar) == typeof(char))
+                {
+                    return Half.IsNegative(value) ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                }
+                else
+                {
+                    vlb.Append(Half.IsNegative(value) ? info.NegativeInfinitySymbolTChar<TChar>() : info.PositiveInfinitySymbolTChar<TChar>());
+                    return null;
+                }
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int precision);
+            byte* pDigits = stackalloc byte[HalfNumberBufferLength];
+
+            if (fmt == '\0')
+            {
+                precision = HalfPrecisionCustomFormat;
+            }
+
+            NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, HalfNumberBufferLength);
+            number.IsNegative = Half.IsNegative(value);
+
+            // We need to track the original precision requested since some formats
+            // accept values like 0 and others may require additional fixups.
+            int nMaxDigits = GetFloatingPointMaxDigitsAndPrecision(fmt, ref precision, info, out bool isSignificantDigits);
+
+            if ((value != default) && (!isSignificantDigits || !Grisu3.TryRunHalf(value, precision, ref number)))
+            {
+                Dragon4Half(value, precision, isSignificantDigits, ref number);
+            }
+
+            number.CheckConsistency();
+
+            // When the number is known to be roundtrippable (either because we requested it be, or
+            // because we know we have enough digits to satisfy roundtrippability), we should validate
+            // that the number actually roundtrips back to the original result.
+
+            Debug.Assert(((precision != -1) && (precision < HalfPrecision)) || (BitConverter.HalfToInt16Bits(value) == BitConverter.HalfToInt16Bits(NumberToFloat<Half>(ref number))));
+
+            if (fmt != 0)
+            {
+                if (precision == -1)
+                {
+                    Debug.Assert((fmt == 'G') || (fmt == 'g') || (fmt == 'R') || (fmt == 'r'));
+
+                    // For the roundtrip and general format specifiers, when returning the shortest roundtrippable
+                    // string, we need to update the maximum number of digits to be the greater of number.DigitsCount
+                    // or SinglePrecision. This ensures that we continue returning "pretty" strings for values with
+                    // less digits. One example this fixes is "-60", which would otherwise be formatted as "-6E+01"
+                    // since DigitsCount would be 1 and the formatter would almost immediately switch to scientific notation.
+
+                    nMaxDigits = Math.Max(number.DigitsCount, HalfPrecision);
+                }
+                NumberToString(ref vlb, ref number, fmt, nMaxDigits, info);
+            }
+            else
+            {
+                Debug.Assert(precision == HalfPrecisionCustomFormat);
+                NumberToStringFormat(ref vlb, ref number, format, info);
+            }
+            return null;
+        }
+
+        public static bool TryFormatHalf<TChar>(Half value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            var vlb = new ValueListBuilder<TChar>(stackalloc TChar[CharStackBufferSize]);
+            string? s = FormatHalf(ref vlb, value, format, info);
+
+            Debug.Assert(s is null || typeof(TChar) == typeof(char));
+            bool success = s != null ?
+                TryCopyTo(s, destination, out charsWritten) :
+                vlb.TryCopyTo(destination, out charsWritten);
+
+            vlb.Dispose();
+            return success;
         }
 
         private static bool TryCopyTo<TChar>(string source, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
@@ -2631,39 +2863,6 @@ namespace System
                 //       = mantissa * 2^(-149)
                 // So f = mantissa, e = -149
                 exponent = -149;
-            }
-
-            return fraction;
-        }
-
-        private static ulong ExtractFractionAndBiasedExponent<TNumber>(TNumber value, out int exponent)
-            where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
-        {
-            ulong bits = TNumber.FloatToBits(value);
-            ulong fraction = (bits & TNumber.DenormalMantissaMask);
-            exponent = ((int)(bits >> TNumber.DenormalMantissaBits) & TNumber.InfinityExponent);
-
-            if (exponent != 0)
-            {
-                // For normalized value,
-                // value = 1.fraction * 2^(exp - ExponentBias)
-                //       = (1 + mantissa / 2^TrailingSignificandLength) * 2^(exp - ExponentBias)
-                //       = (2^TrailingSignificandLength + mantissa) * 2^(exp - ExponentBias - TrailingSignificandLength)
-                //
-                // So f = (2^TrailingSignificandLength + mantissa), e = exp - ExponentBias - TrailingSignificandLength;
-
-                fraction |= (1UL << TNumber.DenormalMantissaBits);
-                exponent -= TNumber.ExponentBias + TNumber.DenormalMantissaBits;
-            }
-            else
-            {
-                // For denormalized value,
-                // value = 0.fraction * 2^(MinBinaryExponent)
-                //       = (mantissa / 2^TrailingSignificandLength) * 2^(MinBinaryExponent)
-                //       = mantissa * 2^(MinBinaryExponent - TrailingSignificandLength)
-                //       = mantissa * 2^(MinBinaryExponent - TrailingSignificandLength)
-                // So f = mantissa, e = MinBinaryExponent - TrailingSignificandLength
-                exponent = TNumber.MinBinaryExponent - TNumber.DenormalMantissaBits;
             }
 
             return fraction;

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Grisu3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Grisu3.cs
@@ -321,13 +321,12 @@ namespace System
                 1000000000, // 10^9
             ];
 
-            public static bool TryRun<TNumber>(TNumber value, int requestedDigits, ref NumberBuffer number)
-                where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
+            public static bool TryRunDouble(double value, int requestedDigits, ref NumberBuffer number)
             {
-                TNumber v = TNumber.IsNegative(value) ? -value : value;
+                double v = double.IsNegative(value) ? -value : value;
 
-                Debug.Assert(v > TNumber.Zero);
-                Debug.Assert(TNumber.IsFinite(v));
+                Debug.Assert(v > 0);
+                Debug.Assert(double.IsFinite(v));
 
                 int length;
                 int decimalExponent;
@@ -340,7 +339,75 @@ namespace System
                 }
                 else
                 {
-                    DiyFp w = DiyFp.Create(v).Normalize();
+                    DiyFp w = new DiyFp(v).Normalize();
+                    result = TryRunCounted(in w, requestedDigits, number.Digits, out length, out decimalExponent);
+                }
+
+                if (result)
+                {
+                    Debug.Assert((requestedDigits == -1) || (length == requestedDigits));
+
+                    number.Scale = length + decimalExponent;
+                    number.Digits[length] = (byte)('\0');
+                    number.DigitsCount = length;
+                }
+
+                return result;
+            }
+
+            public static bool TryRunHalf(Half value, int requestedDigits, ref NumberBuffer number)
+            {
+                Half v = Half.IsNegative(value) ? Half.Negate(value) : value;
+
+                Debug.Assert((double)v > 0);
+                Debug.Assert(Half.IsFinite(v));
+
+                int length;
+                int decimalExponent;
+                bool result;
+
+                if (requestedDigits == -1)
+                {
+                    DiyFp w = DiyFp.CreateAndGetBoundaries(v, out DiyFp boundaryMinus, out DiyFp boundaryPlus).Normalize();
+                    result = TryRunShortest(in boundaryMinus, in w, in boundaryPlus, number.Digits, out length, out decimalExponent);
+                }
+                else
+                {
+                    DiyFp w = new DiyFp(v).Normalize();
+                    result = TryRunCounted(in w, requestedDigits, number.Digits, out length, out decimalExponent);
+                }
+
+                if (result)
+                {
+                    Debug.Assert((requestedDigits == -1) || (length == requestedDigits));
+
+                    number.Scale = length + decimalExponent;
+                    number.Digits[length] = (byte)('\0');
+                    number.DigitsCount = length;
+                }
+
+                return result;
+            }
+
+            public static bool TryRunSingle(float value, int requestedDigits, ref NumberBuffer number)
+            {
+                float v = float.IsNegative(value) ? -value : value;
+
+                Debug.Assert(v > 0);
+                Debug.Assert(float.IsFinite(v));
+
+                int length;
+                int decimalExponent;
+                bool result;
+
+                if (requestedDigits == -1)
+                {
+                    DiyFp w = DiyFp.CreateAndGetBoundaries(v, out DiyFp boundaryMinus, out DiyFp boundaryPlus).Normalize();
+                    result = TryRunShortest(in boundaryMinus, in w, in boundaryPlus, number.Digits, out length, out decimalExponent);
+                }
+                else
+                {
+                    DiyFp w = new DiyFp(v).Normalize();
                     result = TryRunCounted(in w, requestedDigits, number.Digits, out length, out decimalExponent);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Grisu3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Grisu3.cs
@@ -355,12 +355,12 @@ namespace System
                 return result;
             }
 
-            public static bool TryRunHalf(Half value, int requestedDigits, ref NumberBuffer number)
+            public static bool TryRunSingle(float value, int requestedDigits, ref NumberBuffer number)
             {
-                Half v = Half.IsNegative(value) ? Half.Negate(value) : value;
+                float v = float.IsNegative(value) ? -value : value;
 
-                Debug.Assert((double)v > 0);
-                Debug.Assert(Half.IsFinite(v));
+                Debug.Assert(v > 0);
+                Debug.Assert(float.IsFinite(v));
 
                 int length;
                 int decimalExponent;
@@ -389,12 +389,13 @@ namespace System
                 return result;
             }
 
-            public static bool TryRunSingle(float value, int requestedDigits, ref NumberBuffer number)
+            public static bool TryRun<TNumber>(TNumber value, int requestedDigits, ref NumberBuffer number)
+                where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
             {
-                float v = float.IsNegative(value) ? -value : value;
+                TNumber v = TNumber.IsNegative(value) ? -value : value;
 
-                Debug.Assert(v > 0);
-                Debug.Assert(float.IsFinite(v));
+                Debug.Assert(v > TNumber.Zero);
+                Debug.Assert(TNumber.IsFinite(v));
 
                 int length;
                 int decimalExponent;
@@ -407,7 +408,7 @@ namespace System
                 }
                 else
                 {
-                    DiyFp w = new DiyFp(v).Normalize();
+                    DiyFp w = DiyFp.Create(v).Normalize();
                     result = TryRunCounted(in w, requestedDigits, number.Digits, out length, out decimalExponent);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -85,18 +85,6 @@ namespace System
         static abstract TSelf BitsToFloat(ulong bits);
 
         static abstract ulong FloatToBits(TSelf value);
-
-        // Maximum number of digits required to guarantee that any given floating point
-        // number can roundtrip. Some numbers may require less, but none will require more.
-        static abstract int MaxRoundTripDigits { get; }
-
-        // SinglePrecisionCustomFormat and DoublePrecisionCustomFormat are used to ensure that
-        // custom format strings return the same string as in previous releases when the format
-        // would return x digits or less (where x is the value of the corresponding constant).
-        // In order to support more digits, we would need to update ParseFormatSpecifier to pre-parse
-        // the format and determine exactly how many digits are being requested and whether they
-        // represent "significant digits" or "digits after the decimal point".
-        static abstract int MaxPrecisionCustomFormat { get; }
     }
 
     internal static partial class Number

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -85,6 +85,18 @@ namespace System
         static abstract TSelf BitsToFloat(ulong bits);
 
         static abstract ulong FloatToBits(TSelf value);
+
+        // Maximum number of digits required to guarantee that any given floating point
+        // number can roundtrip. Some numbers may require less, but none will require more.
+        static abstract int MaxRoundTripDigits { get; }
+
+        // SinglePrecisionCustomFormat and DoublePrecisionCustomFormat are used to ensure that
+        // custom format strings return the same string as in previous releases when the format
+        // would return x digits or less (where x is the value of the corresponding constant).
+        // In order to support more digits, we would need to update ParseFormatSpecifier to pre-parse
+        // the format and determine exactly how many digits are being requested and whether they
+        // represent "significant digits" or "digits after the decimal point".
+        static abstract int MaxPrecisionCustomFormat { get; }
     }
 
     internal static partial class Number

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -349,33 +349,33 @@ namespace System
 
         public override string ToString()
         {
-            return Number.FormatFloat(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatSingle(m_value, null, NumberFormatInfo.CurrentInfo);
         }
 
         public string ToString(IFormatProvider? provider)
         {
-            return Number.FormatFloat(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatSingle(m_value, null, NumberFormatInfo.GetInstance(provider));
         }
 
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format)
         {
-            return Number.FormatFloat(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatSingle(m_value, format, NumberFormatInfo.CurrentInfo);
         }
 
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, IFormatProvider? provider)
         {
-            return Number.FormatFloat(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatSingle(m_value, format, NumberFormatInfo.GetInstance(provider));
         }
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatFloat(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatSingle(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatFloat(m_value, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
+            return Number.TryFormatSingle(m_value, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
         }
 
         // Parses a float from a String in the given style.  If
@@ -2216,10 +2216,6 @@ namespace System
         static float IBinaryFloatParseAndFormatInfo<float>.BitsToFloat(ulong bits) => BitConverter.UInt32BitsToSingle((uint)(bits));
 
         static ulong IBinaryFloatParseAndFormatInfo<float>.FloatToBits(float value) => BitConverter.SingleToUInt32Bits(value);
-
-        static int IBinaryFloatParseAndFormatInfo<float>.MaxRoundTripDigits => 9;
-
-        static int IBinaryFloatParseAndFormatInfo<float>.MaxPrecisionCustomFormat => 7;
 
         //
         // Helpers

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -2217,6 +2217,10 @@ namespace System
 
         static ulong IBinaryFloatParseAndFormatInfo<float>.FloatToBits(float value) => BitConverter.SingleToUInt32Bits(value);
 
+        static int IBinaryFloatParseAndFormatInfo<float>.MaxRoundTripDigits => 9;
+
+        static int IBinaryFloatParseAndFormatInfo<float>.MaxPrecisionCustomFormat => 7;
+
         //
         // Helpers
         //


### PR DESCRIPTION
Partially reverts #102683. Closes #104076.

The first commits reverts the original PR. The second commit reapplies it on `Half`, with suggested renaming.