### PR TITLE
JIT: Add a release config to enable/disable IV opts

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -2405,6 +2405,12 @@ PhaseStatus Compiler::optInductionVariables()
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
+    if (JitConfig.JitEnableInductionVariableOpts() == 0)
+    {
+        JITDUMP("  Skipping since it is disabled due to JitEnableInductionVariableOpts\n");
+        return PhaseStatus::MODIFIED_NOTHING;
+    }
+
     bool changed = false;
 
     optReachableBitVecTraits = nullptr;

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -775,6 +775,9 @@ RELEASE_CONFIG_INTEGER(JitDoReversePostOrderLayout, W("JitDoReversePostOrderLayo
 // Enable strength reduction
 RELEASE_CONFIG_INTEGER(JitEnableStrengthReduction, W("JitEnableStrengthReduction"), 1)
 
+// Enable IV optimizations
+RELEASE_CONFIG_INTEGER(JitEnableInductionVariableOpts, W("JitEnableInductionVariableOpts"), 1)
+
 // JitFunctionFile: Name of a file that contains a list of functions. If the currently compiled function is in the
 // file, certain other JIT config variables will be active. If the currently compiled function is not in the file,
 // the specific JIT config variables will not be active.


### PR DESCRIPTION
Allow easily turning off all the new IV opts to enable some quick coarse-grained diagnosis.