### PR TITLE
[EventPipe] Block EventPipeProvider Deletion for ongoing callbacks

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -85,6 +85,9 @@ namespace System.Diagnostics.Tracing
         }
 
         // Unregister an event provider.
+        // Calling Unregister within a Callback will result in a deadlock
+        // as deleting the provider with an active tracing session will block
+        // until all of the provider's callbacks are completed.
         internal override void Unregister()
         {
             if (_provHandle != 0)

--- a/src/mono/mono/eventpipe/test/ep-provider-callback-dataqueue-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-provider-callback-dataqueue-tests.c
@@ -57,7 +57,8 @@ test_provider_callback_data_queue (void)
 			1,
 			EP_EVENT_LEVEL_LOGALWAYS,
 			true,
-			0);
+			0,
+			NULL);
 		ep_provider_callback_data_queue_enqueue (provider_callback_data_queue, provider_enqueue_callback_data);
 		ep_provider_callback_data_fini (provider_enqueue_callback_data);
 	}

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -193,6 +193,9 @@ ep_provider_alloc (
 	instance->event_list = dn_list_alloc ();
 	ep_raise_error_if_nok (instance->event_list != NULL);
 
+	ep_rt_wait_event_alloc (&instance->callbacks_complete_event, true /* bManual */, false /* bInitial */);
+	ep_raise_error_if_nok (ep_rt_wait_event_is_valid (&instance->callbacks_complete_event));
+
 	instance->keywords = 0;
 	instance->provider_level = EP_EVENT_LEVEL_CRITICAL;
 	instance->callback_func = callback_func;
@@ -200,6 +203,7 @@ ep_provider_alloc (
 	instance->config = config;
 	instance->delete_deferred = false;
 	instance->sessions = 0;
+	instance->uninvoked_prepared_callbacks_counter = 0;
 
 ep_on_exit:
 	return instance;
@@ -225,6 +229,7 @@ ep_provider_free (EventPipeProvider * provider)
 	}
 
 ep_on_exit:
+	ep_rt_wait_event_free (&provider->callbacks_complete_event);
 	ep_rt_utf16_string_free (provider->provider_name_utf16);
 	ep_rt_utf8_string_free (provider->provider_name);
 	ep_rt_object_free (provider);

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -86,7 +86,8 @@ provider_prepare_callback_data (
 		keywords,
 		provider_level,
 		provider->sessions != 0,
-		session_id);
+		session_id,
+		provider);
 }
 
 static

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -374,7 +374,9 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 {
 	EP_ASSERT (provider_callback_data != NULL);
 
-	// Lock should not be held when invoking callback.
+	// A lock should not be held when invoking the callback, as concurrent callbacks
+	// may trigger a deadlock with the EventListenersLock as detailed in
+	// https://github.com/dotnet/runtime/pull/105734
 	ep_requires_lock_not_held ();
 
 	const ep_char8_t *filter_data = ep_provider_callback_data_get_filter_data (provider_callback_data);
@@ -438,6 +440,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 			callback_data /* CallbackContext */);
 	}
 
+	// The callback completed, can take the lock again.
 	EP_LOCK_ENTER (section1)
 		if (callback_function != NULL) {
 			EventPipeProvider *provider = provider_callback_data->provider;

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -442,6 +442,11 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 		if (callback_function != NULL) {
 			EventPipeProvider *provider = provider_callback_data->provider;
 			provider->uninvoked_prepared_callbacks_counter--;
+			if (provider->uninvoked_prepared_callbacks_counter == 0 && provider->callback_func == NULL) {
+				// ep_delete_provider deferred provider deletion and is waiting for all in-flight callbacks
+				// to complete. This is the last callback, so signal completion.
+				ep_rt_wait_event_set (&provider->callbacks_complete_event);
+			}
 		}
 	EP_LOCK_EXIT (section1)
 

--- a/src/native/eventpipe/ep-provider.h
+++ b/src/native/eventpipe/ep-provider.h
@@ -42,10 +42,9 @@ struct _EventPipeProvider_Internal {
 	// True if the provider has been deleted, but that deletion
 	// has been deferred until tracing is stopped.
 	bool delete_deferred;
-	// The number of EventPipeProvider callbacks that have been
-	// prepared but not yet invoked.
-	// Used to determine when it is safe to delete a provider.
-	int64_t uninvoked_prepared_callbacks_counter;
+	// The number of pending EventPipeProvider callbacks that have
+	// not completed.
+	int64_t callbacks_pending;
 	// Event object used to signal eventpipe provider deletion
 	// that all in flight callbacks have completed.
 	ep_rt_wait_event_handle_t callbacks_complete_event;

--- a/src/native/eventpipe/ep-provider.h
+++ b/src/native/eventpipe/ep-provider.h
@@ -42,6 +42,13 @@ struct _EventPipeProvider_Internal {
 	// True if the provider has been deleted, but that deletion
 	// has been deferred until tracing is stopped.
 	bool delete_deferred;
+	// The number of EventPipeProvider callbacks that have been
+	// prepared but not yet invoked.
+	// Used to determine when it is safe to delete a provider.
+	int64_t uninvoked_prepared_callbacks_counter;
+	// Event object used to signal eventpipe provider deletion
+	// that all in flight callbacks have completed.
+	ep_rt_wait_event_handle_t callbacks_complete_event;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_PROVIDER_GETTER_SETTER)

--- a/src/native/eventpipe/ep-types.h
+++ b/src/native/eventpipe/ep-types.h
@@ -76,6 +76,7 @@ struct _EventPipeProviderCallbackData_Internal {
 	EventPipeEventLevel provider_level;
 	bool enabled;
 	EventPipeSessionID session_id;
+	EventPipeProvider *provider;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_EP_GETTER_SETTER)
@@ -100,7 +101,8 @@ ep_provider_callback_data_alloc (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	EventPipeSessionID session_id);
+	EventPipeSessionID session_id,
+	EventPipeProvider *provider);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_callback_data_src);
@@ -117,7 +119,8 @@ ep_provider_callback_data_init (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	EventPipeSessionID session_id);
+	EventPipeSessionID session_id,
+	EventPipeProvider *provider);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init_copy (

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -225,7 +225,8 @@ ep_provider_callback_data_alloc (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	EventPipeSessionID session_id)
+	EventPipeSessionID session_id,
+	EventPipeProvider *provider)
 {
 	EventPipeProviderCallbackData *instance = ep_rt_object_alloc (EventPipeProviderCallbackData);
 	ep_raise_error_if_nok (instance != NULL);
@@ -238,7 +239,8 @@ ep_provider_callback_data_alloc (
 		keywords,
 		provider_level,
 		enabled,
-		session_id) != NULL);
+		session_id,
+		provider) != NULL);
 
 ep_on_exit:
 	return instance;
