### PR TITLE
Align methods at 16-byte boundaries for CFG

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -449,7 +449,7 @@ namespace Internal.JitInterface
             var relocs = _codeRelocs.ToArray();
             Array.Sort(relocs, (x, y) => (x.Offset - y.Offset));
 
-            int alignment = JitConfigProvider.Instance.HasFlag(CorJitFlag.CORJIT_FLAG_SIZE_OPT) ?
+            int alignment = JitConfigProvider.Instance.HasFlag(CorJitFlag.CORJIT_FLAG_SIZE_OPT) && !JitConfigProvider.Instance.HasFlag(CorJitFlag.CORJIT_FLAG_ENABLE_CFG) ?
                 _compilation.NodeFactory.Target.MinimumFunctionAlignment :
                 _compilation.NodeFactory.Target.OptimumFunctionAlignment;
 


### PR DESCRIPTION
Fixes #105326

Per https://learn.microsoft.com/en-us/windows/win32/secbp/pe-metadata#function-alignment "Functions that are address taken and are therefore included in the GFIDS table should be made 16-byte aligned, if possible.". We'd align at 4 bytes if SIZE_OPT is enabled.

Cc @dotnet/ilc-contrib 