### PR TITLE
[mono][aot] Emit marhsalling exception when dealing with MONO_MARSHAL_CONV_OBJECT_IUNKNOWN

### DIFF
--- a/src/mono/mono/metadata/marshal-shared.c
+++ b/src/mono/mono/metadata/marshal-shared.c
@@ -1225,6 +1225,11 @@ mono_marshal_shared_emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *ty
 		mono_mb_emit_byte (mb, CEE_STIND_I);
 		break;
 	}
+	case MONO_MARSHAL_CONV_OBJECT_IUNKNOWN: {
+		char *msg = g_strdup_printf ("Marshaling not supported for COM type MONO_MARSHAL_CONV_OBJECT_IUNKNOWN.");
+		mono_marshal_shared_mb_emit_exception_marshal_directive (mb, msg);
+		break;
+	}
 
 	default: {
 		g_error ("marshalling conversion %d not implemented", conv);

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -727,16 +727,22 @@ namespace Wasm.Build.Tests
                 using System.Runtime.InteropServices;
                 using System.Runtime.InteropServices.ComTypes;
 
-                public static int Main(string[] args)
+                public class Test
                 {
-                    var s = new STGMEDIUM();
-                    ReleaseStgMedium(ref s);
-                    return 42;
+                    public static int Main(string[] args)
+                    {
+                        var s = new STGMEDIUM();
+                        ReleaseStgMedium(ref s);
+                        return 42;
+                    }
+
+                    [DllImport(""ole32.dll"")]
+                    internal static extern void ReleaseStgMedium(ref STGMEDIUM medium);
                 }
 
-                [DllImport(""ole32.dll"")]
-                internal static extern void ReleaseStgMedium(ref STGMEDIUM medium);
             ";
+
+            buildArgs = ExpandBuildArgs(buildArgs);
 
             (string libraryDir, string output) = BuildProject(buildArgs,
                                         id: id,
@@ -746,7 +752,6 @@ namespace Wasm.Build.Tests
                                                 File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), programText);
                                             },
                                             Publish: buildArgs.AOT,
-                                            // Verbosity: "diagnostic",
                                             DotnetWasmFromRuntimePack: true));
 
             Assert.Contains("Generated app bundle at " + libraryDir, output);

--- a/src/mono/wasm/Wasm.Build.Tests/README.md
+++ b/src/mono/wasm/Wasm.Build.Tests/README.md
@@ -14,7 +14,7 @@ being generated.
 
 - Running:
 
-Linux/macOS: `$ make -C src/mono/wasm run-build-tests`
+Linux/macOS: `$ make -C src/mono/(browser|wasi) run-build-tests`
 Windows: `.\dotnet.cmd build .\src\mono\wasm\Wasm.Build.Tests\Wasm.Build.Tests.csproj -c Release -t:Test -p:TargetOS=browser -p:TargetArchitecture=wasm`
 
 - Specific tests can be run via `XUnitClassName`, and `XUnitMethodName`


### PR DESCRIPTION
This change prevents the aot compiler from erroring out when dealing with COM types that were not marked with MarshalAs attributes. In most scenarios that we support, we want to allow pinvokes to aot compile as in cases like anything COM interop, will end up with PNSE at runtime if you try to use it.

Fixes https://github.com/dotnet/runtime/issues/104463