@@ -298,7 +300,8 @@ ep_provider_callback_data_init (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	EventPipeSessionID session_id)
+	EventPipeSessionID session_id,
+	EventPipeProvider *provider)
 {
 	EP_ASSERT (provider_callback_data != NULL);
 
@@ -309,6 +312,7 @@ ep_provider_callback_data_init (
 	provider_callback_data->provider_level = provider_level;
 	provider_callback_data->enabled = enabled;
 	provider_callback_data->session_id = session_id;
+	provider_callback_data->provider = provider;
 
 	return provider_callback_data;
 }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -404,9 +404,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/nativeruntimeeventsource/*">
             <Issue>https://github.com/dotnet/runtime/issues/68690</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
-            <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/regress/vsw/373472/**">
             <Issue>Allocates large contiguous array that is not consistently available on 32-bit platforms</Issue>
         </ExcludeList>
@@ -419,9 +416,6 @@
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsOSX)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' ">
         <ExcludeList Include="$(XunitTestBinBase)/profiler/eventpipe/eventpipe/*">
             <Issue>https://github.com/dotnet/runtime/issues/66174</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
-            <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/80666

This PR aims to align behavior between [EventPipe's Unregister logic](https://github.com/dotnet/runtime/blob/7dd55a0aa662dc70e85149e66b8c3f19456408ed/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs#L92) and [ETW's Unregister logic]( https://github.com/dotnet/runtime/blob/7dd55a0aa662dc70e85149e66b8c3f19456408ed/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs#L858) by blocking EventPipe's DeleteProvider for in-flight callbacks, so that the gchandle will not be [freed](https://github.com/dotnet/runtime/blob/7dd55a0aa662dc70e85149e66b8c3f19456408ed/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs#L97) before the callback [completes](https://github.com/dotnet/runtime/blob/7dd55a0aa662dc70e85149e66b8c3f19456408ed/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs#L65-L69). ([ETW has its own lock for ETW commands/callbacks](https://github.com/dotnet/runtime/blob/7dd55a0aa662dc70e85149e66b8c3f19456408ed/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs#L157-L163)).

Our [initial attempt to add a corresponding EventPipe lock](https://github.com/dotnet/runtime/pull/105734) revealed to us that locks should not be taken around the callback (specifically performing the callback within a lock) because it [breaks concurrent callbacks scenarios](https://github.com/dotnet/runtime/pull/105734#issuecomment-2263786867).

In this PR, we track the EventPipeProvider's callbacks that have been [prepared](https://github.com/dotnet/runtime/blob/5fb42a458bc9c476978ec45092cc398f92371186/src/native/eventpipe/ep-provider.c#L70) but not yet [invoked](https://github.com/dotnet/runtime/blob/5fb42a458bc9c476978ec45092cc398f92371186/src/native/eventpipe/ep-provider.c#L419) (i.e. in-flight callbacks), and leverage a signal set/wait to block the [EventPipe Provider's deferred deletion](https://github.com/dotnet/runtime/blob/5fb42a458bc9c476978ec45092cc398f92371186/src/native/eventpipe/ep.c#L1319).

-------------------------------------------
## Repro

Reproduced the crash by:
```C#
Console.WriteLine("MIHW Ready to create TestEventSource");
Console.ReadKey();
var testEventSource = new TestEventSource();
Console.WriteLine("MIHW Ready to dispose TestEventSource");
Console.ReadKey();
testEventSource.Dispose();
Console.WriteLine($"MIHW TestEventSource disposed.");

[EventSource(Name = "TestEventSource")]
public class TestEventSource : EventSource
...
```

1. Launching the above sample app in windbg
2. Connecting an EventPipe session via `dotnet-trace collect --providers TestEventSource -p <pid of app from dotnet-trace ps>`
3. Setting a breakpoint in ep-provider.c provider_invoke_callback at callback invocation
4. Closing the EventPipe session (enter || ctrl + c) to hit that breakpoint and freezing the thread
5. Continuing the application logic by disposing the EventSource
6. Unfreezing the previously frozen thread and continuing

Resulted in a NullReferenceException crash.

## Testing

Performed the same steps as above with the changes in this PR, Dispose is blocked until the callback completes.