### PR TITLE
JIT: Split trees containing no-return calls to avoid creating illegal IR

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5330,6 +5330,7 @@ public:
     bool fgHasSwitch; // any BBJ_SWITCH jumps?
 
     bool fgRemoveRestOfBlock; // true if we know that we will throw
+    bool fgHasNoReturnCall;   // true if statement we morphed had a no-return call
     bool fgStmtRemoved;       // true if we remove statements -> need new DFA
 
     enum FlowGraphOrder
@@ -5462,6 +5463,8 @@ public:
 
     bool fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg));
     void fgMorphStmtBlockOps(BasicBlock* block, Statement* stmt);
+
+    bool gtRemoveTreesAfterNoReturnCall(BasicBlock* block, Statement* stmt);
 
     //------------------------------------------------------------------------------------------------------------
     // MorphMDArrayTempCache: a simple cache of compiler temporaries in the local variable table, used to minimize

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -72,8 +72,10 @@ void Compiler::fgInit()
 #endif // SWIFT_SUPPORT
 
     /* We haven't reached the global morphing phase */
-    fgGlobalMorph     = false;
-    fgGlobalMorphDone = false;
+    fgGlobalMorph       = false;
+    fgGlobalMorphDone   = false;
+    fgRemoveRestOfBlock = false;
+    fgHasNoReturnCall   = false;
 
     fgModified = false;
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7149,9 +7149,9 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     if (call->IsNoReturn())
     {
         //
-        // If we know that the call does not return then we can set fgRemoveRestOfBlock
-        // to remove all subsequent statements and change the call's basic block to BBJ_THROW.
-        // As a result the compiler won't need to preserve live registers across the call.
+        // If this call does not return then set fgHasNoReturnCall = true to
+        // indicate to fgMorphStmts that we can remove trees/statements after
+        // this call.
         //
         // This isn't need for tail calls as there shouldn't be any code after the call anyway.
         // Besides, the tail call code is part of the epilog and converting the block to

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13232,16 +13232,6 @@ void Compiler::fgMorphStmts(BasicBlock* block)
         }
 #endif
 
-        if (fgHasNoReturnCall)
-        {
-            fgHasNoReturnCall = false;
-            if (gtRemoveTreesAfterNoReturnCall(block, stmt))
-            {
-                fgRemoveRestOfBlock = true;
-                morphedTree         = stmt->GetRootNode();
-            }
-        }
-
         /* Check for morphedTree as a GT_COMMA with an unconditional throw */
         if (!gtIsActiveCSE_Candidate(morphedTree) && fgIsCommaThrow(morphedTree, true))
         {
@@ -13254,6 +13244,17 @@ void Compiler::fgMorphStmts(BasicBlock* block)
         }
 
         stmt->SetRootNode(morphedTree);
