### PR TITLE
Remove HelperMethodFrame from `GetMulticastInvoke`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
@@ -497,7 +497,7 @@ namespace System
                 Debug.Assert(ptr != null);
                 Debug.Assert(ptr == GetMulticastInvoke(pMT));
             }
-            GC.KeepAlive(this);
+            // No GC.KeepAlive() since the caller must keep instance alive to use returned pointer.
             return (IntPtr)ptr;
         }
 
@@ -508,7 +508,7 @@ namespace System
         {
             MethodTable* pMT = RuntimeHelpers.GetMethodTable(this);
             void* ptr = GetInvokeMethod(pMT);
-            GC.KeepAlive(this);
+            // No GC.KeepAlive() since the caller must keep instance alive to use returned pointer.
             return (IntPtr)ptr;
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
@@ -482,10 +482,35 @@ namespace System
         private extern void DelegateConstruct(object target, IntPtr slot);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern IntPtr GetMulticastInvoke();
+        private static extern unsafe void* GetMulticastInvoke(MethodTable* pMT);
+
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Delegate_GetMulticastInvokeSlow")]
+        private static unsafe partial void* GetMulticastInvokeSlow(MethodTable* pMT);
+
+        internal unsafe IntPtr GetMulticastInvoke()
+        {
+            MethodTable* pMT = RuntimeHelpers.GetMethodTable(this);
+            void* ptr = GetMulticastInvoke(pMT);
+            if (ptr == null)
+            {
+                ptr = GetMulticastInvokeSlow(pMT);
+                Debug.Assert(ptr != null);
+                Debug.Assert(ptr == GetMulticastInvoke(pMT));
+            }
+            GC.KeepAlive(this);
+            return (IntPtr)ptr;
+        }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal extern IntPtr GetInvokeMethod();
+        private static extern unsafe void* GetInvokeMethod(MethodTable* pMT);
+
+        internal unsafe IntPtr GetInvokeMethod()
+        {
+            MethodTable* pMT = RuntimeHelpers.GetMethodTable(this);
+            void* ptr = GetInvokeMethod(pMT);
+            GC.KeepAlive(this);
+            return (IntPtr)ptr;
+        }
 
         internal IRuntimeMethodInfo FindMethodHandle()
         {

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -2120,35 +2120,42 @@ extern "C" BOOL QCALLTYPE Delegate_InternalEqualMethodHandles(QCall::ObjectHandl
     return fRet;
 }
 
-FCIMPL1(MethodDesc*, COMDelegate::GetInvokeMethod, Object* refThisIn)
+FCIMPL1(MethodDesc*, COMDelegate::GetInvokeMethod, MethodTable* pDelegateMT)
 {
     FCALL_CONTRACT;
+    _ASSERTE(pDelegateMT != NULL);
 
-    OBJECTREF refThis = ObjectToOBJECTREF(refThisIn);
-    MethodTable * pDelMT = refThis->GetMethodTable();
-
-    MethodDesc* pMD = ((DelegateEEClass*)(pDelMT->GetClass()))->GetInvokeMethod();
-    _ASSERTE(pMD);
+    MethodDesc* pMD = ((DelegateEEClass*)(pDelegateMT->GetClass()))->GetInvokeMethod();
+    _ASSERTE(pMD != NULL);
     return pMD;
 }
 FCIMPLEND
 
-FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
+FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, MethodTable *pDelegateMT)
 {
     FCALL_CONTRACT;
+    _ASSERTE(pDelegateMT != NULL);
 
-    OBJECTREF refThis = ObjectToOBJECTREF(refThisIn);
-    MethodTable *pDelegateMT = refThis->GetMethodTable();
+    DelegateEEClass *delegateEEClass = (DelegateEEClass*)pDelegateMT->GetClass();
+    Stub *pStub = delegateEEClass->m_pMultiCastInvokeStub;
+    return (pStub != NULL) ? pStub->GetEntryPoint() : NULL;
+}
+FCIMPLEND
 
-    DelegateEEClass *delegateEEClass = ((DelegateEEClass*)(pDelegateMT->GetClass()));
+extern "C" PCODE QCALLTYPE Delegate_GetMulticastInvokeSlow(MethodTable* pDelegateMT)
+{
+    QCALL_CONTRACT;
+    _ASSERTE(pDelegateMT != NULL);
+
+    PCODE fptr = NULL;
+
+    BEGIN_QCALL;
+
+    DelegateEEClass *delegateEEClass = (DelegateEEClass*)pDelegateMT->GetClass();
     Stub *pStub = delegateEEClass->m_pMultiCastInvokeStub;
     if (pStub == NULL)
     {
         MethodDesc* pMD = delegateEEClass->GetInvokeMethod();
-
-        HELPER_METHOD_FRAME_BEGIN_RET_0();
-
-        GCX_PREEMP();
 
         MetaSig sig(pMD);
 
@@ -2162,7 +2169,7 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
         DWORD dwLoopCounterNum = pCode->NewLocal(ELEMENT_TYPE_I4);
 
         DWORD dwReturnValNum = -1;
-        if(fReturnVal)
+        if (fReturnVal)
             dwReturnValNum = pCode->NewLocal(sig.GetRetTypeHandleNT());
 
         ILCodeLabel *nextDelegate = pCode->NewCodeLabel();
@@ -2192,7 +2199,7 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
         pCode->EmitCALL(pCode->GetToken(pMD), sig.NumFixedArgs(), fReturnVal);
 
         // Save return value.
-        if(fReturnVal)
+        if (fReturnVal)
             pCode->EmitSTLOC(dwReturnValNum);
 
         // increment counter
@@ -2203,7 +2210,7 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
 
         //Label_checkCount
         pCode->EmitLabel(checkCount);
-        
+
 #ifdef DEBUGGING_SUPPORTED
         ILCodeLabel *invokeTraceHelper = pCode->NewCodeLabel();
         ILCodeLabel *debuggerCheckEnd = pCode->NewCodeLabel();
@@ -2228,7 +2235,7 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
         pCode->EmitBLT(nextDelegate);
 
         // load the return value. return value from the last delegate call is returned
-        if(fReturnVal)
+        if (fReturnVal)
             pCode->EmitLDLOC(dwReturnValNum);
 
         // return
@@ -2247,8 +2254,7 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
 
         PCCOR_SIGNATURE pSig;
         DWORD cbSig;
-
-        pMD->GetSig(&pSig,&cbSig);
+        pMD->GetSig(&pSig, &cbSig);
 
         MethodDesc* pStubMD = ILStubCache::CreateAndLinkNewILStubMethodDesc(pMD->GetLoaderAllocator(),
                                                                pMD->GetMethodTable(),
@@ -2257,17 +2263,18 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
                                                                pSig, cbSig,
                                                                NULL,
                                                                &sl);
-
         pStub = Stub::NewStub(JitILStub(pStubMD));
 
         InterlockedCompareExchangeT<PTR_Stub>(&delegateEEClass->m_pMultiCastInvokeStub, pStub, NULL);
-
-        HELPER_METHOD_FRAME_END();
+        pStub = delegateEEClass->m_pMultiCastInvokeStub;
     }
 
-    return pStub->GetEntryPoint();
+    fptr = pStub->GetEntryPoint();
+
+    END_QCALL;
+
+    return fptr;
 }
-FCIMPLEND
 
 PCODE COMDelegate::GetWrapperInvoke(MethodDesc* pMD)
 {

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -2138,7 +2138,7 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, MethodTable* pDelegateMT)
 
     DelegateEEClass* delegateEEClass = (DelegateEEClass*)pDelegateMT->GetClass();
     Stub *pStub = delegateEEClass->m_pMultiCastInvokeStub;
-    return (pStub != NULL) ? pStub->GetEntryPoint() : NULL;
+    return (pStub != NULL) ? pStub->GetEntryPoint() : (PCODE)NULL;
 }
 FCIMPLEND
 
