### PR TITLE
Fix double printing in StressLog and simplify stresslog macros

### DIFF
--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -179,17 +179,17 @@ struct StressLogMsg
     }
 
     template<>
-    static void* ConvertArgument(float arg) = delete;
+    void* ConvertArgument(float arg) = delete;
 
 #if TARGET_64BIT
     template<>
-    static void* ConvertArgument(double arg)
+    void* ConvertArgument(double arg)
     {
         return (void*)(size_t)(*((uint64_t*)&arg));
     }
 #else
     template<>
-    static void* ConvertArgument(double arg) = delete;
+    void* ConvertArgument(double arg) = delete;
 #endif
 
     StressLogMsg(const char* format) : m_cArgs(0), m_format(format)

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -198,198 +198,38 @@ struct StressLogMsg
     const char* m_format;
     void* m_args[16];
 
+    template<typename T>
+    static void* ConvertArgument(T arg)
+    {
+        static_assert_no_msg(sizeof(T) <= sizeof(void*));
+        return (void*)(size_t)arg;
+    }
+
+    template<>
+    static void* ConvertArgument(float arg) = delete;
+
+#if TARGET_64BIT
+    template<>
+    static void* ConvertArgument(double arg)
+    {
+        return (void*)(size_t)(*((uint64_t*)&arg));
+    }
+#else
+    template<>
+    static void* ConvertArgument(double arg) = delete;
+#endif
+
     StressLogMsg(const char* format) : m_cArgs(0), m_format(format)
     {
     }
 
-    template < typename T1 >
-    StressLogMsg(const char* format, T1 data1) : m_cArgs(1), m_format(format)
+    template<typename... Ts>
+    StressLogMsg(const char* format, Ts... args)
+        : m_cArgs(sizeof...(args))
+        , m_format(format),
+        m_args{ ConvertArgument(args)... }
     {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-    }
-
-    template < typename T1, typename T2 >
-    StressLogMsg(const char* format, T1 data1, T2 data2) : m_cArgs(2), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-    }
-
-    template < typename T1, typename T2, typename T3 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3) : m_cArgs(3), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4) : m_cArgs(4), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5) : m_cArgs(5), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6) : m_cArgs(6), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7) : m_cArgs(7), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8) : m_cArgs(8), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9) : m_cArgs(9), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10) : m_cArgs(10), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11) : m_cArgs(11), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12) : m_cArgs(12), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-        m_args[11] = (void*)(size_t)data12;
-    }
-
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13) : m_cArgs(13), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-        m_args[11] = (void*)(size_t)data12;
-        m_args[12] = (void*)(size_t)data13;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13, T14 data14) : m_cArgs(14), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*) && sizeof(T14) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-        m_args[11] = (void*)(size_t)data12;
-        m_args[12] = (void*)(size_t)data13;
-        m_args[13] = (void*)(size_t)data14;
+        static_assert_no_msg(sizeof...(args) <= ARRAY_SIZE(m_args));
     }
 };
 

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -75,13 +75,6 @@
             LOG((facility, level, msg, data1, data2));                                  \
             } while(0)
 
-#define STRESS_LOG2_CHECK_EE_STARTED(facility, level, msg, data1, data2) do { \
-            if (g_fEEStarted)                                                 \
-                STRESS_LOG2(facility, level, msg, data1, data2);              \
-            else                                                              \
-                LOG((facility, level, msg, data1, data2));                    \
-            } while(0)
-
 #define STRESS_LOG3(facility, level, msg, data1, data2, data3) do {                             \
             if (StressLog::LogOn(facility, level))                                              \
                 StressLog::LogMsg(level, facility,                                              \

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -204,6 +204,19 @@ void* StressLogMsg::ConvertArgument(double arg)
 #else
 template<>
 void* StressLogMsg::ConvertArgument(double arg) = delete;
+
+// COMPAT: Truncate 64-bit integer arguments to 32-bit
+template<>
+void* StressLogMsg::ConvertArgument(uint64_t arg)
+{
+    return (void*)(size_t)arg;
+}
+
+template<>
+void* StressLogMsg::ConvertArgument(int64_t arg)
+{
+    return (void*)(size_t)arg;
+}
 #endif
 
 class StressLog

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -197,7 +197,7 @@ void* StressLogMsg::ConvertArgument(float arg) = delete;
 
 #if TARGET_64BIT
 template<>
-void* StressLogMsg::ConvertArgument(double arg)
+inline void* StressLogMsg::ConvertArgument(double arg)
 {
     return (void*)(size_t)(*((uint64_t*)&arg));
 }
@@ -207,13 +207,13 @@ void* StressLogMsg::ConvertArgument(double arg) = delete;
 
 // COMPAT: Truncate 64-bit integer arguments to 32-bit
 template<>
-void* StressLogMsg::ConvertArgument(uint64_t arg)
+inline void* StressLogMsg::ConvertArgument(uint64_t arg)
 {
     return (void*)(size_t)arg;
 }
 
 template<>
-void* StressLogMsg::ConvertArgument(int64_t arg)
+inline void* StressLogMsg::ConvertArgument(int64_t arg)
 {
     return (void*)(size_t)arg;
 }

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -178,20 +178,6 @@ struct StressLogMsg
         return (void*)(size_t)arg;
     }
 
