### PR TITLE
[mono] Mark AOT modules unusable if no AOT version is found

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2102,15 +2102,13 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 		find_symbol (sofile, globals, "mono_aot_file_info", (gpointer*)&info);
 	}
 
-	// Copy aotid to MonoImage
-	memcpy(&assembly->image->aotid, info->aotid, 16);
-
 	if (version_symbol) {
 		/* Old file format */
 		version = atoi (version_symbol);
-	} else {
-		g_assert (info);
+	} else if (info) {
 		version = info->version;
+	} else {
+		version = -1;
 	}
 
 	if (version != MONO_AOT_FILE_VERSION) {
@@ -2120,6 +2118,9 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 		guint8 *blob;
 		void *handle;
 
+		// Copy aotid to MonoImage
+		memcpy(&assembly->image->aotid, info->aotid, 16);
+		
 		if (info->flags & MONO_AOT_FILE_FLAG_SEPARATE_DATA) {
 			aot_data = open_aot_data (assembly, info, &handle);
 

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2118,6 +2118,8 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 		guint8 *blob;
 		void *handle;
 
+		g_assert (info);
+		
 		// Copy aotid to MonoImage
 		memcpy(&assembly->image->aotid, info->aotid, 16);
 		


### PR DESCRIPTION
## Description
On Android, we might hit a collision where we instead of `<libName>.dll.so` try to load `<libName>.so`. By detecting this issue early we can mark the library as AOT unusable. We do this by checking if we were able to get the AOT file version and if not, we mark the `.so` file as unusable.

Full issue description https://github.com/dotnet/runtime/issues/104397.

This is a fix from https://github.com/dotnet/runtime/issues/104397#issuecomment-2206999715. cc: @lambdageek 

## Verification
Tried locally build runtime with Xamarin Android app previously crashing due to SkiaSharp load. The crash wasn't present with this PR and the app started up correctly.

Previous behavior: 
```
02-10 22:05:39.195 25696 25696 D monodroid-assembly: monodroid_dlopen: hash for name 'SkiaSharp.so' is 0x12e73d483788709d
02-10 22:05:39.195 25696 25696 D monodroid-assembly: monodroid_dlopen: hash match found, DSO name is 'libSkiaSharp.so'
--------- beginning of crash
02-10 22:05:39.198 25696 25696 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x234 in tid 25696 (aSharpLoadCrash), pid 25696 (aSharpLoadCrash)
```

This PR:
```
02-11 00:32:00.684 30843 30843 D monodroid-assembly: monodroid_dlopen: hash for name 'SkiaSharp.so' is 0x12e73d483788709d
02-11 00:32:00.684 30843 30843 D monodroid-assembly: monodroid_dlopen: hash match found, DSO name is 'libSkiaSharp.so'
02-11 00:32:00.687 30843 30843 D Mono    : AOT: module SkiaSharp.so is unusable: wrong file format version (expected 186 got -1).
02-11 00:32:00.687 30843 30843 D Mono    : Assembly found with the filesystem probing logic: 'SkiaSharp'.
02-11 00:32:00.687 30843 30843 D Mono    : Requesting loading reference 0 (of 3) of SkiaSharp
02-11 00:32:00.687 30843 30843 D Mono    : Loading reference 0 of SkiaSharp (default ALC), looking for System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
02-11 00:32:00.687 30843 30843 D Mono    : Request to load System.Private.CoreLib in alc 0x7579e4bdc0
02-11 00:32:00.687 30843 30843 D Mono    : Assembly already loaded in the active ALC: 'System.Private.CoreLib'.
02-11 00:32:00.687 30843 30843 D Mono    : Assembly Ref addref SkiaSharp[0x760f7729a0] -> System.Private.CoreLib[0x760f771640]: 5
```