### PR TITLE
Make Config generator test only for down-casts

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 CollectionInstantiationStrategy instantiationStrategy;
                 CollectionInstantiationConcreteType instantiationConcreteType;
                 CollectionPopulationCastType populationCastType;
-                bool shouldTestCast = false;
+                bool shouldTryCast = false;
 
                 if (HasPublicParameterLessCtor(type))
                 {
@@ -425,7 +425,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     instantiationConcreteType = CollectionInstantiationConcreteType.Dictionary;
                     // is IReadonlyDictionary<,>  -- test cast to IDictionary<,>
                     populationCastType = CollectionPopulationCastType.IDictionary;
-                    shouldTestCast = true;
+                    shouldTryCast = true;
                 }
                 else
                 {
@@ -435,7 +435,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 TypeRef keyTypeRef = EnqueueTransitiveType(typeParseInfo, keyTypeSymbol, DiagnosticDescriptors.DictionaryKeyNotSupported);
                 TypeRef elementTypeRef = EnqueueTransitiveType(typeParseInfo, elementTypeSymbol, DiagnosticDescriptors.ElementTypeNotSupported);
 
-                Debug.Assert(!shouldTestCast || !type.IsValueType, "Should not test cast for value types.");
+                Debug.Assert(!shouldTryCast || !type.IsValueType, "Should not test cast for value types.");
                 return new DictionarySpec(type)
                 {
                     KeyTypeRef = keyTypeRef,
@@ -443,7 +443,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     InstantiationStrategy = instantiationStrategy,
                     InstantiationConcreteType = instantiationConcreteType,
                     PopulationCastType = populationCastType,
-                    ShouldTestCast = shouldTestCast
+                    ShouldTryCast = shouldTryCast
                 };
             }
 
@@ -464,7 +464,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 CollectionInstantiationStrategy instantiationStrategy;
                 CollectionInstantiationConcreteType instantiationConcreteType;
                 CollectionPopulationCastType populationCastType;
-                bool shouldTestCast = false;
+                bool shouldTryCast = false;
 
                 if (HasPublicParameterLessCtor(type))
                 {
@@ -497,7 +497,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     instantiationConcreteType = CollectionInstantiationConcreteType.List;
                     // is IEnumerable<> -- test cast to ICollection<>
                     populationCastType = CollectionPopulationCastType.ICollection;
-                    shouldTestCast = true;
+                    shouldTryCast = true;
                 }
                 else if (IsInterfaceMatch(type, _typeSymbols.ISet_Unbound))
                 {
@@ -511,7 +511,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     instantiationConcreteType = CollectionInstantiationConcreteType.HashSet;
                     // is IReadOnlySet<> -- test cast to ISet<>
                     populationCastType = CollectionPopulationCastType.ISet;
-                    shouldTestCast = true;
+                    shouldTryCast = true;
                 }
                 else if (IsInterfaceMatch(type, _typeSymbols.IReadOnlyList_Unbound) || IsInterfaceMatch(type, _typeSymbols.IReadOnlyCollection_Unbound))
                 {
@@ -519,7 +519,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     instantiationConcreteType = CollectionInstantiationConcreteType.List;
                     // is IReadOnlyList<> or IReadOnlyCollection<> -- test cast to ICollection<>
                     populationCastType = CollectionPopulationCastType.ICollection;
-                    shouldTestCast = true;
+                    shouldTryCast = true;
                 }
                 else
                 {
@@ -528,14 +528,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                 TypeRef elementTypeRef = EnqueueTransitiveType(typeParseInfo, elementType, DiagnosticDescriptors.ElementTypeNotSupported);
 
-                Debug.Assert(!shouldTestCast || !type.IsValueType, "Should not test cast for value types.");
+                Debug.Assert(!shouldTryCast || !type.IsValueType, "Should not test cast for value types.");
                 return new EnumerableSpec(type)
                 {
                     ElementTypeRef = elementTypeRef,
                     InstantiationStrategy = instantiationStrategy,
                     InstantiationConcreteType = instantiationConcreteType,
                     PopulationCastType = populationCastType,
-                    ShouldTestCast = shouldTestCast
+                    ShouldTryCast = shouldTryCast
                 };
             }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
