### PR TITLE
Spill side effects before impStoreNullableFields

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3152,6 +3152,7 @@ int Compiler::impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                              (info.compCompHnd->isNullableType(unboxResolvedToken.hClass) == TypeCompareState::Must) &&
                              (info.compCompHnd->getTypeForBox(unboxResolvedToken.hClass) == pResolvedToken->hClass))
                     {
+                        impSpillSideEffects(false, CHECK_SPILL_ALL DEBUGARG("spilling side-effects"));
                         GenTree* result = impStoreNullableFields(unboxResolvedToken.hClass, impPopStack().val);
                         impPushOnStack(result, typeInfo(result->TypeGet()));
                         optimize = true;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105518/Runtime_105518.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105518/Runtime_105518.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_105518
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Problem<decimal?, decimal>()!;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static T GetValue<T>() => (T)(object)100M;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static TTo Problem<TTo, TFrom>() => (TTo)(object)GetValue<TFrom>()!;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105518/Runtime_105518.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105518/Runtime_105518.cs
@@ -9,12 +9,12 @@ public class Runtime_105518
     [Fact]
     public static void TestEntryPoint()
     {
-        Problem<decimal?, decimal>()!;
+        Problem<decimal?, decimal>();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static T GetValue<T>() => (T)(object)100M;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static TTo Problem<TTo, TFrom>() => (TTo)(object)GetValue<TFrom>()!;
+    private static TTo Problem<TTo, TFrom>() => (TTo)(object)GetValue<TFrom>();
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105518/Runtime_105518.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105518/Runtime_105518.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105518

The root cause of the issue is the IR like this:
```
[000852] UAC-G------                         *  STORE_LCL_FLD struct<System.Decimal, 16> V41 tmp36        [+8]
[000849] S-C-G------                         \--*  CALLV vt-ind struct Microsoft.Data.Sqlite.SqliteValueReader:GetDecimal(int):System.Decimal:this
[000847] ----------- this                       +--*  LCL_VAR   ref    V00 this         
[000848] ----------- arg1                       \--*  LCL_VAR   int    V02 arg1     
```

since that call demands a ret-buffer (to return System.Decimal) on Windows, we have to spill it right in the importer. @jakobbotsch pointed me to `impStoreStruct` helper that takes care about ABI for such stores.

This led to an assert in LowerStructCall in Checked and to an invalid program exception in Release in EF. I've validated that this fix fixes the EF repro.

It's a bit unfortunate that we have to care about codegen-level things like ABI handling that early, but 🤷 
