### PR TITLE
JIT: Clear register assignment after defining trees used from spill temps

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2148,6 +2148,12 @@ void CodeGen::genProduceReg(GenTree* tree)
             tree->gtFlags |= GTF_SPILLED;
             tree->gtFlags &= ~GTF_SPILL;
 
+            if (tree->isUsedFromSpillTemp())
+            {
+                // The register assignment is not meaningful for the use.
+                tree->ClearRegNum();
+            }
+
             return;
         }
     }


### PR DESCRIPTION
Fix #105837