### PR TITLE
Generate type generic composition information as constructed

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -13,6 +13,7 @@ using Debug = System.Diagnostics.Debug;
 using EcmaModule = Internal.TypeSystem.Ecma.EcmaModule;
 using CustomAttributeHandle = System.Reflection.Metadata.CustomAttributeHandle;
 using ExportedTypeHandle = System.Reflection.Metadata.ExportedTypeHandle;
+using FlowAnnotations = ILLink.Shared.TrimAnalysis.FlowAnnotations;
 
 namespace ILCompiler
 {
@@ -32,7 +33,7 @@ namespace ILCompiler
         public AnalysisBasedMetadataManager(CompilerTypeSystemContext typeSystemContext)
             : this(typeSystemContext, new FullyBlockedMetadataBlockingPolicy(),
                 new FullyBlockedManifestResourceBlockingPolicy(), null, new NoStackTraceEmissionPolicy(),
-                new NoDynamicInvokeThunkGenerationPolicy(), Array.Empty<ModuleDesc>(), Array.Empty<TypeDesc>(),
+                new NoDynamicInvokeThunkGenerationPolicy(), null, Array.Empty<ModuleDesc>(), Array.Empty<TypeDesc>(),
                 Array.Empty<ReflectableEntity<TypeDesc>>(), Array.Empty<ReflectableEntity<MethodDesc>>(),
                 Array.Empty<ReflectableEntity<FieldDesc>>(), Array.Empty<ReflectableCustomAttribute>(),
                 default)
@@ -46,6 +47,7 @@ namespace ILCompiler
             string logFile,
             StackTraceEmissionPolicy stackTracePolicy,
             DynamicInvokeThunkGenerationPolicy invokeThunkGenerationPolicy,
+            FlowAnnotations flowAnnotations,
             IEnumerable<ModuleDesc> modulesWithMetadata,
             IEnumerable<TypeDesc> forcedTypes,
             IEnumerable<ReflectableEntity<TypeDesc>> reflectableTypes,
@@ -53,7 +55,7 @@ namespace ILCompiler
             IEnumerable<ReflectableEntity<FieldDesc>> reflectableFields,
             IEnumerable<ReflectableCustomAttribute> reflectableAttributes,
             MetadataManagerOptions options)
