### PR TITLE
Fix bug in handling of duplicate properties in the fast-path source generator.

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -1049,7 +1049,7 @@ namespace System.Text.Json.SourceGeneration
                     {
                         // Overwrite previously cached property since it has [JsonIgnore].
                         state.AddedProperties[propertySpec.EffectiveJsonPropertyName] = (propertySpec, memberInfo, index);
-                        state.Properties[index] = state.Properties.Count;
+                        state.Properties[index] = propertyIndex;
                         state.IsPropertyOrderSpecified |= propertySpec.Order != 0;
                     }
                     else

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
@@ -333,4 +333,28 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public new int ShadowProperty { get; set; }
     }
+
+    public sealed class ClassWithConflictingIgnoredProperties
+    {
+        [JsonIgnore]
+        public List<string>? UserList { get; set; }
+
+        [JsonPropertyName("userlist")]
+        public List<string>? SystemTextJsonUserList { get; set; }
+
+        [JsonIgnore]
+        public List<string>? UserGroupsList { get; set; }
+
+        [JsonPropertyName("usergroupslist")]
+        public List<string>? SystemTextJsonUserGroupsList { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public List<string>? SystemTextJsonIPAddresses { get; set; }
+
+        [JsonIgnore]
+        public List<object>? QueryParams { get; set; }
+
+        [JsonPropertyName("queryparams")]
+        public List<object>? SystemTextJsonQueryParams { get; set; }
+    }
 }


### PR DESCRIPTION
The fast-path generator has a bug that results in the incorrect property being resolved in cases where there exist case-insensitive property name conflicts.

Fix #99988.