### PR TITLE
[release/8.0-staging] Sys.RT.Caching.MemoryCache - Remove unhandled exception handler

### DIFF
--- a/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddXamarinPlaceholderFilesToPackage>true</AddXamarinPlaceholderFilesToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -39,7 +39,6 @@ namespace System.Runtime.Caching
         private bool _useMemoryCacheManager = true;
         private bool _throwOnDisposed;
         private EventHandler _onAppDomainUnload;
-        private UnhandledExceptionEventHandler _onUnhandledException;
 #if NETCOREAPP
         [UnsupportedOSPlatformGuard("browser")]
         private static bool _countersSupported => !OperatingSystem.IsBrowser();
@@ -219,9 +218,6 @@ namespace System.Runtime.Caching
                 EventHandler onAppDomainUnload = new EventHandler(OnAppDomainUnload);
                 appDomain.DomainUnload += onAppDomainUnload;
                 _onAppDomainUnload = onAppDomainUnload;
-                UnhandledExceptionEventHandler onUnhandledException = new UnhandledExceptionEventHandler(OnUnhandledException);
-                appDomain.UnhandledException += onUnhandledException;
-                _onUnhandledException = onUnhandledException;
                 dispose = false;
             }
             finally
@@ -236,16 +232,6 @@ namespace System.Runtime.Caching
         private void OnAppDomainUnload(object unusedObject, EventArgs unusedEventArgs)
         {
             Dispose();
-        }
-
-        private void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
-        {
-            // if the CLR is terminating, dispose the cache.
-            // This will dispose the perf counters
-            if (eventArgs.IsTerminating)
-            {
-                Dispose();
-            }
         }
 
         private static void ValidatePolicy(CacheItemPolicy policy)
@@ -499,10 +485,6 @@ namespace System.Runtime.Caching
             if (_onAppDomainUnload != null)
             {
                 appDomain.DomainUnload -= _onAppDomainUnload;
-            }
-            if (_onUnhandledException != null)
-            {
-                appDomain.UnhandledException -= _onUnhandledException;
             }
         }
 


### PR DESCRIPTION
- **Description** - Timer was updated in 5.0 to improve performance, but is prone to deadlocks when manipulated in an unhandled exception handler. Which MemoryCache does. And MemoryCache is probably more likely to witness unhandled exceptions like OOM than typical code.
- **Customer Impact** - The deadlock was affecting a first-party team (running services on Substrate) from migrating to .Net 6 and 8.
- **Regression?** - Yes, since .Net 5.0. And also a regression from NetFx.
- **Risk** Low.

Original Issue: #64115 (and #102666)
.Net 9.0 PR: #105853
(This was originally fixed in 9.0 with #103937, but after discussion with servicing shiproom, we have decided on a different approach. These servicing PR's are minimal and do not include the removal of the AppDomain.DomainUnload handler, per [this comment](https://github.com/dotnet/runtime/pull/105853#pullrequestreview-2214706430).)

System.Runtime.Caching is an OOB package that ships alongside the runtime.