### PR TITLE
[release/8.0] Bump additional npm deps and lock file format

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -35,7 +35,7 @@
     <WasmExtraFilesToDeploy Include="package.json" />
     <WasmExtraFilesToDeploy Include="package-lock.json" />
 
-    <NodeNpmModule Include="ws" Alias="WebSocket" />
+    <NodeNpmModule Include="ws" />
     <NodeNpmModule Include="node-fetch" />
     <NodeNpmModule Include="node-abort-controller" />
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/package-lock.json
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/package-lock.json
@@ -6,64 +6,118 @@
     "": {
       "name": "system.net.websockets.client.tests",
       "dependencies": {
-        "node-abort-controller": "3.0.1",
-        "node-fetch": "2.6.7",
-        "ws": "8.4.0"
+        "node-abort-controller": "3.1.1",
+        "node-fetch": "3.3.2",
+        "ws": "8.17.1"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha1-2P6ysogeak9YwuCKz9Dig04mIi4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha1-8JuNS71Frcbwwgt+eH55PjCdzOk=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha1-JIB8McnUAuACqz2McgFEzriEhCM=",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/node-abort-controller": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
-      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg=",
+      "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha1-aIjbRqH3HAt2s/dVUBa2P+ZHZuU=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
         }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha1-0eiJus33M7T/OyskPrehKGagt4s=",
+      "license": "MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha1-IHO5Gi/bH7+9QB594KyfghTOy0s=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.17.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha1-kpPaUwu1SP68lTcdkPnIeHJ9kZs=",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -76,42 +130,57 @@
     }
   },
   "dependencies": {
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha1-2P6ysogeak9YwuCKz9Dig04mIi4="
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha1-8JuNS71Frcbwwgt+eH55PjCdzOk=",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha1-JIB8McnUAuACqz2McgFEzriEhCM=",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
     "node-abort-controller": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
-      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha1-aIjbRqH3HAt2s/dVUBa2P+ZHZuU="
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "3.3.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha1-0eiJus33M7T/OyskPrehKGagt4s=",
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha1-IHO5Gi/bH7+9QB594KyfghTOy0s="
     },
     "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.17.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha1-kpPaUwu1SP68lTcdkPnIeHJ9kZs=",
       "requires": {}
     }
   }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/package.json
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "node-abort-controller": "3.0.1",
-    "node-fetch": "2.6.7",
-    "ws": "8.4.0"
+    "node-abort-controller": "3.1.1",
+    "node-fetch": "3.3.2",
+    "ws": "8.17.1"
   }
 }

--- a/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -26,7 +26,7 @@
     <WasmExtraFilesToDeploy Include="package.json" />
     <WasmExtraFilesToDeploy Include="package-lock.json" />
 
-    <NodeNpmModule Include="ws" Alias="WebSocket" />
+    <NodeNpmModule Include="ws" />
   </ItemGroup>
 
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->

--- a/src/libraries/System.Net.WebSockets.Client/tests/package-lock.json
+++ b/src/libraries/System.Net.WebSockets.Client/tests/package-lock.json
@@ -1,27 +1,25 @@
 {
   "name": "system.net.websockets.client.tests",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "system.net.websockets.client.tests",
-      "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
-        "ws": "^8.4.0"
+        "ws": "8.17.1"
       }
     },
     "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.17.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha1-kpPaUwu1SP68lTcdkPnIeHJ9kZs=",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -31,14 +29,6 @@
           "optional": true
         }
       }
-    }
-  },
-  "dependencies": {
-    "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-      "requires": {}
     }
   }
 }

--- a/src/libraries/System.Net.WebSockets.Client/tests/package.json
+++ b/src/libraries/System.Net.WebSockets.Client/tests/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "ws": "8.4.0"
+    "ws": "8.17.1"
   }
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/103639

The https://github.com/dotnet/runtime/pull/104359 PR did not have the package.json and package-lock.json changes in System.Net.WebSockets.Client and System.Net.Http.Functional.Tests projects.