### PR TITLE
[PERF] Update tool build framework version

### DIFF
--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -158,36 +158,36 @@ jobs:
       displayName: Copy scenario support files (Linux/MAC)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
     # build Startup
-    - script: $(PayloadDirectory)\dotnet\dotnet.exe publish -c Release -o $(WorkItemDirectory)\Startup -f net7.0 -r win-$(Architecture) $(PerformanceDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+    - script: $(PayloadDirectory)\dotnet\dotnet.exe publish -c Release -o $(WorkItemDirectory)\Startup -f net8.0 -r win-$(Architecture) $(PerformanceDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
       displayName: Build Startup tool (Windows)
       env:
-        PERFLAB_TARGET_FRAMEWORKS: net7.0
+        PERFLAB_TARGET_FRAMEWORKS: net8.0
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
-    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/startup -f net7.0 -r linux-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/startup -f net8.0 -r linux-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
       displayName: Build Startup tool (Linux)
       env:
-        PERFLAB_TARGET_FRAMEWORKS: net7.0
+        PERFLAB_TARGET_FRAMEWORKS: net8.0
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Linux'))
-    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/startup -f net7.0 -r osx-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/startup -f net8.0 -r osx-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
       displayName: Build Startup tool (MAC)
       env:
-        PERFLAB_TARGET_FRAMEWORKS: net7.0
+        PERFLAB_TARGET_FRAMEWORKS: net8.0
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Darwin'))
     # build SizeOnDisk
-    - script: $(PayloadDirectory)\dotnet\dotnet.exe publish -c Release -o $(WorkItemDirectory)\SOD -f net7.0 -r win-$(Architecture) $(PerformanceDirectory)\src\tools\ScenarioMeasurement\SizeOnDisk\SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+    - script: $(PayloadDirectory)\dotnet\dotnet.exe publish -c Release -o $(WorkItemDirectory)\SOD -f net8.0 -r win-$(Architecture) $(PerformanceDirectory)\src\tools\ScenarioMeasurement\SizeOnDisk\SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
       displayName: Build SizeOnDisk tool (Windows)
       env:
-        PERFLAB_TARGET_FRAMEWORKS: net7.0
+        PERFLAB_TARGET_FRAMEWORKS: net8.0
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
-    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/SOD -f net7.0 -r linux-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/SOD -f net8.0 -r linux-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
       displayName: Build SizeOnDisk tool (Linux)
       env:
-        PERFLAB_TARGET_FRAMEWORKS: net7.0
+        PERFLAB_TARGET_FRAMEWORKS: net8.0
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Linux'))
-    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/SOD -f net7.0 -r osx-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/SOD -f net8.0 -r osx-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
       displayName: Build SizeOnDisk tool (MAC)
       env:
-        PERFLAB_TARGET_FRAMEWORKS: net7.0
+        PERFLAB_TARGET_FRAMEWORKS: net8.0
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Darwin'))
 
     # Zip the workitem directory (for xharness (mobile) based workitems)


### PR DESCRIPTION
Update tool build framework to fix scenario runs in dotnet-runtime-perf pipeline.

This fixes runtime-perf pipeline errors around building tools due to https://github.com/dotnet/performance/pull/4342:
```
/Users/runner/work/1/s/Payload/performance/src/tools/ScenarioMeasurement/Startup/Startup.csproj : error NU1201: Project Util is not compatible with net7.0 (.NETCoreApp,Version=v7.0). Project Util supports: net8.0 (.NETCoreApp,Version=v8.0)
/Users/runner/work/1/s/Payload/performance/src/tools/ScenarioMeasurement/Startup/Startup.csproj : error NU1201: Project Util is not compatible with net7.0 (.NETCoreApp,Version=v7.0) / osx-x64. Project Util supports: net8.0 (.NETCoreApp,Version=v8.0)
```