-            : base(typeSystemContext, blockingPolicy, resourceBlockingPolicy, logFile, stackTracePolicy, invokeThunkGenerationPolicy, options)
+            : base(typeSystemContext, blockingPolicy, resourceBlockingPolicy, logFile, stackTracePolicy, invokeThunkGenerationPolicy, options, flowAnnotations)
         {
             _modulesWithMetadata = new List<ModuleDesc>(modulesWithMetadata);
             _forcedTypes = new List<TypeDesc>(forcedTypes);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1254,7 +1254,8 @@ namespace ILCompiler.DependencyAnalysis
 
                     ISymbolNode compositionNode;
 
-                    if (this == factory.MaximallyConstructableType(_type))
+                    if (this == factory.MaximallyConstructableType(_type)
+                        && factory.MetadataManager.IsTypeInstantiationReflectionVisible(_type))
                     {
                         compositionNode = _type.Instantiation.Length > 1
                             ? factory.ConstructedGenericComposition(_type.Instantiation)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1252,9 +1252,20 @@ namespace ILCompiler.DependencyAnalysis
                     else
                         objData.EmitPointerReloc(typeDefNode);
 
-                    ISymbolNode compositionNode = _type.Instantiation.Length > 1
-                        ? factory.GenericComposition(_type.Instantiation)
-                        : factory.NecessaryTypeSymbol(_type.Instantiation[0]);
+                    ISymbolNode compositionNode;
+
+                    if (this == factory.MaximallyConstructableType(_type))
+                    {
+                        compositionNode = _type.Instantiation.Length > 1
+                            ? factory.ConstructedGenericComposition(_type.Instantiation)
+                            : factory.MaximallyConstructableType(_type.Instantiation[0]);
+                    }
+                    else
+                    {
+                        compositionNode = _type.Instantiation.Length > 1
+                            ? factory.GenericComposition(_type.Instantiation)
+                            : factory.NecessaryTypeSymbol(_type.Instantiation[0]);
+                    }
 
                     if (factory.Target.SupportsRelativePointers)
                         objData.EmitReloc(compositionNode, RelocType.IMAGE_REL_BASED_RELPTR32);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -478,7 +478,12 @@ namespace ILCompiler.DependencyAnalysis
 
             _genericCompositions = new NodeCache<Instantiation, GenericCompositionNode>((Instantiation details) =>
             {
-                return new GenericCompositionNode(details);
+                return new GenericCompositionNode(details, constructed: false);
+            });
+
+            _constructedGenericCompositions = new NodeCache<Instantiation, GenericCompositionNode>((Instantiation details) =>
+            {
+                return new GenericCompositionNode(details, constructed: true);
             });
 
             _genericVariances = new NodeCache<GenericVarianceDetails, GenericVarianceNode>((GenericVarianceDetails details) =>
@@ -845,6 +850,13 @@ namespace ILCompiler.DependencyAnalysis
         internal ISymbolNode GenericComposition(Instantiation details)
         {
             return _genericCompositions.GetOrAdd(details);
+        }
+
+        private NodeCache<Instantiation, GenericCompositionNode> _constructedGenericCompositions;
+
+        internal ISymbolNode ConstructedGenericComposition(Instantiation details)
+        {
+            return _constructedGenericCompositions.GetOrAdd(details);
         }
 
         private NodeCache<GenericVarianceDetails, GenericVarianceNode> _genericVariances;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -65,8 +65,6 @@ namespace ILCompiler
         private readonly HashSet<string> _trimmedAssemblies;
         private readonly List<string> _satelliteAssemblyFiles;
 
-        internal FlowAnnotations FlowAnnotations { get; }
-
         internal Logger Logger { get; }
 
         public UsageBasedMetadataManager(
@@ -86,12 +84,11 @@ namespace ILCompiler
             IEnumerable<string> additionalRootedAssemblies,
             IEnumerable<string> trimmedAssemblies,
             IEnumerable<string> satelliteAssemblyFilePaths)
-            : base(typeSystemContext, blockingPolicy, resourceBlockingPolicy, logFile, stackTracePolicy, invokeThunkGenerationPolicy, options)
+            : base(typeSystemContext, blockingPolicy, resourceBlockingPolicy, logFile, stackTracePolicy, invokeThunkGenerationPolicy, options, flowAnnotations)
         {
             _compilationModuleGroup = group;
             _generationOptions = generationOptions;
 
-            FlowAnnotations = flowAnnotations;
             Logger = logger;
 
             _linkAttributesHashTable = new LinkAttributesHashTable(Logger, featureSwitchValues);
@@ -896,7 +893,7 @@ namespace ILCompiler
             }
 
             return new AnalysisBasedMetadataManager(
-                _typeSystemContext, _blockingPolicy, _resourceBlockingPolicy, _metadataLogFile, _stackTraceEmissionPolicy, _dynamicInvokeThunkGenerationPolicy,
+                _typeSystemContext, _blockingPolicy, _resourceBlockingPolicy, _metadataLogFile, _stackTraceEmissionPolicy, _dynamicInvokeThunkGenerationPolicy, FlowAnnotations,
                 _modulesWithMetadata, _typesWithForcedEEType, reflectableTypes.ToEnumerable(), reflectableMethods.ToEnumerable(),
                 reflectableFields.ToEnumerable(), _customAttributesWithMetadata, _options);
         }

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -72,6 +72,8 @@ internal static class ReflectionTest
         TestAbstractGenericLdtoken.Run();
         TestTypeHandlesVisibleFromIDynamicInterfaceCastable.Run();
         TestCompilerGeneratedCode.Run();
+        Test105034Regression.Run();
+
 
         //
         // Mostly functionality tests
@@ -710,6 +712,45 @@ internal static class ReflectionTest
             TestGeneric<string>();
 
             TestGeneric<int>();
+        }
+    }
+
+    class Test105034Regression
+    {
+        interface IFactory
+        {
+            object Make();
+        }
+
+        interface IOption<T> where T : new() { }
+
+        class OptionFactory<T> : IFactory where T : class, new()
+        {
+            public object Make() => new T();
+        }
+
+        class Gen<T> { }
+
+        struct Atom { }
+
+        static Type Register<T>() => typeof(T).GetGenericArguments()[0];
+        static IFactory Activate(Type t) => (IFactory)Activator.CreateInstance(typeof(OptionFactory<>).MakeGenericType(t));
+
+        public static void Run()
+        {
+            Console.WriteLine(nameof(Test105034Regression));
+
+            Wrap<Atom>();
+
+            static void Wrap<T>()
+            {
+
+                Type t = Register();
+                static Type Register() => Register<IOption<Gen<T>>>();
+
+                var f = Activate(t);
+                f.Make();
+            }
         }
     }
 
