### PR TITLE
Fix UseCompilerGeneratedDocXmlFile default value

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -389,6 +389,8 @@
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
     <!-- Warnings to always disable -->
     <NoWarn>$(NoWarn);CS8500;CS8969</NoWarn>
+    <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors for private assemblies. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</KeepNativeSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -390,7 +390,7 @@
     <!-- Warnings to always disable -->
     <NoWarn>$(NoWarn);CS8500;CS8969</NoWarn>
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors for private assemblies. -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn Condition="'$(IsPrivateAssembly)' == 'true'">$(NoWarn);CS1591</NoWarn>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</KeepNativeSymbols>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -14,7 +14,7 @@
     <IntermediateDocFileItemFromIntellisensePackage>$(IntermediateOutputPath)$(TargetName).intellisense-package.xml</IntermediateDocFileItemFromIntellisensePackage>
 
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors when the intellisense package xml file is used. -->
-    <NoWarn Condition="'$(SkipIntellisenseNoWarnCS1591)' != 'true'">$(NoWarn);1591</NoWarn>
+    <NoWarn Condition="'$(SkipIntellisenseNoWarnCS1591)' != 'true'">$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <!-- Flow these properties to consuming projects for Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj to only
@@ -30,6 +30,15 @@
   <ItemGroup>
     <PackageDownload Include="Microsoft.Private.Intellisense" Version="[$(MicrosoftPrivateIntellisenseVersion)]" />
   </ItemGroup>
+
+  <!-- Warn if the docs team provided package doesn't have an intellisense file for a given library and the library explicitly
+       opts out from using the compiler generated xml file. -->
+  <Target Name="ValidateIntellisensePackageXmlFilePathExists"
+          Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' and
+                     '$(IntellisensePackageXmlFilePath)' == ''"
+          BeforeTargets="CoreCompile">
+    <Warning Text="The 'UseCompilerGeneratedDocXmlFile' property was set to '$(UseCompilerGeneratedDocXmlFile)', but the doc team doesn't provide a file for this assembly. Remove the 'UseCompilerGeneratedDocXmlFile' property to let the compiler generate the file." />
+  </Target>
 
   <!-- Prepare the intellisense package xml file by copying it to the project's intermediate folder and update its file timestamp.
        This is necessary so that all project outputs are newer than all project inputs. Directly copying from the intellisense package
@@ -47,7 +56,7 @@
   <Target Name="ChangeDocumentationFileForPackaging"
           DependsOnTargets="PrepareIntellisensePackageXmlFile"
           BeforeTargets="CopyFilesToOutputDirectory;DocumentationProjectOutputGroup"
-          Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' and '$(IntellisensePackageXmlFilePath)' != ''">
+          Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' and '$(IntellisensePackageXmlFilePath)' != ''">   
     <ItemGroup>
       <DocFileItem Remove="@(DocFileItem)" />
       <DocFileItem Include="$(IntermediateDocFileItemFromIntellisensePackage)" />

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -1,5 +1,9 @@
 <Project>
 
+  <PropertyGroup>
+    <UseCompilerGeneratedDocXmlFile Condition="'$(UseCompilerGeneratedDocXmlFile)' == ''">true</UseCompilerGeneratedDocXmlFile>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true'">
     <IntellisensePackageXmlRootFolder>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.private.intellisense', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles'))</IntellisensePackageXmlRootFolder>
     <IntellisensePackageXmlFilePathFromNetFolder>$([MSBuild]::NormalizePath('$(IntellisensePackageXmlRootFolder)', 'net', '1033', '$(AssemblyName).xml'))</IntellisensePackageXmlFilePathFromNetFolder>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -56,7 +56,7 @@
   <Target Name="ChangeDocumentationFileForPackaging"
           DependsOnTargets="PrepareIntellisensePackageXmlFile"
           BeforeTargets="CopyFilesToOutputDirectory;DocumentationProjectOutputGroup"
-          Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' and '$(IntellisensePackageXmlFilePath)' != ''">   
+          Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' and '$(IntellisensePackageXmlFilePath)' != ''">
     <ItemGroup>
       <DocFileItem Remove="@(DocFileItem)" />
       <DocFileItem Include="$(IntermediateDocFileItemFromIntellisensePackage)" />

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -24,6 +24,7 @@
       <UseCompilerGeneratedDocXmlFile>$(UseCompilerGeneratedDocXmlFile)</UseCompilerGeneratedDocXmlFile>
       <IsPartialFacadeAssembly>$(IsPartialFacadeAssembly)</IsPartialFacadeAssembly>
       <IsPlatformNotSupportedAssembly Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">true</IsPlatformNotSupportedAssembly>
