### PR TITLE
[browser] http streaming request server error

### DIFF
--- a/src/libraries/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/libraries/Common/tests/System/Net/Configuration.Http.cs
@@ -51,6 +51,7 @@ namespace System.Net.Test.Common
             private const string EmptyContentHandler = "EmptyContent.ashx";
             private const string RedirectHandler = "Redirect.ashx";
             private const string VerifyUploadHandler = "VerifyUpload.ashx";
+            private const string StatusCodeHandler = "StatusCode.ashx";
             private const string DeflateHandler = "Deflate.ashx";
             private const string GZipHandler = "GZip.ashx";
             private const string RemoteLoopHandler = "RemoteLoop";
@@ -71,6 +72,7 @@ namespace System.Net.Test.Common
             public static readonly Uri RemoteVerifyUploadServer = new Uri("http://" + Host + "/" + VerifyUploadHandler);
             public static readonly Uri SecureRemoteVerifyUploadServer = new Uri("https://" + SecureHost + "/" + VerifyUploadHandler);
             public static readonly Uri Http2RemoteVerifyUploadServer = new Uri("https://" + Http2Host + "/" + VerifyUploadHandler);
+            public static readonly Uri Http2RemoteStatusCodeServer = new Uri("https://" + Http2Host + "/" + StatusCodeHandler);
 
             public static readonly Uri RemoteEmptyContentServer = new Uri("http://" + Host + "/" + EmptyContentHandler);
             public static readonly Uri RemoteDeflateServer = new Uri("http://" + Host + "/" + DeflateHandler);

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/GenericHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/GenericHandler.cs
@@ -51,7 +51,7 @@ namespace NetCoreServer
 
             if (path.Equals(new PathString("/statuscode.ashx")))
             {
-                StatusCodeHandler.Invoke(context);
+                await StatusCodeHandler.InvokeAsync(context);
                 return;
             }
 

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/StatusCodeHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/StatusCodeHandler.cs
@@ -3,21 +3,37 @@
 
 using System;
 using Microsoft.AspNetCore.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
 
 namespace NetCoreServer
 {
     public class StatusCodeHandler
     {
-        public static void Invoke(HttpContext context)
+        public static async Task InvokeAsync(HttpContext context)
         {
             string statusCodeString = context.Request.Query["statuscode"];
             string statusDescription = context.Request.Query["statusdescription"];
+            string delayString = context.Request.Query["delay"];
             try
             {
                 int statusCode = int.Parse(statusCodeString);
+                int delay = string.IsNullOrWhiteSpace(delayString) ? 0 : int.Parse(delayString);
+
                 context.Response.StatusCode = statusCode;
-                context.Response.SetStatusDescription(
-                    string.IsNullOrWhiteSpace(statusDescription) ? " " : statusDescription);
+                context.Response.SetStatusDescription(string.IsNullOrWhiteSpace(statusDescription) ? " " : statusDescription);
+
+                if (delay > 0)
+                {
+                    var buffer = new byte[1];
+                    if (context.Request.Method == HttpMethod.Post.Method)
+                    {
+                        await context.Request.Body.ReadExactlyAsync(buffer, CancellationToken.None);
+                    }
+                    await context.Response.StartAsync(CancellationToken.None);
+                    await Task.Delay(delay);
+                }
             }
             catch (Exception)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -160,7 +160,7 @@ namespace System.Net.Http
 
                 if (!_httpController.IsDisposed)
                 {
-                    BrowserHttpInterop.AbortRequest(_httpController);
+                    BrowserHttpInterop.Abort(_httpController);
                 }
             }, httpController);
 
@@ -351,7 +351,7 @@ namespace System.Net.Http
             {
                 if (!_jsController.IsDisposed)
                 {
-                    BrowserHttpInterop.AbortRequest(_jsController);// aborts also response
+                    BrowserHttpInterop.Abort(_jsController);// aborts also response
                 }
                 _jsController.Dispose();
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -160,6 +160,10 @@ namespace System.Net.Http
                 {
                     throw Http.CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
                 }
+                if (jse.Message.Contains("BrowserHttpWriteStream.Rejected", StringComparison.Ordinal))
+                {
+                    throw; // do not translate
+                }
                 Http.CancellationHelper.ThrowIfCancellationRequested(jse, cancellationToken);
                 throw new HttpRequestException(jse.Message, jse);
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -20,13 +20,8 @@ namespace System.Net.Http
         [JSImport("INTERNAL.http_wasm_create_controller")]
         public static partial JSObject CreateController();
 
-        [JSImport("INTERNAL.http_wasm_abort_request")]
-        public static partial void AbortRequest(
-            JSObject httpController);
-
-        [JSImport("INTERNAL.http_wasm_abort_response")]
-        public static partial void AbortResponse(
-            JSObject httpController);
+        [JSImport("INTERNAL.http_wasm_abort")]
+        public static partial void Abort(JSObject httpController);
 
         [JSImport("INTERNAL.http_wasm_transform_stream_write")]
         public static partial Task TransformStreamWrite(
@@ -143,7 +138,7 @@ namespace System.Net.Http
                     CancelablePromise.CancelPromise(_promise);
                     if (!_jsController.IsDisposed)
                     {
-                        AbortResponse(_jsController);
+                        Abort(_jsController);
                     }
                 }, (promise, jsController)))
                 {

--- a/src/mono/browser/runtime/exports-internal.ts
+++ b/src/mono/browser/runtime/exports-internal.ts
@@ -6,7 +6,7 @@ import WasmEnableThreads from "consts:wasmEnableThreads";
 import { MonoObjectNull, type MonoObject } from "./types/internal";
 import cwraps, { profiler_c_functions, threads_c_functions as twraps } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_controller, http_wasm_abort_request, http_wasm_abort_response, http_wasm_transform_stream_write, http_wasm_transform_stream_close, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes, http_wasm_get_response_type, http_wasm_get_response_status } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_controller, http_wasm_abort, http_wasm_transform_stream_write, http_wasm_transform_stream_close, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes, http_wasm_get_response_type, http_wasm_get_response_status } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -80,8 +80,7 @@ export function export_internal (): any {
         http_wasm_create_controller,
         http_wasm_get_response_type,
         http_wasm_get_response_status,
-        http_wasm_abort_request,
-        http_wasm_abort_response,
+        http_wasm_abort,
         http_wasm_transform_stream_write,
         http_wasm_transform_stream_close,
         http_wasm_fetch,

--- a/src/mono/browser/runtime/http.ts
+++ b/src/mono/browser/runtime/http.ts
@@ -110,9 +110,13 @@ export function http_wasm_transform_stream_write (controller: HttpController, bu
     return wrap_as_cancelable_promise(async () => {
         mono_assert(controller.streamWriter, "expected streamWriter");
         mono_assert(controller.responsePromise, "expected fetch promise");
-        // race with fetch because fetch does not cancel the ReadableStream see https://bugs.chromium.org/p/chromium/issues/detail?id=1480250
-        await Promise.race([controller.streamWriter.ready, controller.responsePromise]);
-        await Promise.race([controller.streamWriter.write(copy), controller.responsePromise]);
+        try {
+            // race with fetch because fetch does not cancel the ReadableStream see https://bugs.chromium.org/p/chromium/issues/detail?id=1480250
+            await Promise.race([controller.streamWriter.ready, controller.responsePromise]);
+            await Promise.race([controller.streamWriter.write(copy), controller.responsePromise]);
+        } catch (ex) {
+            throw new Error("BrowserHttpWriteStream.Rejected");
+        }
     });
 }
 
@@ -121,9 +125,13 @@ export function http_wasm_transform_stream_close (controller: HttpController): C
     return wrap_as_cancelable_promise(async () => {
         mono_assert(controller.streamWriter, "expected streamWriter");
         mono_assert(controller.responsePromise, "expected fetch promise");
-        // race with fetch because fetch does not cancel the ReadableStream see https://bugs.chromium.org/p/chromium/issues/detail?id=1480250
-        await Promise.race([controller.streamWriter.ready, controller.responsePromise]);
-        await Promise.race([controller.streamWriter.close(), controller.responsePromise]);
+        try {
+            // race with fetch because fetch does not cancel the ReadableStream see https://bugs.chromium.org/p/chromium/issues/detail?id=1480250
+            await Promise.race([controller.streamWriter.ready, controller.responsePromise]);
+            await Promise.race([controller.streamWriter.close(), controller.responsePromise]);
+        } catch (ex) {
+            throw new Error("BrowserHttpWriteStream.Rejected");
+        }
     });
 }
 

