### PR TITLE
Fix resourcemanagement.yml for os-ios, os-android etc

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -321,20 +321,6 @@ configuration:
             label: area-Tools-ILLink
         - labelAdded:
             label: area-vm-coreclr
-        - labelAdded:
-            label: linkable-framework
-        - labelAdded:
-            label: size-reduction
-        - labelAdded:
-            label: arch-wasm
-        - labelAdded:
-            label: os-ios
-        - labelAdded:
-            label: os-tvos
-        - labelAdded:
-            label: os-maccatalyst
-        - labelAdded:
-            label: os-android
       then:
       - if:
         - hasLabel:
@@ -1609,112 +1595,6 @@ configuration:
 
               See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
             assignMentionees: False
-      - if:
-        - hasLabel:
-            label: linkable-framework
-        then:
-        - mentionUsers:
-            mentionees:
-            - eerhardt
-            - vitek-karas
-            - LakshanF
-            - sbomer
-            - joperezr
-            - marek-safar
-            replyTemplate: >-
-              Tagging subscribers to 'linkable-framework': ${mentionees}
-
-              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
-            assignMentionees: False
-      - if:
-        - hasLabel:
-            label: size-reduction
-        then:
-        - mentionUsers:
-            mentionees:
-            - eerhardt
-            - SamMonoRT
-            - marek-safar
-            replyTemplate: >-
-              Tagging subscribers to 'size-reduction': ${mentionees}
-
-              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
-            assignMentionees: False
-      - if:
-        - hasLabel:
-            label: arch-wasm
-        then:
-        - mentionUsers:
-            mentionees:
-            - lewing
-            replyTemplate: >-
-              Tagging subscribers to 'arch-wasm': ${mentionees}
-
-              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
-            assignMentionees: False
-      - if:
-        - hasLabel:
-            label: os-ios
-        then:
-        - mentionUsers:
-            mentionees:
-            - vitek-karas
-            - kotlarmilos
-            - ivanpovazan
-            - steveisok
-            - akoeplinger
-            replyTemplate: >-
-              Tagging subscribers to 'os-ios': ${mentionees}
-
-              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
-            assignMentionees: False
-      - if:
-        - hasLabel:
-            label: os-android
-        then:
-        - mentionUsers:
-            mentionees:
-            - vitek-karas
-            - simonrozsival
-            - steveisok
-            - akoeplinger
-            replyTemplate: >-
-              Tagging subscribers to 'arch-android': ${mentionees}
-
-              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
-            assignMentionees: False
-      - if:
-        - hasLabel:
-            label: os-tvos
-        then:
-        - mentionUsers:
-            mentionees:
-            - vitek-karas
-            - kotlarmilos
-            - ivanpovazan
-            - steveisok
-            - akoeplinger
-            replyTemplate: >-
-              Tagging subscribers to 'os-tvos': ${mentionees}
-
-              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
-            assignMentionees: False
-      - if:
-        - hasLabel:
-            label: os-maccatalyst
-        then:
-        - mentionUsers:
-            mentionees:
-            - vitek-karas
-            - kotlarmilos
-            - ivanpovazan
-            - steveisok
-            - akoeplinger
-            replyTemplate: >-
-              Tagging subscribers to 'os-maccatalyst': ${mentionees}
-
-              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
-            assignMentionees: False
       description: Area-owners
     - if:
       - payloadType: Issues
@@ -1790,6 +1670,140 @@ configuration:
       - addLabel:
           label: linkable-framework
       description: '[Linkable-framework workgroup] Add linkable-framework label to Prs that get changes pushed where they touch *ILLInk* files'
+    - if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: linkable-framework
+      then:
+      - mentionUsers:
+          mentionees:
+          - eerhardt
+          - vitek-karas
+          - LakshanF
+          - sbomer
+          - joperezr
+          - marek-safar
+          replyTemplate: >-
+            Tagging subscribers to 'linkable-framework': ${mentionees}
+
+            See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+          assignMentionees: False
+      description: '@Mention for linkable-framework'
+    - if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: size-reduction
+      then:
+        - mentionUsers:
+            mentionees:
+            - eerhardt
+            - SamMonoRT
+            - marek-safar
+            replyTemplate: >-
+              Tagging subscribers to 'size-reduction': ${mentionees}
+
+              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+            assignMentionees: False
+      description: '@Mention for size-reduction'
+    - if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: arch-wasm
+      then:
+      - mentionUsers:
+          mentionees:
+          - lewing
+          replyTemplate: >-
+            Tagging subscribers to 'arch-wasm': ${mentionees}
+
+            See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+          assignMentionees: False
+      description: '@Mention for arch-wasm'
+    - if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: os-ios
+      then:
+      - mentionUsers:
+          mentionees:
+          - vitek-karas
+          - kotlarmilos
+          - ivanpovazan
+          - steveisok
+          - akoeplinger
+          replyTemplate: >-
+            Tagging subscribers to 'os-ios': ${mentionees}
+
+            See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+          assignMentionees: False
+      description: '@Mention for os-ios'
+    - if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: os-android
+      then:
+      - mentionUsers:
+          mentionees:
+          - vitek-karas
+          - simonrozsival
+          - steveisok
+          - akoeplinger
+          replyTemplate: >-
+            Tagging subscribers to 'arch-android': ${mentionees}
+
+            See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+          assignMentionees: False
+      description: '@Mention for os-android'
+    - if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: os-tvos
+      then:
+      - mentionUsers:
+          mentionees:
+          - vitek-karas
+          - kotlarmilos
+          - ivanpovazan
+          - steveisok
+          - akoeplinger
+          replyTemplate: >-
+            Tagging subscribers to 'os-tvos': ${mentionees}
+
+            See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+          assignMentionees: False
+      description: '@Mention for os-tvos'
+    - if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - labelAdded:
+          label: os-maccatalyst
+      then:
+      - mentionUsers:
+          mentionees:
+          - vitek-karas
+          - kotlarmilos
+          - ivanpovazan
+          - steveisok
+          - akoeplinger
+          replyTemplate: >-
+            Tagging subscribers to 'os-maccatalyst': ${mentionees}
+
+            See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+          assignMentionees: False
+      description: '@Mention for os-maccatalyst'
     - if:
       - payloadType: Issues
       - labelAdded:


### PR DESCRIPTION
They need to be a separate section otherwise it triggers `area-*` subscriptions too when an `os-*` is added.