### PR TITLE
Don't overbuild source generator when root building for net48

### DIFF
--- a/src/libraries/oob-gen.proj
+++ b/src/libraries/oob-gen.proj
@@ -1,5 +1,11 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
+  <PropertyGroup Condition="'$(BuildTargetFramework)' != '' and '$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">
+    <TargetFramework>$(BuildTargetFramework)</TargetFramework>
+    <!-- Filter ProjectReferences to build the best matching target framework only. -->
+    <FilterTraversalProjectReferences>true</FilterTraversalProjectReferences>
+  </PropertyGroup>
+
   <!-- Reference all out-of-band generator projects. -->
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\gen\**\*.*proj"


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105364

Just noticed that source generators are now built twice. Regressed with https://github.com/dotnet/runtime/commit/e2a3511925e43217ef4814eb633ae729ed8d7246

![image](https://github.com/user-attachments/assets/82db27d9-608a-4656-abf5-cc276c551840)

Adding this blurb as in oob-all, oob-ref and oob-src.proj fixes that.
