### PR TITLE
Add support for nested types in the `corelib.h` parser for rooting descriptors

### DIFF
--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -1123,15 +1123,10 @@ DEFINE_METHOD(UTF8STRINGMARSHALLER, CONVERT_TO_MANAGED, ConvertToManaged, SM_Ptr
 DEFINE_METHOD(UTF8STRINGMARSHALLER, CONVERT_TO_UNMANAGED, ConvertToUnmanaged, SM_Str_RetPtrByte)
 DEFINE_METHOD(UTF8STRINGMARSHALLER, FREE, Free, SM_PtrByte_RetVoid)
 
-// The generator for the ILLink XML doesn't understand inner classes so generation
-// needs to skip the following type.
-// See https://github.com/dotnet/runtime/issues/71847
-#ifndef FOR_ILLINK
 DEFINE_CLASS(UTF8STRINGMARSHALLER_IN, Marshalling, Utf8StringMarshaller+ManagedToUnmanagedIn)
 DEFINE_METHOD(UTF8STRINGMARSHALLER_IN, FROM_MANAGED, FromManaged, IM_Str_SpanOfByte_RetVoid)
 DEFINE_METHOD(UTF8STRINGMARSHALLER_IN, TO_UNMANAGED, ToUnmanaged, IM_RetPtrByte)
 DEFINE_METHOD(UTF8STRINGMARSHALLER_IN, FREE, Free, IM_RetVoid)
-#endif // FOR_ILLINK
 
 DEFINE_CLASS(UTF8BUFFERMARSHALER, StubHelpers, UTF8BufferMarshaler)
 DEFINE_METHOD(UTF8BUFFERMARSHALER, CONVERT_TO_NATIVE, ConvertToNative, NoSig)
@@ -1180,9 +1175,7 @@ DEFINE_CLASS(EXCEPTIONSERVICES_INTERNALCALLS, ExceptionServices, InternalCalls)
 DEFINE_CLASS(STACKFRAMEITERATOR, Runtime, StackFrameIterator)
 #endif // FEATURE_EH_FUNCLETS
 
-#ifndef FOR_ILLINK
 DEFINE_CLASS(EXINFO, Runtime, EH+ExInfo)
-#endif // FOR_ILLINK
 
 DEFINE_CLASS_U(System, GCMemoryInfoData, GCMemoryInfoData)
 DEFINE_FIELD_U(_highMemoryLoadThresholdBytes, GCMemoryInfoData, highMemLoadThresholdBytes)

--- a/src/tools/illink/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/tools/illink/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -471,7 +471,10 @@ namespace ILLink.Tasks
 				Log.LogError ($"Unknown namespace '{classNamespace}'.");
 			}
 
-			return namespaceDictionary[classNamespace] + "." + className;
+			// Convert from the System.Reflection/CoreCLR nested type name format to the IL/Cecil format.
+			string classNameWithCecilNestedFormat = className.Replace ('+', '/');
+
+			return namespaceDictionary[classNamespace] + "." + classNameWithCecilNestedFormat;
 		}
 
 		void InitializeDefineConstants ()

--- a/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -93,7 +93,7 @@ namespace ILLink.Tasks.Tests
 						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBothForILLink")),
 						new XElement ("method", new XAttribute ("name", "TestMethodForILLink"))),
 					new XElement ("type", new XAttribute("fullname", "TestNS.TestClass/Nested"),
-						new XElement ("method", new XAttribute("name", "TestMethod")))
+						new XElement ("method", new XAttribute("name", "TestMethod"))),
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestAlwaysException"),
 						new XElement ("method", new XAttribute ("name", ".ctor"))),
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestFeatureOnException"),

--- a/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -39,7 +39,9 @@ namespace ILLink.Tasks.Tests
 				"#endif // FEATURE_BOTH",
 				"#if FOR_ILLINK",
 				"DEFINE_METHOD(TESTCLASS, TESTMETHODFORILLINK, TestMethodForILLink, 5)",
-				"#endif"
+				"#endif",
+				"DEFINE_CLASS(NESTEDTESTCLASS, TestNS, TestClass+Nested)",
+				"DEFINE_METHOD(NESTEDTESTCLASS, TESTMETHOD, TestMethod, 0)"
 				});
 
 			File.WriteAllText ("namespace.h",
@@ -93,7 +95,9 @@ namespace ILLink.Tasks.Tests
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestAlwaysException"),
 						new XElement ("method", new XAttribute ("name", ".ctor"))),
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestFeatureOnException"),
-						new XElement ("method", new XAttribute ("name", ".ctor")))
+						new XElement ("method", new XAttribute ("name", ".ctor"))),
+					new XElement ("type", new XAttribute("fullname", "TestNS.TestClass/Nested"),
+						new XElement ("method", new XAttribute("name", "TestMethod")))
 					)).ToString ();
 			Assert.Equal (expectedXml, output.Root.ToString ());
 		}

--- a/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -92,12 +92,12 @@ namespace ILLink.Tasks.Tests
 						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBoth")),
 						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBothForILLink")),
 						new XElement ("method", new XAttribute ("name", "TestMethodForILLink"))),
+					new XElement ("type", new XAttribute("fullname", "TestNS.TestClass/Nested"),
+						new XElement ("method", new XAttribute("name", "TestMethod")))
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestAlwaysException"),
 						new XElement ("method", new XAttribute ("name", ".ctor"))),
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestFeatureOnException"),
 						new XElement ("method", new XAttribute ("name", ".ctor"))),
-					new XElement ("type", new XAttribute("fullname", "TestNS.TestClass/Nested"),
-						new XElement ("method", new XAttribute("name", "TestMethod")))
 					)).ToString ();
 			Assert.Equal (expectedXml, output.Root.ToString ());
 		}

--- a/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/src/tools/illink/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -97,7 +97,7 @@ namespace ILLink.Tasks.Tests
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestAlwaysException"),
 						new XElement ("method", new XAttribute ("name", ".ctor"))),
 					new XElement ("type", new XAttribute ("fullname", "TestNS.TestFeatureOnException"),
-						new XElement ("method", new XAttribute ("name", ".ctor"))),
+						new XElement ("method", new XAttribute ("name", ".ctor")))
 					)).ToString ();
 			Assert.Equal (expectedXml, output.Root.ToString ());
 		}


### PR DESCRIPTION
Fixes #71847