### PR TITLE
Consider methods returning constants same as substitutions

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -663,7 +663,7 @@ namespace ILCompiler
         {
             method = method.GetTypicalMethodDefinition();
 
-            TypeFlags returnType = method.Signature.ReturnType.Category;
+            TypeFlags returnType = method.Signature.ReturnType.UnderlyingType.Category;
             if (returnType is < TypeFlags.Boolean or > TypeFlags.UInt32
                 || method.IsIntrinsic
                 || _nestedILProvider.GetMethodIL(method) is not MethodIL methodIL)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -659,6 +659,41 @@ namespace ILCompiler
             return new SubstitutedMethodIL(method.GetMethodILDefinition(), newBody, newEHRegions.ToArray(), debugInfo, newStrings.ToArray());
         }
 
+        private bool TryGetMethodConstantValue(MethodDesc method, out int constant)
+        {
+            method = method.GetTypicalMethodDefinition();
+
+            TypeFlags returnType = method.Signature.ReturnType.Category;
+            if (returnType is < TypeFlags.Boolean or > TypeFlags.UInt32
+                || method.IsIntrinsic
+                || _nestedILProvider.GetMethodIL(method) is not MethodIL methodIL)
+            {
+                constant = 0;
+                return false;
+            }
+
+            var reader = new ILReader(methodIL.GetILBytes());
+            var opcode = reader.ReadILOpcode();
+            switch (opcode)
+            {
+                case ILOpcode.ldc_i4: constant = (int)reader.ReadILUInt32(); break;
+                case ILOpcode.ldc_i4_s: constant = (sbyte)reader.ReadILByte(); break;
+                case >= ILOpcode.ldc_i4_0 and <= ILOpcode.ldc_i4_8: constant = opcode - ILOpcode.ldc_i4_0; break;
+                case ILOpcode.ldc_i4_m1: constant = -1; break;
+                default:
+                    constant = 0;
+                    return false;
+            }
+
+            if (reader.ReadILOpcode() != ILOpcode.ret)
+            {
+                constant = 0;
+                return false;
+            }
+
+            return true;
+        }
+
         private bool TryGetConstantArgument(MethodIL methodIL, byte[] body, OpcodeFlags[] flags, int offset, int argIndex, out int constant)
         {
             if ((flags[offset] & OpcodeFlags.BasicBlockStart) != 0)
@@ -684,6 +719,11 @@ namespace ILCompiler
                             && (opcode != ILOpcode.callvirt || !method.IsVirtual))
                         {
                             constant = (int)substitution.Value;
+                            return true;
+                        }
+                        if ((opcode != ILOpcode.callvirt || !method.IsVirtual)
+                            && TryGetMethodConstantValue(method, out constant))
+                        {
                             return true;
                         }
                         else if (method.IsIntrinsic && method.Name is "get_IsValueType" or "get_IsEnum"

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -18,38 +18,17 @@ using MethodDebugInformation = Internal.IL.MethodDebugInformation;
 
 namespace ILCompiler
 {
-    public class SubstitutedILProviderBase : ILProvider
+    public class SubstitutedILProvider : ILProvider
     {
-        protected readonly ILProvider _nestedILProvider;
-        protected readonly SubstitutionProvider _substitutionProvider;
-        public SubstitutedILProviderBase(ILProvider nestedILProvider, SubstitutionProvider substitutionProvider)
+        private readonly ILProvider _nestedILProvider;
+        private readonly SubstitutionProvider _substitutionProvider;
+        private readonly DevirtualizationManager _devirtualizationManager;
+
+        public SubstitutedILProvider(ILProvider nestedILProvider, SubstitutionProvider substitutionProvider, DevirtualizationManager devirtualizationManager)
         {
             _nestedILProvider = nestedILProvider;
             _substitutionProvider = substitutionProvider;
-        }
-
-        public override MethodIL GetMethodIL(MethodDesc method)
-        {
-            BodySubstitution substitution = _substitutionProvider.GetSubstitution(method);
-            if (substitution != null)
-            {
-                return substitution.EmitIL(method);
-            }
-
-            return _nestedILProvider.GetMethodIL(method);
-        }
-    }
-
-    public class SubstitutedILProvider : SubstitutedILProviderBase
-    {
-        private readonly DevirtualizationManager _devirtualizationManager;
-        private readonly SubstitutedILProviderBase _nested;
-
-        public SubstitutedILProvider(ILProvider nestedILProvider, SubstitutionProvider substitutionProvider, DevirtualizationManager devirtualizationManager)
-            : base(nestedILProvider, substitutionProvider)
-        {
             _devirtualizationManager = devirtualizationManager;
-            _nested = new SubstitutedILProviderBase(nestedILProvider, substitutionProvider);
         }
 
         public override MethodIL GetMethodIL(MethodDesc method)
@@ -691,13 +670,6 @@ namespace ILCompiler
             {
                 constant = 0;
                 return false;
-            }
-
-            if (!method.HasInstantiation && !method.OwningType.HasInstantiation
-                && method.Signature.Length == 0
-                && TypePreinit.TryGetConstant(_nested, method, out constant))
-            {
-                return true;
             }
 
             var reader = new ILReader(methodIL.GetILBytes());

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -666,6 +666,7 @@ namespace ILCompiler
             TypeFlags returnType = method.Signature.ReturnType.UnderlyingType.Category;
             if (returnType is < TypeFlags.Boolean or > TypeFlags.UInt32
                 || method.IsIntrinsic
+                || method.IsNoInlining
                 || _nestedILProvider.GetMethodIL(method) is not MethodIL methodIL)
             {
                 constant = 0;

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -381,7 +381,7 @@ namespace ILCompiler
             ILProvider unsubstitutedILProvider = ilProvider;
             ilProvider = new SubstitutedILProvider(ilProvider, substitutionProvider, new DevirtualizationManager());
 
-            CompilerGeneratedState compilerGeneratedState = new CompilerGeneratedState(ilProvider, logger);
+            CompilerGeneratedState compilerGeneratedState = new CompilerGeneratedState(unsubstitutedILProvider, logger);
 
             var stackTracePolicy = Get(_command.EmitStackTraceData) ?
                 (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -18,6 +18,7 @@ class DeadCodeElimination
         TestAbstractNeverDerivedWithDevirtualizedCall.Run();
         TestAbstractDerivedByUnrelatedTypeWithDevirtualizedCall.Run();
         TestUnusedDefaultInterfaceMethod.Run();
+        TestInlinedDeadBranchElimination.Run();
         TestArrayElementTypeOperations.Run();
         TestStaticVirtualMethodOptimizations.Run();
         TestTypeEquals.Run();
@@ -248,6 +249,37 @@ class DeadCodeElimination
             s_instance.DoSomething();
 
             ThrowIfPresent(typeof(TestUnusedDefaultInterfaceMethod), nameof(NeverReferenced));
+        }
+    }
+
+    class TestInlinedDeadBranchElimination
+    {
+        static int GetIntConstant() => 42;
+        static int GetIntConstantWrapper() => GetIntConstant();
+
+        class NeverReferenced1 { }
+
+        enum MyEnum { One, Two }
+
+        static MyEnum GetEnumConstant() => MyEnum.Two;
+
+        class NeverReferenced2 { }
+
+        public static void Run()
+        {
+            if (GetIntConstantWrapper() == 1)
+            {
+                Activator.CreateInstance(typeof(NeverReferenced1));
+            }
+
+            ThrowIfPresent(typeof(TestInlinedDeadBranchElimination), nameof(NeverReferenced1));
+
+            if (GetEnumConstant() == MyEnum.One)
+            {
+                Activator.CreateInstance(typeof(NeverReferenced2));
+            }
+
+            ThrowIfPresent(typeof(TestInlinedDeadBranchElimination), nameof(NeverReferenced2));
         }
     }
 


### PR DESCRIPTION
Fixes #105806

Ports a bit of the logic from ILLinker that allows constant propagation across methods ("inlining").

Cc @dotnet/ilc-contrib 