### PR TITLE
Change DefaultMaximumErrorResponseLength to KB from Byte

### DIFF
--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -346,7 +346,7 @@ namespace System.Net
                     return contentStream;
                 }
 
-                return new TruncatedReadStream(contentStream, maxErrorResponseLength);
+                return new TruncatedReadStream(contentStream, maxErrorResponseLength * 1024);
             }
 
             return Stream.Null;

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -381,7 +381,7 @@ namespace System.Net
 
         private static string GetHeaderValueAsString(IEnumerable<string> values) => string.Join(", ", values);
 
-        internal sealed class TruncatedReadStream(Stream innerStream, int maxSize) : Stream
+        internal sealed class TruncatedReadStream(Stream innerStream, long maxSize) : Stream
         {
             public override bool CanRead => true;
             public override bool CanSeek => false;
@@ -399,7 +399,7 @@ namespace System.Net
 
             public override int Read(Span<byte> buffer)
             {
-                int readBytes = innerStream.Read(buffer.Slice(0, Math.Min(buffer.Length, maxSize)));
+                int readBytes = innerStream.Read(buffer.Slice(0, (int)Math.Min(buffer.Length, maxSize)));
                 maxSize -= readBytes;
                 return readBytes;
             }
@@ -411,7 +411,7 @@ namespace System.Net
 
             public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
             {
-                int readBytes = await innerStream.ReadAsync(buffer.Slice(0, Math.Min(buffer.Length, maxSize)), cancellationToken)
+                int readBytes = await innerStream.ReadAsync(buffer.Slice(0, (int)Math.Min(buffer.Length, maxSize)), cancellationToken)
                     .ConfigureAwait(false);
                 maxSize -= readBytes;
                 return readBytes;


### PR DESCRIPTION
Fixes #105387

This PR makes the property's behavior same as .NET Framework, this property was no-op until recently (#97537).