### PR TITLE
Fix NativeAOT runtime build without FEATURE_EVENT_TRACE

### DIFF
--- a/src/coreclr/gc/env/etmdummy.h
+++ b/src/coreclr/gc/env/etmdummy.h
@@ -419,3 +419,4 @@
 #define FireEtwEventSource(eventID, eventName, eventSourceName, payload) 0
 #define FireEtwWaitHandleWaitStart(WaitSource, AssociatedObjectID, ClrInstanceID) 0
 #define FireEtwWaitHandleWaitStop(ClrInstanceID) 0
+#define FireEtwYieldProcessorMeasurement(ClrInstanceID, NsPerYield, EstablishedNsPerYield) 0

--- a/src/coreclr/vm/yieldprocessornormalizedshared.cpp
+++ b/src/coreclr/vm/yieldprocessornormalizedshared.cpp
@@ -282,6 +282,7 @@ void YieldProcessorNormalization::FireMeasurementEvents()
     }
     CONTRACTL_END;
 
+#ifdef FEATURE_EVENT_TRACE
     if (!EventEnabledYieldProcessorMeasurement())
     {
         return;
@@ -304,6 +305,7 @@ void YieldProcessorNormalization::FireMeasurementEvents()
             nextIndex = 0;
         }
     }
+#endif // FEATURE_EVENT_TRACE
 }
 
 double YieldProcessorNormalization::AtomicLoad(double *valueRef)


### PR DESCRIPTION
Downstream -> upstream code sync (https://github.com/dotnet/runtimelab/pull/2647).