### PR TITLE
Fix flaky tests in WindowsServiceLifetimeTests

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceLifetimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceLifetimeTests.cs
@@ -144,7 +144,11 @@ namespace Microsoft.Extensions.Hosting
                     .Build();
 
                 var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-                applicationLifetime.ApplicationStarted.Register(() => FileLogger.Log($"lifetime started"));
+                applicationLifetime.ApplicationStarted.Register(() =>
+                {
+                    FileLogger.Log($"lifetime started");
+                    are.Set();
+                });
                 applicationLifetime.ApplicationStopping.Register(() => FileLogger.Log($"lifetime stopping"));
                 applicationLifetime.ApplicationStopped.Register(() => FileLogger.Log($"lifetime stopped"));
 
@@ -171,7 +175,7 @@ namespace Microsoft.Extensions.Hosting
                 serviceTester.Start();
 
                 // service will proceed to stopped without any error
-                serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+                serviceTester.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.MaxValue);
 
                 var status = serviceTester.QueryServiceStatus();
                 Assert.Equal(0, status.win32ExitCode);
@@ -194,6 +198,8 @@ namespace Microsoft.Extensions.Hosting
                 """, logText);
         }
 
+        private static AutoResetEvent are = new AutoResetEvent(false);
+
         [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void ServiceSequenceIsCorrect()
         {
@@ -209,7 +215,12 @@ namespace Microsoft.Extensions.Hosting
                     .Build();
 
                 var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-                applicationLifetime.ApplicationStarted.Register(() => FileLogger.Log($"lifetime started"));
+                applicationLifetime.ApplicationStarted.Register(() =>
+                {
+                    FileLogger.Log($"lifetime started");
+                    are.Set();
+                });
+
                 applicationLifetime.ApplicationStopping.Register(() => FileLogger.Log($"lifetime stopping"));
                 applicationLifetime.ApplicationStopped.Register(() => FileLogger.Log($"lifetime stopped"));
 
@@ -268,6 +279,7 @@ namespace Microsoft.Extensions.Hosting
 
             protected override void OnStop()
             {
+                are.WaitOne();
                 FileLogger.Log("WindowsServiceLifetime.OnStop");
                 base.OnStop();
             }


### PR DESCRIPTION
- `ServiceCanStopItself` test fails with `System.ServiceProcess.TimeoutException : The operation requested for service 'ServiceCanStopItself' has not been completed within the specified time interval.` The interval is 30 milliseconds, changing it to `TimeSpan.MaxValue` because the test is expected to stop eventually, it's not defined what time interval will be enough.
- `ServiceSequenceIsCorrect` test fails because of race condition, it looks `serviceTester.Stop()` started before `serviceTester.Start()` completed. It was suggested to `introduce a synchronization primitive here and have the test wait for that to be signaled by the service`. Added `AutoResetEvent` instance that signals when windows service started completely

Fixes https://github.com/dotnet/runtime/issues/103262
Fixes https://github.com/dotnet/runtime/issues/93194