### PR TITLE
[mono][llvm] Fix handling of compare when last instruction in bblock

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -6299,6 +6299,9 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			gboolean likely = (ins->flags & MONO_INST_LIKELY) != 0;
 			gboolean unlikely = FALSE;
 
+			if (!ins->next)
+				break;
+
 			if (MONO_IS_COND_BRANCH_OP (ins->next)) {
 				if (ins->next->inst_false_bb->out_of_line)
 					likely = TRUE;


### PR DESCRIPTION
Compare opcodes are logically meant to set compare flags and they are always followed by a conditional instruction (that either branches or loads the comparison result in a register). When handling this instruction, if the next instruction was a nop or not a conditional instruction, then we can make the assumption that the conditional instruction was optimized out so there is no need to generate the compare instruction. We were missing the scenario when the conditional instruction was optimized out and the compare was left as the last instruction of the bblock, in which case we were crashing.

Fixes https://github.com/dotnet/runtime/issues/106137