### PR TITLE
[browser][AOT] disable jiterp for jitcall trampolines

### DIFF
--- a/src/mono/browser/build/BrowserWasmApp.targets
+++ b/src/mono/browser/build/BrowserWasmApp.targets
@@ -296,6 +296,7 @@
       <_EmccCommonFlags Include="-v"                                       Condition="'$(EmccVerbose)' != 'false'" />
       <_EmccCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"          Condition="'$(WasmEnableExceptionHandling)' == 'false'" />
       <_EmccCommonFlags Include="-fwasm-exceptions"                        Condition="'$(WasmEnableExceptionHandling)' == 'true'" />
+      <_EmccCommonFlags Include="-fsanitize=address"                       Condition="'$(WasmEnableAsan)' == 'true'" />
       <_EmccCommonFlags Include="-s MAXIMUM_MEMORY=$(EmccMaximumHeapSize)" Condition="'$(EmccMaximumHeapSize)' != ''" />
 
       <_EmccIncludePaths Include="$(_WasmIntermediateOutputPath.TrimEnd('\/'))" />

--- a/src/mono/browser/test-main.js
+++ b/src/mono/browser/test-main.js
@@ -371,6 +371,9 @@ async function run() {
                 console.log(`test-main.js exiting ${app_args.length > 1 ? main_assembly_name + " " + app_args[0] : main_assembly_name} with result ${result} and linear memory ${App.runtime.Module.HEAPU8.length} bytes`);
                 mono_exit(result);
             } catch (error) {
+                if (App.runtime && App.runtime.Module && App.runtime.Module.HEAPU8) {
+                    console.log(`test-main.js exception while linear memory ${App.runtime.Module.HEAPU8.length} bytes`);
+                }
                 if (error.name != "ExitStatus") {
                     mono_exit(1, error);
                 }

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -78,16 +78,11 @@ bundled_resources_is_known_assembly_extension (const char *ext)
 static char *
 key_from_id (const char *id, char *buffer, guint buffer_len)
 {
-	size_t id_length = 0;
-	size_t extension_offset = -1;
-	const char *extension = NULL;
-
-	if (id){
-		id_length = strlen (id);
-		extension = g_memrchr (id, '.', id_length);
-		if (extension)
-			extension_offset = extension - id;
-	}
+	size_t id_length = strlen (id),
+		extension_offset = -1;
+	const char *extension = g_memrchr (id, '.', id_length);
+	if (extension)
+		extension_offset = extension - id;
 	if (!buffer) {
 		// Add space for .dll and null terminator
 		buffer_len = (guint)(id_length + 6);
@@ -95,7 +90,7 @@ key_from_id (const char *id, char *buffer, guint buffer_len)
 	}
 	buffer[0] = 0;
 
-	if (extension_offset != -1 && bundled_resources_is_known_assembly_extension (extension)) {
+	if (extension_offset && bundled_resources_is_known_assembly_extension (extension)) {
 		// Subtract from buffer_len to make sure we have space for .dll
 		g_strlcpy (buffer, id, MIN(buffer_len - 4, extension_offset + 2));
 		strcat (buffer, "dll");

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -78,11 +78,16 @@ bundled_resources_is_known_assembly_extension (const char *ext)
 static char *
 key_from_id (const char *id, char *buffer, guint buffer_len)
 {
-	size_t id_length = strlen (id),
-		extension_offset = -1;
-	const char *extension = g_memrchr (id, '.', id_length);
-	if (extension)
-		extension_offset = extension - id;
+	size_t id_length = 0;
+	size_t extension_offset = -1;
+	const char *extension = NULL;
+
+	if (id){
+		id_length = strlen (id);
+		extension = g_memrchr (id, '.', id_length);
+		if (extension)
+			extension_offset = extension - id;
+	}
 	if (!buffer) {
 		// Add space for .dll and null terminator
 		buffer_len = (guint)(id_length + 6);
@@ -90,7 +95,7 @@ key_from_id (const char *id, char *buffer, guint buffer_len)
 	}
 	buffer[0] = 0;
 
-	if (extension_offset && bundled_resources_is_known_assembly_extension (extension)) {
+	if (extension_offset != -1 && bundled_resources_is_known_assembly_extension (extension)) {
 		// Subtract from buffer_len to make sure we have space for .dll
 		g_strlcpy (buffer, id, MIN(buffer_len - 4, extension_offset + 2));
 		strcat (buffer, "dll");

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -84,7 +84,9 @@ DEFINE_BOOL(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", TRUE, "JIT
 // interp_entry_enabled controls whether specialized interp_entry wrappers will be jitted
 DEFINE_BOOL(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry-enabled", TRUE, "JIT specialized WASM interp_entry wrappers")
 // jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
-DEFINE_BOOL(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", TRUE, "JIT specialized WASM do_jit_call trampolines")
+
+//disable because of ActiveIssue https://github.com/dotnet/runtime/issues/106200
+DEFINE_BOOL(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", FALSE, "JIT specialized WASM do_jit_call trampolines")
 
 DEFINE_BOOL(wasm_gc_safepoints, "wasm-gc-safepoints", FALSE, "Use GC safepoints on WASM")
 #else

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -620,7 +620,7 @@
     </PropertyGroup>
 
     <Error Condition="'$(RunAOTCompilation)' == 'true' and '$(PublishTrimmed)' != 'true'"
-           Text="AOT is not supported without IL trimming (PublishTrimmed=true required)." />
+           Text="AOT is not supported without IL trimming (EnableAggressiveTrimming=true or PublishTrimmed=true required)." />
     <Error Condition="'$(RunAOTCompilation)' == 'true' and '$(Configuration)' == 'Debug'"
            Text="AOT is not supported in debug configuration (Configuration=Release required)." />
     <Error Condition="'@(_WasmAssembliesInternal)' == ''" Text="Item _WasmAssembliesInternal is empty" />


### PR DESCRIPTION
- disable jiterp for jitcall trampolines with ActiveIssue https://github.com/dotnet/runtime/issues/106200
- memory size reporting from `test-main.js` also on exception
- `WasmEnableAsan` feature, needs to be used with `WasmCachePath`