### PR TITLE
Fix method numbering in Memory-model.md example code

### DIFF
--- a/docs/design/specs/Memory-model.md
+++ b/docs/design/specs/Memory-model.md
@@ -188,7 +188,7 @@ void ThreadFunc1()
 }
 
 // thread #2
-void ThreadFunc1()
+void ThreadFunc2()
 {
     while (true)
     {
@@ -197,7 +197,7 @@ void ThreadFunc1()
 }
 
 // thread #3
-void ThreadFunc2()
+void ThreadFunc3()
 {
     MyClass localObj = obj;
     if (localObj != null)


### PR DESCRIPTION
Comments are numbering ThreadFuncs as 1,2,3 while method names are ThreadFunc1, ThreadFunc1, ThreadFunc2.