### PR TITLE
[wasm] Do not expect that promise won't get resolved faster than we start awaiting in  `JsImportResolvedPromiseReturnsCompletedTask` test

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -1151,11 +1151,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public async Task JsImportResolvedPromiseReturnsCompletedTask()
         {
-            var promise = JavaScriptTestHelper.ReturnResolvedPromise();
-#if !FEATURE_WASM_MANAGED_THREADS
-            Assert.False(promise.IsCompleted);
-#endif
-            await promise;
+            var promise = await JavaScriptTestHelper.ReturnResolvedPromise();
             Assert.True(promise.IsCompleted);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105861.

Even in ST we are not able to avoid racing, we should remove the check to avoid random failures.