### PR TITLE
[NRBF] List all exceptions that can be thrown by the decoder

### DIFF
--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NrbfDecoder.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NrbfDecoder.cs
@@ -115,6 +115,7 @@ public static class NrbfDecoder
     /// </exception>
     /// <exception cref="DecoderFallbackException">Reading from <paramref name="payload"/>
     /// encounters an invalid UTF8 sequence.</exception>
+    /// <exception cref="EndOfStreamException">The end of the stream is reached before reading <see cref="SerializationRecordType.MessageEnd"/> record.</exception>
     public static SerializationRecord Decode(Stream payload, PayloadOptions? options = default, bool leaveOpen = false)
         => Decode(payload, out _, options, leaveOpen);
 

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NrbfDecoder.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NrbfDecoder.cs
@@ -107,6 +107,12 @@ public static class NrbfDecoder
     /// <exception cref="ArgumentNullException"><paramref name="payload"/> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException"><paramref name="payload"/> does not support reading or is already closed.</exception>
     /// <exception cref="SerializationException">Reading from <paramref name="payload"/> encounters invalid NRBF data.</exception>
+    /// <exception cref="NotSupportedException">
+    /// Reading from <paramref name="payload"/> encounters not supported records.
+    /// For example, arrays with non-zero offset or not supported record types
+    /// (<see cref="SerializationRecordType.ClassWithMembers"/>, <see cref="SerializationRecordType.SystemClassWithMembers"/>,
+    /// <see cref="SerializationRecordType.MethodCall"/> or <see cref="SerializationRecordType.MethodReturn"/>).
+    /// </exception>
     /// <exception cref="DecoderFallbackException">Reading from <paramref name="payload"/>
     /// encounters an invalid UTF8 sequence.</exception>
     public static SerializationRecord Decode(Stream payload, PayloadOptions? options = default, bool leaveOpen = false)

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
@@ -46,7 +46,7 @@ public abstract class SerializationRecord
     /// </summary>
     /// <remarks>
     /// <para>This method ignores assembly names.</para>
-    /// <para>This method does NOT take into account member names or their generic types.</para>
+    /// <para>This method does NOT take into account member names or their types.</para>
     /// </remarks>
     /// <param name="type">The type to compare against.</param>
     /// <returns><see langword="true" /> if the serialized type name match provided type; otherwise, <see langword="false" />.</returns>

--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -2427,7 +2427,7 @@ namespace System.Reflection.Metadata
         internal TypeName() { }
         public string AssemblyQualifiedName { get { throw null; } }
         public AssemblyNameInfo? AssemblyName { get { throw null; } }
-        public System.Reflection.Metadata.TypeName? DeclaringType { get { throw null; } }
+        public System.Reflection.Metadata.TypeName DeclaringType { get { throw null; } }
         public string FullName { get { throw null; } }
         public bool IsArray { get { throw null; } }
         public bool IsByRef { get { throw null; } }


### PR DESCRIPTION
@jeffhandley while answering the questions from Threat Model questionnaire I've realized that there are two exceptions which can be thrown by the decoder, but are not documented.

I've also found one `TypeName` property that can never return null and should not be nullable:

https://github.com/dotnet/runtime/blob/ca8e63e1495a529a293a9644ff5cd9118108b6d1/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeName.cs#L95-L106

I request for permission to merge to main.
 