### PR TITLE
Don't throw when deserializing SettingsPropertyValue that's not byte[]

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
@@ -95,11 +95,11 @@ namespace System.Configuration
                     {
                         value = GetObjectFromString(Property.PropertyType, Property.SerializeAs, (string)SerializedValue);
                     }
-                    else
+                    else if (SerializedValue is byte[] serializedBytes)
                     {
                         if (SettingsProperty.EnableUnsafeBinaryFormatterInPropertyValueSerialization)
                         {
-                            using (MemoryStream ms = new MemoryStream((byte[])SerializedValue))
+                            using (MemoryStream ms = new MemoryStream(serializedBytes))
                             {
 #pragma warning disable SYSLIB0011 // BinaryFormatter serialization is obsolete and should not be used.
                                 value = (new BinaryFormatter()).Deserialize(ms);

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -6,6 +6,7 @@
     <DefineConstants>$(DefineConstants);LEGACY_GETRESOURCESTRING_USER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)TestUtilities\System\DisableParallelization.cs" Link="Common\TestUtilities\System\DisableParallelization.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs" Link="Common\System\IO\TempDirectory.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs" Link="Common\System\IO\TempFile.cs" />
     <Compile Include="..\src\System\Configuration\ConfigPathUtility.cs" Link="Source\ConfigPathUtility.cs" />

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Configuration;
 using Xunit;
 
 namespace System.ConfigurationTests
 {
+    [Collection(nameof(DisableParallelization))]
     public class LocalFileSettingsProviderTests
     {
         private readonly SettingsContext _testContext = new SettingsContext
@@ -14,7 +16,6 @@ namespace System.ConfigurationTests
             ["SettingsKey"] = "SettingsKeyFoo"
         };
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/29429")]
         [Fact]
         public void GetPropertyValues_NotStoredProperty_ValueEqualsNull()
         {
@@ -30,7 +31,6 @@ namespace System.ConfigurationTests
             Assert.Null(propertyValues["PropertyName"].PropertyValue);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/29429")]
         [Fact]
         public void GetPropertyValues_NotStoredConnectionStringProperty_ValueEqualsEmptyString()
         {
@@ -46,6 +46,33 @@ namespace System.ConfigurationTests
 
             Assert.Equal(1, propertyValues.Count);
             Assert.Equal(string.Empty, propertyValues["PropertyName"].PropertyValue);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(42)]
+        [InlineData(867.5309)]
+        [InlineData(StringComparison.Ordinal)]
+        public void GetPropertyValues_DefaultValueApplied(object defaultValue)
+        {
+            var provider = new LocalFileSettingsProvider();
+            var property = new SettingsProperty(
+                "Test",
+                defaultValue.GetType(),
+                provider,
+                false,
+                defaultValue,
+                SettingsSerializeAs.Xml,
+                new SettingsAttributeDictionary(),
+                false,
+                false);
+            property.Attributes.Add(typeof(UserScopedSettingAttribute), new UserScopedSettingAttribute());
+
+            var properties = new SettingsPropertyCollection() { property };
+            var propertyValues = provider.GetPropertyValues(_testContext, properties);
+
+            Assert.Equal(1, propertyValues.Count);
+            Assert.Equal(defaultValue, propertyValues["Test"].PropertyValue);
         }
     }
 }


### PR DESCRIPTION
Fixes: #104914, #29429

As mentioned in the issue, this problem was introduced in net6.0 when `EnableUnsafeBinaryFormatterInPropertyValueSerialization` check was added.

Previously this would not even hit BinaryFormatter, it would thow when casting to `byte[]` and that would be caught and execution would continue.

With the change in 6.0 it began throwing when `EnableUnsafeBinaryFormatterInPropertyValueSerialization` was not set.  To avoid this, we'll test first if we could even use `BinaryFormatter` before consulting the flag to throw.

This also fixes #29429 which was caused by contention for user.config between the tests in `LocalFileSettingsProviderTests`.