@@ -2485,7 +2526,7 @@ internal static class ReflectionTest
     {
         class Atom { }
 
-        public static object MakeMdArray<T>() => new T[1,1,1];
+        public static object MakeMdArray<T>() => new T[1, 1, 1];
 
         public static void Run()
         {

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -268,12 +268,31 @@ class DeadCodeElimination
                 if (!o.ToString().Contains(nameof(Marker1)))
                     throw new Exception();
             }
+
+            // ...but not reference type element types
+            {
+                Array arr = new NeverAllocated3[1];
+                arr.GetValue(0);
+                ThrowIfPresent(typeof(TestArrayElementTypeOperations), nameof(Marker3));
+            }
         }
 
         class Marker1 { }
         struct NeverAllocated1
         {
             public override string ToString() => typeof(Marker1).ToString();
+        }
+
+        class Marker2 { }
+        struct NeverAllocated2
+        {
+            public override string ToString() => typeof(Marker2).ToString();
+        }
+
+        class Marker3 { }
+        class NeverAllocated3
+        {
+            public override string ToString() => typeof(Marker3).ToString();
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -268,39 +268,12 @@ class DeadCodeElimination
                 if (!o.ToString().Contains(nameof(Marker1)))
                     throw new Exception();
             }
-
-            // ...but not nullable...
-            {
-                Array arr = new Nullable<NeverAllocated2>[1];
-                arr.GetValue(0);
-                ThrowIfPresent(typeof(TestArrayElementTypeOperations), nameof(Marker2));
-            }
-
-
-            // ...or reference type element types
-            {
-                Array arr = new NeverAllocated3[1];
-                arr.GetValue(0);
-                ThrowIfPresent(typeof(TestArrayElementTypeOperations), nameof(Marker3));
-            }
         }
 
         class Marker1 { }
         struct NeverAllocated1
         {
             public override string ToString() => typeof(Marker1).ToString();
-        }
-
-        class Marker2 { }
-        struct NeverAllocated2
-        {
-            public override string ToString() => typeof(Marker2).ToString();
-        }
-
-        class Marker3 { }
-        class NeverAllocated3
-        {
-            public override string ToString() => typeof(Marker3).ToString();
         }
     }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlowMarking.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlowMarking.cs
@@ -97,7 +97,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					public static void PublicMethod () { }
 					static void PrivateMethod () { }
 
-					[Kept]
+					[Kept(By = Tool.Trimmer)]
 					public void Use () { }
 				}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlowMarking.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlowMarking.cs
@@ -97,7 +97,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					public static void PublicMethod () { }
 					static void PrivateMethod () { }
 
-					[Kept(By = Tool.Trimmer)]
+					[Kept]
 					public void Use () { }
 				}
 


### PR DESCRIPTION
Fixes #105034.

Before this PR, whenever we had a generic instance `Foo<SomeType, OtherType<SomeOtherType>>` and we had a constructed `MethodTable` for this (i.e. `MethodTable` that is suitable to be used for types on the GC heap), we'd still try to optimize out the `MethodTable`s for `SomeType`, `OtherType<SomeOtherType>` into the "unconstructed" form (i.e. without a GCDesc or vtable).

This is generally a safe optimization - if `Foo<,>` actually had a `typeof(T)` somewhere, we'd upgrade the unconstructed forms into constructed forms, for example.

One place where the unconstructed types can be obtained is when reflection-inspecting such instantiation - asking for `GetGenericArguments` of a type could produce things that have unconstructed `MethodTable`s in them. In general, this is also fine - one can't do much reflection with these and asking for e.g. names would still work fine. Trying to access members or activating something obtained from `GetGenericArguments` would trigger trimming warnings, so that's also fine.

Enter Microsoft.Extension.DependencyInjection and a trimming warning suppression in there.

DI has support for something called `IOption<T>` where the T is annotated with DAM attributes. Then there's another type (`OptionFactory<T>`? Can't be bothered to look at that again.) that has the T annotated the same way. Then there's some code that will deconstruct the `IOption` instance that we saw statically, and `MakeGenericType` an `OptionFactory` with its generic arguments. The warnings on MakeGenericType are suppressed on account of: T is annotated the same, and T is not a valuetype.

The suppression _sounds_ reasonable. It just doesn't hold right now, since nothing accesses the T in IOption and we're therefore left with the unconstructed form of the T. The OptionFactory though accesses the T and tries to activate it.

This is especially a problem if IOption is instantiated over a generic type that is instantiated over a valuetype. We know we need to keep the ctor due to the annotation, but not on unconstructed forms of the type.

I was struggling with how to fix this. The easiest fix is to just stop optimizing things into unconstructed forms. This is a size regression.

Cc @dotnet/ilc-contrib 