@@ -391,6 +391,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 CollectionInstantiationStrategy instantiationStrategy;
                 CollectionInstantiationConcreteType instantiationConcreteType;
                 CollectionPopulationCastType populationCastType;
+                bool shouldTestCast = false;
 
                 if (HasPublicParameterLessCtor(type))
                 {
@@ -403,6 +404,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     }
                     else if (_typeSymbols.GenericIDictionary is not null && GetInterface(type, _typeSymbols.GenericIDictionary_Unbound) is not null)
                     {
+                        // implements IDictionary<,> -- cast to it.
                         populationCastType = CollectionPopulationCastType.IDictionary;
                     }
                     else
@@ -421,7 +423,9 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 {
                     instantiationStrategy = CollectionInstantiationStrategy.LinqToDictionary;
                     instantiationConcreteType = CollectionInstantiationConcreteType.Dictionary;
+                    // is IReadonlyDictionary<,>  -- test cast to IDictionary<,>
                     populationCastType = CollectionPopulationCastType.IDictionary;
+                    shouldTestCast = true;
                 }
                 else
                 {
@@ -431,6 +435,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 TypeRef keyTypeRef = EnqueueTransitiveType(typeParseInfo, keyTypeSymbol, DiagnosticDescriptors.DictionaryKeyNotSupported);
                 TypeRef elementTypeRef = EnqueueTransitiveType(typeParseInfo, elementTypeSymbol, DiagnosticDescriptors.ElementTypeNotSupported);
 
+                Debug.Assert(!shouldTestCast || !type.IsValueType, "Should not test cast for value types.");
                 return new DictionarySpec(type)
                 {
                     KeyTypeRef = keyTypeRef,
@@ -438,6 +443,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     InstantiationStrategy = instantiationStrategy,
                     InstantiationConcreteType = instantiationConcreteType,
                     PopulationCastType = populationCastType,
+                    ShouldTestCast = shouldTestCast
                 };
             }
 
@@ -458,6 +464,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 CollectionInstantiationStrategy instantiationStrategy;
                 CollectionInstantiationConcreteType instantiationConcreteType;
                 CollectionPopulationCastType populationCastType;
+                bool shouldTestCast = false;
 
                 if (HasPublicParameterLessCtor(type))
                 {
@@ -470,6 +477,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     }
                     else if (_typeSymbols.GenericICollection is not null && GetInterface(type, _typeSymbols.GenericICollection_Unbound) is not null)
                     {
+                        // implements ICollection<> -- cast to it
                         populationCastType = CollectionPopulationCastType.ICollection;
                     }
                     else
