### PR TITLE
[mono] Exit early to prevent endless loop when crashing

### DIFF
--- a/src/mono/mono/mini/mini-posix.c
+++ b/src/mono/mono/mini/mini-posix.c
@@ -788,7 +788,8 @@ dump_native_stacktrace (const char *signal, MonoContext *mctx)
 		g_assertion_disable_global (assert_printer_callback);
 	} else {
 		g_async_safe_printf ("\nAn error has occurred in the native fault reporting. Some diagnostic information will be unavailable.\n");
-
+		g_async_safe_printf ("\nExiting early due to double fault.\n");
+		_exit (-1);
 	}
 
 #ifdef HAVE_BACKTRACE_SYMBOLS
@@ -845,11 +846,6 @@ dump_native_stacktrace (const char *signal, MonoContext *mctx)
 		waitpid (pid, &status, 0);
 	} else {
 		// If we can't fork, do as little as possible before exiting
-	}
-
-	if (double_faulted) {
-		g_async_safe_printf("\nExiting early due to double fault.\n");
-		_exit (-1);
 	}
 
 #endif


### PR DESCRIPTION
We hit an issue where we got into an endless loop of crashes while trying to dump the stack trace. Move the existing code to protect against this up to make sure we abort early enough.