+      <SuppressPlatformNotSupportedAssemblyDocXmlError>$(SuppressPlatformNotSupportedAssemblyDocXmlError)</SuppressPlatformNotSupportedAssemblyDocXmlError>
     </TargetPathWithTargetPlatformMoniker>
   </ItemDefinitionGroup>
 

--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.cs
@@ -13,7 +13,9 @@ using System.Runtime.Versioning;
 namespace System.Security.Cryptography.X509Certificates
 {
     [UnsupportedOSPlatform("browser")]
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105974
     public static partial class X509CertificateLoader
+#pragma warning restore 1591
     {
         private const int MemoryMappedFileCutoff = 1_048_576;
 

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -645,6 +645,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105974
         public static IHttpClientBuilder AddAsKeyed(this IHttpClientBuilder builder, ServiceLifetime lifetime = ServiceLifetime.Scoped)
         {
             ThrowHelper.ThrowIfNull(builder);
@@ -703,6 +704,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return builder;
         }
+#pragma warning restore 1591
 
         // workaround for https://github.com/dotnet/runtime/issues/102654
         private static void UpdateEmptyNameHttpClient(IServiceCollection services, HttpClientMappingRegistry registry)

--- a/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
@@ -28,7 +28,6 @@
   <Target Name="IncludeProjectReferenceCompilerGeneratedSecondaryOutputInPackage"
           DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
-
       <!-- Exclude private assemblies -->
       <ProjectReferenceCopyLocalPathNonPrivate Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('IsPrivateAssembly', 'false'))" />
 
@@ -41,13 +40,16 @@
 
     <ItemGroup>
       <PartialFacadeCompilerGeneratedXmlDocFile Include="@(CompilerGeneratedXmlDocFile->WithMetadataValue('IsPartialFacadeAssembly', 'true'))" />
+
       <PlatformNotSupportedCompilerGeneratedXmlDocFile Include="@(CompilerGeneratedXmlDocFile->WithMetadataValue('IsPlatformNotSupportedAssembly', 'true'))" />
+      <!-- Allow libraries to temporarily suppress the PNSE error. -->
+      <PlatformNotSupportedCompilerGeneratedXmlDocFile Remove="@(PlatformNotSupportedCompilerGeneratedXmlDocFile->WithMetadataValue('SuppressPlatformNotSupportedAssemblyDocXmlError', 'true'))" />
     </ItemGroup>
 
-    <Error Text="Compiler generated XML documentation files are missing data because partial facade assemblies aren't yet supported by the repo infrastructure. Consider removing the partial facade feature or setting the 'GenerateDocumentationFile' property to false in the project file. Assemblies: @(PartialFacadeCompilerGeneratedXmlDocFile->Metadata('Filename'), ', ')."
+    <Error Text="Compiler generated XML documentation files are missing data because partial facade assemblies aren't supported by the repo infrastructure. Consider removing the partial facade feature. Assemblies: @(PartialFacadeCompilerGeneratedXmlDocFile->Metadata('Filename'), ', ')."
            Condition="'@(PartialFacadeCompilerGeneratedXmlDocFile)' != ''" />
 
-    <Error Text="Compiler generated XML documentation files are missing data because PNSE (platform not supported exception) assemblies aren't yet supported by the repo infrastructure. Consider removing the PNSE feature or setting the 'GenerateDocumentationFile' property to false in the project file. Assemblies: @(PlatformNotSupportedCompilerGeneratedXmlDocFile->Metadata('Filename'), ', ')."
+    <Error Text="Compiler generated XML documentation files are missing data because PNSE (platform not supported exception) assemblies aren't supported by the repo infrastructure. Consider removing the PNSE feature. Assemblies: @(PlatformNotSupportedCompilerGeneratedXmlDocFile->Metadata('Filename'), ', ')."
            Condition="'@(PlatformNotSupportedCompilerGeneratedXmlDocFile)' != ''" />
   </Target>
 

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-freebsd;$(NetCoreAppCurrent)-maccatalyst;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-solaris;$(NetCoreAppCurrent)-haiku;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);HTTP_DLL</DefineConstants>
+    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/libraries/System.Numerics.Tensors/src/System/NIndex.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/NIndex.cs
@@ -91,8 +91,10 @@ namespace System.Buffers
             return new NIndex(~value);
         }
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public Index ToIndex() => checked((Index)this);
         public Index ToIndexUnchecked() => (Index)this;
