### PR TITLE
Bring back assert in fx_ver_t::parse

### DIFF
--- a/src/native/corehost/fxr/fx_ver.cpp
+++ b/src/native/corehost/fxr/fx_ver.cpp
@@ -373,7 +373,6 @@ bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_
 bool fx_ver_t::parse(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_production)
 {
     bool valid = parse_internal(ver, fx_ver, parse_only_production);
-    // Causes a SIGABRT in free() on MacOS at least in singlefile, possibly elsewhere
-    // assert(!valid || fx_ver->as_str() == ver);
+    assert(!valid || fx_ver->as_str() == ver);
     return valid;
 }


### PR DESCRIPTION
I don't think we got to what exactly might have been included in a bad order, but enough has changed (like `fx_ver_t::as_str` that the assert here no longer aborts.

Fixes https://github.com/dotnet/runtime/issues/68927

cc @dotnet/appmodel 