### PR TITLE
Reenable GC stress testing for MultipleALCs test

### DIFF
--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for GCStressIncompatible, UnloadabilityIncompatible, CMakeProjectReference -->
+    <!-- Needed for UnloadabilityIncompatible, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="RunInALC.cs" />


### PR DESCRIPTION
I was unable to repro the issue #47696 anymore even after running the tests for more than a day in a loop, so I am reenabling GC stress for it.

Close #47696