### PR TITLE
ARM64-SVE: Avoid containing non-embedded conditional select #105719

### DIFF
--- a/eng/pipelines/coreclr/jitstress-isas-sve.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-sve.yml
@@ -8,14 +8,16 @@ pr:
     - main
   paths:
     include:
-    - src/coreclr/jit/hwintrinsiccodegenarm64.cpp
-    - src/coreclr/jit/hwintrinsiclistarm64sve.h
-    - src/coreclr/jit/hwintrinsicarm64.cpp
-    - src/coreclr/jit/instrsarm64sve.h
+    - src/coreclr/jit/codegenarmarch.cpp
     - src/coreclr/jit/emitarm64sve.cpp
     - src/coreclr/jit/emitfmtsarm64sve.h
-    - src/coreclr/jit/lsraarm64.cpp
+    - src/coreclr/jit/hwintrinsicarm64.cpp
+    - src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+    - src/coreclr/jit/hwintrinsiclistarm64sve.h
+    - src/coreclr/jit/instrsarm64sve.h
     - src/coreclr/jit/lowerarmarch.cpp
+    - src/coreclr/jit/lsraarmarch.cpp
+    - src/coreclr/jit/lsraarm64.cpp
 
 schedules:
 - cron: "30 19 * * 6"

--- a/eng/pipelines/coreclr/jitstress-isas-sve.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-sve.yml
@@ -15,6 +15,7 @@ pr:
     - src/coreclr/jit/emitarm64sve.cpp
     - src/coreclr/jit/emitfmtsarm64sve.h
     - src/coreclr/jit/lsraarm64.cpp
+    - src/coreclr/jit/lowerarmarch.cpp
 
 schedules:
 - cron: "30 19 * * 6"

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -4067,7 +4067,8 @@ GenTree* Lowering::LowerHWIntrinsicCndSel(GenTreeHWIntrinsic* cndSelNode)
     else if (op1->IsMaskAllBitsSet())
     {
         // Any case where op2 is not an embedded HWIntrinsic
-        if (!op2->OperIsHWIntrinsic() || !HWIntrinsicInfo::IsEmbeddedMaskedOperation(op2->AsHWIntrinsic()->GetHWIntrinsicId()))
+        if (!op2->OperIsHWIntrinsic() ||
+            !HWIntrinsicInfo::IsEmbeddedMaskedOperation(op2->AsHWIntrinsic()->GetHWIntrinsicId()))
         {
             JITDUMP("lowering ConditionalSelect HWIntrinisic (before):\n");
             DISPTREERANGE(BlockRange(), cndSelNode);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3919,11 +3919,11 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                 }
 
                 // Handle op3
-                if (op3->IsVectorZero() && op1->IsMaskAllBitsSet())
+                if (op3->IsVectorZero() && op1->IsMaskAllBitsSet() && op2->IsEmbMaskOp())
                 {
                     // When we are merging with zero, we can specialize
                     // and avoid instantiating the vector constant.
-                    // Do this only if op1 was AllTrueMask
+                    // Do this only if op1 was AllTrueMask and op2 is embedded.
                     MakeSrcContained(node, op3);
                 }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+
+public class Runtime_105723
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        if (Sve.IsSupported)
+        {
+            var vr3 = Sve.CreateTrueMaskInt32();
+            var vr4 = Vector.Create<int>(1);
+            var vr5 = Vector128.CreateScalar(0).AsVector();
+            Vector<int> vr6 = Sve.ConditionalSelect(vr3, vr4, vr5);
+            Consume(vr6);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Consume(Vector<int> v)
+    {
+        ;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.csproj
@@ -1,12 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestEnvironmentVariable -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
-
-    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
+    <NoWarn>$(NoWarn);SYSLIB5003</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105719/Runtime_105719.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #105719

`CONDSELECT(TRUE, EMBBEDMASKOP(), 0)`
For this scenario, during codegeneration, the SELECT will not be generated and instead just generate the embedded mask operation. To do this, op3 can be contained.

`CONDSELECT(TRUE, VECTOR, 0)`
For this senario, the SELECT operation will be generated (and then in emit a MOV will be generated instead). To do this, op3 cannot be contained and must be generated into a register.
