### PR TITLE
DATAS tuning fixes

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -33520,7 +33520,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
     plan_generation_starts (consing_gen);
 #endif //!USE_REGIONS
 
-    //descr_generations ("AP");
+    descr_generations ("AP");
 
     print_free_and_plug ("AP");
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3326,7 +3326,7 @@ gc_heap::dt_high_frag_p (gc_tuning_point tp,
                     }
                 }
 #endif //!MULTIPLE_HEAPS
-                size_t fr = generation_unusable_fragmentation (generation_of (gen_number));
+                size_t fr = generation_unusable_fragmentation (generation_of (gen_number), heap_number);
                 ret = (fr > dd_fragmentation_limit(dd));
                 if (ret)
                 {
@@ -21337,6 +21337,68 @@ bool gc_heap::init_table_for_region (int gen_number, heap_segment* region)
     return true;
 }
 #endif //USE_REGIONS
+
+// The following 2 methods Use integer division to prevent potential floating point exception.
+// FPE may occur if we use floating point division because of speculative execution.
+//
+// Return the percentage of efficiency (between 0 and 100) of the allocator. 
+inline
+size_t gc_heap::generation_allocator_efficiency_percent (generation* inst)
+{
+#ifdef DYNAMIC_HEAP_COUNT
+    if (dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes)
+    {
+        uint64_t total_plan_allocated = generation_total_plan_allocated (inst);
+        uint64_t condemned_allocated = generation_condemned_allocated (inst);
+        return ((total_plan_allocated == 0) ? 0 : (100 * (total_plan_allocated - condemned_allocated) / total_plan_allocated));
+    }
+    else
+#endif //DYNAMIC_HEAP_COUNT
+    {
+        uint64_t free_obj_space = generation_free_obj_space (inst);
+        uint64_t free_list_allocated = generation_free_list_allocated (inst);
+        if ((free_list_allocated + free_obj_space) == 0)
+            return 0;
+        return (size_t)((100 * free_list_allocated) / (free_list_allocated + free_obj_space));
+    }
+}
+
+inline
+size_t gc_heap::generation_unusable_fragmentation (generation* inst, int hn)
+{
+#ifdef DYNAMIC_HEAP_COUNT
+    if (dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes)
+    {
+        uint64_t total_plan_allocated = generation_total_plan_allocated (inst);
+        uint64_t condemned_allocated = generation_condemned_allocated (inst);
+        uint64_t unusable_frag = 0;
+        size_t fo_space = (((ptrdiff_t)generation_free_obj_space (inst) < 0) ? 0 : generation_free_obj_space (inst));
+
+        if (total_plan_allocated != 0)
+        {
+            unusable_frag = fo_space + (condemned_allocated * generation_free_list_space (inst) / total_plan_allocated);
+        }
+
+        dprintf (6666, ("h%d g%d FLa: %Id, ESa: %Id, Ca: %Id | FO: %Id, FL %Id, fl effi %.3f, unusable fl is %Id",
+            hn, inst->gen_num,
+            generation_free_list_allocated (inst), generation_end_seg_allocated (inst), (size_t)condemned_allocated,
+            fo_space, generation_free_list_space (inst),
+            ((total_plan_allocated == 0) ? 1.0 : ((float)(total_plan_allocated - condemned_allocated) / (float)total_plan_allocated)),
+            (size_t)unusable_frag));
+
+        return (size_t)unusable_frag;
+    }
+    else
+#endif //DYNAMIC_HEAP_COUNT
+    {
+        uint64_t free_obj_space = generation_free_obj_space (inst);
+        uint64_t free_list_allocated = generation_free_list_allocated (inst);
+        uint64_t free_list_space = generation_free_list_space (inst);
+        if ((free_list_allocated + free_obj_space) == 0)
+            return 0;
+        return (size_t)(free_obj_space + (free_obj_space * free_list_space) / (free_list_allocated + free_obj_space));
+    }
+}
 
 #ifdef _PREFAST_
 #pragma warning(push)
@@ -43812,6 +43874,24 @@ void gc_heap::compute_new_dynamic_data (int gen_number)
     size_t total_gen_size = generation_size (gen_number);
     //keep track of fragmentation
     dd_fragmentation (dd) = generation_free_list_space (gen) + generation_free_obj_space (gen);
+
+    // We need to reset the condemned alloc for the condemned generation because it will participate in the free list efficiency
+    // calculation. And if a generation is condemned, it means all the allocations into this generation during that GC will be
+    // condemned and it wouldn't make sense to use this value to calculate the FL efficiency since at this point the FL hasn't
+    // been built.
+    generation_condemned_allocated (gen) = 0;
+
+    if (settings.concurrent)
+    {
+        // For BGC we could have non zero values due to gen1 FGCs. We reset all 3 allocs to start anew.
+        generation_free_list_allocated (gen) = 0;
+        generation_end_seg_allocated (gen) = 0;
+    }
+    else
+    {
+        assert (generation_free_list_allocated (gen) == 0);
+        assert (generation_end_seg_allocated (gen) == 0);
+    }
 
     // make sure the subtraction below doesn't overflow
     if (dd_fragmentation (dd) <= total_gen_size)

