### PR TITLE
[wasm][hotreload] Add explanation to workaround for build `ApplyUpdateReferencedAssembly` with source link 

### DIFF
--- a/src/mono/browser/debugger/tests/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
+++ b/src/mono/browser/debugger/tests/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
@@ -14,7 +14,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EmbedAllSources>true</EmbedAllSources>
 
-    <!-- FIXME: issue -->
+    <!-- workaround to avoid this error: "Expected only one module in the delta, got 0" -->
     <DisableSourceLink>true</DisableSourceLink>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/62618.

Removal of workaround reveals the issue is still there. Leave it, update the comment.