### PR TITLE
Fix some core typeof(...) references

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ArrayMethod.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ArrayMethod.cs
@@ -18,10 +18,10 @@ namespace System.Reflection.Emit
 
         #region Constructor
         // This is a kind of MethodInfo to represent methods for array type of unbaked type
-        internal ArrayMethod(ModuleBuilder module, Type arrayClass, string methodName,
+        internal ArrayMethod(ModuleBuilderImpl module, Type arrayClass, string methodName,
             CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes)
         {
-            _returnType = returnType ?? typeof(void);
+            _returnType = returnType ?? module.GetTypeFromCoreAssembly(CoreTypeId.Void);
             if (parameterTypes != null)
             {
                 _parameterTypes = new Type[parameterTypes.Length];

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -440,7 +440,6 @@ namespace System.Reflection.Emit
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:DynamicallyAccessedMembers", Justification = "The members of 'ValueType' are not referenced in this context")]
-```suggestion
         private FieldBuilder DefineDataHelper(string name, byte[] data, int size, FieldAttributes attributes)
         {
             ArgumentException.ThrowIfNullOrEmpty(name);

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -439,7 +439,8 @@ namespace System.Reflection.Emit
             return DefineDataHelper(name, new byte[size], size, attributes);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:DynamicallyAccessedMembers", Justification = "Types are preserved via ModuleBuilderImpl.s_coreTypes")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:DynamicallyAccessedMembers", Justification = "The members of 'ValueType' are not referenced in this context")]
+```suggestion
         private FieldBuilder DefineDataHelper(string name, byte[] data, int size, FieldAttributes attributes)
         {
             ArgumentException.ThrowIfNullOrEmpty(name);

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -439,6 +439,7 @@ namespace System.Reflection.Emit
             return DefineDataHelper(name, new byte[size], size, attributes);
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:DynamicallyAccessedMembers", Justification = "Types are preserved via ModuleBuilderImpl.s_coreTypes")]
         private FieldBuilder DefineDataHelper(string name, byte[] data, int size, FieldAttributes attributes)
         {
             ArgumentException.ThrowIfNullOrEmpty(name);
@@ -456,7 +457,7 @@ namespace System.Reflection.Emit
                 TypeAttributes typeAttributes = TypeAttributes.Public | TypeAttributes.ExplicitLayout | TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AnsiClass;
 
                 // Define the backing value class
-                valueClassType = (TypeBuilderImpl)_module.DefineType(strValueClassName, typeAttributes, typeof(ValueType), PackingSize.Size1, size);
+                valueClassType = (TypeBuilderImpl)_module.DefineType(strValueClassName, typeAttributes, _module.GetTypeFromCoreAssembly(CoreTypeId.ValueType), PackingSize.Size1, size);
                 valueClassType.CreateType();
             }
 


### PR DESCRIPTION
 - Fix `typeof(ValueType)` usage in `DefineUninitializedData` on `TypeBuilder` mentioned in https://github.com/dotnet/runtime/issues/105772
- Fix another similar case in `GetArrayMethod` on `ModuleBuidler` that uses `typeof(void)`
- There is another case for creating `EnumBuilderImpl` constructor where `typeof(Enum)` is used as parent type, but according to the tests I added it appears to be fine, no need to change `typeof(Enum)` reference here https://github.com/dotnet/runtime/blob/f120fff4838fbae622123c6578734275d909a3f2/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/EnumBuilderImpl.cs#L14-L20

Fixes https://github.com/dotnet/runtime/issues/105772