### PR TITLE
Ensure that WaitForPendingFinalizers has seen the expected Full GC count

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -276,7 +276,7 @@ namespace System.Runtime
 
         // Indicate that the current round of finalizations is complete.
         [DllImport(Redhawk.BaseName)]
-        internal static extern void RhpSignalFinalizationComplete(uint fCount);
+        internal static extern void RhpSignalFinalizationComplete(uint fCount, int observedFullGcCount);
 
         [DllImport(Redhawk.BaseName)]
         internal static extern ulong RhpGetTickCount64();

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
@@ -29,11 +29,14 @@ namespace System.Runtime
                 // otherwise memory is low and we should initiate a collection.
                 if (InternalCalls.RhpWaitForFinalizerRequest() != 0)
                 {
+                    int observedFullGcCount = RuntimeImports.RhGetGcCollectionCount(RuntimeImports.RhGetMaxGcGeneration(), false);
                     uint finalizerCount = DrainQueue();
 
-                    // Tell anybody that's interested that the finalization pass is complete (there is a race condition here
-                    // where we might immediately signal a new request as complete, but this is acceptable).
-                    InternalCalls.RhpSignalFinalizationComplete(finalizerCount);
+                    // Anyone waiting to drain the Q can now wake up.  Note that there is a
+                    // race in that another thread starting a drain, as we leave a drain, may
+                    // consider itself satisfied by the drain that just completed.
+                    // Thus we include the Full GC count that we have certaily observed.
+                    InternalCalls.RhpSignalFinalizationComplete(finalizerCount, observedFullGcCount);
                 }
                 else
                 {

--- a/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
@@ -135,7 +135,10 @@ EXTERN_C void QCALLTYPE RhWaitForPendingFinalizers(UInt32_BOOL allowReentrantWai
         // Wait for the finalizer thread to get back to us.
         g_FinalizerDoneEvent.Wait(INFINITE, false, allowReentrantWait);
 
-        if (desiredFullGcCount - g_fullGcCountSeenByFinalization > 0)
+        // we use unsigned math here as the collection counts, which are size_t internally,
+        // can in theory overflow an int and wrap around.
+        // unsigned math would have more defined/portable behavior in such case
+        if ((unsigned int)desiredFullGcCount - (unsigned int)g_fullGcCountSeenByFinalization > 0)
         {
             // There were some Full GCs happening before we started waiting and possibly not seen by the
             // last finalization cycle. This is rare, but we need to be sure we have seen those,

--- a/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
@@ -138,7 +138,7 @@ EXTERN_C void QCALLTYPE RhWaitForPendingFinalizers(UInt32_BOOL allowReentrantWai
         // we use unsigned math here as the collection counts, which are size_t internally,
         // can in theory overflow an int and wrap around.
         // unsigned math would have more defined/portable behavior in such case
-        if ((unsigned int)desiredFullGcCount - (unsigned int)g_fullGcCountSeenByFinalization > 0)
+        if ((int)((unsigned int)desiredFullGcCount - (unsigned int)g_fullGcCountSeenByFinalization) > 0)
         {
             // There were some Full GCs happening before we started waiting and possibly not seen by the
             // last finalization cycle. This is rare, but we need to be sure we have seen those,

--- a/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
@@ -94,6 +94,22 @@ EXTERN_C void QCALLTYPE RhInitializeFinalizerThread()
     g_FinalizerEvent.Set();
 }
 
+static int32_t g_fullGcCountSeenByFinalization;
+
+// Indicate that the current round of finalizations is complete.
+EXTERN_C void QCALLTYPE RhpSignalFinalizationComplete(uint32_t fcount, int32_t observedFullGcCount)
+{
+    FireEtwGCFinalizersEnd_V1(fcount, GetClrInstanceId());
+
+    g_fullGcCountSeenByFinalization = observedFullGcCount;
+    g_FinalizerDoneEvent.Set();
+
+    if (YieldProcessorNormalization::IsMeasurementScheduled())
+    {
+        YieldProcessorNormalization::PerformMeasurement();
+    }
+}
+
 EXTERN_C void QCALLTYPE RhWaitForPendingFinalizers(UInt32_BOOL allowReentrantWait)
 {
     // This must be called via p/invoke rather than RuntimeImport since it blocks and could starve the GC if
@@ -103,6 +119,14 @@ EXTERN_C void QCALLTYPE RhWaitForPendingFinalizers(UInt32_BOOL allowReentrantWai
     // Can't call this from the finalizer thread itself.
     if (ThreadStore::GetCurrentThread() != g_pFinalizerThread)
     {
+        // We may see a completion of finalization cycle that might not see objects that became
+        // F-reachable in recent GCs. In such case we want to wait for a completion of another cycle.
+        // However, since an object cannot be prevented from promoting, one can only rely on Full GCs
+        // to collect unreferenced objects deterministically. Thus we only care about Full GCs here.
+        int desiredFullGcCount =
+            GCHeapUtilities::GetGCHeap()->CollectionCount(GCHeapUtilities::GetGCHeap()->GetMaxGeneration());
+
+    tryAgain:
         // Clear any current indication that a finalization pass is finished and wake the finalizer thread up
         // (if there's no work to do it'll set the done event immediately).
         g_FinalizerDoneEvent.Reset();
@@ -110,6 +134,14 @@ EXTERN_C void QCALLTYPE RhWaitForPendingFinalizers(UInt32_BOOL allowReentrantWai
 
         // Wait for the finalizer thread to get back to us.
         g_FinalizerDoneEvent.Wait(INFINITE, false, allowReentrantWait);
+
+        if (desiredFullGcCount - g_fullGcCountSeenByFinalization > 0)
+        {
+            // There were some Full GCs happening before we started waiting and possibly not seen by the
+            // last finalization cycle. This is rare, but we need to be sure we have seen those,
+            // so we try one more time.
+            goto tryAgain;
+        }
     }
 }
 
@@ -174,18 +206,6 @@ EXTERN_C UInt32_BOOL QCALLTYPE RhpWaitForFinalizerRequest()
             return FALSE;
         }
     } while (true);
-}
-
-// Indicate that the current round of finalizations is complete.
-EXTERN_C void QCALLTYPE RhpSignalFinalizationComplete(uint32_t fcount)
-{
-    FireEtwGCFinalizersEnd_V1(fcount, GetClrInstanceId());
-    g_FinalizerDoneEvent.Set();
-
-    if (YieldProcessorNormalization::IsMeasurementScheduled())
-    {
-        YieldProcessorNormalization::PerformMeasurement();
-    }
 }
 
 //

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -104,5 +104,15 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhBulkMoveWithWriteBarrier")]
         internal static extern unsafe void RhBulkMoveWithWriteBarrier(ref byte dmem, ref byte smem, nuint size);
+
+        // Get maximum GC generation number.
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhGetMaxGcGeneration")]
+        internal static extern int RhGetMaxGcGeneration();
+
+        // Get count of collections so far.
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhGetGcCollectionCount")]
+        internal static extern int RhGetGcCollectionCount(int generation, bool getSpecialGCCount);
     }
 }

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -596,7 +596,7 @@ void FinalizerThread::FinalizerThreadWait()
         // we use unsigned math here as the collection counts, which are size_t internally,
         // can in theory overflow an int and wrap around.
         // unsigned math would have more defined/portable behavior in such case
-        if ((unsigned int)desiredFullGcCount - (unsigned int)g_fullGcCountSeenByFinalization > 0)
+        if ((int)((unsigned int)desiredFullGcCount - (unsigned int)g_fullGcCountSeenByFinalization) > 0)
         {
             // There were some Full GCs happening before we started waiting and possibly not seen by the
             // last finalization cycle. This is rare, but we need to be sure we have seen those,

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -404,13 +404,15 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
         }
         LOG((LF_GC, LL_INFO100, "***** Calling Finalizers\n"));
 
+        int observedFullGcCount =
+            GCHeapUtilities::GetGCHeap()->CollectionCount(GCHeapUtilities::GetGCHeap()->GetMaxGeneration());
         FinalizeAllObjects();
 
         // Anyone waiting to drain the Q can now wake up.  Note that there is a
         // race in that another thread starting a drain, as we leave a drain, may
-        // consider itself satisfied by the drain that just completed.  This is
-        // acceptable.
-        SignalFinalizationDone();
+        // consider itself satisfied by the drain that just completed.
+        // Thus we include the Full GC count that we have certaily observed.
+        SignalFinalizationDone(observedFullGcCount);
     }
 
     if (s_InitializedFinalizerThreadForPlatform)
