### PR TITLE
[release/8.0-staging] Fix copy constructor injection for unsafe value classes

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -3898,8 +3898,18 @@ uint32_t CEEInfo::getClassAttribsInternal (CORINFO_CLASS_HANDLE clsHnd)
             if (pMT->IsByRefLike())
                 ret |= CORINFO_FLG_BYREF_LIKE;
 
-            if (pClass->IsUnsafeValueClass())
+            // In Reverse P/Invoke stubs, we are generating the code
+            // and we are not generating the code patterns that the GS checks
+            // are meant to catch.
+            // As a result, we can skip setting this flag.
+            // We do this as the GS checks (emitted when this flag is set)
+            // can break C++/CLI's copy-constructor semantics by missing copies.
+            if (pClass->IsUnsafeValueClass()
+                && !(m_pMethodBeingCompiled->IsILStub()
+                    && dac_cast<PTR_DynamicMethodDesc>(m_pMethodBeingCompiled)->GetILStubType() == DynamicMethodDesc::StubNativeToCLRInterop))
+            {
                 ret |= CORINFO_FLG_UNSAFE_VALUECLASS;
+            }
         }
         if (pClass->HasExplicitFieldOffsetLayout() && pClass->HasOverlaidField())
             ret |= CORINFO_FLG_OVERLAPPING_FIELDS;


### PR DESCRIPTION
Fixes Issue https://github.com/dotnet/runtime/issues/100751

main PR #105779

# Description

C++/CLI structs with copy constructors and C-style fixed-length array fields can have a copy constructor missed. This case was missed in #100050. This PR makes a targetted change to disable the JIT feature that was causing the missed copy in Reverse P/Invoke IL stubs.

# Customer Impact

Same customer impact as #100033 if the repro had a C-style fixed-length array field.

> > The DTS bug contains the repro. Essentially, a copy ctor of std::vector<>::iterator is not called when pushing the argument onto the stack for the call to the native method, which takes an argument of type iterator. This leads to STL's iterator debugging book-keeping code to later assert.
> 
> This happens only for x86 and does not repro in the desktop framework where the copy ctor is correctly called.
> 
> The workaround is to disable debug iterators or change the legacy code to avoid the problematic pattern. Both of these are unacceptable long-term in-production fixes.

# Regression

Regression from .NET Framework, not from modern .NET

# Testing

We've added unit tests in main and manually validated in this branch that no copy constructors are missed.

# Risk

Low risk. We control all code emitted into IL stubs so we don't need to worry about this feature being disabled.
