### PR TITLE
`Guid(Int32, Int16, Int16, Byte[])` changes

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/StandardCommands.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/StandardCommands.cs
@@ -1346,7 +1346,7 @@ namespace System.ComponentModel.Design
             internal static readonly Guid guidDsdCmdId = new Guid("{1F0FD094-8e53-11d2-8f9c-0060089fc486}");
             internal static readonly Guid SID_SOleComponentUIManager = new Guid("{5efc7974-14bc-11cf-9b2b-00aa00573819}");
             internal static readonly Guid GUID_VSTASKCATEGORY_DATADESIGNER = new Guid("{6B32EAED-13BB-11d3-A64F-00C04F683820}");
-            internal static readonly Guid GUID_PropertyBrowserToolWindow = new Guid(unchecked((int)0xeefa5220), unchecked((short)0xe298), unchecked((short)0x11d0), new byte[] { 0x8f, 0x78, 0x0, 0xa0, 0xc9, 0x11, 0x0, 0x57 });
+            internal static readonly Guid GUID_PropertyBrowserToolWindow = new Guid(0xeefa5220, 0xe298, 0x11d0, 0x8f, 0x78, 0x0, 0xa0, 0xc9, 0x11, 0x0, 0x57);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -127,13 +127,17 @@ namespace System
                 throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "8"), nameof(d));
             }
 
-            Unsafe.SkipInit(out this);
-
             _a = a;
             _b = b;
             _c = c;
-
-            Unsafe.CopyBlockUnaligned(ref _d, ref MemoryMarshal.GetArrayDataReference(d), 8);
+            _d = d[0];
+            _e = d[1];
+            _f = d[2];
+            _g = d[3];
+            _h = d[4];
+            _i = d[5];
+            _j = d[6];
+            _k = d[7];
         }
 
         // Creates a new GUID initialized to the value represented by the

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -127,17 +127,13 @@ namespace System
                 throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "8"), nameof(d));
             }
 
+            Unsafe.SkipInit(out this);
+
             _a = a;
             _b = b;
             _c = c;
-            _d = d[0];
-            _e = d[1];
-            _f = d[2];
-            _g = d[3];
-            _h = d[4];
-            _i = d[5];
-            _j = d[6];
-            _k = d[7];
+
+            Unsafe.CopyBlockUnaligned(ref _d, ref MemoryMarshal.GetArrayDataReference(d), 8);
         }
 
         // Creates a new GUID initialized to the value represented by the

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -130,7 +130,6 @@ namespace System
             _a = a;
             _b = b;
             _c = c;
-            _k = d[7]; // hoist bounds checks
             _d = d[0];
             _e = d[1];
             _f = d[2];
@@ -138,6 +137,7 @@ namespace System
             _h = d[4];
             _i = d[5];
             _j = d[6];
+            _k = d[7];
         }
 
         // Creates a new GUID initialized to the value represented by the


### PR DESCRIPTION
* Write bytes in order as the JIT can now elide the bounds check.
* Avoid use of this constructor (saves an array allocation).
