### PR TITLE
Disable Comparer_get_Default test on win-arm64-crossgen

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -673,6 +673,13 @@
             <Issue>https://github.com/dotnet/runtime/issues/85663</Issue>
         </ExcludeList>
     </ItemGroup>
+    
+    <!-- Crossgen2 win-arm64 specific excludes -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'windows'">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Devirtualization/Comparer_get_Default/*">
+            <Issue>https://github.com/dotnet/runtime/issues/104927</Issue>
+        </ExcludeList>
+    </ItemGroup>
 
     <!-- NativeAOT specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr'">


### PR DESCRIPTION
Disable this test (https://github.com/dotnet/runtime/issues/104927) on win-arm64 on crossgen pipelines, the issue seems to be DoubleEnum type specific (not marked as HVA)

I'll take a look post-P7 snap