### PR TITLE
[LoongArch64] Enable TLS on linux/loongarch64 only for static resolver.

### DIFF
--- a/src/coreclr/vm/loongarch64/asmhelpers.S
+++ b/src/coreclr/vm/loongarch64/asmhelpers.S
@@ -1088,7 +1088,7 @@ GenerateProfileHelper ProfileTailcall, PROFILE_TAILCALL
 NESTED_ENTRY OnCallCountThresholdReachedStub, _TEXT, NoHandler
     PROLOG_WITH_TRANSITION_BLOCK
 
-    addi.d     $a0, $sp, __PWTB_TransitionBlock // TransitionBlock *
+    addi.d  $a0, $sp, __PWTB_TransitionBlock // TransitionBlock *
     ori     $a1, $t1, 0 // stub-identifying token
     bl      C_FUNC(OnCallCountThresholdReached)
     ori     $t4,$a0,0
@@ -1111,4 +1111,19 @@ LEAF_ENTRY GetThreadStaticsVariableOffset, _TEXT
         EPILOG_RESTORE_REG_PAIR_INDEXED 22, 1, 16
         EPILOG_RETURN
 LEAF_END GetThreadStaticsVariableOffset, _TEXT
+// ------------------------------------------------------------------
+
+// ------------------------------------------------------------------
+// size_t GetTLSResolverAddress()
+
+// Helper to get the TLS resolver address. This will be then used to determine if we have a static or dynamic resolver.
+LEAF_ENTRY GetTLSResolverAddress, _TEXT
+        //                           $fp,$ra
+        PROLOG_SAVE_REG_PAIR_INDEXED  22, 1, 16
+        pcalau12i  $a0, %desc_pc_hi20(t_ThreadStatics)
+        addi.d     $a0, $a0, %desc_pc_lo12(t_ThreadStatics)
+        ld.d       $a0, $a0, %desc_ld(t_ThreadStatics)
+        EPILOG_RESTORE_REG_PAIR_INDEXED  22, 1, 16
+        EPILOG_RETURN
+LEAF_END GetTLSResolverAddress, _TEXT
 // ------------------------------------------------------------------


### PR DESCRIPTION
ThreadLocal optimization during JIT should detect static/dynamic resolver. #104518

This PR referenced the ARM64's #106052