### PR TITLE
[release/8.0-staging] Fix problem in ReadyToRun_TypeGenericInfoMap::HasConstraints

### DIFF
--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -1945,7 +1945,7 @@ bool ReadyToRun_TypeGenericInfoMap::HasVariance(mdTypeDef input, bool *foundResu
 bool ReadyToRun_TypeGenericInfoMap::HasConstraints(mdTypeDef input, bool *foundResult) const
 {
     ReadyToRunTypeGenericInfo typeGenericInfo = GetTypeGenericInfo(input, foundResult);
-    return !!((uint8_t)typeGenericInfo & (uint8_t)ReadyToRunTypeGenericInfo::HasVariance);
+    return !!((uint8_t)typeGenericInfo & (uint8_t)ReadyToRunTypeGenericInfo::HasConstraints);
 }
 
 bool ReadyToRun_MethodIsGenericMap::IsGeneric(mdMethodDef input, bool *foundResult) const


### PR DESCRIPTION
## Customer Impact

- [x] Customer reported
- [ ] Found internally

Backport of PR #96358 to *release/8.0*. This bug came to light as reported by a customer in issue #96225. Since it reproduces on .NET 8 but was gone by .NET 9 preview 1, some further bisecting was done to figure out the fix.

The problem was that the code in the VM that is supposed to check for whether a generic type had (a) constraining clause(s), actually checked for whether said type was either covariant or contravariant. This completely different and therefore erroneous behavior broke some scenarios with generics and made them crash, like the one hindering our customer in this case.

## Regression

- [x] Yes
- [ ] No

This is a regression as the same scenario works properly in .NET 7 and .NET 6 versions. For context, it was accidentally introduced in this PR: https://github.com/dotnet/runtime/pull/85743

## Testing

This was validated using the customer's failing repro scenarios.

## Risk

This PR poses little to no risk to the product. Since it's a small and simple one, we decided it would be a convenient and easy backport. The failure is well understood and has a well defined scope.