### PR TITLE
Fix issue 98506 - Excessive exceptions generated in StackTraceSymbols

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
@@ -63,7 +63,7 @@ namespace System.Diagnostics
             {
                 Handle handle = MetadataTokens.Handle(methodToken);
 
-                if (handle.Kind == HandleKind.MethodDefinition)
+                if (!handle.IsNil && handle.Kind == HandleKind.MethodDefinition)
                 {
                     MethodDebugInformationHandle methodDebugHandle = ((MethodDefinitionHandle)handle).ToDebugInformationHandle();
                     MethodDebugInformation methodInfo = reader.GetMethodDebugInformation(methodDebugHandle);

--- a/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
@@ -58,12 +58,11 @@ namespace System.Diagnostics
             sourceLine = 0;
             sourceColumn = 0;
 
-            MetadataReader? reader = TryGetReader(assembly, assemblyPath, loadedPeAddress, loadedPeSize, isFileLayout, inMemoryPdbAddress, inMemoryPdbSize);
-            if (reader != null)
+            Handle handle = MetadataTokens.Handle(methodToken);
+            if (!handle.IsNil && handle.Kind == HandleKind.MethodDefinition)
             {
-                Handle handle = MetadataTokens.Handle(methodToken);
-
-                if (!handle.IsNil && handle.Kind == HandleKind.MethodDefinition)
+                MetadataReader? reader = TryGetReader(assembly, assemblyPath, loadedPeAddress, loadedPeSize, isFileLayout, inMemoryPdbAddress, inMemoryPdbSize);
+                if (reader != null)
                 {
                     MethodDebugInformationHandle methodDebugHandle = ((MethodDefinitionHandle)handle).ToDebugInformationHandle();
                     MethodDebugInformation methodInfo = reader.GetMethodDebugInformation(methodDebugHandle);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/98506 by checking the token for nil.