### PR TITLE
[RISC-V][LoongArch64] Pass structs containing empty struct arrays according to integer calling convention

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2764,7 +2764,7 @@ static bool HandleInlineArray(int elementTypeIndex, int nElements, FpStructInReg
     int nFlattenedFieldsPerElement = typeIndex - elementTypeIndex;
     if (nFlattenedFieldsPerElement == 0)
     {
-        assert(nElements == 1); // HasImpliedRepeatedFields must have returned a false positive
+        assert(nElements == 1); // HasImpliedRepeatedFields must have returned a false positive, it can't be an array
         LOG((LF_JIT, LL_EVERYTHING, "FpStructInRegistersInfo:%*s  * ignoring empty struct\n",
             nestingLevel * 4, ""));
         return true;
@@ -2873,6 +2873,17 @@ static bool FlattenFields(TypeHandle th, uint32_t offset, FpStructInRegistersInf
         {
             assert(nFields == 1);
             int nElements = pMT->GetNumInstanceFieldBytes() / fields[0].GetSize();
+
+            // Only InlineArrays can have element type of empty struct, fixed-size buffers take only primitives
+            if ((typeIndex - elementTypeIndex) == 0 && pMT->GetClass()->IsInlineArray())
+            {
+                assert(nElements > 0); // InlineArray length must be > 0
+                LOG((LF_JIT, LL_EVERYTHING, "FpStructInRegistersInfo:%*s "
+                    " * struct %s containing a %i-element array of empty structs %s is passed by integer calling convention\n",
+                    nestingLevel * 4, "", pMT->GetDebugClassName(), nElements, fields[0].GetDebugName()));
+                return false;
+            }
+
             if (!HandleInlineArray(elementTypeIndex, nElements, info, typeIndex DEBUG_ARG(nestingLevel + 1)))
                 return false;
         }

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
@@ -292,6 +292,26 @@ extern "C" DLLEXPORT DoubleFloatNestedEmpty Echo_DoubleFloatNestedEmpty_InIntege
 }
 
 
+struct ArrayOfEmpties
+{
+	Empty e[1];
+};
+
+struct ArrayOfEmptiesFloatDouble
+{
+	ArrayOfEmpties ArrayOfEmpties0;
+	float Float0;
+	double Double0;
+};
+
+extern "C" DLLEXPORT ArrayOfEmptiesFloatDouble Echo_ArrayOfEmptiesFloatDouble_RiscV(int a0, float fa0,
+	ArrayOfEmptiesFloatDouble a1_a2, int a3, float fa1)
+{
+	a1_a2.Double0 += (double)a3 + fa1;
+	return a1_a2;
+}
+
+
 struct EmptyUshortAndDouble
 {
 	struct EmptyUshort

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cpp
@@ -287,8 +287,8 @@ extern "C" DLLEXPORT DoubleFloatNestedEmpty Echo_DoubleFloatNestedEmpty_InIntege
 	float fa0, float fa1, float fa2, float fa3, float fa4, float fa5, float fa6,
 	DoubleFloatNestedEmpty a1_a2, int a3, float fa7)
 {
-	return a1_a2;
 	a1_a2.Float0 += (float)a3 + fa7;
+	return a1_a2;
 }
 
 

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
@@ -1123,6 +1123,66 @@ public static class Program
 	}
 #endregion
 
+#region ArrayOfEmptiesFloatDouble_RiscVTests
+	[InlineArray(1)]
+	public struct ArrayOfEmpties
+	{
+		public Empty e;
+	}
+
+	public struct ArrayOfEmptiesFloatDouble
+	{
+		public ArrayOfEmpties ArrayOfEmpties0;
+		public float Float0;
+		public double Double0;
+
+		public static ArrayOfEmptiesFloatDouble Get()
+			=> new ArrayOfEmptiesFloatDouble { Float0 = 3.14159f, Double0 = 2.71828 };
+
+		public bool Equals(ArrayOfEmptiesFloatDouble other)
+			=> Float0 == other.Float0 && Double0 == other.Double0;
+
+		public override string ToString()
+			=> $"{{Float0:{Float0}, Double0:{Double0}}}";
+	}
+
+	[DllImport("EmptyStructsLib")]
+	public static extern ArrayOfEmptiesFloatDouble Echo_ArrayOfEmptiesFloatDouble_RiscV(int a0, float fa0,
+		ArrayOfEmptiesFloatDouble a1_a2, int a3, float fa1);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	public static ArrayOfEmptiesFloatDouble Echo_ArrayOfEmptiesFloatDouble_RiscV_Managed(int a0, float fa0,
+		ArrayOfEmptiesFloatDouble a1_a2, int a3, float fa1)
+	{
+		a1_a2.Double0 += (double)a3 + fa1;
+		return a1_a2;
+	}
+
+	[Fact]
+	public static void Test_ArrayOfEmptiesFloatDouble_RiscV()
+	{
+		ArrayOfEmptiesFloatDouble expected = ArrayOfEmptiesFloatDouble.Get();
+		ArrayOfEmptiesFloatDouble native = Echo_ArrayOfEmptiesFloatDouble_RiscV(0, 0f, expected, 1, -1f);
+		ArrayOfEmptiesFloatDouble managed = Echo_ArrayOfEmptiesFloatDouble_RiscV_Managed(0, 0f, expected, 1, -1f);
+
+		Assert.Equal(expected, native);
+		Assert.Equal(expected, managed);
+	}
+
+	[Fact]
+	public static void Test_ArrayOfEmptiesFloatDouble_ByReflection_RiscV()
+	{
+		var expected = ArrayOfEmptiesFloatDouble.Get();
+		var native = (ArrayOfEmptiesFloatDouble)typeof(Program).GetMethod("Echo_ArrayOfEmptiesFloatDouble_RiscV").Invoke(
+			null, new object[] {0, 0f, expected, 1, -1f});
+		var managed = (ArrayOfEmptiesFloatDouble)typeof(Program).GetMethod("Echo_ArrayOfEmptiesFloatDouble_RiscV_Managed").Invoke(
+			null, new object[] {0, 0f, expected, 1, -1f});
+
+		Assert.Equal(expected, native);
+		Assert.Equal(expected, managed);
+	}
+#endregion
+
 #region EmptyUshortAndDouble_RiscVTests
 	public struct EmptyUshortAndDouble
 	{

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
@@ -77,8 +77,8 @@ public static class Program
 		public static IntEmpty Get()
 			=> new IntEmpty { Int0 = 0xBabc1a };
 
-		public bool Equals(IntEmpty other)
-			=> Int0 == other.Int0;
+		public override bool Equals(object other)
+			=> other is IntEmpty o && Int0 == o.Int0;
 		
 		public override string ToString()
 			=> $"{{Int0:{Int0:x}}}";
@@ -128,8 +128,8 @@ public static class Program
 		public static IntEmptyPair Get()
 			=> new IntEmptyPair { IntEmpty0 = IntEmpty.Get(), IntEmpty1 = IntEmpty.Get() };
 
-		public bool Equals(IntEmptyPair other)
-			=> IntEmpty0.Equals(other.IntEmpty0) && IntEmpty1.Equals(other.IntEmpty1);
+		public override bool Equals(object other)
+			=> other is IntEmptyPair o && IntEmpty0.Equals(o.IntEmpty0) && IntEmpty1.Equals(o.IntEmpty1);
 		
 		public override string ToString()
 			=> $"{{IntEmpty0:{IntEmpty0}, IntEmpty1:{IntEmpty1}}}";
@@ -181,8 +181,8 @@ public static class Program
 		public static EmptyFloatIntInt Get()
 			=> new EmptyFloatIntInt { Float0 = 2.71828f, Int0 = 0xBabc1a, Int1 = 0xC10c1a };
 
-		public bool Equals(EmptyFloatIntInt other)
-			=> Float0 == other.Float0 && Int0 == other.Int0 && Int1 == other.Int1;
+		public override bool Equals(object other)
+			=> other is EmptyFloatIntInt o && Float0 == o.Float0 && Int0 == o.Int0 && Int1 == o.Int1;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Int0:{Int0:x}, Int1:{Int1:x}}}";
@@ -236,8 +236,8 @@ public static class Program
 		public static FloatFloatEmptyFloat Get()
 			=> new FloatFloatEmptyFloat { Float0 = 2.71828f, Float1 = 3.14159f, Float2 = 1.61803f };
 
