### PR TITLE
Make System.IO.Packaging test trim safe

### DIFF
--- a/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
@@ -17,8 +17,8 @@ namespace System.IO.Packaging.Tests
         private record class PartConstructionParameters (string FullPath, bool CreateAsAtomic, bool CreateAsValidPieceSequence, bool UppercaseFileName, bool ShufflePieces, int[] PieceLengths, FileContentsGenerator PieceGenerator)
         { }
 
-        private static Type s_ZipPackagePartPieceType = typeof(ZipPackage).Assembly.GetType("System.IO.Packaging.ZipPackagePartPiece");
-        private static MethodInfo s_TryParseZipPackagePartPiece = s_ZipPackagePartPieceType.GetMethod("TryParse", BindingFlags.Static | BindingFlags.NonPublic);
+        private static Type s_ZipPackagePartPieceType = Type.GetType("System.IO.Packaging.ZipPackagePartPiece, System.IO.Packaging");
+        private static MethodInfo s_TryParseZipPackagePartPiece = Type.GetType("System.IO.Packaging.ZipPackagePartPiece, System.IO.Packaging").GetMethod("TryParse", BindingFlags.Static | BindingFlags.NonPublic);
 
         private string m_contentTypesXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Types xmlns=""http://schemas.openxmlformats.org/package/2006/content-types"">

--- a/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
@@ -17,6 +18,7 @@ namespace System.IO.Packaging.Tests
         private record class PartConstructionParameters (string FullPath, bool CreateAsAtomic, bool CreateAsValidPieceSequence, bool UppercaseFileName, bool ShufflePieces, int[] PieceLengths, FileContentsGenerator PieceGenerator)
         { }
 
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
         private static Type s_ZipPackagePartPieceType = Type.GetType("System.IO.Packaging.ZipPackagePartPiece, System.IO.Packaging");
         private static MethodInfo s_TryParseZipPackagePartPiece = Type.GetType("System.IO.Packaging.ZipPackagePartPiece, System.IO.Packaging").GetMethod("TryParse", BindingFlags.Static | BindingFlags.NonPublic);
 


### PR DESCRIPTION
The existing pattern doesn't get statically analyzed and is breaking outerloop testing.