### PR TITLE
Cache the path on `Module` for easier diagnostics

### DIFF
--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -231,6 +231,9 @@ inline SString::SString(const WCHAR *string)
 
     Set(string);
 
+    _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
+    SetNormalized();
+
     SS_RETURN;
 }
 
@@ -248,6 +251,9 @@ inline SString::SString(const WCHAR *string, COUNT_T count)
     SS_CONTRACT_END;
 
     Set(string, count);
+
+    _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
+    SetNormalized();
 
     SS_RETURN;
 }

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -414,7 +414,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
 
     m_loaderAllocator = GetAssembly()->GetLoaderAllocator();
     m_pSimpleName = m_pPEAssembly->GetSimpleName();
-    m_path = m_pPEAssembly->GetPath();
+    m_path = m_pPEAssembly->GetPath().GetUnicode();
     _ASSERTE(m_path != NULL);
     m_baseAddress = m_pPEAssembly->HasLoadedPEImage() ? m_pPEAssembly->GetLoadedLayout()->GetBase() : NULL;
     if (m_pPEAssembly->IsReflectionEmit())

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -414,6 +414,8 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
 
     m_loaderAllocator = GetAssembly()->GetLoaderAllocator();
     m_pSimpleName = m_pPEAssembly->GetSimpleName();
+    m_path = m_pPEAssembly->GetPath();
+    _ASSERTE(m_path != NULL);
     m_baseAddress = m_pPEAssembly->HasLoadedPEImage() ? m_pPEAssembly->GetLoadedLayout()->GetBase() : NULL;
     if (m_pPEAssembly->IsReflectionEmit())
         m_dwTransientFlags |= IS_REFLECTION_EMIT;

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1381,7 +1381,12 @@ public:
     }
 
     HRESULT GetScopeName(LPCUTF8 * pszName) { WRAPPER_NO_CONTRACT; return m_pPEAssembly->GetScopeName(pszName); }
-    const SString &GetPath() { WRAPPER_NO_CONTRACT; return m_pPEAssembly->GetPath(); }
+    const SString &GetPath()
+    {
+        WRAPPER_NO_CONTRACT;
+        _ASSERTE(SString{m_path}.Equals(m_pPEAssembly->GetPath()));
+        return m_pPEAssembly->GetPath();
+    }
 
 #ifdef LOGGING
     LPCUTF8 GetDebugName() { WRAPPER_NO_CONTRACT; return m_pPEAssembly->GetDebugName(); }

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -43,11 +43,9 @@
 #include "ilinstrumentation.h"
 #include "codeversion.h"
 
-class Stub;
 class MethodDesc;
 class FieldDesc;
 class Crst;
-class ClassConverter;
 class RefClassWriter;
 class ReflectionModule;
 class EEStringData;
@@ -56,11 +54,9 @@ class SigTypeContext;
 class Assembly;
 class BaseDomain;
 class AppDomain;
-class DomainModule;
 class SystemDomain;
 class Module;
 class SString;
-class Pending;
 class MethodTable;
 class DynamicMethodTable;
 class TieredCompilationManager;
@@ -615,6 +611,7 @@ class Module : public ModuleBase
 
 private:
     PTR_CUTF8               m_pSimpleName; // Cached simple name for better performance and easier diagnostics
+    const WCHAR*            m_path;        // Cached path for easier diagnostics
 
     PTR_PEAssembly          m_pPEAssembly;
     PTR_VOID                m_baseAddress; // Cached base address for easier diagnostics

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1384,7 +1384,8 @@ public:
     const SString &GetPath()
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(SString{m_path}.Equals(m_pPEAssembly->GetPath()));
+        // Validate the pointers are the same to ensure the lifetime of m_path is handled.
+        _ASSERTE(m_path == m_pPEAssembly->GetPath().GetUnicode());
         return m_pPEAssembly->GetPath();
     }
 

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -615,9 +615,8 @@ void PEImage::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 
 #endif // #ifdef DACCESS_COMPILE
 
-
-PEImage::PEImage():
-    m_path(),
+PEImage::PEImage(const WCHAR* path):
+    m_path{path},
     m_pathHash(0),
     m_refCount(1),
     m_bInHashMap(FALSE),
