### PR TITLE
Enable ReceiveAsync_Cancel_Success test

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -62,7 +62,6 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/19217")]
         public async Task ReceiveAsync_Cancel_Success(Uri server)
         {
             await TestCancellation(async (cws) =>


### PR DESCRIPTION
Fixes #19217

Looks like this test has been fixed already, let's enable it and test it over CI.