### PR TITLE
Correctly identify when an unmanaged exception hijack is occurring and display unmanaged frames in callstack

### DIFF
--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -13506,6 +13506,8 @@ bool CordbProcess::IsSpecialStackOverflowCase(CordbUnmanagedThread *pUThread, co
 #ifdef FEATURE_INTEROP_DEBUGGING
 bool CordbProcess::IsUnmanagedThreadHijacked(ICorDebugThread * pICorDebugThread)
 {
+    PUBLIC_REENTRANT_API_ENTRY_FOR_SHIM(this);
+
     if (GetShim() == NULL || !IsInteropDebugging())
     {
         return false;

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -13503,6 +13503,38 @@ bool CordbProcess::IsSpecialStackOverflowCase(CordbUnmanagedThread *pUThread, co
     return true;
 }
 
+#ifdef FEATURE_INTEROP_DEBUGGING
+bool CordbProcess::IsUnmanagedThreadHijacked(ICorDebugThread * pICorDebugThread)
+{
+    if (GetShim() == NULL || !IsInteropDebugging())
+    {
+        return false;
+    }
+
+    {
+        RSLockHolder lockHolder(GetProcessLock());
+        CordbThread * pCordbThread = static_cast<CordbThread *> (pICorDebugThread);
+        HRESULT hr = pCordbThread->EnsureThreadIsAlive();
+        if (FAILED(hr))
+        {
+            return false;
+        }
+
+        // And only if we have a CordbUnmanagedThread and we are hijacked to code:Debugger::GenericHijackFunc
+        CordbUnmanagedThread * pUT = GetUnmanagedThread(pCordbThread->GetVolatileOSThreadID());
+        if (pUT != NULL)
+        {
+            if (pUT->IsFirstChanceHijacked() || pUT->IsGenericHijacked())
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+#endif // FEATURE_INTEROP_DEBUGGING
+
+
 //-----------------------------------------------------------------------------
 // Longhorn broke ContinueDebugEvent.
 // In previous OS releases, DBG_CONTINUE would continue a  non-continuable exception.

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -2880,7 +2880,9 @@ public:
 
     virtual bool IsThreadSuspendedOrHijacked(ICorDebugThread * pThread) = 0;
 
+#ifdef FEATURE_INTEROP_DEBUGGING
     virtual bool IsUnmanagedThreadHijacked(ICorDebugThread * pICorDebugThread) = 0;
+#endif
 };
 
 

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -2879,6 +2879,8 @@ public:
     virtual void RequestSyncAtEvent()= 0;
 
     virtual bool IsThreadSuspendedOrHijacked(ICorDebugThread * pThread) = 0;
+
+    virtual bool IsUnmanagedThreadHijacked(ICorDebugThread * pICorDebugThread) = 0;
 };
 
 
@@ -3462,6 +3464,8 @@ public:
         _ASSERTE(ThreadHoldsProcessLock());
         return m_unmanagedThreads.GetBase(dwThreadId);
     }
+
+    virtual bool IsUnmanagedThreadHijacked(ICorDebugThread * pICorDebugThread);
 #endif // FEATURE_INTEROP_DEBUGGING
 
     /*

--- a/src/coreclr/debug/di/shimpriv.h
+++ b/src/coreclr/debug/di/shimpriv.h
@@ -644,7 +644,7 @@ protected:
 class ShimStackWalk
 {
 public:
-    ShimStackWalk(ShimProcess * pProcess, ICorDebugThread * pThread);
+    ShimStackWalk(ShimProcess * pProcess, ICorDebugThread * pThread, bool fIsHijacked);
     ~ShimStackWalk();
 
     // These functions do not adjust the reference count.
@@ -844,6 +844,8 @@ private:
     // the thread on which we are doing a stackwalk, i.e. the "owning" thread
     RSExtSmartPtr<ShimProcess>     m_pProcess;
     RSExtSmartPtr<ICorDebugThread> m_pThread;
+
+    BOOL m_isHijacked;
 };
 
 

--- a/src/coreclr/debug/di/shimpriv.h
+++ b/src/coreclr/debug/di/shimpriv.h
@@ -644,7 +644,7 @@ protected:
 class ShimStackWalk
 {
 public:
-    ShimStackWalk(ShimProcess * pProcess, ICorDebugThread * pThread, bool fIsHijacked);
+    ShimStackWalk(ShimProcess * pProcess, ICorDebugThread * pThread);
     ~ShimStackWalk();
 
     // These functions do not adjust the reference count.
@@ -844,8 +844,6 @@ private:
     // the thread on which we are doing a stackwalk, i.e. the "owning" thread
     RSExtSmartPtr<ShimProcess>     m_pProcess;
     RSExtSmartPtr<ICorDebugThread> m_pThread;
-
-    BOOL m_isHijacked;
 };
 
 

--- a/src/coreclr/debug/di/shimpriv.h
+++ b/src/coreclr/debug/di/shimpriv.h
@@ -431,6 +431,8 @@ public:
 
     bool IsThreadSuspendedOrHijacked(ICorDebugThread * pThread);
 
+    bool IsUnmanagedThreadHijacked(ICorDebugThread * pThread);
+
     // Expose m_attached to CordbProcess.
     bool GetAttached();
 

--- a/src/coreclr/debug/di/shimprocess.cpp
+++ b/src/coreclr/debug/di/shimprocess.cpp
@@ -1654,3 +1654,12 @@ bool ShimProcess::IsThreadSuspendedOrHijacked(ICorDebugThread * pThread)
 {
     return m_pProcess->IsThreadSuspendedOrHijacked(pThread);
 }
+
+bool ShimProcess::IsUnmanagedThreadHijacked(ICorDebugThread * pThread)
+{
+#ifdef FEATURE_INTEROP_DEBUGGING
+    return m_pProcess->IsUnmanagedThreadHijacked(pThread);
+#else
+    return false;
+#endif
+}

--- a/src/coreclr/debug/di/shimprocess.cpp
+++ b/src/coreclr/debug/di/shimprocess.cpp
@@ -1487,7 +1487,8 @@ ShimStackWalk * ShimProcess::LookupOrCreateShimStackWalk(ICorDebugThread * pThre
     if (pSW == NULL)
     {
         // create one if it's not found and add it to the hash table
-        NewHolder<ShimStackWalk> pNewSW(new ShimStackWalk(this, pThread));
+        bool fIsHijacked = m_pProcess->IsUnmanagedThreadHijacked(pThread);
+        NewHolder<ShimStackWalk> pNewSW(new ShimStackWalk(this, pThread, fIsHijacked));
 
         {
             // Do the lookup again under the Shim lock, and only add the new ShimStackWalk if no other thread

--- a/src/coreclr/debug/di/shimprocess.cpp
+++ b/src/coreclr/debug/di/shimprocess.cpp
@@ -1487,8 +1487,7 @@ ShimStackWalk * ShimProcess::LookupOrCreateShimStackWalk(ICorDebugThread * pThre
     if (pSW == NULL)
     {
         // create one if it's not found and add it to the hash table
-        bool fIsHijacked = m_pProcess->IsUnmanagedThreadHijacked(pThread);
-        NewHolder<ShimStackWalk> pNewSW(new ShimStackWalk(this, pThread, fIsHijacked));
+        NewHolder<ShimStackWalk> pNewSW(new ShimStackWalk(this, pThread));
 
         {
             // Do the lookup again under the Shim lock, and only add the new ShimStackWalk if no other thread

--- a/src/coreclr/debug/di/shimstackwalk.cpp
+++ b/src/coreclr/debug/di/shimstackwalk.cpp
@@ -22,13 +22,14 @@ static const ULONG32 REGISTER_AMD64_MAX = REGISTER_AMD64_XMM15 + 1;
 static const ULONG32 MAX_MASK_COUNT     = (REGISTER_AMD64_MAX + 7) >> 3;
 #endif
 
-ShimStackWalk::ShimStackWalk(ShimProcess * pProcess, ICorDebugThread * pThread)
+ShimStackWalk::ShimStackWalk(ShimProcess * pProcess, ICorDebugThread * pThread, bool fIsHijacked)
   : m_pChainEnumList(NULL),
     m_pFrameEnumList(NULL)
 {
     // The following assignments increment the ref count.
     m_pProcess.Assign(pProcess);
     m_pThread.Assign(pThread);
+    m_isHijacked = fIsHijacked;
 
     Populate();
 }
@@ -155,7 +156,7 @@ BOOL ShimStackWalk::ShouldTrackUMChain(StackWalkInfo * pswInfo)
     // returning false above. We need to check the exception state to make sure we don't
     // track the chain in this case. Since we know the type of Frame we are dealing with, 
     // we can make a more accurate determination of whether we should track the chain.
-    if (GetInternalFrameType(pswInfo->GetCurrentInternalFrame()) == STUBFRAME_EXCEPTION) 
+    if (!m_isHijacked && GetInternalFrameType(pswInfo->GetCurrentInternalFrame()) == STUBFRAME_EXCEPTION) 
         return FALSE;
 
     return TRUE;

--- a/src/coreclr/debug/di/shimstackwalk.cpp
+++ b/src/coreclr/debug/di/shimstackwalk.cpp
@@ -156,12 +156,7 @@ BOOL ShimStackWalk::ShouldTrackUMChain(StackWalkInfo * pswInfo)
     // track the chain in this case. Since we know the type of Frame we are dealing with, 
     // we can make a more accurate determination of whether we should track the chain.
     // However if we are interop debugging and the thread is hijacked, we should track the chain.
-    if (
-#ifdef FEATURE_INTEROP_DEBUGGING
-        !m_pProcess->IsUnmanagedThreadHijacked(m_pThread) && 
-#endif
-        GetInternalFrameType(pswInfo->GetCurrentInternalFrame()) == STUBFRAME_EXCEPTION
-    ) 
+    if (!m_pProcess->IsUnmanagedThreadHijacked(m_pThread) && GetInternalFrameType(pswInfo->GetCurrentInternalFrame()) == STUBFRAME_EXCEPTION) 
         return FALSE;
 
     return TRUE;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105116