### PR TITLE
Fix testcase for ILC behavior with preserved generated code

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeInPreservedAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeInPreservedAssembly.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	[ExpectedNoWarnings]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
 	[SetupLinkerDescriptorFile ("CompilerGeneratedCodeInPreservedAssembly.xml")]
+	[SetupLinkerArgument ("--feature", "AlwaysFalse", "false")]
 	class CompilerGeneratedCodeInPreservedAssembly
 	{
 		public static void Main ()
@@ -40,9 +41,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				}
 
 				// Analyzer doesn't implement constant propagation and branch removal, so it reaches this code
-				// NativeAOT behavioral difference:
-				//   https://github.com/dotnet/runtime/issues/85161
-				[ExpectedWarning ("IL2026", Tool.Analyzer | Tool.NativeAot, "")]
+				[ExpectedWarning ("IL2026", Tool.Analyzer, "")]
 				void LocalWithWarning ()
 				{
 					// No warning
@@ -62,15 +61,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			// Analyzer doesn't implement constant propagation and branch removal, so it reaches this code
-			// NativeAOT behavioral difference:
-			//   https://github.com/dotnet/runtime/issues/85161
-			[ExpectedWarning ("IL2026", Tool.Analyzer | Tool.NativeAot, "")]
+			[ExpectedWarning ("IL2026", Tool.Analyzer, "")]
 			void LocalWithWarning ()
 			{
 				Requires ();
 			}
 		}
 
+		[FeatureSwitchDefinition ("AlwaysFalse")]
 		public static bool AlwaysFalse => false;
 
 		[RequiresUnreferencedCode ("RUC")]


### PR DESCRIPTION
The feature setting ensures that ILC sees a constant and has the same warning behavior as ILLink. We decided this is the desired behavior in https://github.com/dotnet/runtime/issues/85161.

Fixes https://github.com/dotnet/runtime/issues/85161