--- a/src/mono/browser/runtime/http.ts
+++ b/src/mono/browser/runtime/http.ts
@@ -72,30 +72,31 @@ export function http_wasm_create_controller (): HttpController {
     return controller;
 }
 
-export function http_wasm_abort_request (controller: HttpController): void {
-    try {
-        if (controller.streamWriter) {
-            controller.streamWriter.abort();
+function handle_abort_error (promise:Promise<any>) {
+    promise.catch((err) => {
+        if (err && err !== "AbortError" && err.name !== "AbortError" ) {
+            Module.err("Unexpected error: " + err);
         }
-    } catch (err) {
-        // ignore
-    }
-    http_wasm_abort_response(controller);
+        // otherwise, it's expected
+    });
 }
 
-export function http_wasm_abort_response (controller: HttpController): void {
+export function http_wasm_abort (controller: HttpController): void {
     if (BuildConfiguration === "Debug") commonAsserts(controller);
     try {
-        controller.isAborted = true;
-        if (controller.streamReader) {
-            controller.streamReader.cancel().catch((err) => {
-                if (err && err.name !== "AbortError") {
-                    Module.err("Error in http_wasm_abort_response: " + err);
-                }
-                // otherwise, it's expected
-            });
+        if (!controller.isAborted) {
+            if (controller.streamWriter) {
+                handle_abort_error(controller.streamWriter.abort());
+                controller.isAborted = true;
+            }
+            if (controller.streamReader) {
+                handle_abort_error(controller.streamReader.cancel());
+                controller.isAborted = true;
+            }
         }
-        controller.abortController.abort();
+        if (!controller.isAborted) {
+            controller.abortController.abort("AbortError");
+        }
     } catch (err) {
         // ignore
     }
@@ -111,9 +112,8 @@ export function http_wasm_transform_stream_write (controller: HttpController, bu
         mono_assert(controller.streamWriter, "expected streamWriter");
         mono_assert(controller.responsePromise, "expected fetch promise");
         try {
-            // race with fetch because fetch does not cancel the ReadableStream see https://bugs.chromium.org/p/chromium/issues/detail?id=1480250
-            await Promise.race([controller.streamWriter.ready, controller.responsePromise]);
-            await Promise.race([controller.streamWriter.write(copy), controller.responsePromise]);
+            await controller.streamWriter.ready;
+            await controller.streamWriter.write(copy);
         } catch (ex) {
             throw new Error("BrowserHttpWriteStream.Rejected");
         }
@@ -126,9 +126,8 @@ export function http_wasm_transform_stream_close (controller: HttpController): C
         mono_assert(controller.streamWriter, "expected streamWriter");
         mono_assert(controller.responsePromise, "expected fetch promise");
         try {
-            // race with fetch because fetch does not cancel the ReadableStream see https://bugs.chromium.org/p/chromium/issues/detail?id=1480250
-            await Promise.race([controller.streamWriter.ready, controller.responsePromise]);
-            await Promise.race([controller.streamWriter.close(), controller.responsePromise]);
+            await controller.streamWriter.ready;
+            await controller.streamWriter.close();
         } catch (ex) {
             throw new Error("BrowserHttpWriteStream.Rejected");
         }
@@ -139,6 +138,8 @@ export function http_wasm_fetch_stream (controller: HttpController, url: string,
     if (BuildConfiguration === "Debug") commonAsserts(controller);
     const transformStream = new TransformStream<Uint8Array, Uint8Array>();
     controller.streamWriter = transformStream.writable.getWriter();
+    handle_abort_error(controller.streamWriter.closed);
+    handle_abort_error(controller.streamWriter.ready);
     const fetch_promise = http_wasm_fetch(controller, url, header_names, header_values, option_names, option_values, transformStream.readable);
     return fetch_promise;
 }

--- a/src/mono/browser/runtime/loader/exit.ts
+++ b/src/mono/browser/runtime/loader/exit.ts
@@ -291,11 +291,11 @@ function logOnExit (exit_code: number, reason: any) {
         }
     }
 }
-function unhandledrejection_handler (event: any) {
+function unhandledrejection_handler (event: PromiseRejectionEvent) {
     fatal_handler(event, event.reason, "rejection");
 }
 
-function error_handler (event: any) {
+function error_handler (event: ErrorEvent) {
     fatal_handler(event, event.error, "error");
 }
 


### PR DESCRIPTION
 - propagate exceptions from `http_wasm_transform_stream_write` and `http_wasm_transform_stream_close` as `BrowserHttpWriteStream.Rejected`
 - improves `StatusCode.ashx` test helper to be able to delay
 - unified `AbortRequest` and `AbortResponse` into `BrowserHttpInterop.AbortResponse`
 - unified `http_wasm_abort_request` and `http_wasm_abort_response` into `http_wasm_abort`
 - added handler `handle_abort_error`
    - only use `controller.abortController` when there is no `streamWriter` or `streamReader`
 - removed chrome [workaround for abort](https://bugs.chromium.org/p/chromium/issues/detail?id=1480250)
 - enabled `BrowserHttpHandler_StreamingRequest_CancelRequest` on CI

Fixes https://github.com/dotnet/runtime/issues/104612