### PR TITLE
[NativeAOT] Move IsByRefLikeFlag from RareFlags to ExtendedFlags

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -618,7 +618,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return (RareFlags & EETypeRareFlags.IsByRefLikeFlag) != 0;
+                return IsValueType && (_uFlags & (uint)EETypeFlagsEx.IsByRefLikeFlag) != 0;
             }
         }
 

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -162,6 +162,9 @@ private:
         HasCriticalFinalizerFlag = 0x0002,
         IsTrackedReferenceWithFinalizerFlag = 0x0004,
 
+        // This MethodTable is for a Byref-like class (TypedReference, Span<T>, ...)
+        IsByRefLikeFlag = 0x0010,
+
         // This type requires 8-byte alignment for its fields on certain platforms (ARM32, WASM)
         RequiresAlign8Flag = 0x1000
     };

--- a/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -128,6 +128,11 @@ namespace Internal.Runtime
                 flagsEx |= (ushort)EETypeFlagsEx.IDynamicInterfaceCastableFlag;
             }
 
+            if (type.IsByRefLike)
+            {
+                flagsEx |= (ushort)EETypeFlagsEx.IsByRefLikeFlag;
+            }
+
             if (type.RequiresAlign8())
             {
                 flagsEx |= (ushort)EETypeFlagsEx.RequiresAlign8Flag;

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -86,6 +86,11 @@ namespace Internal.Runtime
         IDynamicInterfaceCastableFlag = 0x0008,
 
         /// <summary>
+        /// This MethodTable is for a Byref-like class (TypedReference, Span&lt;T&gt;,...)
+        /// </summary>
+        IsByRefLikeFlag = 0x0010,
+
+        /// <summary>
         /// This type requires 8-byte alignment for its fields on certain platforms (ARM32, WASM)
         /// </summary>
         RequiresAlign8Flag = 0x1000
@@ -163,10 +168,7 @@ namespace Internal.Runtime
 
         // UNUSED = 0x00004000,
 
-        /// <summary>
-        /// This MethodTable is for a Byref-like class (TypedReference, Span&lt;T&gt;,...)
-        /// </summary>
-        IsByRefLikeFlag = 0x00008000,
+        // UNUSED = 0x00008000,
     }
 
     internal enum EETypeField

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1343,24 +1343,8 @@ namespace ILCompiler.DependencyAnalysis
         /// </summary>
         protected internal virtual void ComputeOptionalEETypeFields(NodeFactory factory, bool relocsOnly)
         {
-            ComputeRareFlags();
             ComputeNullableValueOffset();
             ComputeValueTypeFieldPadding();
-        }
-
-        private void ComputeRareFlags()
-        {
-            uint flags = 0;
-
-            if (_type.IsByRefLike)
-            {
-                flags |= (uint)EETypeRareFlags.IsByRefLikeFlag;
-            }
-
-            if (flags != 0)
-            {
-                _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.RareFlags, flags);
-            }
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -40,7 +40,6 @@ namespace ILCompiler.DependencyAnalysis
 
             dataBuilder.RequireInitialPointerAlignment();
             dataBuilder.AddSymbol(this);
-            EETypeRareFlags rareFlags = 0;
 
             uint flags = EETypeBuilderHelpers.ComputeFlags(_type);
 
@@ -51,10 +50,7 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (uint)EETypeFlags.GenericVarianceFlag;
 
             if (_type.IsByRefLike)
-                rareFlags |= EETypeRareFlags.IsByRefLikeFlag;
-
-            if (rareFlags != 0)
-                _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.RareFlags, (uint)rareFlags);
+                flags |= (uint)EETypeFlagsEx.IsByRefLikeFlag;
 
             if (HasOptionalFields)
                 flags |= (uint)EETypeFlags.OptionalFieldsFlag;


### PR DESCRIPTION
The flag is only valid for value types, we have ample space in `EETypeFlagsEx`. This may avoid building the optional fields node in ILC and it's basically free tiny space optimization.