### PR TITLE
JIT: Don't do aggressive block compaction too early

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5167,16 +5167,17 @@ void Compiler::ehUpdateTryLasts(GetTryLast getTryLast, SetTryLast setTryLast)
 
 //-------------------------------------------------------------
 // fgUpdateFlowGraphPhase: run flow graph optimization as a
-//   phase, with no tail duplication
+//   phase, with no tail duplication or aggressive compaction
 //
 // Returns:
 //    Suitable phase status
 //
 PhaseStatus Compiler::fgUpdateFlowGraphPhase()
 {
-    constexpr bool doTailDup   = false;
-    constexpr bool isPhase     = true;
-    const bool     madeChanges = fgUpdateFlowGraph(doTailDup, isPhase);
+    constexpr bool doTailDup              = false;
+    constexpr bool isPhase                = true;
+    constexpr bool doAggressiveCompaction = false;
+    const bool     madeChanges            = fgUpdateFlowGraph(doTailDup, isPhase, doAggressiveCompaction);
 
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }


### PR DESCRIPTION
Several of the regressions in #103972 stem from early aggressive block compaction pessimizing loop inversion. For example, consider the following block layout early in compilation for `System.Linq.Tests.Perf_Enumerable.Aggregate_Seed`. If we don't aggressively compact in `fgUpdateFlowGraphPhase`, we get the following layout right before loop inversion:
```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight   [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1    [000..003)-> BB03(0.5),BB02(0.5)     ( cond )                     i
BB02 [0001]  1       BB01                  0    [003..00A)                           (throw )                     i rare hascall gcsafe
BB03 [0002]  1       BB01                  1    [00A..00D)-> BB05(0.5),BB04(0.5)     ( cond )                     i
BB04 [0003]  1       BB03                  0    [00D..013)                           (throw )                     i rare hascall gcsafe
BB05 [0004]  1       BB03                  1    [013..01C)-> BB06(1)                 (always)                     i hascall gcsafe
BB06 [0005]  1  0    BB05                  1    [01C..01E)-> BB08(1)                 (always) T0      try {       i keep
BB07 [0006]  1  0    BB08                  1    [01E..02E)-> BB08(1)                 (always) T0                  i hascall gcsafe bwd bwd-target
BB08 [0007]  2  0    BB06,BB07             1    [02E..036)-> BB07(0.5),BB16(0.5)     ( cond ) T0      }           i hascall bwd bwd-src
BB16 [0015]  1       BB08                  1    [038..03B)-> BB17(1)                 (always)                     i keep cfb
BB17 [0016]  1       BB16                  1    [03B..042)-> BB15(1)                 (always)                     i hascall gcsafe
BB15 [0012]  1       BB17                  1    [042..044)                           (return)                     i
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ funclets follow
BB12 [0009]  1     0                       1    [038..03B)-> BB14(0.5),BB13(0.5)     ( cond )    H0 F fault {     i keep flet
BB13 [0010]  1     0 BB12                  1    [03B..041)-> BB14(1)                 (always)    H0               i hascall gcsafe
BB14 [0011]  2     0 BB12,BB13             1    [041..042)                           (falret)    H0   }           i
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

In the try region, there's an opportunity to aggressively compact, and get the following loop shape:
```
BB06 [0005]  2  0    BB05,BB07             1    [01C..036)-> BB07(0.5),BB16(0.5)     ( cond ) T0      try {       i keep hascall bwd
BB07 [0006]  1  0    BB06                  1    [01E..02E)-> BB06(1)                 (always) T0      }           i hascall gcsafe bwd bwd-target
BB16 [0015]  1       BB06                  1    [038..03B)-> BB17(1)                 (always)                     i keep cfb
```

Loop inversion won't kick in for this, and since `fgMoveHotJumps` won't modify the first block of an EH region, we don't get the opportunity to flip this shape, so we end up with subpar loop layout.

If we don't aggressively compact, loop inversion kicks in, and we get the following shape:
```
BB06 [0005]  1  0    BB05                  1    [01C..01E)-> BB15(1)                 (always) T0      try {       i keep
BB15 [0018]  1  0    BB06                  1    [???..???)-> BB09(0.5),BB07(0.5)     ( cond ) T0                  internal
BB07 [0006]  2  0    BB08,BB15             1    [01E..02E)-> BB08(1)                 (always) T0                  i hascall gcsafe bwd bwd-target
BB08 [0007]  1  0    BB07                  1    [02E..036)-> BB07(0.5),BB09(0.5)     ( cond ) T0      }           i hascall bwd bwd-src
BB09 [0015]  2       BB08,BB15             1    [038..03B)-> BB10(1)                 (always)                     i keep cfb
```

After flow opts and block layout run, our final shape looks like this:
```
BB04 [0005]  1  0    BB03                  1    [01C..01E)-> BB06(0.5),BB05(0.5)     ( cond ) T0      try {       i keep
BB05 [0019]  2  0    BB04,BB05             4    [01E..036)-> BB05(0.5),BB06(0.5)     ( cond ) T0      }           i loophead gcsafe bwd
BB06 [0015]  2       BB04,BB05             1    [038..044)                           (return)                     i keep gcsafe cfb
```

I don't think we are losing anything by reserving aggressive compaction for later flow opt phases, and the upside is more opportunities for loop inversion, which may unlock other loop opts.