### PR TITLE
[release/8.0-staging] Build Mono build tasks packs only when targeting mobile

### DIFF
--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -28,7 +28,7 @@
     <ProjectReference Include="Microsoft.NET.Runtime.LibraryBuilder.Sdk\Microsoft.NET.Runtime.LibraryBuilder.Sdk.pkgproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' and '$(TargetsMobile)' == 'true'">
     <ProjectReference Include="Microsoft.NET.Runtime.MonoTargets.Sdk\Microsoft.NET.Runtime.MonoTargets.Sdk.pkgproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/105153 to release/8.0-staging

## Customer Impact

- [ ] Customer reported
- [x] Found internally

This PR limits building `Microsoft.NET.Runtime.MonoTargets.Sdk` package only when the build targets mobile platforms. It helps in prevention of publishing different versions of the same package in an official build, which causes issues with symbol verification during VS insertion. More details on the exact encountered scenario are provided in the description of https://github.com/dotnet/runtime/pull/105153.

## Regression

- [ ] Yes
- [x] No

[If yes, specify when the regression was introduced. Provide the PR or commit if known.]

## Testing

Verified that on the `main` branch official build succeeds producing required packages.

## Risk
Low

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
