### PR TITLE
[release/8.0-staging] Fix TimeZone Names

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -220,6 +220,10 @@ namespace System
             return rulesList.ToArray();
         }
 
+        private string NameLookupId =>
+                HasIanaId ? Id :
+                (_equivalentZones is not null && _equivalentZones.Count > 0 ? _equivalentZones[0].Id : (GetAlternativeId(Id, out _) ?? Id));
+
         private string? PopulateDisplayName()
         {
             if (IsUtcAlias(Id))
@@ -231,7 +235,7 @@ namespace System
             if (GlobalizationMode.Invariant)
                 return displayName;
 
-            GetFullValueForDisplayNameField(Id, BaseUtcOffset, ref displayName);
+            GetFullValueForDisplayNameField(NameLookupId, BaseUtcOffset, ref displayName);
 
             return displayName;
         }
@@ -245,7 +249,7 @@ namespace System
             if (GlobalizationMode.Invariant)
                 return standardDisplayName;
 
-            GetStandardDisplayName(Id, ref standardDisplayName);
+            GetStandardDisplayName(NameLookupId, ref standardDisplayName);
 
             return standardDisplayName;
         }
@@ -259,7 +263,7 @@ namespace System
             if (GlobalizationMode.Invariant)
                 return daylightDisplayName;
 
-            GetDaylightDisplayName(Id, ref daylightDisplayName);
+            GetDaylightDisplayName(NameLookupId, ref daylightDisplayName);
 
             return daylightDisplayName;
         }

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -3211,6 +3211,32 @@ namespace System.Tests
             Assert.Equal(string.Empty, custom.DisplayName);
         }
 
+        [InlineData("Eastern Standard Time", "America/New_York")]
+        [InlineData("Central Standard Time", "America/Chicago")]
+        [InlineData("Mountain Standard Time", "America/Denver")]
+        [InlineData("Pacific Standard Time", "America/Los_Angeles")]
+        [ConditionalTheory(nameof(SupportICUAndRemoteExecution))]
+        public static void TestTimeZoneNames(string windowsId, string ianaId)
+        {
+            RemoteExecutor.Invoke(static (wId, iId) =>
+            {
+                TimeZoneInfo info1, info2;
+                if (PlatformDetection.IsWindows)
+                {
+                    info1 = TimeZoneInfo.FindSystemTimeZoneById(iId);
+                    info2 = TimeZoneInfo.FindSystemTimeZoneById(wId);
+                }
+                else
+                {
+                    info1 = TimeZoneInfo.FindSystemTimeZoneById(wId);
+                    info2 = TimeZoneInfo.FindSystemTimeZoneById(iId);
+                }
+                Assert.Equal(info1.StandardName, info2.StandardName);
+                Assert.Equal(info1.DaylightName, info2.DaylightName);
+                Assert.Equal(info1.DisplayName, info2.DisplayName);
+            }, windowsId, ianaId).Dispose();
+        }
+
         private static bool IsEnglishUILanguage => CultureInfo.CurrentUICulture.Name.Length == 0 || CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "en";
 
         private static bool IsEnglishUILanguageAndRemoteExecutorSupported => IsEnglishUILanguage && RemoteExecutor.IsSupported;


### PR DESCRIPTION
Backport of #106038 to release/8.0-dtaging

/cc @tarekgh

## Customer Impact

Creating a TimeZoneInfo object using Windows zone Id e.g. `Eastern Standard Time` when running on non-Windows OS e.g. Linux, the created Zone object will report wrong standard, daylight, and display zone names.
This is a regression occurred in .NET 8.0 and reported by the user through the issue https://github.com/dotnet/docs/issues/41830.

## Details

In .NET 8.0 we have done some optimization work to delay initializing the time zone names (Standard, Daylight, and Display names). The reason is the names initialization is extremely expensive especially on non-Windows OS's because we do some heuristics and call ICU to extract such names. Unintentionally doing lazy initialization names on non-Windows OS's caused a problem with the time zones created using Windows Ids e.g. `Eastern Standard Time`. The reason is to get the correct names of the time zone you need to call ICU using the IANA ids e.g. `America/New_York` which not done with the lazy initialization. The fix here is to ensure using the IANA ids on non-Windows OS's when requesting the names from ICU. 

The repro of the issue, on Linux use code like:

```C#
TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
Console.WriteLine($"{zoneName}: {timeZone.Id} ... {timeZone.StandardName} ... {timeZone.DaylightName} ");
```

This code will display names like `GMT` which are wrong as expected to show something like `Eastern Standard Time: Eastern Standard Time ... Eastern Standard Time ... Eastern Daylight Time`. 

## Testing

Passed the regression tests and added more tests to cover the failing cases.

## Risk
Low, this change is targeting only the broken case when creating a TimeZoneInfo object using Windows zone Id while ensuring picking up the right Id when trying to retrieve the zone names.

**IMPORTANT**: If this backport is for a servicing release, please verify that:
- The PR target branch is `release/X.0-staging`, not `release/X.0`.
- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
