### PR TITLE
[RISC-V][LoongArch64] HijackFrame::UpdateRegDisplay update A0

### DIFF
--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -818,6 +818,8 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD, bool updateFloats)
     s = s + s%16;
     pRD->pCurrentContext->Sp = PTR_TO_TADDR(m_Args) + s ;
 
+    pRD->pCurrentContext->A0 = m_Args->A0;
+
     pRD->pCurrentContext->S0 = m_Args->S0;
     pRD->pCurrentContext->S1 = m_Args->S1;
     pRD->pCurrentContext->S2 = m_Args->S2;

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -738,6 +738,8 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD, bool updateFloats)
     s = s + s%16;
     pRD->pCurrentContext->Sp = PTR_TO_TADDR(m_Args) + s ;
 
+    pRD->pCurrentContext->A0 = m_Args->A0;
+
     pRD->pCurrentContext->S1 = m_Args->S1;
     pRD->pCurrentContext->S2 = m_Args->S2;
     pRD->pCurrentContext->S3 = m_Args->S3;


### PR DESCRIPTION
Update A0 as for [arm64](https://github.com/dotnet/runtime/blob/d606c601510c1a1a28cb6ef3550f12db049c0776/src/coreclr/vm/arm64/stubs.cpp#L787), [arm](https://github.com/dotnet/runtime/blob/d606c601510c1a1a28cb6ef3550f12db049c0776/src/coreclr/vm/arm/stubs.cpp#L1678C17-L1678C39) and [amd64](https://github.com/dotnet/runtime/blob/d606c601510c1a1a28cb6ef3550f12db049c0776/src/coreclr/vm/amd64/cgenamd64.cpp#L341).

cc @dotnet/samsung part of #84834.