### PR TITLE
[cdac] Pass a delegate into Target

### DIFF
--- a/src/native/managed/cdacreader/src/Entrypoints.cs
+++ b/src/native/managed/cdacreader/src/Entrypoints.cs
@@ -15,7 +15,13 @@ internal static class Entrypoints
     private static unsafe int Init(ulong descriptor, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext, IntPtr* handle)
     {
         // TODO: [cdac] Better error code/details
-        if (!Target.TryCreate(descriptor, (address, buffer, bufferLength) => readFromTarget(address, buffer, bufferLength, readContext), out Target? target))
+        if (!Target.TryCreate(descriptor, (address, buffer) =>
+            {
+                fixed (byte* bufferPtr = buffer)
+                {
+                    return readFromTarget(address, bufferPtr, (uint)buffer.Length, readContext);
+                }
+            }, out Target? target))
             return -1;
 
         GCHandle gcHandle = GCHandle.Alloc(target);

--- a/src/native/managed/cdacreader/src/Entrypoints.cs
+++ b/src/native/managed/cdacreader/src/Entrypoints.cs
@@ -15,7 +15,7 @@ internal static class Entrypoints
     private static unsafe int Init(ulong descriptor, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext, IntPtr* handle)
     {
         // TODO: [cdac] Better error code/details
-        if (!Target.TryCreate(descriptor, readFromTarget, readContext, out Target? target))
+        if (!Target.TryCreate(descriptor, (address, buffer, bufferLength) => readFromTarget(address, buffer, bufferLength, readContext), out Target? target))
             return -1;
 
         GCHandle gcHandle = GCHandle.Alloc(target);

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -81,9 +81,11 @@ public sealed unsafe class Target
     internal Contracts.Registry Contracts { get; }
     internal DataCache ProcessedData { get; }
 
-    public static bool TryCreate(ulong contractDescriptor, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext, out Target? target)
+    public delegate int ReadFromTargetDelegate(ulong address, byte* buffer, uint bytesToRead);
+
+    public static bool TryCreate(ulong contractDescriptor, ReadFromTargetDelegate readFromTarget, out Target? target)
     {
-        Reader reader = new Reader(readFromTarget, readContext);
+        Reader reader = new Reader(readFromTarget);
         if (TryReadContractDescriptor(contractDescriptor, reader, out Configuration config, out ContractDescriptorParser.ContractDescriptor? descriptor, out TargetPointer[] pointerData))
         {
             target = new Target(config, descriptor!, pointerData, reader);
@@ -418,26 +420,17 @@ public sealed unsafe class Target
         }
     }
 
-    private sealed class Reader
+    private struct Reader(Target.ReadFromTargetDelegate readFromTarget)
     {
-        private readonly delegate* unmanaged<ulong, byte*, uint, void*, int> _readFromTarget;
-        private readonly void* _context;
-
-        public Reader(delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* context)
-        {
-            _readFromTarget = readFromTarget;
-            _context = context;
-        }
-
         public int ReadFromTarget(ulong address, Span<byte> buffer)
         {
             fixed (byte* bufferPtr = buffer)
             {
-                return _readFromTarget(address, bufferPtr, (uint)buffer.Length, _context);
+                return readFromTarget(address, bufferPtr, (uint)buffer.Length);
             }
         }
 
         public int ReadFromTarget(ulong address, byte* buffer, uint bytesToRead)
-            => _readFromTarget(address, buffer, bytesToRead, _context);
+            => readFromTarget(address, buffer, bytesToRead);
     }
 }

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -159,19 +159,16 @@ internal unsafe static class MockMemorySpace
 
     public static bool TryCreateTarget(ReadContext* context, out Target? target)
     {
-        return Target.TryCreate(ContractDescriptorAddr, (address, buffer, length) => ReadFromTarget(address, buffer, length, context), out target);
+        return Target.TryCreate(ContractDescriptorAddr, (address, buffer) => ReadFromTarget(address, buffer, context), out target);
     }
 
-    private static int ReadFromTarget(ulong address, byte* buffer, uint length, ReadContext* context)
+    private static int ReadFromTarget(ulong address, Span<byte> span, ReadContext* readContext)
     {
-        ReadContext* readContext = (ReadContext*)context;
-        var span = new Span<byte>(buffer, (int)length);
-
         // Populate the span with the requested portion of the contract descriptor
-        if (address >= ContractDescriptorAddr && address <= ContractDescriptorAddr + (ulong)readContext->ContractDescriptorLength - length)
+        if (address >= ContractDescriptorAddr && address <= ContractDescriptorAddr + (ulong)readContext->ContractDescriptorLength - (uint)span.Length)
         {
             ulong offset = address - ContractDescriptorAddr;
-            new ReadOnlySpan<byte>(readContext->ContractDescriptor + offset, (int)length).CopyTo(span);
+            new ReadOnlySpan<byte>(readContext->ContractDescriptor + offset, span.Length).CopyTo(span);
             return 0;
         }
 
@@ -183,10 +180,10 @@ internal unsafe static class MockMemorySpace
         }
 
         // Populate the span with the requested portion of the pointer data
-        if (address >= ContractPointerDataAddr && address <= ContractPointerDataAddr + (ulong)readContext->PointerDataLength - length)
+        if (address >= ContractPointerDataAddr && address <= ContractPointerDataAddr + (ulong)readContext->PointerDataLength - (uint)span.Length)
         {
             ulong offset = address - ContractPointerDataAddr;
-            new ReadOnlySpan<byte>(readContext->PointerData + offset, (int)length).CopyTo(span);
+            new ReadOnlySpan<byte>(readContext->PointerData + offset, span.Length).CopyTo(span);
             return 0;
         }
 

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -159,11 +159,10 @@ internal unsafe static class MockMemorySpace
 
     public static bool TryCreateTarget(ReadContext* context, out Target? target)
     {
-        return Target.TryCreate(ContractDescriptorAddr, &ReadFromTarget, context, out target);
+        return Target.TryCreate(ContractDescriptorAddr, (address, buffer, length) => ReadFromTarget(address, buffer, length, context), out target);
     }
 
-    [UnmanagedCallersOnly]
-    private static int ReadFromTarget(ulong address, byte* buffer, uint length, void* context)
+    private static int ReadFromTarget(ulong address, byte* buffer, uint length, ReadContext* context)
     {
         ReadContext* readContext = (ReadContext*)context;
         var span = new Span<byte>(buffer, (int)length);


### PR DESCRIPTION
Today, the Target type in cdacreader takes an unmanaged function pointer and a context object to enable reading from target memory. This works well for the current implementation, where cdacreader is an implementation detail of the C++ DAC. However, this is more difficult for scenarios where the "reader" is also in managed code, as whatever the "context" object represents must be converted into an unmanaged function pointer. For the StressLogAnalyzer (#104999), it was relatively easy to represent the context object as a pointer. However, this is more difficult in scenarios like SOS's managed component, where the functionality to access memory is provided by a service object that's injected by a DI/IOC container.

To simplify managed-only usage scenarios, take a delegate instead of taking an unmanaged function pointer when constructing a `Target` object.