### PR TITLE
[iOS] Disable JIT/Directed/PrimitiveABI on apple mobile due to missing native library

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3712,6 +3712,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_ro/**">
             <Issue>https://github.com/dotnet/runtime/issues/92129</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Directed/PrimitiveABI/**">
+            <Issue>https://github.com/dotnet/runtime/issues/92129</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm' or '$(TargetsMobile)' == 'true'">


### PR DESCRIPTION
We currently do not support tests with native libraries on Apple mobile CI https://github.com/dotnet/runtime/issues/92129. Disabling the test to keep the CI clean. Failures https://dev.azure.com/dnceng-public/public/_build/results?buildId=754812&view=logs&j=28c2a171-0c43-5d2a-7ef1-2d2cea8331ba&t=3df1997a-11aa-5246-c452-91536bb3018b.

fyi: @tomeksowi 