### PR TITLE
Support [DefaultValue] when new feature switch is disabled

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/tests/TrimmingTests/DefaultValueAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/TrimmingTests/DefaultValueAttributeTests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using System.Reflection;
+
+/// <summary>
+/// Tests that using the [DefaultValue] ctor(Type, String) throws and other ctors with primitive values do not throw.
+/// </summary>
+class Program
+{
+    static int Main(string[] args)
+    {
+        object value;
+        DefaultValueAttribute attribute;
+
+        // Primitive types should not throw.
+        attribute = typeof(TestClass).GetProperty(nameof(TestClass.MyPropertyWithDefaultValue))!.GetCustomAttribute<DefaultValueAttribute>()!;
+        value = attribute.Value;
+        if (value == null || (int)value != 42)
+        {
+            return -1;
+        }
+
+        attribute = typeof(TestClass).GetProperty(nameof(TestClass.MyPropertyWithDefaultValueUsingTypeConverter))!.GetCustomAttribute<DefaultValueAttribute>()!;
+        try
+        {
+            value = attribute.Value;
+        }
+        catch (ArgumentException)
+        {
+            // The System.ComponentModel.DefaultValueAttribute.IsSupported feature switch is off so ArgumentException should be thrown.
+            return 100;
+        }
+
+        return -2;
+    }
+}
+
+public class TestClass
+{
+    [DefaultValue(42)]
+    public int MyPropertyWithDefaultValue { get; set; }
+
+    [DefaultValue(typeof(int), "42")]
+    public int MyPropertyWithDefaultValueUsingTypeConverter { get; set; }
+}

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/TrimmingTests/System.ComponentModel.TypeConverter.TrimmingTests.proj
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/TrimmingTests/System.ComponentModel.TypeConverter.TrimmingTests.proj
@@ -3,6 +3,9 @@
 
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="ComObjectTypeTest.cs" />
+    <TestConsoleAppSourceFiles Include="DefaultValueAttributeTests.cs">
+      <DisabledFeatureSwitches>System.ComponentModel.DefaultValueAttribute.IsSupported</DisabledFeatureSwitches>
+    </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="InterfaceTypeTest.cs" />
     <TestConsoleAppSourceFiles Include="TypeConverterIsReadOnly.cs" />
     <TestConsoleAppSourceFiles Include="TypeConverterTest.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
@@ -247,7 +247,7 @@ namespace System.ComponentModel
         {
             get
             {
-                if (!IsSupported && object.ReferenceEquals(_value, s_throwSentinel))
+                if (!IsSupported && ReferenceEquals(_value, s_throwSentinel))
                 {
                     throw new ArgumentException(SR.RuntimeInstanceNotAllowed);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
@@ -28,6 +28,7 @@ namespace System.ComponentModel
 #pragma warning disable IL4000
         internal static bool IsSupported => AppContext.TryGetSwitch("System.ComponentModel.DefaultValueAttribute.IsSupported", out bool isSupported) ? isSupported : true;
 #pragma warning restore IL4000
+        private static readonly object? s_throwSentinel = IsSupported ? null : new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref='DefaultValueAttribute'/>
@@ -44,6 +45,7 @@ namespace System.ComponentModel
             Debug.Assert(IsSupported, "Runtime instantiation of this attribute is not allowed with trimming.");
             if (!IsSupported)
             {
+                _value = s_throwSentinel;
                 return;
             }
 
@@ -245,14 +247,14 @@ namespace System.ComponentModel
         {
             get
             {
-                if (!IsSupported)
+                if (!IsSupported && object.ReferenceEquals(_value, s_throwSentinel))
                 {
                     throw new ArgumentException(SR.RuntimeInstanceNotAllowed);
                 }
+
                 return _value;
             }
         }
-
 
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
@@ -260,6 +262,7 @@ namespace System.ComponentModel
             {
                 return true;
             }
+
             if (obj is not DefaultValueAttribute other)
             {
                 return false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/103542

Throw only on the (Type, String) ctor.