### PR TITLE
Disable ImportWithPasswordOrFileName_IterationCountLimitExceeded on 32-bit CPUs

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxIterationCountTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxIterationCountTests.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Contains(FwlinkId, ce.Message);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
         [MemberData(nameof(GetCertsWith_IterationCountExceedingDefaultLimit_MemberData))]
         public void ImportWithPasswordOrFileName_IterationCountLimitExceeded(string name, string password, bool usesPbes2, byte[] blob, long iterationCount, bool usesRC2)
         {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxIterationCountTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxIterationCountTests.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Contains(FwlinkId, ce.Message);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
         [MemberData(nameof(GetCertsWith_IterationCountExceedingDefaultLimit_MemberData))]
         public void ImportWithPasswordOrFileName_IterationCountLimitExceeded(string name, string password, bool usesPbes2, byte[] blob, long iterationCount, bool usesRC2)
         {


### PR DESCRIPTION
The test is occasionally running out-of-memory on Android arm32 CI devices, see https://github.com/dotnet/runtime/issues/105325. Disabling the test on 32-bit architectures.