### PR TITLE
Fix codespaces build by bumping clang llvm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
-# Clang-16 up is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
+# Clang-16 up is required but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
 RUN apt-get update \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
     && apt-get install software-properties-common -y \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,11 +6,18 @@ ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
+# Clang-16 up is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
+RUN apt-get update \
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
+    && apt-get install software-properties-common -y \
+    && add-apt-repository "deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main" -y \
+    && apt-get update \
+    && apt-get install clang-18 -y
+
+# Set up machine requirements to build the repo and the gh CLI
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         cmake \
-        llvm \
-        clang \
         build-essential \
         python3 \
         curl \

--- a/.devcontainer/wasm-multiThreaded/Dockerfile
+++ b/.devcontainer/wasm-multiThreaded/Dockerfile
@@ -6,7 +6,7 @@ ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
-# Clang-16 up is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
+# Clang-16 up is required but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
 RUN apt-get update \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
     && apt-get install software-properties-common -y \

--- a/.devcontainer/wasm-multiThreaded/Dockerfile
+++ b/.devcontainer/wasm-multiThreaded/Dockerfile
@@ -6,11 +6,18 @@ ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
+# Clang-16 up is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
+RUN apt-get update \
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
+    && apt-get install software-properties-common -y \
+    && add-apt-repository "deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main" -y \
+    && apt-get update \
+    && apt-get install clang-18 -y
+
+# Set up machine requirements to build the repo and the gh CLI
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         cmake \
-        llvm \
-        clang \
         build-essential \
         python3 \
         curl \

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -6,19 +6,13 @@ ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
-# Clang-16 is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
+# Clang-16 up is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
 RUN apt-get update \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
     && apt-get install software-properties-common -y \
     && add-apt-repository "deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main" -y \
     && apt-get update \
     && apt-get install clang-18 -y
-# the following is most probably not needed if we do not have other clang (don't we?)
-#    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 \
-#    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
-#    && update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-18 100
-#    && update-alternatives --install /usr/bin/llc llc /usr/bin/llc-18 100
-#    && update-alternatives --install /usr/bin/opt opt /usr/bin/opt-18 100
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -6,11 +6,23 @@ ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
+# Clang-16 is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
+RUN apt-get update \
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
+    && apt-get install software-properties-common -y \
+    && add-apt-repository "deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main" -y \
+    && apt-get update \
+    && apt-get install clang-18 -y
+# the following is most probably not needed if we do not have other clang (don't we?)
+#    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 \
+#    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
+#    && update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-18 100
+#    && update-alternatives --install /usr/bin/llc llc /usr/bin/llc-18 100
+#    && update-alternatives --install /usr/bin/opt opt /usr/bin/opt-18 100
+
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         cmake \
-        llvm \
-        clang \
         build-essential \
         python3 \
         curl \

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -6,7 +6,7 @@ ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
-# Clang-16 up is rquired but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
+# Clang-16 up is required but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
 RUN apt-get update \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
     && apt-get install software-properties-common -y \

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -37,7 +37,7 @@ Install the following packages for the toolchain:
 * CMake 3.20 or newer
 * llvm
 * lld
-* clang
+* clang 16 or newer
 * build-essential
 * python-is-python3
 * curl
@@ -59,6 +59,7 @@ sudo apt install -y cmake llvm lld clang build-essential \
 ```
 
 **NOTE**: As of now, Ubuntu's `apt` only has until CMake version 3.16.3 if you're using Ubuntu 20.04 LTS (less in older Ubuntu versions), and version 3.18.4 in Debian 11 (less in older Debian versions). This is lower than the required 3.20, which in turn makes it incompatible with the repo. For this case, we can use the `snap` package manager or the _Kitware APT feed_ to get a new enough version of CMake.
+**NOTE**: If you have Ubuntu 22.04 LTS and older and your `apt` does not have clang version 16, you can add `"deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main"` repository to your `apt`. See how we do it for linux-based containers [here](./../../../.devcontainer/Dockerfile).
 
 For snap:
 


### PR DESCRIPTION
Command e.g. `./build.sh mono+libs -c release -os browser`

Without this change:
```
  In file included from /workspaces/runtime/artifacts/obj/mono/browser.wasm.Release/llvm//x64/include/c++/v1/stdint.h:106:
  /workspaces/runtime/artifacts/obj/mono/browser.wasm.Release/llvm//x64/include/c++/v1/__config:48:8: warning: "Libc++ only supports Clang 16 and later" [-W#warnings]
  #      warning "Libc++ only supports Clang 16 and later"
         ^
....
  /workspaces/runtime/artifacts/obj/mono/browser.wasm.Release/llvm//x64/include/c++/v1/new:227:14: error: 'std' is not a class, namespace, or enumeration
  operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
               ^
  /workspaces/runtime/artifacts/obj/mono/browser.wasm.Release/llvm//x64/include/c++/v1/__fwd/functional.h:18:1: note: 'std' declared here
  _LIBCPP_BEGIN_NAMESPACE_STD
  ^
  /workspaces/runtime/artifacts/obj/mono/browser.wasm.Release/llvm//x64/include/c++/v1/__config:853:81: note: expanded from macro '_LIBCPP_BEGIN_NAMESPACE_STD'
                                        namespace _LIBCPP_TYPE_VISIBILITY_DEFAULT std {                                  \
                                                                                  ^
  fatal error: too many errors emitted, stopping now [-ferror-limit=]
  1 warning and 20 errors generated.
  [333/385] Building C object mono/mini/CMakeFiles/monosgen-objects.dir/interp/transform-opt.c.o
  [334/385] Building C object mono/mini/CMakeFiles/monosgen-objects.dir/interp/interp.c.o
  [335/385] Building C object mono/mini/CMakeFiles/monosgen-objects.dir/interp/transform.c.o
  [336/385] Building C object mono/mini/CMakeFiles/monosgen-objects.dir/mini-llvm.c.o
  [337/385] Building C object mono/mini/CMakeFiles/monosgen-objects.dir/method-to-ir.c.o
  ninja: build stopped: subcommand failed.
/workspaces/runtime/src/mono/mono.proj(1049,5): error MSB3073: The command " cmake --build . --target install --config Release" exited with code 1.

Build FAILED.
```

With this change:
build succeeds.

Both are tested with applying the fix from https://github.com/dotnet/runtime/pull/105110.

Ubuntu 22.04 does not have system clang/llvm newer than 14.0, so we have to manually add repo and update packages from it. I took v=18 because that's what we have on CI.