### PR TITLE
Slightly improve MinOpts JIT TP

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5273,7 +5273,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
 #ifdef DEBUG
     // Stash the current estimate of the function's size if necessary.
-    if (verbose)
+    if (verbose && opts.OptimizationEnabled())
     {
         compSizeEstimate  = 0;
         compCycleEstimate = 0;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9985,6 +9985,8 @@ public:
 // Maximum number of locals before turning off the inlining
 #define MAX_LV_NUM_COUNT_FOR_INLINING 512
 
+        bool canUseTier0Opts;
+        bool canUseAllOpts;
         bool compMinOpts;
         bool compMinOptsIsSet;
 #ifdef DEBUG
@@ -10011,13 +10013,22 @@ public:
         }
 #endif // !DEBUG
 
+        // TODO: we should convert these into a single OptimizationLevel
+
         bool OptimizationDisabled() const
         {
-            return MinOpts() || compDbgCode;
+            assert(compMinOptsIsSet);
+            return !canUseAllOpts;
         }
         bool OptimizationEnabled() const
         {
-            return !OptimizationDisabled();
+            assert(compMinOptsIsSet);
+            return canUseAllOpts;
+        }
+        bool Tier0OptimizationEnabled() const
+        {
+            assert(compMinOptsIsSet);
+            return canUseTier0Opts;
         }
 
         void SetMinOpts(bool val)
@@ -10026,6 +10037,9 @@ public:
             assert(!compMinOptsIsSet || (compMinOpts == val));
             compMinOpts      = val;
             compMinOptsIsSet = true;
+
+            canUseTier0Opts = !compDbgCode && !jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
+            canUseAllOpts   = canUseTier0Opts && !val;
         }
 
         // true if the CLFLG_* for an optimization is set.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3655,6 +3655,7 @@ public:
     bool gtMarkAddrMode(GenTree* addr, int* costEx, int* costSz, var_types type);
 
     unsigned gtSetEvalOrder(GenTree* tree);
+    unsigned gtSetEvalOrderMinOpts(GenTree* tree);
     bool gtMayHaveStoreInterference(GenTree* treeWithStores, GenTree* tree);
     bool gtTreeHasLocalRead(GenTree* tree, unsigned lclNum);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4848,6 +4848,11 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 {
     assert(tree);
 
+    if (opts.OptimizationDisabled())
+    {
+        return gtSetEvalOrderMinOpts(tree);
+    }
+
 #ifdef DEBUG
     /* Clear the GTF_DEBUG_NODE_MORPHED flag as well */
     tree->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
@@ -6211,6 +6216,166 @@ DONE:
 #ifdef _PREFAST_
 #pragma warning(pop)
 #endif
+
+//------------------------------------------------------------------------
+// gtSetEvalOrderMinOpts: A MinOpts specific version of gtSetEvalOrder. We don't
+//    need to set costs, but we're looking for opportunities to swap operands.
+//
+// Arguments:
+//    tree - The tree for which we are setting the evaluation order.
+//
+// Return Value:
+//    the Sethi 'complexity' estimate for this tree (the higher
+//    the number, the higher is the tree's resources requirement)
+//
+unsigned Compiler::gtSetEvalOrderMinOpts(GenTree* tree)
+{
+    assert(tree);
+
+    if (tree->OperIsLeaf())
+    {
+        // Nothing to do for leaves.
+        return 0;
+    }
+
+    unsigned level = 1;
+    if (tree->OperIsSimple())
+    {
+        GenTree* op1 = tree->AsOp()->gtOp1;
+        GenTree* op2 = tree->gtGetOp2IfPresent();
+
+        // Check for addressing mode with a null base
+        if (tree->OperIsAddrMode() && (op1 == nullptr))
+        {
+            std::swap(op1, op2);
+        }
+
+        // Check for a nilary operator
+        if (op1 == nullptr)
+        {
+            assert(op2 == nullptr);
+            return level;
+        }
+
+        if (op2 == nullptr)
+        {
+            gtSetEvalOrderMinOpts(op1);
+            return level;
+        }
+
+        // Default Binary ops have a cost of 1,1
+        level         = gtSetEvalOrderMinOpts(op1);
+        unsigned lvl2 = gtSetEvalOrderMinOpts(op2);
+
+        bool allowReversal = true;
+        // for certain operators.
+        switch (tree->OperGet())
+        {
+            case GT_COMMA:
+            case GT_BOUNDS_CHECK:
+            case GT_INTRINSIC:
+            case GT_QMARK:
+            case GT_COLON:
+                // We're not going to swap operands in these
+                allowReversal = false;
+                break;
+
+            case GT_STORE_BLK:
+            case GT_STOREIND:
+            {
+                if (op1->IsInvariant())
+                {
+                    allowReversal = false;
+                    tree->SetReverseOp();
+                    break;
+                }
+                if ((op1->gtFlags & GTF_ALL_EFFECT) != 0)
+                {
+                    break;
+                }
+
+                // In case op2 assigns to a local var that is used in op1, we have to evaluate op1 first.
+                if (gtMayHaveStoreInterference(op2, op1))
+                {
+                    // TODO-ASG-Cleanup: move this guard to "gtCanSwapOrder".
+                    allowReversal = false;
+                    break;
+                }
+
+                // If op2 is simple then evaluate op1 first
+                if (op2->OperIsLeaf())
+                {
+                    break;
+                }
+
+                allowReversal = false;
+                tree->SetReverseOp();
+                break;
+            }
+
+            default:
+                break;
+        }
+
+        bool tryToSwap = false;
+        if (fgOrder != FGOrderLinear)
+        {
+            tryToSwap = tree->IsReverseOp() ? level > lvl2 : level < lvl2;
+        }
+
+        if (tryToSwap && allowReversal)
+        {
+            // Can we swap the order by commuting the operands?
+            bool canSwap = tree->IsReverseOp() ? gtCanSwapOrder(op2, op1) : gtCanSwapOrder(op1, op2);
+            if (canSwap)
+            {
+                if (tree->OperIsCmpCompare())
+                {
+                    genTreeOps oper = tree->OperGet();
+                    if (GenTree::SwapRelop(oper) != oper)
+                    {
+                        tree->SetOper(GenTree::SwapRelop(oper));
+                    }
+                    std::swap(tree->AsOp()->gtOp1, tree->AsOp()->gtOp2);
+                }
+                else if (tree->OperIsCommutative())
+                {
+                    std::swap(tree->AsOp()->gtOp1, tree->AsOp()->gtOp2);
+                }
+                else
+                {
+                    // Mark the operand's evaluation order to be swapped.
+                    tree->gtFlags ^= GTF_REVERSE_OPS;
+                }
+            }
+        }
+
+        // Swap the level counts
+        if (tree->IsReverseOp())
+        {
+            std::swap(level, lvl2);
+        }
+
+        // Compute the sethi number for this binary operator
+        if (level < 1)
+        {
+            level = lvl2;
+        }
+        else if (level == lvl2)
+        {
+            level++;
+        }
+    }
+    else if (tree->IsCall())
+    {
+        for (CallArg& arg : tree->AsCall()->gtArgs.EarlyArgs())
+        {
+            gtSetEvalOrderMinOpts(arg.GetEarlyNode());
+        }
+        level = 3;
+    }
+    return level;
+}
 
 //------------------------------------------------------------------------
 // gtMayHaveStoreInterference: Check if two trees may interfere because of a

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -13340,10 +13340,7 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
         return tree;
     }
 
