### PR TITLE
[release/8.0-staging] Add runtime config parameter to force ijwhost to load assemblies in an isolated context

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -49,7 +49,7 @@ namespace Internal.Runtime.InteropServices
         /// </summary>
         /// <param name="moduleHandle">The native module handle for the assembly.</param>
         /// <param name="assemblyPath">The path to the assembly (as a pointer to a UTF-16 C string).</param>
-        /// <param name="loadContext">Load context (currently must be IntPtr.Zero)</param>
+        /// <param name="loadContext">Load context (currently must be either IntPtr.Zero for default ALC or -1 for isolated ALC)</param>
         [UnmanagedCallersOnly]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "The same C++/CLI feature switch applies to LoadInMemoryAssembly and this function. We rely on the warning from LoadInMemoryAssembly.")]
@@ -58,9 +58,12 @@ namespace Internal.Runtime.InteropServices
             if (!IsSupported)
                 throw new NotSupportedException(SR.NotSupported_CppCli);
 
-            ArgumentOutOfRangeException.ThrowIfNotEqual(loadContext, IntPtr.Zero);
+            if ((loadContext != IntPtr.Zero) && (loadContext != -1))
+            {
+                throw new ArgumentOutOfRangeException(nameof(loadContext));
+            }
 
-            LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath, AssemblyLoadContext.Default);
+            LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath, (loadContext == IntPtr.Zero) ? AssemblyLoadContext.Default : null);
         }
 
         [RequiresUnreferencedCode("C++/CLI is not trim-compatible", Url = "https://aka.ms/dotnet-illink/nativehost")]

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
@@ -41,6 +41,41 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public void LoadLibrary_ContextConfig(bool load_isolated)
+        {
+            // make a copy of a portion of the shared state because we will modify it
+            using (var app = sharedState.IjwApp.Copy())
+            {
+                string[] args = {
+                    "ijwhost",
+                    app.AppDll,
+                    "NativeEntryPoint"
+                };
+
+                RuntimeConfig.FromFile(app.RuntimeConfigJson)
+                    .WithProperty("System.Runtime.InteropServices.CppCLI.LoadComponentInIsolatedContext", load_isolated.ToString())
+                    .Save();
+
+                CommandResult result = sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
+                    .Execute();
+
+                result.Should().Pass()
+                    .And.HaveStdOutContaining("[C++/CLI] NativeEntryPoint: calling managed class");
+
+                if (load_isolated)  // Assembly should be loaded in an isolated context
+                {
+                    result.Should().HaveStdOutContaining("[C++/CLI] ManagedClass: AssemblyLoadContext = \"IsolatedComponentLoadContext");
+                }
+                else  // Assembly should be loaded in the default context
+                {
+                    result.Should().HaveStdOutContaining("[C++/CLI] ManagedClass: AssemblyLoadContext = \"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void ManagedHost(bool selfContained)
         {
             string [] args = {

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         {
             string [] args = {
                 "ijwhost",
-                sharedState.IjwLibraryPath,
+                sharedState.IjwApp.AppDll,
                 "NativeEntryPoint"
             };
             CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.RepoDirectories.BuiltDotnet)
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     .WithProperty("System.Runtime.InteropServices.CppCLI.LoadComponentInIsolatedContext", load_isolated.ToString())
                     .Save();
 
-                CommandResult result = sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
+                CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.RepoDirectories.BuiltDotnet)
                     .Execute();
 
                 result.Should().Pass()
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         {
             string [] args = {
                 "ijwhost",
-                sharedState.IjwLibraryPath,
+                sharedState.IjwApp.AppDll,
                 "NativeEntryPoint"
             };
             TestProjectFixture fixture = selfContained ? sharedState.ManagedHostFixture_SelfContained : sharedState.ManagedHostFixture_FrameworkDependent;
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
         public class SharedTestState : SharedTestStateBase
         {
-            public string IjwLibraryPath { get; }
+            public TestApp IjwApp {get;}
 
             public TestProjectFixture ManagedHostFixture_FrameworkDependent { get; }
             public TestProjectFixture ManagedHostFixture_SelfContained { get; }
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             public SharedTestState()
             {
                 string folder = Path.Combine(BaseDirectory, "ijw");
-                Directory.CreateDirectory(folder);
+                IjwApp = new TestApp(folder, "ijw");
 
                 // Copy over ijwhost
                 string ijwhostName = "ijwhost.dll";
@@ -114,8 +114,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
                 // Copy over the C++/CLI test library
                 string ijwLibraryName = "ijw.dll";
-                IjwLibraryPath = Path.Combine(folder, ijwLibraryName);
-                File.Copy(Path.Combine(RepoDirectories.HostTestArtifacts, ijwLibraryName), IjwLibraryPath);
+                File.Copy(Path.Combine(RepoDirectories.HostTestArtifacts, ijwLibraryName), Path.Combine(folder, ijwLibraryName));
 
                 // Create a runtimeconfig.json for the C++/CLI test library
                 new RuntimeConfig(Path.Combine(folder, "ijw.runtimeconfig.json"))

--- a/src/native/corehost/ijwhost/ijwhost.cpp
+++ b/src/native/corehost/ijwhost/ijwhost.cpp
@@ -20,7 +20,7 @@
 #define IJW_API SHARED_API
 #endif // _WIN32
 
-pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate)
+pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate, void **load_context)
 {
     get_function_pointer_fn get_function_pointer;
     int status = load_fxr_and_get_delegate(
@@ -40,7 +40,17 @@ pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_m
 
             return StatusCode::Success;
         },
-        [](pal::dll_t fxr, hostfxr_handle context){ },
+        [load_context](pal::dll_t fxr, hostfxr_handle context)
+        {
+            *load_context = nullptr;   // default load context
+            auto get_runtime_property_value = reinterpret_cast<hostfxr_get_runtime_property_value_fn>(pal::get_symbol(fxr, "hostfxr_get_runtime_property_value"));
+            const pal::char_t* value;
+            if (get_runtime_property_value(context, _X("System.Runtime.InteropServices.CppCLI.LoadComponentInIsolatedContext"), &value) == StatusCode::Success
+                && pal::strcasecmp(value, _X("true")) == 0)
+            {
+                *load_context = ISOLATED_CONTEXT; // Isolated load context
+            }
+        },
         reinterpret_cast<void**>(&get_function_pointer)
     );
     if (status != StatusCode::Success)

--- a/src/native/corehost/ijwhost/ijwhost.h
+++ b/src/native/corehost/ijwhost/ijwhost.h
@@ -15,8 +15,10 @@ bool are_thunks_installed_for_module(HMODULE instance);
 
 using load_in_memory_assembly_fn = void(STDMETHODCALLTYPE*)(pal::dll_t handle, const pal::char_t* path, void* load_context);
 
-pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate);
+pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate, void **load_context);
 
 extern HANDLE g_heapHandle;
+
+#define ISOLATED_CONTEXT (void*)-1
 
 #endif

--- a/src/native/corehost/ijwhost/ijwthunk.cpp
+++ b/src/native/corehost/ijwhost/ijwthunk.cpp
@@ -119,7 +119,9 @@ extern "C" std::uintptr_t __stdcall start_runtime_and_get_target_address(std::ui
     bootstrap_thunk *pThunk = bootstrap_thunk::get_thunk_from_cookie(cookie);
     load_in_memory_assembly_fn loadInMemoryAssembly;
     pal::dll_t moduleHandle = pThunk->get_dll_handle();
-    pal::hresult_t status = get_load_in_memory_assembly_delegate(moduleHandle, &loadInMemoryAssembly);
+
+    void* load_context = nullptr;
+    pal::hresult_t status = get_load_in_memory_assembly_delegate(moduleHandle, &loadInMemoryAssembly, &load_context);
 
     if (status != StatusCode::Success)
     {
@@ -145,7 +147,7 @@ extern "C" std::uintptr_t __stdcall start_runtime_and_get_target_address(std::ui
 #pragma warning (pop)
     }
 
-    loadInMemoryAssembly(moduleHandle, app_path.c_str(), nullptr);
+    loadInMemoryAssembly(moduleHandle, app_path.c_str(), load_context);
 
     std::uintptr_t thunkAddress = *(pThunk->get_slot_address());
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/105337 to release/8.0-staging

cc @mikeoliphant @AaronRobinsonMSFT 

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Issue: https://github.com/dotnet/runtime/issues/104480

When trying to load a second copy of a C++/CLI assembly that has already been loaded from a different location, the runtime ends up in an infinite loop calling into the `ijwhost` stub for starting the runtime/loading the managed assembly. There is no workaround.

## Regression

- [x] Yes
- [ ] No

We made a change to make C++/CLI assemblies always load in the default ALC - this was based on common user feedback / pain points and made the behaviour better match .NET Framework (that migration being the major use case). However, this ends up breaking the reported scenario where multiple copies of a C++/CLI assembly (same assembly name in metadata) are loaded from different locations.

## Testing

Customer validated (and implemented). Automated tests added.

## Risk

Low. This adds a configuration option the change the load behaviour. It does not change the default behaviour.