### PR TITLE
Fix condition to run CertificateCallbackThrowPropagates test on msquic 2.4 and higher

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -52,7 +52,7 @@ namespace System.Net.Quic.Tests
     {
         private static byte[] s_data = "Hello world!"u8.ToArray();
         readonly CertificateSetup _certificates;
-        static bool SupportsAsyncCertValidation => QuicTestCollection.MsQuicVersion >= new Version(2, 4);
+        static bool NotSupportAsyncCertValidation => QuicTestCollection.MsQuicVersion < new Version(2, 4);
 
         public MsQuicTests(ITestOutputHelper output, CertificateSetup setup) : base(output)
         {
@@ -354,7 +354,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074", typeof(MsQuicTests), nameof(SupportsAsyncCertValidation))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074", typeof(MsQuicTests), nameof(NotSupportAsyncCertValidation))]
         public async Task CertificateCallbackThrowPropagates()
         {
             using CancellationTokenSource cts = new CancellationTokenSource(PassingTestTimeout);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -52,7 +52,7 @@ namespace System.Net.Quic.Tests
     {
         private static byte[] s_data = "Hello world!"u8.ToArray();
         readonly CertificateSetup _certificates;
-        static bool NotSupportAsyncCertValidation => QuicTestCollection.MsQuicVersion < new Version(2, 4);
+        static bool DoesNotSupportAsyncCertValidation => QuicTestCollection.MsQuicVersion < new Version(2, 4);
 
         public MsQuicTests(ITestOutputHelper output, CertificateSetup setup) : base(output)
         {
@@ -354,7 +354,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074", typeof(MsQuicTests), nameof(NotSupportAsyncCertValidation))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074", typeof(MsQuicTests), nameof(DoesNotSupportAsyncCertValidation))]
         public async Task CertificateCallbackThrowPropagates()
         {
             using CancellationTokenSource cts = new CancellationTokenSource(PassingTestTimeout);


### PR DESCRIPTION
Fixes #105778