### PR TITLE
JIT: Remove fallthrough constraint for `BBJ_SWITCH -> BBJ_COND` conversion

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1775,12 +1775,10 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
 
         return true;
     }
-    else if ((block->GetSwitchTargets()->bbsCount == 2) &&
-             block->NextIs(block->GetSwitchTargets()->bbsDstTab[1]->getDestinationBlock()))
+    else if (block->GetSwitchTargets()->bbsCount == 2)
     {
         /* Use a BBJ_COND(switchVal==0) for a switch with only one
-           significant clause besides the default clause, if the
-           default clause is bbNext */
+           significant clause besides the default clause */
         GenTree* switchVal = switchTree->AsOp()->gtOp1;
         noway_assert(genActualTypeIsIntOrI(switchVal->TypeGet()));
 


### PR DESCRIPTION
I noticed this unnecessary fallthrough check while exploring if we can avoid calling `fgUpdateFlowGraph` again after reordering blocks, as the new layout doesn't introduce any new blocks. Switch conversion shouldn't rely on what the current block layout happens to be when it's run; if we can do these transformations before running block layout, then removing the post-layout `fgUpdateFlowGraph` call should be a no-diff change.

Local diffs are relatively small, though more `BBJ_SWITCH -> BBJ_COND` conversion tends to unlock other flow opts, like more block compaction (we currently skip compacting `target` into `block` if `target` is the successor a switch block, as we don't bother updating the switch block's successor table).