### PR TITLE
Extend preinitialization arithmetic and string manipulation

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/String.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/String.NativeAot.cs
@@ -18,6 +18,7 @@ namespace System
         [Intrinsic]
         public static readonly string Empty = "";
 
+        [Intrinsic]
         internal static unsafe string FastAllocateString(int length)
         {
             // We allocate one extra char as an interop convenience so that our strings are null-

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1958,7 +1958,21 @@ namespace ILCompiler
                         && parameters[1] is ByRefValue src
                         && parameters[2] is ValueTypeValue len)
                     {
-                        int length = context.Target.PointerSize == 8 ? checked ((int)len.AsInt64()) : len.AsInt32();
+                        int length;
+                        if (context.Target.PointerSize == 8)
+                        {
+                            long longLength = len.AsInt64();
+                            if (longLength > int.MaxValue || longLength < int.MinValue)
+                            {
+                                return false;
+                            }
+
+                            length = (int)longLength;
+                        }
+                        else
+                        {
+                            length = len.AsInt32();
+                        }
                         var srcSpan = new Span<byte>(src.PointedToBytes, src.PointedToOffset, length);
                         var dstSpan = new Span<byte>(dest.PointedToBytes, dest.PointedToOffset, length);
                         srcSpan.CopyTo(dstSpan);

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -17,6 +17,7 @@ internal class Program
 #if !MULTIMODULE_BUILD
         TestHardwareIntrinsics.Run();
         TestLdstr.Run();
+        TestStringManip.Run();
         TestException.Run();
         TestThreadStaticNotInitialized.Run();
         TestUntouchedThreadStaticInitialized.Run();
@@ -119,6 +120,27 @@ class TestLdstr
         Assert.IsPreinitialized(typeof(TestLdstr));
         Assert.AreSame(nameof(TestLdstr), s_mine);
         Assert.True(s_literalsEqual);
+    }
+}
+
+class TestStringManip
+{
+    static string testString;
+
+    static TestStringManip()
+    {
+        string test = "";
+        for (int i = 0; i < 3; i++)
+        {
+            test += "A";
+        }
+        testString = test;
+    }
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(TestStringManip));
+        Assert.AreSame("AAA", testString);
     }
 }
 


### PR DESCRIPTION
After talking to Fabian on #allow-unsafe-blocks who trying to use preinitialization as const expressions for the purposes of obfuscating string literals, he encountered a few hurdles that were trivial to resolve:

Makes it possible to dynamically allocate and preinitialize those strings.
Extends arithmetic support to handle `nint operator int32` operations (needed for string manip)
Adds xor / not / shr support and extends casting for floating point types