### PR TITLE
Fix SOS !dumpmt -md command

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -490,20 +490,22 @@ ClrDataAccess::GetMethodTableSlotEnumerator(CLRDATA_ADDRESS mt, ISOSMethodEnum *
 
 HRESULT DacMethodTableSlotEnumerator::Init(PTR_MethodTable mTable)
 {
-    unsigned int slot = 0;
-
     WORD numVtableSlots = mTable->GetNumVtableSlots();
-    while (slot < numVtableSlots)
+    for (WORD slot = 0; slot < numVtableSlots; slot++)
     {
-        MethodDesc* pMD = mTable->GetMethodDescForSlot_NoThrow(slot);
-        SOSMethodData methodData = {0};
-        methodData.MethodDesc = HOST_CDADDR(pMD);
-        methodData.Entrypoint = mTable->GetSlot(slot);
-        methodData.DefininingMethodTable = PTR_CDADDR(pMD->GetMethodTable());
-        methodData.DefiningModule = HOST_CDADDR(pMD->GetModule());
-        methodData.Token = pMD->GetMemberDef();
+        SOSMethodData methodData = {0, 0, 0, 0, 0, 0};
 
-        methodData.Slot = slot++;
+        MethodDesc* pMD = mTable->GetMethodDescForSlot_NoThrow(slot);
+        if (pMD != nullptr)
+        {
+            methodData.MethodDesc = HOST_CDADDR(pMD);
+            methodData.DefininingMethodTable = PTR_CDADDR(pMD->GetMethodTable());
+            methodData.DefiningModule = HOST_CDADDR(pMD->GetModule());
+            methodData.Token = pMD->GetMemberDef();
+        }
+
+        methodData.Entrypoint = mTable->GetSlot(slot);
+        methodData.Slot = slot;
 
         if (!mMethods.Add(methodData))
             return E_OUTOFMEMORY;

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -494,8 +494,17 @@ HRESULT DacMethodTableSlotEnumerator::Init(PTR_MethodTable mTable)
     for (WORD slot = 0; slot < numVtableSlots; slot++)
     {
         SOSMethodData methodData = {0, 0, 0, 0, 0, 0};
+        MethodDesc* pMD = nullptr;
 
-        MethodDesc* pMD = mTable->GetMethodDescForSlot_NoThrow(slot);
+        EX_TRY
+        {
+            pMD = mTable->GetMethodDescForSlot_NoThrow(slot);
+        }
+        EX_CATCH
+        {
+        }
+        EX_END_CATCH(SwallowAllExceptions)
+
         if (pMD != nullptr)
         {
             methodData.MethodDesc = HOST_CDADDR(pMD);

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2626,15 +2626,22 @@ MethodDesc* MethodDesc::GetMethodDescFromStubAddr(PCODE addr, BOOL fSpeculative 
 
     MethodDesc *  pMD = NULL;
 
-    // Otherwise this must be some kind of precode
-    //
-    PTR_Precode pPrecode = Precode::GetPrecodeFromEntryPoint(addr, fSpeculative);
-    PREFIX_ASSUME(fSpeculative || (pPrecode != NULL));
-    if (pPrecode != NULL)
+    EX_TRY
     {
-        pMD = pPrecode->GetMethodDesc(fSpeculative);
-        RETURN(pMD);
+        // Otherwise this must be some kind of precode
+        //
+        PTR_Precode pPrecode = Precode::GetPrecodeFromEntryPoint(addr, fSpeculative);
+        PREFIX_ASSUME(fSpeculative || (pPrecode != NULL));
+        if (pPrecode != NULL)
+        {
+            pMD = pPrecode->GetMethodDesc(fSpeculative);
+            RETURN(pMD);
+        }
     }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(SwallowAllExceptions)
 
     RETURN(NULL); // Not found
 }

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2624,26 +2624,18 @@ MethodDesc* MethodDesc::GetMethodDescFromStubAddr(PCODE addr, BOOL fSpeculative 
     }
     CONTRACT_END;
 
-    MethodDesc *  pMD = NULL;
+    MethodDesc* pMD = NULL;
 
-    EX_TRY
+    // Otherwise this must be some kind of precode
+    //
+    PTR_Precode pPrecode = Precode::GetPrecodeFromEntryPoint(addr, fSpeculative);
+    PREFIX_ASSUME(fSpeculative || (pPrecode != NULL));
+    if (pPrecode != NULL)
     {
-        // Otherwise this must be some kind of precode
-        //
-        PTR_Precode pPrecode = Precode::GetPrecodeFromEntryPoint(addr, fSpeculative);
-        PREFIX_ASSUME(fSpeculative || (pPrecode != NULL));
-        if (pPrecode != NULL)
-        {
-            pMD = pPrecode->GetMethodDesc(fSpeculative);
-            RETURN(pMD);
-        }
+        pMD = pPrecode->GetMethodDesc(fSpeculative);
     }
-    EX_CATCH
-    {
-    }
-    EX_END_CATCH(SwallowAllExceptions)
 
-    RETURN(NULL); // Not found
+    RETURN(pMD);
 }
 
 //*******************************************************************************


### PR DESCRIPTION
The new virtual method slot enumerator failed if any of the Precode slot values were not in the dump. There are usually 2 or so that are invalid/not in dump but that should not stop/fail the new enumeration DAC API.

Part of this is to make MethodTable::GetMethodDescForSlot_NoThrow not throw a read exception and return a null MD.