### PR TITLE
JIT: Improve and fix `StaysWithinManagedObject`

### DIFF
--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -1501,16 +1501,13 @@ RelopEvaluationResult ScalarEvolutionContext::EvaluateRelop(ValueNum vn)
     }
 
     // Evaluate by using dominators and RBO's logic.
+    assert(m_comp->m_domTree != nullptr);
     //
     // TODO-CQ: Using assertions could be stronger given its dataflow, but it
     // is not convenient to use (optVNConstantPropOnJTrue does not actually
     // make any use of assertions to evaluate conditionals, so it seems like
     // the logic does not actually exist anywhere.)
     //
-    if (m_comp->m_domTree == nullptr)
-    {
-        m_comp->m_domTree = FlowGraphDominatorTree::Build(m_comp->m_dfsTree);
-    }
 
     for (BasicBlock* idom = m_loop->GetHeader()->bbIDom; idom != nullptr; idom = idom->bbIDom)
     {

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -239,10 +239,9 @@ class ScalarEvolutionContext
     Scev* CreateScevForConstant(GenTreeIntConCommon* tree);
     void  ExtractAddOperands(ScevBinop* add, ArrayStack<Scev*>& operands);
 
-    VNFunc                MapRelopToVNFunc(genTreeOps oper, bool isUnsigned);
-    RelopEvaluationResult EvaluateRelop(ValueNum relop);
-    bool                  MayOverflowBeforeExit(ScevAddRec* lhs, Scev* rhs, VNFunc exitOp);
-    bool AddRecMayOverflow(ScevAddRec* addRec, bool signedBound, const SimplificationAssumptions& assumptions);
+    VNFunc MapRelopToVNFunc(genTreeOps oper, bool isUnsigned);
+    bool   MayOverflowBeforeExit(ScevAddRec* lhs, Scev* rhs, VNFunc exitOp);
+    bool   AddRecMayOverflow(ScevAddRec* addRec, bool signedBound, const SimplificationAssumptions& assumptions);
 
     bool Materialize(Scev* scev, bool createIR, GenTree** result, ValueNumPair* resultVN);
 
@@ -262,7 +261,8 @@ public:
     static const SimplificationAssumptions NoAssumptions;
     Scev* Simplify(Scev* scev, const SimplificationAssumptions& assumptions = NoAssumptions);
 
-    Scev* ComputeExitNotTakenCount(BasicBlock* exiting);
+    Scev*                 ComputeExitNotTakenCount(BasicBlock* exiting);
+    RelopEvaluationResult EvaluateRelop(ValueNum relop);
 
     GenTree*     Materialize(Scev* scev);
     ValueNumPair MaterializeVN(Scev* scev);


### PR DESCRIPTION
- For string accesses we also produce `ARR_ADDR`, so we must take care to use `GenTreeArrAddr::GetFirstElemOffset` instead of hardcoding `OFFSETOF__CORINFO_Array__data`
- There are cases where VN is fully able to prove that bound < ARR_LENGTH(vn), specifically when the array is stored in a static readonly field. In those cases everything reduces to constants, so allow VN to try to prove it but fall back to our manual logic otherwise.
- Rephrase the fallback as a VN test as well. In a standard `for (;i < arr.Length;)` loop we have a bound on the backedge of the shape `ARR_LENGTH(array) - 1`. The previous strategy was to syntactically check if the LHS was such an array length on the same array as the base of the add recurrence.

  Instead of doing that, we can ask more generally for any shape `x - c` whether we know that `x <= ARR_LENGTH(array)`. In the usual case of `x == ARR_LENGTH(array)` this is trivially true and VN knows that. However, there are other cases where this is provable by RBO due to a dominating compare; particularly loop cloning introduces these dominating compares when cloning loops of the shape `for (; i < n;)`. This fixes #105087.