### PR TITLE
[NativeAOT] Move RequiresAlign8 flag from RareFlags into ExtendedFlags

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -732,14 +732,14 @@ namespace Internal.Runtime
         {
             get
             {
-                // Use the same trick as HasComponentSize. HasComponentSizeFlag is sign bit, so if
-                // it's set then _uFlags are negative. Once we mask the value we get negative value
-                // for HasComponentSize == true, 0 for HasComponentSize == false && RequiresAlign8 == false
-                // and positive value for HasComponentSize == false && RequiresAlign8 == true.
-                //
-                // return (Flags & ((uint)EETypeFlags.HasComponentSizeFlag | (uint)EETypeFlagsEx.RequiresAlign8Flag)) == (uint)EETypeFlagsEx.RequiresAlign8Flag;
-
-                return (int)(_uFlags & ((uint)EETypeFlags.HasComponentSizeFlag | (uint)EETypeFlagsEx.RequiresAlign8Flag)) > 0;
+                // NOTE: Does not work for types with HasComponentSize, ie. arrays and strings.
+                // Since this is called early through RhNewObject we cannot use regular Debug.Assert
+                // here to enforce the assumption.
+#if DEBUG
+                if (!HasComponentSize)
+                    Debug.Fail("RequiresAlign8 called for array or string");
+#endif
+                return (_uFlags & (uint)EETypeFlagsEx.RequiresAlign8Flag) != 0;
             }
         }
 

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -736,7 +736,7 @@ namespace Internal.Runtime
                 // Since this is called early through RhNewObject we cannot use regular Debug.Assert
                 // here to enforce the assumption.
 #if DEBUG
-                if (!HasComponentSize)
+                if (HasComponentSize)
                     Debug.Fail("RequiresAlign8 called for array or string");
 #endif
                 return (_uFlags & (uint)EETypeFlagsEx.RequiresAlign8Flag) != 0;

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -732,7 +732,14 @@ namespace Internal.Runtime
         {
             get
             {
-                return (Flags & ((uint)EETypeFlags.HasComponentSizeFlag | (uint)EETypeFlagsEx.RequiresAlign8Flag)) == (uint)EETypeFlagsEx.RequiresAlign8Flag;
+                // Use the same trick as HasComponentSize. HasComponentSizeFlag is sign bit, so if
+                // it's set then _uFlags are negative. Once we mask the value we get negative value
+                // for HasComponentSize == true, 0 for HasComponentSize == false && RequiresAlign8 == false
+                // and positive value for HasComponentSize == false && RequiresAlign8 == true.
+                //
+                // return (Flags & ((uint)EETypeFlags.HasComponentSizeFlag | (uint)EETypeFlagsEx.RequiresAlign8Flag)) == (uint)EETypeFlagsEx.RequiresAlign8Flag;
+
+                return (int)(_uFlags & ((uint)EETypeFlags.HasComponentSizeFlag | (uint)EETypeFlagsEx.RequiresAlign8Flag)) > 0;
             }
         }
 

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -732,7 +732,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return (RareFlags & EETypeRareFlags.RequiresAlign8Flag) != 0;
+                return (Flags & ((uint)EETypeFlags.HasComponentSizeFlag | (uint)EETypeFlagsEx.RequiresAlign8Flag)) == (uint)EETypeFlagsEx.RequiresAlign8Flag;
             }
         }
 

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -61,7 +61,8 @@ namespace System.Runtime
             Debug.Assert(pEEType->IsArray || pEEType->IsString);
 
 #if FEATURE_64BIT_ALIGNMENT
-            if (pEEType->RequiresAlign8)
+            MethodTable* pEEElementType = pEEType->RelatedParameterType;
+            if (pEEElementType->IsValueType && pEEElementType->RequiresAlign8)
             {
                 return InternalCalls.RhpNewArrayAlign8(pEEType, length);
             }
@@ -381,7 +382,8 @@ namespace System.Runtime
 
                 case RuntimeHelperKind.AllocateArray:
 #if FEATURE_64BIT_ALIGNMENT
-                    if (pEEType->RequiresAlign8)
+                    MethodTable* pEEElementType = pEEType->RelatedParameterType;
+                    if (pEEElementType->IsValueType && pEEElementType->RequiresAlign8)
                         return (IntPtr)(delegate*<MethodTable*, int, object>)&InternalCalls.RhpNewArrayAlign8;
 #endif // FEATURE_64BIT_ALIGNMENT
 

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -163,7 +163,7 @@ private:
         IsTrackedReferenceWithFinalizerFlag = 0x0004,
 
         // This type requires 8-byte alignment for its fields on certain platforms (ARM32, WASM)
