### PR TITLE
JIT: Fix placement of `GT_START_NOGC` for tailcalls in face of bulk copy with write barrier calls

### DIFF
--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1872,6 +1872,22 @@ GenTree* LIR::LastNode(GenTree** nodes, size_t numNodes)
     return lastNode;
 }
 
+//------------------------------------------------------------------------
+// LIR::FirstNode:
+//    Given two nodes in the same block range, find which node appears first.
+//
+// Arguments:
+//    node1 - The first node
+//    node2 - The second node
+//
+// Returns:
+//    Node that appears first.
+//
+GenTree* LIR::FirstNode(GenTree* node1, GenTree* node2)
+{
+    return LastNode(node1, node2) == node1 ? node2 : node1;
+}
+
 #ifdef DEBUG
 void GenTree::dumpLIRFlags()
 {

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -317,6 +317,7 @@ public:
 
     static GenTree* LastNode(GenTree* node1, GenTree* node2);
     static GenTree* LastNode(GenTree** nodes, size_t numNodes);
+    static GenTree* FirstNode(GenTree* node1, GenTree* node2);
 };
 
 inline void GenTree::SetUnusedValue()

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3060,52 +3060,22 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
     // call could over-write the stack arg that is setup earlier.
     ArrayStack<GenTree*> putargs(comp->getAllocator(CMK_ArrayStack));
 
-    for (CallArg& arg : call->gtArgs.EarlyArgs())
+    for (CallArg& arg : call->gtArgs.Args())
     {
-        if (arg.GetEarlyNode()->OperIs(GT_PUTARG_STK))
+        if (arg.GetNode()->OperIs(GT_PUTARG_STK))
         {
-            putargs.Push(arg.GetEarlyNode());
-        }
-    }
-
-    for (CallArg& arg : call->gtArgs.LateArgs())
-    {
-        if (arg.GetLateNode()->OperIs(GT_PUTARG_STK))
-        {
-            putargs.Push(arg.GetLateNode());
+            putargs.Push(arg.GetNode());
         }
     }
 
     GenTree* startNonGCNode = nullptr;
-    if (!putargs.Empty())
+    if (putargs.Height() > 0)
     {
-        // Get the earliest operand of the first PUTARG_STK node. We will make
-        // the required copies of args before this node.
-        bool     unused;
-        GenTree* insertionPoint = BlockRange().GetTreeRange(putargs.Bottom(), &unused).FirstNode();
-        // Insert GT_START_NONGC node before we evaluate the PUTARG_STK args.
-        // Note that if there are no args to be setup on stack, no need to
-        // insert GT_START_NONGC node.
-        startNonGCNode = new (comp, GT_START_NONGC) GenTree(GT_START_NONGC, TYP_VOID);
-        BlockRange().InsertBefore(insertionPoint, startNonGCNode);
-
-        // Gc-interruptability in the following case:
-        //     foo(a, b, c, d, e) { bar(a, b, c, d, e); }
-        //     bar(a, b, c, d, e) { foo(a, b, d, d, e); }
-        //
-        // Since the instruction group starting from the instruction that sets up first
-        // stack arg to the end of the tail call is marked as non-gc interruptible,
-        // this will form a non-interruptible tight loop causing gc-starvation. To fix
-        // this we insert GT_NO_OP as embedded stmt before GT_START_NONGC, if the method
-        // has a single basic block and is not a GC-safe point.  The presence of a single
-        // nop outside non-gc interruptible region will prevent gc starvation.
-        if ((comp->fgBBcount == 1) && !comp->compCurBB->HasFlag(BBF_GC_SAFE_POINT))
+        GenTree* firstPutargStk = putargs.Bottom(0);
+        for (int i = 1; i < putargs.Height(); i++)
         {
-            assert(comp->fgFirstBB == comp->compCurBB);
-            GenTree* noOp = new (comp, GT_NO_OP) GenTree(GT_NO_OP, TYP_VOID);
-            BlockRange().InsertBefore(startNonGCNode, noOp);
+            firstPutargStk = LIR::FirstNode(firstPutargStk, putargs.Bottom(i));
         }
-
         // Since this is a fast tailcall each PUTARG_STK will place the argument in the
         // _incoming_ arg space area. This will effectively overwrite our already existing
         // incoming args that live in that area. If we have later uses of those args, this
@@ -3175,10 +3145,10 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
                 GenTree* lookForUsesFrom = put->gtNext;
                 if (overwrittenStart != argStart)
                 {
-                    lookForUsesFrom = insertionPoint;
+                    lookForUsesFrom = firstPutargStk;
                 }
 
-                RehomeArgForFastTailCall(callerArgLclNum, insertionPoint, lookForUsesFrom, call);
+                RehomeArgForFastTailCall(callerArgLclNum, firstPutargStk, lookForUsesFrom, call);
                 // The above call can introduce temps and invalidate the pointer.
                 callerArgDsc = comp->lvaGetDesc(callerArgLclNum);
 
@@ -3192,9 +3162,32 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
                 unsigned int fieldsEnd   = fieldsFirst + callerArgDsc->lvFieldCnt;
                 for (unsigned int j = fieldsFirst; j < fieldsEnd; j++)
                 {
-                    RehomeArgForFastTailCall(j, insertionPoint, lookForUsesFrom, call);
+                    RehomeArgForFastTailCall(j, firstPutargStk, lookForUsesFrom, call);
                 }
             }
