### PR TITLE
[EventPipe] Block eventpipe delete provider for pending callbacks

### DIFF
--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -493,6 +493,7 @@ provider_free (EventPipeProvider * provider)
 
 	dn_list_custom_free (provider->event_list, event_free_func);
 
+	ep_rt_wait_event_free (&provider->callbacks_complete_event);
 	ep_rt_utf16_string_free (provider->provider_name_utf16);
 	ep_rt_utf8_string_free (provider->provider_name);
 	ep_rt_object_free (provider);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/106113

https://github.com/dotnet/runtime/pull/106040 previously only blocked EventPipeEventProvider's Dispose for the EventPipe Provider's deferred deletion scenarios. This PR extends the blocking behavior for non deferred deletion scenarios as well, so EventPipeEventProvider.Dispose/Unregister will *always* be blocked by in flight callbacks.