-        RequiresAlign8 = 0x1000
+        RequiresAlign8Flag = 0x1000
     };
 
 public:

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -161,6 +161,9 @@ private:
         // GC depends on this bit, this type has a critical finalizer
         HasCriticalFinalizerFlag = 0x0002,
         IsTrackedReferenceWithFinalizerFlag = 0x0004,
+
+        // This type requires 8-byte alignment for its fields on certain platforms (ARM32, WASM)
+        RequiresAlign8 = 0x1000
     };
 
 public:

--- a/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -128,6 +128,11 @@ namespace Internal.Runtime
                 flagsEx |= (ushort)EETypeFlagsEx.IDynamicInterfaceCastableFlag;
             }
 
+            if (type.RequiresAlign8())
+            {
+                flagsEx |= (ushort)EETypeFlagsEx.RequiresAlign8Flag;
+            }
+
             return flagsEx;
         }
 

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -84,6 +84,11 @@ namespace Internal.Runtime
         /// This type implements IDynamicInterfaceCastable to allow dynamic resolution of interface casts.
         /// </summary>
         IDynamicInterfaceCastableFlag = 0x0008,
+
+        /// <summary>
+        /// This type requires 8-byte alignment for its fields on certain platforms (ARM32, WASM)
+        /// </summary>
+        RequiresAlign8 = 0x1000
     }
 
     internal enum EETypeKind : uint
@@ -116,10 +121,7 @@ namespace Internal.Runtime
     [Flags]
     internal enum EETypeRareFlags : int
     {
-        /// <summary>
-        /// This type requires 8-byte alignment for its fields on certain platforms (only ARM currently).
-        /// </summary>
-        RequiresAlign8Flag = 0x00000001,
+        // UNUSED = 0x00000001,
 
         // UNUSED1 = 0x00000002,
 

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -88,7 +88,7 @@ namespace Internal.Runtime
         /// <summary>
         /// This type requires 8-byte alignment for its fields on certain platforms (ARM32, WASM)
         /// </summary>
-        RequiresAlign8 = 0x1000
+        RequiresAlign8Flag = 0x1000
     }
 
     internal enum EETypeKind : uint

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1352,11 +1352,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             uint flags = 0;
 
