### PR TITLE
Emit instantiated types as external references if possible

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -91,6 +91,7 @@ namespace ILCompiler.DependencyAnalysis
             else if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                 Debug.Assert((this is CanonicalEETypeNode) || (this is NecessaryCanonicalEETypeNode));
 
+            Debug.Assert(!type.IsGenericParameter);
             Debug.Assert(!type.IsRuntimeDeterminedSubtype);
             _type = type;
             _optionalFieldsNode = new EETypeOptionalFieldsNode(this);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -544,6 +544,14 @@ namespace ILCompiler.DependencyAnalysis
             {
                 Debug.Assert(Marked, "WriteVertex should only happen for marked vertices");
 
+                Debug.Assert(factory.MarkingComplete);
+                if (!_type.ContainsSignatureVariables() && !_type.IsRuntimeDeterminedSubtype && factory.NecessaryTypeSymbol(_type).Marked)
+                {
+                    IEETypeNode eetypeNode = factory.NecessaryTypeSymbol(_type);
+                    uint typeIndex = factory.MetadataManager.NativeLayoutInfo.ExternalReferences.GetIndex(eetypeNode);
+                    return GetNativeWriter(factory).GetExternalTypeSignature(typeIndex);
+                }
+
                 Vertex genericDefVertex = _genericTypeDefSig.WriteVertex(factory);
                 Vertex[] args = new Vertex[_instantiationArgs.Length];
                 for (int i = 0; i < args.Length; i++)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -232,7 +232,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override string GetName(NodeFactory factory) => "NativeLayoutMethodLdTokenVertexNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
         public NativeLayoutMethodLdTokenVertexNode(NodeFactory factory, MethodDesc method)
-            : base(factory, method, 0)
+            : base(factory, method, method.IsRuntimeDeterminedExactMethod ? 0 : MethodEntryFlags.CreateInstantiatedSignature)
         {
         }
 
@@ -543,14 +543,6 @@ namespace ILCompiler.DependencyAnalysis
             public override Vertex WriteVertex(NodeFactory factory)
             {
                 Debug.Assert(Marked, "WriteVertex should only happen for marked vertices");
-
-                Debug.Assert(factory.MarkingComplete);
-                if (!_type.ContainsSignatureVariables() && !_type.IsRuntimeDeterminedSubtype && factory.NecessaryTypeSymbol(_type).Marked)
-                {
-                    IEETypeNode eetypeNode = factory.NecessaryTypeSymbol(_type);
-                    uint typeIndex = factory.MetadataManager.NativeLayoutInfo.ExternalReferences.GetIndex(eetypeNode);
-                    return GetNativeWriter(factory).GetExternalTypeSignature(typeIndex);
-                }
 
                 Vertex genericDefVertex = _genericTypeDefSig.WriteVertex(factory);
                 Vertex[] args = new Vertex[_instantiationArgs.Length];

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -232,7 +232,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override string GetName(NodeFactory factory) => "NativeLayoutMethodLdTokenVertexNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
         public NativeLayoutMethodLdTokenVertexNode(NodeFactory factory, MethodDesc method)
-            : base(factory, method, method.IsRuntimeDeterminedExactMethod ? 0 : MethodEntryFlags.CreateInstantiatedSignature)
+            : base(factory, method, method.IsRuntimeDeterminedExactMethod || method.IsGenericMethodDefinition ? 0 : MethodEntryFlags.CreateInstantiatedSignature)
         {
         }
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -58,6 +58,7 @@ class Generics
         Test99198Regression.Run();
         Test102259Regression.Run();
         Test104913Regression.Run();
+        Test105397Regression.Run();
         TestInvokeMemberCornerCaseInGenerics.Run();
         TestRefAny.Run();
         TestNullableCasting.Run();
@@ -3626,6 +3627,31 @@ class Generics
             (Type t1, Type t2) = ((IFoo)new Foo()).InvokeInstance<Bar>();
             if (t1 != typeof(Bar) || t2 != typeof(int))
                 throw new Exception();
+        }
+    }
+
+    class Test105397Regression
+    {
+        interface IEnumerable<T> { }
+
+        interface ITest<TResult>
+        {
+            TReturn UsingDatabaseResult<TState, TReturn>(TState state, Func<TResult, TState, TReturn> @using);
+        }
+        class Test<TResult> : ITest<TResult>
+        {
+            public TReturn UsingDatabaseResult<TState, TReturn>(TState state, Func<TResult, TState, TReturn> @using)
+            {
+                return default;
+            }
+        }
+
+        struct GenStruct<T> { }
+
+        public static void Run()
+        {
+            ITest<object> t = new Test<object>();
+            t.UsingDatabaseResult<IEnumerable<IEnumerable<GenStruct<double>>>, int>(null, (x, y) => 1);
         }
     }
 


### PR DESCRIPTION
Fixes #105397.

The repro case hits an interesting problem in native layout - we emit the `IEnumerable<IEnumerable<double?>>` type as a constructed type, however the components of it are only generated as necessary. Because native layout expresses it as a decomposed instantiation, we're not able to find the type because the component of it is not constructed and we don't really keep track of those.

This can be fixed by simply not generating types as composed out of various components if the `MethodTable` already exists in the compilation.

Cc @dotnet/ilc-contrib 