### PR TITLE
Backport https://github.com/dotnet/runtime/pull/100528 to release/8.0 to fix Perf runs.

### DIFF
--- a/eng/pipelines/common/upload-intermediate-artifacts-step.yml
+++ b/eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -2,6 +2,7 @@ parameters:
   name: ''
   publishPackagesCondition: always()
   publishVSSetupCondition: false
+  isOfficialBuild: true
 
 steps:
 - task: CopyFiles@2
@@ -27,7 +28,7 @@ steps:
 
 - template: /eng/pipelines/common/templates/publish-build-artifacts.yml
   parameters:
-    isOfficialBuild: true
+    isOfficialBuild: ${{ parameters.isOfficialBuild }}
     displayName: Publish intermediate artifacts
     inputs:
       PathtoPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -417,6 +417,7 @@ jobs:
           - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
             parameters:
               name: MonoRuntimePacks
+              isOfficialBuild: false
 
   # build PerfBDN app
   - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
Backport https://github.com/dotnet/runtime/pull/100528 to release/8.0 to fix Perf runs.
@carlossanlop is the release/8.0 branch open? We have been doing some work and noticed our performance release/8.0 pipeline runs weren't working due to this not being backported. Thanks.