### PR TITLE
Fix dump generation on background threads

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5336,6 +5336,10 @@ DefaultCatchHandler(PEXCEPTION_POINTERS pExceptionPointers,
     FlushLogging();     // Flush any logging output
     GCPROTECT_END();
 
+#ifdef HOST_WINDOWS
+    CreateCrashDumpIfEnabled();
+#endif
+
 #ifdef _DEBUG
     // Do not care about lock check for unhandled exception.
     while (unbreakableLockCount)


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/103000

PR from main: https://github.com/dotnet/runtime/pull/105830

# Customer Impact

External dev found that dumps were not be generated for unhandled exceptions on background threads. 

# Testing

A simple test case was provided and used to verify this fix.

# Risk

Very low. A couple of lines of code in the termination path for unhandled exceptions. This is Windows only.
