### PR TITLE
JIT: Use conservative VNs in `StaysWithinManagedObject`

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1766,8 +1766,7 @@ void StrengthReductionContext::AdvanceCursors(ArrayStack<CursorInfo>* cursors, A
 //   This function may remove cursors from m_cursors1 and m_cursors2 if it
 //   decides to no longer consider some cursors for strength reduction.
 //
-bool StrengthReductionContext::CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors,
-                                                    ScevAddRec**            nextIV)
+bool StrengthReductionContext::CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors, ScevAddRec** nextIV)
 {
     *nextIV = nullptr;
 

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1844,14 +1844,14 @@ bool StrengthReductionContext::StaysWithinManagedObject(ArrayStack<CursorInfo>* 
 
     ScevLocal* local = (ScevLocal*)baseScev;
 
-    ValueNum vn = m_scevContext.MaterializeVN(baseScev);
-    if (vn == ValueNumStore::NoVN)
+    ValueNumPair vnp = m_scevContext.MaterializeVN(baseScev);
+    if (vnp.GetConservative() == ValueNumStore::NoVN)
     {
         return false;
     }
 
     BasicBlock* preheader = m_loop->EntryEdge(0)->getSourceBlock();
-    if (!m_comp->optAssertionVNIsNonNull(vn, preheader->bbAssertionOut))
+    if (!m_comp->optAssertionVNIsNonNull(vnp.GetConservative(), preheader->bbAssertionOut))
     {
         return false;
     }
@@ -1889,15 +1889,15 @@ bool StrengthReductionContext::StaysWithinManagedObject(ArrayStack<CursorInfo>* 
             continue;
         }
 
-        ValueNum boundBaseVN = m_scevContext.MaterializeVN(boundBase);
+        ValueNumPair boundBaseVN = m_scevContext.MaterializeVN(boundBase);
 
         VNFuncApp vnf;
-        if (!m_comp->vnStore->GetVNFunc(boundBaseVN, &vnf))
+        if (!m_comp->vnStore->GetVNFunc(boundBaseVN.GetConservative(), &vnf))
         {
             continue;
         }
 
-        if ((vnf.m_func != VNF_ARR_LENGTH) || (vnf.m_args[0] != vn))
+        if ((vnf.m_func != VNF_ARR_LENGTH) || (vnf.m_args[0] != vnp.GetConservative()))
         {
             continue;
         }

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1300,7 +1300,7 @@ class StrengthReductionContext
     bool        InitializeCursors(GenTreeLclVarCommon* primaryIVLcl, ScevAddRec* primaryIV);
     bool        IsUseExpectedToBeRemoved(BasicBlock* block, Statement* stmt, GenTreeLclVarCommon* tree);
     void        AdvanceCursors(ArrayStack<CursorInfo>* cursors, ArrayStack<CursorInfo>* nextCursors);
-    bool        CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors, int derivedLevel, ScevAddRec** nextIV);
+    bool        CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors, ScevAddRec** nextIV);
     bool        StaysWithinManagedObject(ArrayStack<CursorInfo>* cursors, ScevAddRec* addRec);
     bool        TryReplaceUsesWithNewPrimaryIV(ArrayStack<CursorInfo>* cursors, ScevAddRec* iv);
     BasicBlock* FindUpdateInsertionPoint(ArrayStack<CursorInfo>* cursors);
@@ -1423,7 +1423,7 @@ bool StrengthReductionContext::TryStrengthReduce()
 
             // Verify that all cursors still represent the same IV
             ScevAddRec* nextIV = nullptr;
-            if (!CheckAdvancedCursors(nextCursors, derivedLevel + 1, &nextIV))
+            if (!CheckAdvancedCursors(nextCursors, &nextIV))
             {
                 break;
             }