-		public bool Equals(FloatFloatEmptyFloat other)
-			=> Float0 == other.Float0 && Float1 == other.Float1 && Float2 == other.Float2;
+		public override bool Equals(object other)
+			=> other is FloatFloatEmptyFloat o && Float0 == o.Float0 && Float1 == o.Float1 && Float2 == o.Float2;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Float1:{Float1}, Float2:{Float2}}}";
@@ -294,8 +294,8 @@ public static class Program
 		public static Empty8Float Get()
 			=> new Empty8Float { Float0 = 2.71828f };
 
-		public bool Equals(Empty8Float other)
-			=> Float0 == other.Float0;
+		public override bool Equals(object other)
+			=> other is Empty8Float o && Float0 == o.Float0;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}}}";
@@ -474,8 +474,8 @@ public static class Program
 		public static FloatEmpty8Float Get()
 			=> new FloatEmpty8Float { Float0 = 2.71828f, Float1 = 3.14159f };
 
-		public bool Equals(FloatEmpty8Float other)
-			=> Float0 == other.Float0 && Float1 == other.Float1;
+		public override bool Equals(object other)
+			=> other is FloatEmpty8Float o && Float0 == o.Float0 && Float1 == o.Float1;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Float1:{Float1}}}";
@@ -654,8 +654,8 @@ public static class Program
 		public static FloatEmptyShort Get()
 			=> new FloatEmptyShort { Float0 = 2.71828f, Short0 = 0x1dea };
 
