### PR TITLE
Fix ECMA 355 Partition download links

### DIFF
--- a/docs/project/dotnet-standards.md
+++ b/docs/project/dotnet-standards.md
@@ -33,12 +33,12 @@ ECMA 335 - CLI
 
 **ECMA 335 Partitions with added Microsoft Specific Implementation Notes**
 
-- [Partition I: Concepts and Architecture](http://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20I.pdf)
-- [Partition II: Meta Data Definition and Semantics](http://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20II.pdf)
-- [Partition III: CIL Instruction Set](http://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20III.pdf)
-- [Partition IV: Profiles and Libraries](http://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20IV.pdf)
-- [Partition V: Debug Interchange Format](http://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20V.pdf)
-- [Partition VI: Annexes](http://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20VI.pdf)
+- [Partition I: Concepts and Architecture](https://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20I.pdf)
+- [Partition II: Meta Data Definition and Semantics](https://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20II.pdf)
+- [Partition III: CIL Instruction Set](https://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20III.pdf)
+- [Partition IV: Profiles and Libraries](https://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20IV.pdf)
+- [Partition V: Debug Interchange Format](https://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20V.pdf)
+- [Partition VI: Annexes](https://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20VI.pdf)
 
 **ECMA Technical Report 084: Information Derived from Partition IV XML File**
 


### PR DESCRIPTION
On https://github.com/dotnet/runtime/blob/main/docs/project/dotnet-standards.md the Partition with Notes download links using HTTP protocol fail to download in Chrome:

>Mixed Content: The site at 'https://github.com/' was loaded over a secure connection, but the file at 'https://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20I.pdf' was redirected through an insecure connection. This file should be served over HTTPS. See https://blog.chromium.org/2020/02/protecting-users-from-insecure.html for more details.

(It might be reasonable for somebody else to follow-up, fixing all domains on all pages with regex `\(http://([.a-z0-9-]+)` replacing with `(https://$1`, but I didn't test each blog site supports HTTPS.)