-    template<>
-    void* ConvertArgument(float arg) = delete;
-
-#if TARGET_64BIT
-    template<>
-    void* ConvertArgument(double arg)
-    {
-        return (void*)(size_t)(*((uint64_t*)&arg));
-    }
-#else
-    template<>
-    void* ConvertArgument(double arg) = delete;
-#endif
-
     StressLogMsg(const char* format) : m_cArgs(0), m_format(format)
     {
     }
@@ -205,6 +191,20 @@ struct StressLogMsg
         static_assert_no_msg(sizeof...(args) <= ARRAY_SIZE(m_args));
     }
 };
+
+template<>
+void* StressLogMsg::ConvertArgument(float arg) = delete;
+
+#if TARGET_64BIT
+template<>
+void* StressLogMsg::ConvertArgument(double arg)
+{
+    return (void*)(size_t)(*((uint64_t*)&arg));
+}
+#else
+template<>
+void* StressLogMsg::ConvertArgument(double arg) = delete;
+#endif
 
 class StressLog
 {

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -55,65 +55,38 @@
             LOGALWAYS(msg);                                                   \
             } while(0)
 
+#define STRESS_LOG_WRITE(facility, level, msg, ...) do {                            \
+            if (StressLog::LogOn(facility, level))                                  \
+                StressLog::LogMsg(facility, level, StressLogMsg(msg, __VA_ARGS__)); \
+            LOG((facility, level, msg, __VA_ARGS__));                               \
+            } while(0)
+
 #define STRESS_LOG0(facility, level, msg) do {                                \
             if (StressLog::LogOn(facility, level))                            \
                 StressLog::LogMsg(level, facility, StressLogMsg(msg));        \
             LOG((facility, level, msg));                                      \
             } while(0)
 
-#define STRESS_LOG1(facility, level, msg, data1) do {                              \
-            if (StressLog::LogOn(facility, level))                                 \
-                StressLog::LogMsg(level, facility,                                 \
-                    StressLogMsg(msg, (void*)(size_t)(data1)));                    \
-            LOG((facility, level, msg, data1));                                    \
-            } while(0)
+#define STRESS_LOG1(facility, level, msg, data1) \
+    STRESS_LOG_WRITE(facility, level, msg, data1)
 
-#define STRESS_LOG2(facility, level, msg, data1, data2) do {                            \
-            if (StressLog::LogOn(facility, level))                                      \
-                StressLog::LogMsg(level, facility,                                      \
-                    StressLogMsg(msg, (void*)(size_t)(data1), (void*)(size_t)(data2))); \
-            LOG((facility, level, msg, data1, data2));                                  \
-            } while(0)
+#define STRESS_LOG2(facility, level, msg, data1, data2) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2)
 
-#define STRESS_LOG3(facility, level, msg, data1, data2, data3) do {                             \
-            if (StressLog::LogOn(facility, level))                                              \
-                StressLog::LogMsg(level, facility,                                              \
-                    StressLogMsg(msg,                                                           \
-                        (void*)(size_t)(data1),(void*)(size_t)(data2),(void*)(size_t)(data3))); \
-            LOG((facility, level, msg, data1, data2, data3));                                   \
-            } while(0)
+#define STRESS_LOG3(facility, level, msg, data1, data2, data3) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3)
 
-#define STRESS_LOG4(facility, level, msg, data1, data2, data3, data4) do {                              \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility,                                                      \
-                    StressLogMsg(msg, (void*)(size_t)(data1),(void*)(size_t)(data2),                    \
-                        (void*)(size_t)(data3),(void*)(size_t)(data4)));                                \
-            LOG((facility, level, msg, data1, data2, data3, data4));                                    \
-            } while(0)
+#define STRESS_LOG4(facility, level, msg, data1, data2, data3, data4) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4)
 
-#define STRESS_LOG5(facility, level, msg, data1, data2, data3, data4, data5) do {                       \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility, 5, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5));                                                            \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5));                             \
-            } while(0)
+#define STRESS_LOG5(facility, level, msg, data1, data2, data3, data4, data5) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5)
 
-#define STRESS_LOG6(facility, level, msg, data1, data2, data3, data4, data5, data6) do {                \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility, 6, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6));                                    \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5, data6));                      \
-            } while(0)
+#define STRESS_LOG6(facility, level, msg, data1, data2, data3, data4, data5, data6) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5, data6)
 
-#define STRESS_LOG7(facility, level, msg, data1, data2, data3, data4, data5, data6, data7) do {         \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility, 7, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6), (void*)(size_t)(data7));            \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5, data6, data7));               \
-            } while(0)
+#define STRESS_LOG7(facility, level, msg, data1, data2, data3, data4, data5, data6, data7)  \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5, data6, data7)
 
 #define LOGALWAYS(msg)
 

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -226,8 +226,8 @@ struct StressLogMsg
     template<typename... Ts>
     StressLogMsg(const char* format, Ts... args)
         : m_cArgs(sizeof...(args))
