### PR TITLE
Add support for filtering merged tests by display name

### DIFF
--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -309,7 +309,7 @@ public class TestFilter
         {
             "FullyQualifiedName" => TermKind.FullyQualifiedName,
             "DisplayName" => TermKind.DisplayName,
-            _ => throw new ArgumentException("Test filtering not supported with property" + termName, argName),
+            _ => throw new ArgumentException("Test filtering not supported with property " + termName, argName),
         };
 
         return new NameClause(termKind, testName, substring: isSubstring);

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -171,16 +171,7 @@ public class TestFilter
 
         if (filterString is not null)
         {
-            if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
-            {
-                throw new ArgumentException("Complex test filter expressions are not supported today."
-                                          + " The only filters currently supported are the simple forms"
-                                          + " supported in 'dotnet test --filter' (substrings of the"
-                                          + " test's fully qualified name). If further filtering options"
-                                          + " are desired, file an issue on dotnet/runtime for support.",
-                                            nameof(filterArgs));
-            }
-            _filter = new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
+            _filter = ParseFilter(filterString, nameof(filterArgs));
         }
         _testExclusionTable = testExclusionTable;
     }
@@ -291,5 +282,36 @@ public class TestFilter
                 table.Add(testPath, skipReason);
             }
         }
+    }
+
+    private static ISearchClause ParseFilter(string filterString, string argName)
+    {
+        ReadOnlySpan<string> unsupported = ["|", "&", "(", ")", "!=", "!~"];
+        foreach (string s in unsupported)
+        {
+            if (filterString.Contains(s))
+            {
+                throw new ArgumentException("Test filtering with |, &, (, ), !=, !~ is not supported", argName);
+            }
+        }
+
+        int delimiter = filterString.IndexOfAny(['=', '~']);
+        if (delimiter == -1)
+        {
+            return new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
+        }
+
+        bool isSubstring = filterString[delimiter] == '~';
+        string termName = filterString.Substring(0, delimiter);
+        string testName = filterString.Substring(delimiter + 1);
+
+        TermKind termKind = termName switch
+        {
+            "FullyQualifiedName" => TermKind.FullyQualifiedName,
+            "DisplayName" => TermKind.DisplayName,
+            _ => throw new ArgumentException("Test filtering not supported with property" + termName, argName),
+        };
+
+        return new NameClause(termKind, testName, substring: isSubstring);
     }
 }


### PR DESCRIPTION
This allows you to use `DisplayName=<test display name>` or `DisplayName~<substring of test display name>` when running merged test wrappers to filter down by display name. The display name is the name that the test infrastructure prints to the log.

So for example, for the log https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-heads-main-7426c61032e740658b/Regression_3.0.1/1/console.aa0ab162.log?helixlogtype=result, when seeing
```scala
23:17:28.437 Running test: JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294/DevDiv_255294.cmd

Assert failure(PID 21 [0x00000015], Thread: 21 [0x0015]): !CREATE_CHECK_STRING(pMT && pMT->Validate())
    File: /__w/1/s/src/coreclr/vm/object.cpp:553
    Image: /root/helix/work/correlation/corerun
```

this particular test can now be filtered to by using `corerun Regression_3.dll DisplayName=JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294/DevDiv_255294.cmd`.

Fix #93452

cc @dotnet/jit-contrib since it seems we're the ones who run into needing this the most.

PTAL @jkoritzinsky 