### PR TITLE
Fix incremental builds by modifying timestamps of unchanged outputs

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -56,6 +56,11 @@
       SourceFiles="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')"
       DestinationFiles="@(AsnXml -> '%(Identity).cs')" />
 
+    <!-- We need to touch all of the files' timestamps even if there were no meaningful changes the the output.
+    Otherwise, MSBuild will think the output from the target is still out of date, and it will continue to re-run the
+    target for all inputs for incremental builds. -->
+    <Touch Files="@(AsnXml -> '%(Identity).cs')" />
+
     <Warning Condition="'@(_FilesDiffer)' == 'true'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
   </Target>
 </Project>

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -56,10 +56,11 @@
       SourceFiles="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')"
       DestinationFiles="@(AsnXml -> '%(Identity).cs')" />
 
-    <!-- We need to touch all of the files' timestamps even if there were no meaningful changes the the output.
+    <!-- For files that were not copied because there were no meaningful changes, we still need to touch the timestamp
+    if they were part of the build input.
     Otherwise, MSBuild will think the output from the target is still out of date, and it will continue to re-run the
     target for all inputs for incremental builds. -->
-    <Touch Files="@(AsnXml -> '%(Identity).cs')" />
+    <Touch Condition="'@(_FilesDiffer)' != 'true'" Files="@(AsnXml -> '%(Identity).cs')" />
 
     <Warning Condition="'@(_FilesDiffer)' == 'true'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
   </Target>


### PR DESCRIPTION
This fixes incremental builds for the AsnXml targets.

Each C# file has a dependency on their respective XML file. For example:

https://github.com/dotnet/runtime/blob/e441c1847dd408ee6f374a49c2026d795a7748d9/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj#L58-L61

Now let's say I make a non-meaningful change to the XML file that does not affect the output of the C#. Maybe I added an XML comment that explains something or fixed some formatting.

MSBuild will see that the XML file changed, and think that it needs to update the output from the target. However, our target only conditionally copies the file to the output if there were changes, this would result in no change to the C# file - including the timestamp. So the C# file was never modified (including the timestamp).

The next time MSBuild runs and does an incremental build, it is going to see, again, that the C# file is out of date because its timestamp was not modified. So it runs the AsnXml target, and the transformation, again for the input.

This is more pronounced when you modify `asn.xslt`, as that affects _all_ outputs, and is an input into the task:

https://github.com/dotnet/runtime/blob/e441c1847dd408ee6f374a49c2026d795a7748d9/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets#L34

If `asn.xslt` changes, then it expects all of the C# files to be updated. If they aren't,  it runs the XSLT transformation every single time for all inputs.

Fixes #105077.

/cc @ViktorHofer 