### PR TITLE
[RISC-V,QEMU] Disable execution of two corefx tests on QEMU

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -564,6 +564,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/105686", typeof(PlatformDetection), nameof(PlatformDetection.IsQemuLinux))]
         public void TestMaxWorkingSet()
         {
             CreateDefaultProcess();
@@ -619,6 +620,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/105686", typeof(PlatformDetection), nameof(PlatformDetection.IsQemuLinux))]
         public void TestMinWorkingSet()
         {
             CreateDefaultProcess();


### PR DESCRIPTION
Disable execution of two corefx tests on QEMU

System.Diagnostics.Tests.ProcessTests.TestMaxWorkingSet() 
System.Diagnostics.Tests.ProcessTests.TestMinWorkingSet()

These two corefx tests fail because on QEMU the file /proc/pid/stat contains incorrect values.

See issue #105686 for details.

Part of #84834, cc @dotnet/samsung