### PR TITLE
Fix platform analyzer attribute order for MacCatalyst

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Aead.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Aead.cs
@@ -30,9 +30,9 @@ internal static partial class Interop
 
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
+        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void ChaCha20Poly1305Encrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,
@@ -68,9 +68,9 @@ internal static partial class Interop
 
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
+        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void ChaCha20Poly1305Decrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,
@@ -113,9 +113,9 @@ internal static partial class Interop
 
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
+        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void AesGcmEncrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,
@@ -151,9 +151,9 @@ internal static partial class Interop
 
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
+        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void AesGcmDecrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/RuntimeMetrics.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/RuntimeMetrics.cs
@@ -191,10 +191,10 @@ namespace System.Diagnostics.Metrics
             }
         }
 
-        [SupportedOSPlatform("maccatalyst")]
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
         [UnsupportedOSPlatform("browser")]
+        [SupportedOSPlatform("maccatalyst")]
         private static IEnumerable<Measurement<double>> GetCpuTime()
         {
             Debug.Assert(s_processCpuTime is not null);

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.UnixOrBrowser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.UnixOrBrowser.cs
@@ -75,10 +75,10 @@ namespace System
         /// Get the CPU usage, including the process time spent running the application code, the process time spent running the operating system code,
         /// and the total time spent running both the application and operating system code.
         /// </summary>
-        [SupportedOSPlatform("maccatalyst")]
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
         [UnsupportedOSPlatform("browser")]
+        [SupportedOSPlatform("maccatalyst")]
         public static ProcessCpuUsage CpuUsage
         {
             get

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
@@ -364,10 +364,10 @@ namespace System
         /// Get the CPU usage, including the process time spent running the application code, the process time spent running the operating system code,
         /// and the total time spent running both the application and operating system code.
         /// </summary>
-        [SupportedOSPlatform("maccatalyst")]
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
         [UnsupportedOSPlatform("browser")]
+        [SupportedOSPlatform("maccatalyst")]
         public static ProcessCpuUsage CpuUsage
         {
             get => Interop.Kernel32.GetProcessTimes(Interop.Kernel32.GetCurrentProcess(), out _, out _, out long procKernelTime, out long procUserTime) ?

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -121,9 +121,9 @@ namespace System.Security.Cryptography
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
-    [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
     [System.Runtime.Versioning.SupportedOSPlatform("ios13.0")]
     [System.Runtime.Versioning.SupportedOSPlatform("tvos13.0")]
+    [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
     public sealed partial class AesGcm : System.IDisposable
     {
         [System.ObsoleteAttribute("AesGcm should indicate the required tag size for encryption and decryption. Use a constructor that accepts the tag size.", DiagnosticId="SYSLIB0053", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
@@ -287,9 +287,9 @@ namespace System.Security.Cryptography
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
-    [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
     [System.Runtime.Versioning.SupportedOSPlatform("ios13.0")]
     [System.Runtime.Versioning.SupportedOSPlatform("tvos13.0")]
+    [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
     public sealed partial class ChaCha20Poly1305 : System.IDisposable
     {
         public ChaCha20Poly1305(byte[] key) { }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesGcm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesGcm.cs
@@ -10,9 +10,9 @@ namespace System.Security.Cryptography
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
-    [SupportedOSPlatform("maccatalyst")]
     [SupportedOSPlatform("ios13.0")]
     [SupportedOSPlatform("tvos13.0")]
+    [SupportedOSPlatform("maccatalyst")]
     public sealed partial class AesGcm : IDisposable
     {
         private const int NonceSize = 12;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ChaCha20Poly1305.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ChaCha20Poly1305.cs
@@ -9,9 +9,9 @@ namespace System.Security.Cryptography
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
-    [SupportedOSPlatform("maccatalyst")]
     [SupportedOSPlatform("ios13.0")]
     [SupportedOSPlatform("tvos13.0")]
+    [SupportedOSPlatform("maccatalyst")]
     public sealed partial class ChaCha20Poly1305 : IDisposable
     {
         // Per https://tools.ietf.org/html/rfc7539, ChaCha20Poly1305 AEAD requires a 256-bit key and 96-bit nonce,


### PR DESCRIPTION
We need to make sure the attribute for MacCatalyst comes _after_ the iOS one due to how MacCatalyst is a superset of iOS: https://learn.microsoft.com/en-us/dotnet/standard/analyzers/platform-compat-analyzer#platform-inclusion

This caused an error in aspnetcore in the latest dependency flow because the analyzer thought AesGcm is _only_ supported on MacCatalyst:
> error CA1416: (NETCORE_ENGINEERING_TELEMETRY=Build) This call site is reachable on all platforms. 'AesGcm.Decrypt(ReadOnlySpan<byte>, ReadOnlySpan<byte>, ReadOnlySpan<byte>, Span<byte>, ReadOnlySpan<byte>)' is only supported on: 'maccatalyst' 13.0 and later.

I noticed a couple more instances where this was the case but all of them were in `src` and the corresponding `ref` already had the correct order. I fixed them regardless.