### PR TITLE
Merge `.managedcode` and `hydrated` sections into well-known sections

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -89,6 +89,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="@(NativeLibrary->'&quot;%(Identity)&quot;')" />
       <LinkerArg Include="@(SdkNativeLibrary->'&quot;%(Identity)&quot;')" />
       <LinkerArg Include="/NOLOGO /MANIFEST:NO" />
+      <LinkerArg Condition="$(IlcMergeSections) != 'false'" Include="/MERGE:.managedcode=.text /MERGE:hydrated=.bss" />
       <LinkerArg Condition="$(NativeDebugSymbols) == 'true'" Include="/DEBUG" />
       <!-- The runtime is not compatible with jump stubs inserted by incremental linking. -->
       <LinkerArg Include="/INCREMENTAL:NO" />


### PR DESCRIPTION
Contributes to #105959 and #33745.

Certain "antiviruses" seem to consider any executable with non-standard sections malware. So don't emit non-standard sections.

Hello World before this PR: https://www.virustotal.com/gui/file/2f611e8459b612f9071d60aaefb90441079952130a631d28bc537d4ef0ea61bd?nocache=1

Hello World after this PR: https://www.virustotal.com/gui/file/802789e700e3d012bad7d598598199fe09bb1e329ca652fea6984e39228973f3?nocache=1

Cc @dotnet/ilc-contrib 