### PR TITLE
[wasm] Condition dwarfdebug on WasmNativeDebugSymbols

### DIFF
--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -706,7 +706,7 @@
       DisableParallelAot="$(DisableParallelAot)"
       DedupAssembly="$(_WasmDedupAssembly)"
       CacheFilePath="$(_AOTCompilerCacheFile)"
-      LLVMDebug="dwarfdebug"
+      UseDwarfDebug="$(WasmNativeDebugSymbols)"
       LLVMPath="$(_WasmLLVMPathForAOT)"
       CollectTrimmingEligibleMethods="$(WasmStripILAfterAOT)"
       TrimmingEligibleMethodsOutputDirectory="$(_WasmIntermediateOutputPath)tokens"


### PR DESCRIPTION
Respect the symbol setting in the aot codegen not just the link step.  UseDwarfDebug just appends "dwarfdebug" to the aotArgs the same way LLVMDebug="dwarfdebug" does.