### PR TITLE
Fix native libs selection in System.IO.Ports package

### DIFF
--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -18,22 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageSupportedRID Include="android-arm" />
-    <PackageSupportedRID Include="android-arm64" />
-    <PackageSupportedRID Include="android-x64" />
-    <PackageSupportedRID Include="android-x86" />
-    <PackageSupportedRID Include="linux-arm" />
-    <PackageSupportedRID Include="linux-arm64" />
-    <PackageSupportedRID Include="linux-bionic-arm64" />
-    <PackageSupportedRID Include="linux-bionic-x64" />
-    <PackageSupportedRID Include="linux-musl-arm" />
-    <PackageSupportedRID Include="linux-musl-arm64" />
-    <PackageSupportedRID Include="linux-musl-x64" />
-    <PackageSupportedRID Include="linux-x64" />
-    <PackageSupportedRID Include="maccatalyst-arm64" />
-    <PackageSupportedRID Include="maccatalyst-x64" />
-    <PackageSupportedRID Include="osx-arm64" />
-    <PackageSupportedRID Include="osx-x64" />
+    <!-- Extract supported RIDs from the .proj file names -->
+    <RIDSpecificProject Include="$(MSBuildThisFileDirectory)runtime.*.runtime.native.System.IO.Ports.proj" />
+    <PackageSupportedRID Include="@(RIDSpecificProject->'%(Filename)'->Replace('.runtime.native.System.IO.Ports', '')->Replace('runtime.', ''))" />
 
     <!-- We need to add a placeholder file for all RIDs except the one that is actually included in the RID-specific package.
          This prevents an issue where during publish the SDK would select e.g. both linux-x64 and linux-musl-x64 assets because of the fallback path in the RID graph. -->

--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -18,10 +18,41 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageSupportedRID Include="android-arm" />
+    <PackageSupportedRID Include="android-arm64" />
+    <PackageSupportedRID Include="android-x64" />
+    <PackageSupportedRID Include="android-x86" />
+    <PackageSupportedRID Include="linux-arm" />
+    <PackageSupportedRID Include="linux-arm64" />
+    <PackageSupportedRID Include="linux-bionic-arm64" />
+    <PackageSupportedRID Include="linux-bionic-x64" />
+    <PackageSupportedRID Include="linux-musl-arm" />
+    <PackageSupportedRID Include="linux-musl-arm64" />
+    <PackageSupportedRID Include="linux-musl-x64" />
+    <PackageSupportedRID Include="linux-x64" />
+    <PackageSupportedRID Include="maccatalyst-arm64" />
+    <PackageSupportedRID Include="maccatalyst-x64" />
+    <PackageSupportedRID Include="osx-arm64" />
+    <PackageSupportedRID Include="osx-x64" />
+
+    <!-- We need to add a placeholder file for all RIDs except the one that is actually included in the RID-specific package.
+         This prevents an issue where during publish the SDK would select e.g. both linux-x64 and linux-musl-x64 assets because of the fallback path in the RID graph. -->
+    <PackagePlaceholderRID Include="@(PackageSupportedRID)" Exclude="$(OutputRID)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="$(NativeBinDir)$(LibPrefix)System.IO.Ports.Native$(LibSuffix)"
           PackagePath="runtimes/$(OutputRID)/native"
           Pack="true" />
+    <None Include="$(PlaceholderFile)"
+          PackagePath="@(PackagePlaceholderRID->'runtimes/%(Identity)/native')"
+          Pack="true" />
   </ItemGroup>
+
+  <Target Name="ValidatePackageSupportedRID" BeforeTargets="Build">
+    <Error Text="$(OutputRID) is missing from PackageSupportedRID."
+           Condition="!@(PackageSupportedRID->AnyHaveMetadataValue('Identity', '$(OutputRID)'))" />
+  </Target>
 
   <Target Name="AddRuntimeSpecificNativeSymbolToPackage">
     <ItemGroup>


### PR DESCRIPTION
The runtime.native.System.IO.Ports package depends on all the RID-specific packages, this causes an issue when publishing for a RID like `linux-musl-x64` since the RID graph has a fallback path of `linux-musl-x64 -> linux-x64 -> linux` so the SDK would select the native libs from _both_ the `runtime.linux-musl-x64.runtime.native.System.IO.Ports` and `runtime.linux-x64.runtime.native.System.IO.Ports` packages which causes a conflict.

To fix this we add `_._` placeholder entries for all RIDs except the one where we have a native asset so the SDK ignores the non-matching ones.

Fixes https://github.com/dotnet/runtime/issues/104710