+#pragma warning restore 1591
 
         /// <summary>Returns the NIndex value.</summary>
         public nint Value

--- a/src/libraries/System.Numerics.Tensors/src/System/NRange.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/NRange.cs
@@ -121,6 +121,7 @@ namespace System.Buffers
 
         private static void ThrowArgumentOutOfRangeException() => throw new ArgumentOutOfRangeException("length");
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public static implicit operator NRange(Range range) => new NRange(range.Start, range.End);
 
         public static explicit operator Range(NRange value) => new Range((Index)value.Start, (Index)value.End);
@@ -128,5 +129,6 @@ namespace System.Buffers
 
         public Range ToRange() => new Range(checked((Index)Start), checked((Index)End));
         public Range ToRangeUnchecked() => new Range((Index)Start, (Index)End);
+#pragma warning restore 1591
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/IReadOnlyTensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/IReadOnlyTensor.cs
@@ -5,6 +5,8 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
+
 namespace System.Numerics.Tensors
 {
     [Experimental(Experimentals.TensorTDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
@@ -44,3 +46,5 @@ namespace System.Numerics.Tensors
         bool TryFlattenTo(scoped Span<T> destination);
     }
 }
+
+#pragma warning restore 1591

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ITensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ITensor.cs
@@ -4,6 +4,8 @@
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
+
 namespace System.Numerics.Tensors
 {
     [Experimental(Experimentals.TensorTDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
@@ -37,3 +39,5 @@ namespace System.Numerics.Tensors
         new ref T GetPinnableReference();
     }
 }
+
+#pragma warning restore 1591

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -600,7 +600,9 @@ namespace System.Numerics.Tensors
         }
 
         //public static explicit operator TensorSpan<T>(Array? array);
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public static implicit operator ReadOnlyTensorSpan<T>(T[]? array) => new ReadOnlyTensorSpan<T>(array);
+#pragma warning restore 1591
 
         /// <summary>
         /// Returns a <see cref="string"/> with the name of the type and the number of elements.

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
@@ -175,6 +175,7 @@ namespace System.Numerics.Tensors
             return new Tensor<T>(values, lengths, strides, pinned);
         }
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public static ref readonly TensorSpan<T> FillGaussianNormalDistribution<T>(in TensorSpan<T> destination, Random? random = null) where T : IFloatingPoint<T>
         {
             Span<T> span = MemoryMarshal.CreateSpan<T>(ref destination._reference, (int)destination._shape._memoryLength);
@@ -193,5 +194,6 @@ namespace System.Numerics.Tensors
 
             return ref destination;
         }
