### PR TITLE
Fix TimeZone Names

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -224,6 +224,10 @@ namespace System
             return rulesList.ToArray();
         }
 
+        private string NameLookupId =>
+                HasIanaId ? Id :
+                (_equivalentZones is not null && _equivalentZones.Count > 0 ? _equivalentZones[0].Id : (GetAlternativeId(Id, out _) ?? Id));
+
         private string? PopulateDisplayName()
         {
             if (IsUtcAlias(Id))
@@ -239,7 +243,7 @@ namespace System
             if (!GlobalizationMode.Hybrid)
                 return displayName;
 #endif
-            GetFullValueForDisplayNameField(Id, BaseUtcOffset, ref displayName);
+            GetFullValueForDisplayNameField(NameLookupId, BaseUtcOffset, ref displayName);
 
             return displayName;
         }
@@ -257,7 +261,7 @@ namespace System
             if (!GlobalizationMode.Hybrid)
                 return standardDisplayName;
 #endif
-            GetStandardDisplayName(Id, ref standardDisplayName);
+            GetStandardDisplayName(NameLookupId, ref standardDisplayName);
 
             return standardDisplayName;
         }
@@ -275,7 +279,7 @@ namespace System
             if (!GlobalizationMode.Hybrid)
                 return daylightDisplayName;
 #endif
-            GetDaylightDisplayName(Id, ref daylightDisplayName);
+            GetDaylightDisplayName(NameLookupId, ref daylightDisplayName);
 
             return daylightDisplayName;
         }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -3222,6 +3222,33 @@ namespace System.Tests
             Assert.Equal(string.Empty, custom.DisplayName);
         }
 
+        [InlineData("Eastern Standard Time", "America/New_York")]
+        [InlineData("Central Standard Time", "America/Chicago")]
+        [InlineData("Mountain Standard Time", "America/Denver")]
+        [InlineData("Pacific Standard Time", "America/Los_Angeles")]
+        [ConditionalTheory(nameof(SupportICUAndRemoteExecution))]
+        public static void TestTimeZoneNames(string windowsId, string ianaId)
+        {
+            RemoteExecutor.Invoke(static (wId, iId) =>
+            {
+                TimeZoneInfo info1, info2;
+                if (PlatformDetection.IsWindows)
+                {
+                    info1 = TimeZoneInfo.FindSystemTimeZoneById(iId);
+                    info2 = TimeZoneInfo.FindSystemTimeZoneById(wId);
+                }
+                else
+                {
+                    info1 = TimeZoneInfo.FindSystemTimeZoneById(wId);
+                    info2 = TimeZoneInfo.FindSystemTimeZoneById(iId);
+                }
+
+                Assert.Equal(info1.StandardName, info2.StandardName);
+                Assert.Equal(info1.DaylightName, info2.DaylightName);
+                Assert.Equal(info1.DisplayName, info2.DisplayName);
+            }, windowsId, ianaId).Dispose();
+        }
+
         private static bool IsEnglishUILanguage => CultureInfo.CurrentUICulture.Name.Length == 0 || CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "en";
 
         private static bool IsEnglishUILanguageAndRemoteExecutorSupported => IsEnglishUILanguage && RemoteExecutor.IsSupported;


### PR DESCRIPTION
In .NET 8.0 we have done some optimization work to delay initializing the time zone names (Standard, Daylight, and Display names). The reason is the names initialization is extremely expensive especially on non-Windows OS's because we do some heuristics and call ICU to extract such names. Unintentionally doing names lazy initialization on non-Windows OS's caused a problem with the time zones created using Windows Ids e.g. `Eastern Standard Time`. The reason is to get the correct names of the time zone you need to call ICU using the IANA ids e.g. `America/New_York` which not done with the lazy initialization. The fix here is to ensure using the IANA ids on non-Windows OS's when requesting the names from ICU. 

The repro of the issue, on Linux use code like:

```C#
TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
Console.WriteLine($"{zoneName}: {timeZone.Id} ... {timeZone.StandardName} ... {timeZone.DaylightName} ");
```

This code will display names like `GMT` which are wrong as expected to show something like `Eastern Standard Time: Eastern Standard Time ... Eastern Standard Time ... Eastern Daylight Time`. 