### PR TITLE
Clean up ILLink logic for "inflating" generic types

### DIFF
--- a/src/tools/illink/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/MethodReferenceExtensions.cs
@@ -71,10 +71,10 @@ namespace Mono.Linker
 			return sb.ToString ();
 		}
 
-		public static TypeReference? GetReturnType (this MethodReference method, LinkContext context)
+		public static TypeReference? GetReturnType (this MethodReference method)
 		{
 			if (method.DeclaringType is GenericInstanceType genericInstance)
-				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.ReturnType, context);
+				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.ReturnType);
 
 			return method.ReturnType;
 		}
@@ -84,11 +84,11 @@ namespace Mono.Linker
 			return method.ReturnType.WithoutModifiers ().MetadataType == MetadataType.Void;
 		}
 
-		public static TypeReference? GetInflatedParameterType (this MethodReference method, int parameterIndex, LinkContext context)
+		public static TypeReference? GetInflatedParameterType (this MethodReference method, int parameterIndex)
 		{
 #pragma warning disable RS0030 // MethodReference.Parameters is banned -- it's best to leave this as is for now
 			if (method.DeclaringType is GenericInstanceType genericInstance)
-				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.Parameters[parameterIndex].ParameterType, context);
+				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.Parameters[parameterIndex].ParameterType);
 
 			return method.Parameters[parameterIndex].ParameterType;
 #pragma warning restore RS0030 // Do not used banned APIs

--- a/src/tools/illink/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/MethodReferenceExtensions.cs
@@ -71,7 +71,7 @@ namespace Mono.Linker
 			return sb.ToString ();
 		}
 
-		public static TypeReference? GetReturnType (this MethodReference method)
+		public static TypeReference GetReturnType (this MethodReference method)
 		{
 			if (method.DeclaringType is GenericInstanceType genericInstance)
 				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.ReturnType);
@@ -84,7 +84,7 @@ namespace Mono.Linker
 			return method.ReturnType.WithoutModifiers ().MetadataType == MetadataType.Void;
 		}
 
-		public static TypeReference? GetInflatedParameterType (this MethodReference method, int parameterIndex)
+		public static TypeReference GetInflatedParameterType (this MethodReference method, int parameterIndex)
 		{
 #pragma warning disable RS0030 // MethodReference.Parameters is banned -- it's best to leave this as is for now
 			if (method.DeclaringType is GenericInstanceType genericInstance)

--- a/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
@@ -154,7 +154,7 @@ namespace Mono.Linker
 					return;
 				// Get all explicit interfaces of this type
 				foreach (var iface in type.Interfaces) {
-					var interfaceType = iface.InterfaceType.TryInflateFrom (typeRef, Context);
+					var interfaceType = iface.InterfaceType.TryInflateFrom (typeRef);
 					if (interfaceType is null) {
 						continue;
 					}
@@ -166,7 +166,7 @@ namespace Mono.Linker
 				// Recursive interfaces after all direct interfaces to preserve Inherit/Implement tree order
 				foreach (var iface in type.Interfaces) {
 					// If we can't resolve the interface type we can't find recursive interfaces
-					var ifaceDirectlyOnType = iface.InterfaceType.TryInflateFrom (typeRef, Context);
+					var ifaceDirectlyOnType = iface.InterfaceType.TryInflateFrom (typeRef);
 					if (ifaceDirectlyOnType is null) {
 						continue;
 					}
@@ -310,7 +310,7 @@ namespace Mono.Linker
 				var baseType = context.TryResolve (type)?.BaseType;
 
 				if (baseType is GenericInstanceType)
-					return TypeReferenceExtensions.InflateGenericType (genericInstance, baseType, context);
+					return TypeReferenceExtensions.InflateGenericType (genericInstance, baseType);
 
 				return baseType;
 			}
@@ -389,7 +389,7 @@ namespace Mono.Linker
 		}
 
 		[SuppressMessage ("ApiDesign", "RS0030:Do not used banned APIs", Justification = "It's best to leave working code alone.")]
-		bool MethodMatch (MethodReference candidate, MethodReference method)
+		static bool MethodMatch (MethodReference candidate, MethodReference method)
 		{
 			if (candidate.HasParameters != method.HasMetadataParameters ())
 				return false;
@@ -402,8 +402,8 @@ namespace Mono.Linker
 
 			// we need to track what the generic parameter represent - as we cannot allow it to
 			// differ between the return type or any parameter
-			if (candidate.GetReturnType (context) is not TypeReference candidateReturnType ||
-				method.GetReturnType (context) is not TypeReference methodReturnType ||
+			if (candidate.GetReturnType () is not TypeReference candidateReturnType ||
+				method.GetReturnType () is not TypeReference methodReturnType ||
 				!TypeMatch (candidateReturnType, methodReturnType))
 				return false;
 
@@ -419,8 +419,8 @@ namespace Mono.Linker
 				return false;
 
 			for (int i = 0; i < cp.Count; i++) {
-				if (candidate.GetInflatedParameterType (i, context) is not TypeReference candidateParameterType ||
-					method.GetInflatedParameterType (i, context) is not TypeReference methodParameterType ||
+				if (candidate.GetInflatedParameterType (i) is not TypeReference candidateParameterType ||
+					method.GetInflatedParameterType (i) is not TypeReference methodParameterType ||
 					!TypeMatch (candidateParameterType, methodParameterType))
 					return false;
 			}

--- a/src/tools/illink/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/TypeReferenceExtensions.cs
@@ -151,7 +151,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		public static TypeReference? TryInflateFrom (this TypeReference typeToInflate, TypeReference maybeGenericInstanceProvider)
+		public static TypeReference InflateFrom (this TypeReference typeToInflate, TypeReference maybeGenericInstanceProvider)
 		{
 			if (maybeGenericInstanceProvider is GenericInstanceType genericInstanceProvider)
 				return InflateGenericType (genericInstanceProvider, typeToInflate);
@@ -166,18 +166,15 @@ namespace Mono.Linker
 				yield break;
 
 			if (typeRef is GenericInstanceType genericInstance) {
-				foreach (var interfaceImpl in typeDef.Interfaces) {
-					// InflateGenericType only returns null when inflating generic parameters (and the generic instance type doesn't resolve).
-					// Here we are not inflating a generic parameter but an interface type reference.
-					yield return (InflateGenericType (genericInstance, interfaceImpl.InterfaceType), interfaceImpl)!;
-				}
+				foreach (var interfaceImpl in typeDef.Interfaces)
+					yield return (InflateGenericType (genericInstance, interfaceImpl.InterfaceType), interfaceImpl);
 			} else {
 				foreach (var interfaceImpl in typeDef.Interfaces)
 					yield return (interfaceImpl.InterfaceType, interfaceImpl);
 			}
 		}
 
-		public static TypeReference? InflateGenericType (GenericInstanceType genericInstanceProvider, TypeReference typeToInflate)
+		public static TypeReference InflateGenericType (GenericInstanceType genericInstanceProvider, TypeReference typeToInflate)
 		{
 			if (typeToInflate is ArrayType arrayType) {
 				var inflatedElementType = InflateGenericType (genericInstanceProvider, arrayType.ElementType);


### PR DESCRIPTION
- Avoid passing LinkContext through. This was only used to resolve the generic context type to get its parameter index, which was unnecessary.
- Use non-nullable return type and simplify some callsites.

This cleanup helps with https://github.com/dotnet/runtime/issues/105345 - it makes it so we don't have to pass through LinkContext when operating on our proxy types just to get the generic instantiation.