### PR TITLE
Skip reloc handling for IMAGE_REL_BASED_DIR64 if already handled

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
@@ -894,8 +894,8 @@ void CompileResult::applyRelocs(RelocContext* rc, unsigned char* block1, ULONG b
                 }
                 break;
 
-                case IMAGE_REL_ARM64_SECREL_HIGH12A:
-                case IMAGE_REL_ARM64_SECREL_LOW12A:
+                case IMAGE_REL_ARM64_SECREL_HIGH12A: // TLSDESC ADD for High-12 Add
+                case IMAGE_REL_ARM64_SECREL_LOW12A:  // TLSDESC ADD for Low-12 Add
                 case IMAGE_REL_AARCH64_TLSDESC_LD64_LO12:
                 case IMAGE_REL_AARCH64_TLSDESC_ADD_LO12: // TLSDESC ADD for corresponding ADRP
                 case IMAGE_REL_AARCH64_TLSDESC_CALL:
@@ -918,7 +918,7 @@ void CompileResult::applyRelocs(RelocContext* rc, unsigned char* block1, ULONG b
 
         if (IsSpmiTarget64Bit())
         {
-            if (relocType == IMAGE_REL_BASED_DIR64)
+            if (!wasRelocHandled && (relocType == IMAGE_REL_BASED_DIR64))
             {
                 DWORDLONG fixupLocation = tmp.location;
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/104584 and resolves https://github.com/dotnet/runtime/issues/104441