### PR TITLE
[EventSource] Block EventCommandExecuted callback during initialization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -46,8 +46,9 @@ namespace System.Diagnostics.Tracing
 
         private void OnEventSourceCommand(object? sender, EventCommandEventArgs e)
         {
-            // Should only be enable or disable
-            Debug.Assert(e.Command == EventCommand.Enable || e.Command == EventCommand.Disable);
+            // Should only be enable or disable, but during EventSource initialization, update may be seen as this callback
+            // is invoked on all m_deferredCommands while processing them synchronously through EventSource.DoCommand.
+            Debug.Assert(e.Command == EventCommand.Enable || e.Command == EventCommand.Disable || e.Command == EventCommand.Update);
 
             lock (s_counterGroupLock)      // Lock the CounterGroup
             {
@@ -73,9 +74,8 @@ namespace System.Diagnostics.Tracing
                         EnableTimer(intervalValue);
                     }
                 }
-                else
+                else if (e.Command == EventCommand.Disable)
                 {
-                    Debug.Assert(e.Command == EventCommand.Disable);
                     // Since we allow sessions to send multiple Enable commands to update the interval, we cannot
                     // rely on ref counting to determine when to enable and disable counters. You will get an arbitrary
                     // number of Enables and one Disable per session.
@@ -90,6 +90,12 @@ namespace System.Diagnostics.Tracing
                     {
                         DisableTimer();
                     }
+                }
+                else
+                {
+                    // Encountered EventCommand.Update while registering this callback on all deferred commands
+                    // during EventSource initialization before they are all processed.
+                    return;
                 }
 
                 Debug.Assert((s_counterGroupEnabledList == null && !_eventSource.IsEnabled())

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -46,9 +46,8 @@ namespace System.Diagnostics.Tracing
 
         private void OnEventSourceCommand(object? sender, EventCommandEventArgs e)
         {
-            // Should only be enable or disable, but during EventSource initialization, update may be seen as this callback
-            // is invoked on all m_deferredCommands while processing them synchronously through EventSource.DoCommand.
-            Debug.Assert(e.Command == EventCommand.Enable || e.Command == EventCommand.Disable || e.Command == EventCommand.Update);
+            // Should only be enable or disable
+            Debug.Assert(e.Command == EventCommand.Enable || e.Command == EventCommand.Disable);
 
             lock (s_counterGroupLock)      // Lock the CounterGroup
             {
@@ -74,8 +73,9 @@ namespace System.Diagnostics.Tracing
                         EnableTimer(intervalValue);
                     }
                 }
-                else if (e.Command == EventCommand.Disable)
+                else
                 {
+                    Debug.Assert(e.Command == EventCommand.Disable);
                     // Since we allow sessions to send multiple Enable commands to update the interval, we cannot
                     // rely on ref counting to determine when to enable and disable counters. You will get an arbitrary
                     // number of Enables and one Disable per session.
@@ -90,12 +90,6 @@ namespace System.Diagnostics.Tracing
                     {
                         DisableTimer();
                     }
-                }
-                else
-                {
-                    // Encountered EventCommand.Update while registering this callback on all deferred commands
-                    // during EventSource initialization before they are all processed.
-                    return;
                 }
 
                 Debug.Assert((s_counterGroupEnabledList == null && !_eventSource.IsEnabled())

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1641,9 +1641,6 @@ namespace System.Diagnostics.Tracing
                 m_eventPipeProvider = eventPipeProvider;
 #endif
                 Debug.Assert(!m_eventSourceEnabled);     // We can't be enabled until we are completely initted.
-                // We are logically completely initialized at this point, but set m_completelyInited after
-                // doing deferred commands under the EventListenersLock to avoid a race with SendCommand which
-                // can clear deferred commands before they are done.
             }
             catch (Exception e)
             {
@@ -2583,12 +2580,8 @@ namespace System.Diagnostics.Tracing
 
             // PRECONDITION: We should be holding the EventListener.EventListenersLock
             Debug.Assert(Monitor.IsEntered(EventListener.EventListenersLock));
-            // We defer commands until we are completely inited.  This allows error messages to be sent.
-            // Technically, by this point initialization should be complete, but m_completelyInited
-            // is only set after processing deferred commands at the end of Initialize to
-            // avoid possibly double invoking the m_eventCommandExecuted callback should EventCommandExecuted
-            // be set during OnEventCommand.
 
+            // We defer commands until we can send error messages.
             if (m_etwProvider == null)     // If we failed to construct
                 return;
 


### PR DESCRIPTION
During managed startup, the managed EventSource [`RuntimeEventSource` is initialized](https://github.com/dotnet/runtime/blob/fccbc77d2f8c32462a35488751657c8339c88508/src/coreclr/System.Private.CoreLib/src/System/StartupHookProvider.CoreCLR.cs#L19), kicking off EventSource initialization where all deferred commands `m_deferredCommands` for that EventSource instance are processed [one at a time](https://github.com/dotnet/runtime/blob/fccbc77d2f8c32462a35488751657c8339c88508/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L1660) at the end of `EventSource.Initialize`.

However, should a derived EventSource set its callback `EventCommandExecuted` within its `OnEventCommand`, then because of [the decision to invoke the callback on all deferred commands](https://github.com/dotnet/runtime/blob/4fbd498cc25ca9ca2ca6cac4764866bf08d1988f/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L503-L510), the callback will be invoked before all deferred commands could be initially processed in `EventSource.Initialize`.

CounterGroup registers its callback during construction, so should multiple events be sent to `RuntimeEventSource` during initialization (e.g. `m_deferredCommands = [ Update, Update, Update, ... ]`), then because `RuntimeEventSource` [initializes multiple event counters](https://github.com/dotnet/runtime/blob/fccbc77d2f8c32462a35488751657c8339c88508/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs#L100-L131) once the deferred command is processed at the end of `EventSource.Initialize()` ((i.e. `m_deferredCommands = [ Enable, Update, Update, ... ]`), then the callback is invoked on all deferred commands before they are converted from Update.
This leads to an assertion error as demonstrated by
```
EventSource[2000003047]Invoke deferred command on this value:System.Diagnostics.Tracing.EventCommandEventArgs(-1391687009 Command = Enable)
EventSource[2000003047]Invoke deferred command on this value:System.Diagnostics.Tracing.EventCommandEventArgs(663802102 Command = Update)
```
 in https://github.com/dotnet/runtime/issues/96324#issue-2056808808.
 
This PR aims to avoid double-invocations of the same callback `m_eventCommandExecuted` during `EventSource.Initialize` should the more-derived EventSource class set-up its `EventCommandExecuted` callback within its `OnEventCommand`.

To do so, we defer invoking the `EventCommandExecuted` callback on deferred commands until **after** all deferred commands are first-processed during initialization.

Fixes #94964 
Fixes #96324
Fixes #99497
Fixes #92519