+        }
+
+        // Now insert GT_START_NONGC node before we evaluate the first PUTARG_STK.
+        // Note that if there are no args to be setup on stack, no need to
+        // insert GT_START_NONGC node.
+        startNonGCNode = new (comp, GT_START_NONGC) GenTree(GT_START_NONGC, TYP_VOID);
+        BlockRange().InsertBefore(firstPutargStk, startNonGCNode);
+
+        // Gc-interruptability in the following case:
+        //     foo(a, b, c, d, e) { bar(a, b, c, d, e); }
+        //     bar(a, b, c, d, e) { foo(a, b, d, d, e); }
+        //
+        // Since the instruction group starting from the instruction that sets up first
+        // stack arg to the end of the tail call is marked as non-gc interruptible,
+        // this will form a non-interruptible tight loop causing gc-starvation. To fix
+        // this we insert GT_NO_OP as embedded stmt before GT_START_NONGC, if the method
+        // has a single basic block and is not a GC-safe point.  The presence of a single
+        // nop outside non-gc interruptible region will prevent gc starvation.
+        if ((comp->fgBBcount == 1) && !comp->compCurBB->HasFlag(BBF_GC_SAFE_POINT))
+        {
+            assert(comp->fgFirstBB == comp->compCurBB);
+            GenTree* noOp = new (comp, GT_NO_OP) GenTree(GT_NO_OP, TYP_VOID);
+            BlockRange().InsertBefore(startNonGCNode, noOp);
         }
     }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3069,7 +3069,7 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
     }
 
     GenTree* startNonGCNode = nullptr;