@@ -1734,7 +1734,7 @@ void StrengthReductionContext::AdvanceCursors(ArrayStack<CursorInfo>* cursors, A
         for (int i = 0; i < nextCursors->Height(); i++)
         {
             CursorInfo& nextCursor = nextCursors->BottomRef(i);
-            printf("    [%d] [%06u]%s: ", i, nextCursor.Tree == nullptr ? 0 : Compiler::dspTreeID(nextCursor.Tree));
+            printf("    [%d] [%06u]: ", i, nextCursor.Tree == nullptr ? 0 : Compiler::dspTreeID(nextCursor.Tree));
             if (nextCursor.IV == nullptr)
             {
                 printf("<null IV>");
@@ -1755,8 +1755,6 @@ void StrengthReductionContext::AdvanceCursors(ArrayStack<CursorInfo>* cursors, A
 //
 // Parameters:
 //   cursors      - List of cursors that were advanced.
-//   derivedLevel - The derived level of the advanced IVs. That is, the number
-//                  of times they are derived from the primary IV.
 //   nextIV       - [out] The next derived IV from the subset of advanced
 //                  cursors to now consider strength reducing.
 //
@@ -1769,7 +1767,6 @@ void StrengthReductionContext::AdvanceCursors(ArrayStack<CursorInfo>* cursors, A
 //   decides to no longer consider some cursors for strength reduction.
 //
 bool StrengthReductionContext::CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors,
-                                                    int                     derivedLevel,
                                                     ScevAddRec**            nextIV)
 {
     *nextIV = nullptr;

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1300,7 +1300,7 @@ class StrengthReductionContext
     bool        InitializeCursors(GenTreeLclVarCommon* primaryIVLcl, ScevAddRec* primaryIV);
     bool        IsUseExpectedToBeRemoved(BasicBlock* block, Statement* stmt, GenTreeLclVarCommon* tree);
     void        AdvanceCursors(ArrayStack<CursorInfo>* cursors, ArrayStack<CursorInfo>* nextCursors);
-    bool        CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors, ScevAddRec** nextIV);
+    bool        CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors, int derivedLevel, ScevAddRec** nextIV);
     bool        StaysWithinManagedObject(ArrayStack<CursorInfo>* cursors, ScevAddRec* addRec);
     bool        TryReplaceUsesWithNewPrimaryIV(ArrayStack<CursorInfo>* cursors, ScevAddRec* iv);
     BasicBlock* FindUpdateInsertionPoint(ArrayStack<CursorInfo>* cursors);
@@ -1423,7 +1423,7 @@ bool StrengthReductionContext::TryStrengthReduce()
 
             // Verify that all cursors still represent the same IV
             ScevAddRec* nextIV = nullptr;
-            if (!CheckAdvancedCursors(nextCursors, &nextIV))
+            if (!CheckAdvancedCursors(nextCursors, derivedLevel + 1, &nextIV))
             {
                 break;
             }
@@ -1734,7 +1734,7 @@ void StrengthReductionContext::AdvanceCursors(ArrayStack<CursorInfo>* cursors, A
         for (int i = 0; i < nextCursors->Height(); i++)
         {
             CursorInfo& nextCursor = nextCursors->BottomRef(i);
-            printf("    [%d] [%06u]: ", i, nextCursor.Tree == nullptr ? 0 : Compiler::dspTreeID(nextCursor.Tree));
+            printf("    [%d] [%06u]%s: ", i, nextCursor.Tree == nullptr ? 0 : Compiler::dspTreeID(nextCursor.Tree));
             if (nextCursor.IV == nullptr)
             {
                 printf("<null IV>");
@@ -1755,6 +1755,8 @@ void StrengthReductionContext::AdvanceCursors(ArrayStack<CursorInfo>* cursors, A
 //
 // Parameters:
 //   cursors      - List of cursors that were advanced.
+//   derivedLevel - The derived level of the advanced IVs. That is, the number
+//                  of times they are derived from the primary IV.
 //   nextIV       - [out] The next derived IV from the subset of advanced
 //                  cursors to now consider strength reducing.
 //
@@ -1766,7 +1768,9 @@ void StrengthReductionContext::AdvanceCursors(ArrayStack<CursorInfo>* cursors, A
 //   This function may remove cursors from m_cursors1 and m_cursors2 if it
 //   decides to no longer consider some cursors for strength reduction.
 //
-bool StrengthReductionContext::CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors, ScevAddRec** nextIV)
+bool StrengthReductionContext::CheckAdvancedCursors(ArrayStack<CursorInfo>* cursors,
+                                                    int                     derivedLevel,
+                                                    ScevAddRec**            nextIV)
 {
     *nextIV = nullptr;
 

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -244,7 +244,7 @@ class ScalarEvolutionContext
     bool                  MayOverflowBeforeExit(ScevAddRec* lhs, Scev* rhs, VNFunc exitOp);
     bool AddRecMayOverflow(ScevAddRec* addRec, bool signedBound, const SimplificationAssumptions& assumptions);
 
-    bool Materialize(Scev* scev, bool createIR, GenTree** result, ValueNum* resultVN);
+    bool Materialize(Scev* scev, bool createIR, GenTree** result, ValueNumPair* resultVN);
 
 public:
     ScalarEvolutionContext(Compiler* comp);
@@ -264,6 +264,6 @@ public:
 
     Scev* ComputeExitNotTakenCount(BasicBlock* exiting);
 
-    GenTree* Materialize(Scev* scev);
-    ValueNum MaterializeVN(Scev* scev);
+    GenTree*     Materialize(Scev* scev);
+    ValueNumPair MaterializeVN(Scev* scev);
 };


### PR DESCRIPTION
- Switch `MaterializeVN` to materialize a full VNP
- Switch `StaysWithinManagedObject` to use conservative VNs to prove
  whether the array is non-null, to be consistent with assertion prop

This allows us to prove that add recs stay within an array (much) more often.