--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -344,8 +344,8 @@ inline bool IsServerHeap()
 #define MAX_LONGPATH 1024
 #endif // MAX_LONGPATH
 
- #define TRACE_GC
- #define SIMPLE_DPRINTF
+// #define TRACE_GC
+// #define SIMPLE_DPRINTF
 
 #ifdef TRACE_GC
 #define MIN_CUSTOM_LOG_LEVEL 7
@@ -374,8 +374,7 @@ inline bool IsServerHeap()
 HRESULT initialize_log_file();
 void flush_gc_log (bool);
 void GCLog (const char *fmt, ... );
-//#define dprintf(l,x) {if ((l == 1) || (l == GTC_LOG)) {GCLog x;}}
-#define dprintf(l,x) {if (l == 6666) {GCLog x;}}
+#define dprintf(l,x) {if ((l == 1) || (l == GTC_LOG)) {GCLog x;}}
 #else //SIMPLE_DPRINTF
 #ifdef HOST_64BIT
 #define dprintf(l,x) STRESS_LOG_VA(l,x);

--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -344,8 +344,8 @@ inline bool IsServerHeap()
 #define MAX_LONGPATH 1024
 #endif // MAX_LONGPATH
 
-// #define TRACE_GC
-// #define SIMPLE_DPRINTF
+ #define TRACE_GC
+ #define SIMPLE_DPRINTF
 
 #ifdef TRACE_GC
 #define MIN_CUSTOM_LOG_LEVEL 7
@@ -374,7 +374,8 @@ inline bool IsServerHeap()
 HRESULT initialize_log_file();
 void flush_gc_log (bool);
 void GCLog (const char *fmt, ... );
-#define dprintf(l,x) {if ((l == 1) || (l == GTC_LOG)) {GCLog x;}}
+//#define dprintf(l,x) {if ((l == 1) || (l == GTC_LOG)) {GCLog x;}}
+#define dprintf(l,x) {if (l == 6666) {GCLog x;}}
 #else //SIMPLE_DPRINTF
 #ifdef HOST_64BIT
 #define dprintf(l,x) STRESS_LOG_VA(l,x);

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2110,6 +2110,9 @@ private:
     PER_HEAP_METHOD void walk_survivors_relocation (void* profiling_context, record_surv_fn fn);
     PER_HEAP_METHOD void walk_survivors_for_uoh (void* profiling_context, record_surv_fn fn, int gen_number);
 
+    PER_HEAP_ISOLATED_METHOD size_t generation_allocator_efficiency_percent (generation* inst);
+    PER_HEAP_ISOLATED_METHOD size_t generation_unusable_fragmentation (generation* inst, int hn);
+
     PER_HEAP_METHOD int generation_to_condemn (int n,
                                BOOL* blocking_collection_p,
                                BOOL* elevation_requested_p,
@@ -5825,6 +5828,12 @@ size_t& generation_sweep_allocated (generation* inst)
 {
     return inst->sweep_allocated;
 }
+// These are allocations we did while doing planning, we use this to calculate free list efficiency.
+inline
+size_t generation_total_plan_allocated (generation* inst)
+{
+    return (inst->free_list_allocated + inst->end_seg_allocated + inst->condemned_allocated);
+}
 #ifdef DOUBLY_LINKED_FL
 inline
 BOOL&  generation_set_bgc_mark_bit_p (generation* inst)
@@ -5854,32 +5863,6 @@ size_t& generation_allocated_since_last_pin (generation* inst)
     return inst->allocated_since_last_pin;
 }
 #endif //FREE_USAGE_STATS
