### PR TITLE
Add unmanaged assembly skipping to ILStrip task

### DIFF
--- a/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
@@ -237,5 +237,19 @@ namespace AssemblyStripper
             AssemblyDefinition assembly = AssemblyFactory.GetAssembly(assemblyFile);
             AssemblyStripper.StripAssembly(assembly, outputPath);
         }
+
+        public static bool TryStripAssembly(string assemblyFile, string outputPath)
+        {
+            try
+            {
+                StripAssembly(assemblyFile, outputPath);
+                return true;
+            }
+            // Skip unmanged assemblies
+            catch (ImageFormatException)
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -96,10 +96,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
                                                         }
                                                     });
 
-            if (TrimIndividualMethods)
-            {
-                UpdatedAssemblies = ConvertAssembliesDictToOrderedList(_processedAssemblies, Assemblies).ToArray();
-            }
+            UpdatedAssemblies = ConvertAssembliesDictToOrderedList(_processedAssemblies, Assemblies).ToArray();
 
             if (!result.IsCompleted && !Log.HasLoggedErrors)
             {
@@ -130,7 +127,14 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
         try
         {
-            AssemblyStripper.AssemblyStripper.StripAssembly (assemblyFile, outputPath);
+            if(!AssemblyStripper.AssemblyStripper.TryStripAssembly(assemblyFile, outputPath))
+            {
+                Log.LogMessage(MessageImportance.Low, $"[ILStrip] Skipping {assemblyFile} because it is not a managed assembly.");
+            }
+            else
+            {
+                _processedAssemblies.GetOrAdd(assemblyItem.ItemSpec, GetTrimmedAssemblyItem(assemblyItem, outputPath, assemblyFile));
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Feeding unmanaged assembly to ILStrip resulted in task failure. This change allows ILStrip to skip unmanaged assemblies. The final list of processed assemblies is to be found at `UpdatedAssemblies` output. Changes to `xamarin-macios` will be done in separate PR. 


Contributes to https://github.com/dotnet/runtime/issues/101967