### PR TITLE
JIT: Widen self-updates as part of IV widening

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -88,6 +88,7 @@ class OptBoolsDsc;          // defined in optimizer.cpp
 struct JumpThreadInfo;      // defined in redundantbranchopts.cpp
 class ProfileSynthesis;     // defined in profilesynthesis.h
 class LoopLocalOccurrences; // defined in inductionvariableopts.cpp
+class LoopOptimizationInfo; // defined in inductionvariableopts.cpp
 #ifdef DEBUG
 struct IndentStack;
 #endif
@@ -7652,11 +7653,16 @@ public:
     bool optCanAndShouldChangeExitTest(GenTree* cond, bool dump);
     bool optPrimaryIVHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);
 
-    bool optWidenIVs(ScalarEvolutionContext& scevContext, FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);
-    bool optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
-                           unsigned              lclNum,
-                           ScevAddRec*           addRec,
-                           LoopLocalOccurrences* loopLocals);
+    bool optWidenIVs(ScalarEvolutionContext& scevContext,
+                     FlowGraphNaturalLoop*   loop,
+                     LoopOptimizationInfo&   loopOptInfo,
+                     LoopLocalOccurrences*   loopLocals);
+    bool optWidenPrimaryIV(ScalarEvolutionContext& scevContext,
+                           FlowGraphNaturalLoop*   loop,
+                           unsigned                lclNum,
+                           ScevAddRec*             addRec,
+                           LoopOptimizationInfo&   loopOptInfo,
+                           LoopLocalOccurrences*   loopLocals);
 
     bool optCanSinkWidenedIV(unsigned lclNum, FlowGraphNaturalLoop* loop);
     bool optIsIVWideningProfitable(unsigned              lclNum,
@@ -7666,7 +7672,13 @@ public:
                                    LoopLocalOccurrences* loopLocals);
     void optBestEffortReplaceNarrowIVUses(
         unsigned lclNum, unsigned ssaNum, unsigned newLclNum, BasicBlock* block, Statement* firstStmt);
-    void optReplaceWidenedIV(unsigned lclNum, unsigned ssaNum, unsigned newLclNum, Statement* stmt);
+    void optReplaceWidenedIV(unsigned                lclNum,
+                             unsigned                ssaNum,
+                             unsigned                newLclNum,
+                             BasicBlock*             block,
+                             Statement*              stmt,
+                             ScalarEvolutionContext* scevContext,
+                             LoopOptimizationInfo*   loopOptInfo);
     void optSinkWidenedIV(unsigned lclNum, unsigned newLclNum, FlowGraphNaturalLoop* loop);
 
     bool optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);


### PR DESCRIPTION
For certain Intel CPUs it can be a perf regression to keep an IV update as a 32-bit operation when the IV is later used as a 64-bit register, despite the fact that the operation should come with explicit zeroing of the upper bits.

This PR starts detecting and widening some self-updates as part of IV widening when we can prove that doing the self-update as a 64 bit operation is safe (i.e. ends up with the same zeroed upper bits).

Fix #104655
Fix `System.Collections.IndexerSet.List` regression in #99315

Some code size regressions expected since the encoding for the 64 bit operations is larger. Some new strength reductions expected due to the improved logic in `AddRecMayOverflow`.

Example:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public List<int> List()
{
    var list = _list;
    for (int i = 0; i < list.Count; i++)
        list[i] = default;
    return list;
}
```

```diff
@@ -1,59 +1,59 @@
 ; Assembly listing for method Program:List():System.Collections.Generic.List`1[int]:this (FullOpts)
 ; Emitting BLENDED_CODE for X64 with AVX - Windows
 ; FullOpts code
 ; optimized code
 ; rsp based frame
 ; fully interruptible
 ; No PGO data
 ; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data
 ; Final local variable assignments
 ;
 ;  V00 this         [V00,T04] (  3,  3   )     ref  ->  rcx         this class-hnd single-def <Program>
 ;  V01 loc0         [V01,T02] (  6, 15   )     ref  ->  rax         class-hnd single-def <System.Collections.Generic.List`1[int]>
 ;* V02 loc1         [V02,T05] (  0,  0   )     int  ->  zero-ref   
 ;  V03 OutArgs      [V03    ] (  1,  1   )  struct (32) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
 ;  V04 tmp1         [V04,T01] (  3, 24   )     ref  ->   r8         "arr expr"
 ;  V05 cse0         [V05,T03] (  4, 10   )     int  ->  rdx         "CSE #01: aggressive"
 ;  V06 rat0         [V06,T00] (  7, 25   )    long  ->  rcx         "Widened IV V02"
 ;
 ; Lcl frame size = 40
 
 G_M48712_IG01:  ;; offset=0x0000
        sub      rsp, 40
 						;; size=4 bbWeight=1 PerfScore 0.25
 G_M48712_IG02:  ;; offset=0x0004
        mov      rax, gword ptr [rcx+0x08]
        xor      ecx, ecx
        mov      edx, dword ptr [rax+0x10]
        test     edx, edx
        jle      SHORT G_M48712_IG04
        align    [15 bytes for IG03]
 						;; size=28 bbWeight=1 PerfScore 5.75
 G_M48712_IG03:  ;; offset=0x0020
        cmp      ecx, edx
        jae      SHORT G_M48712_IG05
        mov      r8, gword ptr [rax+0x08]
        cmp      ecx, dword ptr [r8+0x08]
        jae      SHORT G_M48712_IG06
        xor      r10d, r10d
        mov      dword ptr [r8+4*rcx+0x10], r10d
        inc      dword ptr [rax+0x14]
-       inc      ecx
+       inc      rcx
        cmp      ecx, edx
        jl       SHORT G_M48712_IG03
-						;; size=31 bbWeight=4 PerfScore 52.00
-G_M48712_IG04:  ;; offset=0x003F
+						;; size=32 bbWeight=4 PerfScore 52.00
+G_M48712_IG04:  ;; offset=0x0040
        add      rsp, 40
        ret      
 						;; size=5 bbWeight=1 PerfScore 1.25
-G_M48712_IG05:  ;; offset=0x0044
+G_M48712_IG05:  ;; offset=0x0045
        call     [System.ThrowHelper:ThrowArgumentOutOfRange_IndexMustBeLessException()]
        int3     
 						;; size=7 bbWeight=0 PerfScore 0.00
-G_M48712_IG06:  ;; offset=0x004B
+G_M48712_IG06:  ;; offset=0x004C
        call     CORINFO_HELP_RNGCHKFAIL
        int3     
 						;; size=6 bbWeight=0 PerfScore 0.00
 
-; Total bytes of code 81, prolog size 4, PerfScore 59.25, instruction count 24, allocated bytes for code 81 (MethodHash=a57541b7) for method Program:List():System.Collections.Generic.List`1[int]:this (FullOpts)
+; Total bytes of code 82, prolog size 4, PerfScore 59.25, instruction count 24, allocated bytes for code 82 (MethodHash=a57541b7) for method Program:List():System.Collections.Generic.List`1[int]:this (FullOpts)
```