### PR TITLE
Add cross-linking between guidance files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ Ports have a weaker contribution bar, at least initially. A functionally correct
 
 #### Copying Files from Other Projects
 
-The .NET runtime uses some files from other projects, typically where a binary distribution does not exist or would be inconvenient.
+The .NET runtime uses some files from other projects, per [copyright](./docs/project/copyright.md) rules.
 
 The following rules must be followed for PRs that include files from another project:
 

--- a/docs/project/copyright.md
+++ b/docs/project/copyright.md
@@ -16,6 +16,8 @@ We use the following approach for code contributions:
 - We will typically reject the use of product code licensed with [Creative Commons](https://creativecommons.org/) or [public domain licenses](https://en.wikipedia.org/wiki/Public-domain-equivalent_license) given their lack of universal acceptance.
 - The [.NET Foundation Contribution License Agreement (CLA)](https://cla.dotnetfoundation.org) is used to license contributions from contributors.
 
+More mechanical guidance is provided in [CONTRIBUTING.md](../../CONTRIBUTING.md#copying-files-from-other-projects).
+
 References:
 
 - https://opensource.org/faq#cc-zero


### PR DESCRIPTION
In support of https://github.com/dotnet/core/pull/9440