### PR TITLE
ILVerify: Added option `--suppress-unverifiable`

### DIFF
--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -207,6 +207,8 @@ namespace Internal.IL
 
         public bool SanityChecks { set; private get; }
 
+        public bool SuppressUnverifiable { set; private get; }
+
         public void Verify()
         {
             _instructionBoundaries = new bool[_ilBytes.Length];
@@ -1236,7 +1238,10 @@ namespace Internal.IL
 
         void Unverifiable()
         {
-            VerificationError(VerifierError.Unverifiable);
+            if (!SuppressUnverifiable)
+            {
+                VerificationError(VerifierError.Unverifiable);
+            }
         }
 
         TypeDesc GetWellKnownType(WellKnownType wellKnownType)
@@ -1538,7 +1543,10 @@ namespace Internal.IL
 
         void ImportCall(ILOpcode opcode, int token)
         {
-            FatalCheck(opcode != ILOpcode.calli, VerifierError.Unverifiable);
+            if (!SuppressUnverifiable)
+            {
+                FatalCheck(opcode != ILOpcode.calli, VerifierError.Unverifiable);
+            }
 
             TypeDesc constrained = null;
             bool tailCall = false;

--- a/src/coreclr/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/tools/ILVerification/Verifier.cs
@@ -181,7 +181,8 @@ namespace ILVerify
             {
                 var importer = new ILImporter(method, methodIL)
                 {
-                    SanityChecks = _verifierOptions.SanityChecks
+                    SanityChecks = _verifierOptions.SanityChecks,
+                    SuppressUnverifiable = _verifierOptions.SuppressUnverifiable
                 };
 
                 importer.ReportVerificationError = (args, code) =>
@@ -325,5 +326,6 @@ namespace ILVerify
     {
         public bool IncludeMetadataTokensInErrorMessages { get; set; }
         public bool SanityChecks { get; set; }
+        public bool SuppressUnverifiable { get; set; }
     }
 }

--- a/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
+++ b/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
@@ -18,6 +18,8 @@ namespace ILVerify
             new("--system-module", "-s") { Description = "System module name (default: mscorlib)" };
         public CliOption<bool> SanityChecks { get; } =
             new("--sanity-checks", "-c") { Description = "Check for valid constructs that are likely mistakes" };
+        public CliOption<bool> SuppressUnverifiable { get; } =
+            new("--suppress-unverifiable") { Description = "Suppresses unverifiable construct errors" };
         public CliOption<string[]> Include { get; } =
             new("--include", "-i") { Description = "Use only methods/types/namespaces, which match the given regular expression(s)" };
         public CliOption<FileInfo> IncludeFile { get; } =
@@ -46,6 +48,7 @@ namespace ILVerify
             Options.Add(Reference);
             Options.Add(SystemModule);
             Options.Add(SanityChecks);
+            Options.Add(SuppressUnverifiable);
             Options.Add(Include);
             Options.Add(IncludeFile);
             Options.Add(Exclude);

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -111,7 +111,8 @@ namespace ILVerify
             _verifier = new Verifier(this, new VerifierOptions
             {
                 IncludeMetadataTokensInErrorMessages = Get(_command.Tokens),
-                SanityChecks = Get(_command.SanityChecks)
+                SanityChecks = Get(_command.SanityChecks),
+                SuppressUnverifiable = Get(_command.SuppressUnverifiable)
             });
             _verifier.SetSystemModuleName(new AssemblyNameInfo(Get(_command.SystemModule) ?? "mscorlib"));
 


### PR DESCRIPTION
For https://github.com/dotnet/runtime/issues/89691

Adds a new command line option `--suppress-unverifiable` that will suppress any unverifiable errors.