### PR TITLE
JIT: Switch `StaysWithinManagedObject` to peel offsets from VNs

### DIFF
--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -512,6 +512,8 @@ public:
 
     CORINFO_CLASS_HANDLE GetObjectType(ValueNum vn, bool* pIsExact, bool* pIsNonNull);
 
+    void PeelOffsets(ValueNum* vn, target_ssize_t* offset);
+
     // And the single constant for an object reference type.
     static ValueNum VNForNull()
     {


### PR DESCRIPTION
The SCEV analysis does not care about the value of something once it is seen to be invariant inside the loop we are currently analyzing. This was problematic for this logic that tries to peel offsets away from an array; for arm64, we may have hoisted `array + 0x10` outside the loop, which would cause us to fail to get back to the base array.

Switch the reasoning to use VNs and peel the offsets from the VNs instead.

No x64 diffs are expected as we do not hoist the `array + 0x10` out of the loop there. Improvements expected on arm64 where we can now prove that a "full" strength reduction is allowable more often.