@@ -538,10 +540,13 @@ void FinalizerThread::FinalizerThreadCreate()
     }
 }
 
-void FinalizerThread::SignalFinalizationDone()
+static int fullGcCountSeenByFinalization;
+
+void FinalizerThread::SignalFinalizationDone(int observedFullGcCount)
 {
     WRAPPER_NO_CONTRACT;
 
+    fullGcCountSeenByFinalization = observedFullGcCount;
     hEventFinalizerDone->Set();
 }
 
@@ -551,6 +556,13 @@ void FinalizerThread::FinalizerThreadWait()
     ASSERT(hEventFinalizerDone->IsValid());
     ASSERT(hEventFinalizer->IsValid());
     ASSERT(GetFinalizerThread());
+
+    // We may see a completion of finalization cycle that might not see objects that became
+    // F-reachable in recent GCs. In such case we want to wait for a completion of another cycle.
+    // However, since an object cannot be prevented from promoting, one can only rely on Full GCs
+    // to collect unreferenced objects deterministically. Thus we only care about Full GCs here.
+    int desiredFullGcCount =
+        GCHeapUtilities::GetGCHeap()->CollectionCount(GCHeapUtilities::GetGCHeap()->GetMaxGeneration());
 
     // Can't call this from within a finalized method.
     if (!IsCurrentThreadFinalizer())