@@ -2147,7 +2147,7 @@ extern "C" PCODE QCALLTYPE Delegate_GetMulticastInvokeSlow(MethodTable* pDelegat
     QCALL_CONTRACT;
     _ASSERTE(pDelegateMT != NULL);
 
-    PCODE fptr = NULL;
+    PCODE fptr = (PCODE)NULL;
 
     BEGIN_QCALL;
 

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -2131,12 +2131,12 @@ FCIMPL1(MethodDesc*, COMDelegate::GetInvokeMethod, MethodTable* pDelegateMT)
 }
 FCIMPLEND
 
-FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, MethodTable *pDelegateMT)
+FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, MethodTable* pDelegateMT)
 {
     FCALL_CONTRACT;
     _ASSERTE(pDelegateMT != NULL);
 
-    DelegateEEClass *delegateEEClass = (DelegateEEClass*)pDelegateMT->GetClass();
+    DelegateEEClass* delegateEEClass = (DelegateEEClass*)pDelegateMT->GetClass();
     Stub *pStub = delegateEEClass->m_pMultiCastInvokeStub;
     return (pStub != NULL) ? pStub->GetEntryPoint() : NULL;
 }

--- a/src/coreclr/vm/comdelegate.h
+++ b/src/coreclr/vm/comdelegate.h
@@ -45,8 +45,8 @@ public:
     static FCDECL3(void, DelegateConstruct, Object* refThis, Object* target, PCODE method);
 
     // Get the invoke method for the delegate. Used to transition delegates to multicast delegates.
-    static FCDECL1(PCODE, GetMulticastInvoke, Object* refThis);
-    static FCDECL1(MethodDesc*, GetInvokeMethod, Object* refThis);
+    static FCDECL1(PCODE, GetMulticastInvoke, MethodTable* pDelegateMT);
+    static FCDECL1(MethodDesc*, GetInvokeMethod, MethodTable* pDelegateMT);
     static PCODE GetWrapperInvoke(MethodDesc* pMD);
     // determines where the delegate needs to be wrapped for non-security reason
     static BOOL NeedsWrapperDelegate(MethodDesc* pTargetMD);
@@ -113,6 +113,8 @@ public:
                              MethodTable   *pExactMethodType,
                              BOOL           fIsOpenDelegate);
 };
+
+extern "C" PCODE QCALLTYPE Delegate_GetMulticastInvokeSlow(MethodTable* pDelegateMT);
 
 extern "C" PCODE QCALLTYPE Delegate_AdjustTarget(QCall::ObjectHandleOnStack target, PCODE method);
 

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -89,6 +89,7 @@ static const Entry s_QCall[] =
     DllImportEntry(Delegate_BindToMethodName)
     DllImportEntry(Delegate_BindToMethodInfo)
     DllImportEntry(Delegate_InitializeVirtualCallStub)
+    DllImportEntry(Delegate_GetMulticastInvokeSlow)
     DllImportEntry(Delegate_AdjustTarget)
     DllImportEntry(Delegate_InternalAlloc)
     DllImportEntry(Delegate_InternalAllocLike)


### PR DESCRIPTION
Move `MethodTable` acquisition from unmanaged to managed.
This allows for converting instance FCalls to static.