### PR TITLE
Use correct IL offset when reporting dataflow warnings for return statements

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -870,7 +870,7 @@ namespace ILCompiler.Dataflow
 
         protected abstract SingleValue GetMethodParameterValue(ParameterProxy parameter);
 
-        protected abstract MethodReturnValue GetReturnValue (MethodIL method);
+        protected abstract MethodReturnValue GetReturnValue(MethodIL method);
 
         private void ScanLdarg(ILOpcode opcode, int parameterIndex, Stack<StackSlot> currentStack, MethodDesc thisMethod)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -1116,7 +1116,7 @@ namespace ILCompiler.Dataflow
         {
         }
 
-        protected virtual void HandleReturnValue(MethodIL method, int offset, MethodReturnValue thisParameter, MultiValue sourceValue)
+        protected virtual void HandleReturnValue(MethodIL method, int offset, MethodReturnValue thisParameter, MultiValue valueToReturn)
         {
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -187,7 +187,7 @@ namespace ILCompiler.Dataflow
         private MethodParameterValue GetMethodParameterValue(ParameterProxy parameter, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
             => _annotations.GetMethodParameterValue(parameter, dynamicallyAccessedMemberTypes);
 
-        protected override MethodReturnValue GetReturnValue (MethodIL method) => _annotations.GetMethodReturnValue (method.OwningMethod, isNewObj: false);
+        protected override MethodReturnValue GetReturnValue(MethodIL method) => _annotations.GetMethodReturnValue(method.OwningMethod, isNewObj: false);
 
         /// <summary>
         /// HandleGetField is called every time the scanner needs to represent a value of the field

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -114,14 +114,6 @@ namespace ILCompiler.Dataflow
         {
             _origin = new MessageOrigin(methodBody.OwningMethod);
             base.Scan(methodBody, ref interproceduralState);
-
-            if (!methodBody.OwningMethod.Signature.ReturnType.IsVoid)
-            {
-                var method = methodBody.OwningMethod;
-                var methodReturnValue = _annotations.GetMethodReturnValue(method, isNewObj: false);
-                if (methodReturnValue.DynamicallyAccessedMemberTypes != 0)
-                    HandleAssignmentPattern(_origin, ReturnValue, methodReturnValue, method.GetDisplayName());
-            }
         }
 
         public static DependencyList ScanAndProcessReturnValue(NodeFactory factory, FlowAnnotations annotations, Logger logger, MethodIL methodBody, out List<INodeWithRuntimeDeterminedDependencies> runtimeDependencies)
@@ -195,6 +187,8 @@ namespace ILCompiler.Dataflow
         private MethodParameterValue GetMethodParameterValue(ParameterProxy parameter, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
             => _annotations.GetMethodParameterValue(parameter, dynamicallyAccessedMemberTypes);
 
+        protected override MethodReturnValue GetReturnValue (MethodIL method) => _annotations.GetMethodReturnValue (method.OwningMethod, isNewObj: false);
+
         /// <summary>
         /// HandleGetField is called every time the scanner needs to represent a value of the field
         /// either as a source or target. It is not called when just a reference to field is created,
@@ -219,7 +213,7 @@ namespace ILCompiler.Dataflow
             if (targetValue.DynamicallyAccessedMemberTypes != 0)
             {
                 _origin = _origin.WithInstructionOffset(methodBody, offset);
-                HandleAssignmentPattern(_origin, sourceValue, targetValue, reason);
+                TrimAnalysisPatterns.Add(new TrimAnalysisAssignmentPattern(sourceValue, targetValue, _origin, reason));
             }
         }
 
@@ -229,7 +223,7 @@ namespace ILCompiler.Dataflow
         protected override void HandleStoreParameter(MethodIL methodBody, int offset, MethodParameterValue parameter, MultiValue valueToStore)
             => HandleStoreValueWithDynamicallyAccessedMembers(methodBody, offset, parameter, valueToStore, parameter.Parameter.Method.GetDisplayName());
 
-        protected override void HandleStoreMethodReturnValue(MethodIL methodBody, int offset, MethodReturnValue returnValue, MultiValue valueToStore)
+        protected override void HandleReturnValue(MethodIL methodBody, int offset, MethodReturnValue returnValue, MultiValue valueToStore)
             => HandleStoreValueWithDynamicallyAccessedMembers(methodBody, offset, returnValue, valueToStore, returnValue.Method.GetDisplayName());
 
         protected override void HandleTypeTokenAccess(MethodIL methodBody, int offset, TypeDesc accessedType)
@@ -412,15 +406,6 @@ namespace ILCompiler.Dataflow
             }
 
             return false;
-        }
-
-        private void HandleAssignmentPattern(
-            in MessageOrigin origin,
-            in MultiValue value,
-            ValueWithDynamicallyAccessedMembers targetValue,
-            string reason)
-        {
-            TrimAnalysisPatterns.Add(new TrimAnalysisAssignmentPattern(value, targetValue, origin, reason));
         }
 
         private void ProcessGenericArgumentDataFlow(MethodDesc method)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
