### PR TITLE
Add new API docs for System.Runtime.InteropServices

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
@@ -188,6 +188,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <summary>
             /// Returns the managed value representing the native array.
             /// </summary>
+            /// <returns>A span over managed values of the array.</returns>
             public ReadOnlySpan<T> ToManaged()
             {
                 return new ReadOnlySpan<T>(_managedValues!);
@@ -196,6 +197,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <summary>
             /// Returns a span that points to the memory where the unmanaged elements of the array are stored.
             /// </summary>
+            /// <param name="numElements">The number of elements in the array.</param>
             /// <returns>A span over unmanaged values of the array.</returns>
             public ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements)
             {
@@ -205,6 +207,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <summary>
             /// Returns a span that points to the memory where the managed elements of the array should be stored.
             /// </summary>
+            /// <param name="numElements">The number of elements in the array.</param>
             /// <returns>A span where managed values of the array should be stored.</returns>
             public Span<T> GetManagedValuesDestination(int numElements)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
@@ -42,6 +42,7 @@ namespace System.Runtime.InteropServices.Swift
     /// Represents the Swift 'self' context when the argument is Swift frozen struct T, which is either enregistered into multiple registers,
     /// or passed by reference in the 'self' register.
     /// </summary>
+    /// <typeparam name="T">The type of the frozen struct to pass in the 'self' context.</typeparam>
     /// <remarks>
     /// <para>
     /// This struct is used to pass the Swift frozen struct T to Swift functions in the context of interop with .NET.

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/ComVariantMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/ComVariantMarshaller.cs
@@ -22,6 +22,13 @@ namespace System.Runtime.InteropServices.Marshalling
         // VARIANT_BOOL constants.
         private const short VARIANT_TRUE = -1;
         private const short VARIANT_FALSE = 0;
+
+        /// <summary>
+        /// Convert a managed object to an unmanaged <see cref="ComVariant"/>.
+        /// </summary>
+        /// <param name="managed">The managed object</param>
+        /// <returns>A <see cref="ComVariant" /> that represents the provided managed object.</returns>
+        /// <exception cref="ArgumentException">The type of <paramref name="managed"/> is not supported.</exception>
         public static ComVariant ConvertToUnmanaged(object? managed)
         {
             if (managed is null)
@@ -103,6 +110,12 @@ namespace System.Runtime.InteropServices.Marshalling
         }
 #pragma warning restore CA1416 // Validate platform compatibility
 
+        /// <summary>
+        /// Convert an unmanaged <see cref="ComVariant"/> to a managed object.
+        /// </summary>
+        /// <param name="unmanaged">The unmanaged variant</param>
+        /// <returns>A managed object that represents the same value as <paramref name="unmanaged"/>.</returns>
+        /// <exception cref="ArgumentException">The type of data stored in <paramref name="unmanaged"/> is not supported.</exception>
         public static unsafe object? ConvertToManaged(ComVariant unmanaged)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -195,6 +208,10 @@ namespace System.Runtime.InteropServices.Marshalling
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        /// <summary>
+        /// Dispose the unmanaged <see cref="ComVariant"/>.
+        /// </summary>
+        /// <param name="unmanaged">The object to dispose.</param>
         public static void Free(ComVariant unmanaged) => unmanaged.Dispose();
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/ComVariantMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/ComVariantMarshaller.cs
@@ -24,9 +24,9 @@ namespace System.Runtime.InteropServices.Marshalling
         private const short VARIANT_FALSE = 0;
 
         /// <summary>
-        /// Convert a managed object to an unmanaged <see cref="ComVariant"/>.
+        /// Converts a managed object to an unmanaged <see cref="ComVariant"/>.
         /// </summary>
-        /// <param name="managed">The managed object</param>
+        /// <param name="managed">The managed object.</param>
         /// <returns>A <see cref="ComVariant" /> that represents the provided managed object.</returns>
         /// <exception cref="ArgumentException">The type of <paramref name="managed"/> is not supported.</exception>
         public static ComVariant ConvertToUnmanaged(object? managed)
@@ -111,9 +111,9 @@ namespace System.Runtime.InteropServices.Marshalling
 #pragma warning restore CA1416 // Validate platform compatibility
 
         /// <summary>
-        /// Convert an unmanaged <see cref="ComVariant"/> to a managed object.
+        /// Converts an unmanaged <see cref="ComVariant"/> to a managed object.
         /// </summary>
-        /// <param name="unmanaged">The unmanaged variant</param>
+        /// <param name="unmanaged">The unmanaged variant.</param>
         /// <returns>A managed object that represents the same value as <paramref name="unmanaged"/>.</returns>
         /// <exception cref="ArgumentException">The type of data stored in <paramref name="unmanaged"/> is not supported.</exception>
         public static unsafe object? ConvertToManaged(ComVariant unmanaged)
@@ -209,7 +209,7 @@ namespace System.Runtime.InteropServices.Marshalling
         }
 
         /// <summary>
-        /// Dispose the unmanaged <see cref="ComVariant"/>.
+        /// Disposes the unmanaged <see cref="ComVariant"/>.
         /// </summary>
         /// <param name="unmanaged">The object to dispose.</param>
         public static void Free(ComVariant unmanaged) => unmanaged.Dispose();


### PR DESCRIPTION
Adds the rest of the missing API docs we can put in code from #105986

@carlossanlop the CollectionsMarshal APIs do have docs in source. Do we need to manually port them to dotnet-api-docs?