-    // NOTE: MinOpts() is always true for Tier0 so we have to check explicit flags instead.
-    // To be fixed in https://github.com/dotnet/runtime/pull/77465
-    const bool tier0opts = !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
-    if (!tier0opts)
+    if (!opts.Tier0OptimizationEnabled())
     {
         return tree;
     }
@@ -13406,7 +13403,7 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
             // special operator that can use only one constant
             // to fold - e.g. booleans
 
-            if (tier0opts && opts.OptimizationDisabled())
+            if (opts.OptimizationDisabled())
             {
                 // Too heavy for tier0
                 return tree;
@@ -15197,10 +15194,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
     GenTree* op1 = tree->gtGetOp1();
     GenTree* op2 = tree->gtGetOp2IfPresent();
 
-    // NOTE: MinOpts() is always true for Tier0 so we have to check explicit flags instead.
-    // To be fixed in https://github.com/dotnet/runtime/pull/77465
-    const bool tier0opts = !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
-    if (!tier0opts)
+    if (!opts.Tier0OptimizationEnabled())
     {
         return tree;
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6375,9 +6375,18 @@ unsigned Compiler::gtSetEvalOrderMinOpts(GenTree* tree)
         }
         level = 3;
     }
+#if defined(FEATURE_HW_INTRINSICS)
+    else if (tree->OperIsHWIntrinsic())
+    {
+        for (size_t i = tree->AsMultiOp()->GetOperandCount(); i >= 1; i--)
+        {
+            unsigned lvl = gtSetEvalOrderMinOpts(tree->AsMultiOp()->Op(i));
+            level        = max(lvl, level + 1);
+        }
+    }
+#endif // FEATURE_HW_INTRINSICS
 
