### PR TITLE
[cdac] Add GetArrayData to Object contract, partially implement ISOSDacInterface::GetObjectData

### DIFF
--- a/docs/design/datacontracts/Object.md
+++ b/docs/design/datacontracts/Object.md
@@ -10,6 +10,9 @@ TargetPointer GetMethodTableAddress(TargetPointer address);
 
 // Get the string corresponding to a managed string object. Error if address does not represent a string.
 string GetStringValue(TargetPointer address);
+
+// Get the pointer to the data corresponding to a managed array object. Error if address does not represent a array.
+TargetPointer GetArrayData(TargetPointer address, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds);
 ```
 
 ## Version 1
@@ -17,6 +20,7 @@ string GetStringValue(TargetPointer address);
 Data descriptors used:
 | Data Descriptor Name | Field | Meaning |
 | --- | --- | --- |
+| `Array` | `m_NumComponents` | Number of items in the array |
 | `Object` | `m_pMethTab` | Method table for the object |
 | `String` | `m_FirstChar` | First character of the string - `m_StringLength` can be used to read the full string (encoded in UTF-16) |
 | `String` | `m_StringLength` | Length of the string in characters (encoded in UTF-16) |
@@ -24,13 +28,20 @@ Data descriptors used:
 Global variables used:
 | Global Name | Type | Purpose |
 | --- | --- | --- |
+| `ArrayBoundsZero` | TargetPointer | Known value for single dimensional, zero-lower-bound array |
+| `ObjectHeaderSize` | uint32 | Size of the object header (sync block and alignment) |
 | `ObjectToMethodTableUnmask` | uint8 | Bits to clear for converting to a method table address |
 | `StringMethodTable` | TargetPointer | The method table for System.String |
+
+Contracts used:
+| Contract Name |
+| --- |
+| `RuntimeTypeSystem` |
 
 ``` csharp
 TargetPointer GetMethodTableAddress(TargetPointer address)
 {
-    TargetPointer mt = _targetPointer.ReadPointer(address + /* Object::m_pMethTab offset */);
+    TargetPointer mt = target.ReadPointer(address + /* Object::m_pMethTab offset */);
     return mt.Value & ~target.ReadGlobal<byte>("ObjectToMethodTableUnmask");
 }
 
@@ -41,13 +52,43 @@ string GetStringValue(TargetPointer address)
     if (mt != stringMethodTable)
         throw new ArgumentException("Address does not represent a string object", nameof(address));
 
-    // Validates the method table
-    _ = target.Contracts.RuntimeTypeSystem.GetTypeHandle(mt);
-
-    Data.String str = _target.ProcessedData.GetOrAdd<Data.String>(address);
     uint length = target.Read<uint>(address + /* String::m_StringLength offset */);
     Span<byte> span = stackalloc byte[(int)length * sizeof(char)];
     target.ReadBuffer(address + /* String::m_FirstChar offset */, span);
     return new string(MemoryMarshal.Cast<byte, char>(span));