-
-// Return the percentage of efficiency (between 0 and 100) of the allocator.
-inline
-size_t generation_allocator_efficiency_percent (generation* inst)
-{
-    // Use integer division to prevent potential floating point exception.
-    // FPE may occur if we use floating point division because of speculative execution.
-    uint64_t free_obj_space = generation_free_obj_space (inst);
-    uint64_t free_list_allocated = generation_free_list_allocated (inst);
-    if ((free_list_allocated + free_obj_space) == 0)
-      return 0;
-    return (size_t)((100 * free_list_allocated) / (free_list_allocated + free_obj_space));
-}
-
-inline
-size_t generation_unusable_fragmentation (generation* inst)
-{
-    // Use integer division to prevent potential floating point exception.
-    // FPE may occur if we use floating point division because of speculative execution.
-    uint64_t free_obj_space = generation_free_obj_space (inst);
-    uint64_t free_list_allocated = generation_free_list_allocated (inst);
-    uint64_t free_list_space = generation_free_list_space (inst);
-    if ((free_list_allocated + free_obj_space) == 0)
-      return 0;
-    return (size_t)(free_obj_space + (free_obj_space * free_list_space) / (free_list_allocated + free_obj_space));
-}
 
 #define plug_skew           sizeof(ObjHeader)
 // We always use USE_PADDING_TAIL when fitting so items on the free list should be

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4371,7 +4371,8 @@ private:
         {
             int adjustment_idx = (current_adjustment_index + recorded_adjustment_size + distance_to_current) % recorded_adjustment_size;
             adjustment* adj = &adjustment_history[adjustment_idx];
-            dprintf (6666, ("adj->metric %d, metric %d, adj#%d: hc_change > 0 = %d, change_int > 0 = %d",
+            dprintf (6666, ("adj->metric %s, metric %s, adj#%d: hc_change > 0 = %d, change_int > 0 = %d",
+                str_adjust_metrics[adj->metric], str_adjust_metrics[metric],
                 adjustment_idx, (adj->hc_change > 0), (change_int > 0)));
             if ((adj->metric == metric) && ((change_int > 0) == (adj->hc_change > 0)))
             {
@@ -5088,6 +5089,12 @@ private:
     // If the last full GC is blocking, this is that GC's index; for BGC, this is the settings.gc_index
     // when the BGC ended.
     PER_HEAP_ISOLATED_FIELD_MAINTAINED size_t gc_index_full_gc_end;
+
+#ifdef BACKGROUND_GC
+    // This is set when change_heap_count wants the next GC to be a BGC for rethreading gen2 FL
+    // and reset during that BGC.
+    PER_HEAP_ISOLATED_FIELD_MAINTAINED bool trigger_bgc_for_rethreading_p;
+#endif //BACKGROUND_GC
 #endif //DYNAMIC_HEAP_COUNT
 
     /****************************************************/

--- a/src/coreclr/inc/gcmsg.inl
+++ b/src/coreclr/inc/gcmsg.inl
@@ -44,13 +44,13 @@
     static const char* gcDetailedStartMsg()
     {
         STATIC_CONTRACT_LEAF;
-        return "*GC* %d(gen0:%d)(%d)(alloc: %zd)(%s)(%d)(%d)";
+        return "*GC* %d(gen0:%d)(%d)(alloced for %.3fms, g0 %zd (b: %zd, %zd/h) (%.3fmb/ms), g3 %zd (%.3fmb/ms), g4 %zd (%.3fmb/ms))(%s)(%d)(%d)(heap size: %.3fmb max: %.3fmb)";
     }
 
     static const char* gcDetailedEndMsg()
     {
         STATIC_CONTRACT_LEAF;
-        return "*EGC* %zd(gen0:%zd)(%zd)(%d)(%s)(%s)(%s)(ml: %d->%d)\n";
+        return "*EGC* %zd(gen0:%zd)(heap size: %.3fmb)(%d)(%s)(%s)(%s)(ml: %d->%d)\n";
     }
 
     static const char* gcStartMarkMsg()


### PR DESCRIPTION
This includes the following tuning fixes

+ unusable fragmentation computation - this was causing gen1's unnecessarily. Also avoid volatility.
+ don't rethread gen2 FL items during HC change because it might take too long. Instead trigger a BGC and disable gen1 GCs during this BGC. During BGC sweep we refresh the gen2 FL completely.
+ reverse the order of calling `distribute_free_regions`/`age_free_regions` and setting BCD - what happened was each time we had to get new regions for alloc because BCD can be >> BCS. And since we don't get regions from decommit list, we keep accumulating more. For this I also cleaned up decommit_ephemeral_segment_pages and related methods and only have them defined when needed. 
+ initialize generation_skip_ratio to 100, not 0 when we recommission a heap - this was causing every eph GC right after an HC change to unnecessarily be a gen1 GC
+ set dd_fragmentation for gen1 during BGC sweep otherwise we can hit the assert `assert (free_list_space_decrease <= dd_fragmentation (dd));` in `merge_fl_from_other_heaps` because frag simply hasn't been updated after a BGC. This can also be reproed by checking for frag at the beginning of a GC.
+ if we haven't done a gen2 GC yet, and we are limited by DATAS for HC, we should trigger a gen2 immediately. this definitely helps for microbenchmarks but I'll need to make this more generic and not limited to just the initial gen2. But that'll come in a separate PR.

and some instrumentation changes
+ do_pre_gc/do_post_gc
+ other dprintf changes for DATAS investigation (so all you need to do is turning logging on)