-		public bool Equals(FloatEmptyShort other)
-			=> Float0 == other.Float0 && Short0 == other.Short0;
+		public override bool Equals(object other)
+			=> other is FloatEmptyShort o && Float0 == o.Float0 && Short0 == o.Short0;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Short0:{Short0}}}";
@@ -793,8 +793,8 @@ public static class Program
 		public static EmptyFloatEmpty5Sbyte Get()
 			=> new EmptyFloatEmpty5Sbyte { Float0 = 2.71828f, Sbyte0 = -123 };
 
-		public bool Equals(EmptyFloatEmpty5Sbyte other)
-			=> Float0 == other.Float0 && Sbyte0 == other.Sbyte0;
+		public override bool Equals(object other)
+			=> other is EmptyFloatEmpty5Sbyte o && Float0 == o.Float0 && Sbyte0 == o.Sbyte0;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Sbyte0:{Sbyte0}}}";
@@ -848,8 +848,8 @@ public static class Program
 		public static EmptyFloatEmpty5Byte Get()
 			=> new EmptyFloatEmpty5Byte { Float0 = 2.71828f, Byte0 = 123 };
 
-		public bool Equals(EmptyFloatEmpty5Byte other)
-			=> Float0 == other.Float0 && Byte0 == other.Byte0;
+		public override bool Equals(object other)
+			=> other is EmptyFloatEmpty5Byte o && Float0 == o.Float0 && Byte0 == o.Byte0;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Byte0:{Byte0}}}";
@@ -1037,8 +1037,8 @@ public static class Program
 		public static DoubleFloatNestedEmpty Get()
 			=> new DoubleFloatNestedEmpty { Double0 = 2.71828, Float0 = 3.14159f };
 
-		public bool Equals(DoubleFloatNestedEmpty other)
-			=> Double0 == other.Double0 && Float0 == other.Float0;
+		public override bool Equals(object other)
+			=> other is DoubleFloatNestedEmpty o && Double0 == o.Double0 && Float0 == o.Float0;
 
 		public override string ToString()
 			=> $"{{Double0:{Double0}, Float0:{Float0}}}";
@@ -1139,8 +1139,8 @@ public static class Program
 		public static ArrayOfEmptiesFloatDouble Get()
 			=> new ArrayOfEmptiesFloatDouble { Float0 = 3.14159f, Double0 = 2.71828 };
 
