### PR TITLE
[test][Eventpipe] Disable eventsourceerror on OSX

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -423,6 +423,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/profiler/eventpipe/eventpipe/*">
             <Issue>https://github.com/dotnet/runtime/issues/66174</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
+            <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- OSX x64 on CoreCLR Runtime -->


### PR DESCRIPTION
After reenabling on non-arm32 linux platforms, https://github.com/dotnet/runtime/issues/80666 is hitting frequently for osx-x64 running on osx-arm64. Unfortunately, one of the dumps generated is too large for uploading, so disabling on OSX to see if we can get this test to crash on another platform where we can grab useful dumps.