### PR TITLE
[EXPERIMENTATION ONLY] - Prevent Reflection's `MakeGenericType()` from Allowing the Instantiation of Abstract Classes

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidator.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidator.cs
@@ -38,7 +38,7 @@ namespace Internal.Reflection.Execution
 
             if ((attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
             {
-                if (!typeArg.HasExplicitOrImplicitPublicDefaultConstructor())
+                if (!typeArg.HasExplicitOrImplicitPublicDefaultConstructor() || typeArg.IsAbstract)
                     return false;
             }
 

--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -1464,7 +1464,9 @@ BOOL TypeVarTypeDesc::SatisfiesConstraints(SigTypeContext *pTypeContextOfConstra
 
         if ((specialConstraints & gpDefaultConstructorConstraint) != 0)
         {
-            if (thArg.IsTypeDesc() || (!thArg.AsMethodTable()->HasExplicitOrImplicitPublicDefaultConstructor()))
+            if (thArg.IsTypeDesc()
+                || (!thArg.AsMethodTable()->HasExplicitOrImplicitPublicDefaultConstructor())
+                || thArg.IsAbstract())
                 return FALSE;
         }
 

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericServices.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericServices.cs
@@ -178,7 +178,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
             if ((attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
             {
                 // value types always have default constructors
-                if (!type.IsValueType && (type.GetConstructor(Type.EmptyTypes) == null))
+                if (!type.IsValueType && ((type.GetConstructor(Type.EmptyTypes) == null) || type.IsAbstract))
                 {
                     return false;
                 }

--- a/src/mono/mono/metadata/verify.c
+++ b/src/mono/mono/metadata/verify.c
@@ -24,6 +24,7 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/class-init.h>
+#include <mono/metadata/class-inlines.h>
 #include <mono/metadata/tokentype.h>
 #include <mono/metadata/mono-basic-block.h>
 #include <mono/metadata/attrdefs.h>
@@ -99,7 +100,7 @@ is_valid_generic_instantiation (MonoGenericContainer *gc, MonoGenericContext *co
 		if ((param_info->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) && m_class_is_valuetype (paramClass))
 			return FALSE;
 
-		if ((param_info->flags & GENERIC_PARAMETER_ATTRIBUTE_CONSTRUCTOR_CONSTRAINT) && !m_class_is_valuetype (paramClass) && !mono_class_has_default_constructor (paramClass, TRUE))
+		if ((param_info->flags & GENERIC_PARAMETER_ATTRIBUTE_CONSTRUCTOR_CONSTRAINT) && !m_class_is_valuetype (paramClass) && (!mono_class_has_default_constructor (paramClass, TRUE) || mono_class_is_abstract (paramClass)))
 			return FALSE;
 
 		if (!param_info->constraints)


### PR DESCRIPTION
Original PR is #101963.

This PR aims to experiment with fixing the loophole where `MakeGenericType()` does not fail when attempting to create an object from an abstract class, and thus resulting in incorrect behavior.