### PR TITLE
Do not emit unsupported thunks for delegates with `allows ref struct` generics

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/DelegateInfo.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/DelegateInfo.cs
@@ -134,77 +134,77 @@ namespace Internal.IL
             _closedStaticThunk = new DelegateInvokeClosedStaticThunk(owningDelegate);
             _closedInstanceOverGeneric = new DelegateInvokeInstanceClosedOverGenericMethodThunk(owningDelegate);
 
-            // Methods that have a byref-like type in the signature cannot be invoked with the object array thunk.
-            // We would need to box the parameter and these can't be boxed.
-            // Neither can be methods that have pointers in the signature.
             MethodSignature delegateSignature = owningDelegate.Signature;
-            bool generateObjectArrayThunk = true;
-            for (int i = 0; i < delegateSignature.Length; i++)
-            {
-                TypeDesc paramType = delegateSignature[i];
-                if (paramType.IsByRef)
-                    paramType = ((ByRefType)paramType).ParameterType;
-                if (!paramType.IsSignatureVariable && paramType.IsByRefLike)
-                {
-                    generateObjectArrayThunk = false;
-                    break;
-                }
-                if (paramType.IsPointer || paramType.IsFunctionPointer)
-                {
-                    generateObjectArrayThunk = false;
-                    break;
-                }
-            }
-            TypeDesc returnType = delegateSignature.ReturnType;
-            if (returnType.IsByRef)
-                generateObjectArrayThunk = false;
-            if (!returnType.IsSignatureVariable && returnType.IsByRefLike)
-                generateObjectArrayThunk = false;
-            if (returnType.IsPointer || returnType.IsFunctionPointer)
-                generateObjectArrayThunk = false;
 
-            if ((owningDelegate.SupportedFeatures & DelegateFeature.ObjectArrayThunk) != 0 && generateObjectArrayThunk)
+            //
+            // Check whether we have an object array thunk
+            //
+            if ((owningDelegate.SupportedFeatures & DelegateFeature.ObjectArrayThunk) != 0
+                && SignatureSupportsObjectArrayThunk(delegateSignature))
+            {
                 _invokeObjectArrayThunk = new DelegateInvokeObjectArrayThunk(owningDelegate);
+            }
 
             //
             // Check whether we have an open instance thunk
             //
-
-            if ((owningDelegate.SupportedFeatures & DelegateFeature.OpenInstanceThunk) != 0 && delegateSignature.Length > 0)
+            if ((owningDelegate.SupportedFeatures & DelegateFeature.OpenInstanceThunk) != 0
+                && delegateSignature.Length > 0
+                && SignatureSupportsOpenInstanceThunks(delegateSignature))
             {
-                TypeDesc firstParam = delegateSignature[0];
-
-                bool generateOpenInstanceMethod;
-
-                switch (firstParam.Category)
-                {
-                    case TypeFlags.Pointer:
-                    case TypeFlags.FunctionPointer:
-                        generateOpenInstanceMethod = false;
-                        break;
-
-                    case TypeFlags.ByRef:
-                        firstParam = ((ByRefType)firstParam).ParameterType;
-                        generateOpenInstanceMethod = firstParam.IsSignatureVariable || firstParam.IsValueType;
-                        break;
-
-                    case TypeFlags.Array:
-                    case TypeFlags.SzArray:
-                    case TypeFlags.SignatureTypeVariable:
-                        generateOpenInstanceMethod = true;
-                        break;
-
-                    default:
-                        Debug.Assert(firstParam.IsDefType);
-                        generateOpenInstanceMethod = !firstParam.IsValueType;
-                        break;
-                }
-
-                if (generateOpenInstanceMethod)
-                {
-                    _openInstanceThunk = new DelegateInvokeOpenInstanceThunk(owningDelegate);
-                }
+                _openInstanceThunk = new DelegateInvokeOpenInstanceThunk(owningDelegate);
             }
+        }
+
+        public bool SignatureSupportsOpenInstanceThunks(MethodSignature signature)
+        {
+            TypeDesc firstParam = signature[0];
+
+            switch (firstParam.Category)
+            {
+                case TypeFlags.Pointer:
+                case TypeFlags.FunctionPointer:
+                    return false;
+
+                case TypeFlags.ByRef:
+                    firstParam = ((ByRefType)firstParam).ParameterType;
+                    return firstParam.IsSignatureVariable || firstParam.IsValueType;
+
+                case TypeFlags.Array:
+                case TypeFlags.SzArray:
+                case TypeFlags.SignatureTypeVariable:
+                    return true;
+
+                default:
+                    Debug.Assert(firstParam.IsDefType);
+                    return !firstParam.IsValueType;
+            }
+        }
+
+        public bool SignatureSupportsObjectArrayThunk(MethodSignature signature)
+        {
+            // Methods that have a byref-like type in the signature cannot be invoked with the object array thunk.
+            // We would need to box the parameter and these can't be boxed.
+            // Neither can be methods that have pointers in the signature.
+            for (int i = 0; i < signature.Length; i++)
+            {
+                TypeDesc paramType = signature[i];
+                if (paramType.IsByRef)
+                    paramType = ((ByRefType)paramType).ParameterType;
+                if (!paramType.IsSignatureVariable && paramType.IsByRefLike)
+                    return false;
+                if (paramType.IsPointer || paramType.IsFunctionPointer)
+                    return false;
+            }
+            TypeDesc returnType = signature.ReturnType;
+            if (returnType.IsByRef)
+                return false;
+            if (!returnType.IsSignatureVariable && returnType.IsByRefLike)
+                return false;
+            if (returnType.IsPointer || returnType.IsFunctionPointer)
+                return false;
+
+            return true;
         }
 
         public MethodDesc this[DelegateThunkKind kind]

--- a/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
@@ -330,7 +330,15 @@ namespace Internal.IL
                         return methodIL;
                 }
 
-                var methodDefinitionIL = GetMethodIL(method.GetTypicalMethodDefinition());
+                MethodDesc typicalMethod = method.GetTypicalMethodDefinition();
+                if (typicalMethod is SpecializableILStubMethod specializableMethod)
+                {
+                    MethodIL methodIL = specializableMethod.EmitIL(method);
+                    if (methodIL != null)
+                        return methodIL;
+                }
+
+                var methodDefinitionIL = GetMethodIL(typicalMethod);
                 if (methodDefinitionIL == null)
                     return null;
                 return new InstantiatedMethodIL(method, methodDefinitionIL);

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -829,4 +829,14 @@ namespace Internal.IL.Stubs
             return false;
         }
     }
+
+    public abstract partial class SpecializableILStubMethod : ILStubMethod
+    {
+        public abstract MethodIL EmitIL(MethodDesc specializedMethod);
+
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+        {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #105029

I looked into redoing delegate thunk management to be per instance but that would be an unnecessarily big diff. Instead adding a facility to allow `ILStubMethodIL` specialize per-instance if needed and in this specialization generate a throwing method body (that should be unreachable at runtime).

Cc @dotnet/ilc-contrib 