### PR TITLE
Allow data dehydration even if CFG is enabled

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -229,7 +229,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(_targetOS) != ''" Include="--targetos:$(_targetOS)" />
       <IlcArg Condition="$(_targetArchitectureWithAbi) != ''" Include="--targetarch:$(_targetArchitectureWithAbi)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
-      <IlcArg Condition="$(IlcMultiModule) != 'true' and '$(IlcDehydrate)' != 'false' and ('$(ControlFlowGuard)' != 'Guard' or '$(_targetOS)' != 'win')" Include="--dehydrate" />
+      <IlcArg Condition="$(IlcMultiModule) != 'true' and '$(IlcDehydrate)' != 'false'" Include="--dehydrate" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
       <IlcArg Condition="$(NativeDebugSymbols) == 'true'" Include="-g" />
       <IlcArg Condition="$(IlcDwarfVersion) == '5'" Include="--gdwarf-5" />


### PR DESCRIPTION
I chose to disable this for CFG but I don't understand why. On one hand it allows more data to be in the read-only segment, which is good for security, but on the other hand we already validate all indirect jumps so corrupting a pointer here still wouldn't lead to control flow hijack. It can still be disabled with an undocumented switch.

Cc @dotnet/ilc-contrib 