-    if (putargs.Height() > 0)
+    if (!putargs.Empty())
     {
         GenTree* firstPutargStk = putargs.Bottom(0);
         for (int i = 1; i < putargs.Height(); i++)


### PR DESCRIPTION
When the JIT generates code for a tailcall it must generate code to write the arguments into the incoming parameter area. Since the GC ness of the arguments of the tailcall may not match the GC ness of the parameters, we have to disable GC before we start writing these. This is done by finding the earliest `GT_PUTARG_STK` node and placing the start of the NOGC region right before it.

In addition, there is logic to take care of potential overlap between the arguments and parameters. For example, if the call has an operand that uses one of the parameters, then we must take care that we do not override that parameter with the tailcall argument before the use of it. To do so, we sometimes may need to introduce copies from the parameter locals to locals on the stack frame.

This used to work fine, however, with #101761 we started transforming block copies into managed calls in certain scenarios. It was possible for the JIT to decide to introduce a copy to a local and for this transformation to then kick in. This would cause us to end up with the managed helper call after starting the nogc region. In checked builds this would hit an assert during GC scan; in release builds, it would end up with corrupted data.

The fix here is to make sure we insert the `GT_START_NOGC` after all the potential temporary copies we may introduce as part of the tailcall logic.

There was an additional assumption that the first `PUTARG_STK` operand was the earliest one in execution order. That is not guaranteed, so this change stops relying on that as well by introducing a new `LIR::FirstNode` and using that to determine the earliest `PUTARG_STK` node.

Fix #102370
Fix #104123
Fix #105441

I will backport this to preview 7. For preview 6, a workaround of setting `DOTNET_TailCallOpt=0` and `DOTNET_ReadyToRun=0` can be utilized.

Codegen diff in a [test case](https://gist.github.com/jakobbotsch/b7b98e082d7be7a189d2edc23b375a89):
```diff
@@ -1,99 +1,99 @@
 ; Assembly listing for method Program:Foo(System.ValueTuple`2[System.Action`1[Program+LargeStruct],Program+LargeStruct]) (Tier1)
 ; Emitting BLENDED_CODE for X64 with AVX - Unix
 ; Tier1 code
 ; optimized code
 ; rbp based frame
 ; fully interruptible
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T01] (  2,  2   )  struct (104) [rbp+0x10]  do-not-enreg[SF] single-def <System.ValueTuple`2[System.Action`1[Program+LargeStruct],Program+LargeStruct]>
 ;# V01 OutArgs      [V01    ] (  1,  1   )  struct ( 0) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
 ;  V02 rat0         [V02,T00] (  3,  6   )  struct (104) [rbp-0x68]  do-not-enreg[SF] must-init "Fast tail call lowering is creating a new local variable" <System.ValueTuple`2[System.Action`1[Program+LargeStruct],Program+LargeStruct]>
 ;
 ; Lcl frame size = 112
 
 G_M54833_IG01:        ; bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref, nogc <-- Prolog IG
        push     rbp
        sub      rsp, 112
        lea      rbp, [rsp+0x70]
        xor      eax, eax
        mov      qword ptr [rbp-0x68], rax
        vxorps   xmm8, xmm8, xmm8
        vmovdqu  ymmword ptr [rbp-0x60], ymm8
        vmovdqu  ymmword ptr [rbp-0x40], ymm8
        vmovdqu  ymmword ptr [rbp-0x20], ymm8
                                                 ;; size=36 bbWeight=1 PerfScore 9.33
 G_M54833_IG02:        ; bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref
-       nop
-                                                ;; size=1 bbWeight=1 PerfScore 0.25
-G_M54833_IG03:        ; bbWeight=1, nogc, extend
        lea      rdi, bword ptr [rbp-0x68]
        ; byrRegs +[rdi]
        lea      rsi, [rbp+0x10]
        mov      edx, 104
        call     [CORINFO_HELP_BULK_WRITEBARRIER]
        ; byrRegs -[rdi]
        ; gcr arg pop 0
+       nop
+                                                ;; size=20 bbWeight=1 PerfScore 4.50
+G_M54833_IG03:        ; bbWeight=1, nogc, extend
        lea      rdi, [rbp+0x10]
        lea      rsi, [rbp+0x18]
        mov      rcx, gword ptr [rsi]
        ; gcrRegs +[rcx]
        mov      gword ptr [rbp+0x10], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x18], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x20], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x28], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x30], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x38], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x40], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x48], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x50], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x58], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x60], rcx
        add      rsi, 8
        add      rdi, 8
        mov      rcx, gword ptr [rsi]
        mov      gword ptr [rbp+0x68], rcx
        mov      rdi, gword ptr [rbp-0x68]
        ; gcrRegs +[rdi]
        mov      rdi, gword ptr [rdi+0x08]
        mov      rax, gword ptr [rbp-0x68]
        ; gcrRegs +[rax]
-                                                ;; size=211 bbWeight=1 PerfScore 50.75
+                                                ;; size=192 bbWeight=1 PerfScore 46.50
 G_M54833_IG04:        ; bbWeight=1, epilog, nogc, extend
        add      rsp, 112
        pop      rbp
        tail.jmp [rax+0x18]System.Action`1[Program+LargeStruct]:Invoke(Program+LargeStruct):this
                                                 ;; size=9 bbWeight=1 PerfScore 2.75
 
 ; Total bytes of code 257, prolog size 36, PerfScore 63.08, instruction count 68, allocated bytes for code 257 (MethodHash=bbe929ce) for method Program:Foo(System.ValueTuple`2[System.Action`1[Program+LargeStruct],Program+LargeStruct]) (Tier1)
 ; ============================================================
```