### PR TITLE
Re-enable ConsoleKeyInfoTests.Equals_SameData test

### DIFF
--- a/src/libraries/System.Console/tests/ConsoleKeyInfoTests.cs
+++ b/src/libraries/System.Console/tests/ConsoleKeyInfoTests.cs
@@ -43,7 +43,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(SampleConsoleKeyInfos))]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/60240", RuntimeTestModes.JitStressRegs)]
         public void Equals_SameData(ConsoleKeyInfo cki)
         {
             ConsoleKeyInfo other = cki; // otherwise compiler warns about comparing the instance with itself


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/60240