### PR TITLE
JIT: fix assert in assertion prop

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4409,7 +4409,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         }
     }
     // If the assertion involves "op2" and "op1" is also a local var, then just morph the tree.
-    else if (op2->gtOper == GT_LCL_VAR)
+    else if (op1->OperIs(GT_LCL_VAR) && op2->OperIs(GT_LCL_VAR))
     {
 #ifdef DEBUG
         if (verbose)


### PR DESCRIPTION
`optAssertionPropGlobal_RelOp` had branch where it was expecting both op2 and op1 to be locals, but only had verified that op2 was.

Add an extra check.

Fixes #105670