### PR TITLE
Initialize RuntimeEventSource as part of coreclr_initialize instead of only when running an app

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/StartupHookProvider.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StartupHookProvider.CoreCLR.cs
@@ -14,11 +14,6 @@ namespace System
     {
         private static unsafe void ManagedStartup(char* pDiagnosticStartupHooks)
         {
-#if FEATURE_PERFTRACING
-            if (EventSource.IsSupported)
-                RuntimeEventSource.Initialize();
-#endif
-
             if (IsSupported)
                 ProcessStartupHooks(new string(pDiagnosticStartupHooks));
         }

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -761,6 +761,9 @@ DEFINE_FIELD_U(rgiColumnNumber,            StackFrameHelper,   rgiColumnNumber)
 DEFINE_FIELD_U(rgiLastFrameFromForeignExceptionStackTrace,            StackFrameHelper,   rgiLastFrameFromForeignExceptionStackTrace)
 DEFINE_FIELD_U(iFrameCount,                StackFrameHelper,   iFrameCount)
 
+DEFINE_CLASS(RUNTIME_EVENT_SOURCE,  Tracing,                RuntimeEventSource)
+DEFINE_METHOD(RUNTIME_EVENT_SOURCE, INITIALIZE, Initialize, SM_RetVoid)
+
 DEFINE_CLASS(STARTUP_HOOK_PROVIDER,  System,                StartupHookProvider)
 DEFINE_METHOD(STARTUP_HOOK_PROVIDER, MANAGED_STARTUP, ManagedStartup, SM_PtrChar_RetVoid)
 DEFINE_METHOD(STARTUP_HOOK_PROVIDER, CALL_STARTUP_HOOK, CallStartupHook, SM_PtrChar_RetVoid)

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -664,6 +664,15 @@ HRESULT CorHost2::CreateAppDomainWithManager(
 
     m_fAppDomainCreated = TRUE;
 
+#ifdef FEATURE_PERFTRACING
+    // Initialize RuntimeEventSource
+    {
+        GCX_COOP();
+        MethodDescCallSite initRuntimeEventSource(METHOD__RUNTIME_EVENT_SOURCE__INITIALIZE);
+        initRuntimeEventSource.Call(NULL);
+    }
+#endif // FEATURE_PERFTRACING
+
     END_EXTERNAL_ENTRYPOINT;
 
     return hr;

--- a/src/coreclr/vm/namespace.h
+++ b/src/coreclr/vm/namespace.h
@@ -18,11 +18,13 @@
 #define g_ThreadingNS       g_SystemNS ".Threading"
 #define g_CollectionsNS     g_SystemNS ".Collections"
 #define g_ResourcesNS       g_SystemNS ".Resources"
-#define g_DiagnosticsNS     g_SystemNS ".Diagnostics"
-#define g_CodeContractsNS   g_DiagnosticsNS ".Contracts"
 #define g_GlobalizationNS   g_SystemNS ".Globalization"
 #define g_TextNS            g_SystemNS ".Text"
 #define g_CollectionsGenericNS g_SystemNS ".Collections.Generic"
+
+#define g_DiagnosticsNS     g_SystemNS ".Diagnostics"
+#define g_CodeContractsNS   g_DiagnosticsNS ".Contracts"
+#define g_TracingNS         g_DiagnosticsNS ".Tracing"
 
 #define g_InteropServicesNS g_SystemNS ".Runtime.InteropServices"
 #define g_InternalInteropServicesNS  "Internal.Runtime.InteropServices"

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -53,7 +53,7 @@ namespace System.Diagnostics.Tracing
 
 #if NATIVEAOT
         // If EventSource feature is enabled, RuntimeEventSource needs to be initialized for NativeAOT
-        // In CoreCLR, this is done via StartupHookProvider.CoreCLR.cs
+        // In CoreCLR, this is done via a call from the runtime as part of coreclr_initialize
 #pragma warning disable CA2255
         [ModuleInitializer]
 #pragma warning restore CA2255


### PR DESCRIPTION
Fixes #83935

We were only initializing `RuntimeEventSource` before running an application. This meant that native hosting scenarios - COM, C++/CLI, custom - would never initialize it. As a result, diagnostic tracing tools - like `dotnet-counters` - did not work properly.

This moves the call to `RuntimeEventSource.Initialize` out of `StartupHookProvider.ManagedStartup` and to be part of `coreclr_initialize`.

Manually validated with dotnet-counters targeting native host and native client for C++/CLI or COM.

cc @dotnet/appmodel 