### PR TITLE
Only apply StringMarshalling to GeneratedComInterface in fixer when needed even in fix-all

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AddGeneratedComClassFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AddGeneratedComClassFixer.cs
@@ -58,5 +58,7 @@ namespace Microsoft.Interop.Analyzers
         {
             return ImmutableDictionary<string, Option>.Empty;
         }
+
+        protected override ImmutableDictionary<string, Option> CombineOptions(ImmutableDictionary<string, Option> fixAllOptions, ImmutableDictionary<string, Option> diagnosticOptions) => fixAllOptions;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceFixer.cs
@@ -55,6 +55,20 @@ namespace Microsoft.Interop.Analyzers
             return optionsBuilder.ToImmutable();
         }
 
+        protected override ImmutableDictionary<string, Option> CombineOptions(ImmutableDictionary<string, Option> fixAllOptions, ImmutableDictionary<string, Option> diagnosticOptions)
+        {
+            ImmutableDictionary<string, Option> combinedOptions = fixAllOptions;
+            if (fixAllOptions.TryGetValue(AddStringMarshallingOption, out Option fixAllAddStringMarshallingOption)
+                && fixAllAddStringMarshallingOption is Option.Bool(true)
+                && (!diagnosticOptions.TryGetValue(AddStringMarshallingOption, out Option addStringMarshallingOption)
+                    || addStringMarshallingOption is Option.Bool(false)))
+            {
+                combinedOptions = combinedOptions.Remove(AddStringMarshallingOption);
+            }
+
+            return combinedOptions;
+        }
+
         private static async Task ConvertComImportToGeneratedComInterfaceAsync(DocumentEditor editor, SyntaxNode node, bool mayRequireAdditionalWork, bool addStringMarshalling, CancellationToken ct)
         {
             var gen = editor.Generator;
@@ -125,6 +139,5 @@ namespace Microsoft.Interop.Analyzers
 
             MakeNodeParentsPartial(editor, node);
         }
-
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Common/ConvertToSourceGeneratedInteropFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Common/ConvertToSourceGeneratedInteropFixer.cs
@@ -96,6 +96,13 @@ namespace Microsoft.Interop.Analyzers
 
         protected abstract ImmutableDictionary<string, Option> ParseOptionsFromDiagnostic(Diagnostic diagnostic);
 
+        protected abstract ImmutableDictionary<string, Option> CombineOptions(ImmutableDictionary<string, Option> fixAllOptions, ImmutableDictionary<string, Option> diagnosticOptions);
+
+        private ImmutableDictionary<string, Option> GetOptionsForIndividualFix(ImmutableDictionary<string, Option> fixAllOptions, Diagnostic diagnostic)
+        {
+            return CombineOptions(fixAllOptions, ParseOptionsFromDiagnostic(diagnostic));
+        }
+
         private static async Task<Solution> ApplyActionAndEnableUnsafe(Solution solution, DocumentId documentId, Func<DocumentEditor, CancellationToken, Task> documentBasedFix, CancellationToken ct)
         {
             var editor = new SolutionEditor(solution);
@@ -194,7 +201,7 @@ namespace Microsoft.Interop.Analyzers
 
                             SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
 
-                            var documentBasedFix = codeFixProvider.CreateFixForSelectedOptions(node, options);
+                            var documentBasedFix = codeFixProvider.CreateFixForSelectedOptions(node, codeFixProvider.GetOptionsForIndividualFix(options, diagnostic));
 
                             await documentBasedFix(editor, ct).ConfigureAwait(false);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Interop.Analyzers
             return optionsBuilder.ToImmutable();
         }
 
+        protected override ImmutableDictionary<string, Option> CombineOptions(ImmutableDictionary<string, Option> fixAllOptions, ImmutableDictionary<string, Option> diagnosticOptions)
+        {
+            return fixAllOptions;
+        }
+
         protected override IEnumerable<ConvertToSourceGeneratedInteropFix> CreateAllFixesForDiagnosticOptions(SyntaxNode node, ImmutableDictionary<string, Option> options)
         {
             bool warnForAdditionalWork = options.TryGetValue(Option.MayRequireAdditionalWork, out Option mayRequireAdditionalWork) && mayRequireAdditionalWork is Option.Bool(true);

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
@@ -135,6 +135,54 @@ namespace ComInterfaceGenerator.Unit.Tests
         }
 
         [Fact]
+        public async Task StringFix_DoesNotAddStringMarshallingToNonStringScenarios()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+
+                [ComImport]
+                [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81B")]
+                [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+                public interface [|IUsesString|]
+                {
+                  string Method();
+                }
+
+                [ComImport]
+                [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81C")]
+                [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+                public interface [|INoString|]
+                {
+                  int Method();
+                }
+                """;
+
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                [GeneratedComInterface(StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(BStrStringMarshaller))]
+                [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81B")]
+                [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+                public partial interface IUsesString
+                {
+                  string Method();
+                }
+
+                [GeneratedComInterface]
+                [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81C")]
+                [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+                public partial interface INoString
+                {
+                  int Method();
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact]
         public async Task Array_DoesNotReportDiagnostic()
         {
             // The default behavior in ComImport for arrays is to marshal as a SAFEARRAY. We don't support SAFEARRAY's, so we don't want to offer a fix here.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94376