-        , m_format(format),
-        m_args{ ConvertArgument(args)... }
+        , m_format(format)
+        , m_args{ ConvertArgument(args)... }
     {
         static_assert_no_msg(sizeof...(args) <= ARRAY_SIZE(m_args));
     }

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -376,7 +376,7 @@ void* StressLog::ConvertArgument(float arg) = delete;
 
 #if TARGET_64BIT
 template<>
-void* StressLog::ConvertArgument(double arg)
+inline void* StressLog::ConvertArgument(double arg)
 {
     return (void*)(size_t)(*((uint64_t*)&arg));
 }
@@ -386,13 +386,13 @@ void* StressLog::ConvertArgument(double arg) = delete;
 
 // COMPAT: Truncate 64-bit integer arguments to 32-bit
 template<>
-void* StressLog::ConvertArgument(uint64_t arg)
+inline void* StressLog::ConvertArgument(uint64_t arg)
 {
     return (void*)(size_t)arg;
 }
 
 template<>
-void* StressLog::ConvertArgument(int64_t arg)
+inline void* StressLog::ConvertArgument(int64_t arg)
 {
     return (void*)(size_t)arg;
 }

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -383,6 +383,19 @@ void* StressLog::ConvertArgument(double arg)
 #else
 template<>
 void* StressLog::ConvertArgument(double arg) = delete;
+
+// COMPAT: Truncate 64-bit integer arguments to 32-bit
+template<>
+void* StressLog::ConvertArgument(uint64_t arg)
+{
+    return (void*)(size_t)arg;
+}
+
+template<>
+void* StressLog::ConvertArgument(int64_t arg)
+{
+    return (void*)(size_t)arg;
+}
 #endif
 
 #ifndef STRESS_LOG_ANALYZER

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -90,13 +90,6 @@
             LOG((facility, level, msg, data1, data2));                             \
             } while(0)
 
-#define STRESS_LOG2_CHECK_EE_STARTED(facility, level, msg, data1, data2) do { \
-            if (g_fEEStarted)                                                 \
-                STRESS_LOG2(facility, level, msg, data1, data2);              \
-            else                                                              \
-                LOG((facility, level, msg, data1, data2));                    \
-            } while(0)
-
 #define STRESS_LOG3(facility, level, msg, data1, data2, data3) do {                           \
             if (StressLog::LogOn(facility, level))                                            \
                 StressLog::LogMsg(level, facility, 3, msg,                                    \
@@ -133,63 +126,6 @@
                     (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
                     (void*)(size_t)(data5), (void*)(size_t)(data6), (void*)(size_t)(data7));            \
             LOG((facility, level, msg, data1, data2, data3, data4, data5, data6, data7));               \
-            } while(0)
-
-#define STRESS_LOG_COND0(facility, level, cond, msg) do {                     \
-            if (StressLog::LogOn(facility, level) && (cond))                  \
-                StressLog::LogMsg(level, facility, 0, msg);                   \
-            LOG((facility, level, msg));                                      \
-            } while(0)
-
-#define STRESS_LOG_COND1(facility, level, cond, msg, data1) do {                    \
-            if (StressLog::LogOn(facility, level) && (cond))                        \
-                StressLog::LogMsg(level, facility, 1, msg, (void*)(size_t)(data1)); \
-            LOG((facility, level, msg, data1));                                     \
-            } while(0)
-
-#define STRESS_LOG_COND2(facility, level, cond, msg, data1, data2) do {            \
-            if (StressLog::LogOn(facility, level) && (cond))                       \
-                StressLog::LogMsg(level, facility, 2, msg,                         \
-                    (void*)(size_t)(data1), (void*)(size_t)(data2));               \
-            LOG((facility, level, msg, data1, data2));                             \
-            } while(0)
-
-#define STRESS_LOG_COND3(facility, level, cond, msg, data1, data2, data3) do {                \
-            if (StressLog::LogOn(facility, level) && (cond))                                  \
-                StressLog::LogMsg(level, facility, 3, msg,                                    \
-                    (void*)(size_t)(data1),(void*)(size_t)(data2),(void*)(size_t)(data3));    \
-            LOG((facility, level, msg, data1, data2, data3));                                 \
-            } while(0)
-
-#define STRESS_LOG_COND4(facility, level, cond, msg, data1, data2, data3, data4) do {                   \
-            if (StressLog::LogOn(facility, level) && (cond))                                            \
-                StressLog::LogMsg(level, facility, 4, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4));              \
-            LOG((facility, level, msg, data1, data2, data3, data4));                                    \
-            } while(0)
-
-#define STRESS_LOG_COND5(facility, level, cond, msg, data1, data2, data3, data4, data5) do {            \
-            if (StressLog::LogOn(facility, level) && (cond))                                            \
-                StressLog::LogMsg(level, facility, 5, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5));                                                            \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5));                             \
-            } while(0)
-
-#define STRESS_LOG_COND6(facility, level, cond, msg, data1, data2, data3, data4, data5, data6) do {     \
-            if (StressLog::LogOn(facility, level) && (cond))                                            \
-                StressLog::LogMsg(level, facility, 6, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6));                                    \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5, data6));                      \
-            } while(0)
-
-#define STRESS_LOG_COND7(facility, level, cond, msg, data1, data2, data3, data4, data5, data6, data7) do { \
-            if (StressLog::LogOn(facility, level) && (cond))                                               \
-                StressLog::LogMsg(level, facility, 7, msg, (void*)(size_t)(data1),                         \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),                  \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6), (void*)(size_t)(data7));               \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5, data6, data7));                  \
             } while(0)
 
 #define STRESS_LOG_RESERVE_MEM(numChunks) do {                              \
