### PR TITLE
Add timeout to QuicConnectionTests for StreamsAvailable tests

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -265,7 +265,7 @@ namespace System.Net.Quic.Tests
             };
 
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(clientOptions);
-            await streamsAvailableFired.WaitAsync();
+            await streamsAvailableFired.WaitAsync().WaitAsync(PassingTestTimeout);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiIncrement);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiIncrement);
 
@@ -275,7 +275,7 @@ namespace System.Net.Quic.Tests
             await serverStreamBidi.DisposeAsync();
 
             // STREAMS_AVAILABLE event comes asynchronously, give it a chance to propagate
-            await streamsAvailableFired.WaitAsync();
+            await streamsAvailableFired.WaitAsync().WaitAsync(PassingTestTimeout);
             Assert.Equal(1, bidiIncrement);
             Assert.Equal(0, unidiIncrement);
 
@@ -285,7 +285,7 @@ namespace System.Net.Quic.Tests
             await serverStreamUnidi.DisposeAsync();
 
             // STREAMS_AVAILABLE event comes asynchronously, give it a chance to propagate
-            await streamsAvailableFired.WaitAsync();
+            await streamsAvailableFired.WaitAsync().WaitAsync(PassingTestTimeout);
             Assert.Equal(0, bidiIncrement);
             Assert.Equal(1, unidiIncrement);
 
@@ -314,7 +314,7 @@ namespace System.Net.Quic.Tests
             };
 
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(clientOptions);
-            await streamsAvailableFired.WaitAsync();
+            await streamsAvailableFired.WaitAsync().WaitAsync(PassingTestTimeout);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiIncrement);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiIncrement);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiTotal);
@@ -353,7 +353,7 @@ namespace System.Net.Quic.Tests
             {
                 await clientStream.DisposeAsync();
                 await (await serverConnection.AcceptInboundStreamAsync()).DisposeAsync();
-                await streamsAvailableFired.WaitAsync();
+                await streamsAvailableFired.WaitAsync().WaitAsync(PassingTestTimeout);
                 Assert.Equal(unidirectional ? 0 : (first ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams + 1 : 1), bidiIncrement);
                 Assert.Equal(unidirectional ? (first ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams + 1 : 1) : 0, unidiIncrement);
                 first = false;
@@ -387,7 +387,7 @@ namespace System.Net.Quic.Tests
             };
 
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(clientOptions);
-            await streamsAvailableFired.WaitAsync();
+            await streamsAvailableFired.WaitAsync().WaitAsync(PassingTestTimeout);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiIncrement);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiIncrement);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiTotal);
@@ -426,7 +426,7 @@ namespace System.Net.Quic.Tests
             {
                 Assert.True(cancelledStream.IsCanceled);
                 await (await serverConnection.AcceptInboundStreamAsync()).DisposeAsync();
-                await streamsAvailableFired.WaitAsync();
+                await streamsAvailableFired.WaitAsync().WaitAsync(PassingTestTimeout);
                 Assert.Equal(unidirectional ? 0 : (first ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams + 1 : 1), bidiIncrement);
                 Assert.Equal(unidirectional ? (first ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams + 1 : 1) : 0, unidiIncrement);
                 first = false;


### PR DESCRIPTION
Prevents test suite from timing out