+}
+
+TargetPointer GetArrayData(TargetPointer address, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds)
+{
+    TargetPointer mt = GetMethodTableAddress(address);
+    Contracts.IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
+    TypeHandle typeHandle = rts.GetTypeHandle(mt);
+    uint rank;
+    if (!rts.IsArray(typeHandle, out rank))
+        throw new ArgumentException("Address does not represent an array object", nameof(address));
+
+    count = target.Read<uint>(address + /* Array::m_NumComponents offset */;
+
+    CorElementType corType = rts.GetSignatureCorElementType(typeHandle);
+    if (corType == CorElementType.Array)
+    {
+        // Multi-dimensional - has bounds as part of the array object
+        // The object is allocated with:
+        //   << fields that are part of the array type info >>
+        //   int32_t bounds[rank];
+        //   int32_t lowerBounds[rank];
+        boundsStart = address + /* Array size */;
+        lowerBounds = boundsStart + (rank * sizeof(int));
+    }
+    else
+    {
+        // Single-dimensional, zero-based - doesn't have bounds
+        boundsStart = address + /* Array::m_NumComponents offset */;
+        lowerBounds = _target.ReadGlobalPointer("ArrayBoundsZero");
+    }
+
+    // Sync block is before `this` pointer, so substract the object header size
+    ulong dataOffset = typeSystemContract.GetBaseSize(typeHandle) - _target.ReadGlobal<uint>("ObjectHeaderSize");
+    return address + dataOffset;
 }
 ```

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -1240,6 +1240,7 @@ public:
     HRESULT GetMethodTableDataImpl(CLRDATA_ADDRESS mt, struct DacpMethodTableData *data);
     HRESULT GetMethodTableForEEClassImpl (CLRDATA_ADDRESS eeClassReallyMT, CLRDATA_ADDRESS *value);
     HRESULT GetMethodTableNameImpl(CLRDATA_ADDRESS mt, unsigned int count, _Inout_updates_z_(count) WCHAR *mtName, unsigned int *pNeeded);
+    HRESULT GetObjectDataImpl(CLRDATA_ADDRESS addr, struct DacpObjectData *objectData);
     HRESULT GetObjectExceptionDataImpl(CLRDATA_ADDRESS objAddr, struct DacpExceptionObjectData *data);
     HRESULT GetObjectStringDataImpl(CLRDATA_ADDRESS obj, unsigned int count, _Inout_updates_z_(count) WCHAR *stringData, unsigned int *pNeeded);
     HRESULT GetUsefulGlobalsImpl(struct DacpUsefulGlobalsData *globalsData);

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -183,6 +183,11 @@ CDAC_TYPE_FIELD(String, /*pointer*/, m_FirstChar, cdac_offsets<StringObject>::m_
 CDAC_TYPE_FIELD(String, /*uint32*/, m_StringLength, cdac_offsets<StringObject>::m_StringLength)
 CDAC_TYPE_END(String)
 
+CDAC_TYPE_BEGIN(Array)
+CDAC_TYPE_SIZE(sizeof(ArrayBase))
+CDAC_TYPE_FIELD(Array, /*pointer*/, m_NumComponents, cdac_offsets<ArrayBase>::m_NumComponents)
+CDAC_TYPE_END(Array)
+
 // Loader
 
 CDAC_TYPE_BEGIN(Module)
@@ -299,6 +304,8 @@ CDAC_GLOBAL(ObjectToMethodTableUnmask, uint8, 1 | 1 << 1)
 #endif //TARGET_64BIT
 CDAC_GLOBAL(SOSBreakingChangeVersion, uint8, SOS_BREAKING_CHANGE_VERSION)
 CDAC_GLOBAL(MethodDescAlignment, uint64, MethodDesc::ALIGNMENT)
+CDAC_GLOBAL(ObjectHeaderSize, uint64, OBJHEADER_SIZE)
+CDAC_GLOBAL_POINTER(ArrayBoundsZero, cdac_offsets<ArrayBase>::s_arrayBoundsZero)
 CDAC_GLOBAL_POINTER(ExceptionMethodTable, &::g_pExceptionClass)
 CDAC_GLOBAL_POINTER(FreeObjectMethodTable, &::g_pFreeObjectMethodTable)
 CDAC_GLOBAL_POINTER(ObjectMethodTable, &::g_pObjectClass)

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -296,6 +296,11 @@ CDAC_GLOBAL(FeatureEHFunclets, uint8, 1)
 #else
 CDAC_GLOBAL(FeatureEHFunclets, uint8, 0)
 #endif
+#if FEATURE_COMINTEROP
+CDAC_GLOBAL(FeatureCOMInterop, uint8, 1)
+#else
+CDAC_GLOBAL(FeatureCOMInterop, uint8, 0)
+#endif
 // See Object::GetGCSafeMethodTable
 #ifdef TARGET_64BIT
 CDAC_GLOBAL(ObjectToMethodTableUnmask, uint8, 1 | 1 << 1 | 1 << 2)

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -638,7 +638,19 @@ public:
 
     inline static unsigned GetBoundsOffset(MethodTable* pMT);
     inline static unsigned GetLowerBoundsOffset(MethodTable* pMT);
+
+    template<typename T> friend struct ::cdac_offsets;
 };
+
+#ifndef DACCESS_COMPILE
+template<>
+struct cdac_offsets<ArrayBase>
+{
+    static constexpr size_t m_NumComponents = offsetof(ArrayBase, m_NumComponents);
+
+    static constexpr INT32* s_arrayBoundsZero = &ArrayBase::s_arrayBoundsZero;
+};
+#endif
 
 //
 // Template used to build all the non-object

--- a/src/native/managed/cdacreader/src/Constants.cs
+++ b/src/native/managed/cdacreader/src/Constants.cs
@@ -27,5 +27,8 @@ internal static class Constants
         internal const string MiniMetaDataBuffMaxSize = nameof(MiniMetaDataBuffMaxSize);
 
         internal const string MethodDescAlignment = nameof(MethodDescAlignment);
+        internal const string ObjectHeaderSize = nameof(ObjectHeaderSize);
+
+        internal const string ArrayBoundsZero = nameof(ArrayBoundsZero);
     }
 }

--- a/src/native/managed/cdacreader/src/Constants.cs
+++ b/src/native/managed/cdacreader/src/Constants.cs
@@ -13,7 +13,9 @@ internal static class Constants
         internal const string FinalizerThread = nameof(FinalizerThread);
         internal const string GCThread = nameof(GCThread);
 
+        internal const string FeatureCOMInterop = nameof(FeatureCOMInterop);
         internal const string FeatureEHFunclets = nameof(FeatureEHFunclets);
+
         internal const string ObjectToMethodTableUnmask = nameof(ObjectToMethodTableUnmask);
         internal const string SOSBreakingChangeVersion = nameof(SOSBreakingChangeVersion);
 

--- a/src/native/managed/cdacreader/src/Contracts/Object.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Object.cs
@@ -22,7 +22,9 @@ internal interface IObject : IContract
     }
 
     public virtual TargetPointer GetMethodTableAddress(TargetPointer address) => throw new NotImplementedException();
+
     public virtual string GetStringValue(TargetPointer address) => throw new NotImplementedException();
+    public virtual TargetPointer GetArrayData(TargetPointer address, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds) => throw new NotImplementedException();
 }
 
 internal readonly struct Object : IObject

--- a/src/native/managed/cdacreader/src/Data/Array.cs
+++ b/src/native/managed/cdacreader/src/Data/Array.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal sealed class Array : IData<Array>
+{
+    static Array IData<Array>.Create(Target target, TargetPointer address)
+        => new Array(target, address);
+
+    public Array(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.Array);
+
+        NumComponents = target.Read<uint>(address + (ulong)type.Fields["m_NumComponents"].Offset);
+    }
+
+    public uint NumComponents { get; init; }
+}

--- a/src/native/managed/cdacreader/src/DataType.cs
+++ b/src/native/managed/cdacreader/src/DataType.cs
@@ -41,4 +41,5 @@ public enum DataType
     String,
     MethodDesc,
     MethodDescChunk,
+    Array,
 }

--- a/src/native/managed/cdacreader/src/Legacy/ISOSDacInterface.cs
+++ b/src/native/managed/cdacreader/src/Legacy/ISOSDacInterface.cs
@@ -92,6 +92,32 @@ internal struct DacpMethodTableData
     public int bContainsGCPointers;
 }
 
+internal enum DacpObjectType
+{
+    OBJ_STRING = 0,
+    OBJ_FREE,
+    OBJ_OBJECT,
+    OBJ_ARRAY,
+    OBJ_OTHER
+};
+
+internal struct DacpObjectData
+{
+    public ulong MethodTable;
+    public DacpObjectType ObjectType;
+    public ulong Size;
+    public ulong ElementTypeHandle;
+    public uint ElementType;
+    public uint dwRank;
+    public ulong dwNumComponents;
+    public ulong dwComponentSize;
+    public ulong ArrayDataPtr;
+    public ulong ArrayBoundsPtr;
+    public ulong ArrayLowerBoundsPtr;
+    public ulong RCW;
+    public ulong CCW;
+}
+
 internal struct DacpUsefulGlobalsData
 {
     public ulong ArrayMethodTable;
@@ -236,7 +262,7 @@ internal unsafe partial interface ISOSDacInterface
 
     // Objects
     [PreserveSig]
-    int GetObjectData(ulong objAddr, /*struct DacpObjectData*/ void* data);
+    int GetObjectData(ulong objAddr, DacpObjectData* data);
     [PreserveSig]
     int GetObjectStringData(ulong obj, uint count, char* stringData, uint* pNeeded);
     [PreserveSig]

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -375,13 +375,16 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface2, 
             }
 
             // TODO: [cdac] Get RCW and CCW from interop info on sync block
+            if (_target.ReadGlobal<byte>(Constants.Globals.FeatureCOMInterop) != 0)
+                return HResults.E_NOTIMPL;
+
         }
         catch (System.Exception ex)
         {
             return ex.HResult;
         }
 
-        return HResults.E_NOTIMPL;
+        return HResults.S_OK;
     }
 
     public unsafe int GetObjectExceptionData(ulong objectAddress, DacpExceptionObjectData* data)

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -21,10 +21,14 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface2, ISOSDacInterface9
 {
     private readonly Target _target;
+    private readonly TargetPointer _stringMethodTable;
+    private readonly TargetPointer _objectMethodTable;
 
     public SOSDacImpl(Target target)
     {
         _target = target;
+        _stringMethodTable = _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.StringMethodTable));
+        _objectMethodTable = _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.ObjectMethodTable));
     }
 
     public unsafe int GetAppDomainConfigFile(ulong appDomain, int count, char* configFile, uint* pNeeded) => HResults.E_NOTIMPL;
@@ -310,7 +314,75 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface2, 
     }
 
     public unsafe int GetObjectClassName(ulong obj, uint count, char* className, uint* pNeeded) => HResults.E_NOTIMPL;
-    public unsafe int GetObjectData(ulong objAddr, void* data) => HResults.E_NOTIMPL;
+
+    public unsafe int GetObjectData(ulong objAddr, DacpObjectData* data)
+    {
+        try
+        {
+            Contracts.IObject objectContract = _target.Contracts.Object;
+            Contracts.IRuntimeTypeSystem runtimeTypeSystemContract = _target.Contracts.RuntimeTypeSystem;
+
+            TargetPointer mt = objectContract.GetMethodTableAddress(objAddr);
+            TypeHandle handle = runtimeTypeSystemContract.GetTypeHandle(mt);
+
+            data->MethodTable = mt;
+            data->Size = runtimeTypeSystemContract.GetBaseSize(handle);
+            data->dwComponentSize = runtimeTypeSystemContract.GetComponentSize(handle); ;
+
+            if (runtimeTypeSystemContract.IsFreeObjectMethodTable(handle))
+            {
+                data->ObjectType = DacpObjectType.OBJ_FREE;
+            }
+            else if (mt == _stringMethodTable)
+            {
+                data->ObjectType = DacpObjectType.OBJ_STRING;
+
+                // Update the size to include the string character components
+                data->Size += (uint)objectContract.GetStringValue(objAddr).Length * data->dwComponentSize;
+            }
+            else if (mt == _objectMethodTable)
+            {
+                data->ObjectType = DacpObjectType.OBJ_OBJECT;
+            }
+            else if (runtimeTypeSystemContract.IsArray(handle, out uint rank))
+            {
+                data->ObjectType = DacpObjectType.OBJ_ARRAY;
+                data->dwRank = rank;
+
+                TargetPointer arrayData = objectContract.GetArrayData(objAddr, out uint numComponents, out TargetPointer boundsStart, out TargetPointer lowerBounds);
+                data->ArrayDataPtr = arrayData;
+                data->dwNumComponents = numComponents;
+                data->ArrayBoundsPtr = boundsStart;
+                data->ArrayLowerBoundsPtr = lowerBounds;
+
+                // Update the size to include the array components
+                data->Size += numComponents * data->dwComponentSize;
+
+                // Get the type of the array elements
+                TypeHandle element = runtimeTypeSystemContract.GetTypeParam(handle);
+                data->ElementTypeHandle = element.Address;
+                data->ElementType = (uint)runtimeTypeSystemContract.GetSignatureCorElementType(element);
+
+                // Validate the element type handles for arrays of arrays
+                while (runtimeTypeSystemContract.IsArray(element, out _))
+                {
+                    element = runtimeTypeSystemContract.GetTypeParam(element);
+                }
+            }
+            else
+            {
+                data->ObjectType = DacpObjectType.OBJ_OTHER;
+            }
+
+            // TODO: [cdac] Get RCW and CCW from interop info on sync block
+        }
+        catch (System.Exception ex)
+        {
+            return ex.HResult;
+        }
+
+        return HResults.E_NOTIMPL;
+    }
 
     public unsafe int GetObjectExceptionData(ulong objectAddress, DacpExceptionObjectData* data)
     {
@@ -437,10 +509,8 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface2, 
         {
             data->ArrayMethodTable = _target.ReadPointer(
                 _target.ReadGlobalPointer(Constants.Globals.ObjectArrayMethodTable));
-            data->StringMethodTable = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.StringMethodTable));
-            data->ObjectMethodTable = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.ObjectMethodTable));
+            data->StringMethodTable = _stringMethodTable;
+            data->ObjectMethodTable = _objectMethodTable;
             data->ExceptionMethodTable = _target.ReadPointer(
                 _target.ReadGlobalPointer(Constants.Globals.ExceptionMethodTable));
             data->FreeMethodTable = _target.ReadPointer(

--- a/src/native/managed/cdacreader/tests/DacStreamsTests.cs
+++ b/src/native/managed/cdacreader/tests/DacStreamsTests.cs
@@ -21,7 +21,7 @@ public class DacStreamsTests
 
     const uint MiniMetaDataStreamsHeaderSize = 12;
 
-    private static readonly (DataType Type, Target.TypeInfo Info)[] DacStreamsTypes =
+    private static readonly Dictionary<DataType, Target.TypeInfo> DacStreamsTypes =
     [
     ];
 

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -8,117 +8,18 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 
+using MockRTS = MockDescriptors.RuntimeTypeSystem;
+
 public unsafe class MethodTableTests
 {
-    const ulong TestFreeObjectMethodTableGlobalAddress = 0x00000000_7a0000a0;
-    const ulong TestFreeObjectMethodTableAddress = 0x00000000_7a0000a8;
-
-    private static readonly Target.TypeInfo MethodTableTypeInfo = new()
-    {
-        Fields = {
-            { nameof(Data.MethodTable.MTFlags), new() { Offset = 4, Type = DataType.uint32}},
-            { nameof(Data.MethodTable.BaseSize), new() { Offset = 8, Type = DataType.uint32}},
-            { nameof(Data.MethodTable.MTFlags2), new() { Offset = 12, Type = DataType.uint32}},
-            { nameof(Data.MethodTable.EEClassOrCanonMT), new () { Offset = 16, Type = DataType.nuint}},
-            { nameof(Data.MethodTable.Module), new () { Offset = 24, Type = DataType.pointer}},
-            { nameof(Data.MethodTable.ParentMethodTable), new () { Offset = 40, Type = DataType.pointer}},
-            { nameof(Data.MethodTable.NumInterfaces), new () { Offset = 48, Type = DataType.uint16}},
-            { nameof(Data.MethodTable.NumVirtuals), new () { Offset = 50, Type = DataType.uint16}},
-            { nameof(Data.MethodTable.PerInstInfo), new () { Offset = 56, Type = DataType.pointer}},
-        }
-    };
-
-    private static readonly Target.TypeInfo EEClassTypeInfo = new Target.TypeInfo()
-    {
-        Fields = {
-            { nameof (Data.EEClass.MethodTable), new () { Offset = 8, Type = DataType.pointer}},
-            { nameof (Data.EEClass.CorTypeAttr), new () { Offset = 16, Type = DataType.uint32}},
-            { nameof (Data.EEClass.NumMethods), new () { Offset = 20, Type = DataType.uint16}},
-            { nameof (Data.EEClass.InternalCorElementType), new () { Offset = 22, Type = DataType.uint8}},
-            { nameof (Data.EEClass.NumNonVirtualSlots), new () { Offset = 24, Type = DataType.uint16}},
-        }
-    };
-
-    private static readonly Target.TypeInfo ArrayClassTypeInfo = new Target.TypeInfo()
-    {
-        Fields = {
-            { nameof (Data.ArrayClass.Rank), new () { Offset = 0x70, Type = DataType.uint8}},
-        }
-    };
-
-    internal static readonly (DataType Type, Target.TypeInfo Info)[] RTSTypes =
-    [
-        (DataType.MethodTable, MethodTableTypeInfo),
-        (DataType.EEClass, EEClassTypeInfo),
-        (DataType.ArrayClass, ArrayClassTypeInfo),
-    ];
-
-    internal static readonly (string Name, ulong Value, string? Type)[] RTSGlobals =
-    [
-        (nameof(Constants.Globals.FreeObjectMethodTable), TestFreeObjectMethodTableGlobalAddress, null),
-        (nameof(Constants.Globals.MethodDescAlignment), 8, nameof(DataType.uint64)),
-    ];
-
-    internal static MockMemorySpace.Builder AddFreeObjectMethodTable(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder)
-    {
-        MockMemorySpace.HeapFragment globalAddr = new() { Name = "Address of Free Object Method Table", Address = TestFreeObjectMethodTableGlobalAddress, Data = new byte[targetTestHelpers.PointerSize] };
-        targetTestHelpers.WritePointer(globalAddr.Data, TestFreeObjectMethodTableAddress);
-        return builder.AddHeapFragments([
-            globalAddr,
-            new () { Name = "Free Object Method Table", Address = TestFreeObjectMethodTableAddress, Data = new byte[targetTestHelpers.SizeOfTypeInfo(MethodTableTypeInfo)] }
-        ]);
-    }
-
-    internal static MockMemorySpace.Builder AddEEClass(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer eeClassPtr, string name, TargetPointer canonMTPtr, uint attr, ushort numMethods, ushort numNonVirtualSlots)
-    {
-        MockMemorySpace.HeapFragment eeClassFragment = new() { Name = $"EEClass '{name}'", Address = eeClassPtr, Data = new byte[targetTestHelpers.SizeOfTypeInfo(EEClassTypeInfo)] };
-        Span<byte> dest = eeClassFragment.Data;
-        targetTestHelpers.WritePointer(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.MethodTable)].Offset), canonMTPtr);
-        targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.CorTypeAttr)].Offset), attr);
-        targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumMethods)].Offset), numMethods);
-        targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumNonVirtualSlots)].Offset), numNonVirtualSlots);
-        return builder.AddHeapFragment(eeClassFragment);
-    }
-
-    internal static MockMemorySpace.Builder AddArrayClass(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer eeClassPtr, string name, TargetPointer canonMTPtr, uint attr, ushort numMethods, ushort numNonVirtualSlots, byte rank)
-    {
-        int size = targetTestHelpers.SizeOfTypeInfo(EEClassTypeInfo) + targetTestHelpers.SizeOfTypeInfo(ArrayClassTypeInfo);
-        MockMemorySpace.HeapFragment eeClassFragment = new() { Name = $"ArrayClass '{name}'", Address = eeClassPtr, Data = new byte[size] };
-        Span<byte> dest = eeClassFragment.Data;
-        targetTestHelpers.WritePointer(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.MethodTable)].Offset), canonMTPtr);
-        targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.CorTypeAttr)].Offset), attr);
-        targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumMethods)].Offset), numMethods);
-        targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumNonVirtualSlots)].Offset), numNonVirtualSlots);
-        targetTestHelpers.Write(dest.Slice(ArrayClassTypeInfo.Fields[nameof(Data.ArrayClass.Rank)].Offset), rank);
-        return builder.AddHeapFragment(eeClassFragment);
-    }
-
-    internal static MockMemorySpace.Builder AddMethodTable(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer methodTablePtr, string name, TargetPointer eeClassOrCanonMT, uint mtflags, uint mtflags2, uint baseSize,
-                                                        TargetPointer module, TargetPointer parentMethodTable, ushort numInterfaces, ushort numVirtuals)
-    {
-        MockMemorySpace.HeapFragment methodTableFragment = new() { Name = $"MethodTable '{name}'", Address = methodTablePtr, Data = new byte[targetTestHelpers.SizeOfTypeInfo(MethodTableTypeInfo)] };
-        Span<byte> dest = methodTableFragment.Data;
-        targetTestHelpers.WritePointer(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.EEClassOrCanonMT)].Offset), eeClassOrCanonMT);
-        targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.MTFlags)].Offset), mtflags);
-        targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.MTFlags2)].Offset), mtflags2);
-        targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.BaseSize)].Offset), baseSize);
-        targetTestHelpers.WritePointer(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.Module)].Offset), module);
-        targetTestHelpers.WritePointer(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.ParentMethodTable)].Offset), parentMethodTable);
-        targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.NumInterfaces)].Offset), numInterfaces);
-        targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.NumVirtuals)].Offset), numVirtuals);
-
-        // TODO fill in the rest of the fields
-        return builder.AddHeapFragment(methodTableFragment);
-    }
-
     // a delegate for adding more heap fragments to the context builder
     private delegate MockMemorySpace.Builder ConfigureContextBuilder(MockMemorySpace.Builder builder);
 
     private static void RTSContractHelper(MockTarget.Architecture arch, ConfigureContextBuilder configure, Action<Target> testCase)
     {
         TargetTestHelpers targetTestHelpers = new(arch);
-        string metadataTypesJson = TargetTestHelpers.MakeTypesJson(RTSTypes);
-        string metadataGlobalsJson = TargetTestHelpers.MakeGlobalsJson(RTSGlobals);
+        string metadataTypesJson = TargetTestHelpers.MakeTypesJson(MockRTS.Types);
+        string metadataGlobalsJson = TargetTestHelpers.MakeGlobalsJson(MockRTS.Globals);
         byte[] json = Encoding.UTF8.GetBytes($$"""
         {
             "version": 0,
@@ -131,13 +32,13 @@ public unsafe class MethodTableTests
         }
         """);
         Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, RTSGlobals.Length);
+        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, MockRTS.Globals.Length);
 
         int pointerSize = targetTestHelpers.PointerSize;
-        Span<byte> pointerData = stackalloc byte[RTSGlobals.Length * pointerSize];
-        for (int i = 0; i < RTSGlobals.Length; i++)
+        Span<byte> pointerData = stackalloc byte[MockRTS.Globals.Length * pointerSize];
+        for (int i = 0; i < MockRTS.Globals.Length; i++)
         {
-            var (_, value, _) = RTSGlobals[i];
+            var (_, value, _) = MockRTS.Globals[i];
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
@@ -149,7 +50,7 @@ public unsafe class MethodTableTests
                     .SetJson(json)
                     .SetPointerData(pointerData);
 
-            builder = AddFreeObjectMethodTable(targetTestHelpers, builder);
+            builder = MockRTS.AddGlobalPointers(targetTestHelpers, builder);
 
             if (configure != null)
             {
@@ -174,7 +75,7 @@ public unsafe class MethodTableTests
         {
             Contracts.IRuntimeTypeSystem metadataContract = target.Contracts.RuntimeTypeSystem;
             Assert.NotNull(metadataContract);
-            Contracts.TypeHandle handle = metadataContract.GetTypeHandle(TestFreeObjectMethodTableAddress);
+            Contracts.TypeHandle handle = metadataContract.GetTypeHandle(MockRTS.TestFreeObjectMethodTableAddress);
             Assert.NotEqual(TargetPointer.Null, handle.Address);
             Assert.True(metadataContract.IsFreeObjectMethodTable(handle));
         });
@@ -185,8 +86,8 @@ public unsafe class MethodTableTests
         System.Reflection.TypeAttributes typeAttributes = System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class;
         const int numMethods = 8; // System.Object has 8 methods
         const int numVirtuals = 3; // System.Object has 3 virtual methods
-        builder = AddEEClass(targetTestHelpers, builder, systemObjectEEClassPtr, "System.Object", systemObjectMethodTablePtr, attr: (uint)typeAttributes, numMethods: numMethods, numNonVirtualSlots: 0);
-        builder = AddMethodTable(targetTestHelpers, builder, systemObjectMethodTablePtr, "System.Object", systemObjectEEClassPtr,
+        builder = MockRTS.AddEEClass(targetTestHelpers, builder, systemObjectEEClassPtr, "System.Object", systemObjectMethodTablePtr, attr: (uint)typeAttributes, numMethods: numMethods, numNonVirtualSlots: 0);
+        builder = MockRTS.AddMethodTable(targetTestHelpers, builder, systemObjectMethodTablePtr, "System.Object", systemObjectEEClassPtr,
                                 mtflags: default, mtflags2: default, baseSize: targetTestHelpers.ObjectBaseSize,
                                 module: TargetPointer.Null, parentMethodTable: TargetPointer.Null, numInterfaces: 0, numVirtuals: numVirtuals);
         return builder;
@@ -240,8 +141,8 @@ public unsafe class MethodTableTests
             const int numInterfaces = 8; // Arbitrary
             const int numVirtuals = 3; // at least as many as System.Object
             uint mtflags = (uint)RuntimeTypeSystem_1.WFLAGS_HIGH.HasComponentSize | /*componentSize: */2;
-            builder = AddEEClass(targetTestHelpers, builder, systemStringEEClassPtr, "System.String", systemStringMethodTablePtr, attr: (uint)typeAttributes, numMethods: numMethods, numNonVirtualSlots: 0);
-            builder = AddMethodTable(targetTestHelpers, builder, systemStringMethodTablePtr, "System.String", systemStringEEClassPtr,
+            builder = MockRTS.AddEEClass(targetTestHelpers, builder, systemStringEEClassPtr, "System.String", systemStringMethodTablePtr, attr: (uint)typeAttributes, numMethods: numMethods, numNonVirtualSlots: 0);
+            builder = MockRTS.AddMethodTable(targetTestHelpers, builder, systemStringMethodTablePtr, "System.String", systemStringEEClassPtr,
                                     mtflags: mtflags, mtflags2: default, baseSize: targetTestHelpers.StringBaseSize,
                                     module: TargetPointer.Null, parentMethodTable: systemObjectMethodTablePtr, numInterfaces: numInterfaces, numVirtuals: numVirtuals);
             return builder;
@@ -275,7 +176,7 @@ public unsafe class MethodTableTests
         (builder) =>
         {
             builder = AddSystemObject(targetTestHelpers, builder, systemObjectMethodTablePtr, systemObjectEEClassPtr);
-            builder = AddMethodTable(targetTestHelpers, builder, badMethodTablePtr, "Bad MethodTable", badMethodTableEEClassPtr, mtflags: default, mtflags2: default, baseSize: targetTestHelpers.ObjectBaseSize, module: TargetPointer.Null, parentMethodTable: systemObjectMethodTablePtr, numInterfaces: 0, numVirtuals: 3);
+            builder = MockRTS.AddMethodTable(targetTestHelpers, builder, badMethodTablePtr, "Bad MethodTable", badMethodTableEEClassPtr, mtflags: default, mtflags2: default, baseSize: targetTestHelpers.ObjectBaseSize, module: TargetPointer.Null, parentMethodTable: systemObjectMethodTablePtr, numInterfaces: 0, numVirtuals: 3);
             return builder;
         },
         (target) =>
@@ -315,14 +216,14 @@ public unsafe class MethodTableTests
             const int numInterfaces = 0;
             const int numVirtuals = 3;
             const uint gtd_mtflags = 0x00000030; // TODO: GenericsMask_TypicalInst
-            builder = AddEEClass(targetTestHelpers, builder, genericDefinitionEEClassPtr, "EEClass GenericDefinition", genericDefinitionMethodTablePtr, attr: (uint)typeAttributes, numMethods: numMethods, numNonVirtualSlots: 0);
-            builder = AddMethodTable(targetTestHelpers, builder, genericDefinitionMethodTablePtr, "MethodTable GenericDefinition", genericDefinitionEEClassPtr,
+            builder = MockRTS.AddEEClass(targetTestHelpers, builder, genericDefinitionEEClassPtr, "EEClass GenericDefinition", genericDefinitionMethodTablePtr, attr: (uint)typeAttributes, numMethods: numMethods, numNonVirtualSlots: 0);
+            builder = MockRTS.AddMethodTable(targetTestHelpers, builder, genericDefinitionMethodTablePtr, "MethodTable GenericDefinition", genericDefinitionEEClassPtr,
                                     mtflags: gtd_mtflags, mtflags2: default, baseSize: targetTestHelpers.ObjectBaseSize,
                                     module: TargetPointer.Null, parentMethodTable: systemObjectMethodTablePtr, numInterfaces: numInterfaces, numVirtuals: numVirtuals);
 
             const uint ginst_mtflags = 0x00000010; // TODO: GenericsMask_GenericInst
             TargetPointer ginstCanonMT = new TargetPointer(genericDefinitionMethodTablePtr.Value | (ulong)1);
-            builder = AddMethodTable(targetTestHelpers, builder, genericInstanceMethodTablePtr, "MethodTable GenericInstance", eeClassOrCanonMT: ginstCanonMT,
+            builder = MockRTS.AddMethodTable(targetTestHelpers, builder, genericInstanceMethodTablePtr, "MethodTable GenericInstance", eeClassOrCanonMT: ginstCanonMT,
                                     mtflags: ginst_mtflags, mtflags2: default, baseSize: targetTestHelpers.ObjectBaseSize,
                                     module: TargetPointer.Null, parentMethodTable: genericDefinitionMethodTablePtr, numInterfaces: numInterfaces, numVirtuals: numVirtuals);
 
@@ -370,16 +271,16 @@ public unsafe class MethodTableTests
             const ushort systemArrayNumMethods = 37; // Arbitrary. Not trying to exactly match  the real System.Array
             const uint systemArrayCorTypeAttr = (uint)(System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
 
-            builder = AddEEClass(targetTestHelpers, builder, systemArrayEEClassPtr, "EEClass System.Array", systemArrayMethodTablePtr, attr: systemArrayCorTypeAttr, numMethods: systemArrayNumMethods, numNonVirtualSlots: 0);
-            builder = AddMethodTable(targetTestHelpers, builder, systemArrayMethodTablePtr, "MethodTable System.Array", systemArrayEEClassPtr,
+            builder = MockRTS.AddEEClass(targetTestHelpers, builder, systemArrayEEClassPtr, "EEClass System.Array", systemArrayMethodTablePtr, attr: systemArrayCorTypeAttr, numMethods: systemArrayNumMethods, numNonVirtualSlots: 0);
+            builder = MockRTS.AddMethodTable(targetTestHelpers, builder, systemArrayMethodTablePtr, "MethodTable System.Array", systemArrayEEClassPtr,
                                     mtflags: default, mtflags2: default, baseSize: targetTestHelpers.ObjectBaseSize,
                                     module: TargetPointer.Null, parentMethodTable: systemObjectMethodTablePtr, numInterfaces: systemArrayNumInterfaces, numVirtuals: 3);
 
             const uint arrayInst_mtflags = (uint)(RuntimeTypeSystem_1.WFLAGS_HIGH.HasComponentSize | RuntimeTypeSystem_1.WFLAGS_HIGH.Category_Array) | arrayInstanceComponentSize;
             const uint arrayInstCorTypeAttr = (uint)(System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class | System.Reflection.TypeAttributes.Sealed);
 
-            builder = AddEEClass(targetTestHelpers, builder, arrayInstanceEEClassPtr, "EEClass ArrayInstance", arrayInstanceMethodTablePtr, attr: arrayInstCorTypeAttr, numMethods: systemArrayNumMethods, numNonVirtualSlots: 0);
-            builder = AddMethodTable(targetTestHelpers, builder, arrayInstanceMethodTablePtr, "MethodTable ArrayInstance", arrayInstanceEEClassPtr,
+            builder = MockRTS.AddEEClass(targetTestHelpers, builder, arrayInstanceEEClassPtr, "EEClass ArrayInstance", arrayInstanceMethodTablePtr, attr: arrayInstCorTypeAttr, numMethods: systemArrayNumMethods, numNonVirtualSlots: 0);
+            builder = MockRTS.AddMethodTable(targetTestHelpers, builder, arrayInstanceMethodTablePtr, "MethodTable ArrayInstance", arrayInstanceEEClassPtr,
                                     mtflags: arrayInst_mtflags, mtflags2: default, baseSize: targetTestHelpers.ObjectBaseSize,
                                     module: TargetPointer.Null, parentMethodTable: systemArrayMethodTablePtr, numInterfaces: systemArrayNumInterfaces, numVirtuals: 3);
 

--- a/src/native/managed/cdacreader/tests/MockDescriptors.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors.cs
@@ -1,0 +1,237 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+
+namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
+
+public class MockDescriptors
+{
+    private static readonly Target.TypeInfo MethodTableTypeInfo = new()
+    {
+        Fields = {
+            { nameof(Data.MethodTable.MTFlags), new() { Offset = 4, Type = DataType.uint32}},
+            { nameof(Data.MethodTable.BaseSize), new() { Offset = 8, Type = DataType.uint32}},
+            { nameof(Data.MethodTable.MTFlags2), new() { Offset = 12, Type = DataType.uint32}},
+            { nameof(Data.MethodTable.EEClassOrCanonMT), new () { Offset = 16, Type = DataType.nuint}},
+            { nameof(Data.MethodTable.Module), new () { Offset = 24, Type = DataType.pointer}},
+            { nameof(Data.MethodTable.ParentMethodTable), new () { Offset = 40, Type = DataType.pointer}},
+            { nameof(Data.MethodTable.NumInterfaces), new () { Offset = 48, Type = DataType.uint16}},
+            { nameof(Data.MethodTable.NumVirtuals), new () { Offset = 50, Type = DataType.uint16}},
+            { nameof(Data.MethodTable.PerInstInfo), new () { Offset = 56, Type = DataType.pointer}},
+        }
+    };
+
+    private static readonly Target.TypeInfo EEClassTypeInfo = new Target.TypeInfo()
+    {
+        Fields = {
+            { nameof (Data.EEClass.MethodTable), new () { Offset = 8, Type = DataType.pointer}},
+            { nameof (Data.EEClass.CorTypeAttr), new () { Offset = 16, Type = DataType.uint32}},
+            { nameof (Data.EEClass.NumMethods), new () { Offset = 20, Type = DataType.uint16}},
+            { nameof (Data.EEClass.InternalCorElementType), new () { Offset = 22, Type = DataType.uint8}},
+            { nameof (Data.EEClass.NumNonVirtualSlots), new () { Offset = 24, Type = DataType.uint16}},
+        }
+    };
+
+    private static readonly Target.TypeInfo ArrayClassTypeInfo = new Target.TypeInfo()
+    {
+        Fields = {
+            { nameof (Data.ArrayClass.Rank), new () { Offset = 0x70, Type = DataType.uint8}},
+        }
+    };
+
+    private static readonly Target.TypeInfo ObjectTypeInfo = new()
+    {
+        Fields = {
+            { "m_pMethTab", new() { Offset = 0, Type = DataType.pointer} },
+        }
+    };
+
+    private static readonly Target.TypeInfo StringTypeInfo = new Target.TypeInfo()
+    {
+        Fields = {
+            { "m_StringLength", new() { Offset = 0x8, Type = DataType.uint32} },
+            { "m_FirstChar", new() { Offset = 0xc, Type = DataType.uint16} },
+        }
+    };
+
+    private static readonly Target.TypeInfo ArrayTypeInfo = new Target.TypeInfo()
+    {
+        Fields = {
+            { "m_NumComponents", new() { Offset = 0x8, Type = DataType.uint32} },
+        },
+    };
+
+    public static class RuntimeTypeSystem
+    {
+        internal const ulong TestFreeObjectMethodTableGlobalAddress = 0x00000000_7a0000a0;
+        internal const ulong TestFreeObjectMethodTableAddress = 0x00000000_7a0000a8;
+
+        internal static readonly Dictionary<DataType, Target.TypeInfo> Types = new()
+        {
+            [DataType.MethodTable] = MethodTableTypeInfo,
+            [DataType.EEClass] = EEClassTypeInfo,
+            [DataType.ArrayClass] = ArrayClassTypeInfo,
+        };
+
+        internal static readonly (string Name, ulong Value, string? Type)[] Globals =
+        [
+            (nameof(Constants.Globals.FreeObjectMethodTable), TestFreeObjectMethodTableGlobalAddress, null),
+            (nameof(Constants.Globals.MethodDescAlignment), 8, nameof(DataType.uint64)),
+        ];
+
+        internal static MockMemorySpace.Builder AddGlobalPointers(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder)
+        {
+            return AddFreeObjectMethodTable(targetTestHelpers, builder);
+        }
+
+        private static MockMemorySpace.Builder AddFreeObjectMethodTable(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder)
+        {
+            MockMemorySpace.HeapFragment globalAddr = new() { Name = "Address of Free Object Method Table", Address = TestFreeObjectMethodTableGlobalAddress, Data = new byte[targetTestHelpers.PointerSize] };
+            targetTestHelpers.WritePointer(globalAddr.Data, TestFreeObjectMethodTableAddress);
+            return builder.AddHeapFragments([
+                globalAddr,
+                new () { Name = "Free Object Method Table", Address = TestFreeObjectMethodTableAddress, Data = new byte[targetTestHelpers.SizeOfTypeInfo(MethodTableTypeInfo)] }
+            ]);
+        }
+
+        internal static MockMemorySpace.Builder AddEEClass(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer eeClassPtr, string name, TargetPointer canonMTPtr, uint attr, ushort numMethods, ushort numNonVirtualSlots)
+        {
+            MockMemorySpace.HeapFragment eeClassFragment = new() { Name = $"EEClass '{name}'", Address = eeClassPtr, Data = new byte[targetTestHelpers.SizeOfTypeInfo(EEClassTypeInfo)] };
+            Span<byte> dest = eeClassFragment.Data;
+            targetTestHelpers.WritePointer(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.MethodTable)].Offset), canonMTPtr);
+            targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.CorTypeAttr)].Offset), attr);
+            targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumMethods)].Offset), numMethods);
+            targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumNonVirtualSlots)].Offset), numNonVirtualSlots);
+            return builder.AddHeapFragment(eeClassFragment);
+        }
+
+        internal static MockMemorySpace.Builder AddArrayClass(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer eeClassPtr, string name, TargetPointer canonMTPtr, uint attr, ushort numMethods, ushort numNonVirtualSlots, byte rank)
+        {
+            int size = targetTestHelpers.SizeOfTypeInfo(EEClassTypeInfo) + targetTestHelpers.SizeOfTypeInfo(ArrayClassTypeInfo);
+            MockMemorySpace.HeapFragment eeClassFragment = new() { Name = $"ArrayClass '{name}'", Address = eeClassPtr, Data = new byte[size] };
+            Span<byte> dest = eeClassFragment.Data;
+            targetTestHelpers.WritePointer(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.MethodTable)].Offset), canonMTPtr);
+            targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.CorTypeAttr)].Offset), attr);
+            targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumMethods)].Offset), numMethods);
+            targetTestHelpers.Write(dest.Slice(EEClassTypeInfo.Fields[nameof(Data.EEClass.NumNonVirtualSlots)].Offset), numNonVirtualSlots);
+            targetTestHelpers.Write(dest.Slice(ArrayClassTypeInfo.Fields[nameof(Data.ArrayClass.Rank)].Offset), rank);
+            return builder.AddHeapFragment(eeClassFragment);
+        }
+
+        internal static MockMemorySpace.Builder AddMethodTable(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer methodTablePtr, string name, TargetPointer eeClassOrCanonMT, uint mtflags, uint mtflags2, uint baseSize,
+                                                            TargetPointer module, TargetPointer parentMethodTable, ushort numInterfaces, ushort numVirtuals)
+        {
+            MockMemorySpace.HeapFragment methodTableFragment = new() { Name = $"MethodTable '{name}'", Address = methodTablePtr, Data = new byte[targetTestHelpers.SizeOfTypeInfo(MethodTableTypeInfo)] };
+            Span<byte> dest = methodTableFragment.Data;
+            targetTestHelpers.WritePointer(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.EEClassOrCanonMT)].Offset), eeClassOrCanonMT);
+            targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.MTFlags)].Offset), mtflags);
+            targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.MTFlags2)].Offset), mtflags2);
+            targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.BaseSize)].Offset), baseSize);
+            targetTestHelpers.WritePointer(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.Module)].Offset), module);
+            targetTestHelpers.WritePointer(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.ParentMethodTable)].Offset), parentMethodTable);
+            targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.NumInterfaces)].Offset), numInterfaces);
+            targetTestHelpers.Write(dest.Slice(MethodTableTypeInfo.Fields[nameof(Data.MethodTable.NumVirtuals)].Offset), numVirtuals);
+
+            // TODO fill in the rest of the fields
+            return builder.AddHeapFragment(methodTableFragment);
+        }
+    }
+
+    public static class Object
+    {
+        const ulong TestStringMethodTableGlobalAddress = 0x00000000_100000a0;
+        const ulong TestStringMethodTableAddress = 0x00000000_100000a8;
+        internal const ulong TestArrayBoundsZeroGlobalAddress = 0x00000000_100000b0;
+
+        internal static Dictionary<DataType, Target.TypeInfo> Types(TargetTestHelpers helpers) => RuntimeTypeSystem.Types.Concat(
+        new Dictionary<DataType, Target.TypeInfo>(){
+            [DataType.Object] = ObjectTypeInfo,
+            [DataType.String] = StringTypeInfo,
+            [DataType.Array] = ArrayTypeInfo with { Size = helpers.ArrayBaseSize }
+        }).ToDictionary();
+
+        internal const ulong TestObjectToMethodTableUnmask = 0x7;
+        internal static (string Name, ulong Value, string? Type)[] Globals(TargetTestHelpers helpers) => RuntimeTypeSystem.Globals.Concat(
+        [
+            (nameof(Constants.Globals.ObjectToMethodTableUnmask), TestObjectToMethodTableUnmask, "uint8"),
+            (nameof(Constants.Globals.StringMethodTable), TestStringMethodTableGlobalAddress, null),
+            (nameof(Constants.Globals.ArrayBoundsZero), TestArrayBoundsZeroGlobalAddress, null),
+            (nameof(Constants.Globals.ObjectHeaderSize), helpers.ObjHeaderSize, "uint32"),
+        ]).ToArray();
+
+        internal static MockMemorySpace.Builder AddGlobalPointers(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder)
+        {
+            builder = RuntimeTypeSystem.AddGlobalPointers(targetTestHelpers, builder);
+            builder = AddStringMethodTablePointer(targetTestHelpers, builder);
+            return builder;
+        }
+
+        private static MockMemorySpace.Builder AddStringMethodTablePointer(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder)
+        {
+            MockMemorySpace.HeapFragment fragment = new() { Name = "Address of String Method Table", Address = TestStringMethodTableGlobalAddress, Data = new byte[targetTestHelpers.PointerSize] };
+            targetTestHelpers.WritePointer(fragment.Data, TestStringMethodTableAddress);
+            return builder.AddHeapFragments([
+                fragment,
+                new () { Name = "String Method Table", Address = TestStringMethodTableAddress, Data = new byte[targetTestHelpers.PointerSize] }
+            ]);
+        }
+
+        internal static MockMemorySpace.Builder AddObject(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer address, TargetPointer methodTable)
+        {
+            MockMemorySpace.HeapFragment fragment = new() { Name = $"Object : MT = '{methodTable}'", Address = address, Data = new byte[targetTestHelpers.SizeOfTypeInfo(ObjectTypeInfo)] };
+            Span<byte> dest = fragment.Data;
+            targetTestHelpers.WritePointer(dest.Slice(ObjectTypeInfo.Fields["m_pMethTab"].Offset), methodTable);
+            return builder.AddHeapFragment(fragment);
+        }
+
+        internal static MockMemorySpace.Builder AddStringObject(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer address, string value)
+        {
+            int size = targetTestHelpers.SizeOfTypeInfo(ObjectTypeInfo) + targetTestHelpers.SizeOfTypeInfo(StringTypeInfo) + value.Length * sizeof(char);
+            MockMemorySpace.HeapFragment fragment = new() { Name = $"String = '{value}'", Address = address, Data = new byte[size] };
+            Span<byte> dest = fragment.Data;
+            targetTestHelpers.WritePointer(dest.Slice(ObjectTypeInfo.Fields["m_pMethTab"].Offset), TestStringMethodTableAddress);
+            targetTestHelpers.Write(dest.Slice(StringTypeInfo.Fields["m_StringLength"].Offset), (uint)value.Length);
+            MemoryMarshal.Cast<char, byte>(value).CopyTo(dest.Slice(StringTypeInfo.Fields["m_FirstChar"].Offset));
+            return builder.AddHeapFragment(fragment);
+        }
+
+        internal static MockMemorySpace.Builder AddArrayObject(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer address, Array array)
+        {
+            bool isSingleDimensionZeroLowerBound = array.Rank == 1 && array.GetLowerBound(0) == 0;
+
+            // Bounds are part of the array object for non-single dimension or non-zero lower bound arrays
+            //   << fields that are part of the array type info >>
+            //   int32_t bounds[rank];
+            //   int32_t lowerBounds[rank];
+            int size = targetTestHelpers.SizeOfTypeInfo(ObjectTypeInfo) + targetTestHelpers.SizeOfTypeInfo(ArrayTypeInfo);
+            if (!isSingleDimensionZeroLowerBound)
+                size += array.Rank * sizeof(int) * 2;
+
+            ulong methodTableAddress = (address.Value + (ulong)size + (TestObjectToMethodTableUnmask - 1)) & ~(TestObjectToMethodTableUnmask - 1);
+            ulong arrayClassAddress = methodTableAddress + (ulong)targetTestHelpers.SizeOfTypeInfo(RuntimeTypeSystem.Types[DataType.MethodTable]);
+
+            uint flags = (uint)(RuntimeTypeSystem_1.WFLAGS_HIGH.HasComponentSize | RuntimeTypeSystem_1.WFLAGS_HIGH.Category_Array) | (uint)array.Length;
+            if (isSingleDimensionZeroLowerBound)
+                flags |= (uint)RuntimeTypeSystem_1.WFLAGS_HIGH.Category_IfArrayThenSzArray;
+
+            string name = string.Join(',', array);
+
+            builder = RuntimeTypeSystem.AddArrayClass(targetTestHelpers, builder, arrayClassAddress, name, methodTableAddress,
+                attr: 0, numMethods: 0, numNonVirtualSlots: 0, rank: (byte)array.Rank);
+            builder = RuntimeTypeSystem.AddMethodTable(targetTestHelpers, builder, methodTableAddress, name, arrayClassAddress,
+                mtflags: flags, mtflags2: default, baseSize: targetTestHelpers.ArrayBaseBaseSize,
+                module: TargetPointer.Null, parentMethodTable: TargetPointer.Null, numInterfaces: 0, numVirtuals: 0);
+
+            MockMemorySpace.HeapFragment fragment = new() { Name = $"Array = '{string.Join(',', array)}'", Address = address, Data = new byte[size] };
+            Span<byte> dest = fragment.Data;
+            targetTestHelpers.WritePointer(dest.Slice(ObjectTypeInfo.Fields["m_pMethTab"].Offset), methodTableAddress);
+            targetTestHelpers.Write(dest.Slice(ArrayTypeInfo.Fields["m_NumComponents"].Offset), (uint)array.Length);
+            return builder.AddHeapFragment(fragment);
+        }
+    }
+}

--- a/src/native/managed/cdacreader/tests/MockTarget.cs
+++ b/src/native/managed/cdacreader/tests/MockTarget.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 
 public class MockTarget
 {
-    public struct Architecture
+    public record struct Architecture
     {
         public bool IsLittleEndian { get; init; }
         public bool Is64Bit { get; init; }

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
@@ -12,6 +15,7 @@ public unsafe class ObjectTests
 {
     const ulong TestStringMethodTableGlobalAddress = 0x00000000_100000a0;
     const ulong TestStringMethodTableAddress = 0x00000000_100000a8;
+    const ulong TestArrayBoundsZeroGlobalAddress = 0x00000000_100000b0;
 
     private static readonly Target.TypeInfo ObjectTypeInfo = new()
     {
@@ -28,18 +32,26 @@ public unsafe class ObjectTests
         }
     };
 
-    private static readonly (DataType Type, Target.TypeInfo Info)[] ObjectTypes =
+    private static readonly Target.TypeInfo ArrayTypeInfo = new Target.TypeInfo()
+    {
+        Fields = {
+            { "m_NumComponents", new() { Offset = 0x8, Type = DataType.uint32} },
+        },
+    };
+
+    private static readonly (DataType Type, Target.TypeInfo Info)[] ObjectTypes = MethodTableTests.RTSTypes.Concat(
     [
         (DataType.Object, ObjectTypeInfo),
         (DataType.String, StringTypeInfo),
-    ];
+    ]).ToArray();
 
     const ulong TestObjectToMethodTableUnmask = 0x7;
-    private static (string Name, ulong Value, string? Type)[] ObjectGlobals =
+    private static (string Name, ulong Value, string? Type)[] ObjectGlobals = MethodTableTests.RTSGlobals.Concat(
     [
         (nameof(Constants.Globals.ObjectToMethodTableUnmask), TestObjectToMethodTableUnmask, "uint8"),
         (nameof(Constants.Globals.StringMethodTable), TestStringMethodTableGlobalAddress, null),
-    ];
+        (nameof(Constants.Globals.ArrayBoundsZero), TestArrayBoundsZeroGlobalAddress, null),
+    ]).ToArray();
 
     private static MockMemorySpace.Builder AddStringMethodTablePointer(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder)
     {
@@ -56,14 +68,22 @@ public unsafe class ObjectTests
     private static void ObjectContractHelper(MockTarget.Architecture arch, ConfigureContextBuilder configure, Action<Target> testCase)
     {
         TargetTestHelpers targetTestHelpers = new(arch);
-        string typesJson = TargetTestHelpers.MakeTypesJson(ObjectTypes);
-        string globalsJson = TargetTestHelpers.MakeGlobalsJson(ObjectGlobals);
+
+        List<(DataType Type, Target.TypeInfo Info)> typesLocal = new (ObjectTypes);
+        typesLocal.Add((DataType.Array, ArrayTypeInfo with { Size = targetTestHelpers.ArrayBaseSize }));
+
+        List<(string Name, ulong Value, string? Type)> globalsLocal = new(ObjectGlobals);
+        globalsLocal.Add((nameof(Constants.Globals.ObjectHeaderSize), targetTestHelpers.ObjHeaderSize, "uint32"));
+
+        string typesJson = TargetTestHelpers.MakeTypesJson(typesLocal);
+        string globalsJson = TargetTestHelpers.MakeGlobalsJson(globalsLocal);
         byte[] json = Encoding.UTF8.GetBytes($$"""
         {
             "version": 0,
             "baseline": "empty",
             "contracts": {
-                "{{nameof(Contracts.Object)}}": 1
+                "{{nameof(Contracts.Object)}}": 1,
+                "{{nameof(Contracts.RuntimeTypeSystem)}}": 1
             },
             "types": { {{typesJson}} },
             "globals": { {{globalsJson}} }
@@ -87,6 +107,7 @@ public unsafe class ObjectTests
                     .SetJson(json)
                     .SetPointerData(pointerData);
 
+            builder = MethodTableTests.AddFreeObjectMethodTable(targetTestHelpers, builder);
             builder = AddStringMethodTablePointer(targetTestHelpers, builder);
 
             if (configure != null)
@@ -123,6 +144,40 @@ public unsafe class ObjectTests
         return builder.AddHeapFragment(fragment);
     }
 
+    private static MockMemorySpace.Builder AddArrayObject(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer address, Array array)
+    {
+        bool isSingleDimensionZeroLowerBound = array.Rank == 1 && array.GetLowerBound(0) == 0;
+
+        // Bounds are part of the array object for non-single dimension or non-zero lower bound arrays
+        //   << fields that are part of the array type info >>
+        //   int32_t bounds[rank];
+        //   int32_t lowerBounds[rank];
+        int size = targetTestHelpers.SizeOfTypeInfo(ObjectTypeInfo) + targetTestHelpers.SizeOfTypeInfo(ArrayTypeInfo);
+        if (!isSingleDimensionZeroLowerBound)
+            size += array.Rank * sizeof(int) * 2;
+
+        ulong methodTableAddress = (address.Value + (ulong)size + (TestObjectToMethodTableUnmask - 1)) & ~(TestObjectToMethodTableUnmask - 1);
+        ulong arrayClassAddress = methodTableAddress + (ulong)targetTestHelpers.SizeOfTypeInfo(MethodTableTests.RTSTypes.First(t => t.Type == DataType.MethodTable).Info);
+
+        uint flags = (uint)(RuntimeTypeSystem_1.WFLAGS_HIGH.HasComponentSize | RuntimeTypeSystem_1.WFLAGS_HIGH.Category_Array) | (uint)array.Length;
+        if (isSingleDimensionZeroLowerBound)
+            flags |= (uint)RuntimeTypeSystem_1.WFLAGS_HIGH.Category_IfArrayThenSzArray;
+
+        string name = string.Join(',', array);
+
+        builder = MethodTableTests.AddArrayClass(targetTestHelpers, builder, arrayClassAddress, name, methodTableAddress,
+            attr: 0, numMethods: 0, numNonVirtualSlots: 0, rank: (byte)array.Rank);
+        builder = MethodTableTests.AddMethodTable(targetTestHelpers, builder, methodTableAddress, name, arrayClassAddress,
+            mtflags: flags, mtflags2: default, baseSize: targetTestHelpers.ArrayBaseBaseSize,
+            module: TargetPointer.Null, parentMethodTable: TargetPointer.Null, numInterfaces: 0, numVirtuals: 0);
+
+        MockMemorySpace.HeapFragment fragment = new() { Name = $"Array = '{string.Join(',', array)}'", Address = address, Data = new byte[size] };
+        Span<byte> dest = fragment.Data;
+        targetTestHelpers.WritePointer(dest.Slice(ObjectTypeInfo.Fields["m_pMethTab"].Offset), methodTableAddress);
+        targetTestHelpers.Write(dest.Slice(ArrayTypeInfo.Fields["m_NumComponents"].Offset), (uint)array.Length);
+        return builder.AddHeapFragment(fragment);
+    }
+
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
     public void UnmaskMethodTableAddress(MockTarget.Architecture arch)
@@ -153,17 +208,65 @@ public unsafe class ObjectTests
         string expected = "test_string_value";
         TargetTestHelpers targetTestHelpers = new(arch);
         ObjectContractHelper(arch,
-        (builder) =>
-        {
-            builder = AddStringObject(targetTestHelpers, builder, TestStringAddress, expected);
-            return builder;
-        },
-        (target) =>
-        {
-            Contracts.IObject contract = target.Contracts.Object;
-            Assert.NotNull(contract);
-            string actual = contract.GetStringValue(TestStringAddress);
-            Assert.Equal(expected, actual);
-        });
+            (builder) =>
+            {
+                builder = AddStringObject(targetTestHelpers, builder, TestStringAddress, expected);
+                return builder;
+            },
+            (target) =>
+            {
+                Contracts.IObject contract = target.Contracts.Object;
+                Assert.NotNull(contract);
+                string actual = contract.GetStringValue(TestStringAddress);
+                Assert.Equal(expected, actual);
+            });
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void ArrayData(MockTarget.Architecture arch)
+    {
+        const ulong SingleDimensionArrayAddress = 0x00000000_20000010;
+        const ulong MultiDimensionArrayAddress = 0x00000000_30000010;
+        const ulong NonZeroLowerBoundArrayAddress = 0x00000000_40000010;
+
+        Array singleDimension = new int[10];
+        Array multiDimension = new int[1, 2, 3, 4];
+        Array nonZeroLowerBound = Array.CreateInstance(typeof(int), [10], [5]);
+        TargetTestHelpers targetTestHelpers = new(arch);
+        ObjectContractHelper(arch,
+            (builder) =>
+            {
+                builder = AddArrayObject(targetTestHelpers, builder, SingleDimensionArrayAddress, singleDimension);
+                builder = AddArrayObject(targetTestHelpers, builder, MultiDimensionArrayAddress, multiDimension);
+                builder = AddArrayObject(targetTestHelpers, builder, NonZeroLowerBoundArrayAddress, nonZeroLowerBound);
+                return builder;
+            },
+            (target) =>
+            {
+                Contracts.IObject contract = target.Contracts.Object;
+                Assert.NotNull(contract);
+                {
+                    TargetPointer data = contract.GetArrayData(SingleDimensionArrayAddress, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds);
+                    Assert.Equal(SingleDimensionArrayAddress + targetTestHelpers.ArrayBaseBaseSize - targetTestHelpers.ObjHeaderSize, data.Value);
+                    Assert.Equal((uint)singleDimension.Length, count);
+                    Assert.Equal(SingleDimensionArrayAddress + (ulong)ArrayTypeInfo.Fields["m_NumComponents"].Offset, boundsStart.Value);
+                    Assert.Equal(TestArrayBoundsZeroGlobalAddress, lowerBounds.Value);
+                }
+                {
+                    TargetPointer data = contract.GetArrayData(MultiDimensionArrayAddress, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds);
+                    Assert.Equal(MultiDimensionArrayAddress + targetTestHelpers.ArrayBaseBaseSize - targetTestHelpers.ObjHeaderSize, data.Value);
+                    Assert.Equal((uint)multiDimension.Length, count);
+                    Assert.Equal(MultiDimensionArrayAddress + targetTestHelpers.ArrayBaseSize, boundsStart.Value);
+                    Assert.Equal(boundsStart.Value + (ulong)(multiDimension.Rank * sizeof(int)), lowerBounds.Value);
+                }
+                {
+                    TargetPointer data = contract.GetArrayData(NonZeroLowerBoundArrayAddress, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds);
+                    Assert.Equal(NonZeroLowerBoundArrayAddress + targetTestHelpers.ArrayBaseBaseSize - targetTestHelpers.ObjHeaderSize, data.Value);
+                    Assert.Equal((uint)nonZeroLowerBound.Length, count);
+                    Assert.Equal(NonZeroLowerBoundArrayAddress + targetTestHelpers.ArrayBaseSize, boundsStart.Value);
+                    Assert.Equal(boundsStart.Value + (ulong)(nonZeroLowerBound.Rank * sizeof(int)), lowerBounds.Value);
+                }
+            });
     }
 }

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -2,81 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 
+using MockObject = MockDescriptors.Object;
+
 public unsafe class ObjectTests
 {
-    const ulong TestStringMethodTableGlobalAddress = 0x00000000_100000a0;
-    const ulong TestStringMethodTableAddress = 0x00000000_100000a8;
-    const ulong TestArrayBoundsZeroGlobalAddress = 0x00000000_100000b0;
-
-    private static readonly Target.TypeInfo ObjectTypeInfo = new()
-    {
-        Fields = {
-            { "m_pMethTab", new() { Offset = 0, Type = DataType.pointer} },
-        }
-    };
-
-    private static readonly Target.TypeInfo StringTypeInfo = new Target.TypeInfo()
-    {
-        Fields = {
-            { "m_StringLength", new() { Offset = 0x8, Type = DataType.uint32} },
-            { "m_FirstChar", new() { Offset = 0xc, Type = DataType.uint16} },
-        }
-    };
-
-    private static readonly Target.TypeInfo ArrayTypeInfo = new Target.TypeInfo()
-    {
-        Fields = {
-            { "m_NumComponents", new() { Offset = 0x8, Type = DataType.uint32} },
-        },
-    };
-
-    private static readonly (DataType Type, Target.TypeInfo Info)[] ObjectTypes = MethodTableTests.RTSTypes.Concat(
-    [
-        (DataType.Object, ObjectTypeInfo),
-        (DataType.String, StringTypeInfo),
-    ]).ToArray();
-
-    const ulong TestObjectToMethodTableUnmask = 0x7;
-    private static (string Name, ulong Value, string? Type)[] ObjectGlobals = MethodTableTests.RTSGlobals.Concat(
-    [
-        (nameof(Constants.Globals.ObjectToMethodTableUnmask), TestObjectToMethodTableUnmask, "uint8"),
-        (nameof(Constants.Globals.StringMethodTable), TestStringMethodTableGlobalAddress, null),
-        (nameof(Constants.Globals.ArrayBoundsZero), TestArrayBoundsZeroGlobalAddress, null),
-    ]).ToArray();
-
-    private static MockMemorySpace.Builder AddStringMethodTablePointer(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder)
-    {
-        MockMemorySpace.HeapFragment fragment = new() { Name = "Address of String Method Table", Address = TestStringMethodTableGlobalAddress, Data = new byte[targetTestHelpers.PointerSize] };
-        targetTestHelpers.WritePointer(fragment.Data, TestStringMethodTableAddress);
-        return builder.AddHeapFragments([
-            fragment,
-            new () { Name = "String Method Table", Address = TestStringMethodTableAddress, Data = new byte[targetTestHelpers.PointerSize] }
-        ]);
-    }
-
     private delegate MockMemorySpace.Builder ConfigureContextBuilder(MockMemorySpace.Builder builder);
 
     private static void ObjectContractHelper(MockTarget.Architecture arch, ConfigureContextBuilder configure, Action<Target> testCase)
     {
         TargetTestHelpers targetTestHelpers = new(arch);
 
-        List<(DataType Type, Target.TypeInfo Info)> typesLocal = new (ObjectTypes);
-        typesLocal.Add((DataType.Array, ArrayTypeInfo with { Size = targetTestHelpers.ArrayBaseSize }));
+        (string Name, ulong Value, string? Type)[] globals = MockObject.Globals(targetTestHelpers);
 
-        List<(string Name, ulong Value, string? Type)> globalsLocal = new(ObjectGlobals);
-        globalsLocal.Add((nameof(Constants.Globals.ObjectHeaderSize), targetTestHelpers.ObjHeaderSize, "uint32"));
-
-        string typesJson = TargetTestHelpers.MakeTypesJson(typesLocal);
-        string globalsJson = TargetTestHelpers.MakeGlobalsJson(globalsLocal);
+        string typesJson = TargetTestHelpers.MakeTypesJson(MockObject.Types(targetTestHelpers));
+        string globalsJson = TargetTestHelpers.MakeGlobalsJson(globals);
         byte[] json = Encoding.UTF8.GetBytes($$"""
         {
             "version": 0,
@@ -90,13 +34,13 @@ public unsafe class ObjectTests
         }
         """);
         Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, ObjectGlobals.Length);
+        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, globals.Length);
 
         int pointerSize = targetTestHelpers.PointerSize;
-        Span<byte> pointerData = stackalloc byte[ObjectGlobals.Length * pointerSize];
-        for (int i = 0; i < ObjectGlobals.Length; i++)
+        Span<byte> pointerData = stackalloc byte[globals.Length * pointerSize];
+        for (int i = 0; i < globals.Length; i++)
         {
-            var (_, value, _) = ObjectGlobals[i];
+            var (_, value, _) = globals[i];
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
@@ -107,8 +51,7 @@ public unsafe class ObjectTests
                     .SetJson(json)
                     .SetPointerData(pointerData);
 
-            builder = MethodTableTests.AddFreeObjectMethodTable(targetTestHelpers, builder);
-            builder = AddStringMethodTablePointer(targetTestHelpers, builder);
+            builder = MockObject.AddGlobalPointers(targetTestHelpers, builder);
 
             if (configure != null)
             {
@@ -125,59 +68,6 @@ public unsafe class ObjectTests
         GC.KeepAlive(json);
     }
 
-    private static MockMemorySpace.Builder AddObject(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer address, TargetPointer methodTable)
-    {
-        MockMemorySpace.HeapFragment fragment = new() { Name = $"Object : MT = '{methodTable}'", Address = address, Data = new byte[targetTestHelpers.SizeOfTypeInfo(ObjectTypeInfo)] };
-        Span<byte> dest = fragment.Data;
-        targetTestHelpers.WritePointer(dest.Slice(ObjectTypeInfo.Fields["m_pMethTab"].Offset), methodTable);
-        return builder.AddHeapFragment(fragment);
-    }
-
-    private static MockMemorySpace.Builder AddStringObject(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer address, string value)
-    {
-        int size = targetTestHelpers.SizeOfTypeInfo(ObjectTypeInfo) + targetTestHelpers.SizeOfTypeInfo(StringTypeInfo) + value.Length * sizeof(char);
-        MockMemorySpace.HeapFragment fragment = new() { Name = $"String = '{value}'", Address = address, Data = new byte[size] };
-        Span<byte> dest = fragment.Data;
-        targetTestHelpers.WritePointer(dest.Slice(ObjectTypeInfo.Fields["m_pMethTab"].Offset), TestStringMethodTableAddress);
-        targetTestHelpers.Write(dest.Slice(StringTypeInfo.Fields["m_StringLength"].Offset), (uint)value.Length);
-        MemoryMarshal.Cast<char, byte>(value).CopyTo(dest.Slice(StringTypeInfo.Fields["m_FirstChar"].Offset));
-        return builder.AddHeapFragment(fragment);
-    }
-
-    private static MockMemorySpace.Builder AddArrayObject(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, TargetPointer address, Array array)
-    {
-        bool isSingleDimensionZeroLowerBound = array.Rank == 1 && array.GetLowerBound(0) == 0;
-
-        // Bounds are part of the array object for non-single dimension or non-zero lower bound arrays
-        //   << fields that are part of the array type info >>
-        //   int32_t bounds[rank];
-        //   int32_t lowerBounds[rank];
-        int size = targetTestHelpers.SizeOfTypeInfo(ObjectTypeInfo) + targetTestHelpers.SizeOfTypeInfo(ArrayTypeInfo);
-        if (!isSingleDimensionZeroLowerBound)
-            size += array.Rank * sizeof(int) * 2;
-
-        ulong methodTableAddress = (address.Value + (ulong)size + (TestObjectToMethodTableUnmask - 1)) & ~(TestObjectToMethodTableUnmask - 1);
-        ulong arrayClassAddress = methodTableAddress + (ulong)targetTestHelpers.SizeOfTypeInfo(MethodTableTests.RTSTypes.First(t => t.Type == DataType.MethodTable).Info);
-
-        uint flags = (uint)(RuntimeTypeSystem_1.WFLAGS_HIGH.HasComponentSize | RuntimeTypeSystem_1.WFLAGS_HIGH.Category_Array) | (uint)array.Length;
-        if (isSingleDimensionZeroLowerBound)
-            flags |= (uint)RuntimeTypeSystem_1.WFLAGS_HIGH.Category_IfArrayThenSzArray;
-
-        string name = string.Join(',', array);
-
-        builder = MethodTableTests.AddArrayClass(targetTestHelpers, builder, arrayClassAddress, name, methodTableAddress,
-            attr: 0, numMethods: 0, numNonVirtualSlots: 0, rank: (byte)array.Rank);
-        builder = MethodTableTests.AddMethodTable(targetTestHelpers, builder, methodTableAddress, name, arrayClassAddress,
-            mtflags: flags, mtflags2: default, baseSize: targetTestHelpers.ArrayBaseBaseSize,
-            module: TargetPointer.Null, parentMethodTable: TargetPointer.Null, numInterfaces: 0, numVirtuals: 0);
-
-        MockMemorySpace.HeapFragment fragment = new() { Name = $"Array = '{string.Join(',', array)}'", Address = address, Data = new byte[size] };
-        Span<byte> dest = fragment.Data;
-        targetTestHelpers.WritePointer(dest.Slice(ObjectTypeInfo.Fields["m_pMethTab"].Offset), methodTableAddress);
-        targetTestHelpers.Write(dest.Slice(ArrayTypeInfo.Fields["m_NumComponents"].Offset), (uint)array.Length);
-        return builder.AddHeapFragment(fragment);
-    }
-
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
     public void UnmaskMethodTableAddress(MockTarget.Architecture arch)
@@ -188,7 +78,7 @@ public unsafe class ObjectTests
         ObjectContractHelper(arch,
             (builder) =>
             {
-                builder = AddObject(targetTestHelpers, builder, TestObjectAddress, TestMethodTableAddress);
+                builder = MockObject.AddObject(targetTestHelpers, builder, TestObjectAddress, TestMethodTableAddress);
                 return builder;
             },
             (target) =>
@@ -196,7 +86,7 @@ public unsafe class ObjectTests
                 Contracts.IObject contract = target.Contracts.Object;
                 Assert.NotNull(contract);
                 TargetPointer mt = contract.GetMethodTableAddress(TestObjectAddress);
-                Assert.Equal(TestMethodTableAddress & ~TestObjectToMethodTableUnmask, mt.Value);
+                Assert.Equal(TestMethodTableAddress & ~MockObject.TestObjectToMethodTableUnmask, mt.Value);
             });
     }
 
@@ -210,7 +100,7 @@ public unsafe class ObjectTests
         ObjectContractHelper(arch,
             (builder) =>
             {
-                builder = AddStringObject(targetTestHelpers, builder, TestStringAddress, expected);
+                builder = MockObject.AddStringObject(targetTestHelpers, builder, TestStringAddress, expected);
                 return builder;
             },
             (target) =>
@@ -237,9 +127,9 @@ public unsafe class ObjectTests
         ObjectContractHelper(arch,
             (builder) =>
             {
-                builder = AddArrayObject(targetTestHelpers, builder, SingleDimensionArrayAddress, singleDimension);
-                builder = AddArrayObject(targetTestHelpers, builder, MultiDimensionArrayAddress, multiDimension);
-                builder = AddArrayObject(targetTestHelpers, builder, NonZeroLowerBoundArrayAddress, nonZeroLowerBound);
+                builder = MockObject.AddArrayObject(targetTestHelpers, builder, SingleDimensionArrayAddress, singleDimension);
+                builder = MockObject.AddArrayObject(targetTestHelpers, builder, MultiDimensionArrayAddress, multiDimension);
+                builder = MockObject.AddArrayObject(targetTestHelpers, builder, NonZeroLowerBoundArrayAddress, nonZeroLowerBound);
                 return builder;
             },
             (target) =>
@@ -250,8 +140,8 @@ public unsafe class ObjectTests
                     TargetPointer data = contract.GetArrayData(SingleDimensionArrayAddress, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds);
                     Assert.Equal(SingleDimensionArrayAddress + targetTestHelpers.ArrayBaseBaseSize - targetTestHelpers.ObjHeaderSize, data.Value);
                     Assert.Equal((uint)singleDimension.Length, count);
-                    Assert.Equal(SingleDimensionArrayAddress + (ulong)ArrayTypeInfo.Fields["m_NumComponents"].Offset, boundsStart.Value);
-                    Assert.Equal(TestArrayBoundsZeroGlobalAddress, lowerBounds.Value);
+                    Assert.Equal(SingleDimensionArrayAddress + (ulong)MockObject.Types(targetTestHelpers)[DataType.Array].Fields["m_NumComponents"].Offset, boundsStart.Value);
+                    Assert.Equal(MockObject.TestArrayBoundsZeroGlobalAddress, lowerBounds.Value);
                 }
                 {
                     TargetPointer data = contract.GetArrayData(MultiDimensionArrayAddress, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds);

--- a/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
+++ b/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
@@ -130,9 +130,9 @@ internal unsafe class TargetTestHelpers
         return $"\"{name}\":{{{string.Join(',', fields)}}}";
     }
 
-    public static string MakeTypesJson(IEnumerable<(DataType Type, Target.TypeInfo Info)> types)
+    public static string MakeTypesJson(IDictionary<DataType, Target.TypeInfo> types)
     {
-        return string.Join(',', types.Select(t => GetTypeJson(t.Type.ToString(), t.Info)));
+        return string.Join(',', types.Select(t => GetTypeJson(t.Key.ToString(), t.Value)));
     }
 
     public static string MakeGlobalsJson(IEnumerable<(string Name, ulong Value, string? Type)> globals)

--- a/src/native/managed/cdacreader/tests/TargetTests.cs
+++ b/src/native/managed/cdacreader/tests/TargetTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -11,28 +12,27 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 
 public unsafe class TargetTests
 {
-
-    private static readonly (DataType Type, Target.TypeInfo Info)[] TestTypes =
-   [
+    private static readonly Dictionary<DataType, Target.TypeInfo> TestTypes = new()
+    {
         // Size and fields
-        (DataType.Thread, new(){
+        [DataType.Thread] = new(){
             Size = 56,
             Fields = {
                 { "Field1", new(){ Offset = 8, Type = DataType.uint16, TypeName = DataType.uint16.ToString() }},
                 { "Field2", new(){ Offset = 16, Type = DataType.GCHandle, TypeName = DataType.GCHandle.ToString() }},
                 { "Field3", new(){ Offset = 32 }}
-            }}),
+            }},
         // Fields only
-        (DataType.ThreadStore, new(){
+        [DataType.ThreadStore] = new(){
             Fields = {
                 { "Field1", new(){ Offset = 0, TypeName = "FieldType" }},
                 { "Field2", new(){ Offset = 8 }}
-            }}),
+            }},
         // Size only
-        (DataType.GCHandle, new(){
+        [DataType.GCHandle] = new(){
             Size = 8
-        })
-    ];
+        }
+    };
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]


### PR DESCRIPTION
- Add `Array` data descriptor
- Add `GetArrayData` to `Object` contract
  - Introduces a dependency on `RuntimeTypeSystem` contract
- Make cDAC implement `ISOSDacInterface::GetObjectData` except for handling CCW/RCWs
  - Returns E_NOTIMPL when runtime supports COM
  - Validated in debugger that cDAC and DAC return the same values for some test single and multidimensional arrays
- Pull out shared test helpers for adding different data to the mock target

Contributes to https://github.com/dotnet/runtime/issues/99302

Ran SOS unit tests from the dotnet/diagnostics repo using a private build to replace the two latest runtimes (not the one that matches the sdk) used in the tests.