### PR TITLE
Don't hit all properties on Color in ColorTranslator

### DIFF
--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -483,7 +483,7 @@ namespace System.Drawing
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void GetRgbValues(out int r, out int g, out int b)
+        internal void GetRgbValues(out int r, out int g, out int b)
         {
             uint value = (uint)Value;
             r = (int)(value & ARGBRedMask) >> ARGBRedShift;

--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/ColorTranslator.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/ColorTranslator.cs
@@ -32,7 +32,11 @@ namespace System.Drawing
         /// </summary>
         public static int ToWin32(Color c)
         {
-            return c.R << COLORREF_RedShift | c.G << COLORREF_GreenShift | c.B << COLORREF_BlueShift;
+            // KnownColor Color values causes a table lookup or OS call for
+            // every access, as such we manually extract the RGB values.
+
+            c.GetRgbValues(out int r, out int g, out int b);
+            return r << COLORREF_RedShift | g << COLORREF_GreenShift | b << COLORREF_BlueShift;
         }
 
         /// <summary>
@@ -386,7 +390,8 @@ namespace System.Drawing
             }
             else
             {
-                colorString = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+                c.GetRgbValues(out int r, out int g, out int b);
+                colorString = $"#{r:X2}{g:X2}{b:X2}";
             }
 
             return colorString;


### PR DESCRIPTION
KnownColor based Color values look up the value with every method/property access. Avoid this by making Color.GetRgbValues internal and use it in ColorTranslator.

This is more of a hit in Windows where system colors also involve a system call.

Fixes #105992