### PR TITLE
[wasm] Use the right env variable in mono.proj for frozen cache

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -250,7 +250,7 @@ LLVM_ROOT = emsdk_path + '/bin'
 NODE_JS = emsdk_path + '/node/bin/node'
 BINARYEN_ROOT = emsdk_path
 
-FROZEN_CACHE = bool(os.getenv('FROZEN_CACHE', 'True'))
+FROZEN_CACHE = bool(os.getenv('EM_FROZEN_CACHE', 'True'))
 
 COMPILER_ENGINE = NODE_JS
 JS_ENGINES = [NODE_JS]


### PR DESCRIPTION
Emscripten uses `EM_` prefix for its configuration through the environment variables