### PR TITLE
ILVerify: Added option `--suppress-type-verification`

### DIFF
--- a/src/coreclr/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/tools/ILVerification/Verifier.cs
@@ -181,7 +181,8 @@ namespace ILVerify
             {
                 var importer = new ILImporter(method, methodIL)
                 {
-                    SanityChecks = _verifierOptions.SanityChecks
+                    SanityChecks = _verifierOptions.SanityChecks,
+                    SuppressTypeVerification = _verifierOptions.SuppressTypeVerification
                 };
 
                 importer.ReportVerificationError = (args, code) =>
@@ -325,5 +326,6 @@ namespace ILVerify
     {
         public bool IncludeMetadataTokensInErrorMessages { get; set; }
         public bool SanityChecks { get; set; }
+        public bool SuppressTypeVerification { get; set; }
     }
 }

--- a/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
+++ b/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
@@ -18,6 +18,8 @@ namespace ILVerify
             new("--system-module", "-s") { Description = "System module name (default: mscorlib)" };
         public CliOption<bool> SanityChecks { get; } =
             new("--sanity-checks", "-c") { Description = "Check for valid constructs that are likely mistakes" };
+        public CliOption<bool> SuppressTypeVerification { get; } =
+            new("--suppress-type-verification") { Description = "Suppress all verification checks related to type safety" };
         public CliOption<string[]> Include { get; } =
             new("--include", "-i") { Description = "Use only methods/types/namespaces, which match the given regular expression(s)" };
         public CliOption<FileInfo> IncludeFile { get; } =
@@ -46,6 +48,7 @@ namespace ILVerify
             Options.Add(Reference);
             Options.Add(SystemModule);
             Options.Add(SanityChecks);
+            Options.Add(SuppressTypeVerification);
             Options.Add(Include);
             Options.Add(IncludeFile);
             Options.Add(Exclude);

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -111,7 +111,8 @@ namespace ILVerify
             _verifier = new Verifier(this, new VerifierOptions
             {
                 IncludeMetadataTokensInErrorMessages = Get(_command.Tokens),
-                SanityChecks = Get(_command.SanityChecks)
+                SanityChecks = Get(_command.SanityChecks),
+                SuppressTypeVerification = Get(_command.SuppressTypeVerification)
             });
             _verifier.SetSystemModuleName(new AssemblyNameInfo(Get(_command.SystemModule) ?? "mscorlib"));
 


### PR DESCRIPTION
For https://github.com/dotnet/runtime/issues/37391 and https://github.com/dotnet/runtime/issues/89691

Adds a new command line option `--suppress-type-verification` that will suppress all type safety verification.

