### PR TITLE
Mention GitHub users when the issue/PR binaryformatter-migration label is added

### DIFF
--- a/.github/policies/binaryformatter-migration.yml
+++ b/.github/policies/binaryformatter-migration.yml
@@ -1,0 +1,25 @@
+id: binaryformatter-migration
+name: BinaryFormatter migration label automation
+owner: jeffhandley
+resource: repository
+disabled: false
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: '@Mention for binaryformatter-migration'
+      if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: binaryformatter-migration
+      then:
+      - mentionUsers:
+          mentionees:
+          - adamsitnik
+          - bartonjs
+          - jeffhandley
+          - terrajobst
+          replyTemplate: >-
+            Tagging subscribers to 'binaryformatter-migration': ${mentionees}
+          assignMentionees: False


### PR DESCRIPTION
Adds a policy to the repository that will automatically mention @adamsitnik, @bartonjs, @jeffhandley, and @terrajobst when the https://github.com/dotnet/runtime/labels/binaryformatter-migration label is added to an issue or pull request.