+
+        if (fgHasNoReturnCall)
+        {
+            fgHasNoReturnCall = false;
+
+            if ((fgGetTopLevelQmark(stmt->GetRootNode()) == nullptr) && gtRemoveTreesAfterNoReturnCall(block, stmt))
+            {
+                fgRemoveRestOfBlock = true;
+                morphedTree         = stmt->GetRootNode();
+            }
+        }
 
         if (fgRemoveRestOfBlock)
         {


### PR DESCRIPTION
When morph sees a no-return call it will remove all statements executed after that no-return call in the block, and convert the block into a `BBJ_THROW` block. However, morph was leaving trees executed after the no-return call in place, which could end up producing illegal IR. For example, if the ancestor node of the call is a `GT_RETURN` node we would end up with a `GT_RETURN` node inside a non-`BBJ_RETURN` block, which is not legal.

This change adds a function to split out all side effects of (ancestor) sibling nodes of the no-return call into separate statements. Once this has been done the no-return call can safely be made the root node of the statement.

Fix #103853

Example diff in JITDUMP for

```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static int Test(C x, C y)
{
    return x.X + (y.X / x.X - Throw());
}

private static int Throw()
{
    throw new Exception("foo");
}

public class C
{
    public int X;
}
```

```diff
@@ -1,51 +1,75 @@
 fgMorphTree BB01, STMT00003 (after)
                [000018] --CXG+-----                         ▌  RETURN    int
                [000017] --CXG+-----                         └──▌  ADD       int
                [000002] ---XG+-----                            ├──▌  IND       int
                [000021] -----+-----                            │  └──▌  ADD       byref
                [000000] -----+-----                            │     ├──▌  LCL_VAR   ref    V00 arg0
                [000020] -----+-----                            │     └──▌  CNS_INT   long   8 Fseq[X]
                [000016] --CXG+-----                            └──▌  SUB       int
                [000009] ---XG+-----                               ├──▌  DIV       int
                [000005] ---XG+-----                               │  ├──▌  IND       int
                [000023] -----+-----                               │  │  └──▌  ADD       byref
                [000003] -----+-----                               │  │     ├──▌  LCL_VAR   ref    V01 arg1          (last use)
                [000022] -----+-----                               │  │     └──▌  CNS_INT   long   8 Fseq[X]
                [000008] ---XG+-----                               │  └──▌  IND       int
                [000025] -----+-----                               │     └──▌  ADD       byref
                [000006] -----+-----                               │        ├──▌  LCL_VAR   ref    V00 arg0          (last use)
                [000024] -----+-----                               │        └──▌  CNS_INT   long   8 Fseq[X]
                [000010] --CXG+-----                               └──▌  CALL      int    Example:Throw():int
+Removing trees after no-return call [000010]
+Extracting side effects of (ancestor) sibling [000002]:
+STMT00004 ( ??? ... ??? )
+               [000002] ---XG+-----                         ▌  IND       int
+               [000021] -----+-----                         └──▌  ADD       byref
+               [000000] -----+-----                            ├──▌  LCL_VAR   ref    V00 arg0
+               [000020] -----+-----                            └──▌  CNS_INT   long   8 Fseq[X]
+Extracting side effects of (ancestor) sibling [000009]:
+STMT00005 ( ??? ... ??? )
+               [000009] ---XG+-----                         ▌  DIV       int
+               [000005] ---XG+-----                         ├──▌  IND       int
+               [000023] -----+-----                         │  └──▌  ADD       byref
+               [000003] -----+-----                         │     ├──▌  LCL_VAR   ref    V01 arg1          (last use)
+               [000022] -----+-----                         │     └──▌  CNS_INT   long   8 Fseq[X]
+               [000008] ---XG+-----                         └──▌  IND       int
+               [000025] -----+-----                            └──▌  ADD       byref
+               [000006] -----+-----                               ├──▌  LCL_VAR   ref    V00 arg0          (last use)
+               [000024] -----+-----                               └──▌  CNS_INT   long   8 Fseq[X]
+New final statement:
+STMT00003 ( ??? ... ??? )
+               [000010] --CXG+-----                         ▌  CALL      int    Example:Throw():int
 Converting BB01 to BBJ_THROW
 morph assertion stats: 64 table size, 2 assertions, 0 dropped

 *************** Finishing PHASE Morph - Global
 Trees after Morph - Global

 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BBnum BBid ref try hnd preds           weight   [IL range]   [jump]                            [EH region]        [flags]
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BB01 [0000]  1                             0    [000..01B)                           (throw )                     i rare hascall gcsafe
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------------ BB01 [0000] [000..01B) (throw), preds={} succs={}

+***** BB01 [0000]
+STMT00004 ( ??? ... ??? )
+               [000002] ---XG+-----                         ▌  IND       int
+               [000021] -----+-----                         └──▌  ADD       byref
+               [000000] -----+-----                            ├──▌  LCL_VAR   ref    V00 arg0
+               [000020] -----+-----                            └──▌  CNS_INT   long   8 Fseq[X]
+
+***** BB01 [0000]
+STMT00005 ( ??? ... ??? )
+               [000009] ---XG+-----                         ▌  DIV       int
+               [000005] ---XG+-----                         ├──▌  IND       int
+               [000023] -----+-----                         │  └──▌  ADD       byref
+               [000003] -----+-----                         │     ├──▌  LCL_VAR   ref    V01 arg1          (last use)
+               [000022] -----+-----                         │     └──▌  CNS_INT   long   8 Fseq[X]
+               [000008] ---XG+-----                         └──▌  IND       int
+               [000025] -----+-----                            └──▌  ADD       byref
+               [000006] -----+-----                               ├──▌  LCL_VAR   ref    V00 arg0          (last use)
+               [000024] -----+-----                               └──▌  CNS_INT   long   8 Fseq[X]
+
 ***** BB01 [0000]
 STMT00003 ( ??? ... ??? )
-               [000018] --CXG+-----                         ▌  RETURN    int
-               [000017] --CXG+-----                         └──▌  ADD       int
-               [000002] ---XG+-----                            ├──▌  IND       int
-               [000021] -----+-----                            │  └──▌  ADD       byref
-               [000000] -----+-----                            │     ├──▌  LCL_VAR   ref    V00 arg0
-               [000020] -----+-----                            │     └──▌  CNS_INT   long   8 Fseq[X]
-               [000016] --CXG+-----                            └──▌  SUB       int
-               [000009] ---XG+-----                               ├──▌  DIV       int
-               [000005] ---XG+-----                               │  ├──▌  IND       int
-               [000023] -----+-----                               │  │  └──▌  ADD       byref
-               [000003] -----+-----                               │  │     ├──▌  LCL_VAR   ref    V01 arg1          (last use)
-               [000022] -----+-----                               │  │     └──▌  CNS_INT   long   8 Fseq[X]
-               [000008] ---XG+-----                               │  └──▌  IND       int
-               [000025] -----+-----                               │     └──▌  ADD       byref
-               [000006] -----+-----                               │        ├──▌  LCL_VAR   ref    V00 arg0          (last use)
-               [000024] -----+-----                               │        └──▌  CNS_INT   long   8 Fseq[X]
-               [000010] --CXG+-----                               └──▌  CALL      int    Example:Throw():int
+               [000010] --CXG+-----                         ▌  CALL      int    Example:Throw():int
```