### PR TITLE
[RISC-V] System.Console CancelKeyPressTests.ExitDetectionNotBlockedByHandler increase timeout

### DIFF
--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -79,7 +79,10 @@ public partial class CancelKeyPressTests
             // Release CancelKeyPress, and give it time to return and tear down the app
             mre.Set();
             Thread.Sleep(WaitFailTestTimeoutSeconds * 1000);
-        }, new RemoteInvokeOptions() { ExpectedExitCode = 130 }).Dispose();
+        }, new RemoteInvokeOptions() {
+            ExpectedExitCode = 130,
+            TimeOut = RemoteExecutor.FailWaitTimeoutMilliseconds * PlatformDetection.SlowRuntimeTimeoutModifier
+        }).Dispose();
     }
 
     private void HandlerInvokedForSignal(int signalOuter, bool redirectStandardInput)

--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -42,6 +42,8 @@ public partial class CancelKeyPressTests
         HandlerInvokedForSignal(SIGQUIT, redirectStandardInput);
     }
 
+    private static readonly int WaitFailTestTimeoutSeconds = 30 * PlatformDetection.SlowRuntimeTimeoutModifier;
+
     [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
     public void ExitDetectionNotBlockedByHandler()
     {

--- a/src/libraries/System.Console/tests/CancelKeyPress.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.cs
@@ -10,8 +10,6 @@ using Xunit;
 
 public partial class CancelKeyPressTests
 {
-    private readonly int WaitFailTestTimeoutSeconds = 30 * PlatformDetection.SlowRuntimeTimeoutModifier;
-
     [Fact]
     [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]
     public static void CanAddAndRemoveHandler()

--- a/src/libraries/System.Console/tests/CancelKeyPress.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 public partial class CancelKeyPressTests
 {
-    private const int WaitFailTestTimeoutSeconds = 30;
+    private readonly int WaitFailTestTimeoutSeconds = 30 * PlatformDetection.SlowRuntimeTimeoutModifier;
 
     [Fact]
     [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]


### PR DESCRIPTION
Increase timeout on CancelKeyPressTests.ExitDetectionNotBlockedByHandler on Debug RISC-V, similar to #96187 or #96186.

Part of #84834, cc @dotnet/samsung