### PR TITLE
JIT: Skip moving `BBJ_COND` jump target if fallthrough target is equally likely

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4536,6 +4536,13 @@ void Compiler::fgMoveHotJumps()
                 targetEdge   = block->GetFalseEdge();
                 unlikelyEdge = block->GetTrueEdge();
             }
+
+            // If we aren't sure which successor is hotter, and we already fall into one of them,
+            // do nothing
+            if ((unlikelyEdge->getLikelihood() == 0.5) && block->NextIs(unlikelyEdge->getDestinationBlock()))
+            {
+                continue;
+            }
         }
         else
         {


### PR DESCRIPTION
Fixes #105083. In `Compiler::fgMoveHotJumps`, if a `BBJ_COND` block falls into one of its targets, and its targets are equally likely to be taken, don't bother moving anything.