### PR TITLE
JIT: Use `jitstd::utility::scoped_code` to unmark trees during lowering

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9327,18 +9327,9 @@ bool Lowering::TryMakeIndirsAdjacent(GenTreeIndir* prevIndir, GenTreeIndir* indi
     JITDUMP(
         "  ..and they are close. Trying to move the following range (where * are nodes part of the data flow):\n\n");
 #ifdef DEBUG
-    bool       isClosed;
-    const bool isMarked      = (prevIndir->gtLIRFlags & LIR::Flags::Mark) != 0;
-    GenTree*   startDumpNode = BlockRange().GetTreeRange(prevIndir, &isClosed).FirstNode();
-    GenTree*   endDumpNode   = indir->gtNext;
-
-    // GetTreeRange will unset LIR::Flags::Mark on prevIndir,
-    // so make sure to restore it before continuing
-    if (isMarked)
-    {
-        assert((prevIndir->gtLIRFlags & LIR::Flags::Mark) == 0);
-        prevIndir->gtLIRFlags |= LIR::Flags::Mark;
-    }
+    bool     isClosed;
+    GenTree* startDumpNode = BlockRange().GetTreeRange(prevIndir, &isClosed).FirstNode();
+    GenTree* endDumpNode   = indir->gtNext;
 
     auto dumpWithMarks = [=]() {
         if (!comp->verbose)

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9327,9 +9327,18 @@ bool Lowering::TryMakeIndirsAdjacent(GenTreeIndir* prevIndir, GenTreeIndir* indi
     JITDUMP(
         "  ..and they are close. Trying to move the following range (where * are nodes part of the data flow):\n\n");
 #ifdef DEBUG
-    bool     isClosed;
-    GenTree* startDumpNode = BlockRange().GetTreeRange(prevIndir, &isClosed).FirstNode();
-    GenTree* endDumpNode   = indir->gtNext;
+    bool       isClosed;
+    const bool isMarked      = (prevIndir->gtLIRFlags & LIR::Flags::Mark) != 0;
+    GenTree*   startDumpNode = BlockRange().GetTreeRange(prevIndir, &isClosed).FirstNode();
+    GenTree*   endDumpNode   = indir->gtNext;
+
+    // GetTreeRange will unset LIR::Flags::Mark on prevIndir,
+    // so make sure to restore it before continuing
+    if (isMarked)
+    {
+        assert((prevIndir->gtLIRFlags & LIR::Flags::Mark) == 0);
+        prevIndir->gtLIRFlags |= LIR::Flags::Mark;
+    }
 
     auto dumpWithMarks = [=]() {
         if (!comp->verbose)


### PR DESCRIPTION
Fixes #105971. `Lowering::TryMakeIndirsAdjacent` and `Lowering::TryMakeIndirAndStoreAdjacent` require that no `GenTree` nodes are marked upon entry, and that marked nodes are cleared upon exit, but in the case of the first method, not every exit path was unmarking the tree. `jitstd::utility::scoped_code` makes this invariant clear.