### PR TITLE
Fix span write in `InvariantCreateSortKeyOrdinalIgnoreCase`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Invariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Invariant.cs
@@ -66,10 +66,11 @@ namespace System.Globalization
                     if (char.IsLowSurrogate(cl))
                     {
                         SurrogateCasing.ToUpper(c, cl, out char hr, out char lr);
-                        BinaryPrimitives.WriteUInt16BigEndian(sortKey, hr);
-                        BinaryPrimitives.WriteUInt16BigEndian(sortKey, lr);
-                        i++;
+                        Span<byte> tmp = sortKey.Slice(0, 2 * sizeof(ushort)); // help with bounds check elimination
+                        BinaryPrimitives.WriteUInt16BigEndian(tmp, hr);
+                        BinaryPrimitives.WriteUInt16BigEndian(tmp.Slice(sizeof(ushort)), lr);
                         sortKey = sortKey.Slice(2 * sizeof(ushort));
+                        i++;
                         continue;
                     }
                 }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/Invariant/InvariantMode.cs
@@ -773,6 +773,7 @@ namespace System.Globalization.Tests
         [InlineData("Hello", CompareOptions.IgnoreCase | CompareOptions.IgnoreWidth, "HELLO")]
         [InlineData("Hell\u00F6", CompareOptions.None, "Hell\u00F6")] // U+00F6 = LATIN SMALL LETTER O WITH DIAERESIS
         [InlineData("Hell\u00F6", CompareOptions.IgnoreCase, "HELL\u00D6")]
+        [InlineData("Hell\uD82A\uDC15", CompareOptions.IgnoreCase, "HELL\uD82A\uDC15")] // U+D82A = High Surrogate; U+DC15 = Low Surrogate
         public unsafe void TestSortKey_FromSpan(string input, CompareOptions options, string expected)
         {
             byte[] expectedOutputBytes = GetExpectedInvariantOrdinalSortKey(expected);


### PR DESCRIPTION
cc: @tarekgh

Existing logic appears to be incorrect:

```csharp
BinaryPrimitives.WriteUInt16BigEndian(sortKey, hr);
BinaryPrimitives.WriteUInt16BigEndian(sortKey, lr)
```