### PR TITLE
Fix ShuffleThunk cache heap

### DIFF
--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1734,11 +1734,7 @@ void AssemblyLoaderAllocator::Init(AppDomain* pAppDomain)
     LoaderAllocator::Init((BaseDomain *)pAppDomain);
     if (IsCollectible())
     {
-        // TODO: the ShuffleThunkCache should really be using the m_pStubHeap, however the unloadability support
-        // doesn't track the stubs or the related delegate classes and so we get crashes when a stub is used after
-        // the AssemblyLoaderAllocator is gone (the stub memory is unmapped).
-        // https://github.com/dotnet/runtime/issues/55697 tracks this issue.
-        m_pShuffleThunkCache = new ShuffleThunkCache(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
+        m_pShuffleThunkCache = new ShuffleThunkCache(m_pStubHeap);
     }
 }
 


### PR DESCRIPTION
There was a problem with using heap from the related LoaderAllocator for shuffle thunk cache heap when I was working on the unloadability stuff a long time ago. I have tested it again now and it seems that the issue is gone.

So I am removing the workaround, making the cache use LoaderAllocator local heap.

Close #55697