### PR TITLE
Revert "Do not encode safe points with -1 offset. (#104336)"

### DIFF
--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -678,8 +678,8 @@ void FASTCALL decodeCallPattern(int         pattern,
 #define NORMALIZE_SIZE_OF_STACK_AREA(x) ((x)>>2)
 #define DENORMALIZE_SIZE_OF_STACK_AREA(x) ((x)<<2)
 #define CODE_OFFSETS_NEED_NORMALIZATION 1
-#define NORMALIZE_CODE_OFFSET(x) ((x)>>1)   // Instructions are 2/4 bytes long in Thumb/ARM states,
-#define DENORMALIZE_CODE_OFFSET(x) ((x)<<1)
+#define NORMALIZE_CODE_OFFSET(x) (x)   // Instructions are 2/4 bytes long in Thumb/ARM states,
+#define DENORMALIZE_CODE_OFFSET(x) (x) // but the safe-point offsets are encoded with a -1 adjustment.
 #define NORMALIZE_REGISTER(x) (x)
 #define DENORMALIZE_REGISTER(x) (x)
 #define NORMALIZE_NUM_SAFE_POINTS(x) (x)
@@ -734,9 +734,9 @@ void FASTCALL decodeCallPattern(int         pattern,
 #define DENORMALIZE_STACK_BASE_REGISTER(x) ((x)^29)
 #define NORMALIZE_SIZE_OF_STACK_AREA(x) ((x)>>3)
 #define DENORMALIZE_SIZE_OF_STACK_AREA(x) ((x)<<3)
-#define CODE_OFFSETS_NEED_NORMALIZATION 1
-#define NORMALIZE_CODE_OFFSET(x) ((x)>>2)   // Instructions are 4 bytes long
-#define DENORMALIZE_CODE_OFFSET(x) ((x)<<2)
+#define CODE_OFFSETS_NEED_NORMALIZATION 0
+#define NORMALIZE_CODE_OFFSET(x) (x)   // Instructions are 4 bytes long, but the safe-point
+#define DENORMALIZE_CODE_OFFSET(x) (x) // offsets are encoded with a -1 adjustment.
 #define NORMALIZE_REGISTER(x) (x)
 #define DENORMALIZE_REGISTER(x) (x)
 #define NORMALIZE_NUM_SAFE_POINTS(x) (x)
@@ -789,9 +789,9 @@ void FASTCALL decodeCallPattern(int         pattern,
 #define DENORMALIZE_STACK_BASE_REGISTER(x) ((x) == 0 ? 22 : 3)
 #define NORMALIZE_SIZE_OF_STACK_AREA(x) ((x)>>3)
 #define DENORMALIZE_SIZE_OF_STACK_AREA(x) ((x)<<3)
-#define CODE_OFFSETS_NEED_NORMALIZATION 1
-#define NORMALIZE_CODE_OFFSET(x) ((x)>>2)   // Instructions are 4 bytes long
-#define DENORMALIZE_CODE_OFFSET(x) ((x)<<2)
+#define CODE_OFFSETS_NEED_NORMALIZATION 0
+#define NORMALIZE_CODE_OFFSET(x) (x)   // Instructions are 4 bytes long, but the safe-point
+#define DENORMALIZE_CODE_OFFSET(x) (x) // offsets are encoded with a -1 adjustment.
 #define NORMALIZE_REGISTER(x) (x)
 #define DENORMALIZE_REGISTER(x) (x)
 #define NORMALIZE_NUM_SAFE_POINTS(x) (x)
@@ -844,9 +844,9 @@ void FASTCALL decodeCallPattern(int         pattern,
 #define DENORMALIZE_STACK_BASE_REGISTER(x) ((x) == 0 ? 8 : 2)
 #define NORMALIZE_SIZE_OF_STACK_AREA(x) ((x)>>3)
 #define DENORMALIZE_SIZE_OF_STACK_AREA(x) ((x)<<3)
-#define CODE_OFFSETS_NEED_NORMALIZATION 1
-#define NORMALIZE_CODE_OFFSET(x) ((x)>>2)   // Instructions are 4 bytes long
-#define DENORMALIZE_CODE_OFFSET(x) ((x)<<2)
+#define CODE_OFFSETS_NEED_NORMALIZATION 0
+#define NORMALIZE_CODE_OFFSET(x) (x)   // Instructions are 4 bytes long, but the safe-point
+#define DENORMALIZE_CODE_OFFSET(x) (x) // offsets are encoded with a -1 adjustment.
 #define NORMALIZE_REGISTER(x) (x)
 #define DENORMALIZE_REGISTER(x) (x)
 #define NORMALIZE_NUM_SAFE_POINTS(x) (x)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1517,6 +1517,29 @@ void CodeGen::genExitCode(BasicBlock* block)
     if (compiler->getNeedsGSSecurityCookie())
     {
         genEmitGSCookieCheck(jmpEpilog);
+
+        if (jmpEpilog)
+        {
+            // Dev10 642944 -
+            // The GS cookie check created a temp label that has no live
+            // incoming GC registers, we need to fix that
+
+            unsigned   varNum;
+            LclVarDsc* varDsc;
+
+            /* Figure out which register parameters hold pointers */
+
+            for (varNum = 0, varDsc = compiler->lvaTable; varNum < compiler->lvaCount && varDsc->lvIsRegArg;
+                 varNum++, varDsc++)
+            {
+                noway_assert(varDsc->lvIsParam);
+
+                gcInfo.gcMarkRegPtrVal(varDsc->GetArgReg(), varDsc->TypeGet());
+            }
+
+            GetEmitter()->emitThisGCrefRegs = GetEmitter()->emitInitGCrefRegs = gcInfo.gcRegGCrefSetCur;
+            GetEmitter()->emitThisByrefRegs = GetEmitter()->emitInitByrefRegs = gcInfo.gcRegByrefSetCur;
+        }
     }
 
     genReserveEpilog(block);

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10427,9 +10427,9 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
 //    of the last instruction in the region makes GC safe again.
 //    In particular - once the IP is on the first instruction, but not executed it yet,
 //    it is still safe to do GC.
-//    The only special case is when NoGC region is used for prologs.
-//    In such case the GC info could be incorrect until the prolog completes, so the first
-//    instruction cannot have GC.
+//    The only special case is when NoGC region is used for prologs/epilogs.
+//    In such case the GC info could be incorrect until the prolog completes and epilogs
+//    may have unwindability restrictions, so the first instruction cannot have GC.
 
 void emitter::emitDisableGC()
 {

--- a/src/coreclr/jit/emitinl.h
+++ b/src/coreclr/jit/emitinl.h
@@ -594,7 +594,8 @@ bool emitter::emitGenNoGCLst(Callback& cb)
             emitter::instrDesc* id = emitFirstInstrDesc(ig->igData);
             assert(id != nullptr);
             assert(id->idCodeSize() > 0);
-            if (!cb(ig->igFuncIdx, ig->igOffs, ig->igSize, id->idCodeSize(), ig->igFlags & (IGF_FUNCLET_PROLOG)))
+            if (!cb(ig->igFuncIdx, ig->igOffs, ig->igSize, id->idCodeSize(),
+                    ig->igFlags & (IGF_FUNCLET_PROLOG | IGF_FUNCLET_EPILOG | IGF_EPILOG)))
             {
                 return false;
             }

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4027,7 +4027,8 @@ public:
     // Report everything between the previous region and the current
     // region as interruptible.
 
-    bool operator()(unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isInProlog)
+    bool operator()(
+        unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isInPrologOrEpilog)
     {
         if (igOffs < m_uninterruptibleEnd)
         {
@@ -4043,7 +4044,7 @@ public:
             // Once the first instruction in IG executes, we cannot have GC.
             // But it is ok to have GC while the IP is on the first instruction, unless we are in prolog/epilog.
             unsigned interruptibleEnd = igOffs;
-            if (!isInProlog)
+            if (!isInPrologOrEpilog)
             {
                 interruptibleEnd += firstInstrSize;
             }

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -675,16 +675,10 @@ void Thread::HijackCallback(NATIVE_CONTEXT* pThreadContext, void* pThreadToHijac
     if (runtime->IsConservativeStackReportingEnabled() ||
         codeManager->IsSafePoint(pvAddress))
     {
-        // IsUnwindable is precise on arm64, but can give false negatives on other architectures.
-        // (when IP is on the first instruction of an epilog, we still can unwind,
-        // but we can tell if the instruction is the first only if we can navigate instructions backwards and check)
-        // The preciseness of IsUnwindable is tracked in https://github.com/dotnet/runtime/issues/101932
-#if defined(TARGET_ARM64)
         // we may not be able to unwind in some locations, such as epilogs.
         // such locations should not contain safe points.
         // when scanning conservatively we do not need to unwind
         ASSERT(codeManager->IsUnwindable(pvAddress) || runtime->IsConservativeStackReportingEnabled());
-#endif
 
         // if we are not given a thread to hijack
         // perform in-line wait on the current thread

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -213,9 +213,18 @@ void UnixNativeCodeManager::EnumGcRefs(MethodInfo *    pMethodInfo,
 
 #ifdef TARGET_ARM
     // Ensure that code offset doesn't have the Thumb bit set. We need
-    // it to be aligned to instruction start
+    // it to be aligned to instruction start to make the !isActiveStackFrame
+    // branch below work.
     ASSERT(((uintptr_t)codeOffset & 1) == 0);
 #endif
+
+    bool executionAborted = ((UnixNativeMethodInfo*)pMethodInfo)->executionAborted;
+
+    if (!isActiveStackFrame && !executionAborted)
+    {
+        // the reasons for this adjustment are explained in EECodeManager::EnumGcRefs
+        codeOffset--;
+    }
 
     GcInfoDecoder decoder(
         GCInfoToken(gcInfo),
@@ -223,8 +232,25 @@ void UnixNativeCodeManager::EnumGcRefs(MethodInfo *    pMethodInfo,
         codeOffset
     );
 
+    if (isActiveStackFrame)
+    {
+        // CONSIDER: We can optimize this by remembering the need to adjust in IsSafePoint and propagating into here.
+        //           Or, better yet, maybe we should change the decoder to not require this adjustment.
+        //           The scenario that adjustment tries to handle (fallthrough into BB with random liveness)
+        //           does not seem possible.
+        if (!decoder.HasInterruptibleRanges())
+        {
+            decoder = GcInfoDecoder(
+                GCInfoToken(gcInfo),
+                GcInfoDecoderFlags(DECODE_GC_LIFETIMES | DECODE_SECURITY_OBJECT | DECODE_VARARG),
+                codeOffset - 1
+            );
+
+            assert(decoder.IsInterruptibleSafePoint());
+        }
+    }
+
     ICodeManagerFlags flags = (ICodeManagerFlags)0;
-    bool executionAborted = ((UnixNativeMethodInfo*)pMethodInfo)->executionAborted;
     if (executionAborted)
         flags = ICodeManagerFlags::ExecutionAborted;
 

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
@@ -440,8 +440,9 @@ void CoffNativeCodeManager::EnumGcRefs(MethodInfo *    pMethodInfo,
     PTR_uint8_t gcInfo;
     uint32_t codeOffset = GetCodeOffset(pMethodInfo, safePointAddress, &gcInfo);
 
-    ICodeManagerFlags flags = (ICodeManagerFlags)0;
     bool executionAborted = ((CoffNativeMethodInfo *)pMethodInfo)->executionAborted;
+
+    ICodeManagerFlags flags = (ICodeManagerFlags)0;
     if (executionAborted)
         flags = ICodeManagerFlags::ExecutionAborted;
 
@@ -452,12 +453,35 @@ void CoffNativeCodeManager::EnumGcRefs(MethodInfo *    pMethodInfo,
         flags = (ICodeManagerFlags)(flags | ICodeManagerFlags::ActiveStackFrame);
 
 #ifdef USE_GC_INFO_DECODER
+    if (!isActiveStackFrame && !executionAborted)
+    {
+        // the reasons for this adjustment are explained in EECodeManager::EnumGcRefs
+        codeOffset--;
+    }
 
     GcInfoDecoder decoder(
         GCInfoToken(gcInfo),
         GcInfoDecoderFlags(DECODE_GC_LIFETIMES | DECODE_SECURITY_OBJECT | DECODE_VARARG),
         codeOffset
     );
+
+    if (isActiveStackFrame)
+    {
+        // CONSIDER: We can optimize this by remembering the need to adjust in IsSafePoint and propagating into here.
+        //           Or, better yet, maybe we should change the decoder to not require this adjustment.
+        //           The scenario that adjustment tries to handle (fallthrough into BB with random liveness)
+        //           does not seem possible.
+        if (!decoder.HasInterruptibleRanges())
+        {
+            decoder = GcInfoDecoder(
+                GCInfoToken(gcInfo),
+                GcInfoDecoderFlags(DECODE_GC_LIFETIMES | DECODE_SECURITY_OBJECT | DECODE_VARARG),
+                codeOffset - 1
+            );
+
+            assert(decoder.IsInterruptibleSafePoint());
+        }
+    }
 
     if (!decoder.EnumerateLiveSlots(
         pRegisterSet,

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
@@ -73,7 +73,6 @@ namespace ILCompiler.Reflection.ReadyToRun
     public class GcInfoTypes
     {
         private Machine _target;
-        private bool _denormalizeCodeOffsets;
 
         internal int SIZE_OF_RETURN_KIND_SLIM { get; } = 2;
         internal int SIZE_OF_RETURN_KIND_FAT { get; } = 2;
@@ -106,10 +105,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         internal int LIVESTATE_RLE_SKIP_ENCBASE { get; } = 4;
         internal int NUM_NORM_CODE_OFFSETS_PER_CHUNK_LOG2 { get; } = 6;
 
-        internal GcInfoTypes(Machine machine, bool denormalizeCodeOffsets)
+        internal GcInfoTypes(Machine machine)
         {
             _target = machine;
-            _denormalizeCodeOffsets = denormalizeCodeOffsets;
 
             switch (machine)
             {
@@ -176,34 +174,6 @@ namespace ILCompiler.Reflection.ReadyToRun
                     return (x << 2);
             }
             return x;
-        }
-
-        internal int NormalizeCodeLength(int x)
-        {
-            switch (_target)
-            {
-                case Machine.ArmThumb2:
-                    return (x >> 1);
-                case Machine.Arm64:
-                case Machine.LoongArch64:
-                case Machine.RiscV64:
-                    return (x >> 2);
-            }
-            return x;
-        }
-
-        internal uint DenormalizeCodeOffset(uint x)
-        {
-            return _denormalizeCodeOffsets ?
-                (uint)DenormalizeCodeLength((int)x) :
-                x;
-        }
-
-        internal uint NormalizeCodeOffset(uint x)
-        {
-            return _denormalizeCodeOffsets ?
-                (uint)NormalizeCodeLength((int)x) :
-                x;
         }
 
         internal int DenormalizeStackSlot(int x)

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -1436,6 +1436,37 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pRD,
     }
 #endif
 
+    /* If we are not in the active method, we are currently pointing
+         * to the return address; at the return address stack variables
+         * can become dead if the call is the last instruction of a try block
+         * and the return address is the jump around the catch block. Therefore
+         * we simply assume an offset inside of call instruction.
+         * NOTE: The GcInfoDecoder depends on this; if you change it, you must
+         * revisit the GcInfoEncoder/Decoder
+         */
+
+    if (!(flags & ExecutionAborted))
+    {
+        if (!(flags & ActiveStackFrame))
+        {
+            curOffs--;
+            LOG((LF_GCINFO, LL_INFO1000, "Adjusted GC reporting offset due to flags !ExecutionAborted && !ActiveStackFrame. Now reporting GC refs for %s at offset %04x.\n",
+                methodName, curOffs));
+        }
+    }
+    else
+    {
+        // Since we are aborting execution, we are either in a frame that actually faulted or in a throwing call.
+        // * We do not need to adjust in a leaf
+        // * A throwing call will have unreachable <brk> after it, thus GC info is the same as before the call.
+        // 
+        // Either way we do not need to adjust.
+
+        // NOTE: only fully interruptible methods may need to report anything here as without
+        //       exception handling all current local variables are already unreachable.
+        //       EnumerateLiveSlots will shortcircuit the partially interruptible case just a bit later.
+    }
+
     // Check if we have been given an override value for relOffset
     if (relOffsetOverride != NO_OVERRIDE_OFFSET)
     {
@@ -1479,6 +1510,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pRD,
     // A frame is non-leaf if we are executing a call, or a fault occurred in the function.
     // The only case in which we need to report scratch slots for a non-leaf frame
     //   is when execution has to be resumed at the point of interruption (via ResumableFrame)
+    //<TODO>Implement ResumableFrame</TODO>
     _ASSERTE( sizeof( BOOL ) >= sizeof( ActiveStackFrame ) );
     reportScratchSlots = (flags & ActiveStackFrame) != 0;
 
@@ -1488,6 +1520,24 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pRD,
                         GcInfoDecoderFlags (DECODE_GC_LIFETIMES | DECODE_SECURITY_OBJECT | DECODE_VARARG),
                         curOffs
                         );
+
+    if ((flags & ActiveStackFrame) != 0)
+    {
+        // CONSIDER: We can optimize this by remembering the need to adjust in IsSafePoint and propagating into here.
+        //           Or, better yet, maybe we should change the decoder to not require this adjustment.
+        //           The scenario that adjustment tries to handle (fallthrough into BB with random liveness)
+        //           does not seem possible.
+        if (!gcInfoDecoder.HasInterruptibleRanges())
+        {
+            gcInfoDecoder = GcInfoDecoder(
+                gcInfoToken,
+                GcInfoDecoderFlags(DECODE_GC_LIFETIMES | DECODE_SECURITY_OBJECT | DECODE_VARARG),
+                curOffs - 1
+            );
+
+            _ASSERTE((InterruptibleSafePointsEnabled() && gcInfoDecoder.CouldBeInterruptibleSafePoint()));
+        }
+    }
 
     if (!gcInfoDecoder.EnumerateLiveSlots(
                         pRD,


### PR DESCRIPTION
This reverts #104336, which appears to fix the gcstress-extra issues filed this morning.

Close #105210 
Close #105212
Close #105213
Close #105214
Close #105215
Close #105216
Close #105218
Close #105219
Close #105220
Close #105221
Close #105222
Close #105223
Close #105224
Close #105225
Close #105226
Close #105227