### PR TITLE
Update assert to handle `object[]` element type

### DIFF
--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -436,7 +436,7 @@ extern "C" void QCALLTYPE ExceptionNative_GetMethodFromStackTrace(QCall::ObjectH
         CorElementType elemType = arrayBaseRef->GetArrayElementType();
         if (elemType != ELEMENT_TYPE_I1)
         {
-            _ASSERTE(elemType == ELEMENT_TYPE_OBJECT || elemType == ELEMENT_TYPE_CLASS);
+            _ASSERTE(elemType == ELEMENT_TYPE_CLASS); // object[]
             PTRARRAYREF ptrArrayRef = (PTRARRAYREF)arrayBaseRef;
             arrayBaseRef = (ARRAYBASEREF)OBJECTREFToObject(ptrArrayRef->GetAt(0));
         }

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -433,9 +433,10 @@ extern "C" void QCALLTYPE ExceptionNative_GetMethodFromStackTrace(QCall::ObjectH
         // The stacktrace can be either sbyte[] or Object[]. In the latter case,
         // the first entry is the actual stack trace sbyte[], the rest are pointers
         // to the method info objects. We only care about the first entry here.
-        if (arrayBaseRef->GetArrayElementType() != ELEMENT_TYPE_I1)
+        CorElementType elemType = arrayBaseRef->GetArrayElementType();
+        if (elemType != ELEMENT_TYPE_I1)
         {
-            _ASSERTE(arrayBaseRef->GetArrayElementType() == ELEMENT_TYPE_OBJECT);
+            _ASSERTE(elemType == ELEMENT_TYPE_OBJECT || elemType == ELEMENT_TYPE_CLASS);
             PTRARRAYREF ptrArrayRef = (PTRARRAYREF)arrayBaseRef;
             arrayBaseRef = (ARRAYBASEREF)OBJECTREFToObject(ptrArrayRef->GetAt(0));
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105186

@jakobbotsch this is very odd. This code path is the same on all platforms, but only seems to be taken with these tests on non-Windows platforms. That is the reason it didn't fail on Windows. Any ideas why exceptions are being thrown on non-Windows, but not on Windows?