### PR TITLE
[mono][x64] Disable EmptyStructs tests on System V

### DIFF
--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.csproj
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.csproj
@@ -5,6 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Tracking issue: https://github.com/dotnet/runtime/issues/92129 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/106071 -->
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x64' and '$(TargetOS)' != 'windows' and '$(RuntimeFlavor)' == 'mono'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Disable tests for empty struct passing due to FullAOT compilation failures in #106071 and failures in reflection calls with empty struct arguments that will be added in #105800.

Part of #84834, cc @dotnet/samsung @matouskozak