@@ -565,8 +577,8 @@ void FinalizerThread::FinalizerThreadWait()
             g_pRCWCleanupList->CleanupWrappersInCurrentCtxThread();
 #endif // FEATURE_COMINTEROP
 
+    tryAgain:
         hEventFinalizerDone->Reset();
-
         EnableFinalization();
 
         // Under GC stress the finalizer queue may never go empty as frequent
@@ -580,6 +592,15 @@ void FinalizerThread::FinalizerThreadWait()
 
         DWORD status;
         status = hEventFinalizerDone->Wait(INFINITE,TRUE);
+
+        if (desiredFullGcCount - fullGcCountSeenByFinalization > 0)
+        {
+            // There were some Full GCs happened before we started waiting and possibly not seen by the
+            // last finalization cycle. This is rare, but we need to be sure we have seen those,
+            // so we try one more time.
+            goto tryAgain;
+        }
+
         _ASSERTE(status == WAIT_OBJECT_0);
     }
 }

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -593,7 +593,10 @@ void FinalizerThread::FinalizerThreadWait()
         DWORD status;
         status = hEventFinalizerDone->Wait(INFINITE,TRUE);
 
-        if (desiredFullGcCount - g_fullGcCountSeenByFinalization > 0)
+        // we use unsigned math here as the collection counts, which are size_t internally,
+        // can in theory overflow an int and wrap around.
+        // unsigned math would have more defined/portable behavior in such case
+        if ((unsigned int)desiredFullGcCount - (unsigned int)g_fullGcCountSeenByFinalization > 0)
         {
             // There were some Full GCs happening before we started waiting and possibly not seen by the
             // last finalization cycle. This is rare, but we need to be sure we have seen those,

--- a/src/coreclr/vm/finalizerthread.h
+++ b/src/coreclr/vm/finalizerthread.h
@@ -67,7 +67,7 @@ public:
 
     static void FinalizerThreadWait();
 
-    static void SignalFinalizationDone();
+    static void SignalFinalizationDone(int observedFullGcCount);
 
     static VOID FinalizerThreadWorker(void *args);
     static DWORD WINAPI FinalizerThreadStart(void *args);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/104218

- [x] CoreCLR
- [x] NativeAOT
- [x] add a test
- [x] make the test outerloop

This fixes a long known race that was very rare in the past, but recently started becoming a nuisance. It goes like this:

- Some unrelated GC happens, completes, and finalization cycle starts
- Finalization thread drains the queue and is just about to report that it is done draining, but gets preempted
- User thread makes allocations, calls `Collect`, calls `WaitForPendingFinalizers`
- Collect runs, pends more items into the queue
- User thread waits in `WaitForPendingFinalizers` on the queue-empty event
- The Finalization thread gets to run and signals the event (while the queue is no longer empty)

This forced people to do unnatural things like calling `Collect(); WaitForPendingFinalizers();` a few times in a row "to be sure". 
That would not help if the objects expected to be finalized are not guaranteed to be unreachable, of course. No number of repeating this would help.  
Otherwise doing `Collect(); WaitForPendingFinalizers();` just once should be enough.

The fix makes sure that a waiter for the queue drain completion event and the releaser of that water are in agreement on what Full GCs have been certainly handled in the finalization cycle. 
In a rare case if the release is too old (in Full GC time), then waiter asks for one more cycle - to make sure there is nothing left in the queue, that the waiter waits for.