@@ -487,7 +495,9 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 {
                     instantiationStrategy = CollectionInstantiationStrategy.CopyConstructor;
                     instantiationConcreteType = CollectionInstantiationConcreteType.List;
+                    // is IEnumerable<> -- test cast to ICollection<>
                     populationCastType = CollectionPopulationCastType.ICollection;
+                    shouldTestCast = true;
                 }
                 else if (IsInterfaceMatch(type, _typeSymbols.ISet_Unbound))
                 {
@@ -499,13 +509,17 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 {
                     instantiationStrategy = CollectionInstantiationStrategy.CopyConstructor;
                     instantiationConcreteType = CollectionInstantiationConcreteType.HashSet;
+                    // is IReadOnlySet<> -- test cast to ISet<>
                     populationCastType = CollectionPopulationCastType.ISet;
+                    shouldTestCast = true;
                 }
                 else if (IsInterfaceMatch(type, _typeSymbols.IReadOnlyList_Unbound) || IsInterfaceMatch(type, _typeSymbols.IReadOnlyCollection_Unbound))
                 {
                     instantiationStrategy = CollectionInstantiationStrategy.CopyConstructor;
                     instantiationConcreteType = CollectionInstantiationConcreteType.List;
+                    // is IReadOnlyList<> or IReadOnlyCollection<> -- test cast to ICollection<>
                     populationCastType = CollectionPopulationCastType.ICollection;
+                    shouldTestCast = true;
                 }
                 else
                 {
@@ -514,12 +528,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                 TypeRef elementTypeRef = EnqueueTransitiveType(typeParseInfo, elementType, DiagnosticDescriptors.ElementTypeNotSupported);
 
+                Debug.Assert(!shouldTestCast || !type.IsValueType, "Should not test cast for value types.");
                 return new EnumerableSpec(type)
                 {
                     ElementTypeRef = elementTypeRef,
                     InstantiationStrategy = instantiationStrategy,
                     InstantiationConcreteType = instantiationConcreteType,
                     PopulationCastType = populationCastType,
+                    ShouldTestCast = shouldTestCast
                 };
             }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -1230,15 +1230,25 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                string castTypeDisplayString = TypeIndex.GetPopulationCastTypeDisplayString(type);
                 instanceIdentifier = Identifier.temp;
+                string castExpression = $"{TypeIndex.GetPopulationCastTypeDisplayString(type)} {instanceIdentifier}";
 
-                _writer.WriteLine($$"""
-                        if ({{Identifier.instance}} is not {{castTypeDisplayString}} {{instanceIdentifier}})
-                        {
-                            return;
-                        }
-                        """);
+                if (type.ShouldTestCast)
+                {
+                    _writer.WriteLine($$"""
+                            if ({{Identifier.instance}} is not {{castExpression}})
+                            {
+                                return;
+                            }
+                            """);
+                }
+                else
+                {
+                    _writer.WriteLine($$"""
+                            {{castExpression}} = {{Identifier.instance}};
+                            """);
+                }
+
                 _writer.WriteLine();
 
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -1233,7 +1233,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 instanceIdentifier = Identifier.temp;
                 string castExpression = $"{TypeIndex.GetPopulationCastTypeDisplayString(type)} {instanceIdentifier}";
 
-                if (type.ShouldTestCast)
+                if (type.ShouldTryCast)
                 {
                     _writer.WriteLine($$"""
                             if ({{Identifier.instance}} is not {{castExpression}})

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/CollectionSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/CollectionSpec.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public required CollectionInstantiationConcreteType InstantiationConcreteType { get; init; }
 
         public required CollectionPopulationCastType PopulationCastType { get; init; }
+
+        public required bool ShouldTestCast {get; init; }
     }
 
     internal sealed record ArraySpec : CollectionSpec

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/CollectionSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/CollectionSpec.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
         public required CollectionPopulationCastType PopulationCastType { get; init; }
 
-        public required bool ShouldTestCast {get; init; }
+        public required bool ShouldTryCast { get; init; }
     }
 
     internal sealed record ArraySpec : CollectionSpec

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
@@ -2420,6 +2420,31 @@ namespace Microsoft.Extensions
             Assert.Equal("ds2", dictionary["k1"]);
         }
 
+        [Fact]
+        public void TestOptionsWithUnsupportedStructs()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"ReadOnlyCollectionStructExplicit:0", "cs1"},
+                {"ReadOnlyCollectionStructExplicit:1", "cs2"},
+                {"ReadOnlyDictionaryStructExplicit:k0", "ds1"},
+                {"ReadOnlyDictionaryStructExplicit:k1", "ds2"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+
+            var config = configurationBuilder.Build();
+
+            var options = new OptionsWithUnsupportedStructs();
+            config.Bind(options);
+
+            IReadOnlyCollection<string> collection = options.ReadOnlyCollectionStructExplicit;
+            Assert.Equal(0, collection.Count);
+
+            IReadOnlyDictionary<string, string> dictionary = options.ReadOnlyDictionaryStructExplicit;
+            Assert.Equal(0, dictionary.Count);
+        }
+
         // Test behavior for root level arrays.
 
         // Tests for TypeConverter usage.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
@@ -2368,6 +2368,58 @@ namespace Microsoft.Extensions
             Assert.Equal("System.Boolean", result[0].Elements[1].Type);
         }
 
+        [Fact]
+        public void TestStringValues()
+        {
+            // StringValues is a struct that implements IList<string> -- though it doesn't actually support Add
+
+            var dic = new Dictionary<string, string>
+            {
+                {"StringValues:0", "Yo1"},
+                {"StringValues:1", "Yo2"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+
+            var config = configurationBuilder.Build();
+
+            var options = new OptionsWithStructs();
+
+#if BUILDING_SOURCE_GENERATOR_TESTS
+            Assert.Throws<NotSupportedException>(() => config.Bind(options));
+#else
+            Assert.Throws<InvalidOperationException>(() => config.Bind(options, (bo) => bo.ErrorOnUnknownConfiguration = true));
+#endif
+        }
+
+        [Fact]
+        public void TestOptionsWithStructs()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"CollectionStructExplicit:0", "cs1"},
+                {"CollectionStructExplicit:1", "cs2"},
+                {"DictionaryStructExplicit:k0", "ds1"},
+                {"DictionaryStructExplicit:k1", "ds2"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+
+            var config = configurationBuilder.Build();
+
+            var options = new OptionsWithStructs();
+            config.Bind(options);
+
+            ICollection<string> collection = options.CollectionStructExplicit;
+            Assert.Equal(2, collection.Count);
+            Assert.Equal(collection, ["cs1", "cs2"]);
+
+            IDictionary<string, string> dictionary = options.DictionaryStructExplicit;
+            Assert.Equal(2, dictionary.Count);
+            Assert.Equal("ds1", dictionary["k0"]);
+            Assert.Equal("ds2", dictionary["k1"]);
+        }
+
         // Test behavior for root level arrays.
 
         // Tests for TypeConverter usage.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
@@ -462,5 +462,50 @@ namespace Microsoft.Extensions
 
             bool IDictionary<string, string>.TryGetValue(string key, out string value) => _dictionary.TryGetValue(key, out value);
         }
+
+        public class OptionsWithUnsupportedStructs
+        {
+            public ReadOnlyCollectionStructExplicit ReadOnlyCollectionStructExplicit { get; set; } = new();
+
+            public ReadOnlyDictionaryStructExplicit ReadOnlyDictionaryStructExplicit { get; set; } = new();
+        }
+
+        public struct ReadOnlyCollectionStructExplicit : IReadOnlyCollection<string>
+        {
+            public ReadOnlyCollectionStructExplicit()
+            {
+                _collection = new List<string>();
+            }
+
+            private readonly IReadOnlyCollection<string> _collection;
+            int IReadOnlyCollection<string>.Count => _collection.Count;
+            IEnumerator<string> IEnumerable<string>.GetEnumerator() => _collection.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_collection).GetEnumerator();
+        }
+
+        public struct ReadOnlyDictionaryStructExplicit : IReadOnlyDictionary<string, string>
+        {
+            public ReadOnlyDictionaryStructExplicit()
+            {
+                _dictionary = new Dictionary<string, string>();
+            }
+
+            private readonly IReadOnlyDictionary<string, string> _dictionary;
+            string IReadOnlyDictionary<string, string>.this[string key] => _dictionary[key];
+
+            IEnumerable<string> IReadOnlyDictionary<string, string>.Keys => _dictionary.Keys;
+
+            IEnumerable<string> IReadOnlyDictionary<string, string>.Values => _dictionary.Values;
+
+            int IReadOnlyCollection<KeyValuePair<string, string>>.Count => _dictionary.Count;
+
+            bool IReadOnlyDictionary<string, string>.ContainsKey(string key) => _dictionary.ContainsKey(key);
+
+            IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => _dictionary.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_dictionary).GetEnumerator();
+
+            bool IReadOnlyDictionary<string, string>.TryGetValue(string key, out string value) => _dictionary.TryGetValue(key, out value);
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions
 #if BUILDING_SOURCE_GENERATOR_TESTS
@@ -387,6 +388,79 @@ namespace Microsoft.Extensions
         public class Element
         {
             public string Type { get; set; }
+        }
+
+        public class OptionsWithStructs
+        {
+            public StringValues StringValues { get; set; }
+
+            public CollectionStructExplicit CollectionStructExplicit { get; set; } = new();
+
+            public DictionaryStructExplicit DictionaryStructExplicit { get; set; } = new();
+        }
+
+        public struct CollectionStructExplicit : ICollection<string>
+        {
+            public CollectionStructExplicit() {}
+
+            ICollection<string> _collection = new List<string>();
+
+            int ICollection<string>.Count => _collection.Count;
+
+            bool ICollection<string>.IsReadOnly => _collection.IsReadOnly;
+
+            void ICollection<string>.Add(string item) => _collection.Add(item);
+
+            void ICollection<string>.Clear() => _collection.Clear();
+
+            bool ICollection<string>.Contains(string item) => _collection.Contains(item);
+
+            void ICollection<string>.CopyTo(string[] array, int arrayIndex) => _collection.CopyTo(array, arrayIndex);
+
+            IEnumerator<string> IEnumerable<string>.GetEnumerator() => _collection.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_collection).GetEnumerator();
+
+            bool ICollection<string>.Remove(string item) => _collection.Remove(item);
+        }
+
+        public struct DictionaryStructExplicit : IDictionary<string, string>
+        {
+            public DictionaryStructExplicit() {}
+
+            IDictionary<string, string> _dictionary = new Dictionary<string, string>();
+
+            string IDictionary<string, string>.this[string key] { get => _dictionary[key]; set => _dictionary[key] = value; }
+
+            ICollection<string> IDictionary<string, string>.Keys => _dictionary.Keys;
+
+            ICollection<string> IDictionary<string, string>.Values => _dictionary.Values;
+
+            int ICollection<KeyValuePair<string, string>>.Count => _dictionary.Count;
+
+            bool ICollection<KeyValuePair<string, string>>.IsReadOnly => _dictionary.IsReadOnly;
+
+            void IDictionary<string, string>.Add(string key, string value) => _dictionary.Add(key, value);
+
+            void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item) => _dictionary.Add(item);
+
+            void ICollection<KeyValuePair<string, string>>.Clear() => _dictionary.Clear();
+
+            bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> item) => _dictionary.Contains(item);
+
+            bool IDictionary<string, string>.ContainsKey(string key) => _dictionary.ContainsKey(key);
+
+            void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] array, int arrayIndex) => _dictionary.CopyTo(array, arrayIndex);
+
+            IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => _dictionary.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_dictionary).GetEnumerator();
+
+            bool IDictionary<string, string>.Remove(string key) => _dictionary.Remove(key);
+
+            bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item) => _dictionary.Remove(item);
+
+            bool IDictionary<string, string>.TryGetValue(string key, out string value) => _dictionary.TryGetValue(key, out value);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/Version0/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/Version0/Collections.generated.txt
@@ -36,12 +36,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
     {
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the configuration instance to a new instance of type T.</summary>
-        [InterceptsLocation(@"src-0.cs", 12, 17)]
+        [InterceptsLocation(@"src-0.cs", 13, 17)]
         public static T? Get<T>(this IConfiguration configuration) => (T?)(GetCore(configuration, typeof(T), configureOptions: null) ?? default(T));
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
-        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary" });
+        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary", "CollectionStructExplicit" });
 
         public static object? GetCore(this IConfiguration configuration, Type type, Action<BinderOptions>? configureOptions)
         {
@@ -121,6 +121,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
+        public static void BindCore(IConfiguration configuration, ref global::Program.CollectionStructExplicit instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
+        {
+            ICollection<string> temp = instance;
+
+            foreach (IConfigurationSection section in configuration.GetChildren())
+            {
+                if (section.Value is string value)
+                {
+                    temp.Add(value);
+                }
+            }
+        }
+
         public static void BindCore(IConfiguration configuration, ref global::Program.MyClassWithCustomCollections instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(global::Program.MyClassWithCustomCollections), s_configKeys_ProgramMyClassWithCustomCollections, configuration, binderOptions);
@@ -155,6 +168,15 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 temp12 = temp12 is null ? (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)new Dictionary<string, int>() : (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
                 BindCore(section10, ref temp12, defaultValueIfNotFound: false, binderOptions);
                 instance.IReadOnlyDictionary = temp12;
+            }
+
+            if (AsConfigWithChildren(configuration.GetSection("CollectionStructExplicit")) is IConfigurationSection section13)
+            {
+                global::Program.CollectionStructExplicit temp14 = instance.CollectionStructExplicit;
+                var temp15 = new global::Program.CollectionStructExplicit();
+                BindCore(section13, ref temp15, defaultValueIfNotFound: false, binderOptions);
+                instance.CollectionStructExplicit = temp15;
+                temp14 = temp15;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/Version1/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/Version1/Collections.generated.txt
@@ -36,12 +36,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
     {
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the configuration instance to a new instance of type T.</summary>
-        [InterceptsLocation(1, "x0/k4h2yDpHi1YoDOFMOUFoBAABzcmMtMC5jcw==")] // src-0.cs(12,17)
+        [InterceptsLocation(1, "2Ny1FTOTCAvRq9jRD2PynXQBAABzcmMtMC5jcw==")] // src-0.cs(13,17)
         public static T? Get<T>(this IConfiguration configuration) => (T?)(GetCore(configuration, typeof(T), configureOptions: null) ?? default(T));
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
-        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary" });
+        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary", "CollectionStructExplicit" });
 
         public static object? GetCore(this IConfiguration configuration, Type type, Action<BinderOptions>? configureOptions)
         {
@@ -121,6 +121,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
+        public static void BindCore(IConfiguration configuration, ref global::Program.CollectionStructExplicit instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
+        {
+            ICollection<string> temp = instance;
+
+            foreach (IConfigurationSection section in configuration.GetChildren())
+            {
+                if (section.Value is string value)
+                {
+                    temp.Add(value);
+                }
+            }
+        }
+
         public static void BindCore(IConfiguration configuration, ref global::Program.MyClassWithCustomCollections instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(global::Program.MyClassWithCustomCollections), s_configKeys_ProgramMyClassWithCustomCollections, configuration, binderOptions);
@@ -155,6 +168,15 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 temp12 = temp12 is null ? (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)new Dictionary<string, int>() : (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
                 BindCore(section10, ref temp12, defaultValueIfNotFound: false, binderOptions);
                 instance.IReadOnlyDictionary = temp12;
+            }
+
+            if (AsConfigWithChildren(configuration.GetSection("CollectionStructExplicit")) is IConfigurationSection section13)
+            {
+                global::Program.CollectionStructExplicit temp14 = instance.CollectionStructExplicit;
+                var temp15 = new global::Program.CollectionStructExplicit();
+                BindCore(section13, ref temp15, defaultValueIfNotFound: false, binderOptions);
+                instance.CollectionStructExplicit = temp15;
+                temp14 = temp15;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/Version0/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/Version0/Collections.generated.txt
@@ -36,12 +36,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
     {
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the configuration instance to a new instance of type T.</summary>
-        [InterceptsLocation(@"src-0.cs", 12, 17)]
+        [InterceptsLocation(@"src-0.cs", 13, 17)]
         public static T? Get<T>(this IConfiguration configuration) => (T?)(GetCore(configuration, typeof(T), configureOptions: null) ?? default(T));
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
-        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary" });
+        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary", "CollectionStructExplicit" });
 
         public static object? GetCore(this IConfiguration configuration, Type type, Action<BinderOptions>? configureOptions)
         {
@@ -118,6 +118,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
+        public static void BindCore(IConfiguration configuration, ref global::Program.CollectionStructExplicit instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
+        {
+            ICollection<string> temp = instance;
+
+            foreach (IConfigurationSection section in configuration.GetChildren())
+            {
+                if (section.Value is string value)
+                {
+                    temp.Add(value);
+                }
+            }
+        }
+
         public static void BindCore(IConfiguration configuration, ref global::Program.MyClassWithCustomCollections instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(global::Program.MyClassWithCustomCollections), s_configKeys_ProgramMyClassWithCustomCollections, configuration, binderOptions);
@@ -152,6 +165,15 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 temp12 = temp12 is null ? (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)new Dictionary<string, int>() : (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
                 BindCore(section10, ref temp12, defaultValueIfNotFound: false, binderOptions);
                 instance.IReadOnlyDictionary = temp12;
+            }
+
+            if (AsConfigWithChildren(configuration.GetSection("CollectionStructExplicit")) is IConfigurationSection section13)
+            {
+                global::Program.CollectionStructExplicit temp14 = instance.CollectionStructExplicit;
+                var temp15 = new global::Program.CollectionStructExplicit();
+                BindCore(section13, ref temp15, defaultValueIfNotFound: false, binderOptions);
+                instance.CollectionStructExplicit = temp15;
+                temp14 = temp15;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/Version1/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/Version1/Collections.generated.txt
@@ -36,12 +36,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
     {
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the configuration instance to a new instance of type T.</summary>
-        [InterceptsLocation(1, "x0/k4h2yDpHi1YoDOFMOUFoBAABzcmMtMC5jcw==")] // src-0.cs(12,17)
+        [InterceptsLocation(1, "2Ny1FTOTCAvRq9jRD2PynXQBAABzcmMtMC5jcw==")] // src-0.cs(13,17)
         public static T? Get<T>(this IConfiguration configuration) => (T?)(GetCore(configuration, typeof(T), configureOptions: null) ?? default(T));
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
-        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary" });
+        private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClassWithCustomCollections = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CustomDictionary", "CustomList", "ICustomDictionary", "ICustomCollection", "IReadOnlyList", "UnsupportedIReadOnlyDictionaryUnsupported", "IReadOnlyDictionary", "CollectionStructExplicit" });
 
         public static object? GetCore(this IConfiguration configuration, Type type, Action<BinderOptions>? configureOptions)
         {
@@ -118,6 +118,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
+        public static void BindCore(IConfiguration configuration, ref global::Program.CollectionStructExplicit instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
+        {
+            ICollection<string> temp = instance;
+
+            foreach (IConfigurationSection section in configuration.GetChildren())
+            {
+                if (section.Value is string value)
+                {
+                    temp.Add(value);
+                }
+            }
+        }
+
         public static void BindCore(IConfiguration configuration, ref global::Program.MyClassWithCustomCollections instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(global::Program.MyClassWithCustomCollections), s_configKeys_ProgramMyClassWithCustomCollections, configuration, binderOptions);
@@ -152,6 +165,15 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 temp12 = temp12 is null ? (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)new Dictionary<string, int>() : (global::System.Collections.Generic.IReadOnlyDictionary<string, int>)temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
                 BindCore(section10, ref temp12, defaultValueIfNotFound: false, binderOptions);
                 instance.IReadOnlyDictionary = temp12;
+            }
+
+            if (AsConfigWithChildren(configuration.GetSection("CollectionStructExplicit")) is IConfigurationSection section13)
+            {
+                global::Program.CollectionStructExplicit temp14 = instance.CollectionStructExplicit;
+                var temp15 = new global::Program.CollectionStructExplicit();
+                BindCore(section13, ref temp15, defaultValueIfNotFound: false, binderOptions);
+                instance.CollectionStructExplicit = temp15;
+                temp14 = temp15;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Baselines.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Baselines.cs
@@ -863,6 +863,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
         public async Task Collections()
         {
             string source = """
+                using System.Collections;
                 using System.Collections.Generic;
                 using Microsoft.Extensions.Configuration;
 
@@ -888,6 +889,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
                         // Diagnostic warning because we don't know how to instantiate the property type.
                         public IReadOnlyDictionary<MyClassWithCustomCollections, int> UnsupportedIReadOnlyDictionaryUnsupported { get; set; }
                         public IReadOnlyDictionary<string, int> IReadOnlyDictionary { get; set; }
+                        public CollectionStructExplicit CollectionStructExplicit { get; set; }
                     }
 
                     public class CustomDictionary<TKey, TValue> : Dictionary<TKey, TValue>
@@ -906,6 +908,32 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
                     // Diagnostic warning because we don't know how to instantiate this type.
                     public interface ICustomSet<T> : ISet<T>
                     {
+                    }
+
+                    // struct that explicitly implements ICollection<string>
+                    public struct CollectionStructExplicit : ICollection<string>
+                    {
+                        public CollectionStructExplicit() {}
+
+                        ICollection<string> _collection = new List<string>();
+
+                        int ICollection<string>.Count => _collection.Count;
+
+                        bool ICollection<string>.IsReadOnly => _collection.IsReadOnly;
+
+                        void ICollection<string>.Add(string item) => _collection.Add(item);
+
+                        void ICollection<string>.Clear() => _collection.Clear();
+
+                        bool ICollection<string>.Contains(string item) => _collection.Contains(item);
+
+                        void ICollection<string>.CopyTo(string[] array, int arrayIndex) => _collection.CopyTo(array, arrayIndex);
+
+                        IEnumerator<string> IEnumerable<string>.GetEnumerator() => _collection.GetEnumerator();
+
+                        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_collection).GetEnumerator();
+
+                        bool ICollection<string>.Remove(string item) => _collection.Remove(item);
                     }
                 }
                 """;


### PR DESCRIPTION
Fix #94547 

We were hitting compiler errors when the generator emitted test casts for value types.  Since those can never be true (value types cannot be derived from, and the compiler can see if the cast will succeed or not).

Fix this by only doing a test cast when we are trying to do a runtime downcast.