### PR TITLE
Update suppression reason for Assembly.GetType call

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
@@ -509,7 +509,7 @@ namespace System.ComponentModel
             /// then a global Type.GetType is performed.
             /// </summary>
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "Calling _type.Assembly.GetType on a non-assembly qualified type will still work. See https://github.com/mono/linker/issues/1895")]
+                Justification = "Trimming requires fully-qualified type names for strings annotated with DynamicallyAccessedMembers, so the call to _type.Assembly.GetType should be unreachable in an app without trim warnings.")]
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057:TypeGetType",
                 Justification = "Using the non-assembly qualified type name will still work.")]
             private Type? GetTypeFromName(


### PR DESCRIPTION
With https://github.com/dotnet/runtime/pull/104060 there will be trim warnings whenever a non-qualified type name is used with this API. So I think the call to `_type.AssemblyGetType` is effectively unreachable in a trimmed app with no trim warnings and it is safe to suppress.

Fixes the original issue mentioned in https://github.com/dotnet/runtime/issues/95265. However, the IL2057 suppression next to this one still looks suspicious, see https://github.com/dotnet/runtime/issues/95265#issuecomment-2253460558.