-		public bool Equals(ArrayOfEmptiesFloatDouble other)
-			=> Float0 == other.Float0 && Double0 == other.Double0;
+		public override bool Equals(object other)
+			=> other is ArrayOfEmptiesFloatDouble o && Float0 == o.Float0 && Double0 == o.Double0;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Double0:{Double0}}}";
@@ -1198,8 +1198,8 @@ public static class Program
 			EmptyUshort0 = new EmptyUshort { Ushort0 = 0xBaca }, Double0 = 2.71828
 		};
 
-		public bool Equals(EmptyUshortAndDouble other)
-			=> EmptyUshort0.Ushort0 == other.EmptyUshort0.Ushort0 && Double0 == other.Double0;
+		public override bool Equals(object other)
+			=> other is EmptyUshortAndDouble o && EmptyUshort0.Ushort0 == o.EmptyUshort0.Ushort0 && Double0 == o.Double0;
 
 		public override string ToString()
 			=> $"{{EmptyUshort0.Ushort0:{EmptyUshort0.Ushort0}, Double0:{Double0}}}";
@@ -1253,8 +1253,8 @@ public static class Program
 		public static PackedEmptyFloatLong Get()
 			=> new PackedEmptyFloatLong { Float0 = 2.71828f, Long0 = 0xDadAddedC0ffee };
 
-		public bool Equals(PackedEmptyFloatLong other)
-			=> Float0 == other.Float0 && Long0 == other.Long0;
+		public override bool Equals(object other)
+			=> other is PackedEmptyFloatLong o && Float0 == o.Float0 && Long0 == o.Long0;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Long0:{Long0}}}";
@@ -1443,8 +1443,8 @@ public static class Program
 		public static PackedFloatEmptyByte Get()
 			=> new PackedFloatEmptyByte { Float0 = 2.71828f, Byte0 = 0xba };
 
-		public bool Equals(PackedFloatEmptyByte other)
-			=> Float0 == other.Float0 && Byte0 == other.Byte0;
+		public override bool Equals(object other)
+			=> other is PackedFloatEmptyByte o && Float0 == o.Float0 && Byte0 == o.Byte0;
 
 		public override string ToString()
 			=> $"{{Float0:{Float0}, Byte0:{Byte0}}}";

--- a/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
+++ b/src/tests/JIT/Directed/StructABI/EmptyStructs.cs
@@ -1,6 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Note: this test checks passing empty struct fields in .NET; confronting it against C++ on native compilers is just
+// a means to assert compliance to the platform calling convention. The native part is using C++ because it defines
+// empty structs as 1 byte like in .NET. Empty structs in C are undefined (it's a GCC extension to define them as 0
+// bytes) and .NET managed/unmanaged interop follows the C ABI, not C++, so signatures with empty struct fields should
+// not be used in any real-world interop calls.
+
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
A note from RISC-V Hardware Floating-point Calling Convention:
> One exceptional case for the flattening rule is an array of empty structs or unions;
> C treats it as an empty field, but C++ treats it as a non-empty field since C++ defines
> the size of an empty struct or union as 1. i.e. for struct { struct {} e[1]; float f;
> } as the first argument, C will treat it like struct { float f; } and pass f in fa0 as
> described below, whereas C++ will pass the pass the entire aggregate in a0 (XLEN =
> 64) or a0 and a1 (XLEN = 32), as described in the integer calling convention. Zerolength
> arrays of empty structs or union will be ignored for both C and C++. i.e. For
> struct { struct {} e[0]; float f; };, as the first argument, C and C++ will treat it
> like struct { float f; } and pass f in fa0 as described below.

