### PR TITLE
Implement `IUtf8SpanParsable` on `Guid`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -12,6 +12,7 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using System.Runtime.Versioning;
+using System.Text;
 
 namespace System
 {
@@ -26,7 +27,8 @@ namespace System
           IComparable<Guid>,
           IEquatable<Guid>,
           ISpanParsable<Guid>,
-          IUtf8SpanFormattable
+          IUtf8SpanFormattable,
+          IUtf8SpanParsable<Guid>
     {
         private const byte Variant10xxMask = 0xC0;
         private const byte Variant10xxValue = 0x80;
@@ -266,7 +268,7 @@ namespace System
             ArgumentNullException.ThrowIfNull(g);
 
             var result = new GuidResult(GuidParseThrowStyle.All);
-            bool success = TryParseGuid(g, ref result);
+            bool success = TryParseGuid(g.AsSpan(), ref result);
             Debug.Assert(success, "GuidParseThrowStyle.All means throw on all failures");
 
             this = result.ToGuid();
@@ -343,6 +345,15 @@ namespace System
             return result.ToGuid();
         }
 
+        public static Guid Parse(ReadOnlySpan<byte> utf8Text)
+        {
+            var result = new GuidResult(GuidParseThrowStyle.AllButOverflow);
+            bool success = TryParseGuid(utf8Text, ref result);
+            Debug.Assert(success, "GuidParseThrowStyle.AllButOverflow means throw on all failures");
+
+            return result.ToGuid();
+        }
+
         public static bool TryParse([NotNullWhen(true)] string? input, out Guid result)
         {
             if (input == null)
@@ -358,6 +369,21 @@ namespace System
         {
             var parseResult = new GuidResult(GuidParseThrowStyle.None);
             if (TryParseGuid(input, ref parseResult))
+            {
+                result = parseResult.ToGuid();
+                return true;
+            }
+            else
+            {
+                result = default;
+                return false;
+            }
+        }
+
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, out Guid result)
+        {
+            var parseResult = new GuidResult(GuidParseThrowStyle.None);
+            if (TryParseGuid(utf8Text, ref parseResult))
             {
                 result = parseResult.ToGuid();
                 return true;
@@ -444,34 +470,39 @@ namespace System
                 return false;
             }
         }
-
-        private static bool TryParseGuid(ReadOnlySpan<char> guidString, ref GuidResult result)
+        private static bool TryParseGuid<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
         {
-            guidString = guidString.Trim(); // Remove whitespace from beginning and end
+            guidString = Number.SpanTrim(guidString); // Remove whitespace from beginning and end
 
             if (guidString.Length < 32) // Minimal length we can parse ('N' format)
             {
                 result.SetFailure(ParseFailure.Format_GuidUnrecognized);
                 return false;
             }
-
-            return (guidString[0]) switch
+            if (guidString[0] == TChar.CastFrom('('))
             {
-                '(' => TryParseExactP(guidString, ref result),
-                '{' => guidString[9] == '-' ?
-                        TryParseExactB(guidString, ref result) :
-                        TryParseExactX(guidString, ref result),
-                _ => guidString[8] == '-' ?
-                        TryParseExactD(guidString, ref result) :
-                        TryParseExactN(guidString, ref result),
-            };
+                return TryParseExactP(guidString, ref result);
+            }
+            if (guidString[0] == TChar.CastFrom('{'))
+            {
+                if (guidString[9] == TChar.CastFrom('-'))
+                {
+                    return TryParseExactB(guidString, ref result);
+                }
+                return TryParseExactX(guidString, ref result);
+            }
+            if (guidString[8] == TChar.CastFrom('-'))
+            {
+                return TryParseExactD(guidString, ref result);
+            }
+            return TryParseExactN(guidString, ref result);
         }
 
