### PR TITLE
Fix resolving types with primary constructors using in parameters

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -575,6 +575,17 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 ServiceCallSite? callSite = null;
                 Type parameterType = parameters[index].ParameterType;
+
+                // reference types cannot be resolved directly, but can be resolved via their underlying type
+                if (parameterType.IsByRef)
+                {
+                    Type? elementType = parameterType.GetElementType();
+                    if (elementType != null)
+                    {
+                        parameterType = elementType;
+                    }
+                }
+
                 foreach (var attribute in parameters[index].GetCustomAttributes(true))
                 {
                     if (serviceIdentifier.ServiceKey != null && attribute is ServiceKeyAttribute)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/Types/TypeWithPrimaryConstructorWithInDependency.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/Types/TypeWithPrimaryConstructorWithInDependency.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    public class TypeWithPrimaryConstructorWithInDependency(in IFakeService fakeService)
+    {
+        private readonly IFakeService _fakeService = fakeService;
+    }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderValidationTests.cs
@@ -240,6 +240,20 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Fact]
+        public void GetService_DoesNotThrow_WhenGetServiceForNonScopedImplementationWithPrimaryConstructorUsingInParameter()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IBar, Bar>();
+            serviceCollection.AddSingleton<IFoo, FooWithInDependency>();
+            var serviceProvider = serviceCollection.BuildServiceProvider(true);
+
+            // Act + Assert
+            var foo = serviceProvider.GetService(typeof(IFoo));
+            Assert.NotNull(foo);
+        }
+
+        [Fact]
         public void BuildServiceProvider_ValidateOnBuild_Throws_WhenScopedIsInjectedIntoSingleton()
         {
             // Arrange
@@ -410,6 +424,11 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             public Foo2(IBar bar)
             {
             }
+        }
+
+        private class FooWithInDependency(in IBar bar) : IFoo
+        {
+            private readonly IBar bar = bar;
         }
 
         private interface IBar


### PR DESCRIPTION
Fixes #105924 

`in` primary constructor parameters are treated as reference types when inspected. Fix here is simply to use the referenced type instead when resolving parameters.