### PR TITLE
[browser][MT] longer timeout for VFS heavy tests

### DIFF
--- a/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
@@ -16,6 +16,11 @@
     <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser' and '$(WasmEnableThreads)' == 'true'">
+    <!-- VSF is emulated on the UI thread and all calls are slow because they are marshaled -->
+    <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="AllowDefaultResolverContext.cs" />
     <Compile Include="ExceptionVerifier.cs" />

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/System.IO.FileSystem.Tests.csproj
@@ -6,6 +6,10 @@
 
     <WasmXHarnessMonoArgs>--working-dir=/test-dir</WasmXHarnessMonoArgs>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser' and '$(WasmEnableThreads)' == 'true'">
+    <!-- VSF is emulated on the UI thread and all calls are slow because they are marshaled -->
+    <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" TargetDir="test-dir" />
   </ItemGroup>

--- a/src/libraries/sendtohelix-browser.targets
+++ b/src/libraries/sendtohelix-browser.targets
@@ -243,6 +243,9 @@
         <Command>$(HelixCommand)</Command>
         <Timeout>$(_workItemTimeout)</Timeout>
         <Timeout Condition="'$(Scenario)' == 'WasmTestOnNodeJS' and '%(FileName)' == 'System.Net.Http.Functional.Tests'">01:20:00</Timeout>
+        <!-- VSF is emulated on the UI thread and all calls are slow because they are marshaled -->
+        <Timeout Condition="'%(FileName)' == 'System.IO.FileSystem.Tests' and '$(WasmEnableThreads)' == 'true'">01:20:00</Timeout>
+        <Timeout Condition="'%(FileName)' == 'System.Private.Xml.Tests' and '$(WasmEnableThreads)' == 'true'">01:20:00</Timeout>
       </HelixWorkItem>
     </ItemGroup>
 
@@ -268,6 +271,9 @@
         <PayloadArchive>%(Identity)</PayloadArchive>
         <Command>$(HelixCommand)</Command>
         <Timeout>$(_workItemTimeout)</Timeout>
+        <!-- VSF is emulated on the UI thread and all calls are slow because they are marshaled -->
+        <Timeout Condition="'%(FileName)' == 'System.IO.FileSystem.Tests' and '$(WasmEnableThreads)' == 'true'">01:20:00</Timeout>
+        <Timeout Condition="'%(FileName)' == 'System.Private.Xml.Tests' and '$(WasmEnableThreads)' == 'true'">01:20:00</Timeout>
       </HelixWorkItem>
 
     </ItemGroup>


### PR DESCRIPTION
longer timeout for MT
- System.IO.FileSystem.Tests
- System.Private.Xml.Tests

because VFS in is in the UI thread and it's slower

Contributes to https://github.com/dotnet/runtime/issues/103524
Contributes to https://github.com/dotnet/runtime/issues/103623