@LuckyXu-HF @shushanhf LoongArch ABI doesn't seem to mention it but from what I could discern [GCC behaves the same way](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXLnwEEAqgGdMABQAenAAy8AVhNK0mDUMgCkAJgBCZ86UX1kBPAMqN0AYVS0Ariwa6XAGTwGTAA5bwAjTGIJAA5SAAdUeUJHBncvH11E5IcBQOCwlkjorjjbTHtUoQImYgJ0718pcsqBatqCfNCIqNibGrqGzOaBzqDuot7SgEobVE9iZHYOeQJiT3sAagBBYmImAE8AeSpsFniHTHljdW3jAHZLW5uATlX1%2BwfLe4ARTcxjABWcxcIE/YwAZied1%2BkOhN227w2BB2e0OJzOFzwVwAYrRUEwCD95uF6AivuT1C9dvtjqdzpd5KjaRiGdj5Oo4ZSXlR8YTNniCQROVDuegSfRNsTPKTMCL4bDRc9bjT0fSsbi%2BUSJZhNthkAhUAB9VV0zGMwWE6Wyo0AJTw8mQADUIEEUUx1KRNryhd6PaRuabWRr5JbtTLJUwuEamKZpuTHtziJgCAsGJsozHTFznrDbhxZrROIDeL5uLxUJxXFYrJt5PNFrqzBCeKQCBoC7MEJgmFhohBZgBrECmAAsADoIRCXgA2e6j0cvQEvMeAvScUeljukSscXjyECe9scTSzOCwJBoc50KLkShX%2BI36LEABuM9HAFpkPpDKUuJ6aFoAgogPCBwm3cIglqA5OFbSDmGIY5wi0Cpj1bK82EEI4GFoGCT14LBwk8YBXDEWgD3LUgsBYAxgHEfCqLwZNKhfK5t0wFQKk8YDYN4N1MCLBjaDwcJ9kQ9wsG3NY8BYXjSFY4hwiSTAfkwGjDGEwwO1mXkmGAeQnWxAB3I54kYOT%2BEEEQxHYSRpEEBRlDUBidCkH8jBrCw9BEg9IFmVAsQECiPyOAAvCsFOIPAsF8gcbAE1DUmcBg3A8Ro/BSrpCmKLIkhSAQhiaBI8tyBgsp6Ep4rsUr2kGNLhiqxK2lGcrJkq1YOkK3QOrqVqcq4WZ6wWJYJELYstwY3dNltABJIRXA/J1Nlfd9gGQTZv1ozZSnHLhx3UTYIFwQgSE2ZsBt4Y9TyHEdTHHGcZ3/e4Z1MQFRxiUwXsBGd1w4TdSDLTQd04fdDzbbTSHPRAUFQa96DICgIAfJ8QBWz81uQLhR3/Pg6GA4hQPAhj4OguSScQo5kNQuSMMYAhsNw7dCOI0jaHIuTqNo%2BigfwZiHFYiigY4rieMo/jBKB4TROgiTliB6TZMohSlMUVT1LooJQHwnT9H0wzMBMsyy1bSzhFEcQ7NNxzVG3HQIT0WiUE86wpdi/zAoYYKwoiqIopi%2BBBoS1pfAgFwuq4F5SACcZst6H7snytJ6qaSOE9Kvq48a4PavqZOJEjloapamOKpAH6etzjIU/6DoM%2BiGdBobEaBt%2BksAe3KbZvmxbDvfD9IIIeRpk2DHtonPaDqO/AiGIM7TBbaZLu0rsez7SgbtMe5x0BZ7sZiKkIXUUoZxiOJBP%2BwGKxBmwwaugtIZgaHkfhu8kdhx94ZAfEBGAWoDVWrGONAL40JhBKCiEybgKQihewNNYaYXpjhPCPNMBERImRCirZOYaTlgRJiiUBbsU4sgbiyxWzi23FLMSBxZZSSiorVsytlJqy5prCGuk9bGVMuZSiptrIWykFbRQNsXIjgdlpEwFgrDeXCG7HcHsvbhR3JFaKbE/JZ1KslVKVcMroDrrlHIqRw7FUMXkEubVupByLp1POzQrFVGLgUUuIwbE6Jcb1cx/VG7DVsmNDgbdL7Aw4Jsb%2Bhg/4IHfCPZA60sa7X2odY6M854LyXtrDegJxyjlMKYGILYuDfXnuoQEgIz4bgmkDXcoMjzL1%2BqYcpV89zgzSfJECSVRxAA%3D) so I left it in for LA as well.

Plus, some fixes to the EmptyStructs test code.

Stems from #101796, part of #84834, cc @dotnet/samsung