### PR TITLE
Simplify platform attribute for AesGcm and ChaCha20Poly1305

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Aead.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Aead.cs
@@ -32,7 +32,6 @@ internal static partial class Interop
         [UnsupportedOSPlatform("tvos")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
-        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void ChaCha20Poly1305Encrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,
@@ -70,7 +69,6 @@ internal static partial class Interop
         [UnsupportedOSPlatform("tvos")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
-        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void ChaCha20Poly1305Decrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,
@@ -115,7 +113,6 @@ internal static partial class Interop
         [UnsupportedOSPlatform("tvos")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
-        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void AesGcmEncrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,
@@ -153,7 +150,6 @@ internal static partial class Interop
         [UnsupportedOSPlatform("tvos")]
         [SupportedOSPlatform("ios13.0")]
         [SupportedOSPlatform("tvos13.0")]
-        [SupportedOSPlatform("maccatalyst")]
         internal static unsafe void AesGcmDecrypt(
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> nonce,

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -123,7 +123,6 @@ namespace System.Security.Cryptography
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
     [System.Runtime.Versioning.SupportedOSPlatform("ios13.0")]
     [System.Runtime.Versioning.SupportedOSPlatform("tvos13.0")]
-    [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
     public sealed partial class AesGcm : System.IDisposable
     {
         [System.ObsoleteAttribute("AesGcm should indicate the required tag size for encryption and decryption. Use a constructor that accepts the tag size.", DiagnosticId="SYSLIB0053", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
@@ -289,7 +288,6 @@ namespace System.Security.Cryptography
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
     [System.Runtime.Versioning.SupportedOSPlatform("ios13.0")]
     [System.Runtime.Versioning.SupportedOSPlatform("tvos13.0")]
-    [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
     public sealed partial class ChaCha20Poly1305 : System.IDisposable
     {
         public ChaCha20Poly1305(byte[] key) { }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesGcm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesGcm.cs
@@ -12,7 +12,6 @@ namespace System.Security.Cryptography
     [UnsupportedOSPlatform("tvos")]
     [SupportedOSPlatform("ios13.0")]
     [SupportedOSPlatform("tvos13.0")]
-    [SupportedOSPlatform("maccatalyst")]
     public sealed partial class AesGcm : IDisposable
     {
         private const int NonceSize = 12;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ChaCha20Poly1305.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ChaCha20Poly1305.cs
@@ -11,7 +11,6 @@ namespace System.Security.Cryptography
     [UnsupportedOSPlatform("tvos")]
     [SupportedOSPlatform("ios13.0")]
     [SupportedOSPlatform("tvos13.0")]
-    [SupportedOSPlatform("maccatalyst")]
     public sealed partial class ChaCha20Poly1305 : IDisposable
     {
         // Per https://tools.ietf.org/html/rfc7539, ChaCha20Poly1305 AEAD requires a 256-bit key and 96-bit nonce,


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/105409, I verified the analyzer works correctly with just having the annotation for iOS.