### PR TITLE
Bump requirement for QUIC async cert validation to MsQuic 2.4

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -62,7 +62,7 @@ internal sealed unsafe partial class MsQuicApi
     internal static string? NotSupportedReason { get; }
 
     // workaround for https://github.com/microsoft/msquic/issues/4132
-    internal static bool SupportsAsyncCertValidation => Version >= new Version(2, 4, 1);
+    internal static bool SupportsAsyncCertValidation => Version >= new Version(2, 4);
 
     internal static bool UsesSChannelBackend { get; }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -62,7 +62,7 @@ internal sealed unsafe partial class MsQuicApi
     internal static string? NotSupportedReason { get; }
 
     // workaround for https://github.com/microsoft/msquic/issues/4132
-    internal static bool SupportsAsyncCertValidation => Version >= new Version(2, 3, 5);
+    internal static bool SupportsAsyncCertValidation => Version >= new Version(2, 4, 1);
 
     internal static bool UsesSChannelBackend { get; }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -52,7 +52,6 @@ namespace System.Net.Quic.Tests
     {
         private static byte[] s_data = "Hello world!"u8.ToArray();
         readonly CertificateSetup _certificates;
-        static bool DoesNotSupportAsyncCertValidation => QuicTestCollection.MsQuicVersion < new Version(2, 4);
 
         public MsQuicTests(ITestOutputHelper output, CertificateSetup setup) : base(output)
         {
@@ -354,7 +353,6 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074", typeof(MsQuicTests), nameof(DoesNotSupportAsyncCertValidation))]
         public async Task CertificateCallbackThrowPropagates()
         {
             using CancellationTokenSource cts = new CancellationTokenSource(PassingTestTimeout);


### PR DESCRIPTION
Closes #99074.

Since MsQuic 2.4.1 is available in package feeds, we can bump the minimum version to guarantee correct behavior in the error case tested by the disabled test.