### PR TITLE
[PERF] Remove Ubuntu Crossgen from perf tests

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -314,7 +314,6 @@ jobs:
       buildConfig: release
       runtimeFlavor: coreclr
       platforms:
-      - linux_x64
       - windows_x64
       - windows_x86
       jobParameters:


### PR DESCRIPTION
Perf: Remove Ubuntu crossgen runs as they are not being used and the queue is outdated. Full removal of queue will likely follow shortly.