### PR TITLE
Avoid signed overflow in DBG_FlushInstructionCache

### DIFF
--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -2068,12 +2068,12 @@ DBG_FlushInstructionCache(
     // As a workaround, we call __builtin___clear_cache on each page separately.
 
     const SIZE_T pageSize = GetVirtualPageSize();
-    INT_PTR begin = (INT_PTR)lpBaseAddress;
-    const INT_PTR end = begin + dwSize;
+    UINT_PTR begin = (UINT_PTR)lpBaseAddress;
+    const UINT_PTR end = begin + dwSize;
 
     while (begin < end)
     {
-        INT_PTR endOrNextPageBegin = ALIGN_UP(begin + 1, pageSize);
+        UINT_PTR endOrNextPageBegin = ALIGN_UP(begin + 1, pageSize);
         if (endOrNextPageBegin > end)
             endOrNextPageBegin = end;
 


### PR DESCRIPTION
On ARM32 Linux we can have an infinite loop because of integer overflow.
For example, if `DBG_FlushInstructionCache` is called with the following parameters & locals:
```C++
  dwSize = 28
  pageSize = 4096
  begin = lpBaseAddress = 0x7ffff000
  end = begin + dwSize = 0x7ffff01c
```
`ALIGN_UP(0x7ffff000, 4096)` returns 0x80000000 which is actually a negative number because `INT_PTR` is just `int32_t` (on ARM32). And here we are getting an infinite loop because `begin` will never be greater or equal than `end`.

Fix the issue by using `UINT_PTR` instead of `INT_PTR`.