@@ -1205,7 +1141,6 @@ struct StressLogMsg
 #define STRESS_LOG0(facility, level, msg)                               do { } while(0)
 #define STRESS_LOG1(facility, level, msg, data1)                        do { } while(0)
 #define STRESS_LOG2(facility, level, msg, data1, data2)                 do { } while(0)
-#define STRESS_LOG2_CHECK_EE_STARTED(facility, level, msg, data1, data2)do { } while(0)
 #define STRESS_LOG3(facility, level, msg, data1, data2, data3)          do { } while(0)
 #define STRESS_LOG4(facility, level, msg, data1, data2, data3, data4)   do { } while(0)
 #define STRESS_LOG5(facility, level, msg, data1, data2, data3, data4, data5)   do { } while(0)

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -941,197 +941,38 @@ struct StressLogMsg
     const char* m_format;
     void* m_args[16];
 
+    template<typename T>
+    static void* ConvertArgument(T arg)
+    {
+        static_assert_no_msg(sizeof(T) <= sizeof(void*));
+        return (void*)(size_t)arg;
+    }
+
+    template<>
+    static void* ConvertArgument(float arg) = delete;
+
+#if TARGET_64BIT
+    template<>
+    static void* ConvertArgument(double arg)
+    {
+        return (void*)(size_t)(*((uint64_t*)&arg));
+    }
+#else
+    template<>
+    static void* ConvertArgument(double arg) = delete;
+#endif
+
     StressLogMsg(const char* format) : m_cArgs(0), m_format(format)
     {
     }
 
-    template < typename T1 >
-    StressLogMsg(const char* format, T1 data1) : m_cArgs(1), m_format(format)
+    template<typename... Ts>
+    StressLogMsg(const char* format, Ts... args)
+        : m_cArgs(sizeof...(args))
+        , m_format(format),
+        m_args{ ConvertArgument(args)... }
     {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-    }
-
-    template < typename T1, typename T2 >
-    StressLogMsg(const char* format, T1 data1, T2 data2) : m_cArgs(2), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-    }
-
-    template < typename T1, typename T2, typename T3 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3) : m_cArgs(3), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4) : m_cArgs(4), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5) : m_cArgs(5), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6) : m_cArgs(6), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7) : m_cArgs(7), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8) : m_cArgs(8), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9) : m_cArgs(9), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10) : m_cArgs(10), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11) : m_cArgs(11), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12) : m_cArgs(12), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-        m_args[11] = (void*)(size_t)data12;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13) : m_cArgs(13), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-        m_args[11] = (void*)(size_t)data12;
-        m_args[12] = (void*)(size_t)data13;
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14 >
-    StressLogMsg(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13, T14 data14) : m_cArgs(14), m_format(format)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*) && sizeof(T14) <= sizeof(void*));
-        m_args[0] = (void*)(size_t)data1;
-        m_args[1] = (void*)(size_t)data2;
-        m_args[2] = (void*)(size_t)data3;
-        m_args[3] = (void*)(size_t)data4;
-        m_args[4] = (void*)(size_t)data5;
-        m_args[5] = (void*)(size_t)data6;
-        m_args[6] = (void*)(size_t)data7;
-        m_args[7] = (void*)(size_t)data8;
-        m_args[8] = (void*)(size_t)data9;
-        m_args[9] = (void*)(size_t)data10;
-        m_args[10] = (void*)(size_t)data11;
-        m_args[11] = (void*)(size_t)data12;
-        m_args[12] = (void*)(size_t)data13;
-        m_args[13] = (void*)(size_t)data14;
+        static_assert_no_msg(sizeof...(args) <= ARRAY_SIZE(m_args));
     }
 };
 

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -325,20 +325,6 @@ public:
         return (void*)(size_t)arg;
     }
 
-    template<>
-    void* ConvertArgument(float arg) = delete;
-
-#if TARGET_64BIT
-    template<>
-    void* ConvertArgument(double arg)
-    {
-        return (void*)(size_t)(*((uint64_t*)&arg));
-    }
-#else
-    template<>
-    void* ConvertArgument(double arg) = delete;
-#endif
-
 // Support functions for STRESS_LOG_VA
 // We disable the warning "conversion from 'type' to 'type' of greater size" since everything will
 // end up on the stack, and LogMsg will know the size of the variable based on the format string.
@@ -383,6 +369,21 @@ typedef USHORT
 // private: // static variables
     static StressLog theLog;    // We only have one log, and this is it
 };
+
+
+template<>
+void* StressLog::ConvertArgument(float arg) = delete;
+
+#if TARGET_64BIT
+template<>
+void* StressLog::ConvertArgument(double arg)
+{
+    return (void*)(size_t)(*((uint64_t*)&arg));
+}
+#else
+template<>
+void* StressLog::ConvertArgument(double arg) = delete;
+#endif
 
 #ifndef STRESS_LOG_ANALYZER
 typedef Holder<CRITSEC_COOKIE, StressLog::Enter, StressLog::Leave, 0, CompareDefault<CRITSEC_COOKIE>> StressLogLockHolder;

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -969,8 +969,8 @@ struct StressLogMsg
     template<typename... Ts>
     StressLogMsg(const char* format, Ts... args)
         : m_cArgs(sizeof...(args))
