### PR TITLE
Fix field offset not being set for 0-offset

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -638,7 +638,7 @@ namespace System.Reflection.Emit
                 Debug.Assert(field._handle == handle);
                 WriteCustomAttributes(field._customAttributes, handle);
 
-                if (field._offset > 0 && (typeBuilder.Attributes & TypeAttributes.ExplicitLayout) != 0)
+                if (field._offset >= 0 && (typeBuilder.Attributes & TypeAttributes.ExplicitLayout) != 0)
                 {
                     AddFieldLayout(handle, field._offset);
                 }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -2740,5 +2740,22 @@ internal class Dummy
                 Assert.Equal(1, result);
             }
         }
+
+        [Fact]
+        public void ExplicitFieldOffsetSavesAndLoads()
+        {
+            PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssemblyForExplicitLayout"), typeof(object).Assembly);
+            ModuleBuilder mob = ab.DefineDynamicModule("MyModule");
+            TypeBuilder tb = mob.DefineType("ExplicitLayoutType", TypeAttributes.ExplicitLayout);
+            FieldBuilder f1 = tb.DefineField("field1", typeof(int), 0);
+            f1.SetOffset(0);
+            tb.CreateType();
+
+            using var stream = new MemoryStream();
+            ab.Save(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var assembly = AssemblyLoadContext.Default.LoadFromStream(stream);
+            var method = assembly.GetType("ExplicitLayoutType")!;
+        }
     }
 }


### PR DESCRIPTION
PersistedAssemblyBuilder didn't write field offset correctly when field offset was 0. This fixes that, and adds a test to ensure the behaviour is working.

Fixes #105795