### PR TITLE
JIT: Fix loop memory dependence recording for memory defined in sibling loops

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4322,16 +4322,22 @@ void Compiler::optRecordLoopMemoryDependence(GenTree* tree, BasicBlock* block, V
         return;
     }
 
-    // If the update block is not the header of a loop containing
-    // block, we can also ignore the update.
+    // If the memory definition is part of an ancestor loop then 'tree' depends
+    // on memory defined in that ancestor loop. Otherwise we can also ignore
+    // the update.
     //
-    if (!updateLoop->ContainsBlock(block))
+    while ((updateLoop != nullptr) && !updateLoop->ContainsBlock(block))
+    {
+        updateLoop = updateLoop->GetParent();
+    }
+
+    if (updateLoop == nullptr)
     {
 #ifdef DEBUG
         FlowGraphNaturalLoop* blockLoop = m_blockToLoop->GetLoop(block);
 
-        JITDUMP("      ==> Not updating loop memory dependence of [%06u]/" FMT_LP ", memory " FMT_VN "/" FMT_LP
-                " is not defined in a contained block\n",
+        JITDUMP("      ==> Not updating loop memory dependence of [%06u]/" FMT_LP ", memory definition " FMT_VN
+                "/" FMT_LP " is not dependent on an ancestor loop\n",
                 dspTreeID(tree), blockLoop->GetIndex(), memoryVN, updateLoop->GetIndex());
 #endif
         return;
@@ -4355,7 +4361,7 @@ void Compiler::optRecordLoopMemoryDependence(GenTree* tree, BasicBlock* block, V
 #ifdef DEBUG
             FlowGraphNaturalLoop* mapLoop = m_blockToLoop->GetLoop(mapBlock);
 
-            JITDUMP("      ==> Not updating loop memory dependence of [%06u]; alrady constrained to " FMT_LP
+            JITDUMP("      ==> Not updating loop memory dependence of [%06u]; already constrained to " FMT_LP
                     " nested in " FMT_LP "\n",
                     dspTreeID(tree), mapLoop->GetIndex(), updateLoop->GetIndex());
 #endif

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105413/Runtime_105413.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105413/Runtime_105413.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_105413
+{
+    private static ushort[] s_field1;
+    private static bool s_field2;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        s_field2 = true;
+        Foo(2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo(int n)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            int j = 0;
+            do
+            {
+                s_field1 = [1];
+                j++;
+            } while (j < n);
+
+            s_field2 = false;
+            Bar(s_field2);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Bar(bool value)
+    {
+        Assert.False(value);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_105413/Runtime_105413.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_105413/Runtime_105413.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
During map selection VN will keep track of memory VNs that the result depends on. This is used so that we can know whether the value computed by a tree inside a loop depends on any previous memory that was defined inside the loop; if so, we cannot allow hoisting for it.

It was possible for the previous memory to be defined inside a more nested loop. Take the following example:

```csharp
for (int i = 0; i < n; i++)
{
  int j = 0;
  do
  {
    s_otherField = [1];
  } while (j < n);

  s_field = true;
  Use(s_field);
}
```

In this case the memory dependence of the load of `s_field` ends up being a memory definition inside the nested loop. (One could think the dependency would come from the `s_field = true` block, but we do not track the memory definitions on a fine-grained basis; rather we get it from the previous memory phi def, which is good enough for hoisting.)

The logic did not properly handle this case; if the memory definition is in a more nested loop, we need to walk the ancestor loops to figure out if the definition is actually happening inside one of them. If so there is still a dependency.

Fix #105413