### PR TITLE
Remove two outdated test inputs from regex match timeout tests

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1264,8 +1264,6 @@ namespace System.Text.RegularExpressions.Tests
                 // Lookarounds
                 yield return new object[] { engine, @"((?=(?>a*))a)+", a1_000_000 };
                 yield return new object[] { engine, @"((?<=(?>a*))a)+", a1_000_000 };
-                yield return new object[] { engine, @"((?!(?>[^a]*))a)+", a1_000_000 };
-                yield return new object[] { engine, @"((?<!(?>[^a]*))a)+", a1_000_000 };
 
                 // All of the below tests have catastrophic backtracking...
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/106096. These are too fast now and may trip over the (lack of) timeout sporadically. 