### PR TITLE
Return null instead of throwing in ServiceDescriptor.ImplementationInstance\Type\Factory if a keyed service

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Resources/Strings.resx
@@ -170,9 +170,6 @@
   <data name="KeyedServicesNotSupported" xml:space="preserve">
     <value>This service provider doesn't support keyed services.</value>
   </data>
-  <data name="KeyedDescriptorMisuse" xml:space="preserve">
-    <value>This service descriptor is keyed. Your service provider may not support keyed services.</value>
-  </data>
   <data name="NonKeyedDescriptorMisuse" xml:space="preserve">
     <value>This service descriptor is not keyed.</value>
   </data>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -155,7 +155,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Gets the <see cref="Type"/> that implements the service,
         /// or returns <see langword="null"/> if <see cref="IsKeyedService"/> is <see langword="true"/>.
         /// </summary>
+        /// <remarks>
         /// If <see cref="IsKeyedService"/> is <see langword="true"/>, <see cref="KeyedImplementationType"/> should be called instead.
+        /// </remarks>
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? ImplementationType => IsKeyedService ? null : _implementationType;
 
@@ -165,7 +167,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <remarks>
         /// If <see cref="IsKeyedService"/> is <see langword="false"/>, <see cref="ImplementationType"/> should be called instead.
-        /// </remarks>>
+        /// </remarks>
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? KeyedImplementationType
         {
@@ -185,7 +187,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Gets the instance that implements the service,
         /// or returns <see langword="null"/> if <see cref="IsKeyedService"/> is <see langword="true"/>.
         /// </summary>
+        /// <remarks>
         /// If <see cref="IsKeyedService"/> is <see langword="true"/>, <see cref="KeyedImplementationInstance"/> should be called instead.
+        /// </remarks>
         public object? ImplementationInstance =>  IsKeyedService ? null : _implementationInstance;
 
         /// <summary>
@@ -194,7 +198,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <remarks>
         /// If <see cref="IsKeyedService"/> is <see langword="false"/>, <see cref="ImplementationInstance"/> should be called instead.
-        /// </remarks>>
+        /// </remarks>
         public object? KeyedImplementationInstance
         {
             get
@@ -215,7 +219,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <remarks>
         /// If <see cref="IsKeyedService"/> is <see langword="true"/>, <see cref="KeyedImplementationFactory"/> should be called instead.
-        /// </remarks>>
+        /// </remarks>
         public Func<IServiceProvider, object>? ImplementationFactory => IsKeyedService ? null : (Func<IServiceProvider, object>?) _implementationFactory;
 
         /// <summary>
@@ -224,7 +228,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <remarks>
         /// If <see cref="IsKeyedService"/> is <see langword="false"/>, <see cref="ImplementationFactory"/> should be called instead.
-        /// </remarks>>
+        /// </remarks>
         public Func<IServiceProvider, object?, object>? KeyedImplementationFactory
         {
             get

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -152,24 +152,20 @@ namespace Microsoft.Extensions.DependencyInjection
         private Type? _implementationType;
 
         /// <summary>
-        /// Gets the <see cref="Type"/> that implements the service.
+        /// Gets the <see cref="Type"/> that implements the service,
+        /// or returns <see langword="null"/> if <see cref="IsKeyedService"/> is <see langword="true"/>.
         /// </summary>
+        /// If <see cref="IsKeyedService"/> is <see langword="true"/>, <see cref="KeyedImplementationType"/> should be called instead.
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-        public Type? ImplementationType
-        {
-            get
-            {
-                if (IsKeyedService)
-                {
-                    ThrowKeyedDescriptor();
-                }
-                return _implementationType;
-            }
-        }
+        public Type? ImplementationType => IsKeyedService ? null : _implementationType;
 
         /// <summary>
-        /// Gets the <see cref="Type"/> that implements the service.
+        /// Gets the <see cref="Type"/> that implements the service,
+        /// or throws <see cref="InvalidOperationException"/> if <see cref="IsKeyedService"/> is <see langword="false"/>.
         /// </summary>
+        /// <remarks>
+        /// If <see cref="IsKeyedService"/> is <see langword="false"/>, <see cref="ImplementationType"/> should be called instead.
+        /// </remarks>>
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? KeyedImplementationType
         {
@@ -186,23 +182,19 @@ namespace Microsoft.Extensions.DependencyInjection
         private object? _implementationInstance;
 
         /// <summary>
-        /// Gets the instance that implements the service.
+        /// Gets the instance that implements the service,
+        /// or returns <see langword="null"/> if <see cref="IsKeyedService"/> is <see langword="true"/>.
         /// </summary>
-        public object? ImplementationInstance
-        {
-            get
-            {
-                if (IsKeyedService)
-                {
-                    ThrowKeyedDescriptor();
-                }
-                return _implementationInstance;
-            }
-        }
+        /// If <see cref="IsKeyedService"/> is <see langword="true"/>, <see cref="KeyedImplementationInstance"/> should be called instead.
+        public object? ImplementationInstance =>  IsKeyedService ? null : _implementationInstance;
 
         /// <summary>
-        /// Gets the instance that implements the service.
+        /// Gets the instance that implements the service,
+        /// or throws <see cref="InvalidOperationException"/> if <see cref="IsKeyedService"/> is <see langword="false"/>.
         /// </summary>
+        /// <remarks>
+        /// If <see cref="IsKeyedService"/> is <see langword="false"/>, <see cref="ImplementationInstance"/> should be called instead.
+        /// </remarks>>
         public object? KeyedImplementationInstance
         {
             get
@@ -218,23 +210,21 @@ namespace Microsoft.Extensions.DependencyInjection
         private object? _implementationFactory;
 
         /// <summary>
-        /// Gets the factory used for creating service instances.
+        /// Gets the factory used for creating service instance,
+        /// or returns <see langword="null"/> if <see cref="IsKeyedService"/> is <see langword="true"/>.
         /// </summary>
-        public Func<IServiceProvider, object>? ImplementationFactory
-        {
-            get
-            {
-                if (IsKeyedService)
-                {
-                    ThrowKeyedDescriptor();
-                }
-                return (Func<IServiceProvider, object>?)_implementationFactory;
-            }
-        }
+        /// <remarks>
+        /// If <see cref="IsKeyedService"/> is <see langword="true"/>, <see cref="KeyedImplementationFactory"/> should be called instead.
+        /// </remarks>>
+        public Func<IServiceProvider, object>? ImplementationFactory => IsKeyedService ? null : (Func<IServiceProvider, object>?) _implementationFactory;
 
         /// <summary>
-        /// Gets the factory used for creating Keyed service instances.
+        /// Gets the factory used for creating Keyed service instances,
+        /// or throws <see cref="InvalidOperationException"/> if <see cref="IsKeyedService"/> is <see langword="false"/>.
         /// </summary>
+        /// <remarks>
+        /// If <see cref="IsKeyedService"/> is <see langword="false"/>, <see cref="ImplementationFactory"/> should be called instead.
+        /// </remarks>>
         public Func<IServiceProvider, object?, object>? KeyedImplementationFactory
         {
             get
@@ -1057,8 +1047,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return debugText;
         }
-
-        private static void ThrowKeyedDescriptor() => throw new InvalidOperationException(SR.KeyedDescriptorMisuse);
 
         private static void ThrowNonKeyedDescriptor() => throw new InvalidOperationException(SR.NonKeyedDescriptorMisuse);
     }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionKeyedServiceExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionKeyedServiceExtensionsTest.cs
@@ -546,9 +546,9 @@ namespace Microsoft.Extensions.DependencyInjection
         public void NotNullServiceKey_IsKeyedServiceTrue(ServiceDescriptor serviceDescriptor)
         {
             Assert.True(serviceDescriptor.IsKeyedService);
-            Assert.Throws<InvalidOperationException>(() => serviceDescriptor.ImplementationInstance);
-            Assert.Throws<InvalidOperationException>(() => serviceDescriptor.ImplementationType);
-            Assert.Throws<InvalidOperationException>(() => serviceDescriptor.ImplementationFactory);
+            Assert.Null(serviceDescriptor.ImplementationInstance);
+            Assert.Null(serviceDescriptor.ImplementationType);
+            Assert.Null(serviceDescriptor.ImplementationFactory);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95789

This fixes a regression for cases where `ServiceDescriptor.ImplementationInstance\Type\Factory` is called for code that is not servicekey-aware. Instead of throwing, `null` is returned.

This will be backported to 8.0.