### PR TITLE
Don't use ZR as target in LSE atomics

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3880,7 +3880,7 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
 
         // These instructions change semantics when targetReg is ZR (the memory ordering becomes weaker).
         // See atomicBarrierDroppedOnZero in LLVM
-        assert((targetReg == REG_NA) || (targetReg == REG_ZR));
+        assert((targetReg != REG_NA) && (targetReg != REG_ZR));
 
         switch (treeNode->gtOper)
         {

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3878,19 +3878,21 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
     {
         assert(!data->isContainedIntOrIImmed());
 
+        // These instructions change semantics when targetReg is ZR (the memory ordering becomes weaker).
+        // See atomicBarrierDroppedOnZero in LLVM
+        assert((targetReg == REG_NA) || (targetReg == REG_ZR));
+
         switch (treeNode->gtOper)
         {
             case GT_XORR:
-                GetEmitter()->emitIns_R_R_R(INS_ldsetal, dataSize, dataReg, (targetReg == REG_NA) ? REG_ZR : targetReg,
-                                            addrReg);
+                GetEmitter()->emitIns_R_R_R(INS_ldsetal, dataSize, dataReg, targetReg, addrReg);
                 break;
             case GT_XAND:
             {
                 // Grab a temp reg to perform `MVN` for dataReg first.
                 regNumber tempReg = internalRegisters.GetSingle(treeNode);
                 GetEmitter()->emitIns_R_R(INS_mvn, dataSize, tempReg, dataReg);
-                GetEmitter()->emitIns_R_R_R(INS_ldclral, dataSize, tempReg, (targetReg == REG_NA) ? REG_ZR : targetReg,
-                                            addrReg);
+                GetEmitter()->emitIns_R_R_R(INS_ldclral, dataSize, tempReg, targetReg, addrReg);
                 break;
             }
             case GT_XCHG:
@@ -3908,8 +3910,7 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
                 break;
             }
             case GT_XADD:
-                GetEmitter()->emitIns_R_R_R(INS_ldaddal, dataSize, dataReg, (targetReg == REG_NA) ? REG_ZR : targetReg,
-                                            addrReg);
+                GetEmitter()->emitIns_R_R_R(INS_ldaddal, dataSize, dataReg, targetReg, addrReg);
                 break;
             default:
                 assert(!"Unexpected treeNode->gtOper");

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1086,11 +1086,19 @@ int LinearScan::BuildNode(GenTree* tree)
                     }
                     setInternalRegsDelayFree = true;
                 }
+                buildInternalRegisterUses();
+                if (dstCount == 1)
+                {
+                    BuildDef(tree);
+                }
             }
-            buildInternalRegisterUses();
-            if (dstCount == 1)
+            else
             {
-                BuildDef(tree);
+                buildInternalRegisterUses();
+                // We can't use ZR as the target reg since it may change the
+                // semantics for some LSE instructions.
+                // See atomicBarrierDroppedOnZero in LLVM
+                BuildDef(tree, availableIntRegs & ~(SRBM_ZR));
             }
         }
         break;

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1094,10 +1094,9 @@ int LinearScan::BuildNode(GenTree* tree)
             }
             else
             {
+                // We always need the target reg for LSE, even if
+                // return value is unused, see genLockedInstructions
                 buildInternalRegisterUses();
-                // We can't use ZR as the target reg since it may change the
-                // semantics for some LSE instructions.
-                // See atomicBarrierDroppedOnZero in LLVM
                 BuildDef(tree);
             }
         }

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1098,7 +1098,7 @@ int LinearScan::BuildNode(GenTree* tree)
                 // We can't use ZR as the target reg since it may change the
                 // semantics for some LSE instructions.
                 // See atomicBarrierDroppedOnZero in LLVM
-                BuildDef(tree, availableIntRegs & ~(SRBM_ZR));
+                BuildDef(tree);
             }
         }
         break;


### PR DESCRIPTION
Addresses @AndyAyersMS's concerns in https://github.com/dotnet/runtime/issues/105441#issuecomment-2264302110

TL;DR - some instructions relax their semantics when ZR register is used as target. LLVM avoids that via `atomicBarrierDroppedOnZero` and `atomicBarrierDroppedOnZero`