### PR TITLE
[browser] Marshalling of resolved Tasks/promises is not resolved in JS/C#

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -275,7 +275,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 }
                 else
                 {
-                    slot.ElementType = slot.Type;
+                    slot.ElementType = MarshalerType.Void;
                     slot.Type = MarshalerType.TaskResolved;
                     return;
                 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
@@ -436,5 +436,12 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             Assert.Equal(JavaScriptLibrary.JavaScriptInterop.ValidationMethod(5, 6), await JavaScriptTestHelper.callJavaScriptLibrary(5, 6));
         }
+
+        [Fact]
+        public async void JSExportCompletedTaskReturnsResolvedPromise()
+        {
+            string result = await JavaScriptTestHelper.InvokeReturnCompletedTask();
+            Assert.Equal("resolved", result);
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -1152,7 +1152,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public async Task JsImportResolvedPromiseReturnsCompletedTask()
         {
             var promise = JavaScriptTestHelper.ReturnResolvedPromise();
-#ifndef FeatureWasmManagedThreads
+#if !FEATURE_WASM_MANAGED_THREADS
             Assert.False(promise.IsCompleted);
 #endif
             await promise;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -1152,7 +1152,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public async Task JsImportResolvedPromiseReturnsCompletedTask()
         {
             var promise = JavaScriptTestHelper.ReturnResolvedPromise();
+#ifndef FeatureWasmManagedThreads
             Assert.False(promise.IsCompleted);
+#endif
             await promise;
             Assert.True(promise.IsCompleted);
         }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -1148,6 +1148,15 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             await task;
         }
 
+        [Fact]
+        public async Task JsImportResolvedPromiseReturnsCompletedTask()
+        {
+            var promise = JavaScriptTestHelper.ReturnResolvedPromise();
+            Assert.False(promise.IsCompleted);
+            await promise;
+            Assert.True(promise.IsCompleted);
+        }
+
         #endregion
 
         #region Action

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -441,6 +441,18 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("invoke1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Promise<JSType.Number>>]
         internal static partial Task<int> invoke1_TaskOfInt([JSMarshalAs<JSType.Promise<JSType.Number>>] Task<int> value, [JSMarshalAs<JSType.String>] string name);
+    
+        [JSImport("returnResolvedPromise", "JavaScriptTestHelper")]
+        internal static partial Task ReturnResolvedPromise();
+
+        [JSImport("invokeReturnCompletedTask", "JavaScriptTestHelper")]
+        internal static partial Task<string> InvokeReturnCompletedTask();
+
+        [JSExport]
+        internal static Task ReturnCompletedTask()
+        {
+            return Task.CompletedTask;
+        }
 
         [JSExport]
         [return: JSMarshalAs<JSType.Promise<JSType.Any>>]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
@@ -246,6 +246,15 @@ export function invoke2(arg1, name) {
     return res;
 }
 
+export function returnResolvedPromise() {
+    return Promise.resolve();
+}
+
+export async function invokeReturnCompletedTask() {
+    await dllExports.System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper.ReturnCompletedTask();
+    return "resolved";
+}
+
 export function invokeStructClassRecords(arg1) {
     return [
         dllExports.JavaScriptTestHelperNamespace.JavaScriptTestHelper.EchoString(arg1),


### PR DESCRIPTION
The PR solves the problem with void Task marshalling. Fixes https://github.com/dotnet/runtime/issues/104772.

- Added lib test for https://github.com/dotnet/runtime/issues/104772
- C# to JS in net8.0.7 returned `Promise is resolved. Success.` -> regression
- Added lib test for `JSImport` that is the same as the issue but with opposite marshalling direction.

cc @pavelsavara

Might be connected: https://github.com/dotnet/runtime/pull/95411