### PR TITLE
Fix throwing exception when calling RunClassConstructor on a generic type with a static constructor

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3768,6 +3768,10 @@ void MethodTable::CheckRunClassInitThrowing()
     if (IsSharedByGenericInstantiations())
         return;
 
+    // For back-compat reasons, act like it has already been initialized
+    if (ContainsGenericVariables())
+        return;
+
     EnsureStaticDataAllocated();
     DoRunClassInitThrowing();
 }

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3769,8 +3769,7 @@ void MethodTable::CheckRunClassInitThrowing()
         return;
 
     // For back-compat reasons, act like it has already been initialized
-    if (ContainsGenericVariables())
-        return;
+    _ASSERTE(!ContainsGenericVariables());
 
     EnsureStaticDataAllocated();
     DoRunClassInitThrowing();

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3768,7 +3768,6 @@ void MethodTable::CheckRunClassInitThrowing()
     if (IsSharedByGenericInstantiations())
         return;
 
-    // For back-compat reasons, act like it has already been initialized
     _ASSERTE(!ContainsGenericVariables());
 
     EnsureStaticDataAllocated();

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1306,7 +1306,8 @@ extern "C" void QCALLTYPE ReflectionInvocation_RunClassConstructor(QCall::TypeHa
         return;
 
     MethodTable *pMT = typeHnd.AsMethodTable();
-    if (pMT->IsClassInited())
+    // The ContainsGenericVariables check is to preserve back-compat where we assume the generic type is already initialized
+    if (pMT->IsClassInited() || pMT->ContainsGenericVariables())
         return;
 
     BEGIN_QCALL;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -103,7 +103,6 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Equal("Hello", HasCctorReceiver.S);
             // Should not throw
             RuntimeHelpers.RunClassConstructor(typeof(GenericHasCctor<>).TypeHandle);
-            return;
         }
 
         internal class HasCctor
@@ -117,6 +116,14 @@ namespace System.Runtime.CompilerServices.Tests
         internal class HasCctorReceiver
         {
             public static string S;
+        }
+
+        internal class GenericHasCctor<T>
+        {
+            static GenericHasCctor()
+            {
+                Thread.Yield(); // Make sure the preinitialization optimization doesn't eat this.
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Xunit;
 
 namespace System.Runtime.CompilerServices.Tests

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -103,7 +103,6 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Equal("Hello", HasCctorReceiver.S);
             // Should not throw
             RuntimeHelpers.RunClassConstructor(typeof(GenericHasCctor<>).TypeHandle);
-            return;
         }
 
         internal class HasCctor

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -101,6 +101,8 @@ namespace System.Runtime.CompilerServices.Tests
             RuntimeTypeHandle t = typeof(HasCctor).TypeHandle;
             RuntimeHelpers.RunClassConstructor(t);
             Assert.Equal("Hello", HasCctorReceiver.S);
+            // Should not throw
+            RuntimeHelpers.RunClassConstructor(typeof(GenericHasCctor<>).TypeHandle);
             return;
         }
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/99183 seems to have done away with assuming that a generic type's static constructor was always "initialized". As a result, if you call RunClassConstructor on it, the runtime would throw an exception.

Fixes https://github.com/dotnet/runtime/issues/103891