### PR TITLE
Fix Enum.ToObject(Type, object) for nint/nuint

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -2214,8 +2214,8 @@ namespace System
                 valueType = valueType.GetEnumUnderlyingType();
             }
 
-            if (valueType == typeof(nint)) ToObject(enumType, (nint)value);
-            if (valueType == typeof(nuint)) ToObject(enumType, (nuint)value);
+            if (valueType == typeof(nint)) return ToObject(enumType, (nint)value);
+            if (valueType == typeof(nuint)) return ToObject(enumType, (nuint)value);
 
             throw new ArgumentException(SR.Arg_MustBeEnumBaseTypeOrEnum, nameof(value));
         }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/EnumTests.cs
@@ -937,6 +937,12 @@ namespace System.Tests
                 // Char
                 yield return new object[] { s_charEnumType, (char)1, Enum.Parse(s_charEnumType, "Value1") };
                 yield return new object[] { s_charEnumType, (char)2, Enum.Parse(s_charEnumType, "Value2") };
+
+                // IntPtr
+                yield return new object[] { s_intPtrEnumType, (nint)1, Enum.ToObject(s_intPtrEnumType, 1) };
+
+                // UIntPtr
+                yield return new object[] { s_uintPtrEnumType, (nuint)1, Enum.ToObject(s_uintPtrEnumType, 1) };
             }
         }
 
@@ -982,8 +988,6 @@ namespace System.Tests
             {
                 yield return new object[] { s_floatEnumType, 1.0f, typeof(ArgumentException) };
                 yield return new object[] { s_doubleEnumType, 1.0, typeof(ArgumentException) };
-                yield return new object[] { s_intPtrEnumType, (IntPtr)1, typeof(ArgumentException) };
-                yield return new object[] { s_uintPtrEnumType, (UIntPtr)1, typeof(ArgumentException) };
             }
         }
 


### PR DESCRIPTION
These were never supported historically. The refactoring in .NET 7 attempted to add support for them, but accidentally still made them nop. We might as well make them work.

Fixes https://github.com/dotnet/runtime/issues/106098