### PR TITLE
Add [DebuggerDisplay] to CancellationTokenSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -22,7 +22,7 @@ namespace System.Threading
     /// concurrently from multiple threads.
     /// </para>
     /// </remarks>
-    [DebuggerDisplay("IsCancellationRequested = {IsCancellationRequested}; Disposed = {_disposed}")]
+    [DebuggerDisplay("IsCancellationRequested = {IsCancellationRequested}")]
     public class CancellationTokenSource : IDisposable
     {
         /// <summary>A <see cref="CancellationTokenSource"/> that's already canceled.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -22,6 +22,7 @@ namespace System.Threading
     /// concurrently from multiple threads.
     /// </para>
     /// </remarks>
+    [DebuggerDisplay("IsCancellationRequested = {IsCancellationRequested}; Disposed = {_disposed}")]
     public class CancellationTokenSource : IDisposable
     {
         /// <summary>A <see cref="CancellationTokenSource"/> that's already canceled.</summary>


### PR DESCRIPTION
Add `[DebuggerDisplay]` to `CancellationTokenSource` to show whether cancelled ~~or disposed~~.

~~I just copied what `CancellationToken` [already does](https://github.com/dotnet/runtime/blob/8aeff36d34f8ecf89c5bdf3925a68b5c57614b02/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs#L29) and added `Disposed` at the end backed by the private field separated by a `;`.~~

Relates to #105698.
