### PR TITLE
Delete unnecessary null checks

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -432,7 +432,7 @@ void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage
         // Fire an ETW FailFast event
         FireEtwFailFast(pszMessage,
                         (const PVOID)address,
-                        ((pExceptionInfo && pExceptionInfo->ExceptionRecord) ? pExceptionInfo->ExceptionRecord->ExceptionCode : 0),
+                        pExceptionInfo->ExceptionRecord ? pExceptionInfo->ExceptionRecord->ExceptionCode : 0,
                         exitCode,
                         GetClrInstanceId());
     }
@@ -477,7 +477,7 @@ void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage
             else
             {
                 WCHAR addressString[MaxIntegerDecHexString + 1];
-                FormatInteger(addressString, ARRAY_SIZE(addressString), "%p", pExceptionInfo ? (SIZE_T)pExceptionInfo->ExceptionRecord->ExceptionAddress : (SIZE_T)address);
+                FormatInteger(addressString, ARRAY_SIZE(addressString), "%p", (SIZE_T)pExceptionInfo->ExceptionRecord->ExceptionAddress);
 
                 // We should always have the reference to the runtime's instance
                 _ASSERTE(GetClrModuleBase() != NULL);
@@ -610,6 +610,8 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
 
     WRAPPER_NO_CONTRACT;
 
+    _ASSERTE(pExceptionInfo != NULL);
+
     // Disable GC stress triggering GC at this point, we don't want the GC to start running
     // on this thread when we have only a very limited space left on the stack
     GCStressPolicy::InhibitHolder iholder;
@@ -620,7 +622,7 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
 #if defined(FEATURE_EH_FUNCLETS)
     *((&fef)->GetGSCookiePtr()) = GetProcessGSCookie();
 #endif // FEATURE_EH_FUNCLETS
-    if (pExceptionInfo && pExceptionInfo->ContextRecord)
+    if (pExceptionInfo->ContextRecord)
     {
         GCX_COOP();
         CONTEXT *pExceptionContext = pExceptionInfo->ContextRecord;
@@ -689,8 +691,8 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
     {
         // Fire an ETW FailFast event
         FireEtwFailFast(W("StackOverflowException"),
-                       (const PVOID)((pExceptionInfo && pExceptionInfo->ContextRecord) ? GetIP(pExceptionInfo->ContextRecord) : 0),
-                       ((pExceptionInfo && pExceptionInfo->ExceptionRecord) ? pExceptionInfo->ExceptionRecord->ExceptionCode : 0),
+                       (const PVOID)(pExceptionInfo->ContextRecord ? GetIP(pExceptionInfo->ContextRecord) : 0),
+                       pExceptionInfo->ExceptionRecord ? pExceptionInfo->ExceptionRecord->ExceptionCode : 0,
                        COR_E_STACKOVERFLOW,
                        GetClrInstanceId());
     }
@@ -728,8 +730,6 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
 #ifndef TARGET_UNIX
         if (IsWatsonEnabled() && (g_pDebugInterface != NULL))
         {
-            _ASSERTE(pExceptionInfo != NULL);
-
             ResetWatsonBucketsParams param;
             param.m_pThread = pThread;
             param.pExceptionRecord = pExceptionInfo->ExceptionRecord;


### PR DESCRIPTION
Delete unnecessary null checks that are confusing some static code analysis tools.

Fixes #100210 and #100212