### PR TITLE
Support field access on variables of type Enum

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
@@ -390,6 +390,10 @@ namespace ILLink.Shared.TrimAnalysis
                             // currently it won't do.
 
                             TypeDesc? staticType = (valueNode as IValueWithStaticType)?.StaticType?.Type;
+                            if (staticType?.IsByRef == true)
+                            {
+                                staticType = ((ByRefType)staticType).ParameterType;
+                            }
                             if (staticType is null || (!staticType.IsDefType && !staticType.IsArray))
                             {
                                 DynamicallyAccessedMemberTypes annotation = default;
@@ -431,6 +435,10 @@ namespace ILLink.Shared.TrimAnalysis
                                 // where a parameter is annotated and if something in the method sets a specific known type to it
                                 // we will also make it just work, even if the annotation doesn't match the usage.
                                 AddReturnValue(new SystemTypeValue(staticType));
+                            }
+                            else if (staticType.IsTypeOf("System", "Enum"))
+                            {
+                                AddReturnValue(_reflectionMarker.Annotations.GetMethodReturnValue(calledMethod, _isNewObj, DynamicallyAccessedMemberTypes.PublicFields));
                             }
                             else
                             {

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
@@ -113,6 +113,8 @@ namespace ILLink.Shared.TrimAnalysis
 							// where a parameter is annotated and if something in the method sets a specific known type to it
 							// we will also make it just work, even if the annotation doesn't match the usage.
 							AddReturnValue (new SystemTypeValue (new (staticType)));
+						} else if (staticType.IsTypeOf ("System", "Enum")) {
+							AddReturnValue (FlowAnnotations.Instance.GetMethodReturnValue (calledMethod, _isNewObj, DynamicallyAccessedMemberTypes.PublicFields));
 						} else {
 							var annotation = FlowAnnotations.GetTypeAnnotation (staticType);
 							AddReturnValue (FlowAnnotations.Instance.GetMethodReturnValue (calledMethod, _isNewObj, annotation));

--- a/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -120,6 +120,8 @@ namespace ILLink.Shared.TrimAnalysis
 						// currently it won't do.
 
 						TypeReference? staticType = (valueNode as IValueWithStaticType)?.StaticType?.Type;
+						if (staticType?.IsByReference == true)
+							staticType = ((ByReferenceType) staticType).ElementType;
 						TypeDefinition? staticTypeDef = staticType?.ResolveToTypeDefinition (_context);
 						if (staticType is null || staticTypeDef is null) {
 							DynamicallyAccessedMemberTypes annotation = default;
@@ -153,6 +155,8 @@ namespace ILLink.Shared.TrimAnalysis
 							// where a parameter is annotated and if something in the method sets a specific known type to it
 							// we will also make it just work, even if the annotation doesn't match the usage.
 							AddReturnValue (new SystemTypeValue (staticType));
+						} else if (staticTypeDef.IsTypeOf ("System", "Enum")) {
+							AddReturnValue (_context.Annotations.FlowAnnotations.GetMethodReturnValue (calledMethod, _isNewObj, DynamicallyAccessedMemberTypes.PublicFields));
 						} else {
 							// Make sure the type is marked (this will mark it as used via reflection, which is sort of true)
 							// This should already be true for most cases (method params, fields, ...), but just in case


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/105351

This adds support for the case when a variable is of type Enum and there are no generics involved, so the following no longer produces trim warnings:
```csharp
static void M(Enum v) {
    v.GetType().GetFields();
}
```

Fixes https://github.com/dotnet/runtime/issues/105506