### PR TITLE
[RISC-V] Fix Reg Order for Float Registers

### DIFF
--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -7132,6 +7132,11 @@ HRESULT CordbNativeFrame::GetLocalFloatingPointValue(DWORD index,
         (index <= REGISTER_ARM_D31)))
         return E_INVALIDARG;
     index -= REGISTER_ARM_D0;
+#elif defined(TARGET_RISCV64)
+    if (!((index >= REGISTER_RISCV64_F0) &&
+        (index <= REGISTER_RISCV64_F31)))
+        return E_INVALIDARG;
+    index -= REGISTER_RISCV64_F0;
 #else
     if (!((index >= REGISTER_X86_FPSTACK_0) &&
           (index <= REGISTER_X86_FPSTACK_7)))

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -486,6 +486,7 @@ public:
         previousInterval = nullptr;
         regNum           = REG_NA;
         isCalleeSave     = false;
+        regOrder         = UCHAR_MAX;
     }
 
     void init(regNumber reg)

--- a/src/coreclr/jit/targetriscv64.h
+++ b/src/coreclr/jit/targetriscv64.h
@@ -84,11 +84,11 @@
                                    REG_T0,REG_T1,REG_T2,REG_T3,REG_T4,REG_T5,REG_T6, \
                                    REG_S1,REG_S2,REG_S3,REG_S4,REG_S5,REG_S6,REG_S7,REG_S8,REG_S9,REG_S10,REG_S11
 
-  #define REG_VAR_ORDER_FLT        REG_F12,REG_F13,REG_F14,REG_F15,REG_F16,REG_F17,REG_F18,REG_F19, \
-                                   REG_F2,REG_F3,REG_F4,REG_F5,REG_F6,REG_F7,REG_F8,REG_F9,REG_F10, \
-                                   REG_F20,REG_F21,REG_F22,REG_F23, \
-                                   REG_F24,REG_F25,REG_F26,REG_F27,REG_F28,REG_F29,REG_F30,REG_F31, \
-                                   REG_F1,REG_F0
+  #define REG_VAR_ORDER_FLT        REG_F4, REG_F5, REG_F6, REG_F7, REG_F28, REG_F29, REG_F30, REG_F31, \
+                                   REG_F12, REG_F13, REG_F14, REG_F15, REG_F16, REG_F17, \
+                                   REG_F0, REG_F1, REG_F2, REG_F3, \
+                                   REG_F22, REG_F23, REG_F24, REG_F25, REG_F26, REG_F27, REG_F18, REG_F19, REG_F20, REG_F21, REG_F8, REG_F9, \
+                                   REG_F11, REG_F10
 
   #define RBM_CALL_GC_REGS_ORDER   RBM_S1,RBM_S2,RBM_S3,RBM_S4,RBM_S5,RBM_S6,RBM_S7,RBM_S8,RBM_S9,RBM_S10,RBM_S11,RBM_INTRET,RBM_INTRET_1
   #define RBM_CALL_GC_REGS         (RBM_S1|RBM_S2|RBM_S3|RBM_S4|RBM_S5|RBM_S6|RBM_S7|RBM_S8|RBM_S9|RBM_S10|RBM_S11|RBM_INTRET|RBM_INTRET_1)


### PR DESCRIPTION
Order for some float registers are not set in `REG_VAR_ORDER_FLT`.
In release build, `regOrder` has invalid values and register allocator sets float registers differently every time.
Fix coreclr test `readytorun.coreroot_determinism.coreroot_determinism.coreroot_determinism` for risc-v release.

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung