### PR TITLE
Refactor GetConnectionString method and add missing key test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>The connection string.</returns>
         public static string? GetConnectionString(this IConfiguration configuration, string name)
         {
-            return configuration?.GetSection("ConnectionStrings")[name];
+            return GetRequiredSection(configuration, "ConnectionStrings")[name];
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationManagerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationManagerTest.cs
@@ -746,11 +746,32 @@ namespace Microsoft.Extensions.Configuration.Test
             var memVal1 = config.GetConnectionString("DB1:Connection1");
             var memVal2 = config.GetConnectionString("DB1:Connection2");
             var memVal3 = config.GetConnectionString("DB2:Connection");
+            var nonExistingValue = config.GetConnectionString("DB2:NonExistingKey");
 
             // Assert
             Assert.Equal("MemVal1", memVal1);
             Assert.Equal("MemVal2", memVal2);
             Assert.Equal("MemVal3", memVal3);
+            Assert.Null(nonExistingValue);
+        }
+
+        [Fact]
+        public void GetConnectionStringMissingThrowException()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Key", "Value"}
+            };
+
+            var config = new ConfigurationManager();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(() => config.GetConnectionString("NonExistingKey"));
+
+            // Assert
+            Assert.Equal("Section 'ConnectionStrings' not found in configuration.", exception.Message);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.Configuration.Test
                 Configuration = configurationRoot,
                 ShouldDisposeConfiguration = false,
             };
-            
+
             var chainedConfiguration = new ChainedConfigurationProvider(chainedConfigurationSource);
             IEnumerable<string> childKeys = chainedConfiguration.GetChildKeys(new string[0], null);
             Assert.Equal(1000, childKeys.Count());
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Configuration.Test
                 Configuration = configurationRoot,
                 ShouldDisposeConfiguration = false,
             };
-            
+
             var chainedConfiguration = new ChainedConfigurationProvider(chainedConfigurationSource);
             IEnumerable<string> childKeys = chainedConfiguration.GetChildKeys(new string[0], null);
             Assert.Equal(1000, childKeys.Count());
@@ -507,11 +507,32 @@ namespace Microsoft.Extensions.Configuration.Test
             var memVal1 = config.GetConnectionString("DB1:Connection1");
             var memVal2 = config.GetConnectionString("DB1:Connection2");
             var memVal3 = config.GetConnectionString("DB2:Connection");
+            var nonExistingValue = config.GetConnectionString("DB2:NonExistingKey");
 
             // Assert
             Assert.Equal("MemVal1", memVal1);
             Assert.Equal("MemVal2", memVal2);
             Assert.Equal("MemVal3", memVal3);
+            Assert.Null(nonExistingValue);
+        }
+
+        [Fact]
+        public void GetConnectionStringMissingThrowException()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Key", "Value"}
+            };
+
+            var config = new ConfigurationManager();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(() => config.GetConnectionString("NonExistingKey"));
+
+            // Assert
+            Assert.Equal("Section 'ConnectionStrings' not found in configuration.", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
This pull request includes the following changes:

- Refactored the GetConnectionString method to use the GetRequiredSection method for improved reliability and error handling.

- Added a test for the GetConnectionString method with a missing key to ensure that it throws the correct exception when the key is not found in the configuration.

These changes enhance the functionality and robustness of the codebase.

### Existing Behavior
Throws hard to identify exception if "ConnectionStrings" key is not there in configuration.
```C#
System.NullReferenceException : Object reference not set to an instance of an object.

at Microsoft.Extensions.Configuration.ConfigurationExtensions.GetConnectionString(IConfiguration configuration, String name)
```
