### PR TITLE
Fix DeepEquals_DeepJsonDocument stack overflow that manifests in xunit.console and netfx.

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -246,6 +246,9 @@
   <data name="JsonElementHasWrongType" xml:space="preserve">
     <value>The requested operation requires an element of type '{0}', but the target element has type '{1}'.</value>
   </data>
+  <data name="JsonElementDeepEqualsInsufficientExecutionStack" xml:space="preserve">
+    <value>Insufficient stack to continue executing 'JsonElement.DeepEquals'. This can happen either because the 'JsonElement' values are too deep or 'DeepEquals' is being called too deep in the stack.</value>
+  </data>
   <data name="JsonNumberExponentTooLarge" xml:space="preserve">
     <value>The exponent value in the specified JSON number is too large.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -161,6 +161,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonTypeInfoResolverWithAddedModifiers.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\PropertyRefCacheBuilder.cs" />
     <Compile Include="System\Text\Json\Serialization\PolymorphicSerializationState.cs" />
+    <Compile Include="System\Text\Json\StackHelper.cs" />
     <Compile Include="System\Text\Json\ValueQueue.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriterCache.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceEqualsWrapper.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1262,6 +1262,11 @@ namespace System.Text.Json
         /// </remarks>
         public static bool DeepEquals(JsonElement element1, JsonElement element2)
         {
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
+            {
+                ThrowHelper.ThrowInsufficientExecutionStackException_JsonElementDeepEqualsInsufficientExecutionStack();
+            }
+
             element1.CheckValidInstance();
             element2.CheckValidInstance();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/StackHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/StackHelper.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Json
+{
+    /// <summary>Provides tools for avoiding stack overflows.</summary>
+    internal static class StackHelper
+    {
+        /// <summary>Tries to ensure there is sufficient stack to execute the average .NET function.</summary>
+        public static bool TryEnsureSufficientExecutionStack()
+        {
+#if NET
+            return RuntimeHelpers.TryEnsureSufficientExecutionStack();
+#else
+            try
+            {
+                RuntimeHelpers.EnsureSufficientExecutionStack();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+#endif
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -719,6 +719,12 @@ namespace System.Text.Json
         {
             throw new ObjectDisposedException(nameof(JsonDocument));
         }
+
+        [DoesNotReturn]
+        public static void ThrowInsufficientExecutionStackException_JsonElementDeepEqualsInsufficientExecutionStack()
+        {
+            throw new InsufficientExecutionStackException(SR.JsonElementDeepEqualsInsufficientExecutionStack);
+        }
     }
 
     internal enum ExceptionResource

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonElementTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonElementTests.cs
@@ -221,7 +221,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
+        [InlineData(500)]
         public static void DeepEquals_DeepJsonDocument(int depth)
         {
             ArrayBufferWriter<byte> bufferWriter = new();


### PR DESCRIPTION
Resolves a stack overflow that only occurs when running netfx tests using xunit.console.

cc @buyaa-n 