### PR TITLE
Move exposed module object from `DomainAssembly` to `Module`

### DIFF
--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -705,24 +705,10 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
             // We should never get here in the GC case - the above should have succeeded.
             CONSISTENCY_CHECK(!FORBIDGC_LOADER_USE_ENABLED());
 
-            DomainAssembly* pDomainModule = NULL;
-            if (loadFlag == Loader::Load)
-            {
-                pDomainModule = GetModule()->LoadModule(mdLinkRef);
-            }
+            if (loadFlag != Loader::Load)
+                return NULL;
 
-            if (pDomainModule == NULL)
-                RETURN NULL;
-            else
-            {
-                pModule = pDomainModule->GetModule();
-                if (pModule == NULL)
-                {
-                    _ASSERTE(loadFlag!=Loader::Load);
-                }
-
-                RETURN pModule;
-            }
+            return GetModule()->LoadModule(mdLinkRef);
 #endif // DACCESS_COMPILE
         }
 
@@ -849,8 +835,8 @@ Module * Assembly::FindModuleByTypeRef(
 #ifndef DACCESS_COMPILE
             if (loadFlag == Loader::Load)
             {
-                DomainAssembly* pActualDomainAssembly = pModule->LoadModule(tkType);
-                RETURN(pActualDomainAssembly->GetModule());
+                Module* pActualModule = pModule->LoadModule(tkType);
+                RETURN(pActualModule);
             }
             else
             {
@@ -1493,7 +1479,7 @@ MethodDesc* Assembly::GetEntryPoint()
     Module *pModule = NULL;
     switch(TypeFromToken(mdEntry)) {
     case mdtFile:
-        pModule = m_pModule->LoadModule(mdEntry)->GetModule();
+        pModule = m_pModule->LoadModule(mdEntry);
 
         mdEntry = pModule->GetEntryPointToken();
         if ( (TypeFromToken(mdEntry) != mdtMethodDef) ||

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -735,7 +735,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetModules(QCall::AssemblyHandle pAssem
         {
             DomainAssembly * pModule = modules[i];
 
-            OBJECTREF o = pModule->GetExposedModuleObject();
+            OBJECTREF o = pModule->GetModule()->GetExposedObject();
             orModules->SetAt(i, o);
         }
 

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -707,16 +707,16 @@ extern "C" void QCALLTYPE AssemblyNative_GetModules(QCall::AssemblyHandle pAssem
     HENUMInternalHolder phEnum(pAssembly->GetMDImport());
     phEnum.EnumInit(mdtFile, mdTokenNil);
 
-    InlineSArray<DomainAssembly *, 8> modules;
+    InlineSArray<Module *, 8> modules;
 
-    modules.Append(pAssembly);
+    modules.Append(pAssembly->GetModule());
 
     mdFile mdFile;
     while (pAssembly->GetMDImport()->EnumNext(&phEnum, &mdFile))
     {
         if (fLoadIfNotFound)
         {
-            DomainAssembly* pModule = pAssembly->GetModule()->LoadModule(mdFile);
+            Module* pModule = pAssembly->GetModule()->LoadModule(mdFile);
             modules.Append(pModule);
         }
     }
@@ -733,9 +733,9 @@ extern "C" void QCALLTYPE AssemblyNative_GetModules(QCall::AssemblyHandle pAssem
 
         for(COUNT_T i = 0; i < modules.GetCount(); i++)
         {
-            DomainAssembly * pModule = modules[i];
+            Module * pModule = modules[i];
 
-            OBJECTREF o = pModule->GetModule()->GetExposedObject();
+            OBJECTREF o = pModule->GetExposedObject();
             orModules->SetAt(i, o);
         }
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -342,7 +342,7 @@ Module::Module(Assembly *pAssembly, PEAssembly *pPEAssembly)
     }
     CONTRACTL_END
 
-    PREFIX_ASSUME(pAssembly != NULL);
+    PREFIX_ASSUME(m_pAssembly != NULL);
 
     m_loaderAllocator = NULL;
     m_pDynamicMetadata = (TADDR)NULL;

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2472,6 +2472,9 @@ Module *Module::GetModuleIfLoaded(mdFile kFile)
 
     ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
 
+    if (kFile == mdFileNil)
+        return this;
+
     // Handle the module ref case
     if (TypeFromToken(kFile) == mdtModuleRef)
     {
@@ -2484,19 +2487,14 @@ Module *Module::GetModuleIfLoaded(mdFile kFile)
         RETURN GetAssembly()->GetModule()->GetModuleIfLoaded(mdFileNil);
     }
 
-    if (kFile == mdFileNil)
-    {
-        return this;
-    }
-
     RETURN NULL;
 }
 
 #ifndef DACCESS_COMPILE
 
-DomainAssembly *ModuleBase::LoadModule(mdFile kFile)
+Module *ModuleBase::LoadModule(mdFile kFile)
 {
-    CONTRACT(DomainAssembly *)
+    CONTRACT(Module *)
     {
         INSTANCE_CHECK;
         THROWS;

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -547,7 +547,7 @@ public:
     virtual PTR_Module LookupModule(mdToken kFile) { return NULL; }; //wrapper over GetModuleIfLoaded, takes modulerefs as well
     virtual Module *GetModuleIfLoaded(mdFile kFile) { return NULL; };
 #ifndef DACCESS_COMPILE
-    virtual DomainAssembly *LoadModule(mdFile kFile);
+    virtual Module *LoadModule(mdFile kFile);
 #endif
     DWORD GetAssemblyRefFlags(mdAssemblyRef tkAssemblyRef);
 

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -897,6 +897,7 @@ protected:
     void SetDomainAssembly(DomainAssembly *pDomainAssembly);
 
     OBJECTREF GetExposedObject();
+    OBJECTREF GetExposedObjectIfExists();
 
     ClassLoader *GetClassLoader();
 #ifdef FEATURE_CODE_VERSIONING
@@ -1600,6 +1601,8 @@ private:
     // is not called for each fixup
 
     PTR_Assembly           *m_NativeMetadataAssemblyRefMap;
+
+    LOADERHANDLE m_hExposedObject;
 
     // Buffer of Metadata storage for dynamic modules. May be NULL. This provides a reasonable way for
     // the debugger to get metadata of dynamic modules from out of process.

--- a/src/coreclr/vm/domainassembly.h
+++ b/src/coreclr/vm/domainassembly.h
@@ -112,17 +112,6 @@ public:
     // Returns NULL if the managed scout was already collected (see code:LoaderAllocator#AssemblyPhases).
     OBJECTREF GetExposedAssemblyObject();
 
-    OBJECTREF GetExposedModuleObjectIfExists()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        OBJECTREF objRet = NULL;
-        GET_LOADERHANDLE_VALUE_FAST(GetLoaderAllocator(), m_hExposedModuleObject, &objRet);
-        return objRet;
-    }
-
-    OBJECTREF GetExposedModuleObject();
-
     BOOL IsSystem()
     {
         WRAPPER_NO_CONTRACT;
@@ -409,7 +398,6 @@ private:
     FileLoadLevel               m_level;
     BOOL                        m_loading;
 
-    LOADERHANDLE                m_hExposedModuleObject;
     LOADERHANDLE                m_hExposedAssemblyObject;
 
     ExInfo*                     m_pError;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -959,10 +959,10 @@ void CEEInfo::resolveToken(/* IN, OUT */ CORINFO_RESOLVED_TOKEN * pResolvedToken
                 ThrowBadTokenException(pResolvedToken);
 
             {
-                DomainAssembly *pTargetModule = pModule->LoadModule(metaTOK);
+                Module *pTargetModule = pModule->LoadModule(metaTOK);
                 if (pTargetModule == NULL)
                     COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
-                th = TypeHandle(pTargetModule->GetModule()->GetGlobalMethodTable());
+                th = TypeHandle(pTargetModule->GetGlobalMethodTable());
                 if (th.IsNull())
                     COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
             }
@@ -6157,7 +6157,7 @@ CORINFO_CLASS_HANDLE  CEEInfo::getTypeForBoxOnStack(CORINFO_CLASS_HANDLE cls)
     JIT_TO_EE_TRANSITION();
 
     TypeHandle VMClsHnd(cls);
-    if (Nullable::IsNullableType(VMClsHnd)) 
+    if (Nullable::IsNullableType(VMClsHnd))
     {
         VMClsHnd = VMClsHnd.AsMethodTable()->GetInstantiation()[0];
     }

--- a/src/coreclr/vm/memberload.cpp
+++ b/src/coreclr/vm/memberload.cpp
@@ -292,10 +292,10 @@ void MemberLoader::GetDescFromMemberRef(ModuleBase * pModule,
     {
     case mdtModuleRef:
         {
-            DomainAssembly *pTargetModule = pModule->LoadModule(parent);
+            Module *pTargetModule = pModule->LoadModule(parent);
             if (pTargetModule == NULL)
                 COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
-            typeHnd = TypeHandle(pTargetModule->GetModule()->GetGlobalMethodTable());
+            typeHnd = TypeHandle(pTargetModule->GetGlobalMethodTable());
             if (typeHnd.IsNull())
                 COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
         }

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -1693,7 +1693,7 @@ public:
         RETURN module;
     }
 
-    DomainAssembly *LoadModule(mdFile kFile) final
+    Module *LoadModule(mdFile kFile) final
     {
         // Native manifest module functionality isn't actually multi-module assemblies, and File tokens are not useable
         if (TypeFromToken(kFile) == mdtFile)
@@ -1702,7 +1702,7 @@ public:
         _ASSERTE(TypeFromToken(kFile) == mdtModuleRef);
         Module* module = m_ModuleReferencesMap.GetElement(RidFromToken(kFile));
         if (module != NULL)
-            return module->GetDomainAssembly();
+            return module;
 
         LPCSTR moduleName;
         if (FAILED(GetMDImport()->GetModuleRefProps(kFile, &moduleName)))
@@ -1751,8 +1751,8 @@ public:
         m_ModuleReferencesMap.TrySetElement(RidFromToken(kFile), module);
 #endif
 
-        return module->GetDomainAssembly();
-    }
+       return module;
+   }
 
     virtual void DECLSPEC_NORETURN ThrowTypeLoadExceptionImpl(IMDInternalImport *pInternalImport,
                                                   mdToken token,

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -167,11 +167,8 @@ NOINLINE ReflectModuleBaseObject* GetRuntimeModuleHelper(LPVOID __me, Module *pM
     if (pModule == NULL)
         return NULL;
 
-    DomainAssembly * pDomainAssembly = pModule->GetDomainAssembly();
-
-    OBJECTREF refModule = (pDomainAssembly != NULL) ? pDomainAssembly->GetExposedModuleObjectIfExists() : NULL;
-
-    if(refModule != NULL)
+    OBJECTREF refModule = pModule->GetExposedObjectIfExists();
+    if (refModule != NULL)
         return (ReflectModuleBaseObject*)OBJECTREFToObject(refModule);
 
     HELPER_METHOD_FRAME_BEGIN_RET_ATTRIB_1(Frame::FRAME_ATTR_EXACT_DEPTH|Frame::FRAME_ATTR_CAPTURE_DEPTH_2, keepAlive);


### PR DESCRIPTION
`DomainAssembly` currently has the exposed object corresponding to its `Module` and `Module` gets it from its `DomainAssembly` - move it to be stored `Module` instead.

`Module::LoadModule` was returning `DomainAssembly` and the common thing callers immediately did was get its `Module` - make it return the `Module` instead. 

Contributes to https://github.com/dotnet/runtime/issues/104590

cc @jkotas @AaronRobinsonMSFT 