### PR TITLE
JIT: Teach middle-end liveness to DCE dead calls without sideeffects

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5594,7 +5594,7 @@ public:
 
     void fgLiveVarAnalysis();
 
-    GenTreeLclVarCommon* fgComputeLifeCall(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, GenTreeCall* call);
+    bool fgComputeLifeCall(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, GenTreeCall* call, GenTreeLclVarCommon** pDefinedLcl);
 
     void fgComputeLifeTrackedLocalUse(VARSET_TP& life, LclVarDsc& varDsc, GenTreeLclVarCommon* node);
     bool fgComputeLifeTrackedLocalDef(VARSET_TP&           life,
@@ -5622,12 +5622,9 @@ public:
 
     bool fgTryRemoveDeadStoreLIR(GenTree* store, GenTreeLclVarCommon* lclNode, BasicBlock* block);
 
-    bool fgRemoveDeadStore(GenTree**        pTree,
-                           LclVarDsc*       varDsc,
-                           VARSET_VALARG_TP life,
+    bool fgRemoveDeadNode(GenTree**        pTree,
                            bool*            doAgain,
-                           bool*            pStmtInfoDirty,
-                           bool* pStoreRemoved DEBUGARG(bool* treeModf));
+                           bool*            pStmtInfoDirty DEBUGARG(bool* treeModf));
 
     void fgInterBlockLocalVarLiveness();
 

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -776,7 +776,10 @@ void Compiler::fgLiveVarAnalysis()
 // Returns:
 //    True if the call's result is unused and the call can be removed
 //
-bool Compiler::fgComputeLifeCall(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, GenTreeCall* call, GenTreeLclVarCommon** pDefinedLcl)
+bool Compiler::fgComputeLifeCall(VARSET_TP&            life,
+                                 VARSET_VALARG_TP      keepAliveVars,
+                                 GenTreeCall*          call,
+                                 GenTreeLclVarCommon** pDefinedLcl)
 {
     assert(call != nullptr);
 
@@ -1222,14 +1225,14 @@ void Compiler::fgComputeLife(VARSET_TP&           life,
     AGAIN:
         assert(tree->OperGet() != GT_QMARK);
 
-        bool       isUse        = false;
-        bool       doAgain      = false;
-        LclVarDsc* varDsc       = nullptr;
+        bool       isUse   = false;
+        bool       doAgain = false;
+        LclVarDsc* varDsc  = nullptr;
 
         if (tree->IsCall())
         {
             GenTreeLclVarCommon* definedLcl;
-            bool isDeadCall = fgComputeLifeCall(life, keepAliveVars, tree->AsCall(), &definedLcl);
+            bool                 isDeadCall = fgComputeLifeCall(life, keepAliveVars, tree->AsCall(), &definedLcl);
             if (isDeadCall)
             {
                 if (fgRemoveDeadNode(&tree, &doAgain, pStmtInfoDirty DEBUGARG(treeModf)))
@@ -1321,8 +1324,8 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
         {
             case GT_CALL:
             {
-                GenTreeCall* const call = node->AsCall();
-                bool isDeadCall = fgComputeLifeCall(life, keepAliveVars, call, nullptr);
+                GenTreeCall* const call       = node->AsCall();
+                bool               isDeadCall = fgComputeLifeCall(life, keepAliveVars, call, nullptr);
                 if (isDeadCall)
                 {
                     JITDUMP("Removing dead call:\n");
@@ -1722,9 +1725,7 @@ bool Compiler::fgTryRemoveDeadStoreLIR(GenTree* store, GenTreeLclVarCommon* lclN
 // Return Value:
 //   true if we should skip the rest of the statement, false if we should continue
 //
-bool Compiler::fgRemoveDeadNode(GenTree**           pTree,
-                                 bool*               doAgain,
-                                 bool*               pStmtInfoDirty DEBUGARG(bool* treeModf))
+bool Compiler::fgRemoveDeadNode(GenTree** pTree, bool* doAgain, bool* pStmtInfoDirty DEBUGARG(bool* treeModf))
 {
     assert(!compRationalIRForm);
 
@@ -1755,7 +1756,7 @@ bool Compiler::fgRemoveDeadNode(GenTree**           pTree,
 
             DISPSTMT(compCurStmt);
 
-           // Update ordering, costs, FP levels, etc.
+            // Update ordering, costs, FP levels, etc.
             gtSetStmtInfo(compCurStmt);
 
             // Re-link the nodes for this statement
@@ -1808,7 +1809,7 @@ bool Compiler::fgRemoveDeadNode(GenTree**           pTree,
         }
         else
         {
-           // No side effects - Change the store to a GT_NOP node
+            // No side effects - Change the store to a GT_NOP node
             tree->gtBashToNOP();
 
             INDEBUG(*treeModf = true);


### PR DESCRIPTION
Currently only the backend liveness pass will DCE calls without side effects when their result is unused. However, unused runtime lookups can end up expanded to control flow that we will be unable to DCE. This teaches the middle-end liveness pass to DCE dead calls as well.

Fix #106129