### PR TITLE
MemoryCache - Remove unhandled exception handler

### DIFF
--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -39,7 +39,6 @@ namespace System.Runtime.Caching
         private bool _useMemoryCacheManager = true;
         private bool _throwOnDisposed;
         private EventHandler _onAppDomainUnload;
-        private UnhandledExceptionEventHandler _onUnhandledException;
 #if NET
         [UnsupportedOSPlatformGuard("browser")]
         private static bool _countersSupported => !OperatingSystem.IsBrowser();
@@ -219,9 +218,6 @@ namespace System.Runtime.Caching
                 EventHandler onAppDomainUnload = new EventHandler(OnAppDomainUnload);
                 appDomain.DomainUnload += onAppDomainUnload;
                 _onAppDomainUnload = onAppDomainUnload;
-                UnhandledExceptionEventHandler onUnhandledException = new UnhandledExceptionEventHandler(OnUnhandledException);
-                appDomain.UnhandledException += onUnhandledException;
-                _onUnhandledException = onUnhandledException;
                 dispose = false;
             }
             finally
@@ -236,16 +232,6 @@ namespace System.Runtime.Caching
         private void OnAppDomainUnload(object unusedObject, EventArgs unusedEventArgs)
         {
             Dispose();
-        }
-
-        private void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
-        {
-            // if the CLR is terminating, dispose the cache.
-            // This will dispose the perf counters
-            if (eventArgs.IsTerminating)
-            {
-                Dispose();
-            }
         }
 
         private static void ValidatePolicy(CacheItemPolicy policy)
@@ -499,10 +485,6 @@ namespace System.Runtime.Caching
             if (_onAppDomainUnload != null)
             {
                 appDomain.DomainUnload -= _onAppDomainUnload;
-            }
-            if (_onUnhandledException != null)
-            {
-                appDomain.UnhandledException -= _onUnhandledException;
             }
         }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -40,7 +40,6 @@ namespace System.Runtime.Caching
         private bool _throwOnDisposed;
         private EventHandler _onAppDomainUnload;
         private UnhandledExceptionEventHandler _onUnhandledException;
-        private int _inUnhandledExceptionHandler;
 #if NET
         [UnsupportedOSPlatformGuard("browser")]
         private static bool _countersSupported => !OperatingSystem.IsBrowser();
@@ -239,19 +238,14 @@ namespace System.Runtime.Caching
             Dispose();
         }
 
-        internal bool InUnhandledExceptionHandler => _inUnhandledExceptionHandler > 0;
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
         {
-            Interlocked.Increment(ref _inUnhandledExceptionHandler);
-
             // if the CLR is terminating, dispose the cache.
             // This will dispose the perf counters
             if (eventArgs.IsTerminating)
             {
                 Dispose();
             }
-
-            Interlocked.Decrement(ref _inUnhandledExceptionHandler);
         }
 
         private static void ValidatePolicy(CacheItemPolicy policy)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -38,7 +38,6 @@ namespace System.Runtime.Caching
         private readonly bool _configLess;
         private bool _useMemoryCacheManager = true;
         private bool _throwOnDisposed;
-        private EventHandler _onAppDomainUnload;
 #if NET
         [UnsupportedOSPlatformGuard("browser")]
         private static bool _countersSupported => !OperatingSystem.IsBrowser();
@@ -214,10 +213,6 @@ namespace System.Runtime.Caching
                     _storeRefs[i] = new GCHandleRef<MemoryCacheStore>(new MemoryCacheStore(this, _perfCounters));
                 }
                 _stats = new MemoryCacheStatistics(this, config);
-                AppDomain appDomain = Thread.GetDomain();
-                EventHandler onAppDomainUnload = new EventHandler(OnAppDomainUnload);
-                appDomain.DomainUnload += onAppDomainUnload;
-                _onAppDomainUnload = onAppDomainUnload;
                 dispose = false;
             }
             finally
@@ -227,11 +222,6 @@ namespace System.Runtime.Caching
                     Dispose();
                 }
             }
-        }
-
-        private void OnAppDomainUnload(object unusedObject, EventArgs unusedEventArgs)
-        {
-            Dispose();
         }
 
         private static void ValidatePolicy(CacheItemPolicy policy)
@@ -457,8 +447,6 @@ namespace System.Runtime.Caching
         {
             if (Interlocked.Exchange(ref _disposed, 1) == 0)
             {
-                // unhook domain events
-                DisposeSafeCritical();
                 // stats must be disposed prior to disposing the stores.
                 _stats?.Dispose();
                 if (_storeRefs != null)
@@ -476,15 +464,6 @@ namespace System.Runtime.Caching
                     }
                 }
                 GC.SuppressFinalize(this);
-            }
-        }
-
-        private void DisposeSafeCritical()
-        {
-            AppDomain appDomain = Thread.GetDomain();
-            if (_onAppDomainUnload != null)
-            {
-                appDomain.DomainUnload -= _onAppDomainUnload;
             }
         }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
@@ -340,19 +340,8 @@ namespace System.Runtime.Caching
                     GCHandleRef<Timer> timerHandleRef = _timerHandleRef;
                     if (timerHandleRef != null && Interlocked.CompareExchange(ref _timerHandleRef, null, timerHandleRef) == timerHandleRef)
                     {
-                        // If inside an unhandled exception handler, Timers may be succeptible to deadlocks. Use a safer approach.
-                        if (_memoryCache.InUnhandledExceptionHandler)
-                        {
-                            // This does not stop/dispose the timer. But the callback on the timer is protected by _disposed, which we have already
-                            // set above.
-                            timerHandleRef.FreeHandle();
-                            Dbg.Trace("MemoryCacheStats", "Freed CacheMemoryTimers");
-                        }
-                        else
-                        {
-                            timerHandleRef.Dispose();
-                            Dbg.Trace("MemoryCacheStats", "Stopped CacheMemoryTimers");
-                        }
+                        timerHandleRef.Dispose();
+                        Dbg.Trace("MemoryCacheStats", "Stopped CacheMemoryTimers");
                     }
                 }
                 while (_inCacheManagerThread != 0)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/SRef.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/SRef.cs
@@ -59,11 +59,6 @@ namespace System.Runtime.Caching
         public void Dispose()
         {
             Target.Dispose();
-            FreeHandle();
-        }
-
-        internal void FreeHandle()
-        {
             // Safe to call Dispose more than once but not thread-safe
             if (_handle.IsAllocated)
             {


### PR DESCRIPTION
Re-fixes #64115 in a different way from the previous fix.

The locks causing deadlock here are not known to MemoryCache at all. They exist in Timer and ThreadPool components. But the unhandled exception handler in MemoryCache doesn't do anything other than dispose the stats timer in .Net Core. (In NetFx, the deadlock risk wasn't the same, and the unhandled exception handler also had to clean up perf counters that could live beyond the process lifetime.) So this exception handler isn't really needed anymore.