### PR TITLE
Ensure that embedded broadcast is correctly checking for EVEX support before use

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -8292,7 +8292,7 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* parentNode, GenTre
                 return false;
             }
 
-            return parentNode->OperIsEmbBroadcastCompatible();
+            return parentNode->OperIsEmbBroadcastCompatible() && comp->canUseEvexEncoding();
         }
 
         default:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96156/Runtime_96156.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96156/Runtime_96156.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_96156
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private unsafe static Vector128<float> BroadcastScalarToVector128(float value)
+    {
+        return Avx.BroadcastScalarToVector128(&value);
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Vector128<float> c = Vector128.Create(1.0f);
+        Vector128<float> r = Problem(2.0f, 0.5f, c);
+        Assert.Equal(Vector128.Create(4.0f), r);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<float> Problem(float a, float b, Vector128<float> c)
+    {
+        return Avx.Multiply(c, BroadcastScalarToVector128(a / b));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96156/Runtime_96156.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96156/Runtime_96156.cs
@@ -18,9 +18,12 @@ public class Runtime_96156
     [Fact]
     public static void TestEntryPoint()
     {
-        Vector128<float> c = Vector128.Create(1.0f);
-        Vector128<float> r = Problem(2.0f, 0.5f, c);
-        Assert.Equal(Vector128.Create(4.0f), r);
+        if (Avx.IsSupported)
+        {
+            Vector128<float> c = Vector128.Create(1.0f);
+            Vector128<float> r = Problem(2.0f, 0.5f, c);
+            Assert.Equal(Vector128.Create(4.0f), r);
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96156/Runtime_96156.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96156/Runtime_96156.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CLRTestEnvironmentVariable Include="DOTNET_EnableAVX512F" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Customer Impact

- [x] Customer reported
- [ ] Found internally

This resolves https://github.com/dotnet/runtime/issues/96156

.NET 8 introduced support for the new AVX512 instruction set and this brought along support for several optimizations when the underlying hardware supported this feature. However, one such place was missing the check for said hardware support and would cause incorrect codegen on older hardware which could lead to incorrect results and behavior.

## Regression

- [x] Yes
- [ ] No

This is a regression as it impacts existing code and hardware when run on the .NET 8 runtime.

## Testing

An explicit test was added covering the regression and additional validation was done against other callsites checking `OperIsEmbBroadcastCompatible` to ensure that they were all correctly validating that the target hardware is AVX512 capable.

## Risk

Low. The failure here is well understood and has had a fix in the .NET 9 previews for almost 2 months now.