### PR TITLE
TransferEncoding chunked testing only if it is last header value

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -89,7 +89,7 @@ namespace System.Net.Http.Headers
                     return true;
                 }
 
-                if (parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked))
+                if (parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked, lastValueOnly:true))
                 {
                     return true;
                 }
@@ -117,8 +117,14 @@ namespace System.Net.Http.Headers
                 if (value == true)
                 {
                     _transferEncodingChunkedSet = true;
-                    if (!_parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked))
+                    if (!_parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked, lastValueOnly: true))
                     {
+                        if (_parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked, lastValueOnly: false))
+                        {
+                            // According to https://www.rfc-editor.org/rfc/rfc7230.html#section-3.3.1 "chunked" must be the last value in the Transfer-Encoding header.
+                            // We have to remove it and add it as last.
+                            _parent.RemoveParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked);
+                        }
                         _parent.AddParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked);
                     }
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -496,7 +496,7 @@ namespace System.Net.Http.Headers
             return false;
         }
 
-        internal bool ContainsParsedValue(HeaderDescriptor descriptor, object value)
+        internal bool ContainsParsedValue(HeaderDescriptor descriptor, object value, bool lastValueOnly = false)
         {
             Debug.Assert(value != null);
 
@@ -516,6 +516,13 @@ namespace System.Net.Http.Headers
                 }
 
                 List<object>? parsedValues = parsedValue as List<object>;
+                if (lastValueOnly && parsedValues?.Count > 1)
+                {
+                    // This can be useful for specific header value pair like for example "TransferEncoding: gzip, chunked" where chunked must be last.
+                    // Relevant RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.3.1
+                    parsedValue = parsedValues[^1];
+                    parsedValues = null;
+                }
 
                 IEqualityComparer? comparer = descriptor.Parser.Comparer;
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -2664,21 +2664,25 @@ namespace System.Net.Http.Tests
         [InlineData(new object[] { "gzip", true, null}, null)]
         public void AddTransferEncoding_SetValues_ChunkedAsExpected(object?[] values, bool? expected)
         {
-            var headers = new HttpRequestHeaders();
+            var req = new HttpRequestHeaders();
+            var resp = new HttpResponseHeaders();
 
             foreach (object value in values)
             {
                 if (value is bool? || value is null)
                 {
-                    headers.TransferEncodingChunked = (bool?)value;
+                    req.TransferEncodingChunked = (bool?)value;
+                    resp.TransferEncodingChunked = (bool?)value;
                 }
                 else
                 {
-                    headers.TransferEncoding.ParseAdd((string)value);
+                    req.TransferEncoding.ParseAdd((string)value);
+                    resp.TransferEncoding.ParseAdd((string)value);
                 }
             }
 
-            Assert.Equal(expected, headers.TransferEncodingChunked);
+            Assert.Equal(expected, req.TransferEncodingChunked);
+            Assert.Equal(expected, resp.TransferEncodingChunked);
         }
 
         public static IEnumerable<object[]> NumberOfHeadersUpToArrayThreshold_AddNonValidated_EnumerateNonValidated()

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -2638,6 +2638,49 @@ namespace System.Net.Http.Tests
             Assert.True(expectedValues.SequenceEqual(values));
         }
 
+        [Theory]
+        [InlineData(new object[] { "chunked" }, true)]
+        [InlineData(new object[] { "gzip", "chunked" }, true)]
+        [InlineData(new object[] { "gzip", "chunked", "deflate", "chunked" }, true)]
+        [InlineData(new object[] { true }, true)]
+        [InlineData(new object[] { true, null, true }, true)]
+        [InlineData(new object[] { "gzip", true }, true)]
+        [InlineData(new object[] { "gzip", true, "deflate", true }, true)]
+        [InlineData(new object[] { true, "deflate", true }, true)]
+        [InlineData(new object[] { false, "deflate", true }, true)]
+        [InlineData(new object[] { false }, false)]
+        [InlineData(new object[] { false, null, false }, false)]
+        [InlineData(new object[] { "gzip", false }, false)]
+        [InlineData(new object[] { false, "gzip" }, false)]
+        [InlineData(new object[] { "gzip", true, false }, false)]
+        [InlineData(new object[] { "gzip", true, "deflate" }, false)]
+        [InlineData(new object[] { "gzip", true, "deflate", false }, false)]
+        [InlineData(new object[] { }, null)]
+        [InlineData(new object[] { null }, null)]
+        [InlineData(new object[] { "gzip" }, null)]
+        [InlineData(new object[] { "chunked", "gzip" }, null)]
+        [InlineData(new object[] { "gzip", "deflate" }, null)]
+        [InlineData(new object[] { "gzip", "chunked", "gzip" }, null)]
+        [InlineData(new object[] { "gzip", true, null}, null)]
+        public void AddTransferEncoding_SetValues_ChunkedAsExpected(object?[] values, bool? expected)
+        {
+            var headers = new HttpRequestHeaders();
+
+            foreach (object value in values)
+            {
+                if (value is bool? || value is null)
+                {
+                    headers.TransferEncodingChunked = (bool?)value;
+                }
+                else
+                {
+                    headers.TransferEncoding.ParseAdd((string)value);
+                }
+            }
+
+            Assert.Equal(expected, headers.TransferEncodingChunked);
+        }
+
         public static IEnumerable<object[]> NumberOfHeadersUpToArrayThreshold_AddNonValidated_EnumerateNonValidated()
         {
             for (int i = 0; i <= HttpHeaders.ArrayThreshold; i++)


### PR DESCRIPTION
Fixes #63053

### Context
Transfer-Encodings are ordered and so the check should only succeed if "chunked" is the final Transfer-Encoding value
See #63053

### Changes made
Test only final value.
During `TransferEncodingChunked` is set to true, it is ensured `chunked` will be last value, even when it was already present.

### Testing
Few new unit tests.

### Note
This could be a **breaking change** if server behave out of spec. Currently if server send `Transfer-Encoding: chunked, gzip`, but actually do gzip and then chunk, client would have handled it without error, with changes in this PR it will fail to receive content.
