### PR TITLE
Remove some overhead from SymbolicRegexMatcher

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
@@ -110,6 +110,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 return (uint)c < (uint)lookup.Length ? lookup[c] : 0;
             }
         }
+
         /// <summary>
         /// Gets a quick mapping from char to minterm for the common case when there are &lt;= 255 minterms.
         /// Null if there are greater than 255 minterms.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/104975
cc: @ieviev, @veanes 

- Avoid try/finally blocks, instead using breaks to break out of a loop to a single return
- Consolidate two almost identical methods for DFA transitions
- Avoid an unnecessary GetPositionKind call that could instead use a hardcoded index
- Avoid a duplicate read for a ref parameter
- Outline a throw

| Type                                  | Toolchain         | Pattern                              | Mean         | Ratio |
|-------------------------------------- |------------------ |------------------------------------- |-------------:|------:|
| Perf_Regex_Industry_RustLang_Sherlock | \main\corerun.exe | \\s[a-zA-Z]{0,12}ing\\s               |  2,697.27 us |  1.00 |
| Perf_Regex_Industry_RustLang_Sherlock | \pr\corerun.exe   | \\s[a-zA-Z]{0,12}ing\\s               |  2,495.75 us |  0.93 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_RustLang_Sherlock | \main\corerun.exe | \\w+\\s+Holmes                        |  2,456.07 us |  1.00 |
| Perf_Regex_Industry_RustLang_Sherlock | \pr\corerun.exe   | \\w+\\s+Holmes                        |  2,217.08 us |  0.90 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_RustLang_Sherlock | \main\corerun.exe | \\w+\\s+Holmes\\s+\\w+                |  2,445.44 us |  1.00 |
| Perf_Regex_Industry_RustLang_Sherlock | \pr\corerun.exe   | \\w+\\s+Holmes\\s+\\w+                |  2,208.26 us |  0.90 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_RustLang_Sherlock | \main\corerun.exe | Sherlock\|Holmes                      |    127.52 us |  1.00 |
| Perf_Regex_Industry_RustLang_Sherlock | \pr\corerun.exe   | Sherlock\|Holmes                      |    117.73 us |  0.92 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_RustLang_Sherlock | \main\corerun.exe | Sherlock\|Holmes\|Watson               |    174.69 us |  1.00 |
| Perf_Regex_Industry_RustLang_Sherlock | \pr\corerun.exe   | Sherlock\|Holmes\|Watson               |    171.71 us |  0.99 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_RustLang_Sherlock | \main\corerun.exe | Sherlock\|Holm(...)er\|John\|Baker [45] |  1,640.95 us |  1.01 |
| Perf_Regex_Industry_RustLang_Sherlock | \pr\corerun.exe   | Sherlock\|Holm(...)er\|John\|Baker [45] |  1,528.37 us |  0.94 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_RustLang_Sherlock | \main\corerun.exe | Sherlock\|Street                      |     52.88 us |  1.00 |
| Perf_Regex_Industry_RustLang_Sherlock | \pr\corerun.exe   | Sherlock\|Street                      |     52.34 us |  0.99 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_Leipzig           | \main\corerun.exe | .{0,2}(Tom\|Sawyer\|Huckleberry\|Finn)   | 63,165.09 us |  1.00 |
| Perf_Regex_Industry_Leipzig           | \pr\corerun.exe   | .{0,2}(Tom\|Sawyer\|Huckleberry\|Finn)   | 58,308.39 us |  0.92 |
|                                       |                   |                                       |              |       |
| Perf_Regex_Industry_Leipzig           | \main\corerun.exe | .{2,4}(Tom\|Sawyer\|Huckleberry\|Finn)   | 62,901.15 us |  1.00 |
| Perf_Regex_Industry_Leipzig           | \pr\corerun.exe   | .{2,4}(Tom\|Sawyer\|Huckleberry\|Finn)   | 54,967.23 us |  0.87 |