@@ -12,7 +12,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
 	public readonly struct TrimAnalysisPatternStore
 	{
-		readonly Dictionary<(IOperation, bool), TrimAnalysisAssignmentPattern> AssignmentPatterns;
+		readonly Dictionary<IOperation, TrimAnalysisAssignmentPattern> AssignmentPatterns;
 		readonly Dictionary<IOperation, TrimAnalysisFieldAccessPattern> FieldAccessPatterns;
 		readonly Dictionary<IOperation, TrimAnalysisGenericInstantiationPattern> GenericInstantiationPatterns;
 		readonly Dictionary<IOperation, TrimAnalysisMethodCallPattern> MethodCallPatterns;
@@ -25,7 +25,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			ValueSetLattice<SingleValue> lattice,
 			FeatureContextLattice featureContextLattice)
 		{
-			AssignmentPatterns = new Dictionary<(IOperation, bool), TrimAnalysisAssignmentPattern> ();
+			AssignmentPatterns = new Dictionary<IOperation, TrimAnalysisAssignmentPattern> ();
 			FieldAccessPatterns = new Dictionary<IOperation, TrimAnalysisFieldAccessPattern> ();
 			GenericInstantiationPatterns = new Dictionary<IOperation, TrimAnalysisGenericInstantiationPattern> ();
 			MethodCallPatterns = new Dictionary<IOperation, TrimAnalysisMethodCallPattern> ();
@@ -35,7 +35,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			FeatureContextLattice = featureContextLattice;
 		}
 
-		public void Add (TrimAnalysisAssignmentPattern trimAnalysisPattern, bool isReturnValue)
+		public void Add (TrimAnalysisAssignmentPattern trimAnalysisPattern)
 		{
 			// Finally blocks will be analyzed multiple times, once for normal control flow and once
 			// for exceptional control flow, and these separate analyses could produce different
@@ -45,12 +45,12 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			// of the normal control-flow state.
 			// We still add patterns to the operation, rather than replacing, to make this resilient to
 			// changes in the analysis algorithm.
-			if (!AssignmentPatterns.TryGetValue ((trimAnalysisPattern.Operation, isReturnValue), out var existingPattern)) {
-				AssignmentPatterns.Add ((trimAnalysisPattern.Operation, isReturnValue), trimAnalysisPattern);
+			if (!AssignmentPatterns.TryGetValue (trimAnalysisPattern.Operation, out var existingPattern)) {
+				AssignmentPatterns.Add (trimAnalysisPattern.Operation, trimAnalysisPattern);
 				return;
 			}
 
-			AssignmentPatterns[(trimAnalysisPattern.Operation, isReturnValue)] = trimAnalysisPattern.Merge (Lattice, FeatureContextLattice, existingPattern);
+			AssignmentPatterns[trimAnalysisPattern.Operation] = trimAnalysisPattern.Merge (Lattice, FeatureContextLattice, existingPattern);
 		}
 
 		public void Add (TrimAnalysisFieldAccessPattern pattern)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -238,9 +238,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			// annotated with DAMT.
 			TrimAnalysisPatterns.Add (
 				// This will copy the values if necessary
-				new TrimAnalysisAssignmentPattern (source, target, operation, OwningSymbol, featureContext),
-				isReturnValue: false
-			);
+				new TrimAnalysisAssignmentPattern (source, target, operation, OwningSymbol, featureContext));
 		}
 
 		public override MultiValue HandleArrayElementRead (MultiValue arrayValue, MultiValue indexValue, IOperation operation)
