### PR TITLE
Update mono to support shuffle for constant inputs

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1431,7 +1431,7 @@ emit_vector_create_elementwise (
 	}
 
 	for (int i = 0; i < param_count; ++i) {
-		if (!is_const (args[i])) {
+		if (!is_const (args[i]) || (vector_size != 16)) {
 			ins = emit_vector_insert_element (cfg, vklass, ins, etype->type, args[i], i, TRUE);
 		}
 	}

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -702,7 +702,8 @@ get_xconst_int_elem (MonoCompile *cfg, MonoInst *ins, MonoTypeEnum etype, int in
 			g_assert (index < 8);
 			return ((guint16*)cns_vec) [index];
 		}
-		case MONO_TYPE_I4: {
+		case MONO_TYPE_I4:
+		case MONO_TYPE_R4: {
 			g_assert (index < 4);
 			return ((gint32*)cns_vec) [index];
 		}
@@ -710,7 +711,8 @@ get_xconst_int_elem (MonoCompile *cfg, MonoInst *ins, MonoTypeEnum etype, int in
 			g_assert (index < 4);
 			return ((guint32*)cns_vec) [index];
 		}
-		case MONO_TYPE_I8: {
+		case MONO_TYPE_I8:
+		case MONO_TYPE_R8: {
 			g_assert (index < 2);
 			return ((gint64*)cns_vec) [index];
 		}

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -686,43 +686,43 @@ get_xconst_int_elem (MonoCompile *cfg, MonoInst *ins, MonoTypeEnum etype, int in
 	}
 	g_assert (index >= 0);
 	switch (etype) {
-		case MONO_TYPE_I1: {
-			g_assert (index < 16);
-			return ((gint8*)cns_vec) [index];
-		}
-		case MONO_TYPE_U1: {
-			g_assert (index < 16);
-			return ((guint8*)cns_vec) [index];
-		}
-		case MONO_TYPE_I2: {
-			g_assert (index < 8);
-			return ((gint16*)cns_vec) [index];
-		}
-		case MONO_TYPE_U2: {
-			g_assert (index < 8);
-			return ((guint16*)cns_vec) [index];
-		}
-		case MONO_TYPE_I4:
-		case MONO_TYPE_R4: {
-			g_assert (index < 4);
-			return ((gint32*)cns_vec) [index];
-		}
-		case MONO_TYPE_U4: {
-			g_assert (index < 4);
-			return ((guint32*)cns_vec) [index];
-		}
-		case MONO_TYPE_I8:
-		case MONO_TYPE_R8: {
-			g_assert (index < 2);
-			return ((gint64*)cns_vec) [index];
-		}
-		case MONO_TYPE_U8: {
-			g_assert (index < 2);
-			return ((guint64*)cns_vec) [index];
-		}
-		default: {
-			g_assert_not_reached ();
-		}
+	case MONO_TYPE_I1: {
+		g_assert (index < 16);
+		return ((gint8*)cns_vec) [index];
+	}
+	case MONO_TYPE_U1: {
+		g_assert (index < 16);
+		return ((guint8*)cns_vec) [index];
+	}
+	case MONO_TYPE_I2: {
+		g_assert (index < 8);
+		return ((gint16*)cns_vec) [index];
+	}
+	case MONO_TYPE_U2: {
+		g_assert (index < 8);
+		return ((guint16*)cns_vec) [index];
+	}
+	case MONO_TYPE_I4:
+	case MONO_TYPE_R4: {
+		g_assert (index < 4);
+		return ((gint32*)cns_vec) [index];
+	}
+	case MONO_TYPE_U4: {
+		g_assert (index < 4);
+		return ((guint32*)cns_vec) [index];
+	}
+	case MONO_TYPE_I8:
+	case MONO_TYPE_R8: {
+		g_assert (index < 2);
+		return ((gint64*)cns_vec) [index];
+	}
+	case MONO_TYPE_U8: {
+		g_assert (index < 2);
+		return ((guint64*)cns_vec) [index];
+	}
+	default: {
+		g_assert_not_reached ();
+	}
 	}
 }
 
@@ -1181,17 +1181,17 @@ emit_vector_insert_element (
 					cns_val = *(const double*)(element->inst_p0);
 				}
 				switch (type) {
-					case MONO_TYPE_R4: {
-						((float*)cns_vec) [index] = (float)cns_val;
-						break;
-					}
-					case MONO_TYPE_R8: {
-						((double*)cns_vec) [index] = (double)cns_val;
-						break;
-					}
-					default: {
-						g_assert_not_reached ();
-					}
+				case MONO_TYPE_R4: {
+					((float*)cns_vec) [index] = (float)cns_val;
+					break;
+				}
+				case MONO_TYPE_R8: {
+					((double*)cns_vec) [index] = (double)cns_val;
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			} else {
 				gint64 cns_val;
@@ -1202,29 +1202,29 @@ emit_vector_insert_element (
 					cns_val = element->inst_l;
 				}
 				switch (type) {
-					case MONO_TYPE_I1:
-					case MONO_TYPE_U1: {
-						((guint8*)cns_vec) [index] = (guint8)cns_val;
-						break;
-					}
-					case MONO_TYPE_I2:
-					case MONO_TYPE_U2: {
-						((guint16*)cns_vec) [index] = (guint16)cns_val;
-						break;
-					}
-					case MONO_TYPE_I4:
-					case MONO_TYPE_U4: {
-						((guint32*)cns_vec) [index] = (guint32)cns_val;
-						break;
-					}
-					case MONO_TYPE_I8:
-					case MONO_TYPE_U8: {
-						((guint64*)cns_vec) [index] = (guint64)cns_val;
-						break;
-					}
-					default: {
-						g_assert_not_reached ();
-					}
+				case MONO_TYPE_I1:
+				case MONO_TYPE_U1: {
+					((guint8*)cns_vec) [index] = (guint8)cns_val;
+					break;
+				}
+				case MONO_TYPE_I2:
+				case MONO_TYPE_U2: {
+					((guint16*)cns_vec) [index] = (guint16)cns_val;
+					break;
+				}
+				case MONO_TYPE_I4:
+				case MONO_TYPE_U4: {
+					((guint32*)cns_vec) [index] = (guint32)cns_val;
+					break;
+				}
+				case MONO_TYPE_I8:
+				case MONO_TYPE_U8: {
+					((guint64*)cns_vec) [index] = (guint64)cns_val;
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			}
 			return emit_xconst_v128 (cfg, vklass, cns_vec);
@@ -1268,21 +1268,21 @@ emit_vector_create_broadcast (
 					cns_val = *(const double*)(arg0->inst_p0);
 				}
 				switch (etype->type) {
-					case MONO_TYPE_R4: {
-						for (int i = 0; i < vector_size / 4; i++) {
-							((float*)cns_vec) [i] = (float)cns_val;
-						}
-						break;
+				case MONO_TYPE_R4: {
+					for (int i = 0; i < vector_size / 4; i++) {
+						((float*)cns_vec) [i] = (float)cns_val;
 					}
-					case MONO_TYPE_R8: {
-						for (int i = 0; i < vector_size / 8; i++) {
-							((double*)cns_vec) [i] = (double)cns_val;
-						}
-						break;
+					break;
+				}
+				case MONO_TYPE_R8: {
+					for (int i = 0; i < vector_size / 8; i++) {
+						((double*)cns_vec) [i] = (double)cns_val;
 					}
-					default: {
-						g_assert_not_reached ();
-					}
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			} else {
 				gint64 cns_val;
@@ -1293,37 +1293,37 @@ emit_vector_create_broadcast (
 					cns_val = arg0->inst_l;
 				}
 				switch (etype->type) {
-					case MONO_TYPE_I1:
-					case MONO_TYPE_U1: {
-						for (int i = 0; i < vector_size / 1; i++) {
-							((guint8*)cns_vec) [i] = (guint8)cns_val;
-						}
-						break;
+				case MONO_TYPE_I1:
+				case MONO_TYPE_U1: {
+					for (int i = 0; i < vector_size / 1; i++) {
+						((guint8*)cns_vec) [i] = (guint8)cns_val;
 					}
-					case MONO_TYPE_I2:
-					case MONO_TYPE_U2: {
-						for (int i = 0; i < vector_size / 2; i++) {
-							((guint16*)cns_vec) [i] = (guint16)cns_val;
-						}
-						break;
+					break;
+				}
+				case MONO_TYPE_I2:
+				case MONO_TYPE_U2: {
+					for (int i = 0; i < vector_size / 2; i++) {
+						((guint16*)cns_vec) [i] = (guint16)cns_val;
 					}
-					case MONO_TYPE_I4:
-					case MONO_TYPE_U4: {
-						for (int i = 0; i < vector_size / 4; i++) {
-							((guint32*)cns_vec) [i] = (guint32)cns_val;
-						}
-						break;
+					break;
+				}
+				case MONO_TYPE_I4:
+				case MONO_TYPE_U4: {
+					for (int i = 0; i < vector_size / 4; i++) {
+						((guint32*)cns_vec) [i] = (guint32)cns_val;
 					}
-					case MONO_TYPE_I8:
-					case MONO_TYPE_U8: {
-						for (int i = 0; i < vector_size / 8; i++) {
-							((guint64*)cns_vec) [i] = (guint64)cns_val;
-						}
-						break;
+					break;
+				}
+				case MONO_TYPE_I8:
+				case MONO_TYPE_U8: {
+					for (int i = 0; i < vector_size / 8; i++) {
+						((guint64*)cns_vec) [i] = (guint64)cns_val;
 					}
-					default: {
-						g_assert_not_reached ();
-					}
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			}
 			return emit_xconst_v128 (cfg, vklass, (guint8*)cns_vec);
@@ -1368,17 +1368,17 @@ emit_vector_create_elementwise (
 				}
 
 				switch (etype->type) {
-					case MONO_TYPE_R4: {
-						((float*)cns_vec) [i] = (float)cns_val;
-						break;
-					}
-					case MONO_TYPE_R8: {
-						((double*)cns_vec) [i] = (double)cns_val;
-						break;
-					}
-					default: {
-						g_assert_not_reached ();
-					}
+				case MONO_TYPE_R4: {
+					((float*)cns_vec) [i] = (float)cns_val;
+					break;
+				}
+				case MONO_TYPE_R8: {
+					((double*)cns_vec) [i] = (double)cns_val;
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			} else {
 				gint64 cns_val;
@@ -1390,29 +1390,29 @@ emit_vector_create_elementwise (
 				}
 
 				switch (etype->type) {
-					case MONO_TYPE_I1:
-					case MONO_TYPE_U1: {
-						((guint8*)cns_vec) [i] = (guint8)cns_val;
-						break;
-					}
-					case MONO_TYPE_I2:
-					case MONO_TYPE_U2: {
-						((guint16*)cns_vec) [i] = (guint16)cns_val;
-						break;
-					}
-					case MONO_TYPE_I4:
-					case MONO_TYPE_U4: {
-						((guint32*)cns_vec) [i] = (guint32)cns_val;
-						break;
-					}
-					case MONO_TYPE_I8:
-					case MONO_TYPE_U8: {
-						((guint64*)cns_vec) [i] = (guint64)cns_val;
-						break;
-					}
-					default: {
-						g_assert_not_reached ();
-					}
+				case MONO_TYPE_I1:
+				case MONO_TYPE_U1: {
+					((guint8*)cns_vec) [i] = (guint8)cns_val;
+					break;
+				}
+				case MONO_TYPE_I2:
+				case MONO_TYPE_U2: {
+					((guint16*)cns_vec) [i] = (guint16)cns_val;
+					break;
+				}
+				case MONO_TYPE_I4:
+				case MONO_TYPE_U4: {
+					((guint32*)cns_vec) [i] = (guint32)cns_val;
+					break;
+				}
+				case MONO_TYPE_I8:
+				case MONO_TYPE_U8: {
+					((guint64*)cns_vec) [i] = (guint64)cns_val;
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			}
 		}
@@ -1465,17 +1465,17 @@ emit_vector_create_scalar (
 				}
 
 				switch (etype->type) {
-					case MONO_TYPE_R4: {
-						((float*)cns_vec) [0] = (float)cns_val;
-						break;
-					}
-					case MONO_TYPE_R8: {
-						((double*)cns_vec) [0] = (double)cns_val;
-						break;
-					}
-					default: {
-						g_assert_not_reached ();
-					}
+				case MONO_TYPE_R4: {
+					((float*)cns_vec) [0] = (float)cns_val;
+					break;
+				}
+				case MONO_TYPE_R8: {
+					((double*)cns_vec) [0] = (double)cns_val;
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			} else {
 				gint64 cns_val;
@@ -1487,29 +1487,29 @@ emit_vector_create_scalar (
 				
 }
 				switch (etype->type) {
-					case MONO_TYPE_I1:
-					case MONO_TYPE_U1: {
-						((guint8*)cns_vec) [0] = (guint8)cns_val;
-						break;
-					}
-					case MONO_TYPE_I2:
-					case MONO_TYPE_U2: {
-						((guint16*)cns_vec) [0] = (guint16)cns_val;
-						break;
-					}
-					case MONO_TYPE_I4:
-					case MONO_TYPE_U4: {
-						((guint32*)cns_vec) [0] = (guint32)cns_val;
-						break;
-					}
-					case MONO_TYPE_I8:
-					case MONO_TYPE_U8: {
-						((guint64*)cns_vec) [0] = (guint64)cns_val;
-						break;
-					}
-					default: {
-						g_assert_not_reached ();
-					}
+				case MONO_TYPE_I1:
+				case MONO_TYPE_U1: {
+					((guint8*)cns_vec) [0] = (guint8)cns_val;
+					break;
+				}
+				case MONO_TYPE_I2:
+				case MONO_TYPE_U2: {
+					((guint16*)cns_vec) [0] = (guint16)cns_val;
+					break;
+				}
+				case MONO_TYPE_I4:
+				case MONO_TYPE_U4: {
+					((guint32*)cns_vec) [0] = (guint32)cns_val;
+					break;
+				}
+				case MONO_TYPE_I8:
+				case MONO_TYPE_U8: {
+					((guint64*)cns_vec) [0] = (guint64)cns_val;
+					break;
+				}
+				default: {
+					g_assert_not_reached ();
+				}
 				}
 			}
 

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -2683,8 +2683,8 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		return emit_simd_ins_for_unary_op (cfg, klass, fsig, args, arg0_type, id);
 	}
 	case SN_Shuffle: {
-		MonoType *etype = fsig->params [0];
-		if (!is_element_type_primitive (etype))
+		MonoType *etype = get_vector_t_elem_type (fsig->ret);
+		if (!MONO_TYPE_IS_VECTOR_PRIMITIVE (etype))
 			return NULL;
 #ifdef TARGET_WASM
 		return emit_simd_ins_for_sig (cfg, klass, OP_WASM_SIMD_SWIZZLE, -1, -1, fsig, args);

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1154,7 +1154,7 @@ emit_vector_insert_element (
 {
 	int op = type_to_insert_op (type);
 
-	if (is_zero_inited && is_zero_const (element)) {
+	if (((is_zero_inited) || (ins->opcode == OP_XZERO)) && is_zero_const (element)) {
 		// element already set to zero
 		return ins;
 	}
@@ -1228,6 +1228,7 @@ emit_vector_insert_element (
 				}
 			}
 			if (ins->opcode == OP_XCONST) {
+				memcpy (ins->inst_p0, cns_vec, 16);
 				return ins;
 			}
 			return emit_xconst_v128 (cfg, vklass, cns_vec);

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1228,8 +1228,7 @@ emit_vector_insert_element (
 				}
 			}
 			if (ins->opcode == OP_XCONST) {
-				memcpy (ins->inst_p0, cns_vec, 16);
-				return ins;
+				return emit_xconst_v128 (cfg, vklass, cns_vec);
 			}
 			return emit_xconst_v128 (cfg, vklass, cns_vec);
 		}

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -2706,6 +2706,8 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		if (COMPILE_LLVM (cfg)) {
 			if ((get_xconst_int_elem (cfg, args [1], MONO_TYPE_U8, 0) == 0x300000002) &&
 				(get_xconst_int_elem (cfg, args [1], MONO_TYPE_U8, 1) == 0x100000000)) {
+				etype = m_class_get_byval_arg (mono_defaults.uint64_class);
+				klass = create_class_instance ("System.Runtime.Intrinsics", "Vector128`1", etype);
 				new_args [1] = args [0];
 				EMIT_NEW_ICONST (cfg, new_args [2], 1);
 				MonoInst* ins = emit_simd_ins (cfg, klass, OP_ARM64_EXT, new_args [0]->dreg, new_args [1]->dreg);
@@ -2732,6 +2734,8 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 				}
 			}
 		}
+		etype = m_class_get_byval_arg (mono_defaults.byte_class);
+		klass = create_class_instance ("System.Runtime.Intrinsics", "Vector128`1", etype);
 		new_args [1] = emit_xconst_v128 (cfg, klass, vec_cns);
 		return emit_simd_ins_for_sig (cfg, klass, OP_XOP_OVR_X_X_X, INTRINS_AARCH64_ADV_SIMD_TBL1, 0, fsig, new_args);
 #elif defined(TARGET_AMD64)
@@ -2789,6 +2793,8 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 				if (!is_SIMD_feature_supported (cfg, MONO_CPU_X86_SSSE3)) {
 					return NULL;
 				}
+				etype = m_class_get_byval_arg (mono_defaults.byte_class);
+				klass = create_class_instance ("System.Runtime.Intrinsics", "Vector128`1", etype);
 				new_args [1] = emit_xconst_v128 (cfg, klass, vec_cns);
 				return emit_simd_ins_for_sig (cfg, klass, OP_XOP_X_X_X, INTRINS_SSE_PSHUFB, 0, fsig, new_args);
 			}
@@ -2798,6 +2804,8 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 				// down into a TYP_INT or TYP_UINT based shuffle, but that's additional complexity for no
 				// real benefit since shuffle gets its own port rather than using the fp specific ports.
 				arg0_type = MONO_TYPE_R8;
+				etype = m_class_get_byval_arg (mono_defaults.double_class);
+				klass = create_class_instance ("System.Runtime.Intrinsics", "Vector128`1", etype);
 			}
 			if ((arg0_type == MONO_TYPE_R4) || (arg0_type == MONO_TYPE_R8)) {
 				int opcode = (arg0_type == MONO_TYPE_R4) ? OP_SSE_SHUFPS : OP_SSE2_SHUFPD;


### PR DESCRIPTION
Mono wasn't accelerating `shuffle` for anything other than byte/sbyte on x64. This was in part because doing so required detecting inputs as constant which didn't exist when that support was first brought online.

However, I had since added basic support for constants last year in https://github.com/dotnet/runtime/pull/81902. This PR adds support that mirrors most of the RyuJIT `Shuffle` importation logic and so we can now do the right thing. As a side effect, the general support for generating such constants for `Create` calls when all inputs are constants was also expanded which should have some indirect benefits in other places.

`Shuffle` having not being accelerated is *very* impactful to the entire BCL and I would expect this to have a broad impact across many core benchmarks including `HexConverter`, `XxHash`, `TensorPrimitives`, `ReverseEndianness`, `Base64Decoder`, `Guid`, `Matrix4x4`, `Quaternion`, `IndexOfAny`, `ProbablisticMap`, various `SpanHelpers` APIs and more.
