### PR TITLE
Move telemetry out of lock scope

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -703,8 +703,8 @@ namespace System.Net
                         lock (s_tasks)
                         {
                             ((ICollection<KeyValuePair<object, Task>>)s_tasks).Remove(new KeyValuePair<object, Task>(key!, task));
-                            // Since it was canceled, func(..) had not executed and call AfterResolution it needs to be called here.
                         }
+                        // Since it was canceled, func(..) had not executed and call AfterResolution it needs to be called here.
                         NameResolutionTelemetry.Log.AfterResolution(key!, activity, new OperationCanceledException());
                     }, key, CancellationToken.None, TaskContinuationOptions.OnlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -704,8 +704,8 @@ namespace System.Net
                         {
                             ((ICollection<KeyValuePair<object, Task>>)s_tasks).Remove(new KeyValuePair<object, Task>(key!, task));
                             // Since it was canceled, func(..) had not executed and call AfterResolution it needs to be called here.
-                            NameResolutionTelemetry.Log.AfterResolution(key!, activity, new OperationCanceledException());
                         }
+                        NameResolutionTelemetry.Log.AfterResolution(key!, activity, new OperationCanceledException());
                     }, key, CancellationToken.None, TaskContinuationOptions.OnlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                 }
 


### PR DESCRIPTION
Fixes: comments for internal discussions

### Context
Although it should not be functional bug, having `lock(static_scope_object)` as short as possible is a good perf practice