### PR TITLE
Fix Deadlock Inside Metrics Code

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
@@ -293,7 +293,7 @@ namespace System.Diagnostics.Metrics
             }
         }
 
-        // Publish is called from Instrument.Publish
+        // GetAllListeners is called from Instrument.Publish inside Instrument.SyncObject lock.
         internal static List<MeterListener>? GetAllListeners() => s_allStartedListeners.Count == 0 ? null : new List<MeterListener>(s_allStartedListeners);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This is a regression from the change in https://github.com/dotnet/runtime/pull/104680.

Thanks to @rokonec who caught it and suggested the fix too.