### PR TITLE
Fix source-build leg

### DIFF
--- a/src/libraries/oob.proj
+++ b/src/libraries/oob.proj
@@ -18,7 +18,8 @@
 
   <ItemGroup Condition="'$(BuildTargetFramework)' != '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
     <ProjectReference Include="oob-all.proj" SkipGetTargetFrameworkProperties="true" />
-    <ProjectReference Include="oob-gen.proj" />
+    <!-- Skip building all source generators when building from source as that would bring new prebuilts in. -->
+    <ProjectReference Include="oob-gen.proj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
   <!-- Support building reference projects only. -->


### PR DESCRIPTION
This regressed with https://github.com/dotnet/runtime/pull/105247 but for whatever reason unknown to me, the failure didn't show up in the PR and the source-build leg ran successfully in there.

OK, this raced with https://github.com/dotnet/runtime/commit/54e15cb81d84fae6760b90287468b09250f63e8c which changed the source-build-reference-packages contents.