### PR TITLE
Fix up Fuzzlyn CI scripts for new hardware intrinsics support

### DIFF
--- a/src/coreclr/scripts/fuzzlyn_run.py
+++ b/src/coreclr/scripts/fuzzlyn_run.py
@@ -134,8 +134,12 @@ class ReduceExamples(threading.Thread):
 
                     if reduce_this:
                         print("Reducing {}".format(ex['Seed']))
-                        output_path = path.join(self.examples_dir, str(ex["Seed"]) + ".cs")
-                        spmi_collections_path = path.join(self.examples_dir, str(ex["Seed"]) + "_spmi")
+                        file_name = str(ex["Seed"])
+                        dash_index = file_name.find('-')
+                        if dash_index != -1:
+                            file_name = file_name[:dash_index]
+                        output_path = path.join(self.examples_dir, file_name + ".cs")
+                        spmi_collections_path = path.join(self.examples_dir, file_name + "_spmi")
                         os.mkdir(spmi_collections_path)
                         cmd = [self.fuzzlyn_path,
                             "--host", self.host_path,

--- a/src/coreclr/scripts/fuzzlyn_summarize.py
+++ b/src/coreclr/scripts/fuzzlyn_summarize.py
@@ -216,8 +216,8 @@ def main(main_args):
                 f.write("\n\n")
 
         if len(remaining) > 0:
-            f.write("# {} uncategorized/unreduced examples remain\n".format(len(remaining)))
-            for ex in remaining:
+            f.write("# {} uncategorized/unreduced examples remain{}\n".format(len(remaining), " (10 shown)" if len(remaining) > 10 else ""))
+            for ex in remaining[:10]:
                 f.write("* `{}`: {}\n".format(ex['Seed'], ex['Kind']))
                 if ex['Message'] and len(ex['Message'].strip()) > 0:
                     f.write("```scala\n")


### PR DESCRIPTION
1) Strip out the extensions in the seed name when using it for file/directory names, since the list of extensions is quite long
2) Limit the number of unreduced/uncategorized example seeds we show