### PR TITLE
[Mono AOT] Fix error when returning zero sized struct

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1610,7 +1610,11 @@ sig_to_llvm_sig_full (EmitContext *ctx, MonoMethodSignature *sig, LLVMCallInfo *
 	case LLVMArgVtypeAsScalar: {
 		int size = mono_class_value_size (mono_class_from_mono_type_internal (rtype), NULL);
 		/* LLVM models this by returning an int */
-		if (size < TARGET_SIZEOF_VOID_P) {
+		if (size == 0) {
+			/* Empty struct with LayoutKind attribute and without specified size */
+			g_assert(cinfo->ret.nslots == 0);
+			ret_type = LLVMIntType (8);
+		} else if (size < TARGET_SIZEOF_VOID_P) {
 			g_assert (cinfo->ret.nslots == 1);
 			ret_type = LLVMIntType (size * 8);
 		} else {

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1593,7 +1593,7 @@ sig_to_llvm_sig_full (EmitContext *ctx, MonoMethodSignature *sig, LLVMCallInfo *
 			ret_type = LLVMStructType (members, 1, FALSE);
 		} else if (cinfo->ret.pair_storage [0] == LLVMArgNone && cinfo->ret.pair_storage [1] == LLVMArgNone) {
 			/* Empty struct */
-			ret_type = LLVMVoidType ();
+			ret_type = LLVMStructType (NULL, 0, FALSE);
 		} else if (cinfo->ret.pair_storage [0] == LLVMArgInIReg && cinfo->ret.pair_storage [1] == LLVMArgInIReg) {
 			LLVMTypeRef members [2];
 
@@ -4948,6 +4948,9 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 	case LLVMArgVtypeInReg: {
 		if (LLVMTypeOf (lcall) == LLVMVoidType ())
 			/* Empty struct */
+			break;
+
+		if (LLVMTypeOf (lcall) == LLVMStructType (NULL, 0, FALSE))
 			break;
 
 		if (!addresses [ins->dreg])

--- a/src/tests/JIT/Regression/JitBlue/Runtime_103628/Runtime_103628.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_103628/Runtime_103628.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct S1
+{
+}
+
+[StructLayout(LayoutKind.Auto)]
+public struct S2
+{
+}
+
+public class Runtime_103628
+{
+    public static S1 Get_S1() => new S1();
+
+    public static S2 Get_S2() => new S2();
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        S1 s1 = Get_S1();
+        S2 s2 = Get_S2();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_103628/Runtime_103628.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_103628/Runtime_103628.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR allows Mono AOT to handle returns of zero sized structs in registers. 

Example: 
```c#
public struct Foo
{
}
```
The `[StructLayout(LayoutKind.Sequential, Size = 1)]` attribute will be added during compilation [SharpLab](https://sharplab.io/#v2:CYLg1APgAgTAjAWAFBQAwAIpwHQCUCuAdgC4CWAtgKbYCSJlATgPYAOAyowG6kDGlAzgG5kyKAGZ0/Yg3w9i6AGJMmyAN7IAvsiA).

```c#
[StructLayout(LayoutKind.Sequential)] // or [StructLayout(LayoutKind.Auto)] 
public struct Foo
{
}
```

However, adding an explicit `[StructLayout(LayoutKind.Sequential]` or `[StructLayout(LayoutKind.Auto)]` will not generate any explicit size metadata causing the struct to have size 0 [SharpLab](https://sharplab.io/#v2:CYLg1APgAgTAjAWAFBQAwAIpwHQCUCuAdgC4CWAtgKbYCSJlATgPYAOAyowG6kDGlAzgG5kyANptiDfD2IAZAIYBPJvmIAKBctUBpUoWDYOAR3yUSpeQBsAlAF1kUAMzp+k6cXQAxJk2QBvZABfZCA==).

---

#### Mono Codegen:

```c#
[StructLayout(LayoutKind.Sequential)]
public struct Foo
{
}

public class Bar
{
   public static Foo GetFoo() => new Foo();
}
```

When processing the return of the `GetFoo()` method mono will evaluate size of struct `Foo` to be equal to zero. Then it tries to pass it in registers, calculating that it needs `0` registers to do so. 
https://github.com/dotnet/runtime/blob/bedf340098a3cf494f200d99a9a53d3df1d1c6c7/src/mono/mono/mini/mini-arm64.c#L1708

Mono JIT handles this by omitting codegen part when `cinfo->ret.nregs` is equal to zero.
https://github.com/dotnet/runtime/blob/d606c601510c1a1a28cb6ef3550f12db049c0776/src/mono/mono/mini/mini-arm64.c#L3894-L3911

This PR proposes to fix the issue in Mono AOT by treating zero sized structs as if they have size 1. 

---

Fixes https://github.com/dotnet/runtime/issues/103628
Fixes https://github.com/dotnet/runtime/issues/106259