### PR TITLE
Delete some useless RareFlags

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -790,14 +790,6 @@ namespace Internal.Runtime
 #endif
         }
 
-        internal bool IsHFA
-        {
-            get
-            {
-                return (RareFlags & EETypeRareFlags.IsHFAFlag) != 0;
-            }
-        }
-
         internal bool IsTrackedReferenceWithFinalizer
         {
             get
@@ -1076,6 +1068,14 @@ namespace Internal.Runtime
 #endif
         }
 
+        internal bool IsDynamicTypeWithCctor
+        {
+            get
+            {
+                return (RareFlags & EETypeRareFlags.IsDynamicTypeWithLazyCctor) != 0;
+            }
+        }
+
         internal IntPtr DynamicGcStaticsData
         {
             get
@@ -1230,14 +1230,6 @@ namespace Internal.Runtime
                 _uFlags = (_uFlags & ~(uint)EETypeFlags.ElementTypeMask) | ((uint)value << (byte)EETypeFlags.ElementTypeShift);
             }
 #endif
-        }
-
-        public bool HasCctor
-        {
-            get
-            {
-                return (RareFlags & EETypeRareFlags.HasCctorFlag) != 0;
-            }
         }
 
         // This method is always called with a known constant and there's a lot of benefit in inlining it.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -489,11 +489,6 @@ namespace Internal.Runtime.Augments
             return typeHandle.ToMethodTable()->IsDynamicType;
         }
 
-        public static bool HasCctor(RuntimeTypeHandle typeHandle)
-        {
-            return typeHandle.ToMethodTable()->HasCctor;
-        }
-
         public static unsafe IntPtr ResolveStaticDispatchOnType(RuntimeTypeHandle instanceType, RuntimeTypeHandle interfaceType, int slot, out RuntimeTypeHandle genericContext)
         {
             MethodTable* genericContextPtr = default;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -29,6 +29,11 @@ namespace Internal.Runtime.TypeLoader
             return rtth.ToEETypePtr()->IsDynamicType;
         }
 
+        public static unsafe bool IsDynamicTypeWithCctor(this RuntimeTypeHandle rtth)
+        {
+            return rtth.ToEETypePtr()->IsDynamicTypeWithCctor;
+        }
+
         public static unsafe int GetNumVtableSlots(this RuntimeTypeHandle rtth)
         {
             return rtth.ToEETypePtr()->NumVtableSlots;
@@ -201,7 +206,10 @@ namespace Internal.Runtime.TypeLoader
 
                 int allocatedNonGCDataSize = state.NonGcDataSize;
                 if (state.HasStaticConstructor)
+                {
                     allocatedNonGCDataSize += -TypeBuilder.ClassConstructorOffset;
+                    rareFlags |= (uint)EETypeRareFlags.IsDynamicTypeWithLazyCctor;
+                }
 
                 if (allocatedNonGCDataSize != 0)
                     rareFlags |= (uint)EETypeRareFlags.IsDynamicTypeWithNonGcStatics;

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -129,21 +129,18 @@ namespace Internal.Runtime
 
         // UNUSED = 0x00000010,
 
-        /// <summary>
-        /// This MethodTable has a Class Constructor
-        /// </summary>
-        HasCctorFlag = 0x0000020,
+        // UNUSED = 0x0000020,
 
         // UNUSED2 = 0x00000040,
 
         // UNUSED = 0x00000080,
 
-        /// <summary>
-        /// This MethodTable represents a structure that is an HFA
-        /// </summary>
-        IsHFAFlag = 0x00000100,
+        // Unused = 0x00000100,
 
-        // Unused = 0x00000200,
+        /// <summary>
+        /// This dynamically created type has a static constructor
+        /// </summary>
+        IsDynamicTypeWithLazyCctor = 0x00000200,
 
         /// <summary>
         /// This dynamically created types has gc statics

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1343,34 +1343,18 @@ namespace ILCompiler.DependencyAnalysis
         /// </summary>
         protected internal virtual void ComputeOptionalEETypeFields(NodeFactory factory, bool relocsOnly)
         {
-            ComputeRareFlags(factory);
+            ComputeRareFlags();
             ComputeNullableValueOffset();
             ComputeValueTypeFieldPadding();
         }
 
-        private void ComputeRareFlags(NodeFactory factory)
+        private void ComputeRareFlags()
         {
             uint flags = 0;
-
-            MetadataType metadataType = _type as MetadataType;
-
-            if (factory.PreinitializationManager.HasLazyStaticConstructor(_type))
-            {
-                flags |= (uint)EETypeRareFlags.HasCctorFlag;
-            }
 
             if (_type.RequiresAlign8())
             {
                 flags |= (uint)EETypeRareFlags.RequiresAlign8Flag;
-            }
-
-            TargetArchitecture targetArch = _type.Context.Target.Architecture;
-            if (metadataType != null &&
-                (targetArch == TargetArchitecture.ARM ||
-                targetArch == TargetArchitecture.ARM64) &&
-                metadataType.IsHomogeneousAggregate)
-            {
-                flags |= (uint)EETypeRareFlags.IsHFAFlag;
             }
 
             if (_type.IsByRefLike)


### PR DESCRIPTION
These are leftovers from universal shared generics and interpreter/JIT prototypes.

Cc @dotnet/ilc-contrib 