### PR TITLE
Skip putting patches in certain stubs to prevent crashing on step-in on M1 with JMC disabled

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -7278,6 +7278,9 @@ void DebuggerStepper::TriggerMethodEnter(Thread * thread,
     // the assert if we end up in the method we started in (which could happen if we trace call
     // instructions before the JMC probe).
     // m_StepInStartMethod may be null (if this step-in didn't start from managed code).
+#if defined(TARGET_ARM64) && defined(__APPLE__)
+    LOG((LF_CORDB, LL_INFO10000, "DebuggerStepper::TriggerMethodEnter: Consistency_check_MSGF not needed because we skip setting breakpoints in certain patches on arm64-macOS\n"));
+#else
     if ((m_StepInStartMethod != pDesc) &&
         (!m_StepInStartMethod->IsLCGMethod()))
     {
@@ -7288,9 +7291,6 @@ void DebuggerStepper::TriggerMethodEnter(Thread * thread,
 
         SString sLog;
         StubManager::DbgGetLog(&sLog);
-        #if defined(TARGET_ARM64) && defined(__APPLE__)
-            LOG((LF_CORDB, LL_INFO10000, "DebuggerStepper::TriggerMethodEnter: Consistency_check_MSGF not needed because we skip setting breakpoints in certain patches on M1\n"));
-        #else
             // Assert b/c the Stub-manager should have caught us first.
             // We don't want people relying on TriggerMethodEnter as the real implementation for Traditional Step-in
             // (see above for reasons why). However, using TME will provide a bandage for the final retail product
@@ -7310,8 +7310,8 @@ void DebuggerStepper::TriggerMethodEnter(Thread * thread,
                 sLog.GetUTF8(),
                 pDesc->m_pszDebugClassName, pDesc->m_pszDebugMethodName
                 ));
-        #endif
     }
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
 #endif
 
     // Place a patch to stop us.

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -7288,26 +7288,29 @@ void DebuggerStepper::TriggerMethodEnter(Thread * thread,
 
         SString sLog;
         StubManager::DbgGetLog(&sLog);
-
-        // Assert b/c the Stub-manager should have caught us first.
-        // We don't want people relying on TriggerMethodEnter as the real implementation for Traditional Step-in
-        // (see above for reasons why). However, using TME will provide a bandage for the final retail product
-        // in cases where we are missing a stub-manager.
-        CONSISTENCY_CHECK_MSGF(false, (
-            "\nThe Stubmanagers failed to identify and trace a stub on step-in. The stub-managers for this code-path path need to be fixed.\n"
-            "See http://team/sites/clrdev/Devdocs/StubManagers.rtf for more information on StubManagers.\n"
-            "Stepper this=0x%p, startMethod='%s::%s'\n"
-            "---------------------------------\n"
-            "Stub manager log:\n%s"
-            "\n"
-            "The thread is now in managed method '%s::%s'.\n"
-            "---------------------------------\n",
-            this,
-            ((m_StepInStartMethod == NULL) ? "unknown" : m_StepInStartMethod->m_pszDebugClassName),
-            ((m_StepInStartMethod == NULL) ? "unknown" : m_StepInStartMethod->m_pszDebugMethodName),
-            sLog.GetUTF8(),
-            pDesc->m_pszDebugClassName, pDesc->m_pszDebugMethodName
-            ));
+        #if defined(TARGET_ARM64) && defined(__APPLE__)
+            LOG((LF_CORDB, LL_INFO10000, "DebuggerStepper::TriggerMethodEnter: Consistency_check_MSGF not needed because we skip setting breakpoints in certain patches on M1\n"));
+        #else
+            // Assert b/c the Stub-manager should have caught us first.
+            // We don't want people relying on TriggerMethodEnter as the real implementation for Traditional Step-in
+            // (see above for reasons why). However, using TME will provide a bandage for the final retail product
+            // in cases where we are missing a stub-manager.
+            CONSISTENCY_CHECK_MSGF(false, (
+                "\nThe Stubmanagers failed to identify and trace a stub on step-in. The stub-managers for this code-path path need to be fixed.\n"
+                "See http://team/sites/clrdev/Devdocs/StubManagers.rtf for more information on StubManagers.\n"
+                "Stepper this=0x%p, startMethod='%s::%s'\n"
+                "---------------------------------\n"
+                "Stub manager log:\n%s"
+                "\n"
+                "The thread is now in managed method '%s::%s'.\n"
+                "---------------------------------\n",
+                this,
+                ((m_StepInStartMethod == NULL) ? "unknown" : m_StepInStartMethod->m_pszDebugClassName),
+                ((m_StepInStartMethod == NULL) ? "unknown" : m_StepInStartMethod->m_pszDebugMethodName),
+                sLog.GetUTF8(),
+                pDesc->m_pszDebugClassName, pDesc->m_pszDebugMethodName
+                ));
+        #endif
     }
 #endif
 

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -2248,10 +2248,9 @@ BOOL TailCallStubManager::TraceManager(Thread * pThread,
 
 #if defined(TARGET_ARM64) && defined(__APPLE__)
         //On ARM64 Mac, we cannot put a breakpoint inside of JIT_TailCallLeave
-        if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallLeave) 
-            || GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallVSDLeave))
+        if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCall))
         {
-            LOG((LF_CORDB, LL_INFO10000, "TCSM::TraceManager: Skipping on M1\n"));
+            LOG((LF_CORDB, LL_INFO10000, "TCSM::TraceManager: Skipping on arm64-macOS\n"));
             return FALSE;
         }
 #endif //defined(TARGET_ARM64) && defined(__APPLE__)

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -2246,15 +2246,6 @@ BOOL TailCallStubManager::TraceManager(Thread * pThread,
     TADDR esp = GetSP(pContext);
     TADDR ebp = GetFP(pContext);
 
-#if defined(TARGET_ARM64) && defined(__APPLE__)
-        //On ARM64 Mac, we cannot put a breakpoint inside of JIT_TailCallLeave
-        if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCall))
-        {
-            LOG((LF_CORDB, LL_INFO10000, "TCSM::TraceManager: Skipping on arm64-macOS\n"));
-            return FALSE;
-        }
-#endif //defined(TARGET_ARM64) && defined(__APPLE__)
-
     // Check if we are stopped at the beginning of JIT_TailCall().
     if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCall))
     {

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -938,10 +938,15 @@ BOOL ThePreStubManager::DoTraceStub(PCODE stubStartAddress, TraceDestination *tr
     // We cannot tell where the stub will end up
     // until after the prestub worker has been run.
     //
+    #if defined(TARGET_ARM64) && defined(__APPLE__)
+        // On ARM64 Mac, we cannot put a breakpoint inside of ThePreStubPatchLabel
+        LOG((LF_CORDB, LL_INFO10000, "TPSM::DoTraceStub: Skipping on M1\n"));
+        return FALSE;
+    #else
+        trace->InitForFramePush(GetEEFuncEntryPoint(ThePreStubPatchLabel));
 
-    trace->InitForFramePush(GetEEFuncEntryPoint(ThePreStubPatchLabel));
-
-    return TRUE;
+        return TRUE;
+    #endif
 }
 
 //-----------------------------------------------------------
@@ -1028,7 +1033,13 @@ BOOL PrecodeStubManager::DoTraceStub(PCODE stubStartAddress,
 #ifdef HAS_NDIRECT_IMPORT_PRECODE
         case PRECODE_NDIRECT_IMPORT:
 #ifndef DACCESS_COMPILE
+    #if defined(TARGET_ARM64) && defined(__APPLE__)
+        // On ARM64 Mac, we cannot put a breakpoint inside of NDirectImportThunk
+        LOG((LF_CORDB, LL_INFO10000, "PSM::DoTraceStub: Skipping on M1\n"));
+        return FALSE;
+    #else
             trace->InitForUnmanaged(GetEEFuncEntryPoint(NDirectImportThunk));
+    #endif
 #else
             trace->InitForOther((PCODE)NULL);
 #endif
@@ -1657,7 +1668,13 @@ BOOL RangeSectionStubManager::DoTraceStub(PCODE stubStartAddress, TraceDestinati
 #ifdef DACCESS_COMPILE
         DacNotImpl();
 #else
+    #if defined(TARGET_ARM64) && defined(__APPLE__)
+        // On ARM64 Mac, we cannot put a breakpoint inside of ExternalMethodFixupPatchLabel
+        LOG((LF_CORDB, LL_INFO10000, "RSM::DoTraceStub: Skipping on M1\n"));
+        return FALSE;
+    #else
         trace->InitForManagerPush(GetEEFuncEntryPoint(ExternalMethodFixupPatchLabel), this);
+    #endif
 #endif
         return TRUE;
 
@@ -1801,7 +1818,13 @@ BOOL ILStubManager::DoTraceStub(PCODE stubStartAddress,
     MethodDesc* pStubMD = ExecutionManager::GetCodeMethodDesc(stubStartAddress);
     if (pStubMD != NULL && pStubMD->AsDynamicMethodDesc()->IsMulticastStub())
     {
-        traceDestination = GetEEFuncEntryPoint(StubHelpers::MulticastDebuggerTraceHelper);
+        #if defined(TARGET_ARM64) && defined(__APPLE__)
+            //On ARM64 Mac, we cannot put a breakpoint inside of MulticastDebuggerTraceHelper
+            LOG((LF_CORDB, LL_INFO10000, "ILSM::DoTraceStub: skipping on M1\n"));
+            return FALSE;
+        #else
+            traceDestination = GetEEFuncEntryPoint(StubHelpers::MulticastDebuggerTraceHelper);
+        #endif
     }
     else
     {
@@ -2104,18 +2127,30 @@ BOOL InteropDispatchStubManager::TraceManager(Thread *thread,
 
     if (IsVarargPInvokeStub(GetIP(pContext)))
     {
-        NDirectMethodDesc *pNMD = (NDirectMethodDesc *)arg;
-        _ASSERTE(pNMD->IsNDirect());
-        PCODE target = (PCODE)pNMD->GetNDirectTarget();
+        #if defined(TARGET_ARM64) && defined(__APPLE__)
+            //On ARM64 Mac, we cannot put a breakpoint inside of VarargPInvokeStub
+            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Skipping on M1\n"));
+            return FALSE;
+        #else
+            NDirectMethodDesc *pNMD = (NDirectMethodDesc *)arg;
+            _ASSERTE(pNMD->IsNDirect());
+            PCODE target = (PCODE)pNMD->GetNDirectTarget();
 
-        LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Vararg P/Invoke case 0x%p\n", target));
-        trace->InitForUnmanaged(target);
+            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Vararg P/Invoke case 0x%p\n", target));
+            trace->InitForUnmanaged(target);
+        #endif
     }
     else if (GetIP(pContext) == GetEEFuncEntryPoint(GenericPInvokeCalliHelper))
     {
-        PCODE target = (PCODE)arg;
-        LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Unmanaged CALLI case 0x%p\n", target));
-        trace->InitForUnmanaged(target);
+        #if defined(TARGET_ARM64) && defined(__APPLE__)
+            //On ARM64 Mac, we cannot put a breakpoint inside of GenericPInvokeCalliHelper
+            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Skipping on M1\n"));
+            return FALSE;
+        #else
+            PCODE target = (PCODE)arg;
+            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Unmanaged CALLI case 0x%p\n", target));
+            trace->InitForUnmanaged(target);
+        #endif
     }
 #ifdef FEATURE_COMINTEROP
     else
@@ -2210,6 +2245,15 @@ BOOL TailCallStubManager::TraceManager(Thread * pThread,
     WRAPPER_NO_CONTRACT;
     TADDR esp = GetSP(pContext);
     TADDR ebp = GetFP(pContext);
+
+    #if defined(TARGET_ARM64) && defined(__APPLE__)
+        //On ARM64 Mac, we cannot put a breakpoint inside of JIT_TailCallLeave
+        if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallLeave) || GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallVSDLeave))
+        {
+            LOG((LF_CORDB, LL_INFO10000, "TCSM::TraceManager: Skipping on M1\n"));
+            return FALSE;
+        }
+    #endif
 
     // Check if we are stopped at the beginning of JIT_TailCall().
     if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCall))

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -938,15 +938,15 @@ BOOL ThePreStubManager::DoTraceStub(PCODE stubStartAddress, TraceDestination *tr
     // We cannot tell where the stub will end up
     // until after the prestub worker has been run.
     //
-    #if defined(TARGET_ARM64) && defined(__APPLE__)
-        // On ARM64 Mac, we cannot put a breakpoint inside of ThePreStubPatchLabel
-        LOG((LF_CORDB, LL_INFO10000, "TPSM::DoTraceStub: Skipping on M1\n"));
-        return FALSE;
-    #else
-        trace->InitForFramePush(GetEEFuncEntryPoint(ThePreStubPatchLabel));
+#if defined(TARGET_ARM64) && defined(__APPLE__)
+    // On ARM64 Mac, we cannot put a breakpoint inside of ThePreStubPatchLabel
+    LOG((LF_CORDB, LL_INFO10000, "TPSM::DoTraceStub: Skipping on arm64-macOS\n"));
+    return FALSE;
+#else
+    trace->InitForFramePush(GetEEFuncEntryPoint(ThePreStubPatchLabel));
 
-        return TRUE;
-    #endif
+    return TRUE;
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
 }
 
 //-----------------------------------------------------------
@@ -1033,13 +1033,13 @@ BOOL PrecodeStubManager::DoTraceStub(PCODE stubStartAddress,
 #ifdef HAS_NDIRECT_IMPORT_PRECODE
         case PRECODE_NDIRECT_IMPORT:
 #ifndef DACCESS_COMPILE
-    #if defined(TARGET_ARM64) && defined(__APPLE__)
-        // On ARM64 Mac, we cannot put a breakpoint inside of NDirectImportThunk
-        LOG((LF_CORDB, LL_INFO10000, "PSM::DoTraceStub: Skipping on M1\n"));
-        return FALSE;
-    #else
+#if defined(TARGET_ARM64) && defined(__APPLE__)
+            // On ARM64 Mac, we cannot put a breakpoint inside of NDirectImportThunk
+            LOG((LF_CORDB, LL_INFO10000, "PSM::DoTraceStub: Skipping on arm64-macOS\n"));
+            return FALSE;
+#else
             trace->InitForUnmanaged(GetEEFuncEntryPoint(NDirectImportThunk));
-    #endif
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
 #else
             trace->InitForOther((PCODE)NULL);
 #endif
@@ -1668,13 +1668,13 @@ BOOL RangeSectionStubManager::DoTraceStub(PCODE stubStartAddress, TraceDestinati
 #ifdef DACCESS_COMPILE
         DacNotImpl();
 #else
-    #if defined(TARGET_ARM64) && defined(__APPLE__)
+#if defined(TARGET_ARM64) && defined(__APPLE__)
         // On ARM64 Mac, we cannot put a breakpoint inside of ExternalMethodFixupPatchLabel
-        LOG((LF_CORDB, LL_INFO10000, "RSM::DoTraceStub: Skipping on M1\n"));
+        LOG((LF_CORDB, LL_INFO10000, "RSM::DoTraceStub: Skipping on arm64-macOS\n"));
         return FALSE;
-    #else
+#else
         trace->InitForManagerPush(GetEEFuncEntryPoint(ExternalMethodFixupPatchLabel), this);
-    #endif
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
 #endif
         return TRUE;
 
@@ -1818,13 +1818,13 @@ BOOL ILStubManager::DoTraceStub(PCODE stubStartAddress,
     MethodDesc* pStubMD = ExecutionManager::GetCodeMethodDesc(stubStartAddress);
     if (pStubMD != NULL && pStubMD->AsDynamicMethodDesc()->IsMulticastStub())
     {
-        #if defined(TARGET_ARM64) && defined(__APPLE__)
-            //On ARM64 Mac, we cannot put a breakpoint inside of MulticastDebuggerTraceHelper
-            LOG((LF_CORDB, LL_INFO10000, "ILSM::DoTraceStub: skipping on M1\n"));
-            return FALSE;
-        #else
-            traceDestination = GetEEFuncEntryPoint(StubHelpers::MulticastDebuggerTraceHelper);
-        #endif
+#if defined(TARGET_ARM64) && defined(__APPLE__)
+        //On ARM64 Mac, we cannot put a breakpoint inside of MulticastDebuggerTraceHelper
+        LOG((LF_CORDB, LL_INFO10000, "ILSM::DoTraceStub: skipping on arm64-macOS\n"));
+        return FALSE;
+#else
+        traceDestination = GetEEFuncEntryPoint(StubHelpers::MulticastDebuggerTraceHelper);
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
     }
     else
     {
@@ -2127,30 +2127,30 @@ BOOL InteropDispatchStubManager::TraceManager(Thread *thread,
 
     if (IsVarargPInvokeStub(GetIP(pContext)))
     {
-        #if defined(TARGET_ARM64) && defined(__APPLE__)
-            //On ARM64 Mac, we cannot put a breakpoint inside of VarargPInvokeStub
-            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Skipping on M1\n"));
-            return FALSE;
-        #else
-            NDirectMethodDesc *pNMD = (NDirectMethodDesc *)arg;
-            _ASSERTE(pNMD->IsNDirect());
-            PCODE target = (PCODE)pNMD->GetNDirectTarget();
+#if defined(TARGET_ARM64) && defined(__APPLE__)
+        //On ARM64 Mac, we cannot put a breakpoint inside of VarargPInvokeStub
+        LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Skipping on arm64-macOS\n"));
+        return FALSE;
+#else
+        NDirectMethodDesc *pNMD = (NDirectMethodDesc *)arg;
+        _ASSERTE(pNMD->IsNDirect());
+        PCODE target = (PCODE)pNMD->GetNDirectTarget();
 
-            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Vararg P/Invoke case 0x%p\n", target));
-            trace->InitForUnmanaged(target);
-        #endif
+        LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Vararg P/Invoke case %p\n", target));
+        trace->InitForUnmanaged(target);
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
     }
     else if (GetIP(pContext) == GetEEFuncEntryPoint(GenericPInvokeCalliHelper))
     {
-        #if defined(TARGET_ARM64) && defined(__APPLE__)
-            //On ARM64 Mac, we cannot put a breakpoint inside of GenericPInvokeCalliHelper
-            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Skipping on M1\n"));
-            return FALSE;
-        #else
-            PCODE target = (PCODE)arg;
-            LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Unmanaged CALLI case 0x%p\n", target));
-            trace->InitForUnmanaged(target);
-        #endif
+#if defined(TARGET_ARM64) && defined(__APPLE__)
+        //On ARM64 Mac, we cannot put a breakpoint inside of GenericPInvokeCalliHelper
+        LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Skipping on arm64-macOS\n"));
+        return FALSE;
+#else
+        PCODE target = (PCODE)arg;
+        LOG((LF_CORDB, LL_INFO10000, "IDSM::TraceManager: Unmanaged CALLI case %p\n", target));
+        trace->InitForUnmanaged(target);
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
     }
 #ifdef FEATURE_COMINTEROP
     else
@@ -2246,14 +2246,15 @@ BOOL TailCallStubManager::TraceManager(Thread * pThread,
     TADDR esp = GetSP(pContext);
     TADDR ebp = GetFP(pContext);
 
-    #if defined(TARGET_ARM64) && defined(__APPLE__)
+#if defined(TARGET_ARM64) && defined(__APPLE__)
         //On ARM64 Mac, we cannot put a breakpoint inside of JIT_TailCallLeave
-        if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallLeave) || GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallVSDLeave))
+        if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallLeave) 
+            || GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCallVSDLeave))
         {
             LOG((LF_CORDB, LL_INFO10000, "TCSM::TraceManager: Skipping on M1\n"));
             return FALSE;
         }
-    #endif
+#endif //defined(TARGET_ARM64) && defined(__APPLE__)
 
     // Check if we are stopped at the beginning of JIT_TailCall().
     if (GetIP(pContext) == GetEEFuncEntryPoint(JIT_TailCall))


### PR DESCRIPTION
We set breakpoints in stubs when stepping into functions. On MacOS, it is not allowed to change binaries while code is running. Thus, if we attempt to put a patch into certain stubs which are in the text section of libcoreclr, the program will crash. 

To prevent this crashing, we return false and skip/slide the step-in which then turns on the JMC probe. 

The stubs that we are skipping putting patches in are VarargPInvokeStub, GenericPInvokeCalliHelper, JIT_TailCallLeave, JIT_TailCallVSDLeave, ThePreStubPatchLabel, NDirectImportThunk, ExternalMethodFixupPatchLabel, MulticastDebuggerTraceHelper