### PR TITLE
Build Mono build tasks packs only when targeting mobile

### DIFF
--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -31,7 +31,7 @@
     <ProjectReference Include="Microsoft.NET.Runtime.LibraryBuilder.Sdk\Microsoft.NET.Runtime.LibraryBuilder.Sdk.pkgproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetsMobile)' == 'true'">
     <ProjectReference Include="Microsoft.NET.Runtime.MonoTargets.Sdk\Microsoft.NET.Runtime.MonoTargets.Sdk.pkgproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

`Microsoft.NET.Runtime.MonoTargets.Sdk` package is built even when it is not required.

From recently we started seeing runtime official builds doing retries (which is a separate concerning problem).

This is problematic for the `Build Workloads` (or `windows-x64 release Workloads`) job of the runtime official build. 
`Build Workloads` depends on the jobs that target mobile platforms, uses their outputs and produces its own artifacts which are later published and used in VS insertion stages. More specifically:
 
- `Build Workloads` dependencies publish `Microsoft.NET.Runtime.MonoTargets.Sdk.nupkg/.symbols`, while
- `Build Workloads` publishes `.msi` variants of this package

However, it can happen that a non-mobile targeted job failed on the first try of the official build e.g., `linux_musl_x64 Mono​` and that `Build Workload` succeeded producing the `.msi` variants. However, when `linux_musl_x64 Mono​` succeeds on the second try it again publishes a different `Microsoft.NET.Runtime.MonoTargets.Sdk.nupkg/.symbols` overwriting what was used in the first run of `Build Workload`, which makes the overall build non-deterministic, ie.:
- `Build Workload` published `.msi` packages with one version of `Microsoft.NET.Runtime.MonoTargets.Sdk`
- retry of `linux_musl_x64 Mono​` published a different version of `Microsoft.NET.Runtime.MonoTargets.Sdk.nupkg/.symbols`

As an end result, VS insertion reports issues during `Symbol Check` as we end up having a miss match between published `Microsoft.NET.Runtime.MonoTargets.Sdk.nupkg/.symbols` and the `.msi` variant.

## Changes

This PR limits building `Microsoft.NET.Runtime.MonoTargets.Sdk` package only when we target mobile which helps in prevention of having different versions of the same package as a result of an official build.

## Testing 

I manually ran an official build with this change in: https://dev.azure.com/dnceng/internal/_build/results?buildId=2493547 and verified that the build succeeds and that the `MergedManifest.xml` includes all the artifacts as without this change.

## Follow-up

Once approved we should backport this to our servicing branches as we have the same issue there as well.

Finally, we should investigate why retries of the official builds are enabled as that seems like an undesired behavior.