### PR TITLE
[browser] avoid OOM in RentingGiganticArraySucceedsOrOOMs

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Buffers.Tests/ArrayPool/UnitTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Buffers.Tests/ArrayPool/UnitTests.cs
@@ -82,7 +82,7 @@ namespace System.Buffers.ArrayPool.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("minimumLength", () => pool.Rent(-1));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         public static void RentingGiganticArraySucceedsOrOOMs()
         {
             try


### PR DESCRIPTION
For the browser, allocating 1.8gb on 32bit address space is no fun. 
Especially with all the preceding and following allocations in the same test suite.

In MT build, it also needs to grow the size of linear memory via UI thread and synchronize it to all threads.

Contributes to https://github.com/dotnet/runtime/issues/102040
Contributes to https://github.com/dotnet/runtime/issues/102195