### PR TITLE
[mono] Remove incorrect offsetof definition that shouldn't be needed

### DIFF
--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -47,10 +47,6 @@
 #include <unistd.h>
 #endif
 
-#ifndef offsetof
-#   define offsetof(s_name,n_name) (size_t)(char *)&(((s_name*)0)->m_name)
-#endif
-
 #ifdef  __cplusplus
 #define G_BEGIN_DECLS  extern "C" {
 #define G_END_DECLS    }


### PR DESCRIPTION
should fix https://github.com/dotnet/runtime/issues/90210

![image](https://github.com/user-attachments/assets/bbd5bfcc-5639-4448-9acb-f6a8ca1cbff2)
