### PR TITLE
Make TooDeepJsonDocument test more consistent across platforms

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonElementTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonElementTests.cs
@@ -230,6 +230,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/105490", TestRuntimes.Mono)]
         public static async Task DeepEquals_TooDeepJsonDocument_ThrowsInsufficientExecutionStackException()
         {
             var tcs = new TaskCompletionSource<bool>();


### PR DESCRIPTION
Run the test on a thread with as consistent a stack size as possible so that we don't inadvertently succeed due to having a really large stack.

Fixes https://github.com/dotnet/runtime/issues/105440
Fixes https://github.com/dotnet/runtime/issues/105425