-            if (_type.RequiresAlign8())
-            {
-                flags |= (uint)EETypeRareFlags.RequiresAlign8Flag;
-            }
-
             if (_type.IsByRefLike)
             {
                 flags |= (uint)EETypeRareFlags.IsByRefLikeFlag;


### PR DESCRIPTION
Implementation of idea from https://github.com/dotnet/runtime/pull/105931/files#r1704319780.

The benchmark code and results are below. I tested it on Raspberry Pi. The tests were run in succession, CPU temperature was around 48 degrees, so no thermal throttling should be involved.

<strike>
Predictably, the performance improves for `RequiresAlign8` cases where we don't need to decode the optional fields block. There's about 5% perf hit for non-align8 array allocations and 2% perf hit for non-align8 value type allocations. Some perf hit for arrays was expected, the other code path needs more investigation though as no hit is expected there.
</strike>

Updated benchmark results here: https://github.com/dotnet/runtime/pull/106010#issuecomment-2271219238

This would make it easier to set the `RequiresAlign8` flag for truncated method tables used in `GCStaticEETypeNode`.

Benchmark code:
```csharp
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.

using System;
using System.Runtime;
using System.Runtime.CompilerServices;

public unsafe class Program
{
    [RuntimeImport("RhNewObject")]
    [MethodImpl(MethodImplOptions.InternalCall)]
    private static extern object RhNewObject(void* pMT);
    [RuntimeImport("RhNewArray")]
    [MethodImpl(MethodImplOptions.InternalCall)]
    private static extern object RhNewArray(void* pMT, int length);

    public static void Main()
    {
        var stopWatch = new System.Diagnostics.Stopwatch();

        for (int j = 0; j < 10; j++)
        {
            stopWatch.Restart();
            for (int i = 0; i < 1000000; i++)
                _ = RhNewArray((void*)typeof(int[]).TypeHandle.Value, 2);
            stopWatch.Stop();
            Console.WriteLine("NewIntArray: " + stopWatch.Elapsed);
        }

        for (int j = 0; j < 10; j++)
        {
            stopWatch.Restart();
            for (int i = 0; i < 1000000; i++)
                _ = RhNewArray((void*)typeof(double[]).TypeHandle.Value, 2);
            stopWatch.Stop();
            Console.WriteLine("NewDoubleArray: " + stopWatch.Elapsed);
        }

        for (int j = 0; j < 10; j++)
        {
            stopWatch.Restart();
            for (int i = 0; i < 1000000; i++)
                _ = RhNewObject((void*)typeof(ValueTuple<int, int>).TypeHandle.Value);
            stopWatch.Stop();
            Console.WriteLine("NewIntTuple: " + stopWatch.Elapsed);
        }

        for (int j = 0; j < 10; j++)
        {
            stopWatch.Restart();
            for (int i = 0; i < 1000000; i++)
                _ = RhNewObject((void*)typeof(ValueTuple<double, double>).TypeHandle.Value);
            stopWatch.Stop();
            Console.WriteLine("NewDoubleTuple: " + stopWatch.Elapsed);
        }
    }
}

namespace System.Runtime
{
    public class RuntimeImportAttribute : Attribute
    {
        public string DllName { get; }
        public string EntryPoint { get; }
        public RuntimeImportAttribute(string entry) => EntryPoint = entry;
    }
}
```

Benchmark results (on Raspberry Pi):
<table>
<tr>
<td>Main</td>
<td>PR</td>
</tr>
<tr>
<td>

```
NewIntArray: 00:00:00.0255011
NewIntArray: 00:00:00.0254985
NewIntArray: 00:00:00.0199294
NewIntArray: 00:00:00.0157785
NewIntArray: 00:00:00.0158397
NewIntArray: 00:00:00.0157611
NewIntArray: 00:00:00.0158823
NewIntArray: 00:00:00.0157390
NewIntArray: 00:00:00.0157586
NewIntArray: 00:00:00.0158148
NewDoubleArray: 00:00:00.0634320
NewDoubleArray: 00:00:00.0634249
NewDoubleArray: 00:00:00.0634018
NewDoubleArray: 00:00:00.0634123
NewDoubleArray: 00:00:00.0633429
NewDoubleArray: 00:00:00.0633701
NewDoubleArray: 00:00:00.0633932
NewDoubleArray: 00:00:00.0633275
NewDoubleArray: 00:00:00.0633318
NewDoubleArray: 00:00:00.0633482
NewIntTuple: 00:00:00.0142524
NewIntTuple: 00:00:00.0142566
NewIntTuple: 00:00:00.0142554
NewIntTuple: 00:00:00.0142424
NewIntTuple: 00:00:00.0142489
NewIntTuple: 00:00:00.0142521
NewIntTuple: 00:00:00.0142627
NewIntTuple: 00:00:00.0142432
NewIntTuple: 00:00:00.0142473
NewIntTuple: 00:00:00.0142491
NewDoubleTuple: 00:00:00.0269727
NewDoubleTuple: 00:00:00.0270101
NewDoubleTuple: 00:00:00.0269876
NewDoubleTuple: 00:00:00.0269796
NewDoubleTuple: 00:00:00.0269837
NewDoubleTuple: 00:00:00.0269709
NewDoubleTuple: 00:00:00.0270441
NewDoubleTuple: 00:00:00.0269772
NewDoubleTuple: 00:00:00.0269737
NewDoubleTuple: 00:00:00.0269802
```

</td>
<td>

```
NewIntArray: 00:00:00.0266514
NewIntArray: 00:00:00.0267529
NewIntArray: 00:00:00.0264482
NewIntArray: 00:00:00.0173164
NewIntArray: 00:00:00.0164856
NewIntArray: 00:00:00.0164668
NewIntArray: 00:00:00.0165303
NewIntArray: 00:00:00.0164860
NewIntArray: 00:00:00.0164870
NewIntArray: 00:00:00.0164756
NewDoubleArray: 00:00:00.0513089
NewDoubleArray: 00:00:00.0513532
NewDoubleArray: 00:00:00.0513423
NewDoubleArray: 00:00:00.0513160
NewDoubleArray: 00:00:00.0513266
NewDoubleArray: 00:00:00.0512910
NewDoubleArray: 00:00:00.0512942
NewDoubleArray: 00:00:00.0513139
NewDoubleArray: 00:00:00.0512965
NewDoubleArray: 00:00:00.0512951
NewIntTuple: 00:00:00.0144171
NewIntTuple: 00:00:00.0144348
NewIntTuple: 00:00:00.0144299
NewIntTuple: 00:00:00.0143846
NewIntTuple: 00:00:00.0144250
NewIntTuple: 00:00:00.0143741
NewIntTuple: 00:00:00.0143745
NewIntTuple: 00:00:00.0144070
NewIntTuple: 00:00:00.0144361
NewIntTuple: 00:00:00.0144255
NewDoubleTuple: 00:00:00.0162535
NewDoubleTuple: 00:00:00.0162460
NewDoubleTuple: 00:00:00.0162538
NewDoubleTuple: 00:00:00.0162349
NewDoubleTuple: 00:00:00.0162483
NewDoubleTuple: 00:00:00.0162368
NewDoubleTuple: 00:00:00.0162206
NewDoubleTuple: 00:00:00.0162730
NewDoubleTuple: 00:00:00.0163367
NewDoubleTuple: 00:00:00.0162350
```

</td>
</tr>
</table>