### PR TITLE
Update the ResourceData API

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -103,6 +103,8 @@ namespace ILCompiler.Win32Resources
         private static string ToUpperForResource(string str)
         {
             // Undocumented semantic for Win32 Resource APIs
+            // This ToUpper logic should only be applied to the
+            // latin range from 'a' to 'z'.
             System.Text.StringBuilder builder = new(str.Length);
             foreach (char c in str)
             {

--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.Win32Resources
 
         private byte[] FindResourceInternal(object name, object type, ushort language)
         {
-            ResType resType = null;
+            ResType resType;
 
             if (type is ushort)
             {

--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics;
 
 #if HOST_MODEL
 namespace Microsoft.NET.HostModel.Win32Resources
@@ -102,7 +103,7 @@ namespace ILCompiler.Win32Resources
         private static string ToUpperForResource(string str)
         {
             // Undocumented semantic for Win32 Resource APIs
-            StringBuilder builder = new(str.Length);
+            System.Text.StringBuilder builder = new(str.Length);
             foreach (char c in str)
             {
                 builder.Append('a' <= c && c <= 'z' ? char.ToUpper(c) : c);

--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -27,8 +27,7 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(type is string);
-                // Undocumented semantic for Win32 Resource APIs
-                type = ((string)type).ToUpperInvariant();
+                type = ToUpperForResource((string)type);
                 if (!_resTypeHeadName.TryGetValue((string)type, out resType))
                 {
                     resType = new ResType();
@@ -49,8 +48,7 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(name is string);
-                // Undocumented semantic for Win32 Resource APIs
-                name = ((string)name).ToUpperInvariant();
+                name = ToUpperForResource((string)name);
                 if (!resType.NameHeadName.TryGetValue((string)name, out resName))
                 {
                     resName = new ResName();
@@ -72,8 +70,7 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(type is string);
-                // Undocumented semantic for Win32 Resource APIs
-                type = ((string)type).ToUpperInvariant();
+                type = ToUpperForResource((string)type);
                 _resTypeHeadName.TryGetValue((string)type, out resType);
             }
 
@@ -89,8 +86,7 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(name is string);
-                // Undocumented semantic for Win32 Resource APIs
-                name = ((string)name).ToUpperInvariant();
+                name = ToUpperForResource((string)name);
                 resType.NameHeadName.TryGetValue((string)name, out resName);
             }
 
@@ -101,6 +97,17 @@ namespace ILCompiler.Win32Resources
                 return null;
 
             return (byte[])resLanguage.DataEntry.Clone();
+        }
+
+        private static string ToUpperForResource(string str)
+        {
+            // Undocumented semantic for Win32 Resource APIs
+            StringBuilder builder = new(str.Length);
+            foreach (char c in str)
+            {
+                builder.Append('a' <= c && c <= 'z' ? char.ToUpper(c) : c);
+            }
+            return builder.ToString();
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -28,7 +28,6 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(type is string);
-                type = ToUpperForResource((string)type);
                 if (!_resTypeHeadName.TryGetValue((string)type, out resType))
                 {
                     resType = new ResType();
@@ -49,7 +48,6 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(name is string);
-                name = ToUpperForResource((string)name);
                 if (!resType.NameHeadName.TryGetValue((string)name, out resName))
                 {
                     resName = new ResName();
@@ -71,7 +69,6 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(type is string);
-                type = ToUpperForResource((string)type);
                 _resTypeHeadName.TryGetValue((string)type, out resType);
             }
 
@@ -87,7 +84,6 @@ namespace ILCompiler.Win32Resources
             else
             {
                 Debug.Assert(name is string);
-                name = ToUpperForResource((string)name);
                 resType.NameHeadName.TryGetValue((string)name, out resName);
             }
 
@@ -98,19 +94,6 @@ namespace ILCompiler.Win32Resources
                 return null;
 
             return (byte[])resLanguage.DataEntry.Clone();
-        }
-
-        private static string ToUpperForResource(string str)
-        {
-            // Undocumented semantic for Win32 Resource APIs
-            // This ToUpper logic should only be applied to the
-            // latin range from 'a' to 'z'.
-            System.Text.StringBuilder builder = new(str.Length);
-            foreach (char c in str)
-            {
-                builder.Append('a' <= c && c <= 'z' ? (char)(c + ('A' - 'a')) : c);
-            }
-            return builder.ToString();
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.Win32Resources
             if (resType == null)
                 return null;
 
-            ResName resName = null;
+            ResName resName;
 
             if (name is ushort)
             {
@@ -106,7 +106,7 @@ namespace ILCompiler.Win32Resources
             System.Text.StringBuilder builder = new(str.Length);
             foreach (char c in str)
             {
-                builder.Append('a' <= c && c <= 'z' ? char.ToUpper(c) : c);
+                builder.Append('a' <= c && c <= 'z' ? (char)(c + ('A' - 'a')) : c);
             }
             return builder.ToString();
         }

--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -26,6 +26,9 @@ namespace ILCompiler.Win32Resources
             }
             else
             {
+                Debug.Assert(type is string);
+                // Undocumented semantic for Win32 Resource APIs
+                type = ((string)type).ToUpperInvariant();
                 if (!_resTypeHeadName.TryGetValue((string)type, out resType))
                 {
                     resType = new ResType();
@@ -45,6 +48,9 @@ namespace ILCompiler.Win32Resources
             }
             else
             {
+                Debug.Assert(name is string);
+                // Undocumented semantic for Win32 Resource APIs
+                name = ((string)name).ToUpperInvariant();
                 if (!resType.NameHeadName.TryGetValue((string)name, out resName))
                 {
                     resName = new ResName();
@@ -63,8 +69,11 @@ namespace ILCompiler.Win32Resources
             {
                 _resTypeHeadID.TryGetValue((ushort)type, out resType);
             }
-            if (type is string)
+            else
             {
+                Debug.Assert(type is string);
+                // Undocumented semantic for Win32 Resource APIs
+                type = ((string)type).ToUpperInvariant();
                 _resTypeHeadName.TryGetValue((string)type, out resType);
             }
 
@@ -77,8 +86,11 @@ namespace ILCompiler.Win32Resources
             {
                 resType.NameHeadID.TryGetValue((ushort)name, out resName);
             }
-            if (name is string)
+            else
             {
+                Debug.Assert(name is string);
+                // Undocumented semantic for Win32 Resource APIs
+                name = ((string)name).ToUpperInvariant();
                 resType.NameHeadName.TryGetValue((string)name, out resName);
             }
 

--- a/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.cs
+++ b/src/coreclr/tools/Common/Compiler/Win32Resources/ResourceData.cs
@@ -60,6 +60,10 @@ namespace ILCompiler.Win32Resources
         /// <summary>
         /// Find a resource in the resource data
         /// </summary>
+        /// <remarks>
+        /// The Win32 APIs typcially perform an uppercase transform on string arguments - during add and find.
+        /// If the resource will be read by Win32 APIs, it is recommended to make the resource name upper case.
+        /// </remarks>
         public byte[] FindResource(string name, string type, ushort language)
         {
             return FindResourceInternal(name, type, language);
@@ -68,6 +72,10 @@ namespace ILCompiler.Win32Resources
         /// <summary>
         /// Find a resource in the resource data
         /// </summary>
+        /// <remarks>
+        /// The Win32 APIs typcially perform an uppercase transform on string arguments - during add and find.
+        /// If the resource will be read by Win32 APIs, it is recommended to make the resource name upper case.
+        /// </remarks>
         public byte[] FindResource(ushort name, string type, ushort language)
         {
             return FindResourceInternal(name, type, language);
@@ -76,6 +84,10 @@ namespace ILCompiler.Win32Resources
         /// <summary>
         /// Find a resource in the resource data
         /// </summary>
+        /// <remarks>
+        /// The Win32 APIs typcially perform an uppercase transform on string arguments - during add and find.
+        /// If the resource will be read by Win32 APIs, it is recommended to make the resource name upper case.
+        /// </remarks>
         public byte[] FindResource(string name, ushort type, ushort language)
         {
             return FindResourceInternal(name, type, language);
@@ -92,16 +104,28 @@ namespace ILCompiler.Win32Resources
         /// <summary>
         /// Add or update resource
         /// </summary>
+        /// <remarks>
+        /// The Win32 APIs typcially perform an uppercase transform on string arguments - during add and find.
+        /// If the resource will be read by Win32 APIs, it is recommended to make the resource name upper case.
+        /// </remarks>
         public void AddResource(string name, string type, ushort language, byte[] data) => AddResourceInternal(name, type, language, data);
 
         /// <summary>
         /// Add or update resource
         /// </summary>
+        /// <remarks>
+        /// The Win32 APIs typcially perform an uppercase transform on string arguments - during add and find.
+        /// If the resource will be read by Win32 APIs, it is recommended to make the resource name upper case.
+        /// </remarks>
         public void AddResource(string name, ushort type, ushort language, byte[] data) => AddResourceInternal(name, type, language, data);
 
         /// <summary>
         /// Add or update resource
         /// </summary>
+        /// <remarks>
+        /// The Win32 APIs typcially perform an uppercase transform on string arguments - during add and find.
+        /// If the resource will be read by Win32 APIs, it is recommended to make the resource name upper case.
+        /// </remarks>
         public void AddResource(ushort name, string type, ushort language, byte[] data) => AddResourceInternal(name, type, language, data);
 
         /// <summary>

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NET.HostModel.ComHost
                             if (tlbFileBytes.Length == 0)
                                 throw new InvalidTypeLibraryException(typeLibrary.Value);
 
-                            updater.AddResource(tlbFileBytes, "typelib", (IntPtr)typeLibrary.Key);
+                            updater.AddResource(tlbFileBytes, "TYPELIB", (IntPtr)typeLibrary.Key);
                         }
                         catch (FileNotFoundException ex)
                         {

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/ResourceUpdaterTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/ResourceUpdaterTests.cs
@@ -79,37 +79,6 @@ public class ResourceUpdaterTests
     }
 
     [Fact]
-    void AddResource_DifferentCasingInAPIs()
-    {
-        using var tempFile = CreateTestPEFileWithoutRsrc();
-
-        using (var updater = new ResourceUpdater(tempFile.Stream, true))
-        {
-            updater.AddResource("Test Resource1"u8.ToArray(), "testtype1", 0);
-            updater.AddResource("Test Resource2"u8.ToArray(), "TESTTYPE2", 0);
-            updater.AddResource("Test Resource3"u8.ToArray(), "\u0165ESTTYPE3", 0);
-            updater.Update();
-        }
-
-        tempFile.Stream.Seek(0, SeekOrigin.Begin);
-
-        using (var reader = new PEReader(tempFile.Stream, PEStreamOptions.LeaveOpen))
-        {
-            var resourceReader = new ResourceData(reader);
-            byte[]? testType1 = resourceReader.FindResource(0, "TESTTYPE1", 0);
-            Assert.Equal("Test Resource1"u8.ToArray(), testType1);
-            byte[]? testType2 = resourceReader.FindResource(0, "testtype2", 0);
-            Assert.Equal("Test Resource2"u8.ToArray(), testType2);
-            byte[]? testType3 = resourceReader.FindResource(0, "\u0165esttype3", 0);
-            Assert.Equal("Test Resource3"u8.ToArray(), testType3);
-
-            // Characters out of 'a' - 'z' are left unaltered
-            byte[]? missing = resourceReader.FindResource(0, "\u0164ESTTYPE3", 0);
-            Assert.Null(missing);
-        }
-    }
-
-    [Fact]
     void AddResource_AddToExistingRsrc()
     {
         using var tempFile = GetCurrentAssemblyMemoryStream();


### PR DESCRIPTION
There is an undocumented semantic of Win32 Resource APIs.
The missing semantic is that all resource type/name
strings are transparently converted to uppercase
when calling any of the Win32 Resource APIs.

We don't want to apply this undocumented semantic to the reader/writer API
so we document it instead. We are avoiding applying the behavior
since ReadyToRun scenarios are designed to be a byte for byte copy
of the resource, including name as it was written by other tooling.