-    // NOTE: we skip many operators here (e.g. GT_HWINTRINSIC)
-    // in order to maintain a good trade-off between CQ and TP.
+    // NOTE: we skip many operators here in order to maintain a good trade-off between CQ and TP.
 
     return level;
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6368,6 +6368,8 @@ unsigned Compiler::gtSetEvalOrderMinOpts(GenTree* tree)
     }
     else if (tree->IsCall())
     {
+        // We ignore late args - they don't bring any noticeable benefits
+        // according to asmdiffs/tpdiff
         for (CallArg& arg : tree->AsCall()->gtArgs.EarlyArgs())
         {
             gtSetEvalOrderMinOpts(arg.GetEarlyNode());

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4836,8 +4836,10 @@ bool Compiler::gtMarkAddrMode(GenTree* addr, int* pCostEx, int* pCostSz, var_typ
     return false;
 }
 
-static void SetIndirectStoreEvalOrder(Compiler* comp, GenTreeStoreInd* store, bool* allowReversal)
+static void SetIndirectStoreEvalOrder(Compiler* comp, GenTreeIndir* store, bool* allowReversal)
 {
+    assert(store->OperIs(GT_STORE_BLK, GT_STOREIND));
+
     GenTree* addr  = store->Addr();
     GenTree* data  = store->Data();
     *allowReversal = true;
@@ -5892,7 +5894,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 // TODO-ASG-Cleanup: this logic emulated the ASG case below. See how of much of it can be deleted.
                 if (!optValnumCSE_phase || optCSE_canSwap(op1, op2))
                 {
-                    SetIndirectStoreEvalOrder(this, tree->AsStoreInd(), &allowReversal);
+                    SetIndirectStoreEvalOrder(this, tree->AsIndir(), &allowReversal);
                 }
                 break;
 
@@ -6310,7 +6312,7 @@ unsigned Compiler::gtSetEvalOrderMinOpts(GenTree* tree)
 
             case GT_STORE_BLK:
             case GT_STOREIND:
-                SetIndirectStoreEvalOrder(this, tree->AsStoreInd(), &allowSwap);
+                SetIndirectStoreEvalOrder(this, tree->AsIndir(), &allowSwap);
                 break;
 
             default:

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1553,7 +1553,7 @@ GenTree* Compiler::impThrowIfNull(GenTreeCall* call)
     assert(call->gtArgs.CountUserArgs() == 2);
     assert(call->TypeIs(TYP_VOID));
 
-    if (opts.compDbgCode || opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT))
+    if (!opts.Tier0OptimizationEnabled())
     {
         // Don't fold it for debug code or forced MinOpts
         return call;
@@ -3302,11 +3302,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
 
     // Allow some lighweight intrinsics in Tier0 which can improve throughput
     // we're fine if intrinsic decides to not expand itself in this case unlike mustExpand.
-    // NOTE: MinOpts() is always true for Tier0 so we have to check explicit flags instead.
-    // To be fixed in https://github.com/dotnet/runtime/pull/77465
-    const bool tier0opts = !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
-
-    if (!mustExpand && tier0opts)
+    if (!mustExpand && opts.Tier0OptimizationEnabled())
     {
         switch (ni)
         {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1103,7 +1103,7 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
                     // TODO-CQ: handle HWI/SIMD/COMMA nodes in multi-reg morphing.
                     SetNeedsTemp(&arg);
                 }
-                else
+                else if (opts.OptimizationEnabled())
                 {
                     // Finally, we call gtPrepareCost to measure the cost of evaluating this tree.
                     comp->gtPrepareCost(argx);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8328,10 +8328,7 @@ DONE_MORPHING_CHILDREN:
     }
 
     // Try to fold it, maybe we get lucky,
-    if (opts.OptimizationEnabled())
-    {
-        tree = gtFoldExpr(tree);
-    }
+    tree = gtFoldExpr(tree);
 
     if (oldTree != tree)
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1476,7 +1476,7 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
                     assert(begTab == endTab);
                     break;
                 }
-                else
+                else if (comp->opts.OptimizationEnabled())
                 {
                     if (!costsPrepared)
                     {
@@ -1491,6 +1491,12 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
                         expensiveArgIndex = curInx;
                         expensiveArg      = arg;
                     }
+                }
+                else
+                {
+                    // We don't have cost information in MinOpts
+                    expensiveArgIndex = curInx;
+                    expensiveArg      = arg;
                 }
             }
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1103,7 +1103,7 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
                     // TODO-CQ: handle HWI/SIMD/COMMA nodes in multi-reg morphing.
                     SetNeedsTemp(&arg);
                 }
-                else if (opts.OptimizationEnabled())
+                else if (comp->opts.OptimizationEnabled())
                 {
                     // Finally, we call gtPrepareCost to measure the cost of evaluating this tree.
                     comp->gtPrepareCost(argx);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8328,7 +8328,10 @@ DONE_MORPHING_CHILDREN:
     }
 
     // Try to fold it, maybe we get lucky,
-    tree = gtFoldExpr(tree);
+    if (opts.OptimizationEnabled())
+    {
+        tree = gtFoldExpr(tree);
+    }
 
     if (oldTree != tree)
     {

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -185,7 +185,7 @@ inline bool varTypeIsArithmetic(T vt)
 template <class T>
 inline bool varTypeIsGC(T vt)
 {
-    return ((varTypeClassification[TypeGet(vt)] & (VTF_GCR | VTF_BYR)) != 0);
+    return (TypeGet(vt) == TYP_REF) || (TypeGet(vt) == TYP_BYREF);
 }
 
 template <class T>


### PR DESCRIPTION
A few tricks to mitigate regressions which raised concerns in https://github.com/dotnet/runtime/pull/105190

PS: I still want to rewrite all OptimizationEnabled/Disabled into an OptLevel like Andy once suggested, but didn't want to do it here.

![image](https://github.com/user-attachments/assets/e1fca7d7-7cf3-4305-8bb6-aad4188c10ed)
