### PR TITLE
Avoid NullReferenceException in CharEnumerator after calling Dispose

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
@@ -9,7 +9,7 @@ namespace System
     /// <summary>Supports iterating over a <see cref="string"/> object and reading its individual characters.</summary>
     public sealed class CharEnumerator : IEnumerator, IEnumerator<char>, IDisposable, ICloneable
     {
-        private string _str; // null after disposal
+        private string _str; // Empty string after disposal
         private int _index = -1;
 
         internal CharEnumerator(string str) => _str = str;
@@ -31,7 +31,7 @@ namespace System
             return false;
         }
 
-        public void Dispose() => _str = String.Empty;
+        public void Dispose() => _str = string.Empty;
 
         object? IEnumerator.Current => Current;
 

--- a/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
@@ -31,7 +31,7 @@ namespace System
             return false;
         }
 
-        public void Dispose() => _str = null!;
+        public void Dispose() => _str = String.Empty;
 
         object? IEnumerator.Current => Current;
 


### PR DESCRIPTION
Calling MoveNext after Dispose previously threw a NullReferenceException (caused by _str.Length). NullReferenceExceptions usually indicate a bug in the code that throws it. This causes confusion during debugging. By settings _str to String.Empty, MoveNext will simply return false.

Also see https://github.com/dotnet/runtime/pull/104821