-        , m_format(format),
-        m_args{ ConvertArgument(args)... }
+        , m_format(format)
+        , m_args{ ConvertArgument(args)... }
     {
         static_assert_no_msg(sizeof...(args) <= ARRAY_SIZE(m_args));
     }

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -351,105 +351,14 @@ public:
 #pragma warning( push )
 #pragma warning( disable : 4312 )
 #endif
+
     static void LogMsgOL(const char* format)
     { LogMsg(LL_ALWAYS, LF_GC, 0, format); }
 
-    template < typename T1 >
-    static void LogMsgOL(const char* format, T1 data1)
+    template<typename... Ts>
+    static void LogMsgOL(const char* format, Ts... args)
     {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 1, format, (void*)(size_t)data1);
-    }
-
-    template < typename T1, typename T2 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 2, format, (void*)(size_t)data1, (void*)(size_t)data2);
-    }
-
-    template < typename T1, typename T2, typename T3 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 3, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 4, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 5, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 6, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 7, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 8, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 9, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 10, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 11, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 12, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11, (void*)(size_t)data12);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 13, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11, (void*)(size_t)data12, (void*)(size_t)data13);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13, T14 data14)
-    {
-        static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*) && sizeof(T14) <= sizeof(void*));
-        LogMsg(LL_ALWAYS, LF_GC, 14, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11, (void*)(size_t)data12, (void*)(size_t)data13, (void*)(size_t)data14);
+        LogMsg(LL_ALWAYS, LF_GC, sizeof...(args), format, StressLogMsg::ConvertArgument(args)...);
     }
 
 #ifdef _MSC_VER

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -71,62 +71,36 @@
             LOGALWAYS(msg);                                                                         \
             } while(0)
 
-#define STRESS_LOG0(facility, level, msg) do {                                \
-            if (StressLog::LogOn(facility, level))                            \
-                StressLog::LogMsg(level, facility, 0, msg);                   \
-            LOG((facility, level, msg));                                      \
+#define STRESS_LOG_WRITE(facility, level, msg, ...) do {                                      \
+            if (StressLog::StressLogOn(facility, level))                                      \
+                StressLog::LogMsgOL(facility, level, msg, __VA_ARGS__);                       \
             } while(0)
 
-#define STRESS_LOG1(facility, level, msg, data1) do {                              \
-            if (StressLog::LogOn(facility, level))                                 \
-                StressLog::LogMsg(level, facility, 1, msg, (void*)(size_t)(data1));\
-            LOG((facility, level, msg, data1));                                    \
+#define STRESS_LOG0(facility, level, msg) do {                                      \
+            if (StressLog::StressLogOn(facility, level))                            \
+                StressLog::LogMsg(facility, level, 0, msg);                         \
             } while(0)
 
-#define STRESS_LOG2(facility, level, msg, data1, data2) do {                       \
-            if (StressLog::LogOn(facility, level))                                 \
-                StressLog::LogMsg(level, facility, 2, msg,                         \
-                    (void*)(size_t)(data1), (void*)(size_t)(data2));               \
-            LOG((facility, level, msg, data1, data2));                             \
-            } while(0)
+#define STRESS_LOG1(facility, level, msg, data1) \
+    STRESS_LOG_WRITE(facility, level, msg, data1)
 
-#define STRESS_LOG3(facility, level, msg, data1, data2, data3) do {                           \
-            if (StressLog::LogOn(facility, level))                                            \
-                StressLog::LogMsg(level, facility, 3, msg,                                    \
-                    (void*)(size_t)(data1),(void*)(size_t)(data2),(void*)(size_t)(data3));    \
-            LOG((facility, level, msg, data1, data2, data3));                                 \
-            } while(0)
+#define STRESS_LOG2(facility, level, msg, data1, data2) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2)
 
-#define STRESS_LOG4(facility, level, msg, data1, data2, data3, data4) do {                              \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility, 4, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4));              \
-            LOG((facility, level, msg, data1, data2, data3, data4));                                    \
-            } while(0)
+#define STRESS_LOG3(facility, level, msg, data1, data2, data3) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3)
 
-#define STRESS_LOG5(facility, level, msg, data1, data2, data3, data4, data5) do {                       \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility, 5, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5));                                                            \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5));                             \
-            } while(0)
+#define STRESS_LOG4(facility, level, msg, data1, data2, data3, data4) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4)
 
-#define STRESS_LOG6(facility, level, msg, data1, data2, data3, data4, data5, data6) do {                \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility, 6, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6));                                    \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5, data6));                      \
-            } while(0)
+#define STRESS_LOG5(facility, level, msg, data1, data2, data3, data4, data5) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5)
 
