### PR TITLE
ARM64-SVE: Generate FMA uses in the correct order #105723

### DIFF
--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1977,10 +1977,20 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
                 // Nothing needs to be done
             }
 
-            tgtPrefUse = BuildUse(emitOp1);
-            srcCount += 1;
-            srcCount += BuildDelayFreeUses(emitOp2, emitOp1);
-            srcCount += BuildDelayFreeUses(emitOp3, emitOp1);
+            GenTree* ops[] = {intrinEmb.op1, intrinEmb.op2, intrinEmb.op3};
+            for (GenTree* op : ops)
+            {
+                if (op == emitOp1)
+                {
+                    tgtPrefUse = BuildUse(op);
+                    srcCount++;
+                }
+                else if (op == emitOp2 || op == emitOp3)
+                {
+                    srcCount += BuildDelayFreeUses(op, emitOp1);
+                }
+            }
+
             srcCount += BuildDelayFreeUses(intrin.op3, emitOp1);
         }
         else

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+
+public class Runtime_105723
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        if (Sve.IsSupported)
+        {
+            Vector<long> vr2 = Vector128.CreateScalar(-2L).AsVector();
+            var vr3 = new sbyte[]
+            {
+                1
+            };
+            var vr4 = Vector128.CreateScalar(9223372036854775806L).AsVector();
+            Vector<long> vr5 = Sve.MultiplySubtract(vr2, vr2, vr4);
+            Consume(vr5);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Consume(Vector<long> v)
+    {
+        ;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.csproj
@@ -1,12 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestEnvironmentVariable -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
-
-    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105723/Runtime_105723.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
+    <NoWarn>$(NoWarn),SYSLIB5003</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Fixes #105723

Nodes for FMA intrinsics may be switched. But the uses were not being generated in the correct order.
Fix in the same way as https://github.com/dotnet/runtime/pull/103100