### PR TITLE
JIT: Expose top-level address computations in local morph

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -665,12 +665,9 @@ public:
 
         WalkTree(stmt->GetRootNodePointer(), nullptr);
 
-        // If we have an address on the stack then we don't need to do anything.
-        // The address tree isn't actually used and it will be discarded during
-        // morphing. So just mark any value as consumed to keep PopValue happy.
-        INDEBUG(TopValue(0).Consume());
-
+        EscapeValue(TopValue(0), nullptr);
         PopValue();
+
         assert(m_valueStack.Empty());
         m_madeChanges |= m_stmtModified;
 
@@ -1245,7 +1242,7 @@ private:
         LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
 
         GenTreeFlags defFlag            = GTF_EMPTY;
-        GenTreeCall* callUser           = user->IsCall() ? user->AsCall() : nullptr;
+        GenTreeCall* callUser           = (user != nullptr) && user->IsCall() ? user->AsCall() : nullptr;
         bool         hasHiddenStructArg = false;
         if (m_compiler->opts.compJitOptimizeStructHiddenBuffer && (callUser != nullptr) &&
             m_compiler->IsValidLclAddr(lclNum, val.Offset()))

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105952/Runtime_105952.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105952/Runtime_105952.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_105952
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+    	new Runtime_105952().Foo();
+    }
+
+    private readonly Vector128<ulong> _field;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Foo()
+    {
+        M2();
+        M(Vector128<ulong>.Zero & _field, M2());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void M(Vector128<ulong> v, int x)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int M2() => 0;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105952/Runtime_105952.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105952/Runtime_105952.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Physical promotion relies on the invariant that we see no `LCL_ADDR`
nodes for unexposed locals (except for retbuf definitions). However,
local morph would not expose top level address computations with a note
that morph would get rid of it.

We could extract side effects for this case, but it does not seem
frequent enough to warrant the special behavior.

Fix #105952