### PR TITLE
Remove zlib from requirements script and instruction files

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -47,7 +47,6 @@ Install the following packages for the toolchain:
 * liblttng-ust-dev
 * libssl-dev
 * libkrb5-dev
-* zlib1g-dev
 * ninja-build (optional, enables building native code with ninja instead of make)
 
 **NOTE**: If you have an Ubuntu version older than 22.04 LTS, or Debian version older than 12, don't install `cmake` using `apt` directly. Follow the note written down below.
@@ -55,7 +54,7 @@ Install the following packages for the toolchain:
 ```bash
 sudo apt install -y cmake llvm lld clang build-essential \
   python-is-python3 curl git lldb libicu-dev liblttng-ust-dev \
-  libssl-dev libkrb5-dev zlib1g-dev ninja-build
+  libssl-dev libkrb5-dev ninja-build
 ```
 
 **NOTE**: As of now, Ubuntu's `apt` only has until CMake version 3.16.3 if you're using Ubuntu 20.04 LTS (less in older Ubuntu versions), and version 3.18.4 in Debian 11 (less in older Debian versions). This is lower than the required 3.20, which in turn makes it incompatible with the repo. For this case, we can use the `snap` package manager or the _Kitware APT feed_ to get a new enough version of CMake.
@@ -99,13 +98,12 @@ Install the following packages for the toolchain:
 * libicu-devel
 * openssl-devel
 * krb5-devel
-* zlib-devel
 * lttng-ust-devel
 * ninja-build (optional, enables building native code with ninja instead of make)
 
 ```bash
 sudo dnf install -y cmake llvm lld lldb clang python curl git libicu-devel openssl-devel \
-  krb5-devel zlib-devel lttng-ust-devel ninja-build
+  krb5-devel lttng-ust-devel ninja-build
 ```
 
 ### Gentoo

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -24,13 +24,13 @@ case "$os" in
             apt update
 
             apt install -y build-essential gettext locales cmake llvm clang lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
-                libssl-dev libkrb5-dev zlib1g-dev
+                libssl-dev libkrb5-dev
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
         elif [ "$ID" = "fedora" ]; then
-            dnf install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel zlib-devel lttng-ust-devel
+            dnf install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel
         elif [ "$ID" = "alpine" ]; then
-            apk add build-base cmake bash curl clang llvm-dev krb5-dev lttng-ust-dev icu-dev zlib-dev openssl-dev
+            apk add build-base cmake bash curl clang llvm-dev krb5-dev lttng-ust-dev icu-dev openssl-dev
         else
             echo "Unsupported distro. distro: $ID"
             exit 1


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105373

Follow up of: https://github.com/dotnet/runtime/pull/105371

**Important**: We should merge this when runtime consumes a version of the SDK that already includes the zlib-ng changes, otherwise the script will break.