-#define STRESS_LOG7(facility, level, msg, data1, data2, data3, data4, data5, data6, data7) do {         \
-            if (StressLog::LogOn(facility, level))                                                      \
-                StressLog::LogMsg(level, facility, 7, msg, (void*)(size_t)(data1),                      \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),               \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6), (void*)(size_t)(data7));            \
-            LOG((facility, level, msg, data1, data2, data3, data4, data5, data6, data7));               \
-            } while(0)
+#define STRESS_LOG6(facility, level, msg, data1, data2, data3, data4, data5, data6) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5, data6)
+
+#define STRESS_LOG7(facility, level, msg, data1, data2, data3, data4, data5, data6, data7)  \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5, data6, data7)
 
 #define STRESS_LOG_RESERVE_MEM(numChunks) do {                              \
             if (StressLog::StressLogOn(LF_ALL, LL_ALWAYS))                  \
@@ -359,6 +333,12 @@ public:
     static void LogMsgOL(const char* format, Ts... args)
     {
         LogMsg(LL_ALWAYS, LF_GC, sizeof...(args), format, StressLogMsg::ConvertArgument(args)...);
+    }
+
+    template<typename... Ts>
+    static void LogMsgOL(unsigned facility, unsigned level, const char* format, Ts... args)
+    {
+        LogMsg(level, facility, sizeof...(args), format, StressLogMsg::ConvertArgument(args)...);
     }
 
 #ifdef _MSC_VER

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -356,6 +356,19 @@ void* StressLog::ConvertArgument(double arg)
 #else
 template<>
 void* StressLog::ConvertArgument(double arg) = delete;
+
+// COMPAT: Truncate 64-bit integer arguments to 32-bit
+template<>
+void* StressLog::ConvertArgument(uint64_t arg)
+{
+    return (void*)(size_t)arg;
+}
+
+template<>
+void* StressLog::ConvertArgument(int64_t arg)
+{
+    return (void*)(size_t)arg;
+}
 #endif
 
 //==========================================================================================

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -326,105 +326,35 @@ public:
     #pragma warning( push )
     #pragma warning( disable : 4312 )
     #endif
+
+    template<typename T>
+    static void* ConvertArgument(T arg)
+    {
+        C_ASSERT(sizeof(T) <= sizeof(void*));
+        return (void*)(size_t)arg;
+    }
+
+    template<>
+    static void* ConvertArgument(float arg) = delete;
+
+#if TARGET_64BIT
+    template<>
+    static void* ConvertArgument(double arg)
+    {
+        return (void*)(size_t)(*((uint64_t*)&arg));
+    }
+#else
+    template<>
+    static void* ConvertArgument(double arg) = delete;
+#endif
+
     static void LogMsgOL(const char* format)
     { LogMsg(LF_GC, 0, format); }
 
-    template < typename T1 >
-    static void LogMsgOL(const char* format, T1 data1)
+    template<typename... Ts>
+    static void LogMsgOL(const char* format, Ts... args)
     {
-        C_ASSERT(sizeof(T1) <= sizeof(void*));
-        LogMsg(LF_GC, 1, format, (void*)(size_t)data1);
-    }
-
-    template < typename T1, typename T2 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*));
-        LogMsg(LF_GC, 2, format, (void*)(size_t)data1, (void*)(size_t)data2);
-    }
-
-    template < typename T1, typename T2, typename T3 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*));
-        LogMsg(LF_GC, 3, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*));
-        LogMsg(LF_GC, 4, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*));
-        LogMsg(LF_GC, 5, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*));
-        LogMsg(LF_GC, 6, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*));
-        LogMsg(LF_GC, 7, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*));
-        LogMsg(LF_GC, 8, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*));
-        LogMsg(LF_GC, 9, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*));
-        LogMsg(LF_GC, 10, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*));
-        LogMsg(LF_GC, 11, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*));
-        LogMsg(LF_GC, 12, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11, (void*)(size_t)data12);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*));
-        LogMsg(LF_GC, 13, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11, (void*)(size_t)data12, (void*)(size_t)data13);
-    }
-
-    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14 >
-    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12, T13 data13, T14 data14)
-    {
-        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*) && sizeof(T13) <= sizeof(void*) && sizeof(T14) <= sizeof(void*));
-        LogMsg(LF_GC, 14, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11, (void*)(size_t)data12, (void*)(size_t)data13, (void*)(size_t)data14);
+        LogMsg(LF_GC, sizeof...(args), format, ConvertArgument(args)...);
     }
 
     #ifdef _MSC_VER

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -317,17 +317,17 @@ public:
     }
 
     template<>
-    static void* ConvertArgument(float arg) = delete;
+    void* ConvertArgument(float arg) = delete;
 
 #if TARGET_64BIT
     template<>
-    static void* ConvertArgument(double arg)
+    void* ConvertArgument(double arg)
     {
         return (void*)(size_t)(*((uint64_t*)&arg));
     }
 #else
     template<>
-    static void* ConvertArgument(double arg) = delete;
+    void* ConvertArgument(double arg) = delete;
 #endif
 
     template<typename... Ts>

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -109,54 +109,36 @@ enum LogFacilitiesEnum: unsigned int {
                 StressLog::LogMsgOL(_Args msg);                                              \
             } WHILE_0
 