-        private static bool TryParseExactB(ReadOnlySpan<char> guidString, ref GuidResult result)
+        private static bool TryParseExactB<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
         {
             // e.g. "{d85b1407-351d-4694-9392-03acc5870eb1}"
 
-            if (guidString.Length != 38 || guidString[0] != '{' || guidString[37] != '}')
+            if (guidString.Length != 38 || guidString[0] != TChar.CastFrom('{') || guidString[37] != TChar.CastFrom('}'))
             {
                 result.SetFailure(ParseFailure.Format_GuidInvLen);
                 return false;
@@ -480,11 +511,11 @@ namespace System
             return TryParseExactD(guidString.Slice(1, 36), ref result);
         }
 
-        private static bool TryParseExactD(ReadOnlySpan<char> guidString, ref GuidResult result)
+        private static bool TryParseExactD<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
         {
             // e.g. "d85b1407-351d-4694-9392-03acc5870eb1"
 
-            if (guidString.Length != 36 || guidString[8] != '-' || guidString[13] != '-' || guidString[18] != '-' || guidString[23] != '-')
+            if (guidString.Length != 36 || guidString[8] != TChar.CastFrom('-') || guidString[13] != TChar.CastFrom('-') || guidString[18] != TChar.CastFrom('-') || guidString[23] != TChar.CastFrom('-'))
             {
                 result.SetFailure(guidString.Length != 36 ? ParseFailure.Format_GuidInvLen : ParseFailure.Format_GuidDashes);
                 return false;
@@ -527,7 +558,7 @@ namespace System
             // We continue to support these but expect them to be incredibly rare.  As such, we
             // optimize for correctly formed strings where all the digits are valid hex, and only
             // fall back to supporting these other forms if parsing fails.
-            if (guidString.ContainsAny('X', 'x', '+') && TryCompatParsing(guidString, ref result))
+            if (guidString.ContainsAny(TChar.CastFrom('X'), TChar.CastFrom('x'), TChar.CastFrom('+')) && TryCompatParsing(guidString, ref result))
             {
                 return true;
             }
@@ -535,7 +566,7 @@ namespace System
             result.SetFailure(ParseFailure.Format_GuidInvalidChar);
             return false;
 
-            static bool TryCompatParsing(ReadOnlySpan<char> guidString, ref GuidResult result)
+            static bool TryCompatParsing(ReadOnlySpan<TChar> guidString, ref GuidResult result)
             {
                 if (TryParseHex(guidString.Slice(0, 8), out result._a) && // _a
                     TryParseHex(guidString.Slice(9, 4), out uint uintTmp)) // _b
@@ -566,7 +597,7 @@ namespace System
             }
         }
 
-        private static bool TryParseExactN(ReadOnlySpan<char> guidString, ref GuidResult result)
+        private static bool TryParseExactN<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
         {
             // e.g. "d85b1407351d4694939203acc5870eb1"
 
@@ -609,11 +640,11 @@ namespace System
             return false;
         }
 
-        private static bool TryParseExactP(ReadOnlySpan<char> guidString, ref GuidResult result)
+        private static bool TryParseExactP<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
         {
             // e.g. "(d85b1407-351d-4694-9392-03acc5870eb1)"
 
-            if (guidString.Length != 38 || guidString[0] != '(' || guidString[37] != ')')
+            if (guidString.Length != 38 || guidString[0] != TChar.CastFrom('(') || guidString[37] != TChar.CastFrom(')'))
             {
                 result.SetFailure(ParseFailure.Format_GuidInvLen);
                 return false;
@@ -622,7 +653,7 @@ namespace System
             return TryParseExactD(guidString.Slice(1, 36), ref result);
         }
 
-        private static bool TryParseExactX(ReadOnlySpan<char> guidString, ref GuidResult result)
+        private static bool TryParseExactX<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
         {
             // e.g. "{0xd85b1407,0x351d,0x4694,{0x93,0x92,0x03,0xac,0xc5,0x87,0x0e,0xb1}}"
 
@@ -637,10 +668,10 @@ namespace System
 
             // Eat all of the whitespace.  Unlike the other forms, X allows for any amount of whitespace
             // anywhere, not just at the beginning and end.
-            guidString = EatAllWhitespace(guidString);
+            guidString = EatAllWhitespace(guidString, ref result);
 
             // Check for leading '{'
-            if (guidString.Length == 0 || guidString[0] != '{')
+            if (guidString.Length == 0 || guidString[0] != TChar.CastFrom('{'))
             {
                 result.SetFailure(ParseFailure.Format_GuidBrace);
                 return false;
@@ -655,7 +686,7 @@ namespace System
 
             // Find the end of this hex number (since it is not fixed length)
             int numStart = 3;
-            int numLen = guidString.Slice(numStart).IndexOf(',');
+            int numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
             if (numLen <= 0)
             {
                 result.SetFailure(ParseFailure.Format_GuidComma);
@@ -677,7 +708,7 @@ namespace System
             }
             // +3 to get by ',0x'
             numStart = numStart + numLen + 3;
-            numLen = guidString.Slice(numStart).IndexOf(',');
+            numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
             if (numLen <= 0)
             {
                 result.SetFailure(ParseFailure.Format_GuidComma);
@@ -699,7 +730,7 @@ namespace System
             }
             // +3 to get by ',0x'
             numStart = numStart + numLen + 3;
-            numLen = guidString.Slice(numStart).IndexOf(',');
+            numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
             if (numLen <= 0)
             {
                 result.SetFailure(ParseFailure.Format_GuidComma);
@@ -714,7 +745,7 @@ namespace System
             }
 
             // Check for '{'
-            if ((uint)guidString.Length <= (uint)(numStart + numLen + 1) || guidString[numStart + numLen + 1] != '{')
+            if ((uint)guidString.Length <= (uint)(numStart + numLen + 1) || guidString[numStart + numLen + 1] != TChar.CastFrom('{'))
             {
                 result.SetFailure(ParseFailure.Format_GuidBrace);
                 return false;
@@ -737,7 +768,7 @@ namespace System
                 // Calculate number length
                 if (i < 7)  // first 7 cases
                 {
-                    numLen = guidString.Slice(numStart).IndexOf(',');
+                    numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
                     if (numLen <= 0)
                     {
                         result.SetFailure(ParseFailure.Format_GuidComma);
@@ -746,7 +777,7 @@ namespace System
                 }
                 else // last case ends with '}', not ','
                 {
-                    numLen = guidString.Slice(numStart).IndexOf('}');
+                    numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom('}'));
                     if (numLen <= 0)
                     {
                         result.SetFailure(ParseFailure.Format_GuidBraceAfterLastNumber);
@@ -771,7 +802,7 @@ namespace System
             }
 
             // Check for last '}'
-            if (numStart + numLen + 1 >= guidString.Length || guidString[numStart + numLen + 1] != '}')
+            if (numStart + numLen + 1 >= guidString.Length || guidString[numStart + numLen + 1] != TChar.CastFrom('}'))
             {
                 result.SetFailure(ParseFailure.Format_GuidEndBrace);
                 return false;
@@ -788,44 +819,45 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static byte DecodeByte(char ch1, char ch2, ref int invalidIfNegative)
+        private static byte DecodeByte<TChar>(TChar ch1, TChar ch2, ref int invalidIfNegative) where TChar : unmanaged, IUtfChar<TChar>
         {
             ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
             Debug.Assert(lookup.Length == 256);
-
-            int upper = (sbyte)lookup[(byte)ch1];
-            int lower = (sbyte)lookup[(byte)ch2];
+            int upper = (sbyte)lookup[byte.CreateTruncating(ch1)];
+            int lower = (sbyte)lookup[byte.CreateTruncating(ch2)];
             int result = (upper << 4) | lower;
 
+            uint c1 = TChar.CastToUInt32(ch1);
+            uint c2 = TChar.CastToUInt32(ch2);
             // Result will be negative if ch1 or/and ch2 are greater than 0xFF
-            result = (ch1 | ch2) >> 8 == 0 ? result : -1;
+            result = (c1 | c2) >> 8 == 0 ? result : -1;
             invalidIfNegative |= result;
             return (byte)result;
         }
 
-        private static bool TryParseHex(ReadOnlySpan<char> guidString, out ushort result, ref bool overflow)
+        private static bool TryParseHex<TChar>(ReadOnlySpan<TChar> guidString, out ushort result, ref bool overflow) where TChar : unmanaged, IUtfChar<TChar>
         {
             bool success = TryParseHex(guidString, out uint tmp, ref overflow);
             result = (ushort)tmp;
             return success;
         }
 
-        private static bool TryParseHex(ReadOnlySpan<char> guidString, out uint result)
+        private static bool TryParseHex<TChar>(ReadOnlySpan<TChar> guidString, out uint result) where TChar : unmanaged, IUtfChar<TChar>
         {
             bool overflowIgnored = false;
             return TryParseHex(guidString, out result, ref overflowIgnored);
         }
 
-        private static bool TryParseHex(ReadOnlySpan<char> guidString, out uint result, ref bool overflow)
+        private static bool TryParseHex<TChar>(ReadOnlySpan<TChar> guidString, out uint result, ref bool overflow) where TChar : unmanaged, IUtfChar<TChar>
         {
             if (guidString.Length > 0)
             {
-                if (guidString[0] == '+')
+                if (guidString[0] == TChar.CastFrom('+'))
                 {
                     guidString = guidString.Slice(1);
                 }
 
-                if (guidString.Length > 1 && guidString[0] == '0' && (guidString[1] | 0x20) == 'x')
+                if (guidString.Length > 1 && guidString[0] == TChar.CastFrom('0') && (guidString[1] | TChar.CastFrom(0x20)) == TChar.CastFrom('x'))
                 {
                     guidString = guidString.Slice(2);
                 }
@@ -833,13 +865,13 @@ namespace System
 
             // Skip past leading 0s.
             int i = 0;
-            for (; i < guidString.Length && guidString[i] == '0'; i++) ;
+            for (; i < guidString.Length && guidString[i] == TChar.CastFrom('0'); i++) ;
 
             int processedDigits = 0;
             uint tmp = 0;
             for (; i < guidString.Length; i++)
             {
-                char c = guidString[i];
+                int c = int.CreateTruncating(guidString[i]);
                 int numValue = HexConverter.FromChar(c);
                 if (numValue == 0xFF)
                 {
@@ -856,43 +888,100 @@ namespace System
             return true;
         }
 
-        private static ReadOnlySpan<char> EatAllWhitespace(ReadOnlySpan<char> str)
+        private static ReadOnlySpan<TChar> EatAllWhitespace<TChar>(ReadOnlySpan<TChar> str, scoped ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
         {
-            // Find the first whitespace character.  If there is none, just return the input.
-            int i;
-            for (i = 0; i < str.Length && !char.IsWhiteSpace(str[i]); i++) ;
-            if (i == str.Length)
+            if (typeof(TChar) == typeof(char))
             {
-                return str;
-            }
-
-            // There was at least one whitespace.  Copy over everything prior to it to a new array.
-            var chArr = new char[str.Length];
-            int newLength = 0;
-            if (i > 0)
-            {
-                newLength = i;
-                str.Slice(0, i).CopyTo(chArr);
-            }
-
-            // Loop through the remaining chars, copying over non-whitespace.
-            for (; i < str.Length; i++)
-            {
-                char c = str[i];
-                if (!char.IsWhiteSpace(c))
+                ReadOnlySpan<char> charSpan = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(str);
+                // Find the first whitespace character. If there is none, just return the input.
+                int i;
+                for (i = 0; i < charSpan.Length && !char.IsWhiteSpace(charSpan[i]); i++) ;
+                if (i == charSpan.Length)
                 {
-                    chArr[newLength++] = c;
+                    return str;
                 }
-            }
 
-            // Return the string with the whitespace removed.
-            return new ReadOnlySpan<char>(chArr, 0, newLength);
+                // There was at least one whitespace. Copy over everything prior to it to a new array.
+                var chArr = new char[charSpan.Length];
+                int newLength = 0;
+                if (i > 0)
+                {
+                    newLength = i;
+                    charSpan.Slice(0, i).CopyTo(chArr);
+                }
+
+                // Loop through the remaining chars, copying over non-whitespace.
+                for (; i < charSpan.Length; i++)
+                {
+                    char c = charSpan[i];
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        chArr[newLength++] = c;
+                    }
+                }
+
+                // Return the string with the whitespace removed.
+                return Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(new ReadOnlySpan<char>(chArr, 0, newLength));
+            }
+            else
+            {
+                Debug.Assert(typeof(TChar) == typeof(byte));
+
+                ReadOnlySpan<byte> srcUtf8Span = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(str);
+                // Find the first whitespace character.  If there is none, just return the input.
+                int i = 0;
+                while (i < srcUtf8Span.Length)
+                {
+                    // in the unlikely event that there is invalid utf8, the parse will fail later anyways
+                    _ = Rune.DecodeFromUtf8(srcUtf8Span.Slice(i), out Rune current, out int bytesConsumed);
+
+                    if (!Rune.IsWhiteSpace(current))
+                    {
+                        break;
+                    }
+                    i += bytesConsumed;
+                }
+                if (i == srcUtf8Span.Length)
+                {
+                    return str;
+                }
+
+                // There was at least one whitespace. Copy over everything prior to it to a new array.
+                Span<byte> destUtf8Span = new byte[srcUtf8Span.Length];
+                int newLength = 0;
+                if (i > 0)
+                {
+                    newLength = i;
+                    srcUtf8Span.Slice(0, i).CopyTo(destUtf8Span);
+                }
+
+                // Loop through the remaining chars, copying over non-whitespace.
+                while (i < srcUtf8Span.Length)
+                {
+                    // Unlike the previous loop, invalid utf8 can't be ignored here
+                    if (Rune.DecodeFromUtf8(srcUtf8Span.Slice(i), out Rune current, out int bytesConsumed) != Buffers.OperationStatus.Done)
+                    {
+                        result.SetFailure(ParseFailure.Format_GuidInvalidChar);
+                        return ReadOnlySpan<TChar>.Empty;
+                    }
+
+                    if (!Rune.IsWhiteSpace(current))
+                    {
+                        srcUtf8Span.Slice(i, bytesConsumed).CopyTo(destUtf8Span.Slice(newLength));
+                        newLength += bytesConsumed;
+                    }
+                    i += bytesConsumed;
+                }
+
+                // Return the string with the whitespace removed.
+                return Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(destUtf8Span.Slice(0, newLength));
+            }
         }
 
-        private static bool IsHexPrefix(ReadOnlySpan<char> str, int i) =>
+        private static bool IsHexPrefix<TChar>(ReadOnlySpan<TChar> str, int i) where TChar : unmanaged, IUtfChar<TChar> =>
             i + 1 < str.Length &&
-            str[i] == '0' &&
-            (str[i + 1] | 0x20) == 'x';
+            str[i] == TChar.CastFrom('0') &&
+            (str[i + 1] | TChar.CastFrom(0x20)) == TChar.CastFrom('x');
 
         // Returns an unsigned byte array containing the GUID.
         public byte[] ToByteArray()
@@ -1751,5 +1840,15 @@ namespace System
         [DoesNotReturn]
         private static void ThrowBadGuidFormatSpecification() =>
             throw new FormatException(SR.Format_InvalidGuidFormatSpecification);
+
+        //
+        // IUtf8SpanParsable
+        //
+
+        /// <inheritdoc cref="IUtf8SpanParsable{TSelf}.Parse(ReadOnlySpan{byte}, IFormatProvider?)" />
+        public static Guid Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => Parse(utf8Text);
+
+        /// <inheritdoc cref="IUtf8SpanParsable{TSelf}.TryParse(ReadOnlySpan{byte}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out Guid result) => TryParse(utf8Text, out result);
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3142,7 +3142,7 @@ namespace System
         Timeout = 3,
         NotApplicable = 4,
     }
-    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable, System.IParsable<System.Guid>, System.ISpanFormattable, System.ISpanParsable<System.Guid>, System.IUtf8SpanFormattable
+    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable, System.IParsable<System.Guid>, System.ISpanFormattable, System.ISpanParsable<System.Guid>, System.IUtf8SpanFormattable, System.IUtf8SpanParsable<System.Guid>
     {
         private readonly int _dummyPrimitive;
         public static readonly System.Guid Empty;
@@ -3171,6 +3171,8 @@ namespace System
         public static bool operator !=(System.Guid a, System.Guid b) { throw null; }
         public static bool operator <(System.Guid left, System.Guid right) { throw null; }
         public static bool operator <=(System.Guid left, System.Guid right) { throw null; }
+        public static System.Guid Parse(System.ReadOnlySpan<byte> utf8Text) { throw null; }
+        public static System.Guid Parse(System.ReadOnlySpan<byte> utf8Text, System.IFormatProvider? provider) { throw null; }
         public static System.Guid Parse(System.ReadOnlySpan<char> input) { throw null; }
         public static System.Guid Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Guid Parse(string input) { throw null; }
@@ -3186,6 +3188,8 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("GuidFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public bool TryFormat(System.Span<byte> utf8Destination, out int bytesWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("GuidFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>)) { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("GuidFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>)) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> utf8Text, out System.Guid result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> utf8Text, System.IFormatProvider? provider, out System.Guid result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> input, out System.Guid result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Guid result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, out System.Guid result) { throw null; }


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/81500

API Proposal: https://github.com/dotnet/runtime/issues/105653

This implements `IUtf8SpanParsable` on `Guid` by making the core of the parsing logic generic on `TChar : IUtfChar<TChar>`. A small amount of it is duplicated, with a version for `char` and `byte`, because doing so prevented a performance regression for `char` parsing.

In addition, it adds a Utf8 `Parse` and `TryParse` without the unused `IFormatProvider` parameter, to match how `ISpanParsable` was implemented. I did not add Utf8 overloads for `ParseExact`, but that can be discussed in the linked API proposal.