### PR TITLE
[.NET 10] Move ProduceReferenceAssembly=false setting to specific places

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -395,6 +395,8 @@
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == ''">false</KeepNativeSymbols>
     <!-- Used for launchSettings.json and runtime config files. -->
     <AppDesignerFolder>Properties</AppDesignerFolder>
+    <!-- By default the SDK only produces ref assemblies for net5.0 or later. Enable for all TFMs for better incremental build performance. -->
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!-- Define test projects and companions -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -395,8 +395,6 @@
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == ''">false</KeepNativeSymbols>
     <!-- Used for launchSettings.json and runtime config files. -->
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <!-- By default the SDK produces ref assembly for 5.0 or later -->
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!-- Define test projects and companions -->
@@ -441,6 +439,8 @@
     <DebugType>none</DebugType>
     <!-- Don't try to publish PDBs for ref assemblies that have none. -->
     <PublishWindowsPdb>false</PublishWindowsPdb>
+    <!-- Don't let the compiler automatically generate a reference assembly for reference assembly projects. -->
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
 

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <ContractProject Condition="'$(ContractProject)' == ''">$(LibrariesProjectRoot)$(MSBuildProjectName)\ref\$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
-    <!-- Don't let the compiler automatically generate a reference assembly when we have a dedicated reference assembly project. -->
-    <ProduceReferenceAssembly Condition="'$(HasMatchingContract)' == 'true'">false</ProduceReferenceAssembly>
     <!-- Don't build against reference assemblies when projects are packable and the tfm is not the latest .NETCoreApp as
          such reference assemblies don't ship to customers and only exist for tooling scenarios. -->
     <AnnotateTargetPathWithContract Condition="'$(AnnotateTargetPathWithContract)' == '' and
@@ -22,6 +20,8 @@
                                                  '$(TargetFrameworkVersion)' == 'v$(NetCoreAppCurrentVersion)'
                                                 )
                                                )">true</AnnotateTargetPathWithContract>
+    <!-- Don't let the compiler automatically generate a reference assembly when there's a dedicated reference assembly project that is being used. -->
+    <ProduceReferenceAssembly Condition="'$(AnnotateTargetPathWithContract)' == 'true'">false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(HasMatchingContract)' == 'true' and '$(ContractProject)' != ''">

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -9,6 +9,8 @@
   <PropertyGroup>
     <ContractProject Condition="'$(ContractProject)' == ''">$(LibrariesProjectRoot)$(MSBuildProjectName)\ref\$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
+    <!-- Don't let the compiler automatically generate a reference assembly when we have a dedicated reference assembly project. -->
+    <ProduceReferenceAssembly Condition="'$(HasMatchingContract)' == 'true'">false</ProduceReferenceAssembly>
     <!-- Don't build against reference assemblies when projects are packable and the tfm is not the latest .NETCoreApp as
          such reference assemblies don't ship to customers and only exist for tooling scenarios. -->
     <AnnotateTargetPathWithContract Condition="'$(AnnotateTargetPathWithContract)' == '' and


### PR DESCRIPTION
A reference assembly is automatically created by the compiler for better incremental build performance.

Don't disable it by default to make use of those gains. Only disable them in the places where they don't make sense:

1. For a reference source project. Assemblies produced by these projects are already as minimal as possible. Producing compiler generated reference assemblies out of those only slows down the build without any gains.
2. For a source project that has a reference source project undearneath. Again, use the already specialized project that we tailor ourselves instead of letting the compiler generate a reference assembly from a source project.