@@ -350,9 +348,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				var returnParameter = new MethodReturnValue (method, isNewObj: false);
 
 				TrimAnalysisPatterns.Add (
-					new TrimAnalysisAssignmentPattern (returnValue, returnParameter, operation, OwningSymbol, featureContext),
-					isReturnValue: true
-				);
+					new TrimAnalysisAssignmentPattern (returnValue, returnParameter, operation, OwningSymbol, featureContext));
 			}
 		}
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -652,10 +652,10 @@ namespace Mono.Linker.Dataflow
 							WarnAboutInvalidILInMethod (methodBody, operation.Offset);
 						}
 						if (hasReturnValue) {
-							StackSlot retValueSlot = PopUnknown (currentStack, 1, methodBody, operation.Offset);
+							StackSlot retStackSlot = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 							// If the return value is a reference, treat it as the value itself for now
 							// We can handle ref return values better later
-							MultiValue retValue = DereferenceValue (retValueSlot.Value, locals, ref interproceduralState);
+							MultiValue retValue = DereferenceValue (retStackSlot.Value, locals, ref interproceduralState);
 							var methodReturnValue = GetReturnValue (methodBody.Method);
 							HandleReturnValue (thisMethod, methodReturnValue, operation, retValue);
 							ValidateNoReferenceToReference (locals, methodBody.Method, operation.Offset);
@@ -717,6 +717,8 @@ namespace Mono.Linker.Dataflow
 		}
 
 		protected abstract SingleValue GetMethodParameterValue (ParameterProxy parameter);
+
+		protected abstract MethodReturnValue GetReturnValue (MethodDefinition method);
 
 		private void ScanLdarg (Instruction operation, Stack<StackSlot> currentStack, MethodDefinition thisMethod)
 		{
@@ -895,8 +897,6 @@ namespace Mono.Linker.Dataflow
 		}
 
 		protected abstract MultiValue GetFieldValue (FieldDefinition field);