+#define STRESS_LOG_WRITE(facility, level, msg, ...) do {                                      \
+            if (StressLog::StressLogOn(facility, level))                                      \
+                StressLog::LogMsgOL(facility, msg, __VA_ARGS__);                              \
+            } WHILE_0
+
 #define STRESS_LOG0(facility, level, msg) do {                                      \
             if (StressLog::StressLogOn(facility, level))                            \
                 StressLog::LogMsg(facility, 0, msg);                                \
             } WHILE_0                                                               \
 
-#define STRESS_LOG1(facility, level, msg, data1) do {                               \
-            if (StressLog::StressLogOn(facility, level))                            \
-                StressLog::LogMsg(facility, 1, msg, (void*)(size_t)(data1));        \
-            } WHILE_0
+#define STRESS_LOG1(facility, level, msg, data1) \
+    STRESS_LOG_WRITE(facility, level, msg, data1)
 
-#define STRESS_LOG2(facility, level, msg, data1, data2) do {                        \
-            if (StressLog::StressLogOn(facility, level))                            \
-                StressLog::LogMsg(facility, 2, msg,                                 \
-                    (void*)(size_t)(data1), (void*)(size_t)(data2));                \
-            } WHILE_0
+#define STRESS_LOG2(facility, level, msg, data1, data2) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2)
 
-#define STRESS_LOG3(facility, level, msg, data1, data2, data3) do {                           \
-            if (StressLog::StressLogOn(facility, level))                                      \
-                StressLog::LogMsg(facility, 3, msg,                                           \
-                    (void*)(size_t)(data1),(void*)(size_t)(data2),(void*)(size_t)(data3));    \
-            } WHILE_0
+#define STRESS_LOG3(facility, level, msg, data1, data2, data3) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3)
 
-#define STRESS_LOG4(facility, level, msg, data1, data2, data3, data4) do {                    \
-            if (StressLog::StressLogOn(facility, level))                                      \
-                StressLog::LogMsg(facility, 4, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4));    \
-            } WHILE_0
+#define STRESS_LOG4(facility, level, msg, data1, data2, data3, data4) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4)
 
-#define STRESS_LOG5(facility, level, msg, data1, data2, data3, data4, data5) do {             \
-            if (StressLog::StressLogOn(facility, level))                                      \
-                StressLog::LogMsg(facility, 5, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),     \
-                    (void*)(size_t)(data5));                                                  \
-            } WHILE_0
+#define STRESS_LOG5(facility, level, msg, data1, data2, data3, data4, data5) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5)
 
-#define STRESS_LOG6(facility, level, msg, data1, data2, data3, data4, data5, data6) do {      \
-            if (StressLog::StressLogOn(facility, level))                                      \
-                StressLog::LogMsg(facility, 6, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),     \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6));                          \
-            } WHILE_0
+#define STRESS_LOG6(facility, level, msg, data1, data2, data3, data4, data5, data6) \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5, data6)
 
-#define STRESS_LOG7(facility, level, msg, data1, data2, data3, data4, data5, data6, data7) do { \
-            if (StressLog::StressLogOn(facility, level))                                      \
-                StressLog::LogMsg(facility, 7, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),     \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6), (void*)(size_t)(data7));  \
-            } WHILE_0
+#define STRESS_LOG7(facility, level, msg, data1, data2, data3, data4, data5, data6, data7)  \
+    STRESS_LOG_WRITE(facility, level, msg, data1, data2, data3, data4, data5, data6, data7)
 
 #define STRESS_LOG_RESERVE_MEM(numChunks) do {                                                \
             if (StressLog::StressLogOn(LF_ALL, LL_ALWAYS))                         \
@@ -348,13 +330,16 @@ public:
     static void* ConvertArgument(double arg) = delete;
 #endif
 
-    static void LogMsgOL(const char* format)
-    { LogMsg(LF_GC, 0, format); }
-
     template<typename... Ts>
     static void LogMsgOL(const char* format, Ts... args)
     {
         LogMsg(LF_GC, sizeof...(args), format, ConvertArgument(args)...);
+    }
+
+    template<typename... Ts>
+    static void LogMsgOL(unsigned facility, const char* format, Ts... args)
+    {
+        LogMsg(facility, sizeof...(args), format, ConvertArgument(args)...);
     }
 
     #ifdef _MSC_VER

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -316,20 +316,6 @@ public:
         return (void*)(size_t)arg;
     }
 
-    template<>
-    void* ConvertArgument(float arg) = delete;
-
-#if TARGET_64BIT
-    template<>
-    void* ConvertArgument(double arg)
-    {
-        return (void*)(size_t)(*((uint64_t*)&arg));
-    }
-#else
-    template<>
-    void* ConvertArgument(double arg) = delete;
-#endif
-
     template<typename... Ts>
     static void LogMsgOL(const char* format, Ts... args)
     {
@@ -357,6 +343,20 @@ public:
     static StressLog theLog;    // We only have one log, and this is it
 };
 
+
+template<>
+void* StressLog::ConvertArgument(float arg) = delete;
+
+#if TARGET_64BIT
+template<>
+void* StressLog::ConvertArgument(double arg)
+{
+    return (void*)(size_t)(*((uint64_t*)&arg));
+}
+#else
+template<>
+void* StressLog::ConvertArgument(double arg) = delete;
+#endif
 
 //==========================================================================================
 // Private classes

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -158,55 +158,6 @@ enum LogFacilitiesEnum: unsigned int {
                     (void*)(size_t)(data5), (void*)(size_t)(data6), (void*)(size_t)(data7));  \
             } WHILE_0
 
