### PR TITLE
Don't enable validation when UseDefaultServiceProvider is called

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Hosting
         private HostingEnvironment? _hostingEnvironment;
         private IServiceProvider? _appServices;
         private PhysicalFileProvider? _defaultProvider;
-        private readonly bool _defaultProviderFactoryUsed;
+        private bool _defaultProviderFactoryUsed;
 
         /// <summary>
         /// Initializes a new instance of <see cref="HostBuilder"/>.
@@ -109,6 +109,7 @@ namespace Microsoft.Extensions.Hosting
             ThrowHelper.ThrowIfNull(factory);
 
             _serviceProviderFactory = new ServiceFactoryAdapter<TContainerBuilder>(factory);
+            _defaultProviderFactoryUsed = false;
             return this;
         }
 
@@ -123,6 +124,7 @@ namespace Microsoft.Extensions.Hosting
             ThrowHelper.ThrowIfNull(factory);
 
             _serviceProviderFactory = new ServiceFactoryAdapter<TContainerBuilder>(() => _hostBuilderContext!, factory);
+            _defaultProviderFactoryUsed = false;
             return this;
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -577,7 +577,23 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             Assert.NotNull(host.Services.GetRequiredService<ServiceA>());
         }
+        [Fact]
+        public void ScopeValidationtEnabledInDevelopmentWithServiceProviderChanges()
+        {
+            var host = new HostBuilder()
+                .UseEnvironment(Environments.Development)
+                .ConfigureServices(services =>
+                {
+                    services.AddScoped<ServiceA>();
+                })
+                .UseDefaultServiceProvider((context, options) =>
+                {
+                    options.ValidateScopes = true;
+                })
+                .Build();
 
+            Assert.Throws<InvalidOperationException>(() => host.Services.GetRequiredService<ServiceA>());
+        }
         [Fact]
         public void ValidateOnBuildNotEnabledInDevelopmentWithServiceProviderChanges()
         {

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -561,6 +561,42 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Fact]
+        public void ScopeValidationNotEnabledInDevelopmentWithServiceProviderChanges()
+        {
+            using var host = new HostBuilder()
+                .UseEnvironment(Environments.Development)
+                .ConfigureServices(serices =>
+                {
+                    serices.AddScoped<ServiceA>();
+                })
+                .UseDefaultServiceProvider((context, options) =>
+                {
+                    options.ValidateScopes = false;
+                })
+                .Build();
+
+            Assert.NotNull(host.Services.GetRequiredService<ServiceA>());
+        }
+
+        [Fact]
+        public void ValidateOnBuildNotEnabledInDevelopmentWithServiceProviderChanges()
+        {
+            using var host = new HostBuilder()
+                .UseEnvironment(Environments.Development)
+                .ConfigureServices(serices =>
+                {
+                    serices.AddSingleton<ServiceC>();
+                })
+                .UseDefaultServiceProvider((context, options) =>
+                {
+                    options.ValidateOnBuild = false;
+                })
+                .Build();
+
+            Assert.NotNull(host);
+        }
+
+        [Fact]
         public void HostingContextContainsAppConfigurationDuringConfigureLogging()
         {
             var hostBuilder = new HostBuilder()


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/105134

Not entirely sure this is the right thing, or if we should just revert the regressing change.

Please have a look @wcsanders1 

