### PR TITLE
Fix _LOGALLOC define

### DIFF
--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -139,10 +139,6 @@ extern size_t gc_global_mechanisms[MAX_GLOBAL_GC_MECHANISMS_COUNT];
 class DacHeapWalker;
 #endif
 
-#ifdef _DEBUG
-#define  _LOGALLOC
-#endif
-
 #define MP_LOCKS
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES

--- a/src/coreclr/inc/log.h
+++ b/src/coreclr/inc/log.h
@@ -47,6 +47,10 @@ enum {
 #define ERROR       0
 #define FATALERROR  0
 
+#ifdef _DEBUG
+#define _LOGALLOC
+#endif
+
 #ifndef LOGGING
 
 #define LOG(x)


### PR DESCRIPTION
_LOGALLOC define was in gc.h while all usages in vm and this vm files do not include gc.h:
```
grep  src/coreclr/ -re LOGALLOC
src/coreclr/vm/gchelpers.cpp:#ifdef  _LOGALLOC
src/coreclr/vm/gchelpers.cpp:#ifdef  _LOGALLOC
src/coreclr/vm/gchelpers.cpp:#endif // _LOGALLOC
src/coreclr/vm/jitinterface.cpp:#ifdef _LOGALLOC
src/coreclr/vm/jitinterface.cpp:#endif // _LOGALLOC
src/coreclr/gc/gc.h:#define  _LOGALLOC
```
It caused lack of object allocation messages in common clr log.