### PR TITLE
Mitigate Crossgen2 Failures in Outerloop CI

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -331,9 +331,7 @@ jobs:
           msbuildParallelism: '/maxcpucount:55'
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
-          ${{ if or(eq(parameters.runtimeFlavor, 'mono'),
-                    and(eq(parameters.testGroup, 'outerloop'),
-                        eq(parameters.readyToRun, true))) }}:
+          ${{ if or(eq(parameters.runtimeFlavor, 'mono'), and(eq(parameters.testGroup, 'outerloop'), eq(parameters.readyToRun, true))) }}:
             # tiered compilation isn't done on mono yet
             scenarios:
             - normal

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -331,7 +331,9 @@ jobs:
           msbuildParallelism: '/maxcpucount:55'
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
-          ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
+          ${{ if or(eq(parameters.runtimeFlavor, 'mono'),
+                    and(eq(parameters.testGroup, 'outerloop'),
+                        eq(parameters.readyToRun, true))) }}:
             # tiered compilation isn't done on mono yet
             scenarios:
             - normal


### PR DESCRIPTION
Currently, many Crossgen2 tests are failing in coreclr outerloop. A fix is coming later on, but meanwhile, having the pipelines all red is not advisable. This PR aims to control the issue while the fix gets propagated.