### PR TITLE
ARM64-SVE: Fix Comment group headers in SVE API (#104846)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.PlatformNotSupported.cs
@@ -31,7 +31,8 @@ namespace System.Runtime.Intrinsics.Arm
             public static new bool IsSupported { [Intrinsic] get { return false; } }
         }
 
-        ///  Abs : Absolute value
+
+        // Absolute value
 
         /// <summary>
         /// svint8_t svabs[_s8]_m(svint8_t inactive, svbool_t pg, svint8_t op)
@@ -75,7 +76,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> Abs(Vector<double> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Absolute compare greater than
+
+        // Absolute compare greater than
 
         /// <summary>
         /// svbool_t svacgt[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -89,7 +91,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareGreaterThan(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Absolute compare greater than or equal to
+
+        // Absolute compare greater than or equal to
 
         /// <summary>
         /// svbool_t svacge[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -103,7 +106,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareGreaterThanOrEqual(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Absolute compare less than
+
+        // Absolute compare less than
 
         /// <summary>
         /// svbool_t svaclt[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -117,7 +121,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareLessThan(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Absolute compare less than or equal to
+
+        // Absolute compare less than or equal to
 
         /// <summary>
         /// svbool_t svacle[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -131,7 +136,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareLessThanOrEqual(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
-        ///  AbsoluteDifference : Absolute difference
+
+        // Absolute difference
 
         /// <summary>
         /// svuint8_t svabd[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -213,7 +219,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> AbsoluteDifference(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Add : Add
+
+        // Add
 
         /// <summary>
         /// svint8_t svadd[_s8]_m(svbool_t pg, svint8_t op1, svint8_t op2)
@@ -285,7 +292,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> Add(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
-        ///  AddAcross : Add reduction
+
+        // Add reduction
 
         /// <summary>
         /// float64_t svaddv[_f64](svbool_t pg, svfloat64_t op)
@@ -347,7 +355,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> AddAcross(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Complex add with rotate
+
+        // Complex add with rotate
 
         /// <summary>
         /// svfloat64_t svcadd[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, uint64_t imm_rotation)
@@ -367,7 +376,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> AddRotateComplex(Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(1))] byte rotation) { throw new PlatformNotSupportedException(); }
 
-        ///  AddSaturate : Saturating add
+
+        // Saturating add
 
         /// <summary>
         /// svuint8_t svqadd[_u8](svuint8_t op1, svuint8_t op2)
@@ -417,7 +427,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> AddSaturate(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
-        ///  AddSequentialAcross : Add reduction (strictly-ordered)
+
+        // Add reduction (strictly-ordered)
 
         /// <summary>
         /// float64_t svadda[_f64](svbool_t pg, float64_t initial, svfloat64_t op)
@@ -431,7 +442,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> AddSequentialAcross(Vector<float> initial, Vector<float> value) { throw new PlatformNotSupportedException(); }
 
-        ///  And : Bitwise AND
+
+        // Bitwise AND
 
         /// <summary>
         /// svuint8_t svand[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -522,7 +534,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> And(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  AndAcross : Bitwise AND reduction to scalar
+        // Bitwise AND reduction to scalar
 
         /// <summary>
         /// uint8_t svandv[_u8](svbool_t pg, svuint8_t op)
@@ -573,7 +585,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> AndAcross(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  BitwiseClear : Bitwise clear
+        // Bitwise clear
 
         /// <summary>
         /// svuint8_t svbic[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -664,7 +676,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> BitwiseClear(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  BooleanNot : Logically invert boolean condition
+        // Logically invert boolean condition
 
         /// <summary>
         /// svuint8_t svcnot[_u8]_m(svuint8_t inactive, svbool_t pg, svuint8_t op)
@@ -730,7 +742,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> BooleanNot(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Shuffle active elements of vector to the right and fill with zero
+
+        // Shuffle active elements of vector to the right and fill with zero
 
         /// <summary>
         /// svfloat64_t svcompact[_f64](svbool_t pg, svfloat64_t op)
@@ -768,7 +781,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> Compact(Vector<ulong> mask, Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Compare equal to
+
+        // Compare equal to
 
         /// <summary>
         /// svbool_t svcmpeq[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -848,7 +862,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> CompareEqual(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Compare greater than
+
+        // Compare greater than
 
         /// <summary>
         /// svbool_t svcmpgt[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -947,7 +962,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CompareGreaterThan(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compare greater than or equal to
+        // Compare greater than or equal to
 
         /// <summary>
         /// svbool_t svcmpge[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1046,7 +1061,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CompareGreaterThanOrEqual(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compare less than
+        // Compare less than
 
         /// <summary>
         /// svbool_t svcmplt[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1145,7 +1160,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CompareLessThan(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compare less than or equal to
+        // Compare less than or equal to
 
         /// <summary>
         /// svbool_t svcmple[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1243,7 +1258,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> CompareLessThanOrEqual(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Compare not equal to
+
+        // Compare not equal to
 
         /// <summary>
         /// svbool_t svcmpne[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1324,7 +1340,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CompareNotEqualTo(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compare unordered with
+        // Compare unordered with
 
         /// <summary>
         /// svbool_t svcmpuo[_f64](svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -1338,7 +1354,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> CompareUnordered(Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Compute vector addresses for 16-bit data
+
+        // Compute vector addresses for 16-bit data
 
         /// <summary>
         /// svuint32_t svadrh[_u32base]_[s32]index(svuint32_t bases, svint32_t indices)
@@ -1365,7 +1382,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Compute16BitAddresses(Vector<ulong> bases, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compute vector addresses for 32-bit data
+        // Compute vector addresses for 32-bit data
 
         /// <summary>
         /// svuint32_t svadrw[_u32base]_[s32]index(svuint32_t bases, svint32_t indices)
@@ -1392,7 +1409,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Compute32BitAddresses(Vector<ulong> bases, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compute vector addresses for 64-bit data
+        // Compute vector addresses for 64-bit data
 
         /// <summary>
         /// svuint32_t svadrd[_u32base]_[s32]index(svuint32_t bases, svint32_t indices)
@@ -1419,7 +1436,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Compute64BitAddresses(Vector<ulong> bases, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compute vector addresses for 8-bit data
+        // Compute vector addresses for 8-bit data
 
         /// <summary>
         /// svuint32_t svadrb[_u32base]_[s32]offset(svuint32_t bases, svint32_t offsets)
@@ -1445,7 +1462,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> Compute8BitAddresses(Vector<ulong> bases, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
-        ///  Conditionally extract element after last
+
+        // Conditionally extract element after last
 
         /// <summary>
         /// svuint8_t svclasta[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1568,7 +1586,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong ConditionalExtractAfterLastActiveElement(Vector<ulong> mask, ulong defaultValues, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Conditionally extract element after last
+        // Conditionally extract element after last
 
         /// <summary>
         /// svuint8_t svclasta[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1631,7 +1649,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ConditionalExtractAfterLastActiveElementAndReplicate(Vector<ulong> mask, Vector<ulong> defaultScalar, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Conditionally extract last element
+        // Conditionally extract last element
 
         /// <summary>
         /// svuint8_t svclastb[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1754,7 +1772,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong ConditionalExtractLastActiveElement(Vector<ulong> mask, ulong defaultValues, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Conditionally extract last element
+        // Conditionally extract last element
 
         /// <summary>
         /// svuint8_t svclastb[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1817,8 +1835,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ConditionalExtractLastActiveElementAndReplicate(Vector<ulong> mask, Vector<ulong> fallback, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Compare equal to
-        ///  ConditionalSelect : Conditionally select elements
+        // Conditionally select elements
 
         /// <summary>
         /// svint8_t svsel[_s8](svbool_t pg, svint8_t op1, svint8_t op2)
@@ -1879,7 +1896,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> ConditionalSelect(Vector<double> mask, Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ConvertToDouble : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svfloat64_t svcvt_f64[_s32]_m(svfloat64_t inactive, svbool_t pg, svint32_t op)
@@ -1927,7 +1944,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> ConvertToDouble(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ConvertToInt32 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svint32_t svcvt_s32[_f64]_m(svint32_t inactive, svbool_t pg, svfloat64_t op)
@@ -1948,7 +1965,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> ConvertToInt32(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ConvertToInt64 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svint64_t svcvt_s64[_f64]_m(svint64_t inactive, svbool_t pg, svfloat64_t op)
@@ -1969,7 +1986,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> ConvertToInt64(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ConvertToSingle : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svfloat32_t svcvt_f32[_f64]_m(svfloat32_t inactive, svbool_t pg, svfloat64_t op)
@@ -2017,7 +2034,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ConvertToSingle(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ConvertToUInt32 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svuint32_t svcvt_u32[_f64]_m(svuint32_t inactive, svbool_t pg, svfloat64_t op)
@@ -2038,7 +2055,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> ConvertToUInt32(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ConvertToUInt64 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svuint64_t svcvt_u64[_f64]_m(svuint64_t inactive, svbool_t pg, svfloat64_t op)
@@ -2059,7 +2076,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ConvertToUInt64(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Count16BitElements : Count the number of 16-bit elements in a vector
+        // Count the number of 16-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcnth_pat(enum svpattern pattern)
@@ -2068,7 +2085,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong Count16BitElements([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Count32BitElements : Count the number of 32-bit elements in a vector
+        // Count the number of 32-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcntw_pat(enum svpattern pattern)
@@ -2077,7 +2094,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong Count32BitElements([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Count64BitElements : Count the number of 64-bit elements in a vector
+        // Count the number of 64-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcntd_pat(enum svpattern pattern)
@@ -2086,7 +2103,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong Count64BitElements([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Count8BitElements : Count the number of 8-bit elements in a vector
+        // Count the number of 8-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcntb_pat(enum svpattern pattern)
@@ -2337,7 +2354,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateBreakPropagateMask(Vector<ulong> totalMask, Vector<ulong> fromMask) { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2346,7 +2363,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<byte> CreateFalseMaskByte() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2355,7 +2372,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> CreateFalseMaskDouble() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2364,7 +2381,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> CreateFalseMaskInt16() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2373,7 +2390,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> CreateFalseMaskInt32() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2382,7 +2399,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> CreateFalseMaskInt64() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2391,7 +2408,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<sbyte> CreateFalseMaskSByte() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2400,7 +2417,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> CreateFalseMaskSingle() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2409,7 +2426,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> CreateFalseMaskUInt16() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2418,7 +2435,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> CreateFalseMaskUInt32() { throw new PlatformNotSupportedException(); }
 
 
-        /// Set all predicate elements to false
+        // Set all predicate elements to false
 
         /// <summary>
         /// svbool_t svpfalse[_b]()
@@ -2500,7 +2517,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateMaskForNextActiveElement(Vector<ulong> mask, Vector<ulong> srcMask) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskByte : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2509,7 +2526,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<byte> CreateTrueMaskByte([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskDouble : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2518,7 +2535,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> CreateTrueMaskDouble([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskInt16 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2527,7 +2544,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> CreateTrueMaskInt16([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskInt32 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2536,7 +2553,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> CreateTrueMaskInt32([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskInt64 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2545,7 +2562,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> CreateTrueMaskInt64([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskSByte : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2554,7 +2571,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<sbyte> CreateTrueMaskSByte([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskSingle : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2563,7 +2580,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> CreateTrueMaskSingle([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskUInt16 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b16(enum svpattern pattern)
@@ -2572,7 +2589,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> CreateTrueMaskUInt16([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskUInt32 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b32(enum svpattern pattern)
@@ -2581,7 +2598,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> CreateTrueMaskUInt32([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateTrueMaskUInt64 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b64(enum svpattern pattern)
@@ -2590,7 +2607,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateTrueMaskUInt64([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanMask16Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b16[_s32](int32_t op1, int32_t op2)
@@ -2617,7 +2634,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> CreateWhileLessThanMask16Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanMask32Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b32[_s32](int32_t op1, int32_t op2)
@@ -2644,7 +2661,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> CreateWhileLessThanMask32Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanMask64Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b64[_s32](int32_t op1, int32_t op2)
@@ -2671,7 +2688,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateWhileLessThanMask64Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanMask8Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b8[_s32](int32_t op1, int32_t op2)
@@ -2698,7 +2715,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<byte> CreateWhileLessThanMask8Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanOrEqualMask16Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b16[_s32](int32_t op1, int32_t op2)
@@ -2725,7 +2742,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> CreateWhileLessThanOrEqualMask16Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanOrEqualMask32Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b32[_s32](int32_t op1, int32_t op2)
@@ -2752,7 +2769,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> CreateWhileLessThanOrEqualMask32Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanOrEqualMask64Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b64[_s32](int32_t op1, int32_t op2)
@@ -2779,7 +2796,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateWhileLessThanOrEqualMask64Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  CreateWhileLessThanOrEqualMask8Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b8[_s32](int32_t op1, int32_t op2)
@@ -2806,7 +2823,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<byte> CreateWhileLessThanOrEqualMask8Bit(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Divide : Divide
+        // Divide
 
         /// <summary>
         /// svfloat32_t svdiv[_f32]_m(svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -2833,7 +2850,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> Divide(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  DotProduct : Dot product
+        // Dot product
 
         /// <summary>
         /// svint32_t svdot[_s32](svint32_t op1, svint8_t op2, svint8_t op3)
@@ -2860,7 +2877,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> DotProduct(Vector<ulong> addend, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  DotProductBySelectedScalar : Dot product
+        // Dot product
 
         /// <summary>
         /// svint32_t svdot_lane[_s32](svint32_t op1, svint8_t op2, svint8_t op3, uint64_t imm_index)
@@ -2887,7 +2904,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> DotProductBySelectedScalar(Vector<ulong> addend, Vector<ushort> left, Vector<ushort> right, [ConstantExpected] byte rightIndex) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Broadcast a scalar value
+        // Broadcast a scalar value
 
         /// <summary>
         /// svuint8_t svdup_lane[_u8](svuint8_t data, uint8_t index)
@@ -3011,7 +3028,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ExtractVector(Vector<ulong> upper, Vector<ulong> lower, [ConstantExpected] byte index) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Floating-point exponential accelerator
+        // Floating-point exponential accelerator
 
         /// <summary>
         /// svfloat64_t svexpa[_f64](svuint64_t op)
@@ -3026,7 +3043,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FloatingPointExponentialAccelerator(Vector<uint> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  FusedMultiplyAdd : Multiply-add, addend first
+        // Multiply-add, addend first
 
         /// <summary>
         /// svfloat64_t svmla[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3045,7 +3062,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplyAdd(Vector<float> addend, Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  FusedMultiplyAddBySelectedScalar : Multiply-add, addend first
+        // Multiply-add, addend first
 
         /// <summary>
         /// svfloat64_t svmla_lane[_f64](svfloat64_t op1, svfloat64_t op2, svfloat64_t op3, uint64_t imm_index)
@@ -3060,7 +3077,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplyAddBySelectedScalar(Vector<float> addend, Vector<float> left, Vector<float> right, [ConstantExpected] byte rightIndex) { throw new PlatformNotSupportedException(); }
 
 
-        ///  FusedMultiplyAddNegated : Negated multiply-add, addend first
+        // Negated multiply-add, addend first
 
         /// <summary>
         /// svfloat64_t svnmla[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3079,7 +3096,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplyAddNegated(Vector<float> addend, Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  FusedMultiplySubtract : Multiply-subtract, minuend first
+        // Multiply-subtract, minuend first
 
         /// <summary>
         /// svfloat64_t svmls[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3098,7 +3115,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplySubtract(Vector<float> minuend, Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  FusedMultiplySubtractBySelectedScalar : Multiply-subtract, minuend first
+        // Multiply-subtract, minuend first
 
         /// <summary>
         /// svfloat64_t svmls_lane[_f64](svfloat64_t op1, svfloat64_t op2, svfloat64_t op3, uint64_t imm_index)
@@ -3113,7 +3130,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplySubtractBySelectedScalar(Vector<float> minuend, Vector<float> left, Vector<float> right, [ConstantExpected] byte rightIndex) { throw new PlatformNotSupportedException(); }
 
 
-        ///  FusedMultiplySubtractNegated : Negated multiply-subtract, minuend first
+        // Negated multiply-subtract, minuend first
 
         /// <summary>
         /// svfloat64_t svnmls[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3132,7 +3149,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplySubtractNegated(Vector<float> minuend, Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Prefetch halfwords
+        // Prefetch halfwords
 
         /// <summary>
         /// void svprfh_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)
@@ -3207,7 +3224,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Prefetch words
+        // Prefetch words
 
         /// <summary>
         /// void svprfw_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)
@@ -3282,7 +3299,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Prefetch doublewords
+        // Prefetch doublewords
 
         /// <summary>
         /// void svprfd_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)
@@ -3357,7 +3374,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Prefetch bytes
+        // Prefetch bytes
 
         /// <summary>
         /// void svprfb_gather_[s32]offset(svbool_t pg, const void *base, svint32_t offsets, enum svprfop op)
@@ -3432,7 +3449,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Unextended load
+        // Unextended load
 
         /// <summary>
         /// svfloat64_t svld1_gather_[s64]index[_f64](svbool_t pg, const float64_t *base, svint64_t indices)
@@ -3547,7 +3564,7 @@ namespace System.Runtime.Intrinsics.Arm
 
 
 
-        ///  Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1ub_gather_[s32]offset_s32(svbool_t pg, const uint8_t *base, svint32_t offsets)
@@ -3624,7 +3641,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorByteZeroExtend(Vector<ulong> mask, byte* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sh_gather_[s32]index_s32(svbool_t pg, const int16_t *base, svint32_t indices)
@@ -3701,7 +3718,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt16SignExtend(Vector<ulong> mask, short* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sh_gather_[s32]offset_s32(svbool_t pg, const int16_t *base, svint32_t offsets)
@@ -3752,7 +3769,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(Vector<ulong> mask, short* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sw_gather_[s64]index_s64(svbool_t pg, const int32_t *base, svint64_t indices)
@@ -3791,7 +3808,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt32SignExtend(Vector<ulong> mask, int* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sw_gather_[s64]offset_s64(svbool_t pg, const int32_t *base, svint64_t offsets)
@@ -3818,7 +3835,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(Vector<ulong> mask, int* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sb_gather_[s32]offset_s32(svbool_t pg, const int8_t *base, svint32_t offsets)
@@ -3895,7 +3912,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorSByteSignExtend(Vector<ulong> mask, sbyte* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1uh_gather_[s32]offset_s32(svbool_t pg, const uint16_t *base, svint32_t offsets)
@@ -3946,7 +3963,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1uh_gather_[s32]index_s32(svbool_t pg, const uint16_t *base, svint32_t indices)
@@ -4023,7 +4040,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uw_gather_[s64]offset_s64(svbool_t pg, const uint32_t *base, svint64_t offsets)
@@ -4074,7 +4091,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uw_gather_[s64]index_s64(svbool_t pg, const uint32_t *base, svint64_t indices)
@@ -4151,7 +4168,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Unextended load
+        // Unextended load
 
         /// <summary>
         /// svfloat64_t svld1_gather_[s64]offset[_f64](svbool_t pg, const float64_t *base, svint64_t offsets)
@@ -4226,7 +4243,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Count set predicate bits
+        // Count set predicate bits
 
         /// <summary>
         /// uint64_t svcntp_b8(svbool_t pg, svbool_t op)
@@ -4289,7 +4306,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong GetActiveElementCount(Vector<ulong> mask, Vector<ulong> from) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Insert scalar into shifted vector
+        // Insert scalar into shifted vector
 
         /// <summary>
         /// svuint8_t svinsr[_n_u8](svuint8_t op1, uint8_t op2)
@@ -4362,7 +4379,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> InsertIntoShiftedVector(Vector<ulong> left, ulong right) { throw new PlatformNotSupportedException(); }
 
 
-        /// Count leading sign bits
+        // Count leading sign bits
 
         /// <summary>
         /// svuint8_t svcls[_s8]_m(svuint8_t inactive, svbool_t pg, svint8_t op)
@@ -4397,7 +4414,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LeadingSignCount(Vector<long> value) { throw new PlatformNotSupportedException(); }
 
 
-        /// Count leading zero bits
+        // Count leading zero bits
 
         /// <summary>
         /// svuint8_t svclz[_s8]_m(svuint8_t inactive, svbool_t pg, svint8_t op)
@@ -4464,7 +4481,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LeadingZeroCount(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVector : Unextended load
+        // Unextended load
 
         /// <summary>
         /// svint8_t svld1[_s8](svbool_t pg, const int8_t *base)
@@ -4720,7 +4737,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVector128AndReplicateToVector(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorByteZeroExtendToInt16 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint16_t svld1ub_s16(svbool_t pg, const uint8_t *base)
@@ -4729,7 +4746,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> LoadVectorByteZeroExtendToInt16(Vector<short> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorByteZeroExtendToInt32 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1ub_s32(svbool_t pg, const uint8_t *base)
@@ -4738,7 +4755,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorByteZeroExtendToInt32(Vector<int> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorByteZeroExtendToInt64 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1ub_s64(svbool_t pg, const uint8_t *base)
@@ -4747,7 +4764,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorByteZeroExtendToInt64(Vector<long> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorByteZeroExtendToUInt16 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svuint16_t svld1ub_u16(svbool_t pg, const uint8_t *base)
@@ -4756,7 +4773,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> LoadVectorByteZeroExtendToUInt16(Vector<ushort> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorByteZeroExtendToUInt32 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svuint32_t svld1ub_u32(svbool_t pg, const uint8_t *base)
@@ -4765,7 +4782,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorByteZeroExtendToUInt32(Vector<uint> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorByteZeroExtendToUInt64 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svuint64_t svld1ub_u64(svbool_t pg, const uint8_t *base)
@@ -4774,7 +4791,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorByteZeroExtendToUInt64(Vector<ulong> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorInt16SignExtendToInt32 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sh_s32(svbool_t pg, const int16_t *base)
@@ -4783,7 +4800,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorInt16SignExtendToInt32(Vector<int> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorInt16SignExtendToInt64 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sh_s64(svbool_t pg, const int16_t *base)
@@ -4792,7 +4809,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorInt16SignExtendToInt64(Vector<long> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorInt16SignExtendToUInt32 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svuint32_t svld1sh_u32(svbool_t pg, const int16_t *base)
@@ -4801,7 +4818,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorInt16SignExtendToUInt32(Vector<uint> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorInt16SignExtendToUInt64 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svuint64_t svld1sh_u64(svbool_t pg, const int16_t *base)
@@ -4810,7 +4827,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorInt16SignExtendToUInt64(Vector<ulong> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorInt32SignExtendToInt64 : Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sw_s64(svbool_t pg, const int32_t *base)
@@ -4819,7 +4836,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorInt32SignExtendToInt64(Vector<long> mask, int* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorInt32SignExtendToUInt64 : Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svuint64_t svld1sw_u64(svbool_t pg, const int32_t *base)
@@ -4828,7 +4845,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorInt32SignExtendToUInt64(Vector<ulong> mask, int* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorSByteSignExtendToInt16 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint16_t svld1sb_s16(svbool_t pg, const int8_t *base)
@@ -4837,7 +4854,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> LoadVectorSByteSignExtendToInt16(Vector<short> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorSByteSignExtendToInt32 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sb_s32(svbool_t pg, const int8_t *base)
@@ -4846,7 +4863,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorSByteSignExtendToInt32(Vector<int> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorSByteSignExtendToInt64 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sb_s64(svbool_t pg, const int8_t *base)
@@ -4855,7 +4872,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorSByteSignExtendToInt64(Vector<long> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorSByteSignExtendToUInt16 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svuint16_t svld1sb_u16(svbool_t pg, const int8_t *base)
@@ -4864,7 +4881,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> LoadVectorSByteSignExtendToUInt16(Vector<ushort> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorSByteSignExtendToUInt32 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svuint32_t svld1sb_u32(svbool_t pg, const int8_t *base)
@@ -4873,7 +4890,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorSByteSignExtendToUInt32(Vector<uint> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorSByteSignExtendToUInt64 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svuint64_t svld1sb_u64(svbool_t pg, const int8_t *base)
@@ -4882,7 +4899,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorSByteSignExtendToUInt64(Vector<ulong> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorUInt16ZeroExtendToInt32 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1uh_s32(svbool_t pg, const uint16_t *base)
@@ -4891,7 +4908,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorUInt16ZeroExtendToInt32(Vector<int> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorUInt16ZeroExtendToInt64 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uh_s64(svbool_t pg, const uint16_t *base)
@@ -4900,7 +4917,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorUInt16ZeroExtendToInt64(Vector<long> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorUInt16ZeroExtendToUInt32 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svuint32_t svld1uh_u32(svbool_t pg, const uint16_t *base)
@@ -4909,7 +4926,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorUInt16ZeroExtendToUInt32(Vector<uint> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorUInt16ZeroExtendToUInt64 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svuint64_t svld1uh_u64(svbool_t pg, const uint16_t *base)
@@ -4918,7 +4935,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorUInt16ZeroExtendToUInt64(Vector<ulong> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorUInt32ZeroExtendToInt64 : Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uw_s64(svbool_t pg, const uint32_t *base)
@@ -4927,7 +4944,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorUInt32ZeroExtendToInt64(Vector<long> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  LoadVectorUInt32ZeroExtendToUInt64 : Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svuint64_t svld1uw_u64(svbool_t pg, const uint32_t *base)
@@ -5187,7 +5204,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe (Vector<ulong>, Vector<ulong>, Vector<ulong>, Vector<ulong>) Load4xVectorAndUnzip(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint32_t svldnf1sh_s32(svbool_t pg, const int16_t *base)
@@ -5196,7 +5214,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorInt16NonFaultingSignExtendToInt32(short* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint64_t svldnf1sh_s64(svbool_t pg, const int16_t *base)
@@ -5205,7 +5223,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorInt16NonFaultingSignExtendToInt64(short* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint32_t svldnf1sh_u32(svbool_t pg, const int16_t *base)
@@ -5214,7 +5232,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorInt16NonFaultingSignExtendToUInt32(short* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint64_t svldnf1sh_u64(svbool_t pg, const int16_t *base)
@@ -5222,7 +5240,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> LoadVectorInt16NonFaultingSignExtendToUInt64(short* address) { throw new PlatformNotSupportedException(); }
 
-        ///  Load 32-bit data and sign-extend, non-faulting
+
+        // Load 32-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint64_t svldnf1sw_s64(svbool_t pg, const int32_t *base)
@@ -5230,7 +5249,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<long> LoadVectorInt32NonFaultingSignExtendToInt64(int* address) { throw new PlatformNotSupportedException(); }
 
-        ///  Load 32-bit data and sign-extend, non-faulting
+
+        // Load 32-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint64_t svldnf1sw_u64(svbool_t pg, const int32_t *base)
@@ -5238,7 +5258,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> LoadVectorInt32NonFaultingSignExtendToUInt64(int* address) { throw new PlatformNotSupportedException(); }
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint16_t svldnf1sb_s16(svbool_t pg, const int8_t *base)
@@ -5247,7 +5268,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> LoadVectorSByteNonFaultingSignExtendToInt16(sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint32_t svldnf1sb_s32(svbool_t pg, const int8_t *base)
@@ -5255,7 +5276,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<int> LoadVectorSByteNonFaultingSignExtendToInt32(sbyte* address) { throw new PlatformNotSupportedException(); }
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint64_t svldnf1sb_s64(svbool_t pg, const int8_t *base)
@@ -5264,7 +5286,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorSByteNonFaultingSignExtendToInt64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint16_t svldnf1sb_u16(svbool_t pg, const int8_t *base)
@@ -5273,7 +5295,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> LoadVectorSByteNonFaultingSignExtendToUInt16(sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint32_t svldnf1sb_u32(svbool_t pg, const int8_t *base)
@@ -5282,7 +5304,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorSByteNonFaultingSignExtendToUInt32(sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint64_t svldnf1sb_u64(svbool_t pg, const int8_t *base)
@@ -5290,7 +5312,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> LoadVectorSByteNonFaultingSignExtendToUInt64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
-        ///  Max : Maximum
+
+        // Maximum
 
         /// <summary>
         /// svuint8_t svmax[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -5383,7 +5406,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Max(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  MaxAcross : Maximum reduction to scalar
+        // Maximum reduction to scalar
 
         /// <summary>
         /// uint8_t svmaxv[_u8](svbool_t pg, svuint8_t op)
@@ -5446,7 +5469,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> MaxAcross(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  MaxNumber : Maximum number
+        // Maximum number
 
         /// <summary>
         /// svfloat64_t svmaxnm[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -5467,7 +5490,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> MaxNumber(Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  MaxNumberAcross : Maximum number reduction to scalar
+        // Maximum number reduction to scalar
 
         /// <summary>
         /// float64_t svmaxnmv[_f64](svbool_t pg, svfloat64_t op)
@@ -5482,7 +5505,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> MaxNumberAcross(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Min : Minimum
+        // Minimum
 
         /// <summary>
         /// svuint8_t svmin[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -5575,7 +5598,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Min(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  MinAcross : Minimum reduction to scalar
+        // Minimum reduction to scalar
 
         /// <summary>
         /// uint8_t svminv[_u8](svbool_t pg, svuint8_t op)
@@ -5638,7 +5661,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> MinAcross(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  MinNumber : Minimum number
+        // Minimum number
 
         /// <summary>
         /// svfloat64_t svminnm[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -5659,7 +5682,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> MinNumber(Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  MinNumberAcross : Minimum number reduction to scalar
+        // Minimum number reduction to scalar
 
         /// <summary>
         /// float64_t svminnmv[_f64](svbool_t pg, svfloat64_t op)
@@ -5673,7 +5696,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MinNumberAcross(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Multiply : Multiply
+
+        // Multiply
 
         /// <summary>
         /// svint8_t svmul[_s8]_m(svbool_t pg, svint8_t op1, svint8_t op2)
@@ -5817,7 +5841,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> Multiply(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
-        ///  MultiplyAdd : Multiply-add, addend first
+
+        // Multiply-add, addend first
 
         /// <summary>
         /// svuint8_t svmla[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2, svuint8_t op3)
@@ -5883,7 +5908,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> MultiplyAdd(Vector<ulong> addend, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Complex multiply-add with rotate
+
+        // Complex multiply-add with rotate
 
         /// <summary>
         /// svfloat64_t svcmla[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3, uint64_t imm_rotation)
@@ -5903,7 +5929,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyAddRotateComplex(Vector<float> addend, Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(3))] byte rotation) { throw new PlatformNotSupportedException(); }
 
-        ///  Complex multiply-add with rotate
+
+        // Complex multiply-add with rotate
 
         /// <summary>
         /// svfloat32_t svcmla_lane[_f32](svfloat32_t op1, svfloat32_t op2, svfloat32_t op3, uint64_t imm_index, uint64_t imm_rotation)
@@ -5911,7 +5938,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyAddRotateComplexBySelectedScalar(Vector<float> addend, Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(1))] byte rightIndex, [ConstantExpected(Min = 0, Max = (byte)(3))] byte rotation) { throw new PlatformNotSupportedException(); }
 
-        ///  MultiplyBySelectedScalar : Multiply
+
+        // Multiply
 
         /// <summary>
         /// svfloat64_t svmul_lane[_f64](svfloat64_t op1, svfloat64_t op2, uint64_t imm_index)
@@ -5925,7 +5953,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyBySelectedScalar(Vector<float> left, Vector<float> right, [ConstantExpected] byte rightIndex) { throw new PlatformNotSupportedException(); }
 
-        ///  MultiplyExtended : Multiply extended (∞×0=2)
+
+        // Multiply extended (∞×0=2)
 
         /// <summary>
         /// svfloat64_t svmulx[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -5943,7 +5972,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyExtended(Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
-        ///  MultiplySubtract : Multiply-subtract, minuend first
+
+        // Multiply-subtract, minuend first
 
         /// <summary>
         /// svuint8_t svmls[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2, svuint8_t op3)
@@ -6009,7 +6039,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> MultiplySubtract(Vector<ulong> minuend, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
-        ///  Negate : Negate
+
+        // Negate
 
         /// <summary>
         /// svfloat64_t svneg[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6059,7 +6090,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> Negate(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Bitwise invert
+
+        // Bitwise invert
 
         /// <summary>
         /// svuint8_t svnot[_u8]_m(svuint8_t inactive, svbool_t pg, svuint8_t op)
@@ -6149,7 +6181,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> Not(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Or : Bitwise inclusive OR
+
+        // Bitwise inclusive OR
 
         /// <summary>
         /// svuint8_t svorr[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -6240,7 +6273,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Or(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  OrAcross : Bitwise inclusive OR reduction to scalar
+        // Bitwise inclusive OR reduction to scalar
 
         /// <summary>
         /// uint8_t svorv[_u8](svbool_t pg, svuint8_t op)
@@ -6290,7 +6323,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> OrAcross(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
-        ///  Count nonzero bits
+
+        // Count nonzero bits
 
         /// <summary>
         /// svuint8_t svcnt[_s8]_m(svuint8_t inactive, svbool_t pg, svint8_t op)
@@ -6397,7 +6431,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void PrefetchInt64(Vector<ulong> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ReciprocalEstimate : Reciprocal estimate
+        // Reciprocal estimate
 
         /// <summary>
         /// svfloat64_t svrecpe[_f64](svfloat64_t op)
@@ -6412,7 +6446,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalEstimate(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ReciprocalExponent : Reciprocal exponent
+        // Reciprocal exponent
 
         /// <summary>
         /// svfloat64_t svrecpx[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6433,7 +6467,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalExponent(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ReciprocalSqrtEstimate : Reciprocal square root estimate
+        // Reciprocal square root estimate
 
         /// <summary>
         /// svfloat64_t svrsqrte[_f64](svfloat64_t op)
@@ -6448,7 +6482,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalSqrtEstimate(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ReciprocalSqrtStep : Reciprocal square root step
+        // Reciprocal square root step
 
         /// <summary>
         /// svfloat64_t svrsqrts[_f64](svfloat64_t op1, svfloat64_t op2)
@@ -6463,7 +6497,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalSqrtStep(Vector<float> left, Vector<float> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ReciprocalStep : Reciprocal step
+        // Reciprocal step
 
         /// <summary>
         /// svfloat64_t svrecps[_f64](svfloat64_t op1, svfloat64_t op2)
@@ -6527,7 +6561,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseBits(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Reverse all elements
+        // Reverse all elements
 
         /// <summary>
         /// svuint8_t svrev[_u8](svuint8_t op)
@@ -6590,7 +6624,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Reverse halfwords within elements
+        // Reverse halfwords within elements
 
         /// <summary>
         /// svint32_t svrevh[_s32]_m(svint32_t inactive, svbool_t pg, svint32_t op)
@@ -6617,7 +6651,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement16(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Reverse words within elements
+        // Reverse words within elements
 
         /// <summary>
         /// svint64_t svrevw[_s64]_m(svint64_t inactive, svbool_t pg, svint64_t op)
@@ -6632,7 +6666,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement32(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Reverse bytes within elements
+        // Reverse bytes within elements
 
         /// <summary>
         /// svint16_t svrevb[_s16]_m(svint16_t inactive, svbool_t pg, svint16_t op)
@@ -6671,7 +6705,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement8(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  RoundAwayFromZero : Round to nearest, ties away from zero
+        // Round to nearest, ties away from zero
 
         /// <summary>
         /// svfloat64_t svrinta[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6692,7 +6726,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundAwayFromZero(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  RoundToNearest : Round to nearest, ties to even
+        // Round to nearest, ties to even
 
         /// <summary>
         /// svfloat64_t svrintn[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6713,7 +6747,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToNearest(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  RoundToNegativeInfinity : Round towards -∞
+        // Round towards -∞
 
         /// <summary>
         /// svfloat64_t svrintm[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6734,7 +6768,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToNegativeInfinity(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  RoundToPositiveInfinity : Round towards +∞
+        // Round towards +∞
 
         /// <summary>
         /// svfloat64_t svrintp[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6755,7 +6789,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToPositiveInfinity(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  RoundToZero : Round towards zero
+        // Round towards zero
 
         /// <summary>
         /// svfloat64_t svrintz[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6776,7 +6810,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToZero(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating decrement by number of halfword elements
+        // Saturating decrement by number of halfword elements
 
         /// <summary>
         /// int32_t svqdech_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6817,7 +6851,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> SaturatingDecrementBy16BitElementCount(Vector<ushort> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating decrement by number of word elements
+        // Saturating decrement by number of word elements
 
         /// <summary>
         /// int32_t svqdecw_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6858,7 +6892,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> SaturatingDecrementBy32BitElementCount(Vector<uint> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating decrement by number of doubleword elements
+        // Saturating decrement by number of doubleword elements
 
         /// <summary>
         /// int32_t svqdecd_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6899,7 +6933,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingDecrementBy64BitElementCount(Vector<ulong> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating decrement by number of byte elements
+        // Saturating decrement by number of byte elements
 
         /// <summary>
         /// int32_t svqdecb_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6926,7 +6960,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong SaturatingDecrementBy8BitElementCount(ulong value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Saturating decrement by active element count
+        // Saturating decrement by active element count
 
         /// <summary>
         /// int32_t svqdecp[_n_s32]_b8(int32_t op, svbool_t pg)
@@ -7061,7 +7095,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingDecrementByActiveElementCount(Vector<ulong> value, Vector<ulong> from) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating increment by number of halfword elements
+        // Saturating increment by number of halfword elements
 
         /// <summary>
         /// int32_t svqinch_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7102,7 +7136,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> SaturatingIncrementBy16BitElementCount(Vector<ushort> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating increment by number of word elements
+        // Saturating increment by number of word elements
 
         /// <summary>
         /// int32_t svqincw_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7143,7 +7177,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> SaturatingIncrementBy32BitElementCount(Vector<uint> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating increment by number of doubleword elements
+        // Saturating increment by number of doubleword elements
 
         /// <summary>
         /// int32_t svqincd_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7184,7 +7218,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingIncrementBy64BitElementCount(Vector<ulong> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        /// Saturating increment by number of byte elements
+        // Saturating increment by number of byte elements
 
         /// <summary>
         /// int32_t svqincb_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7211,7 +7245,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong SaturatingIncrementBy8BitElementCount(ulong value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Saturating increment by active element count
+        // Saturating increment by active element count
 
         /// <summary>
         /// int32_t svqincp[_n_s32]_b8(int32_t op, svbool_t pg)
@@ -7346,7 +7380,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingIncrementByActiveElementCount(Vector<ulong> value, Vector<ulong> from) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Scale : Adjust exponent
+        // Adjust exponent
 
         /// <summary>
         /// svfloat64_t svscale[_f64]_m(svbool_t pg, svfloat64_t op1, svint64_t op2)
@@ -7367,30 +7401,30 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> Scale(Vector<float> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
 
 
-        //  Non-truncating store
+        // Non-truncating store
 
-        // <summary>
-        // void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<long> indicies, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter[_u64base_f64](svbool_t pg, svuint64_t bases, svfloat64_t data)
-        //   ST1D Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter[_u64base_f64](svbool_t pg, svuint64_t bases, svfloat64_t data)
+        ///   ST1D Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter(Vector<double> mask, Vector<ulong> addresses, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<ulong> indicies, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<int> indicies, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -7400,34 +7434,34 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter(Vector<int> mask, Vector<uint> addresses, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<uint> indicies, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<long> indicies, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1D Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1D Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<ulong> indicies, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<int> indicies, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -7437,16 +7471,16 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter(Vector<float> mask, Vector<uint> addresses, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<uint> indicies, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<int> indicies, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -7456,32 +7490,32 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter(Vector<uint> mask, Vector<uint> addresses, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<uint> indicies, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<long> indicies, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1D Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1D Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<ulong> indicies, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        //  Truncate to 16 bits and store
+        // Truncate to 16 bits and store
 
         // <summary>
         // void svst1h_scatter[_u32base_s32](svbool_t pg, svuint32_t bases, svint32_t data)
@@ -7490,200 +7524,200 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter16BitNarrowing(Vector<int> mask, Vector<uint> addresses, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1H Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1H Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter16BitNarrowing(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
         // void svst1h_scatter[_u32base_u32](svbool_t pg, svuint32_t bases, svuint32_t data)
-        //   ST1H Zdata.S, Pg, [Zbases.S, #0]
+        //  ST1H Zdata.S, Pg, [Zbases.S, #0]
         // </summary>
         // Removed as per #103297
         // public static unsafe void Scatter16BitNarrowing(Vector<uint> mask, Vector<uint> addresses, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1H Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1H Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter16BitNarrowing(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        //  Truncate to 16 bits and store
+        // Truncate to 16 bits and store
 
-        // <summary>
-        // void svst1h_scatter_[s32]offset[_s32](svbool_t pg, int16_t *base, svint32_t offsets, svint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s32]offset[_s32](svbool_t pg, int16_t *base, svint32_t offsets, svint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<int> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter_[s32]offset[_u32](svbool_t pg, uint16_t *base, svint32_t offsets, svuint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s32]offset[_u32](svbool_t pg, uint16_t *base, svint32_t offsets, svuint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<int> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        //  Truncate to 32 bits and store
+        // Truncate to 32 bits and store
 
-        // <summary>
-        // void svst1w_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1W Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1w_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1W Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter32BitNarrowing(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1w_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1W Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1w_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1W Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter32BitNarrowing(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        //  Truncate to 32 bits and store, non-temporal
+        // Truncate to 32 bits and store, non-temporal
 
-        // <summary>
-        // void svstnt1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)
-        //   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
-        // </summary>
+        /// <summary>
+        /// void svstnt1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)
+        ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svstnt1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)
-        //   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
-        // </summary>
+        /// <summary>
+        /// void svstnt1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)
+        ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svstnt1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)
-        //   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
-        // </summary>
+        /// <summary>
+        /// void svstnt1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)
+        ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svstnt1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)
-        //   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
-        // </summary>
+        /// <summary>
+        /// void svstnt1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)
+        ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        //  Truncate to 8 bits and store
+        // Truncate to 8 bits and store
 
         // <summary>
         // void svst1b_scatter[_u32base_s32](svbool_t pg, svuint32_t bases, svint32_t data)
-        //   ST1B Zdata.S, Pg, [Zbases.S, #0]
+        //  ST1B Zdata.S, Pg, [Zbases.S, #0]
         // </summary>
         // Removed as per #103297
         // public static unsafe void Scatter8BitNarrowing(Vector<int> mask, Vector<uint> addresses, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1B Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1B Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter8BitNarrowing(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
         // void svst1b_scatter[_u32base_u32](svbool_t pg, svuint32_t bases, svuint32_t data)
-        //   ST1B Zdata.S, Pg, [Zbases.S, #0]
+        //  ST1B Zdata.S, Pg, [Zbases.S, #0]
         // </summary>
         // Removed as per #103297
         // public static unsafe void Scatter8BitNarrowing(Vector<uint> mask, Vector<uint> addresses, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1B Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1B Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter8BitNarrowing(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        //  Truncate to 8 bits and store
+        // Truncate to 8 bits and store
 
-        // <summary>
-        // void svst1b_scatter_[s32]offset[_s32](svbool_t pg, int8_t *base, svint32_t offsets, svint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[s32]offset[_s32](svbool_t pg, int8_t *base, svint32_t offsets, svint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<int> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter_[s32]offset[_u32](svbool_t pg, uint8_t *base, svint32_t offsets, svuint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[s32]offset[_u32](svbool_t pg, uint8_t *base, svint32_t offsets, svuint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<int> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
-        // void svst1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Logical shift left
+        // Logical shift left
 
         /// <summary>
         /// svuint8_t svlsl[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -7818,7 +7852,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ShiftLeftLogical(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Arithmetic shift right
+        // Arithmetic shift right
 
         /// <summary>
         /// svint16_t svasr[_s16]_m(svbool_t pg, svint16_t op1, svuint16_t op2)
@@ -7887,7 +7921,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<sbyte> ShiftRightArithmetic(Vector<sbyte> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Arithmetic shift right for divide by immediate
+        // Arithmetic shift right for divide by immediate
 
         /// <summary>
         /// svint16_t svasrd[_n_s16]_m(svbool_t pg, svint16_t op1, uint64_t imm2)
@@ -7926,7 +7960,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<sbyte> ShiftRightArithmeticForDivide(Vector<sbyte> value, [ConstantExpected(Min = 1, Max = (byte)(8))] byte control) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Logical shift right
+        // Logical shift right
 
         /// <summary>
         /// svuint8_t svlsr[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -7995,7 +8029,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ShiftRightLogical(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  SignExtend16 : Sign-extend the low 16 bits
+        // Sign-extend the low 16 bits
 
         /// <summary>
         /// svint32_t svexth[_s32]_m(svint32_t inactive, svbool_t pg, svint32_t op)
@@ -8022,7 +8056,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtend16(Vector<long> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  SignExtend32 : Sign-extend the low 32 bits
+        // Sign-extend the low 32 bits
 
         /// <summary>
         /// svint64_t svextw[_s64]_m(svint64_t inactive, svbool_t pg, svint64_t op)
@@ -8037,7 +8071,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtend32(Vector<long> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  SignExtend8 : Sign-extend the low 8 bits
+        // Sign-extend the low 8 bits
 
         /// <summary>
         /// svint16_t svextb[_s16]_m(svint16_t inactive, svbool_t pg, svint16_t op)
@@ -8076,7 +8110,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtend8(Vector<long> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Splice two vectors under predicate control
+        // Splice two vectors under predicate control
 
         /// <summary>
         /// svuint8_t svsplice[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -8139,7 +8173,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Splice(Vector<ulong> mask, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Sqrt : Square root
+        // Square root
 
         /// <summary>
         /// svfloat64_t svsqrt[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -8160,7 +8194,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> Sqrt(Vector<float> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Non-truncating store
+        // Non-truncating store
 
         /// <summary>
         /// void svst1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)
@@ -8401,14 +8435,15 @@ namespace System.Runtime.Intrinsics.Arm
         ///   ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]
         /// </summary>
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2, Vector<ulong> Value3, Vector<ulong> Value4) data) { throw new PlatformNotSupportedException(); }
-        ///  Truncate to 8 bits and store
+
+
+        // Truncate to 8 bits and store
 
         /// <summary>
         /// void svst1b[_s16](svbool_t pg, int8_t *base, svint16_t data)
         ///   ST1B Zdata.H, Pg, [Xbase, #0, MUL VL]
         /// </summary>
         public static unsafe void StoreNarrowing(Vector<short> mask, sbyte* address, Vector<short> data) { throw new PlatformNotSupportedException(); }
-
 
         /// <summary>
         /// void svst1b[_s32](svbool_t pg, int8_t *base, svint32_t data)
@@ -8477,7 +8512,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void StoreNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Non-truncating store, non-temporal
+        // Non-truncating store, non-temporal
 
         /// <summary>
         /// void svstnt1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)
@@ -8540,7 +8575,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void StoreNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Subtract : Subtract
+        // Subtract
 
         /// <summary>
         /// svint8_t svsub[_s8]_m(svbool_t pg, svint8_t op1, svint8_t op2)
@@ -8664,7 +8699,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> Subtract(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
-        ///  SubtractSaturate : Saturating subtract
+
+        // Saturating subtract
 
         /// <summary>
         /// svuint8_t svqsub[_u8](svuint8_t op1, svuint8_t op2)
@@ -8715,7 +8751,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SubtractSaturate(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  SignExtendWideningLower : Unpack and extend low half
+        // Unpack and extend low half
 
         /// <summary>
         /// svint16_t svunpklo[_s16](svint8_t op)
@@ -8736,7 +8772,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtendWideningLower(Vector<int> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  SignExtendWideningUpper : Unpack and extend high half
+        // Unpack and extend high half
 
         /// <summary>
         /// svint16_t svunpkhi[_s16](svint8_t op)
@@ -8755,6 +8791,8 @@ namespace System.Runtime.Intrinsics.Arm
         ///   SUNPKHI Zresult.D, Zop.S
         /// </summary>
         public static unsafe Vector<long> SignExtendWideningUpper(Vector<int> value) { throw new PlatformNotSupportedException(); }
+
+        // Test whether any active element is true
 
         /// <summary>
         /// bool svptest_any(svbool_t pg, svbool_t op)
@@ -8804,6 +8842,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe bool TestAnyTrue(Vector<ulong> mask, Vector<ulong> srcMask) { throw new PlatformNotSupportedException(); }
 
+        // Test whether the first active element is true
+
         /// <summary>
         /// bool svptest_first(svbool_t pg, svbool_t op)
         ///   PTEST
@@ -8851,6 +8891,9 @@ namespace System.Runtime.Intrinsics.Arm
         ///   PTEST
         /// </summary>
         public static unsafe bool TestFirstTrue(Vector<ulong> mask, Vector<ulong> srcMask) { throw new PlatformNotSupportedException(); }
+
+
+        // Test whether the last active element is true
 
         /// <summary>
         /// bool svptest_last(svbool_t pg, svbool_t op)
@@ -8901,7 +8944,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe bool TestLastTrue(Vector<ulong> mask, Vector<ulong> srcMask) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Interleave even elements from two inputs
+        // Interleave even elements from two inputs
 
         /// <summary>
         /// svuint8_t svtrn1[_u8](svuint8_t op1, svuint8_t op2)
@@ -8964,7 +9007,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> TransposeEven(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Interleave odd elements from two inputs
+        // Interleave odd elements from two inputs
 
         /// <summary>
         /// svuint8_t svtrn2[_u8](svuint8_t op1, svuint8_t op2)
@@ -9027,7 +9070,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> TransposeOdd(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Trigonometric multiply-add coefficient
+        // Trigonometric multiply-add coefficient
 
         /// <summary>
         /// svfloat64_t svtmad[_f64](svfloat64_t op1, svfloat64_t op2, uint64_t imm3)
@@ -9042,7 +9085,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> TrigonometricMultiplyAddCoefficient(Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(7))] byte control) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Trigonometric select coefficient
+        // Trigonometric select coefficient
 
         /// <summary>
         /// svfloat64_t svtssel[_f64](svfloat64_t op1, svuint64_t op2)
@@ -9057,7 +9100,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> TrigonometricSelectCoefficient(Vector<float> value, Vector<uint> selector) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Trigonometric starting value
+        // Trigonometric starting value
 
         /// <summary>
         /// svfloat64_t svtsmul[_f64](svfloat64_t op1, svuint64_t op2)
@@ -9072,7 +9115,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> TrigonometricStartingValue(Vector<float> value, Vector<uint> sign) { throw new PlatformNotSupportedException(); }
 
 
-        ///  UnzipEven : Concatenate even elements from two inputs
+        // Concatenate even elements from two inputs
 
         /// <summary>
         /// svint8_t svuzp1[_s8](svint8_t op1, svint8_t op2)
@@ -9129,7 +9172,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> UnzipEven(Vector<double> left, Vector<double> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  UnzipOdd : Concatenate odd elements from two inputs
+        // Concatenate odd elements from two inputs
 
         /// <summary>
         /// svuint8_t svuzp2[_u8](svuint8_t op1, svuint8_t op2)
@@ -9187,7 +9230,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> UnzipOdd(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Table lookup in single-vector table
+        // Table lookup in single-vector table
 
         /// <summary>
         /// svuint8_t svtbl[_u8](svuint8_t data, svuint8_t indices)
@@ -9250,7 +9293,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> VectorTableLookup(Vector<ulong> data, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
-        ///  Xor : Bitwise exclusive OR
+        // Bitwise exclusive OR
 
         /// <summary>
         /// svuint8_t sveor[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -9341,7 +9384,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Xor(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  XorAcross : Bitwise exclusive OR reduction to scalar
+        // Bitwise exclusive OR reduction to scalar
 
         /// <summary>
         /// uint8_t sveorv[_u8](svbool_t pg, svuint8_t op)
@@ -9392,7 +9435,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> XorAcross(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ZeroExtend16 : Zero-extend the low 16 bits
+        // Zero-extend the low 16 bits
 
         /// <summary>
         /// svuint32_t svexth[_u32]_m(svuint32_t inactive, svbool_t pg, svuint32_t op)
@@ -9419,7 +9462,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ZeroExtend16(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ZeroExtend32 : Zero-extend the low 32 bits
+        // Zero-extend the low 32 bits
 
         /// <summary>
         /// svuint64_t svextw[_u64]_m(svuint64_t inactive, svbool_t pg, svuint64_t op)
@@ -9433,7 +9476,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> ZeroExtend32(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
-        ///  ZeroExtend8 : Zero-extend the low 8 bits
+
+        // Zero-extend the low 8 bits
 
         /// <summary>
         /// svuint16_t svextb[_u16]_m(svuint16_t inactive, svbool_t pg, svuint16_t op)
@@ -9471,7 +9515,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> ZeroExtend8(Vector<ulong> value) { throw new PlatformNotSupportedException(); }
 
-        ///  ZeroExtendWideningLower : Unpack and extend low half
+
+        // Unpack and extend low half
 
         /// <summary>
         /// svuint16_t svunpklo[_u16](svuint8_t op)
@@ -9492,7 +9537,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ZeroExtendWideningLower(Vector<uint> value) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ZeroExtendWideningUpper : Unpack and extend high half
+        // Unpack and extend high half
 
         /// <summary>
         /// svuint16_t svunpkhi[_u16](svuint8_t op)
@@ -9512,7 +9557,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> ZeroExtendWideningUpper(Vector<uint> value) { throw new PlatformNotSupportedException(); }
 
-        ///  ZipHigh : Interleave elements from high halves of two inputs
+
+        // Interleave elements from high halves of two inputs
 
         /// <summary>
         /// svuint8_t svzip2[_u8](svuint8_t op1, svuint8_t op2)
@@ -9581,7 +9627,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ZipHigh(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
-        ///  ZipLow : Interleave elements from low halves of two inputs
+        // Interleave elements from low halves of two inputs
 
         /// <summary>
         /// svuint8_t svzip1[_u8](svuint8_t op1, svuint8_t op2)
@@ -9650,5 +9696,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   ZIP1 Presult.D, Pop1.D, Pop2.D
         /// </summary>
         public static unsafe Vector<ulong> ZipLow(Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
+
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.Intrinsics.Arm
         }
 
 
-        ///  Abs : Absolute value
+        // Absolute value
 
         /// <summary>
         /// svint8_t svabs[_s8]_m(svint8_t inactive, svbool_t pg, svint8_t op)
@@ -104,7 +104,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> Abs(Vector<double> value) => Abs(value);
 
 
-        ///  Absolute compare greater than
+        // Absolute compare greater than
 
         /// <summary>
         /// svbool_t svacgt[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -118,7 +118,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareGreaterThan(Vector<double> left, Vector<double> right) => AbsoluteCompareGreaterThan(left, right);
 
-        ///  Absolute compare greater than or equal to
+
+        // Absolute compare greater than or equal to
 
         /// <summary>
         /// svbool_t svacge[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -132,7 +133,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareGreaterThanOrEqual(Vector<double> left, Vector<double> right) => AbsoluteCompareGreaterThanOrEqual(left, right);
 
-        ///  Absolute compare less than
+
+        // Absolute compare less than
 
         /// <summary>
         /// svbool_t svaclt[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -146,7 +148,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareLessThan(Vector<double> left, Vector<double> right) => AbsoluteCompareLessThan(left, right);
 
-        ///  Absolute compare less than or equal to
+
+        // Absolute compare less than or equal to
 
         /// <summary>
         /// svbool_t svacle[_f32](svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -160,7 +163,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> AbsoluteCompareLessThanOrEqual(Vector<double> left, Vector<double> right) => AbsoluteCompareLessThanOrEqual(left, right);
 
-        ///  AbsoluteDifference : Absolute difference
+
+        // Absolute difference
 
         /// <summary>
         /// svuint8_t svabd[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -242,7 +246,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> AbsoluteDifference(Vector<ulong> left, Vector<ulong> right) => AbsoluteDifference(left, right);
 
-        ///  Add : Add
+
+        // Add
 
         /// <summary>
         /// svint8_t svadd[_s8]_m(svbool_t pg, svint8_t op1, svint8_t op2)
@@ -315,7 +320,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> Add(Vector<double> left, Vector<double> right) => Add(left, right);
 
 
-        ///  AddAcross : Add reduction
+        // Add reduction
 
         /// <summary>
         /// float64_t svaddv[_f64](svbool_t pg, svfloat64_t op)
@@ -377,7 +382,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> AddAcross(Vector<ulong> value) => AddAcross(value);
 
-        ///  Complex add with rotate
+
+        // Complex add with rotate
 
         /// <summary>
         /// svfloat64_t svcadd[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, uint64_t imm_rotation)
@@ -397,7 +403,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> AddRotateComplex(Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(1))] byte rotation) => AddRotateComplex(left, right, rotation);
 
-        ///  AddSaturate : Saturating add
+
+        // Saturating add
 
         /// <summary>
         /// svuint8_t svqadd[_u8](svuint8_t op1, svuint8_t op2)
@@ -447,7 +454,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> AddSaturate(Vector<ulong> left, Vector<ulong> right) => AddSaturate(left, right);
 
-        ///  AddSequentialAcross : Add reduction (strictly-ordered)
+
+        // Add reduction (strictly-ordered)
 
         /// <summary>
         /// float64_t svadda[_f64](svbool_t pg, float64_t initial, svfloat64_t op)
@@ -461,7 +469,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> AddSequentialAcross(Vector<float> initial, Vector<float> value) => AddSequentialAcross(initial, value);
 
-        ///  And : Bitwise AND
+
+        // Bitwise AND
 
         /// <summary>
         /// svuint8_t svand[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -552,7 +561,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> And(Vector<ulong> left, Vector<ulong> right) => And(left, right);
 
 
-        ///  AndAcross : Bitwise AND reduction to scalar
+        // Bitwise AND reduction to scalar
 
         /// <summary>
         /// uint8_t svandv[_u8](svbool_t pg, svuint8_t op)
@@ -603,7 +612,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> AndAcross(Vector<ulong> value) => AndAcross(value);
 
 
-        ///  BitwiseClear : Bitwise clear
+        // Bitwise clear
 
         /// <summary>
         /// svuint8_t svbic[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -694,7 +703,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> BitwiseClear(Vector<ulong> left, Vector<ulong> right) => BitwiseClear(left, right);
 
 
-        ///  BooleanNot : Logically invert boolean condition
+        // Logically invert boolean condition
 
         /// <summary>
         /// svuint8_t svcnot[_u8]_m(svuint8_t inactive, svbool_t pg, svuint8_t op)
@@ -760,7 +769,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> BooleanNot(Vector<ulong> value) => BooleanNot(value);
 
-        ///  Shuffle active elements of vector to the right and fill with zero
+
+        // Shuffle active elements of vector to the right and fill with zero
 
         /// <summary>
         /// svfloat64_t svcompact[_f64](svbool_t pg, svfloat64_t op)
@@ -799,7 +809,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Compact(Vector<ulong> mask, Vector<ulong> value) => Compact(mask, value);
 
 
-        ///  Compare equal to
+        // Compare equal to
 
         /// <summary>
         /// svbool_t svcmpeq[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -879,7 +889,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> CompareEqual(Vector<ulong> left, Vector<ulong> right) => CompareEqual(left, right);
 
-        ///  Compare greater than
+
+        // Compare greater than
 
         /// <summary>
         /// svbool_t svcmpgt[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -978,7 +989,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CompareGreaterThan(Vector<ulong> left, Vector<ulong> right) => CompareGreaterThan(left, right);
 
 
-        ///  Compare greater than or equal to
+        // Compare greater than or equal to
 
         /// <summary>
         /// svbool_t svcmpge[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1076,7 +1087,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> CompareGreaterThanOrEqual(Vector<ulong> left, Vector<ulong> right) => CompareGreaterThanOrEqual(left, right);
 
-        ///  Compare less than
+
+        // Compare less than
 
         /// <summary>
         /// svbool_t svcmplt[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1175,7 +1187,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CompareLessThan(Vector<ulong> left, Vector<ulong> right) => CompareLessThan(left, right);
 
 
-        ///  Compare less than or equal to
+        // Compare less than or equal to
 
         /// <summary>
         /// svbool_t svcmple[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1273,7 +1285,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> CompareLessThanOrEqual(Vector<ulong> left, Vector<ulong> right) => CompareLessThanOrEqual(left, right);
 
-        ///  Compare not equal to
+
+        // Compare not equal to
 
         /// <summary>
         /// svbool_t svcmpne[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -1354,7 +1367,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CompareNotEqualTo(Vector<ulong> left, Vector<ulong> right) => CompareNotEqualTo(left, right);
 
 
-        ///  Compare unordered with
+        // Compare unordered with
 
         /// <summary>
         /// svbool_t svcmpuo[_f64](svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -1368,7 +1381,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> CompareUnordered(Vector<float> left, Vector<float> right) => CompareUnordered(left, right);
 
-        ///  Compute vector addresses for 16-bit data
+
+        // Compute vector addresses for 16-bit data
 
         /// <summary>
         /// svuint32_t svadrh[_u32base]_[s32]index(svuint32_t bases, svint32_t indices)
@@ -1395,7 +1409,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Compute16BitAddresses(Vector<ulong> bases, Vector<ulong> indices) => Compute16BitAddresses(bases, indices);
 
 
-        ///  Compute vector addresses for 32-bit data
+        // Compute vector addresses for 32-bit data
 
         /// <summary>
         /// svuint32_t svadrw[_u32base]_[s32]index(svuint32_t bases, svint32_t indices)
@@ -1422,7 +1436,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Compute32BitAddresses(Vector<ulong> bases, Vector<ulong> indices) => Compute32BitAddresses(bases, indices);
 
 
-        ///  Compute vector addresses for 64-bit data
+        // Compute vector addresses for 64-bit data
 
         /// <summary>
         /// svuint32_t svadrd[_u32base]_[s32]index(svuint32_t bases, svint32_t indices)
@@ -1449,7 +1463,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Compute64BitAddresses(Vector<ulong> bases, Vector<ulong> indices) => Compute64BitAddresses(bases, indices);
 
 
-        ///  Compute vector addresses for 8-bit data
+        // Compute vector addresses for 8-bit data
 
         /// <summary>
         /// svuint32_t svadrb[_u32base]_[s32]offset(svuint32_t bases, svint32_t offsets)
@@ -1475,7 +1489,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> Compute8BitAddresses(Vector<ulong> bases, Vector<ulong> indices) => Compute8BitAddresses(bases, indices);
 
-        ///  Conditionally extract element after last
+
+        // Conditionally extract element after last
 
         /// <summary>
         /// svuint8_t svclasta[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1598,7 +1613,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong ConditionalExtractAfterLastActiveElement(Vector<ulong> mask, ulong defaultValues, Vector<ulong> data) => ConditionalExtractAfterLastActiveElement(mask, defaultValues, data);
 
 
-        ///  Conditionally extract element after last
+        // Conditionally extract element after last
 
         /// <summary>
         /// svuint8_t svclasta[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1661,7 +1676,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ConditionalExtractAfterLastActiveElementAndReplicate(Vector<ulong> mask, Vector<ulong> defaultScalar, Vector<ulong> data) => ConditionalExtractAfterLastActiveElementAndReplicate(mask, defaultScalar, data);
 
 
-        ///  Conditionally extract last element
+        // Conditionally extract last element
 
         /// <summary>
         /// svuint8_t svclastb[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1784,7 +1799,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong ConditionalExtractLastActiveElement(Vector<ulong> mask, ulong defaultValues, Vector<ulong> data) => ConditionalExtractLastActiveElement(mask, defaultValues, data);
 
 
-        ///  Conditionally extract last element
+        // Conditionally extract last element
 
         /// <summary>
         /// svuint8_t svclastb[_u8](svbool_t pg, svuint8_t fallback, svuint8_t data)
@@ -1847,8 +1862,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ConditionalExtractLastActiveElementAndReplicate(Vector<ulong> mask, Vector<ulong> fallback, Vector<ulong> data) => ConditionalExtractLastActiveElementAndReplicate(mask, fallback, data);
 
 
-        ///  Compare equal to
-        ///  ConditionalSelect : Conditionally select elements
+        // Conditionally select elements
 
         /// <summary>
         /// svint8_t svsel[_s8](svbool_t pg, svint8_t op1, svint8_t op2)
@@ -1937,7 +1951,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> ConditionalSelect(Vector<double> mask, Vector<double> left, Vector<double> right) => ConditionalSelect(mask, left, right);
 
 
-        ///  ConvertToDouble : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svfloat64_t svcvt_f64[_s32]_m(svfloat64_t inactive, svbool_t pg, svint32_t op)
@@ -1985,7 +1999,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> ConvertToDouble(Vector<ulong> value) => ConvertToDouble(value);
 
 
-        ///  ConvertToInt32 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svint32_t svcvt_s32[_f64]_m(svint32_t inactive, svbool_t pg, svfloat64_t op)
@@ -2006,7 +2020,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> ConvertToInt32(Vector<float> value) => ConvertToInt32(value);
 
 
-        ///  ConvertToInt64 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svint64_t svcvt_s64[_f64]_m(svint64_t inactive, svbool_t pg, svfloat64_t op)
@@ -2027,7 +2041,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> ConvertToInt64(Vector<float> value) => ConvertToInt64(value);
 
 
-        ///  ConvertToSingle : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svfloat32_t svcvt_f32[_f64]_m(svfloat32_t inactive, svbool_t pg, svfloat64_t op)
@@ -2075,7 +2089,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ConvertToSingle(Vector<ulong> value) => ConvertToSingle(value);
 
 
-        ///  ConvertToUInt32 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svuint32_t svcvt_u32[_f64]_m(svuint32_t inactive, svbool_t pg, svfloat64_t op)
@@ -2096,7 +2110,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> ConvertToUInt32(Vector<float> value) => ConvertToUInt32(value);
 
 
-        ///  ConvertToUInt64 : Floating-point convert
+        // Floating-point convert
 
         /// <summary>
         /// svuint64_t svcvt_u64[_f64]_m(svuint64_t inactive, svbool_t pg, svfloat64_t op)
@@ -2117,7 +2131,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ConvertToUInt64(Vector<float> value) => ConvertToUInt64(value);
 
 
-        ///  Count16BitElements : Count the number of 16-bit elements in a vector
+        // Count the number of 16-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcnth_pat(enum svpattern pattern)
@@ -2126,7 +2140,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong Count16BitElements([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => Count16BitElements(pattern);
 
 
-        ///  Count32BitElements : Count the number of 32-bit elements in a vector
+        // Count the number of 32-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcntw_pat(enum svpattern pattern)
@@ -2135,7 +2149,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong Count32BitElements([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => Count32BitElements(pattern);
 
 
-        ///  Count64BitElements : Count the number of 64-bit elements in a vector
+        // Count the number of 64-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcntd_pat(enum svpattern pattern)
@@ -2144,7 +2158,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong Count64BitElements([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => Count64BitElements(pattern);
 
 
-        ///  Count8BitElements : Count the number of 8-bit elements in a vector
+        // Count the number of 8-bit elements in a vector
 
         /// <summary>
         /// uint64_t svcntb_pat(enum svpattern pattern)
@@ -2558,7 +2572,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateMaskForNextActiveElement(Vector<ulong> mask, Vector<ulong> srcMask) => CreateMaskForNextActiveElement(mask, srcMask);
 
 
-        ///  CreateTrueMaskByte : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2567,7 +2581,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<byte> CreateTrueMaskByte([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskByte(pattern);
 
 
-        ///  CreateTrueMaskDouble : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2576,7 +2590,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<double> CreateTrueMaskDouble([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskDouble(pattern);
 
 
-        ///  CreateTrueMaskInt16 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2585,7 +2599,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> CreateTrueMaskInt16([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskInt16(pattern);
 
 
-        ///  CreateTrueMaskInt32 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2594,7 +2608,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> CreateTrueMaskInt32([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskInt32(pattern);
 
 
-        ///  CreateTrueMaskInt64 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2603,7 +2617,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> CreateTrueMaskInt64([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskInt64(pattern);
 
 
-        ///  CreateTrueMaskSByte : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2612,7 +2626,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<sbyte> CreateTrueMaskSByte([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskSByte(pattern);
 
 
-        ///  CreateTrueMaskSingle : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b8(enum svpattern pattern)
@@ -2621,7 +2635,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> CreateTrueMaskSingle([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskSingle(pattern);
 
 
-        ///  CreateTrueMaskUInt16 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b16(enum svpattern pattern)
@@ -2630,7 +2644,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> CreateTrueMaskUInt16([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskUInt16(pattern);
 
 
-        ///  CreateTrueMaskUInt32 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b32(enum svpattern pattern)
@@ -2639,7 +2653,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> CreateTrueMaskUInt32([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskUInt32(pattern);
 
 
-        ///  CreateTrueMaskUInt64 : Set predicate elements to true
+        // Set predicate elements to true
 
         /// <summary>
         /// svbool_t svptrue_pat_b64(enum svpattern pattern)
@@ -2648,7 +2662,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateTrueMaskUInt64([ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => CreateTrueMaskUInt64(pattern);
 
 
-        ///  CreateWhileLessThanMask16Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b16[_s32](int32_t op1, int32_t op2)
@@ -2675,7 +2689,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> CreateWhileLessThanMask16Bit(ulong left, ulong right) => CreateWhileLessThanMask16Bit(left, right);
 
 
-        ///  CreateWhileLessThanMask32Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b32[_s32](int32_t op1, int32_t op2)
@@ -2702,7 +2716,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> CreateWhileLessThanMask32Bit(ulong left, ulong right) => CreateWhileLessThanMask32Bit(left, right);
 
 
-        ///  CreateWhileLessThanMask64Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b64[_s32](int32_t op1, int32_t op2)
@@ -2729,7 +2743,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateWhileLessThanMask64Bit(ulong left, ulong right) => CreateWhileLessThanMask64Bit(left, right);
 
 
-        ///  CreateWhileLessThanMask8Bit : While incrementing scalar is less than
+        // While incrementing scalar is less than
 
         /// <summary>
         /// svbool_t svwhilelt_b8[_s32](int32_t op1, int32_t op2)
@@ -2756,7 +2770,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<byte> CreateWhileLessThanMask8Bit(ulong left, ulong right) => CreateWhileLessThanMask8Bit(left, right);
 
 
-        ///  CreateWhileLessThanOrEqualMask16Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b16[_s32](int32_t op1, int32_t op2)
@@ -2783,7 +2797,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> CreateWhileLessThanOrEqualMask16Bit(ulong left, ulong right) => CreateWhileLessThanOrEqualMask16Bit(left, right);
 
 
-        ///  CreateWhileLessThanOrEqualMask32Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b32[_s32](int32_t op1, int32_t op2)
@@ -2810,7 +2824,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> CreateWhileLessThanOrEqualMask32Bit(ulong left, ulong right) => CreateWhileLessThanOrEqualMask32Bit(left, right);
 
 
-        ///  CreateWhileLessThanOrEqualMask64Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b64[_s32](int32_t op1, int32_t op2)
@@ -2837,7 +2851,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> CreateWhileLessThanOrEqualMask64Bit(ulong left, ulong right) => CreateWhileLessThanOrEqualMask64Bit(left, right);
 
 
-        ///  CreateWhileLessThanOrEqualMask8Bit : While incrementing scalar is less than or equal to
+        // While incrementing scalar is less than or equal to
 
         /// <summary>
         /// svbool_t svwhilele_b8[_s32](int32_t op1, int32_t op2)
@@ -2864,7 +2878,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<byte> CreateWhileLessThanOrEqualMask8Bit(ulong left, ulong right) => CreateWhileLessThanOrEqualMask8Bit(left, right);
 
 
-        ///  Divide : Divide
+        // Divide
 
         /// <summary>
         /// svfloat32_t svdiv[_f32]_m(svbool_t pg, svfloat32_t op1, svfloat32_t op2)
@@ -2890,7 +2904,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> Divide(Vector<double> left, Vector<double> right) => Divide(left, right);
 
-        ///  DotProduct : Dot product
+
+        // Dot product
 
         /// <summary>
         /// svint32_t svdot[_s32](svint32_t op1, svint8_t op2, svint8_t op3)
@@ -2917,7 +2932,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> DotProduct(Vector<ulong> addend, Vector<ushort> left, Vector<ushort> right) => DotProduct(addend, left, right);
 
 
-        ///  DotProductBySelectedScalar : Dot product
+        // Dot product
 
         /// <summary>
         /// svint32_t svdot_lane[_s32](svint32_t op1, svint8_t op2, svint8_t op3, uint64_t imm_index)
@@ -2944,7 +2959,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> DotProductBySelectedScalar(Vector<ulong> addend, Vector<ushort> left, Vector<ushort> right, [ConstantExpected] byte rightIndex) => DotProductBySelectedScalar(addend, left, right, rightIndex);
 
 
-        ///  Broadcast a scalar value
+        // Broadcast a scalar value
 
         /// <summary>
         /// svuint8_t svdup_lane[_u8](svuint8_t data, uint8_t index)
@@ -3068,7 +3083,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ExtractVector(Vector<ulong> upper, Vector<ulong> lower, [ConstantExpected] byte index) => ExtractVector(upper, lower, index);
 
 
-        ///  Floating-point exponential accelerator
+        // Floating-point exponential accelerator
 
         /// <summary>
         /// svfloat64_t svexpa[_f64](svuint64_t op)
@@ -3083,7 +3098,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FloatingPointExponentialAccelerator(Vector<uint> value) => FloatingPointExponentialAccelerator(value);
 
 
-        ///  FusedMultiplyAdd : Multiply-add, addend first
+        // Multiply-add, addend first
 
         /// <summary>
         /// svfloat64_t svmla[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3102,7 +3117,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplyAdd(Vector<float> addend, Vector<float> left, Vector<float> right) => FusedMultiplyAdd(addend, left, right);
 
 
-        ///  FusedMultiplyAddBySelectedScalar : Multiply-add, addend first
+        // Multiply-add, addend first
 
         /// <summary>
         /// svfloat64_t svmla_lane[_f64](svfloat64_t op1, svfloat64_t op2, svfloat64_t op3, uint64_t imm_index)
@@ -3117,7 +3132,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplyAddBySelectedScalar(Vector<float> addend, Vector<float> left, Vector<float> right, [ConstantExpected] byte rightIndex) => FusedMultiplyAddBySelectedScalar(addend, left, right, rightIndex);
 
 
-        ///  FusedMultiplyAddNegated : Negated multiply-add, addend first
+        // Negated multiply-add, addend first
 
         /// <summary>
         /// svfloat64_t svnmla[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3136,7 +3151,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplyAddNegated(Vector<float> addend, Vector<float> left, Vector<float> right) => FusedMultiplyAddNegated(addend, left, right);
 
 
-        ///  FusedMultiplySubtract : Multiply-subtract, minuend first
+        // Multiply-subtract, minuend first
 
         /// <summary>
         /// svfloat64_t svmls[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3155,7 +3170,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplySubtract(Vector<float> minuend, Vector<float> left, Vector<float> right) => FusedMultiplySubtract(minuend, left, right);
 
 
-        ///  FusedMultiplySubtractBySelectedScalar : Multiply-subtract, minuend first
+        // Multiply-subtract, minuend first
 
         /// <summary>
         /// svfloat64_t svmls_lane[_f64](svfloat64_t op1, svfloat64_t op2, svfloat64_t op3, uint64_t imm_index)
@@ -3170,7 +3185,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplySubtractBySelectedScalar(Vector<float> minuend, Vector<float> left, Vector<float> right, [ConstantExpected] byte rightIndex) => FusedMultiplySubtractBySelectedScalar(minuend, left, right, rightIndex);
 
 
-        ///  FusedMultiplySubtractNegated : Negated multiply-subtract, minuend first
+        // Negated multiply-subtract, minuend first
 
         /// <summary>
         /// svfloat64_t svnmls[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3)
@@ -3189,7 +3204,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> FusedMultiplySubtractNegated(Vector<float> minuend, Vector<float> left, Vector<float> right) => FusedMultiplySubtractNegated(minuend, left, right);
 
 
-        ///  Prefetch halfwords
+        // Prefetch halfwords
 
         /// <summary>
         /// void svprfh_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)
@@ -3264,7 +3279,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
 
-        ///  Prefetch words
+        // Prefetch words
 
         /// <summary>
         /// void svprfw_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)
@@ -3339,7 +3354,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
 
-        ///  Prefetch doublewords
+        // Prefetch doublewords
 
         /// <summary>
         /// void svprfd_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)
@@ -3414,7 +3429,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
 
-        ///  Prefetch bytes
+        // Prefetch bytes
 
         /// <summary>
         /// void svprfb_gather_[s32]offset(svbool_t pg, const void *base, svint32_t offsets, enum svprfop op)
@@ -3489,7 +3504,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
 
-        ///  Unextended load
+        // Unextended load
 
         /// <summary>
         /// svfloat64_t svld1_gather_[s64]index[_f64](svbool_t pg, const float64_t *base, svint64_t indices)
@@ -3605,7 +3620,7 @@ namespace System.Runtime.Intrinsics.Arm
 
 
 
-        ///  Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1ub_gather_[s32]offset_s32(svbool_t pg, const uint8_t *base, svint32_t offsets)
@@ -3681,7 +3696,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> GatherVectorByteZeroExtend(Vector<ulong> mask, byte* address, Vector<ulong> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
-        ///  Load 16-bit data and sign-extend
+
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sh_gather_[s32]index_s32(svbool_t pg, const int16_t *base, svint32_t indices)
@@ -3758,7 +3774,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt16SignExtend(Vector<ulong> mask, short* address, Vector<ulong> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
 
-        ///  Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sh_gather_[s32]offset_s32(svbool_t pg, const int16_t *base, svint32_t offsets)
@@ -3809,7 +3825,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(Vector<ulong> mask, short* address, Vector<ulong> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
 
-        ///  Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sw_gather_[s64]index_s64(svbool_t pg, const int32_t *base, svint64_t indices)
@@ -3848,7 +3864,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt32SignExtend(Vector<ulong> mask, int* address, Vector<ulong> indices) => GatherVectorInt32SignExtend(mask, address, indices);
 
 
-        ///  Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sw_gather_[s64]offset_s64(svbool_t pg, const int32_t *base, svint64_t offsets)
@@ -3875,7 +3891,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(Vector<ulong> mask, int* address, Vector<ulong> offsets) => GatherVectorInt32WithByteOffsetsSignExtend(mask, address, offsets);
 
 
-        ///  Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sb_gather_[s32]offset_s32(svbool_t pg, const int8_t *base, svint32_t offsets)
@@ -3952,7 +3968,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorSByteSignExtend(Vector<ulong> mask, sbyte* address, Vector<ulong> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
 
-        ///  Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1uh_gather_[s32]offset_s32(svbool_t pg, const uint16_t *base, svint32_t offsets)
@@ -4003,7 +4019,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
 
-        ///  Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1uh_gather_[s32]index_s32(svbool_t pg, const uint16_t *base, svint32_t indices)
@@ -4080,7 +4096,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
 
-        ///  Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uw_gather_[s64]offset_s64(svbool_t pg, const uint32_t *base, svint64_t offsets)
@@ -4131,7 +4147,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtend(mask, address, offsets);
 
 
-        ///  Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uw_gather_[s64]index_s64(svbool_t pg, const uint32_t *base, svint64_t indices)
@@ -4208,7 +4224,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> indices) => GatherVectorUInt32ZeroExtend(mask, address, indices);
 
 
-        ///  Unextended load
+        // Unextended load
 
         /// <summary>
         /// svfloat64_t svld1_gather_[s64]offset[_f64](svbool_t pg, const float64_t *base, svint64_t offsets)
@@ -4283,7 +4299,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> GatherVectorWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<ulong> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
 
-        ///  Count set predicate bits
+        // Count set predicate bits
 
         /// <summary>
         /// uint64_t svcntp_b8(svbool_t pg, svbool_t op)
@@ -4346,7 +4362,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong GetActiveElementCount(Vector<ulong> mask, Vector<ulong> from) => GetActiveElementCount(mask, from);
 
 
-        ///  Insert scalar into shifted vector
+        // Insert scalar into shifted vector
 
         /// <summary>
         /// svuint8_t svinsr[_n_u8](svuint8_t op1, uint8_t op2)
@@ -4419,7 +4435,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> InsertIntoShiftedVector(Vector<ulong> left, ulong right) => InsertIntoShiftedVector(left, right);
 
 
-        ///  LeadingSignCount : Count leading sign bits
+        // Count leading sign bits
 
         /// <summary>
         /// svuint8_t svcls[_s8]_m(svuint8_t inactive, svbool_t pg, svint8_t op)
@@ -4454,7 +4470,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LeadingSignCount(Vector<long> value) => LeadingSignCount(value);
 
 
-        ///  LeadingZeroCount : Count leading zero bits
+        // Count leading zero bits
 
         /// <summary>
         /// svuint8_t svclz[_s8]_m(svuint8_t inactive, svbool_t pg, svint8_t op)
@@ -4521,7 +4537,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LeadingZeroCount(Vector<ulong> value) => LeadingZeroCount(value);
 
 
-        ///  LoadVector : Unextended load
+        // Unextended load
 
         /// <summary>
         /// svint8_t svld1[_s8](svbool_t pg, const int8_t *base)
@@ -4776,7 +4792,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> LoadVector128AndReplicateToVector(Vector<ulong> mask, ulong* address) => LoadVector128AndReplicateToVector(mask, address);
 
-        ///  LoadVectorByteZeroExtendToInt16 : Load 8-bit data and zero-extend
+
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint16_t svld1ub_s16(svbool_t pg, const uint8_t *base)
@@ -4785,7 +4802,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> LoadVectorByteZeroExtendToInt16(Vector<short> mask, byte* address) => LoadVectorByteZeroExtendToInt16(mask, address);
 
 
-        ///  LoadVectorByteZeroExtendToInt32 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1ub_s32(svbool_t pg, const uint8_t *base)
@@ -4794,7 +4811,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorByteZeroExtendToInt32(Vector<int> mask, byte* address) => LoadVectorByteZeroExtendToInt32(mask, address);
 
 
-        ///  LoadVectorByteZeroExtendToInt64 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1ub_s64(svbool_t pg, const uint8_t *base)
@@ -4803,7 +4820,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorByteZeroExtendToInt64(Vector<long> mask, byte* address) => LoadVectorByteZeroExtendToInt64(mask, address);
 
 
-        ///  LoadVectorByteZeroExtendToUInt16 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svuint16_t svld1ub_u16(svbool_t pg, const uint8_t *base)
@@ -4812,7 +4829,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> LoadVectorByteZeroExtendToUInt16(Vector<ushort> mask, byte* address) => LoadVectorByteZeroExtendToUInt16(mask, address);
 
 
-        ///  LoadVectorByteZeroExtendToUInt32 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svuint32_t svld1ub_u32(svbool_t pg, const uint8_t *base)
@@ -4821,7 +4838,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorByteZeroExtendToUInt32(Vector<uint> mask, byte* address) => LoadVectorByteZeroExtendToUInt32(mask, address);
 
 
-        ///  LoadVectorByteZeroExtendToUInt64 : Load 8-bit data and zero-extend
+        // Load 8-bit data and zero-extend
 
         /// <summary>
         /// svuint64_t svld1ub_u64(svbool_t pg, const uint8_t *base)
@@ -4830,7 +4847,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorByteZeroExtendToUInt64(Vector<ulong> mask, byte* address) => LoadVectorByteZeroExtendToUInt64(mask, address);
 
 
-        ///  LoadVectorInt16SignExtendToInt32 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sh_s32(svbool_t pg, const int16_t *base)
@@ -4839,7 +4856,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorInt16SignExtendToInt32(Vector<int> mask, short* address) => LoadVectorInt16SignExtendToInt32(mask, address);
 
 
-        ///  LoadVectorInt16SignExtendToInt64 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sh_s64(svbool_t pg, const int16_t *base)
@@ -4848,7 +4865,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorInt16SignExtendToInt64(Vector<long> mask, short* address) => LoadVectorInt16SignExtendToInt64(mask, address);
 
 
-        ///  LoadVectorInt16SignExtendToUInt32 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svuint32_t svld1sh_u32(svbool_t pg, const int16_t *base)
@@ -4857,7 +4874,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorInt16SignExtendToUInt32(Vector<uint> mask, short* address) => LoadVectorInt16SignExtendToUInt32(mask, address);
 
 
-        ///  LoadVectorInt16SignExtendToUInt64 : Load 16-bit data and sign-extend
+        // Load 16-bit data and sign-extend
 
         /// <summary>
         /// svuint64_t svld1sh_u64(svbool_t pg, const int16_t *base)
@@ -4866,7 +4883,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorInt16SignExtendToUInt64(Vector<ulong> mask, short* address) => LoadVectorInt16SignExtendToUInt64(mask, address);
 
 
-        ///  LoadVectorInt32SignExtendToInt64 : Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sw_s64(svbool_t pg, const int32_t *base)
@@ -4875,7 +4892,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorInt32SignExtendToInt64(Vector<long> mask, int* address) => LoadVectorInt32SignExtendToInt64(mask, address);
 
 
-        ///  LoadVectorInt32SignExtendToUInt64 : Load 32-bit data and sign-extend
+        // Load 32-bit data and sign-extend
 
         /// <summary>
         /// svuint64_t svld1sw_u64(svbool_t pg, const int32_t *base)
@@ -4884,7 +4901,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorInt32SignExtendToUInt64(Vector<ulong> mask, int* address) => LoadVectorInt32SignExtendToUInt64(mask, address);
 
 
-        ///  LoadVectorSByteSignExtendToInt16 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint16_t svld1sb_s16(svbool_t pg, const int8_t *base)
@@ -4893,7 +4910,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> LoadVectorSByteSignExtendToInt16(Vector<short> mask, sbyte* address) => LoadVectorSByteSignExtendToInt16(mask, address);
 
 
-        ///  LoadVectorSByteSignExtendToInt32 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint32_t svld1sb_s32(svbool_t pg, const int8_t *base)
@@ -4902,7 +4919,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorSByteSignExtendToInt32(Vector<int> mask, sbyte* address) => LoadVectorSByteSignExtendToInt32(mask, address);
 
 
-        ///  LoadVectorSByteSignExtendToInt64 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svint64_t svld1sb_s64(svbool_t pg, const int8_t *base)
@@ -4911,7 +4928,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorSByteSignExtendToInt64(Vector<long> mask, sbyte* address) => LoadVectorSByteSignExtendToInt64(mask, address);
 
 
-        ///  LoadVectorSByteSignExtendToUInt16 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svuint16_t svld1sb_u16(svbool_t pg, const int8_t *base)
@@ -4920,7 +4937,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> LoadVectorSByteSignExtendToUInt16(Vector<ushort> mask, sbyte* address) => LoadVectorSByteSignExtendToUInt16(mask, address);
 
 
-        ///  LoadVectorSByteSignExtendToUInt32 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svuint32_t svld1sb_u32(svbool_t pg, const int8_t *base)
@@ -4929,7 +4946,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorSByteSignExtendToUInt32(Vector<uint> mask, sbyte* address) => LoadVectorSByteSignExtendToUInt32(mask, address);
 
 
-        ///  LoadVectorSByteSignExtendToUInt64 : Load 8-bit data and sign-extend
+        // Load 8-bit data and sign-extend
 
         /// <summary>
         /// svuint64_t svld1sb_u64(svbool_t pg, const int8_t *base)
@@ -4938,7 +4955,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorSByteSignExtendToUInt64(Vector<ulong> mask, sbyte* address) => LoadVectorSByteSignExtendToUInt64(mask, address);
 
 
-        ///  LoadVectorUInt16ZeroExtendToInt32 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint32_t svld1uh_s32(svbool_t pg, const uint16_t *base)
@@ -4947,7 +4964,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorUInt16ZeroExtendToInt32(Vector<int> mask, ushort* address) => LoadVectorUInt16ZeroExtendToInt32(mask, address);
 
 
-        ///  LoadVectorUInt16ZeroExtendToInt64 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uh_s64(svbool_t pg, const uint16_t *base)
@@ -4956,7 +4973,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorUInt16ZeroExtendToInt64(Vector<long> mask, ushort* address) => LoadVectorUInt16ZeroExtendToInt64(mask, address);
 
 
-        ///  LoadVectorUInt16ZeroExtendToUInt32 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svuint32_t svld1uh_u32(svbool_t pg, const uint16_t *base)
@@ -4965,7 +4982,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorUInt16ZeroExtendToUInt32(Vector<uint> mask, ushort* address) => LoadVectorUInt16ZeroExtendToUInt32(mask, address);
 
 
-        ///  LoadVectorUInt16ZeroExtendToUInt64 : Load 16-bit data and zero-extend
+        // Load 16-bit data and zero-extend
 
         /// <summary>
         /// svuint64_t svld1uh_u64(svbool_t pg, const uint16_t *base)
@@ -4974,7 +4991,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> LoadVectorUInt16ZeroExtendToUInt64(Vector<ulong> mask, ushort* address) => LoadVectorUInt16ZeroExtendToUInt64(mask, address);
 
 
-        ///  LoadVectorUInt32ZeroExtendToInt64 : Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svint64_t svld1uw_s64(svbool_t pg, const uint32_t *base)
@@ -4983,7 +5000,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorUInt32ZeroExtendToInt64(Vector<long> mask, uint* address) => LoadVectorUInt32ZeroExtendToInt64(mask, address);
 
 
-        ///  LoadVectorUInt32ZeroExtendToUInt64 : Load 32-bit data and zero-extend
+        // Load 32-bit data and zero-extend
 
         /// <summary>
         /// svuint64_t svld1uw_u64(svbool_t pg, const uint32_t *base)
@@ -5243,7 +5260,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe (Vector<ulong>, Vector<ulong>, Vector<ulong>, Vector<ulong>) Load4xVectorAndUnzip(Vector<ulong> mask, ulong* address) => Load4xVectorAndUnzip(mask, address);
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint32_t svldnf1sh_s32(svbool_t pg, const int16_t *base)
@@ -5252,7 +5270,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<int> LoadVectorInt16NonFaultingSignExtendToInt32(short* address) => LoadVectorInt16NonFaultingSignExtendToInt32(address);
 
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint64_t svldnf1sh_s64(svbool_t pg, const int16_t *base)
@@ -5261,7 +5279,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorInt16NonFaultingSignExtendToInt64(short* address) => LoadVectorInt16NonFaultingSignExtendToInt64(address);
 
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint32_t svldnf1sh_u32(svbool_t pg, const int16_t *base)
@@ -5270,7 +5288,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorInt16NonFaultingSignExtendToUInt32(short* address) => LoadVectorInt16NonFaultingSignExtendToUInt32(address);
 
 
-        ///  Load 16-bit data and sign-extend, non-faulting
+        // Load 16-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint64_t svldnf1sh_u64(svbool_t pg, const int16_t *base)
@@ -5278,7 +5296,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> LoadVectorInt16NonFaultingSignExtendToUInt64(short* address) => LoadVectorInt16NonFaultingSignExtendToUInt64(address);
 
-        ///  Load 32-bit data and sign-extend, non-faulting
+
+        // Load 32-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint64_t svldnf1sw_s64(svbool_t pg, const int32_t *base)
@@ -5286,7 +5305,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<long> LoadVectorInt32NonFaultingSignExtendToInt64(int* address) => LoadVectorInt32NonFaultingSignExtendToInt64(address);
 
-        ///  Load 32-bit data and sign-extend, non-faulting
+
+        // Load 32-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint64_t svldnf1sw_u64(svbool_t pg, const int32_t *base)
@@ -5294,7 +5314,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> LoadVectorInt32NonFaultingSignExtendToUInt64(int* address) => LoadVectorInt32NonFaultingSignExtendToUInt64(address);
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint16_t svldnf1sb_s16(svbool_t pg, const int8_t *base)
@@ -5303,7 +5324,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<short> LoadVectorSByteNonFaultingSignExtendToInt16(sbyte* address) => LoadVectorSByteNonFaultingSignExtendToInt16(address);
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint32_t svldnf1sb_s32(svbool_t pg, const int8_t *base)
@@ -5311,7 +5332,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<int> LoadVectorSByteNonFaultingSignExtendToInt32(sbyte* address) => LoadVectorSByteNonFaultingSignExtendToInt32(address);
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svint64_t svldnf1sb_s64(svbool_t pg, const int8_t *base)
@@ -5320,7 +5342,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> LoadVectorSByteNonFaultingSignExtendToInt64(sbyte* address) => LoadVectorSByteNonFaultingSignExtendToInt64(address);
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint16_t svldnf1sb_u16(svbool_t pg, const int8_t *base)
@@ -5329,7 +5351,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> LoadVectorSByteNonFaultingSignExtendToUInt16(sbyte* address) => LoadVectorSByteNonFaultingSignExtendToUInt16(address);
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint32_t svldnf1sb_u32(svbool_t pg, const int8_t *base)
@@ -5338,7 +5360,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> LoadVectorSByteNonFaultingSignExtendToUInt32(sbyte* address) => LoadVectorSByteNonFaultingSignExtendToUInt32(address);
 
 
-        ///  Load 8-bit data and sign-extend, non-faulting
+        // Load 8-bit data and sign-extend, non-faulting
 
         /// <summary>
         /// svuint64_t svldnf1sb_u64(svbool_t pg, const int8_t *base)
@@ -5346,7 +5368,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> LoadVectorSByteNonFaultingSignExtendToUInt64(sbyte* address) => LoadVectorSByteNonFaultingSignExtendToUInt64(address);
 
-        ///  Max : Maximum
+
+        // Maximum
 
         /// <summary>
         /// svuint8_t svmax[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -5439,7 +5462,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Max(Vector<ulong> left, Vector<ulong> right) => Max(left, right);
 
 
-        ///  MaxAcross : Maximum reduction to scalar
+        // Maximum reduction to scalar
 
         /// <summary>
         /// uint8_t svmaxv[_u8](svbool_t pg, svuint8_t op)
@@ -5502,7 +5525,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> MaxAcross(Vector<ulong> value) => MaxAcross(value);
 
 
-        ///  MaxNumber : Maximum number
+        // Maximum number
 
         /// <summary>
         /// svfloat64_t svmaxnm[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -5523,7 +5546,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> MaxNumber(Vector<float> left, Vector<float> right) => MaxNumber(left, right);
 
 
-        ///  MaxNumberAcross : Maximum number reduction to scalar
+        // Maximum number reduction to scalar
 
         /// <summary>
         /// float64_t svmaxnmv[_f64](svbool_t pg, svfloat64_t op)
@@ -5538,7 +5561,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> MaxNumberAcross(Vector<float> value) => MaxNumberAcross(value);
 
 
-        ///  Min : Minimum
+        // Minimum
 
         /// <summary>
         /// svuint8_t svmin[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -5631,7 +5654,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Min(Vector<ulong> left, Vector<ulong> right) => Min(left, right);
 
 
-        ///  MinAcross : Minimum reduction to scalar
+        // Minimum reduction to scalar
 
         /// <summary>
         /// uint8_t svminv[_u8](svbool_t pg, svuint8_t op)
@@ -5694,7 +5717,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> MinAcross(Vector<ulong> value) => MinAcross(value);
 
 
-        ///  MinNumber : Minimum number
+        // Minimum number
 
         /// <summary>
         /// svfloat64_t svminnm[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -5715,7 +5738,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> MinNumber(Vector<float> left, Vector<float> right) => MinNumber(left, right);
 
 
-        ///  MinNumberAcross : Minimum number reduction to scalar
+        // Minimum number reduction to scalar
 
         /// <summary>
         /// float64_t svminnmv[_f64](svbool_t pg, svfloat64_t op)
@@ -5729,6 +5752,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MinNumberAcross(Vector<float> value) => MinNumberAcross(value);
 
+
+        // Multiply
 
         /// <summary>
         /// svint8_t svmul[_s8]_m(svbool_t pg, svint8_t op1, svint8_t op2)
@@ -5872,7 +5897,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> Multiply(Vector<double> left, Vector<double> right) => Multiply(left, right);
 
-        ///  MultiplyAdd : Multiply-add, addend first
+
+        // Multiply-add, addend first
 
         /// <summary>
         /// svuint8_t svmla[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2, svuint8_t op3)
@@ -5938,7 +5964,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> MultiplyAdd(Vector<ulong> addend, Vector<ulong> left, Vector<ulong> right) => MultiplyAdd(addend, left, right);
 
-        ///  Complex multiply-add with rotate
+
+        // Complex multiply-add with rotate
 
         /// <summary>
         /// svfloat64_t svcmla[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2, svfloat64_t op3, uint64_t imm_rotation)
@@ -5958,7 +5985,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyAddRotateComplex(Vector<float> addend, Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(3))] byte rotation) => MultiplyAddRotateComplex(addend, left, right, rotation);
 
-        ///  Complex multiply-add with rotate
+
+        // Complex multiply-add with rotate
 
         /// <summary>
         /// svfloat32_t svcmla_lane[_f32](svfloat32_t op1, svfloat32_t op2, svfloat32_t op3, uint64_t imm_index, uint64_t imm_rotation)
@@ -5966,7 +5994,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyAddRotateComplexBySelectedScalar(Vector<float> addend, Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(1))] byte rightIndex, [ConstantExpected(Min = 0, Max = (byte)(3))] byte rotation) => MultiplyAddRotateComplexBySelectedScalar(addend, left, right, rightIndex, rotation);
 
-        ///  MultiplyBySelectedScalar : Multiply
+
+        // Multiply
 
         /// <summary>
         /// svfloat64_t svmul_lane[_f64](svfloat64_t op1, svfloat64_t op2, uint64_t imm_index)
@@ -5980,7 +6009,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyBySelectedScalar(Vector<float> left, Vector<float> right, [ConstantExpected] byte rightIndex) => MultiplyBySelectedScalar(left, right, rightIndex);
 
-        ///  MultiplyExtended : Multiply extended (∞×0=2)
+
+        // Multiply extended (∞×0=2)
 
         /// <summary>
         /// svfloat64_t svmulx[_f64]_m(svbool_t pg, svfloat64_t op1, svfloat64_t op2)
@@ -5998,7 +6028,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> MultiplyExtended(Vector<float> left, Vector<float> right) => MultiplyExtended(left, right);
 
-        ///  MultiplySubtract : Multiply-subtract, minuend first
+
+        // Multiply-subtract, minuend first
 
         /// <summary>
         /// svuint8_t svmls[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2, svuint8_t op3)
@@ -6064,7 +6095,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> MultiplySubtract(Vector<ulong> minuend, Vector<ulong> left, Vector<ulong> right) => MultiplySubtract(minuend, left, right);
 
-        ///  Negate : Negate
+
+        // Negate
 
         /// <summary>
         /// svfloat64_t svneg[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6114,7 +6146,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<float> Negate(Vector<float> value) => Negate(value);
 
-        ///  Bitwise invert
+
+        // Bitwise invert
 
         /// <summary>
         /// svuint8_t svnot[_u8]_m(svuint8_t inactive, svbool_t pg, svuint8_t op)
@@ -6204,7 +6237,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> Not(Vector<ulong> value) => Not(value);
 
-        ///  Or : Bitwise inclusive OR
+
+        // Bitwise inclusive OR
 
         /// <summary>
         /// svuint8_t svorr[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -6295,7 +6329,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Or(Vector<ulong> left, Vector<ulong> right) => Or(left, right);
 
 
-        ///  OrAcross : Bitwise inclusive OR reduction to scalar
+        // Bitwise inclusive OR reduction to scalar
 
         /// <summary>
         /// uint8_t svorv[_u8](svbool_t pg, svuint8_t op)
@@ -6346,7 +6380,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> OrAcross(Vector<ulong> value) => OrAcross(value);
 
 
-        ///  Count nonzero bits
+        // Count nonzero bits
 
         /// <summary>
         /// svuint8_t svcnt[_s8]_m(svuint8_t inactive, svbool_t pg, svint8_t op)
@@ -6453,7 +6487,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void PrefetchInt64(Vector<ulong> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) => PrefetchInt64(mask, address, prefetchType);
 
 
-        ///  ReciprocalEstimate : Reciprocal estimate
+        // Reciprocal estimate
 
         /// <summary>
         /// svfloat64_t svrecpe[_f64](svfloat64_t op)
@@ -6468,7 +6502,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalEstimate(Vector<float> value) => ReciprocalEstimate(value);
 
 
-        ///  ReciprocalExponent : Reciprocal exponent
+        // Reciprocal exponent
 
         /// <summary>
         /// svfloat64_t svrecpx[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6489,7 +6523,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalExponent(Vector<float> value) => ReciprocalExponent(value);
 
 
-        ///  ReciprocalSqrtEstimate : Reciprocal square root estimate
+        // Reciprocal square root estimate
 
         /// <summary>
         /// svfloat64_t svrsqrte[_f64](svfloat64_t op)
@@ -6504,7 +6538,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalSqrtEstimate(Vector<float> value) => ReciprocalSqrtEstimate(value);
 
 
-        ///  ReciprocalSqrtStep : Reciprocal square root step
+        // Reciprocal square root step
 
         /// <summary>
         /// svfloat64_t svrsqrts[_f64](svfloat64_t op1, svfloat64_t op2)
@@ -6519,7 +6553,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> ReciprocalSqrtStep(Vector<float> left, Vector<float> right) => ReciprocalSqrtStep(left, right);
 
 
-        ///  ReciprocalStep : Reciprocal step
+        // Reciprocal step
 
         /// <summary>
         /// svfloat64_t svrecps[_f64](svfloat64_t op1, svfloat64_t op2)
@@ -6532,7 +6566,7 @@ namespace System.Runtime.Intrinsics.Arm
         ///   FRECPS Zresult.S, Zop1.S, Zop2.S
         /// </summary>
         public static unsafe Vector<float> ReciprocalStep(Vector<float> left, Vector<float> right) => ReciprocalStep(left, right);
-        ///  Reverse bits
+        // Reverse bits
 
         /// <summary>
         /// svuint8_t svrbit[_u8]_x(svbool_t pg, svuint8_t op)
@@ -6583,7 +6617,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseBits(Vector<ulong> value) => ReverseBits(value);
 
 
-        ///  Reverse all elements
+        // Reverse all elements
 
         /// <summary>
         /// svuint8_t svrev[_u8](svuint8_t op)
@@ -6646,7 +6680,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement(Vector<ulong> value) => ReverseElement(value);
 
 
-        ///  Reverse halfwords within elements
+        // Reverse halfwords within elements
 
         /// <summary>
         /// svint32_t svrevh[_s32]_m(svint32_t inactive, svbool_t pg, svint32_t op)
@@ -6673,7 +6707,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement16(Vector<ulong> value) => ReverseElement16(value);
 
 
-        ///  Reverse words within elements
+        // Reverse words within elements
 
         /// <summary>
         /// svint64_t svrevw[_s64]_m(svint64_t inactive, svbool_t pg, svint64_t op)
@@ -6688,7 +6722,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement32(Vector<ulong> value) => ReverseElement32(value);
 
 
-        ///  Reverse bytes within elements
+        // Reverse bytes within elements
 
         /// <summary>
         /// svint16_t svrevb[_s16]_m(svint16_t inactive, svbool_t pg, svint16_t op)
@@ -6727,7 +6761,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ReverseElement8(Vector<ulong> value) => ReverseElement8(value);
 
 
-        ///  RoundAwayFromZero : Round to nearest, ties away from zero
+        // Round to nearest, ties away from zero
 
         /// <summary>
         /// svfloat64_t svrinta[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6748,7 +6782,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundAwayFromZero(Vector<float> value) => RoundAwayFromZero(value);
 
 
-        ///  RoundToNearest : Round to nearest, ties to even
+        // Round to nearest, ties to even
 
         /// <summary>
         /// svfloat64_t svrintn[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6769,7 +6803,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToNearest(Vector<float> value) => RoundToNearest(value);
 
 
-        ///  RoundToNegativeInfinity : Round towards -∞
+        // Round towards -∞
 
         /// <summary>
         /// svfloat64_t svrintm[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6790,7 +6824,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToNegativeInfinity(Vector<float> value) => RoundToNegativeInfinity(value);
 
 
-        ///  RoundToPositiveInfinity : Round towards +∞
+        // Round towards +∞
 
         /// <summary>
         /// svfloat64_t svrintp[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6811,7 +6845,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToPositiveInfinity(Vector<float> value) => RoundToPositiveInfinity(value);
 
 
-        ///  RoundToZero : Round towards zero
+        // Round towards zero
 
         /// <summary>
         /// svfloat64_t svrintz[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -6832,7 +6866,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> RoundToZero(Vector<float> value) => RoundToZero(value);
 
 
-        ///  Saturating decrement by number of halfword elements
+        // Saturating decrement by number of halfword elements
 
         /// <summary>
         /// int32_t svqdech_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6871,7 +6905,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> SaturatingDecrementBy16BitElementCount(Vector<ushort> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingDecrementBy16BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating decrement by number of word elements
+        // Saturating decrement by number of word elements
 
         /// <summary>
         /// int32_t svqdecw_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6910,7 +6944,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> SaturatingDecrementBy32BitElementCount(Vector<uint> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingDecrementBy32BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating decrement by number of doubleword elements
+        // Saturating decrement by number of doubleword elements
 
         /// <summary>
         /// int32_t svqdecd_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6949,7 +6983,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingDecrementBy64BitElementCount(Vector<ulong> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingDecrementBy64BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating decrement by number of byte elements
+        // Saturating decrement by number of byte elements
 
         /// <summary>
         /// int32_t svqdecb_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -6976,7 +7010,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong SaturatingDecrementBy8BitElementCount(ulong value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingDecrementBy8BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating decrement by active element count
+        // Saturating decrement by active element count
 
         /// <summary>
         /// int32_t svqdecp[_n_s32]_b8(int32_t op, svbool_t pg)
@@ -7111,7 +7145,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingDecrementByActiveElementCount(Vector<ulong> value, Vector<ulong> from) => SaturatingDecrementByActiveElementCount(value, from);
 
 
-        ///  Saturating increment by number of halfword elements
+        // Saturating increment by number of halfword elements
 
         /// <summary>
         /// int32_t svqinch_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7150,7 +7184,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ushort> SaturatingIncrementBy16BitElementCount(Vector<ushort> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingIncrementBy16BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating increment by number of word elements
+        // Saturating increment by number of word elements
 
         /// <summary>
         /// int32_t svqincw_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7189,7 +7223,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<uint> SaturatingIncrementBy32BitElementCount(Vector<uint> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingIncrementBy32BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating increment by number of doubleword elements
+        // Saturating increment by number of doubleword elements
 
         /// <summary>
         /// int32_t svqincd_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7228,7 +7262,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingIncrementBy64BitElementCount(Vector<ulong> value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingIncrementBy64BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating increment by number of byte elements
+        // Saturating increment by number of byte elements
 
         /// <summary>
         /// int32_t svqincb_pat[_n_s32](int32_t op, enum svpattern pattern, uint64_t imm_factor)
@@ -7255,7 +7289,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe ulong SaturatingIncrementBy8BitElementCount(ulong value, [ConstantExpected(Min = 1, Max = (byte)(16))] byte scale, [ConstantExpected] SveMaskPattern pattern = SveMaskPattern.All) => SaturatingIncrementBy8BitElementCount(value, scale, pattern);
 
 
-        ///  Saturating increment by active element count
+        // Saturating increment by active element count
 
         /// <summary>
         /// int32_t svqincp[_n_s32]_b8(int32_t op, svbool_t pg)
@@ -7390,7 +7424,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SaturatingIncrementByActiveElementCount(Vector<ulong> value, Vector<ulong> from) => SaturatingIncrementByActiveElementCount(value, from);
 
 
-        ///  Scale : Adjust exponent
+        // Adjust exponent
 
         /// <summary>
         /// svfloat64_t svscale[_f64]_m(svbool_t pg, svfloat64_t op1, svint64_t op2)
@@ -7411,30 +7445,31 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> Scale(Vector<float> left, Vector<int> right) => Scale(left, right);
 
 
-        ///  Non-truncating store
+        // Non-truncating store
 
-        // <summary>
-        // void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+
+        /// <summary>
+        /// void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<long> indicies, Vector<double> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter[_u64base_f64](svbool_t pg, svuint64_t bases, svfloat64_t data)
-        //   ST1D Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter[_u64base_f64](svbool_t pg, svuint64_t bases, svfloat64_t data)
+        ///   ST1D Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter(Vector<double> mask, Vector<ulong> addresses, Vector<double> data) => Scatter(mask, addresses, data);
 
-        // <summary>
-        // void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<ulong> indicies, Vector<double> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<int> indicies, Vector<int> data) => Scatter(mask, address, indicies, data);
 
         // <summary>
@@ -7444,34 +7479,34 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter(Vector<int> mask, Vector<uint> addresses, Vector<int> data) => Scatter(mask, addresses, data);
 
-        // <summary>
-        // void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<uint> indicies, Vector<int> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<long> indicies, Vector<long> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1D Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1D Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) => Scatter(mask, addresses, data);
 
-        // <summary>
-        // void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<ulong> indicies, Vector<long> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<int> indicies, Vector<float> data) => Scatter(mask, address, indicies, data);
 
         // <summary>
@@ -7481,16 +7516,16 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter(Vector<float> mask, Vector<uint> addresses, Vector<float> data) => Scatter(mask, addresses, data);
 
-        // <summary>
-        // void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<uint> indicies, Vector<float> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<int> indicies, Vector<uint> data) => Scatter(mask, address, indicies, data);
 
         // <summary>
@@ -7500,28 +7535,28 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter(Vector<uint> mask, Vector<uint> addresses, Vector<uint> data) => Scatter(mask, addresses, data);
 
-        // <summary>
-        // void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
-        //   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
+        ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<uint> indicies, Vector<uint> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<long> indicies, Vector<ulong> data) => Scatter(mask, address, indicies, data);
 
-        // <summary>
-        // void svst1_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1D Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1D Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) => Scatter(mask, addresses, data);
 
-        // <summary>
-        // void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
-        //   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
+        ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<ulong> indicies, Vector<ulong> data) => Scatter(mask, address, indicies, data);
 
 
@@ -7534,10 +7569,10 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter16BitNarrowing(Vector<int> mask, Vector<uint> addresses, Vector<int> data) => Scatter16BitNarrowing(mask, addresses, data);
 
-        // <summary>
-        // void svst1h_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1H Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1H Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter16BitNarrowing(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) => Scatter16BitNarrowing(mask, addresses, data);
 
         // <summary>
@@ -7547,107 +7582,109 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter16BitNarrowing(Vector<uint> mask, Vector<uint> addresses, Vector<uint> data) => Scatter16BitNarrowing(mask, addresses, data);
 
-        // <summary>
-        // void svst1h_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1H Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1H Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter16BitNarrowing(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) => Scatter16BitNarrowing(mask, addresses, data);
 
 
         //  Truncate to 16 bits and store
 
-        // <summary>
-        // void svst1h_scatter_[s32]offset[_s32](svbool_t pg, int16_t *base, svint32_t offsets, svint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s32]offset[_s32](svbool_t pg, int16_t *base, svint32_t offsets, svint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<int> offsets, Vector<int> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<uint> offsets, Vector<int> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<long> offsets, Vector<long> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<ulong> offsets, Vector<long> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1h_scatter_[s32]offset[_u32](svbool_t pg, uint16_t *base, svint32_t offsets, svuint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s32]offset[_u32](svbool_t pg, uint16_t *base, svint32_t offsets, svuint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<int> offsets, Vector<uint> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)
-        //   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)
+        ///   ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<uint> offsets, Vector<uint> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<long> offsets, Vector<ulong> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)
-        //   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)
+        ///   ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
 
         //  Truncate to 32 bits and store
 
-        // <summary>
-        // void svst1w_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1W Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1w_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1W Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter32BitNarrowing(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) => Scatter32BitNarrowing(mask, addresses, data);
 
-        // <summary>
-        // void svst1w_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1W Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1w_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1W Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter32BitNarrowing(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) => Scatter32BitNarrowing(mask, addresses, data);
 
 
-        //  Truncate to 32 bits and store
+        // Truncate to 32 bits and store
 
-        // <summary>
-        // void svst1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)
-        //   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+
+        /// <summary>
+        /// void svst1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)
+        ///   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<long> offsets, Vector<long> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)
-        //   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)
+        ///   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<ulong> offsets, Vector<long> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)
-        //   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)
+        ///   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<long> offsets, Vector<ulong> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)
-        //   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)
+        ///   ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
 
-        //  Truncate to 8 bits and store
+        // Truncate to 8 bits and store
+
 
         // <summary>
         // void svst1b_scatter[_u32base_s32](svbool_t pg, svuint32_t bases, svint32_t data)
@@ -7656,10 +7693,10 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter8BitNarrowing(Vector<int> mask, Vector<uint> addresses, Vector<int> data) => Scatter8BitNarrowing(mask, addresses, data);
 
-        // <summary>
-        // void svst1b_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
-        //   ST1B Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter[_u64base_s64](svbool_t pg, svuint64_t bases, svint64_t data)
+        ///   ST1B Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter8BitNarrowing(Vector<long> mask, Vector<ulong> addresses, Vector<long> data) => Scatter8BitNarrowing(mask, addresses, data);
 
         // <summary>
@@ -7669,65 +7706,66 @@ namespace System.Runtime.Intrinsics.Arm
         // Removed as per #103297
         // public static unsafe void Scatter8BitNarrowing(Vector<uint> mask, Vector<uint> addresses, Vector<uint> data) => Scatter8BitNarrowing(mask, addresses, data);
 
-        // <summary>
-        // void svst1b_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
-        //   ST1B Zdata.D, Pg, [Zbases.D, #0]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter[_u64base_u64](svbool_t pg, svuint64_t bases, svuint64_t data)
+        ///   ST1B Zdata.D, Pg, [Zbases.D, #0]
+        /// </summary>
         public static unsafe void Scatter8BitNarrowing(Vector<ulong> mask, Vector<ulong> addresses, Vector<ulong> data) => Scatter8BitNarrowing(mask, addresses, data);
 
 
-        //  Truncate to 8 bits and store
+        // Truncate to 8 bits and store
 
-        // <summary>
-        // void svst1b_scatter_[s32]offset[_s32](svbool_t pg, int8_t *base, svint32_t offsets, svint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+
+        /// <summary>
+        /// void svst1b_scatter_[s32]offset[_s32](svbool_t pg, int8_t *base, svint32_t offsets, svint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<int> offsets, Vector<int> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<uint> offsets, Vector<int> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<long> offsets, Vector<long> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<ulong> offsets, Vector<long> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1b_scatter_[s32]offset[_u32](svbool_t pg, uint8_t *base, svint32_t offsets, svuint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[s32]offset[_u32](svbool_t pg, uint8_t *base, svint32_t offsets, svuint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<int> offsets, Vector<uint> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)
-        //   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)
+        ///   ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<uint> offsets, Vector<uint> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<long> offsets, Vector<ulong> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
-        // <summary>
-        // void svst1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)
-        //   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
-        // </summary>
+        /// <summary>
+        /// void svst1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)
+        ///   ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]
+        /// </summary>
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
 
-        ///  Logical shift left
+        // Logical shift left
 
         /// <summary>
         /// svuint8_t svlsl[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -7862,7 +7900,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ShiftLeftLogical(Vector<ulong> left, Vector<ulong> right) => ShiftLeftLogical(left, right);
 
 
-        ///  Arithmetic shift right
+        // Arithmetic shift right
 
         /// <summary>
         /// svint16_t svasr[_s16]_m(svbool_t pg, svint16_t op1, svuint16_t op2)
@@ -7931,7 +7969,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<sbyte> ShiftRightArithmetic(Vector<sbyte> left, Vector<ulong> right) => ShiftRightArithmetic(left, right);
 
 
-        ///  Arithmetic shift right for divide by immediate
+        // Arithmetic shift right for divide by immediate
 
         /// <summary>
         /// svint16_t svasrd[_n_s16]_m(svbool_t pg, svint16_t op1, uint64_t imm2)
@@ -7970,7 +8008,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<sbyte> ShiftRightArithmeticForDivide(Vector<sbyte> value, [ConstantExpected(Min = 1, Max = (byte)(8))] byte control) => ShiftRightArithmeticForDivide(value, control);
 
 
-        ///  Logical shift right
+        // Logical shift right
 
         /// <summary>
         /// svuint8_t svlsr[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -8039,7 +8077,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ShiftRightLogical(Vector<ulong> left, Vector<ulong> right) => ShiftRightLogical(left, right);
 
 
-        ///  SignExtend16 : Sign-extend the low 16 bits
+        // Sign-extend the low 16 bits
 
         /// <summary>
         /// svint32_t svexth[_s32]_m(svint32_t inactive, svbool_t pg, svint32_t op)
@@ -8065,7 +8103,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<long> SignExtend16(Vector<long> value) => SignExtend16(value);
 
-        ///  SignExtend32 : Sign-extend the low 32 bits
+
+        // Sign-extend the low 32 bits
 
         /// <summary>
         /// svint64_t svextw[_s64]_m(svint64_t inactive, svbool_t pg, svint64_t op)
@@ -8080,7 +8119,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtend32(Vector<long> value) => SignExtend32(value);
 
 
-        ///  SignExtend8 : Sign-extend the low 8 bits
+        // Sign-extend the low 8 bits
 
         /// <summary>
         /// svint16_t svextb[_s16]_m(svint16_t inactive, svbool_t pg, svint16_t op)
@@ -8119,7 +8158,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtend8(Vector<long> value) => SignExtend8(value);
 
 
-        ///  SignExtendWideningLower : Unpack and extend low half
+        // Unpack and extend low half
 
         /// <summary>
         /// svint16_t svunpklo[_s16](svint8_t op)
@@ -8140,7 +8179,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtendWideningLower(Vector<int> value) => SignExtendWideningLower(value);
 
 
-        ///  SignExtendWideningUpper : Unpack and extend high half
+        // Unpack and extend high half
 
         /// <summary>
         /// svint16_t svunpkhi[_s16](svint8_t op)
@@ -8161,7 +8200,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<long> SignExtendWideningUpper(Vector<int> value) => SignExtendWideningUpper(value);
 
 
-        ///  Splice two vectors under predicate control
+        // Splice two vectors under predicate control
 
         /// <summary>
         /// svuint8_t svsplice[_u8](svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -8224,7 +8263,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Splice(Vector<ulong> mask, Vector<ulong> left, Vector<ulong> right) => Splice(mask, left, right);
 
 
-        ///  Sqrt : Square root
+        // Square root
 
         /// <summary>
         /// svfloat64_t svsqrt[_f64]_m(svfloat64_t inactive, svbool_t pg, svfloat64_t op)
@@ -8245,7 +8284,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> Sqrt(Vector<float> value) => Sqrt(value);
 
 
-        ///  Non-truncating store
+        // Non-truncating store
 
         /// <summary>
         /// void svst1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)
@@ -8486,8 +8525,9 @@ namespace System.Runtime.Intrinsics.Arm
         ///   ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]
         /// </summary>
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2, Vector<ulong> Value3, Vector<ulong> Value4) data) => StoreAndZip(mask, address, data);
-        ///  Truncate to 8 bits and store
 
+
+        // Truncate to 8 bits and store
 
         /// <summary>
         /// void svst1b[_s16](svbool_t pg, int8_t *base, svint16_t data)
@@ -8562,7 +8602,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void StoreNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> data) => StoreNarrowing(mask, address, data);
 
 
-        ///  StoreNonTemporal : Non-truncating store, non-temporal
+        // Non-truncating store, non-temporal
 
         /// <summary>
         /// void svstnt1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)
@@ -8625,7 +8665,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void StoreNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> data) => StoreNonTemporal(mask, address, data);
 
 
-        ///  Subtract : Subtract
+        // Subtract
 
         /// <summary>
         /// svint8_t svsub[_s8]_m(svbool_t pg, svint8_t op1, svint8_t op2)
@@ -8749,7 +8789,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<double> Subtract(Vector<double> left, Vector<double> right) => Subtract(left, right);
 
-        ///  SubtractSaturate : Saturating subtract
+
+        // Saturating subtract
 
         /// <summary>
         /// svuint8_t svqsub[_u8](svuint8_t op1, svuint8_t op2)
@@ -8800,6 +8841,8 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> SubtractSaturate(Vector<ulong> left, Vector<ulong> right) => SubtractSaturate(left, right);
 
 
+        // Test whether any active element is true
+
         /// <summary>
         /// bool svptest_any(svbool_t pg, svbool_t op)
         ///   PTEST
@@ -8848,6 +8891,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe bool TestAnyTrue(Vector<ulong> mask, Vector<ulong> srcMask) => TestAnyTrue(mask, srcMask);
 
+        // Test whether the first active element is true
+
         /// <summary>
         /// bool svptest_first(svbool_t pg, svbool_t op)
         ///   PTEST
@@ -8895,6 +8940,9 @@ namespace System.Runtime.Intrinsics.Arm
         ///   PTEST
         /// </summary>
         public static unsafe bool TestFirstTrue(Vector<ulong> mask, Vector<ulong> srcMask) => TestFirstTrue(mask, srcMask);
+
+
+        // Test whether the last active element is true
 
         /// <summary>
         /// bool svptest_last(svbool_t pg, svbool_t op)
@@ -8945,7 +8993,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe bool TestLastTrue(Vector<ulong> mask, Vector<ulong> srcMask) => TestLastTrue(mask, srcMask);
 
 
-        ///  Interleave even elements from two inputs
+        // Interleave even elements from two inputs
 
         /// <summary>
         /// svuint8_t svtrn1[_u8](svuint8_t op1, svuint8_t op2)
@@ -9008,7 +9056,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> TransposeEven(Vector<ulong> left, Vector<ulong> right) => TransposeEven(left, right);
 
 
-        ///  Interleave odd elements from two inputs
+        // Interleave odd elements from two inputs
 
         /// <summary>
         /// svuint8_t svtrn2[_u8](svuint8_t op1, svuint8_t op2)
@@ -9071,7 +9119,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> TransposeOdd(Vector<ulong> left, Vector<ulong> right) => TransposeOdd(left, right);
 
 
-        ///  Trigonometric multiply-add coefficient
+        // Trigonometric multiply-add coefficient
 
         /// <summary>
         /// svfloat64_t svtmad[_f64](svfloat64_t op1, svfloat64_t op2, uint64_t imm3)
@@ -9086,7 +9134,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> TrigonometricMultiplyAddCoefficient(Vector<float> left, Vector<float> right, [ConstantExpected(Min = 0, Max = (byte)(7))] byte control) => TrigonometricMultiplyAddCoefficient(left, right, control);
 
 
-        ///  Trigonometric select coefficient
+        // Trigonometric select coefficient
 
         /// <summary>
         /// svfloat64_t svtssel[_f64](svfloat64_t op1, svuint64_t op2)
@@ -9101,7 +9149,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> TrigonometricSelectCoefficient(Vector<float> value, Vector<uint> selector) => TrigonometricSelectCoefficient(value, selector);
 
 
-        ///  Trigonometric starting value
+        // Trigonometric starting value
 
         /// <summary>
         /// svfloat64_t svtsmul[_f64](svfloat64_t op1, svuint64_t op2)
@@ -9116,7 +9164,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<float> TrigonometricStartingValue(Vector<float> value, Vector<uint> sign) => TrigonometricStartingValue(value, sign);
 
 
-        ///  UnzipEven : Concatenate even elements from two inputs
+        // Concatenate even elements from two inputs
 
         /// <summary>
         /// svuint8_t svuzp1[_u8](svuint8_t op1, svuint8_t op2)
@@ -9187,7 +9235,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> UnzipEven(Vector<ulong> left, Vector<ulong> right) => UnzipEven(left, right);
 
 
-        ///  UnzipOdd : Concatenate odd elements from two inputs
+        // Concatenate odd elements from two inputs
 
         /// <summary>
         /// svuint8_t svuzp2[_u8](svuint8_t op1, svuint8_t op2)
@@ -9258,7 +9306,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> UnzipOdd(Vector<ulong> left, Vector<ulong> right) => UnzipOdd(left, right);
 
 
-        ///  Table lookup in single-vector table
+        // Table lookup in single-vector table
 
         /// <summary>
         /// svuint8_t svtbl[_u8](svuint8_t data, svuint8_t indices)
@@ -9321,7 +9369,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> VectorTableLookup(Vector<ulong> data, Vector<ulong> indices) => VectorTableLookup(data, indices);
 
 
-        ///  Xor : Bitwise exclusive OR
+        // Bitwise exclusive OR
 
         /// <summary>
         /// svuint8_t sveor[_u8]_m(svbool_t pg, svuint8_t op1, svuint8_t op2)
@@ -9412,7 +9460,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> Xor(Vector<ulong> left, Vector<ulong> right) => Xor(left, right);
 
 
-        ///  XorAcross : Bitwise exclusive OR reduction to scalar
+        // Bitwise exclusive OR reduction to scalar
 
         /// <summary>
         /// uint8_t sveorv[_u8](svbool_t pg, svuint8_t op)
@@ -9463,7 +9511,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> XorAcross(Vector<ulong> value) => XorAcross(value);
 
 
-        ///  ZeroExtend16 : Zero-extend the low 16 bits
+        // Zero-extend the low 16 bits
 
         /// <summary>
         /// svuint32_t svexth[_u32]_m(svuint32_t inactive, svbool_t pg, svuint32_t op)
@@ -9490,7 +9538,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ZeroExtend16(Vector<ulong> value) => ZeroExtend16(value);
 
 
-        ///  ZeroExtend32 : Zero-extend the low 32 bits
+        // Zero-extend the low 32 bits
 
         /// <summary>
         /// svuint64_t svextw[_u64]_m(svuint64_t inactive, svbool_t pg, svuint64_t op)
@@ -9505,7 +9553,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ZeroExtend32(Vector<ulong> value) => ZeroExtend32(value);
 
 
-        ///  ZeroExtend8 : Zero-extend the low 8 bits
+        // Zero-extend the low 8 bits
 
         /// <summary>
         /// svuint16_t svextb[_u16]_m(svuint16_t inactive, svbool_t pg, svuint16_t op)
@@ -9543,7 +9591,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> ZeroExtend8(Vector<ulong> value) => ZeroExtend8(value);
 
-        ///  ZeroExtendWideningLower : Unpack and extend low half
+
+        // Unpack and extend low half
 
         /// <summary>
         /// svuint16_t svunpklo[_u16](svuint8_t op)
@@ -9564,7 +9613,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ZeroExtendWideningLower(Vector<uint> value) => ZeroExtendWideningLower(value);
 
 
-        ///  ZeroExtendWideningUpper : Unpack and extend high half
+        // Unpack and extend high half
 
         /// <summary>
         /// svuint16_t svunpkhi[_u16](svuint8_t op)
@@ -9586,7 +9635,8 @@ namespace System.Runtime.Intrinsics.Arm
         /// </summary>
         public static unsafe Vector<ulong> ZeroExtendWideningUpper(Vector<uint> value) => ZeroExtendWideningUpper(value);
 
-        ///  ZipHigh : Interleave elements from high halves of two inputs
+
+        // Interleave elements from high halves of two inputs
 
         /// <summary>
         /// svuint8_t svzip2[_u8](svuint8_t op1, svuint8_t op2)
@@ -9655,7 +9705,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector<ulong> ZipHigh(Vector<ulong> left, Vector<ulong> right) => ZipHigh(left, right);
 
 
-        ///  ZipLow : Interleave elements from low halves of two inputs
+        // Interleave elements from low halves of two inputs
 
         /// <summary>
         /// svuint8_t svzip1[_u8](svuint8_t op1, svuint8_t op2)


### PR DESCRIPTION
Also fix up Scatter summary blocks.

This was mostly done via regex.

Personally, I'd prefer of the form `//  AddSaturate : Saturating add`, (ie add the method name to the start of the comment). But happy enough with how it is in the PR.

There are still quite a few additional changes that need making to these files to tidy them up, but I'll put them in separate PRs to simplify the review process.

Fixes #104846