### PR TITLE
fix redundant CRLF response during SMTP negotiate

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
@@ -63,10 +63,6 @@ namespace System.Net.Mail
                     {
                         return null;
                     }
-                    if (clientContext.IsAuthenticated && resp == null)
-                    {
-                        resp = "\r\n";
-                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #105938

Removes redundant CRLF response appended by Negotiate module. `SmtpCommand` already handles appending right message to the response, Negotiate doing this it in the auth module appears wrong and leads to CRLF being appended twice -- leading to SMTP server throwing an error. 

This fix is important because MailKit, which is currently recommended in the docs, does not support Kerberos(https://github.com/jstedfast/MailKit/issues/1249). Not having a functional Kerberos support in the BCL `SmtpClient` blocks any efforts of migrating from .NET framework.  