### PR TITLE
[release/8.0-staging] Ensure we consistently broadcast the result of simd dot product

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -4865,8 +4865,9 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                 horizontalAdd = NI_SSE3_HorizontalAdd;
 
-                if (!comp->compOpportunisticallyDependsOn(InstructionSet_SSE3))
+                if ((simdSize == 8) || !comp->compOpportunisticallyDependsOn(InstructionSet_SSE3))
                 {
+                    // We also do this for simdSize == 8 to ensure we broadcast the result as expected
                     shuffle = NI_SSE_Shuffle;
                 }
                 break;
@@ -4917,10 +4918,8 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                 horizontalAdd = NI_SSE3_HorizontalAdd;
 
-                if (!comp->compOpportunisticallyDependsOn(InstructionSet_SSE3))
-                {
-                    shuffle = NI_SSE2_Shuffle;
-                }
+                // We need to ensure we broadcast the result as expected
+                shuffle = NI_SSE2_Shuffle;
                 break;
             }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10724,16 +10724,6 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
                 break;
             }
 
-#if defined(TARGET_XARCH)
-            if ((node->GetSimdSize() == 8) && !compOpportunisticallyDependsOn(InstructionSet_SSE41))
-            {
-                // When SSE4.1 isn't supported then Vector2 only needs a single horizontal add
-                // which means the result isn't broadcast across the entire vector and we can't
-                // optimize
-                break;
-            }
-#endif // TARGET_XARCH
-
             GenTree* op1      = node->Op(1);
             GenTree* sqrt     = nullptr;
             GenTree* toScalar = nullptr;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_99391/Runtime_99391.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_99391/Runtime_99391.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using Xunit;
+
+public class Runtime_99391
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Vector2 result2a = Vector2.Normalize(Value2);
+        Assert.Equal(new Vector2(0, 1), result2a);
+
+        Vector2 result2b = Vector2.Normalize(new Vector2(0, 2));
+        Assert.Equal(new Vector2(0, 1), result2b);
+
+        Vector3 result3a = Vector3.Normalize(Value3);
+        Assert.Equal(new Vector3(0, 0, 1), result3a);
+
+        Vector3 result3b = Vector3.Normalize(new Vector3(0, 0, 2));
+        Assert.Equal(new Vector3(0, 0, 1), result3b);
+
+        Vector4 result4a = Vector4.Normalize(Value4);
+        Assert.Equal(new Vector4(0, 0, 0, 1), result4a);
+
+        Vector4 result4b = Vector4.Normalize(new Vector4(0, 0, 0, 2));
+        Assert.Equal(new Vector4(0, 0, 0, 1), result4b);
+    }
+
+    private static Vector2 Value2
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        get => new Vector2(0, 2);
+    }
+
+    private static Vector3 Value3
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        get => new Vector3(0, 0, 2);
+    }
+
+    private static Vector4 Value4
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        get => new Vector4(0, 0, 0, 2);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_99391/Runtime_99391.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_99391/Runtime_99391.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #105888 to release/8.0-staging

/cc @tannergooding

## Customer Impact

- [x] Customer reported: https://github.com/dotnet/runtime/issues/99391
- [ ] Found internally

Users with hardware that supports SSE3-SSSE3 (2004-2007) and using Vector2 can experience incorrect results in some cases as the result is not correctly replicated to all elements of the vector. This is not an issue with hardware that only supports SSE2 (our baseline ISA) or with hardware that supports SSE4.1+ (2007).

## Regression

- [x] Yes
- [ ] No

The bug was introduced in https://github.com/dotnet/runtime/pull/81335 when an optimization was added to avoid redundant broadcast. It was missed that for SSE3-SSSE3 and for Vector2 in particular (but not for `Vector3/4` or `Vector64/128/256/512<T>`), a slightly different code path was gone down under which the broadcast was not redundant.

## Testing

Explicit tests covering the bug were added. Additional tests covering the repro for the other vector types were also added.

## Risk

Low. This impacts a single type and only on relatively old hardware. Users can also see the failure on new hardware if they are doing testing and set the `DOTNET_EnableSSE41=0` environment variable.

The effective fix here was to execute the same code path as was already being used by SSE2 hardware (the same baseline that NAOT, Crossgen, and ReadyToRun default to).