@@ -788,7 +787,7 @@ PTR_PEImage PEImage::CreateFromByteArray(const BYTE* array, COUNT_T size)
     }
     CONTRACT_END;
 
-    PEImageHolder pImage(new PEImage());
+    PEImageHolder pImage(new PEImage(NULL /*path*/));
     PTR_PEImageLayout pLayout = PEImageLayout::CreateFromByteArray(pImage, array, size);
     _ASSERTE(!pLayout->IsMapped());
 

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -104,7 +104,7 @@ public:
     static void Startup();
 
     ~PEImage();
-    PEImage();
+    PEImage(const WCHAR* path);
 
     BOOL Equals(PEImage* pImage);
 
@@ -121,7 +121,7 @@ public:
         MDInternalImportFlags flags = MDInternalImport_Default,
         BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
 
-    static PTR_PEImage FindByPath(LPCWSTR pPath, BOOL isInBundle = TRUE);
+    static PTR_PEImage FindByPath(LPCWSTR pPath, BOOL isInBundle);
     void AddToHashMap();
 #endif
 
@@ -206,7 +206,7 @@ private:
     // Private routines
     // ------------------------------------------------------------
 
-    void Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation);
+    void Init(BundleFileLocation bundleFileLocation);
 
     struct PEImageLocator
     {
@@ -285,7 +285,7 @@ private:
     // Instance fields
     // ------------------------------------------------------------
 
-    SString   m_path;
+    const SString   m_path;
     ULONG     m_pathHash;
     LONG      m_refCount;
 

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -104,7 +104,7 @@ public:
     static void Startup();
 
     ~PEImage();
-    PEImage(const WCHAR* path);
+    explicit PEImage(const WCHAR* path);
 
     BOOL Equals(PEImage* pImage);
 

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -276,7 +276,7 @@ inline CHECK PEImage::CheckFormat()
     CHECK_OK;
 }
 
-inline void  PEImage::Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation)
+inline void  PEImage::Init(BundleFileLocation bundleFileLocation)
 {
     CONTRACTL
     {
@@ -286,8 +286,6 @@ inline void  PEImage::Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation)
     }
     CONTRACTL_END;
 
-    m_path.Set(pPath);
-    m_path.Normalize();
     m_pathHash = m_path.HashCaseInsensitive();
     m_bundleFileLocation = bundleFileLocation;
     SetModuleFileNameHintForDAC();
@@ -296,7 +294,7 @@ inline void  PEImage::Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation)
 
 
 /*static*/
-inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle /* = TRUE */)
+inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle)
 {
     CONTRACTL
     {
@@ -316,13 +314,13 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle /* = TRUE 
 }
 
 /* static */
-inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags /* = MDInternalImport_Default */, BundleFileLocation bundleFileLocation)
+inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags /* = MDInternalImport_Default */, BundleFileLocation bundleFileLocation /* = BundleFileLocation::Invalid() */)
 {
     BOOL forbidCache = (flags & MDInternalImport_NoCache);
     if (forbidCache)
     {
-        PEImageHolder pImage(new PEImage);
-        pImage->Init(pPath, bundleFileLocation);
+        PEImageHolder pImage(new PEImage{pPath});
+        pImage->Init(bundleFileLocation);
         return dac_cast<PTR_PEImage>(pImage.Extract());
     }
 
@@ -337,8 +335,8 @@ inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags
             return NULL;
         }
 
-        PEImageHolder pImage(new PEImage);
-        pImage->Init(pPath, bundleFileLocation);
+        PEImageHolder pImage(new PEImage{pPath});
+        pImage->Init(bundleFileLocation);
 
         pImage->AddToHashMap();
         return dac_cast<PTR_PEImage>(pImage.Extract());


### PR DESCRIPTION
- Make `PEImage` take a path in its constructor and make its member const
- Store the path when initializing `Module`

I'm trying to avoid having to expose PEAssembly/PEImage in data descriptors to the cDAC just to get the module path.
Contributes to https://github.com/dotnet/runtime/issues/99302

cc @lambdageek @davidwrighton 