### PR TITLE
[mono] Disable JIT/Methodical/Methodical_[r,d][o,1] on x64 AOT and fullAOT

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2617,8 +2617,8 @@
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'llvmfullaot' and '$(TargetArchitecture)' == 'x64'">
     </ItemGroup>
 
-    <!-- Disabled tests on Mono x64 fullAOT -->
-    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(TargetArchitecture)' == 'x64' and ('$(RuntimeVariant)' == 'llvmfullaot' or '$(RuntimeVariant)' == 'minifullaot')">
+    <!-- Disabled tests on Mono x64 AOT and fullAOT -->
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(TargetArchitecture)' == 'x64' and ('$(RuntimeVariant)' == 'llvmaot' or '$(RuntimeVariant)' == 'llvmfullaot' or '$(RuntimeVariant)' == 'minifullaot')">
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_d1/**">
             <Issue>https://github.com/dotnet/runtime/issues/105395</Issue>
         </ExcludeList>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1283,18 +1283,6 @@
             <Issue>Crashes during LLVM AOT compilation.</Issue>
         </ExcludeList>
 
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_d1/**">
-            <Issue>Crashes during LLVM AOT compilation.</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_do/**">
-            <Issue>Crashes during LLVM AOT compilation.</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_r1/**">
-            <Issue>Crashes during LLVM AOT compilation.</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_ro/**">
-            <Issue>Crashes during LLVM AOT compilation.</Issue>
-        </ExcludeList>
 
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/StructABI/StructABI/**">
             <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
@@ -2628,6 +2616,23 @@
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'llvmfullaot' and '$(TargetArchitecture)' == 'x64'">
     </ItemGroup>
+
+    <!-- Disabled tests on Mono x64 fullAOT -->
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(TargetArchitecture)' == 'x64' and ('$(RuntimeVariant)' == 'llvmfullaot' or '$(RuntimeVariant)' == 'minifullaot')">
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_d1/**">
+            <Issue>https://github.com/dotnet/runtime/issues/105395</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_do/**">
+            <Issue>https://github.com/dotnet/runtime/issues/105395</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_r1/**">
+            <Issue>https://github.com/dotnet/runtime/issues/105395</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Methodical_ro/**">
+            <Issue>https://github.com/dotnet/runtime/issues/105395</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'minijit' and '$(TargetArchitecture)' == 'arm64'">
         <ExcludeList Include="$(XunitTestBinBase)/Interop/SuppressGCTransition/SuppressGCTransitionTest/**">


### PR DESCRIPTION
The JIT/Methodical/Methodical_[r,d][o,1] runtime tests are failing due to LLVM 19 bump (see https://github.com/dotnet/runtime/issues/105395). Disabling until the issue is fixed.