### PR TITLE
Disable manifest generation tests since they are flaky in CI

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -31,7 +31,7 @@ namespace BasicEventSourceTests
         /// ETW only works with elevated process
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServerAndRemoteExecutorSupported))]
         [SkipOnCoreClr("Test should only be run in non-stress modes", ~RuntimeTestModes.RegularRun)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/97255", typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88027")]
         public void Test_EventSource_EtwManifestGeneration()
         {
             var pid = Process.GetCurrentProcess().Id;
@@ -72,7 +72,7 @@ namespace BasicEventSourceTests
 
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServerAndRemoteExecutorSupported))]
         [SkipOnCoreClr("Test should only be run in non-stress modes", ~RuntimeTestModes.RegularRun)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/97255", typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88027")]
         public void Test_EventSource_EtwManifestGenerationRollover()
         {
             var pid = Process.GetCurrentProcess().Id;


### PR DESCRIPTION
The test failure is not understood and would require a significant investment to figure out what is failing, disabling since we keep getting hits in #88027