### PR TITLE
[mono] Fail on LLVM version mismatch and add instructions for updating

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -604,6 +604,11 @@ if(LLVM_PREFIX)
   file(STRINGS ${llvm_config_path} llvm_api_version_line REGEX "MONO_API_VERSION ")
   string(REGEX REPLACE ".*MONO_API_VERSION ([0-9]+)" "\\1" llvm_api_version ${llvm_api_version_line})
 
+  # IMPORTANT: when bumping LLVM make sure to rerun the llvm-config commands below and update the variables accordingly
+  if (NOT ${llvm_api_version} EQUAL 1900)
+    message(FATAL_ERROR "Unexpected LLVM version: ${llvm_api_version}.")
+  endif()
+
   # llvm-config --libs analysis core bitwriter mcjit orcjit
   set(MONO_llvm_core_libs "LLVMOrcJIT" "LLVMPasses" "LLVMIRPrinter" "LLVMHipStdPar" "LLVMCoroutines" "LLVMipo" "LLVMInstrumentation" "LLVMVectorize" "LLVMLinker" "LLVMFrontendOpenMP" "LLVMFrontendOffloading" "LLVMCodeGen" "LLVMScalarOpts" "LLVMInstCombine" "LLVMObjCARCOpts" "LLVMCodeGenTypes" "LLVMCFGuard" "LLVMAggressiveInstCombine" "LLVMTransformUtils" "LLVMWindowsDriver" "LLVMJITLink" "LLVMOption" "LLVMMCJIT" "LLVMExecutionEngine" "LLVMTarget" "LLVMRuntimeDyld" "LLVMOrcTargetProcess" "LLVMOrcShared" "LLVMBitWriter" "LLVMAnalysis" "LLVMProfileData" "LLVMSymbolize" "LLVMDebugInfoBTF" "LLVMDebugInfoPDB" "LLVMDebugInfoMSF" "LLVMDebugInfoDWARF" "LLVMObject" "LLVMTextAPI" "LLVMMCParser" "LLVMIRReader" "LLVMAsmParser" "LLVMMC" "LLVMDebugInfoCodeView" "LLVMBitReader" "LLVMCore" "LLVMRemarks" "LLVMBitstreamReader" "LLVMBinaryFormat" "LLVMTargetParser" "LLVMSupport" "LLVMDemangle")
 
@@ -616,24 +621,16 @@ if(LLVM_PREFIX)
   # llvm-config --libs aarch64codegen
   set(MONO_llvm_extra_libs_aarch64codegen "LLVMAArch64CodeGen" "LLVMGlobalISel" "LLVMSelectionDAG" "LLVMCFGuard" "LLVMAsmPrinter" "LLVMCodeGen" "LLVMTarget" "LLVMScalarOpts" "LLVMInstCombine" "LLVMAggressiveInstCombine" "LLVMObjCARCOpts" "LLVMTransformUtils" "LLVMBitWriter" "LLVMAnalysis" "LLVMProfileData" "LLVMSymbolize" "LLVMDebugInfoBTF" "LLVMDebugInfoPDB" "LLVMDebugInfoMSF" "LLVMDebugInfoDWARF" "LLVMObject" "LLVMTextAPI" "LLVMMCParser" "LLVMIRReader" "LLVMAsmParser" "LLVMBitReader" "LLVMAArch64Desc" "LLVMCodeGenTypes" "LLVMAArch64Utils" "LLVMCore" "LLVMRemarks" "LLVMBitstreamReader" "LLVMAArch64Info" "LLVMMC" "LLVMDebugInfoCodeView" "LLVMBinaryFormat" "LLVMTargetParser" "LLVMSupport" "LLVMDemangle")
 
-  if(HOST_LINUX AND NOT HOST_WASM AND NOT HOST_WASI AND ${llvm_api_version} GREATER_EQUAL 1600)
+  if(HOST_LINUX AND NOT HOST_WASM AND NOT HOST_WASI)
     set(MONO_stdlib "-nostdinc++ -nostdlib++")
     set(MONO_cxx_lib "-L${LLVM_PREFIX}/lib -lc++ -lc++abi")
     set(MONO_cxx_include "-isystem ${LLVM_PREFIX}/include/c++/v1")
   endif()
 
-  if(${llvm_api_version} GREATER_EQUAL 1600)
-    if(HOST_WIN32)
-      set(MONO_cxx_std_version "/std:c++17")
-    else()
-      set(MONO_cxx_std_version "-std=c++17")
-    endif()
+  if(HOST_WIN32)
+    set(MONO_cxx_std_version "/std:c++17")
   else()
-    if(HOST_WIN32)
-      set(MONO_cxx_std_version "/std:c++14")
-    else()
-      set(MONO_cxx_std_version "-std=c++14")
-    endif()
+    set(MONO_cxx_std_version "-std=c++17")
   endif()
 
   # llvm-config --cflags
@@ -671,10 +668,6 @@ if(LLVM_PREFIX)
   set(llvm_libs ${llvm_core_libs} ${llvm_extra})
   list(TRANSFORM llvm_libs PREPEND "${LLVM_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}")
   list(TRANSFORM llvm_libs APPEND "${CMAKE_STATIC_LIBRARY_SUFFIX}")
-
-  if (${llvm_api_version} LESS 1100)
-    message(FATAL_ERROR "LLVM version too old.")
-  endif()
 
   set(ENABLE_LLVM 1)
   set(ENABLE_LLVM_RUNTIME 1)


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/105110.