-#define STRESS_LOG_COND0(facility, level, msg) do {                                 \
-            if (StressLog::StressLogOn(facility, level) && (cond))                  \
-                StressLog::LogMsg(facility, 0, msg);                                \
-            } WHILE_0
-
-#define STRESS_LOG_COND1(facility, level, cond, msg, data1) do {                    \
-            if (StressLog::StressLogOn(facility, level) && (cond))                  \
-                StressLog::LogMsg(facility, 1, msg, (void*)(size_t)(data1));        \
-            } WHILE_0
-
-#define STRESS_LOG_COND2(facility, level, cond, msg, data1, data2) do {             \
-            if (StressLog::StressLogOn(facility, level) && (cond))                  \
-                StressLog::LogMsg(facility, 2, msg,                                 \
-                    (void*)(size_t)(data1), (void*)(size_t)(data2));                \
-            } WHILE_0
-
-#define STRESS_LOG_COND3(facility, level, cond, msg, data1, data2, data3) do {      \
-            if (StressLog::StressLogOn(facility, level) && (cond))                  \
-                StressLog::LogMsg(facility, 3, msg,                                 \
-                    (void*)(size_t)(data1),(void*)(size_t)(data2),(void*)(size_t)(data3));    \
-            } WHILE_0
-
-#define STRESS_LOG_COND4(facility, level, cond, msg, data1, data2, data3, data4) do {         \
-            if (StressLog::StressLogOn(facility, level) && (cond))                            \
-                StressLog::LogMsg(facility, 4, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4));    \
-            } WHILE_0
-
-#define STRESS_LOG_COND5(facility, level, cond, msg, data1, data2, data3, data4, data5) do {  \
-            if (StressLog::StressLogOn(facility, level) && (cond))                            \
-                StressLog::LogMsg(facility, 5, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),     \
-                    (void*)(size_t)(data5));                                                  \
-            } WHILE_0
-
-#define STRESS_LOG_COND6(facility, level, cond, msg, data1, data2, data3, data4, data5, data6) do {     \
-            if (StressLog::StressLogOn(facility, level) && (cond))                            \
-                StressLog::LogMsg(facility, 6, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),     \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6));                          \
-            } WHILE_0
-
-#define STRESS_LOG_COND7(facility, level, cond, msg, data1, data2, data3, data4, data5, data6, data7) do {  \
-            if (StressLog::StressLogOn(facility, level) && (cond))                            \
-                StressLog::LogMsg(facility, 7, msg, (void*)(size_t)(data1),                   \
-                    (void*)(size_t)(data2),(void*)(size_t)(data3),(void*)(size_t)(data4),     \
-                    (void*)(size_t)(data5), (void*)(size_t)(data6), (void*)(size_t)(data7));  \
-            } WHILE_0
-
 #define STRESS_LOG_RESERVE_MEM(numChunks) do {                                                \
             if (StressLog::StressLogOn(LF_ALL, LL_ALWAYS))                         \
                 {StressLog::ReserveStressLogChunks (numChunks);}                              \

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -349,7 +349,7 @@ void* StressLog::ConvertArgument(float arg) = delete;
 
 #if TARGET_64BIT
 template<>
-void* StressLog::ConvertArgument(double arg)
+inline void* StressLog::ConvertArgument(double arg)
 {
     return (void*)(size_t)(*((uint64_t*)&arg));
 }
@@ -359,13 +359,13 @@ void* StressLog::ConvertArgument(double arg) = delete;
 
 // COMPAT: Truncate 64-bit integer arguments to 32-bit
 template<>
-void* StressLog::ConvertArgument(uint64_t arg)
+inline void* StressLog::ConvertArgument(uint64_t arg)
 {
     return (void*)(size_t)arg;
 }
 
 template<>
-void* StressLog::ConvertArgument(int64_t arg)
+inline void* StressLog::ConvertArgument(int64_t arg)
 {
     return (void*)(size_t)arg;
 }

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -4231,7 +4231,10 @@ void Thread::SetLastThrownObject(OBJECTREF throwable, BOOL isUnhandled)
     }
     CONTRACTL_END;
 
-    STRESS_LOG_COND1(LF_EH, LL_INFO100, OBJECTREFToObject(throwable) != NULL, "in Thread::SetLastThrownObject: obj = %p\n", OBJECTREFToObject(throwable));
+    if (OBJECTREFToObject(throwable) != NULL)
+    {
+        STRESS_LOG1(LF_EH, LL_INFO100, "in Thread::SetLastThrownObject: obj = %p\n", OBJECTREFToObject(throwable));
+    }
 
     // you can't have a NULL unhandled exception
     _ASSERTE(!(throwable == NULL && isUnhandled));


### PR DESCRIPTION
Add correct support for double parameter in stresslog macros. The GC uses these and they don't actually work today (they get cast to an integer value and then that integer value's bytes are re-interpreted as a double).

Also while I'm here, clean up the StressLog macros to get equivalent behavior for all forms and use variadic macros to reduce duplication without having to change use sites.