+#pragma warning restore 1591
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -19,8 +19,10 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 namespace System.Numerics.Tensors
 {
     [Experimental(Experimentals.TensorTDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
     public sealed class Tensor<T>
         : ITensor<Tensor<T>, T>
+#pragma warning restore 1591
     {
         /// <summary>A byref or a native ptr.</summary>
         internal readonly T[] _values;
@@ -365,11 +367,13 @@ namespace System.Numerics.Tensors
             }
         }
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public static implicit operator Tensor<T>(T[] array) => new Tensor<T>(array, [array.Length]);
 
         public static implicit operator TensorSpan<T>(Tensor<T> value) => new TensorSpan<T>(ref MemoryMarshal.GetArrayDataReference(value._values), value._lengths, value._strides, value._flattenedLength);
 
         public static implicit operator ReadOnlyTensorSpan<T>(Tensor<T> value) => new ReadOnlyTensorSpan<T>(ref MemoryMarshal.GetArrayDataReference(value._values), value._lengths, value._strides, value.FlattenedLength);
+#pragma warning restore 1591
 
         /// <summary>
         /// Converts this <see cref="Tensor{T}"/> to a <see cref="TensorSpan{T}"/> pointing to the same backing memory."/>
@@ -614,10 +618,12 @@ namespace System.Numerics.Tensors
         }
 
         // REVIEW: PENDING API REVIEW TO DETERMINE IMPLEMENTATION
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public override int GetHashCode()
         {
             throw new NotImplementedException();
         }
+#pragma warning restore 1591
 
         /// <summary>
         /// Get a string representation of the tensor.

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -19,7 +19,9 @@ using System.Diagnostics.CodeAnalysis;
 namespace System.Numerics.Tensors
 {
     [Experimental(Experimentals.TensorTDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
     public static partial class Tensor
+#pragma warning restore 1591
     {
         #region AsReadOnlySpan
         /// <summary>
@@ -6587,6 +6589,7 @@ namespace System.Numerics.Tensors
         }
         #endregion
 
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public static nint[] GetSmallestBroadcastableLengths(ReadOnlySpan<nint> shape1, ReadOnlySpan<nint> shape2)
         {
             if (!TensorHelpers.IsBroadcastableTo(shape1, shape2))
@@ -6604,6 +6607,7 @@ namespace System.Numerics.Tensors
 
             return intermediateShape;
         }
+#pragma warning restore 1591
 
         #region TensorPrimitivesHelpers
         private delegate void PerformCalculationSpanInSpanOut<T>(ReadOnlySpan<T> input, Span<T> output);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
@@ -629,7 +629,9 @@ namespace System.Numerics.Tensors
         }
 
         //public static explicit operator TensorSpan<T>(Array? array);
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105981
         public static implicit operator TensorSpan<T>(T[]? array) => new TensorSpan<T>(array);
+#pragma warning restore 1591
 
         /// <summary>
         /// Defines an implicit conversion of a <see cref="TensorSpan{T}"/> to a <see cref="ReadOnlyTensorSpan{T}"/>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
@@ -15,8 +15,9 @@ using static System.Buffers.Text.Base64Helper;
 namespace System.Buffers.Text
 {
     // AVX2 and Vector128 version based on https://github.com/gfoidl/Base64/blob/5383320e28cac6c7ac6f86502fb05d23a048a21d/source/gfoidl.Base64/Internal/Encodings/Base64UrlEncoding.cs
-
+#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105974
     public static partial class Base64Url
+#pragma warning restore 1591
     {
         private const int MaxStackallocThreshold = 256;
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/libraries/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -6,7 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Too much private reflection. Do not bother with trimming -->
     <ILLinkTrimAssembly>false</ILLinkTrimAssembly>
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
+++ b/src/libraries/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <RootNamespace>System.Xml</RootNamespace>
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>System.Xml</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -7,8 +7,9 @@
     <!-- CS0649: uninitialized interop type fields -->
     <!-- SA1129: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3277 -->
     <NoWarn>$(NoWarn);CS0649;SA1129;IDE0059;IDE0060;CA1822;CA1852</NoWarn>
+    <!-- TODO: Document public visible types and members. https://github.com/dotnet/runtime/issues/87711 -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IsTrimmable>false</IsTrimmable>
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>

--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -7,8 +7,13 @@
     <!-- CS0649: uninitialized interop type fields -->
     <!-- SA1129: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3277 -->
     <NoWarn>$(NoWarn);CS0649;SA1129;IDE0059;IDE0060;CA1822;CA1852</NoWarn>
-    <!-- TODO: Document public visible types and members. https://github.com/dotnet/runtime/issues/87711 -->
+
+    <!-- TODO: Document public visible types and members. https://github.com/dotnet/runtime/issues/87711
+         Set SuppressPlatformNotSupportedAssemblyDocXmlError as this library uses the PNSE infrastructure
+         which is incompatible. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <SuppressPlatformNotSupportedAssemblyDocXmlError>true</SuppressPlatformNotSupportedAssemblyDocXmlError>
+
     <IsTrimmable>false</IsTrimmable>
     <IsPackable>true</IsPackable>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>


### PR DESCRIPTION
Fixes what was reported in https://github.com/dotnet/runtime/issues/105974#issuecomment-2274090272 by @michaelgsharp (thanks!)

Regressed with https://github.com/dotnet/runtime/pull/94234

For now suppress the undocumented public APIs that got added since the property got switched to the wrong default. These public APIs are tracked via https://github.com/dotnet/runtime/issues/105974.

@carlossanlop @ericstj please take a look and merge