### PR TITLE
Fix copy constructor injection for unsafe value classes

### DIFF
--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
@@ -72,10 +72,15 @@ namespace CopyConstructorMarshaler
             Assert.Equal(0, (int)testMethod.Invoke(testInstance, null));
         }
 
-        [DllImport("kernel32.dll")]
-        static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, int dwFlags);
+        [Fact]
+        public static void CopyConstructorsInArgumentStackSlotsWithUnsafeValueType()
+        {
+            Assembly ijwNativeDll = Assembly.Load("IjwCopyConstructorMarshaler");
+            Type testType = ijwNativeDll.GetType("TestClass");
+            object testInstance = Activator.CreateInstance(testType);
+            MethodInfo testMethod = testType.GetMethod("ExposedThisUnsafeValueTypeCopyConstructorScenario");
 
-        [DllImport("kernel32.dll")]
-        static extern IntPtr GetModuleHandle(string lpModuleName);
+            Assert.Equal(0, (int)testMethod.Invoke(testInstance, null));
+        }
     }
 }

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
@@ -62,6 +62,7 @@ namespace CopyConstructorMarshaler
         }
 
         [Fact]
+        [SkipOnCoreClr("JitStress and MinOpts can introduce extra copies that won't happen in production scenarios.", RuntimeTestModes.JitStress | RuntimeTestModes.JitMinOpts)]
         public static void CopyConstructorsInArgumentStackSlots()
         {
             Assembly ijwNativeDll = Assembly.Load("IjwCopyConstructorMarshaler");
@@ -73,6 +74,7 @@ namespace CopyConstructorMarshaler
         }
 
         [Fact]
+        [SkipOnCoreClr("JitStress and MinOpts can introduce extra copies that won't happen in production scenarios.", RuntimeTestModes.JitStress | RuntimeTestModes.JitMinOpts)]
         public static void CopyConstructorsInArgumentStackSlotsWithUnsafeValueType()
         {
             Assembly ijwNativeDll = Assembly.Load("IjwCopyConstructorMarshaler");

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
@@ -62,7 +62,7 @@ namespace CopyConstructorMarshaler
         }
 
         [Fact]
-        [SkipOnCoreClr("JitStress and MinOpts can introduce extra copies that won't happen in production scenarios.", RuntimeTestModes.JitStress | RuntimeTestModes.JitMinOpts)]
+        [SkipOnCoreClr("JitStress can introduce extra copies that won't happen in production scenarios.", RuntimeTestModes.JitStress)]
         public static void CopyConstructorsInArgumentStackSlots()
         {
             Assembly ijwNativeDll = Assembly.Load("IjwCopyConstructorMarshaler");
@@ -74,7 +74,7 @@ namespace CopyConstructorMarshaler
         }
 
         [Fact]
-        [SkipOnCoreClr("JitStress and MinOpts can introduce extra copies that won't happen in production scenarios.", RuntimeTestModes.JitStress | RuntimeTestModes.JitMinOpts)]
+        [SkipOnCoreClr("JitStress can introduce extra copies that won't happen in production scenarios.", RuntimeTestModes.JitStress)]
         public static void CopyConstructorsInArgumentStackSlotsWithUnsafeValueType()
         {
             Assembly ijwNativeDll = Assembly.Load("IjwCopyConstructorMarshaler");

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/IjwCopyConstructorMarshaler.cpp
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/IjwCopyConstructorMarshaler.cpp
@@ -86,6 +86,90 @@ namespace ExposedThis
     }
 }
 
+#pragma unmanaged
+namespace ExposedThisUnsafeValueType
+{
+    struct Relative;
+
+    std::vector<Relative*> relatives;
+
+    int numMissedCopies = 0;
+
+    struct Relative
+    {
+        void* relative;
+        uint8_t buffer[1];
+        Relative()
+        {
+            std::cout << "Registering " << std::hex << this << "\n";
+            relatives.push_back(this);
+            relative = this - 1;
+        }
+
+        Relative(const Relative& other)
+        {
+            std::cout << "Registering copy of " << std::hex << &other << " at " << this << "\n";
+            relatives.push_back(this);
+            relative = this - 1;
+        }
+
+        ~Relative()
+        {
+            auto location = std::find(relatives.begin(), relatives.end(), this);
+            if (location != relatives.end())
+            {
+                std::cout << "Unregistering " << std::hex << this << "\n";
+                relatives.erase(location);
+            }
+            else
+            {
+                std::cout << "Error: Relative object " << std::hex << this << " not registered\n";
+                numMissedCopies++;
+            }
+
+            if (relative != this - 1)
+            {
+                std::cout << " Error: Relative object " << std::hex << this << " has invalid relative pointer " << std::hex << relative << "\n";
+                numMissedCopies++;
+            }
+        }
+    };
+
+    void UseRelative(Relative rel)
+    {
+        std::cout << "Unmanaged: Using relative at address " << std::hex << &rel << "\n";
+    }
+
+    void UseRelativeManaged(Relative rel);
+
+    void CallRelative()
+    {
+        Relative rel;
+        UseRelativeManaged(rel);
+    }
+
+#pragma managed
+
+    int RunScenario()
+    {
+        // Managed to unmanaged
+        {
+            Relative rel;
+            UseRelative(rel);
+        }
+
+        // Unmanaged to managed
+        CallRelative();
+
+        return numMissedCopies;
+    }
+
+    void UseRelativeManaged(Relative rel)
+    {
+        std::cout << "Managed: Using relative at address " << std::hex << &rel << "\n";
+    }
+}
+
 #pragma managed
 class A
 {
@@ -191,5 +275,10 @@ public:
     int ExposedThisCopyConstructorScenario()
     {
         return ExposedThis::RunScenario();
+    }
+
+    int ExposedThisUnsafeValueTypeCopyConstructorScenario()
+    {
+        return ExposedThisUnsafeValueType::RunScenario();
     }
 };


### PR DESCRIPTION
For C++/CLI types with C-style array fields (`int x[N];`), the JIT was introducing extra copies without calling the copy constructor.

This was discovered through JitStress, which forcibly set the flag that the C++/CLI compiler sets when it sees a C-style array field.

To avoid adding a new API to the JIT interface just for usage by C++/CLI, I made a targeted fix to disable the GS cookie checking in Reverse P/Invoke stubs as we control the IL and we don't emit IL that would interact with these fields in a dangerous manner. As this fix was in CoreCLR and not propagated to the JIT, I still had to disable the tests that were failing from JitStress as setting the flag for the local in the JIT will still cause the bad behavior.

Alternatively, we could enhance the JIT interface to enable the JIT to discover when a type has a copy constructor and do one of the following:

- Skip GS cookie checks
- Create `GT_CALL` nodes to the copy constructor and destructor instead of generating a `GT_STORE_LCL_VAR` node.

If we were to go the second route, then I'd prefer moving all the "copy construct into the arg's stack slot" logic into the JIT and remove the code we added in the IL marshallers that supports that case.

I think a fix for this bug is worth considering backporting (as it would likely lead to hard-to-diagnose bugs and violates C++/CLI semantics). We may want a more targeted fix like this instead of a more expansive fix for backporting, I'm not sure.

Fixes #100751
Related to #100033