### PR TITLE
[wasm][debugger] Fix debugging when JMC is enabled

### DIFF
--- a/src/mono/browser/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1769,6 +1769,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                     if (assemblyAndPdbData == null || assemblyAndPdbData.AsmBytes == null)
                     {
                         var unescapedFileName = Uri.UnescapeDataString(step.Url);
+                        if (isFingerprinted)
+                            unescapedFileName = string.Concat(Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(unescapedFileName)), Path.GetExtension(unescapedFileName));
                         assemblies.Add(AssemblyInfo.WithoutDebugInfo(Path.GetFileName(unescapedFileName), logger));
                         logger.LogDebug($"Bytes from assembly {step.Url} is NULL");
                         continue;


### PR DESCRIPTION
If JMC was enabled it was trying to get information from runtime passing the name of the assembly with the fingerprinted part and then runtime was returning "null".