### PR TITLE
[System.Diagnostics.DiagnosticSource] Support listening to meters out-of-proc using a wildcard

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -88,7 +88,17 @@ namespace System.Diagnostics.Metrics
 
         public void Include(string meterName)
         {
-            Include(i => meterName == "*" || i.Meter.Name == meterName);
+            Include(i => i.Meter.Name == meterName);
+        }
+
+        public void IncludeAll()
+        {
+            Include(i => true);
+        }
+
+        public void IncludePrefix(string meterNamePrefix)
+        {
+            Include(i => i.Meter.Name.StartsWith(meterNamePrefix, StringComparison.OrdinalIgnoreCase));
         }
 
         public void Include(string meterName, string instrumentName)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -88,7 +88,7 @@ namespace System.Diagnostics.Metrics
 
         public void Include(string meterName)
         {
-            Include(i => i.Meter.Name == meterName);
+            Include(i => i.Meter.Name.Equals(meterName, StringComparison.OrdinalIgnoreCase));
         }
 
         public void IncludeAll()
@@ -103,7 +103,8 @@ namespace System.Diagnostics.Metrics
 
         public void Include(string meterName, string instrumentName)
         {
-            Include(i => i.Meter.Name == meterName && i.Name == instrumentName);
+            Include(i => i.Meter.Name.Equals(meterName, StringComparison.OrdinalIgnoreCase)
+                && i.Name.Equals(instrumentName, StringComparison.OrdinalIgnoreCase));
         }
 
         private void Include(Predicate<Instrument> instrumentFilter)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -88,7 +88,7 @@ namespace System.Diagnostics.Metrics
 
         public void Include(string meterName)
         {
-            Include(i => i.Meter.Name == meterName);
+            Include(i => meterName == "*" || i.Meter.Name == meterName);
         }
 
         public void Include(string meterName, string instrumentName)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -653,6 +653,22 @@ namespace System.Diagnostics.Metrics
                     {
                         _aggregationManager!.Include(spec.MeterName, spec.InstrumentName);
                     }
+                    else if (
+#if NET8_0_OR_GREATER
+                        spec.MeterName.EndsWith('*'))
+#else
+                        spec.MeterName.EndsWith("*", StringComparison.Ordinal))
+#endif
+                    {
+                        if (spec.MeterName.Length == 1)
+                        {
+                            _aggregationManager!.IncludeAll();
+                        }
+                        else
+                        {
+                            _aggregationManager!.IncludePrefix(spec.MeterName.Substring(0, spec.MeterName.Length - 1));
+                        }
+                    }
                     else
                     {
                         _aggregationManager!.Include(spec.MeterName);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -653,12 +653,8 @@ namespace System.Diagnostics.Metrics
                     {
                         _aggregationManager!.Include(spec.MeterName, spec.InstrumentName);
                     }
-                    else if (
-#if NET8_0_OR_GREATER
-                        spec.MeterName.EndsWith('*'))
-#else
-                        spec.MeterName.EndsWith("*", StringComparison.Ordinal))
-#endif
+                    else if (spec.MeterName.Length > 0
+                        && spec.MeterName[spec.MeterName.Length - 1] == '*')
                     {
                         if (spec.MeterName.Length == 1)
                         {
@@ -666,7 +662,8 @@ namespace System.Diagnostics.Metrics
                         }
                         else
                         {
-                            _aggregationManager!.IncludePrefix(spec.MeterName.Substring(0, spec.MeterName.Length - 1));
+                            _aggregationManager!.IncludePrefix(
+                                spec.MeterName.Substring(0, spec.MeterName.Length - 1));
                         }
                     }
                     else


### PR DESCRIPTION
## Changes

* Adds support inside `MetricsEventSource` for listening to meters out-of-proc by using a wildcard\prefix style (ex: `*`, `Company.Library*`) for meter name in spec

/cc @noahfalk @samsp-msft @tarekgh @rajkumar-rangaraj 