### PR TITLE
Add CollectionsMarshal.AsMemory

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -12,6 +12,18 @@ namespace System.Runtime.InteropServices
     public static class CollectionsMarshal
     {
         /// <summary>
+        /// Get a <see cref="Memory{T}"/> view over a <see cref="List{T}"/>'s data.
+        /// Items should not be added or removed from the <see cref="List{T}"/> while the <see cref="Memory{T}"/> is in use.
+        /// </summary>
+        /// <param name="list">The list to get the data view over.</param>
+        /// <typeparam name="T">The type of the elements in the list.</typeparam>
+        public static Memory<T> AsMemory<T>(List<T>? list)
+        {
+            ArgumentNullException.ThrowIfNull(list);
+            return new Memory<T>(list._items, 0, list._size);
+        }
+        
+        /// <summary>
         /// Get a <see cref="Span{T}"/> view over a <see cref="List{T}"/>'s data.
         /// Items should not be added or removed from the <see cref="List{T}"/> while the <see cref="Span{T}"/> is in use.
         /// </summary>

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -655,6 +655,7 @@ namespace System.Runtime.InteropServices
     }
     public static partial class CollectionsMarshal
     {
+        public static System.Memory<T> AsMemory<T>(System.Collections.Generic.List<T> list) { throw null; }
         public static System.Span<T> AsSpan<T>(System.Collections.Generic.List<T>? list) { throw null; }
         public static ref TValue GetValueRefOrNullRef<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key) where TKey : notnull { throw null; }
         public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, out bool exists) where TKey : notnull { throw null; }


### PR DESCRIPTION
This adds a new way to access the backing array of a `List<T>`. It works similarly to `CollectionsMarshal.AsSpan`, but returns a `Memory<T>` instead of a `Span<T>`.

Fixes #105179.