### PR TITLE
Simplify MethodDesc::GetLoaderModule

### DIFF
--- a/src/coreclr/vm/genmeth.cpp
+++ b/src/coreclr/vm/genmeth.cpp
@@ -63,6 +63,7 @@
 
 // Helper method that creates a method-desc off a template method desc
 static MethodDesc* CreateMethodDesc(LoaderAllocator *pAllocator,
+                                    Module* pLoaderModule,
                                     MethodTable *pMT,
                                     MethodDesc *pTemplateMD,
                                     DWORD classification,
@@ -91,7 +92,8 @@ static MethodDesc* CreateMethodDesc(LoaderAllocator *pAllocator,
                                      TRUE /* fNonVtableSlot*/,
                                      fNativeCodeSlot,
                                      pMT,
-                                     pamTracker);
+                                     pamTracker,
+                                     pLoaderModule);
 
     // Now initialize the MDesc at the single method descriptor in
     // the new chunk
@@ -415,6 +417,7 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
         // used in some of the subsequent setup methods for method descs.
         //
         pNewMD = (InstantiatedMethodDesc*) (CreateMethodDesc(pAllocator,
+                                                             pExactMDLoaderModule,
                                                              pExactMT,
                                                              pGenericMDescInRepMT,
                                                              mcInstantiated,
@@ -894,6 +897,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                     AllocMemTracker amt;
 
                     pResultMD = CreateMethodDesc(pAllocator,
+                                                 pLoaderModule,
                                                  pRepMT,
                                                  pMDescInCanonMT,
                                                  mcInstantiated,
@@ -975,6 +979,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                     _ASSERTE(pDefMD->GetClassification() == mcInstantiated);
 
                     pResultMD = CreateMethodDesc(pAllocator,
+                                                 pLoaderModule,
                                                  pExactMT,
                                                  pNonUnboxingStub,
                                                  mcInstantiated,

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1506,6 +1506,20 @@ DWORD MethodDesc::GetImplAttrs()
     return props;
 }
 
+PTR_Module MethodDescChunk::GetLoaderModule()
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    if (IsLoaderModuleAttachedToChunk())
+    {
+        TADDR ppLoaderModule = dac_cast<TADDR>(this) + SizeOf() - sizeof(PTR_Module);
+        return *dac_cast<DPTR(PTR_Module)>(ppLoaderModule);
+    }
+    else
+    {
+        return GetMethodTable()->GetLoaderModule();
+    }
+}
+
 //*******************************************************************************
 Module* MethodDesc::GetLoaderModule()
 {
@@ -1517,17 +1531,24 @@ Module* MethodDesc::GetLoaderModule()
     }
     CONTRACTL_END;
 
+    Module* pLoaderModule = GetMethodDescChunk()->GetLoaderModule();
+
+#ifdef _DEBUG
+    // Verify that the LoaderModule stored in the MethodDescChunk matches the result achieved by computation
     if (HasMethodInstantiation() && !IsGenericMethodDefinition())
     {
-        Module *retVal = ClassLoader::ComputeLoaderModule(GetMethodTable(),
+        Module *computeLoaderModuleAlgorithmResult = ClassLoader::ComputeLoaderModule(GetMethodTable(),
                                                 GetMemberDef(),
                                                 GetMethodInstantiation());
-        return retVal;
+        _ASSERTE(computeLoaderModuleAlgorithmResult == pLoaderModule);
     }
     else
     {
-        return GetMethodTable()->GetLoaderModule();
+        _ASSERTE(pLoaderModule == GetMethodTable()->GetLoaderModule());
     }
+#endif // _DEBUG
+
+    return pLoaderModule;
 }
 
 //*******************************************************************************
@@ -1845,7 +1866,7 @@ MethodDesc* MethodDesc::StripMethodInstantiation()
 
 //*******************************************************************************
 MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDescCount,
-    DWORD classification, BOOL fNonVtableSlot, BOOL fNativeCodeSlot, MethodTable *pInitialMT, AllocMemTracker *pamTracker)
+    DWORD classification, BOOL fNonVtableSlot, BOOL fNativeCodeSlot, MethodTable *pInitialMT, AllocMemTracker *pamTracker, Module *pLoaderModule)
 {
     CONTRACT(MethodDescChunk *)
     {
@@ -1878,18 +1899,28 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
 
     MethodDescChunk * pFirstChunk = NULL;
 
+    bool needsExplicitLoaderModule = false;
+    if (pLoaderModule != NULL && pLoaderModule != pInitialMT->GetLoaderModule())
+    {
+        needsExplicitLoaderModule = true;
+    }
+
     do
     {
         DWORD count = min(methodDescCount, maxMethodDescsPerChunk);
 
         void * pMem = pamTracker->Track(
-                pHeap->AllocMem(S_SIZE_T(sizeof(MethodDescChunk) + oneSize * count)));
+                pHeap->AllocMem(S_SIZE_T(sizeof(MethodDescChunk) + oneSize * count + (needsExplicitLoaderModule ? sizeof(Module *) : 0))));
 
         // Skip pointer to temporary entrypoints
         MethodDescChunk * pChunk = (MethodDescChunk *)((BYTE*)pMem);
 
         pChunk->SetSizeAndCount(oneSize * count, count);
         pChunk->SetMethodTable(pInitialMT);
+        if (needsExplicitLoaderModule)
+        {
+            pChunk->SetLoaderModuleAttachedToChunk(pLoaderModule);
+        }
 
         MethodDesc * pMD = pChunk->GetFirstMethodDesc();
         for (DWORD i = 0; i < count; i++)


### PR DESCRIPTION
Turn `MethodDesc::GetLoaderModule` and `MethodDesc::GetLoaderAllocator` into O(1) operations

- Today these are dependent on calling into `ClassLoader::ComputerLoaderModule`, which can be a very complex operation, and always requires walking all of the method's instantiation arguments.
- This change makes puts a pointer to the Loader Module onto the `MethodDescChunk` and removes the need for running the potentially complex `ComputeLoaderModule` algorithm.