### PR TITLE
Fix intellisense package xml file failing up-to-date check in libs projects

### DIFF
--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -7,6 +7,8 @@
     <IntellisensePackageXmlFilePath Condition="'$(IntellisensePackageXmlFilePath)' == '' and Exists($(IntellisensePackageXmlFilePathFromNetFolder))">$(IntellisensePackageXmlFilePathFromNetFolder)</IntellisensePackageXmlFilePath>
     <IntellisensePackageXmlFilePath Condition="'$(IntellisensePackageXmlFilePath)' == '' and Exists($(IntellisensePackageXmlFilePathFromDotNetPlatExtFolder))">$(IntellisensePackageXmlFilePathFromDotNetPlatExtFolder)</IntellisensePackageXmlFilePath>
 
+    <IntermediateDocFileItemFromIntellisensePackage>$(IntermediateOutputPath)$(TargetName).intellisense-package.xml</IntermediateDocFileItemFromIntellisensePackage>
+
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors when the intellisense package xml file is used. -->
     <NoWarn Condition="'$(SkipIntellisenseNoWarnCS1591)' != 'true'">$(NoWarn);1591</NoWarn>
   </PropertyGroup>
@@ -25,13 +27,26 @@
     <PackageDownload Include="Microsoft.Private.Intellisense" Version="[$(MicrosoftPrivateIntellisenseVersion)]" />
   </ItemGroup>
 
+  <!-- Prepare the intellisense package xml file by copying it to the project's intermediate folder and update its file timestamp.
+       This is necessary so that all project outputs are newer than all project inputs. Directly copying from the intellisense package
+       would violate that and break fast up-to-date check. -->
+  <Target Name="PrepareIntellisensePackageXmlFile"
+          Inputs="$(IntellisensePackageXmlFilePath)"
+          Outputs="$(IntermediateDocFileItemFromIntellisensePackage)">
+    <Copy SourceFiles="$(IntellisensePackageXmlFilePath)"
+          DestinationFiles="$(IntermediateDocFileItemFromIntellisensePackage)" />
+
+    <Touch Files="$(IntermediateDocFileItemFromIntellisensePackage)" />
+  </Target>
+
   <!-- Replace the compiler generated xml file in the obj folder with the one that comes from the intellisense package. -->
   <Target Name="ChangeDocumentationFileForPackaging"
+          DependsOnTargets="PrepareIntellisensePackageXmlFile"
           BeforeTargets="CopyFilesToOutputDirectory;DocumentationProjectOutputGroup"
           Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' and '$(IntellisensePackageXmlFilePath)' != ''">
     <ItemGroup>
       <DocFileItem Remove="@(DocFileItem)" />
-      <DocFileItem Include="$(IntellisensePackageXmlFilePath)" />
+      <DocFileItem Include="$(IntermediateDocFileItemFromIntellisensePackage)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/92940

Tested locally and verified that the correct xml file lands in the intermediate and in the final output folder, with the correct time stamps. Also tested that this really fixes the broken fast up-to-date check.