### PR TITLE
Update runtime metrics tests to avoid failures on some platforms

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime;
 using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,6 +17,9 @@ namespace System.Diagnostics.Metrics.Tests
         private const string GreaterThanOrEqualToZeroMessage = "Expected value to be greater than or equal to zero.";
 
         private static readonly string[] s_genNames = ["gen0", "gen1", "gen2", "loh", "poh"];
+
+        // On some platforms and AoT scenarios, the JIT may not be in use. Some assertions will consider zero as a valid in such cases.
+        private static bool s_jitHasRun = JitInfo.GetCompiledMethodCount() > 0;
 
         private static readonly Func<bool> s_forceGc = () =>
         {
@@ -69,7 +73,7 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.True(measurements.Count >= gensExpected, $"Expected to find at least one measurement for each generation ({gensExpected}) " +
                 $"but received {measurements.Count} measurements.");
 
-            foreach (Measurement<long> measurement in measurements.Where(m => m.Value >= 1))
+            foreach (Measurement<long> measurement in measurements)
             {
                 var tags = measurement.Tags.ToArray();
                 var tag = tags.SingleOrDefault(k => k.Key == "gc.heap.generation");
@@ -228,9 +232,9 @@ namespace System.Diagnostics.Metrics.Tests
             new object[] { "dotnet.gc.heap.total_allocated", s_longGreaterThanZero, null },
             new object[] { "dotnet.gc.last_collection.memory.committed_size", s_longGreaterThanZero, s_forceGc },
             new object[] { "dotnet.gc.pause.time", s_doubleGreaterThanOrEqualToZero, s_forceGc }, // may be zero if no GC has occurred
-            new object[] { "dotnet.jit.compiled_il.size", s_longGreaterThanZero, null },
-            new object[] { "dotnet.jit.compiled_methods", s_longGreaterThanZero, null },
-            new object[] { "dotnet.jit.compilation.time", s_doubleGreaterThanZero, null },
+            new object[] { "dotnet.jit.compiled_il.size", s_jitHasRun ? s_longGreaterThanZero : s_longGreaterThanOrEqualToZero, null },
+            new object[] { "dotnet.jit.compiled_methods", s_jitHasRun ? s_longGreaterThanZero : s_longGreaterThanOrEqualToZero, null },
+            new object[] { "dotnet.jit.compilation.time", s_jitHasRun ? s_longGreaterThanZero : s_longGreaterThanOrEqualToZero, null },
             new object[] { "dotnet.monitor.lock_contentions", s_longGreaterThanOrEqualToZero, null },
             new object[] { "dotnet.thread_pool.thread.count", s_longGreaterThanZero, null },
             new object[] { "dotnet.thread_pool.work_item.count", s_longGreaterThanOrEqualToZero, null },

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
@@ -242,7 +242,7 @@ namespace System.Diagnostics.Metrics.Tests
             new object[] { "dotnet.timer.count", s_longGreaterThanOrEqualToZero, null },
         };
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile))]
         [MemberData(nameof(Measurements))]
         public void ValidateMeasurements<T>(string metricName, Func<T, (bool, string?)>? valueAssertion, Func<bool>? beforeRecord)
             where T : struct

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
@@ -116,7 +116,7 @@ namespace System.Diagnostics.Metrics.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile))]
         public void CpuTime()
         {
            using InstrumentRecorder<double> instrumentRecorder = new("dotnet.process.cpu.time");
@@ -125,7 +125,7 @@ namespace System.Diagnostics.Metrics.Tests
 
            bool[] foundCpuModes = [false, false];
 
-           foreach (Measurement<double> measurement in instrumentRecorder.GetMeasurements().Where(m => m.Value >= 0))
+           foreach (Measurement<double> measurement in instrumentRecorder.GetMeasurements())
            {
                var tags = measurement.Tags.ToArray();
                var tag = tags.SingleOrDefault(k => k.Key == "cpu.mode");

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
@@ -224,7 +224,7 @@ namespace System.Diagnostics.Metrics.Tests
             }
         }
 
-        public static IEnumerable<object[]> LongMeasurements => new List<object[]>
+        public static IEnumerable<object[]> Measurements => new List<object[]>
         {
             new object[] { "dotnet.process.memory.working_set", s_longGreaterThanZero, null },
             new object[] { "dotnet.assembly.count", s_longGreaterThanZero, null },
@@ -234,7 +234,7 @@ namespace System.Diagnostics.Metrics.Tests
             new object[] { "dotnet.gc.pause.time", s_doubleGreaterThanOrEqualToZero, s_forceGc }, // may be zero if no GC has occurred
             new object[] { "dotnet.jit.compiled_il.size", s_jitHasRun ? s_longGreaterThanZero : s_longGreaterThanOrEqualToZero, null },
             new object[] { "dotnet.jit.compiled_methods", s_jitHasRun ? s_longGreaterThanZero : s_longGreaterThanOrEqualToZero, null },
-            new object[] { "dotnet.jit.compilation.time", s_jitHasRun ? s_longGreaterThanZero : s_longGreaterThanOrEqualToZero, null },
+            new object[] { "dotnet.jit.compilation.time", s_jitHasRun ? s_doubleGreaterThanZero : s_doubleGreaterThanOrEqualToZero, null },
             new object[] { "dotnet.monitor.lock_contentions", s_longGreaterThanOrEqualToZero, null },
             new object[] { "dotnet.thread_pool.thread.count", s_longGreaterThanZero, null },
             new object[] { "dotnet.thread_pool.work_item.count", s_longGreaterThanOrEqualToZero, null },
@@ -243,7 +243,7 @@ namespace System.Diagnostics.Metrics.Tests
         };
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [MemberData(nameof(LongMeasurements))]
+        [MemberData(nameof(Measurements))]
         public void ValidateMeasurements<T>(string metricName, Func<T, (bool, string?)>? valueAssertion, Func<bool>? beforeRecord)
             where T : struct
         {


### PR DESCRIPTION
This updates the jit metrics assertions to only assertions for greater than zero measurements when the JIT appears to have run.

I've further limited the GcCollectionsCount test to allow zero measurements, which is best in cases where a forced GC may not have run.

This should fix #105202 and #105203.

What do you think of this approach @tarekgh? We could also more stringently skip platforms with an `IsNotMobile` check, but I think it's worth having these run if possible while allowing zero values for measurements when those occur. We mostly want to test that the metrics return a measurement for the expected metric name, and the value is less important and less deterministic.

