### PR TITLE
Disable failing schema test on mono runtimes.

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -26,6 +26,7 @@ namespace System.Text.Json.Schema.Tests
 
         [Theory]
         [MemberData(nameof(GetTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/103694", TestRuntimes.Mono)]
         public void TestTypes_GeneratesExpectedJsonSchema(ITestData testData)
         {
             JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(testData.Type, testData.Options);


### PR DESCRIPTION
Even though this disables the impacted `TestTypes_GeneratesExpectedJsonSchema` test on mono runtimes which checks for syntactic equality, the `TestTypes_SerializedValueMatchesGeneratedSchema` which evaluates the schema still runs on all platforms. 

Contributes to https://github.com/dotnet/runtime/issues/103694.