### PR TITLE
Fix JitStackChecks failures

### DIFF
--- a/src/tests/Interop/DisabledRuntimeMarshalling/PInvokeAssemblyMarshallingEnabled/Delegates.cs
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/PInvokeAssemblyMarshallingEnabled/Delegates.cs
@@ -11,7 +11,10 @@ namespace DisabledRuntimeMarshalling.PInvokeAssemblyMarshallingEnabled;
 [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
 public unsafe class DelegatesFromExternalAssembly
 {
-    [Fact]
+    public static bool IsWindowsX86Process => OperatingSystem.IsWindows() && RuntimeInformation.ProcessArchitecture == Architecture.X86;
+    public static bool IsNotWindowsX86Process => !IsWindowsX86Process;
+
+    [ConditionalFact(nameof(IsNotWindowsX86Process))]
     public static void StructWithDefaultNonBlittableFields()
     {
         short s = 42;
@@ -21,8 +24,8 @@ public unsafe class DelegatesFromExternalAssembly
 
         Assert.False(cb(new StructWithShortAndBool(s, b), s, b));
     }
-
-    [Fact]
+    
+    [ConditionalFact(nameof(IsNotWindowsX86Process))]
     [PlatformSpecific(TestPlatforms.Windows)]
     public static void StructWithDefaultNonBlittableFields_MarshalAsInfo()
     {

--- a/src/tests/Interop/DisabledRuntimeMarshalling/PInvokeAssemblyMarshallingEnabled/PInvokes.cs
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/PInvokeAssemblyMarshallingEnabled/PInvokes.cs
@@ -24,7 +24,7 @@ public class PInvokes
         Assert.False(DisabledRuntimeMarshallingNative.CheckStructWithShortAndBool(new StructWithShortAndBool(s, b), s, b));
     }
 
-    [Fact]
+    [ConditionalFact(nameof(IsNotWindowsX86Process))]
     [SkipOnMono("Mono doesn't support marshalling a .NET Char to a C char (only a char16_t).")]
     public static void StructWithDefaultNonBlittableFields_Char()
     {
@@ -45,7 +45,7 @@ public class PInvokes
         Assert.True(DisabledRuntimeMarshallingNative.CheckStructWithShortAndBool(new StructWithShortAndBoolWithMarshalAs(s, b), s, b));
     }
 
-    [Fact]
+    [ConditionalFact(nameof(IsNotWindowsX86Process))]
     [SkipOnMono("Mono doesn't support marshalling a .NET Char to a C char (only a char16_t).")]
     public static void StructWithDefaultNonBlittableFields_Char_MarshalAsInfo()
     {

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
@@ -40,7 +40,7 @@ namespace System.Runtime.InteropServices.Tests
             public static ICustomMarshaler GetInstance(string cookie) => new StringForwardingCustomMarshaler();
         }
 
-        [DllImport(LibcLibrary, EntryPoint = "atoi")]
+        [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int MarshalerOnStringTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(StringForwardingCustomMarshaler))] string str);
 
         public static void CustomMarshaler_ArrayType_Success()
@@ -62,7 +62,7 @@ namespace System.Runtime.InteropServices.Tests
             public static ICustomMarshaler GetInstance(string cookie) => new ArrayForwardingCustomMarshaler();
         }
 
-        [DllImport(LibcLibrary, EntryPoint = "atoi")]
+        [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int MarshalerOnArrayTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "System.Runtime.InteropServices.Tests.ICustomMarshalerTests+ArrayForwardingCustomMarshaler")] string[] str);
 
         public static void CustomMarshaler_BoxedValueType_Success()
@@ -89,7 +89,7 @@ namespace System.Runtime.InteropServices.Tests
             public static ICustomMarshaler GetInstance(string cookie) => new BoxedValueTypeCustomMarshaler();
         }
 
-        [DllImport(LibcLibrary, EntryPoint = "atoi")]
+        [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int MarshalerOnBoxedValueTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(BoxedValueTypeCustomMarshaler))] object i);
 
         public static void Parameter_CustomMarshalerProvidedOnClassType_ForwardsCorrectly()


### PR DESCRIPTION
Disable tests that actively mess up parameter marshalling on x86 (which passes arguments on the stack instead of registers)

Fix calling conventions

Fixes #74280 