-
-		protected abstract MethodReturnValue GetReturnValue (MethodDefinition method);
 
 		private void ScanLdfld (
 			Instruction operation,

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -72,13 +72,6 @@ namespace Mono.Linker.Dataflow
 		{
 			_origin = new MessageOrigin (methodIL.Method);
 			base.Scan (methodIL, ref interproceduralState);
-
-			if (!methodIL.Method.ReturnsVoid ()) {
-				var method = methodIL.Method;
-				var methodReturnValue = _annotations.GetMethodReturnValue (method, isNewObj: false);
-				if (methodReturnValue.DynamicallyAccessedMemberTypes != 0)
-					HandleAssignmentPattern (_origin, ReturnValue, methodReturnValue);
-			}
 		}
 
 		protected override void WarnAboutInvalidILInMethod (MethodBody method, int ilOffset)
@@ -100,11 +93,13 @@ namespace Mono.Linker.Dataflow
 
 		protected override MultiValue GetFieldValue (FieldDefinition field) => _annotations.GetFieldValue (field);
 
+		protected override MethodReturnValue GetReturnValue (MethodDefinition method) => _annotations.GetMethodReturnValue (method, isNewObj: false);
+
 		private void HandleStoreValueWithDynamicallyAccessedMembers (ValueWithDynamicallyAccessedMembers targetValue, Instruction operation, MultiValue sourceValue)
 		{
 			if (targetValue.DynamicallyAccessedMemberTypes != 0) {
 				_origin = _origin.WithInstructionOffset (operation.Offset);
-				HandleAssignmentPattern (_origin, sourceValue, targetValue);
+				TrimAnalysisPatterns.Add (new TrimAnalysisAssignmentPattern (sourceValue, targetValue, _origin));
 			}
 		}
 
@@ -114,7 +109,7 @@ namespace Mono.Linker.Dataflow
 		protected override void HandleStoreParameter (MethodDefinition method, MethodParameterValue parameter, Instruction operation, MultiValue valueToStore)
 			=> HandleStoreValueWithDynamicallyAccessedMembers (parameter, operation, valueToStore);
 
-		protected override void HandleStoreMethodReturnValue (MethodDefinition method, MethodReturnValue returnValue, Instruction operation, MultiValue valueToStore)
+		protected override void HandleReturnValue (MethodDefinition method, MethodReturnValue returnValue, Instruction operation, MultiValue valueToStore)
 			=> HandleStoreValueWithDynamicallyAccessedMembers (returnValue, operation, valueToStore);
 
 		public override MultiValue HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams)
@@ -246,14 +241,6 @@ namespace Mono.Linker.Dataflow
 			}
 
 			return false;
-		}
-
-		void HandleAssignmentPattern (
-			in MessageOrigin origin,
-			in MultiValue value,
-			ValueWithDynamicallyAccessedMembers targetValue)
-		{
-			TrimAnalysisPatterns.Add (new TrimAnalysisAssignmentPattern (value, targetValue, origin));
 		}
 
 		internal static bool IsPInvokeDangerous (MethodDefinition methodDefinition, LinkContext context, out bool comDangerousMethod)

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -216,6 +216,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task MultipleReturnsDataFlow ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task GetInterfaceDataFlow ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,6 +21,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 		[Fact]
 		public Task MethodByRefParameterDataFlow ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
+		public Task MultipleReturnsDataFlow ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -20,13 +20,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task MethodByRefParameterDataFlow ()
+		public Task InterfaceImplementedThroughBaseValidation ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]
-		public Task MultipleReturnsDataFlow ()
+		public Task MethodByRefParameterDataFlow ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MultipleReturnsDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MultipleReturnsDataFlow.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	// Optimized code makes it easier to produce a method body with multiple return statements in IL.
+	[SetupCompileArgument ("/optimize+")]
+	public class MultipleReturnsDataFlow
+	{
+		public static void Main ()
+		{
+			MultipleReturnsOfSameValueMismatch ();
+		}
+
+		static Type GetUnannotatedType () => null;
+
+		[ExpectedWarning ("IL2073",
+			nameof (MultipleReturnsDataFlow) + "." + nameof (MultipleReturnsOfSameValueMismatch))]
+		[ExpectedWarning ("IL2073",
+			nameof (MultipleReturnsDataFlow) + "." + nameof (MultipleReturnsOfSameValueMismatch))]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+		static Type MultipleReturnsOfSameValueMismatch (int condition = 0)
+		{
+			var value = GetUnannotatedType ();
+			if (condition is 0)
+				return value;
+
+			if (condition is 1)
+				return null;
+
+			return GetUnannotatedType ();
+		}
+	}
+}


### PR DESCRIPTION
Instead of merging all returned values into a single return value and reporting warnings based on that, report warnings per return statement, using the IL offset at that point. This allows us to fix the message origin to match the IL offset of each individual return statement, so we can remove a workaround from the pattern store.

Fixes https://github.com/dotnet/linker/issues/2778

@dotnet/appmodel PTAL