### PR TITLE
SPMI: Increase superpmi-collect build timeout

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -43,6 +43,7 @@ extends:
           jobParameters:
             testGroup: outerloop
             buildArgs: -s clr+libs+libs.tests -rc $(_BuildConfig) -c Release /p:ArchiveTests=true
+            timeoutInMinutes: 120
             postBuildSteps:
               - template: /eng/pipelines/coreclr/templates/build-native-test-assets-step.yml
               - template: /eng/pipelines/common/upload-artifact-step.yml
@@ -78,6 +79,7 @@ extends:
           jobParameters:
             testGroup: outerloop
             buildArgs: -s clr+libs+libs.tests -rc $(_BuildConfig) -c Release /p:ArchiveTests=true
+            timeoutInMinutes: 120
             postBuildSteps:
               # Build CLR assets for x64 as well as the target as we need an x64 mcs
               - template: /eng/pipelines/common/templates/global-build-step.yml
@@ -117,6 +119,7 @@ extends:
           jobParameters:
             testGroup: outerloop
             buildArgs: -s clr+libs+libs.tests -rc $(_BuildConfig) -c Release /p:ArchiveTests=true
+            timeoutInMinutes: 120
             postBuildSteps:
               # Build CLR assets for x64 as well as the target as we need an x64 mcs
               - template: /eng/pipelines/common/templates/global-build-step.yml


### PR DESCRIPTION
For a while we have been intermittently hitting the default 1 hour build timeout for win-arm64. Other builds also seem to be dangerously close:

![image](https://github.com/user-attachments/assets/3d51dfcb-4c81-4e52-95a4-9715d9c925cc)

For superpmi-collect we build clr+clr.libs+clr.tests, so the build is a bit larger than the usual builds in this repo, which is probably why we're starting to hit this now. This PR increases the timeout to 2 hours instead.