### PR TITLE
[HttpClientFactory] Don't log header values by default

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Logging;
 
 namespace Microsoft.Extensions.Http
 {
@@ -72,7 +73,7 @@ namespace Microsoft.Extensions.Http
         /// <summary>
         /// The <see cref="Func{T, R}"/> which determines whether to redact the HTTP header value before logging.
         /// </summary>
-        public Func<string, bool> ShouldRedactHeaderValue { get; set; } = (header) => false;
+        public Func<string, bool> ShouldRedactHeaderValue { get; set; } = LogHelper.ShouldRedactHeaderValue;
 
         /// <summary>
         /// <para>

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LogHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LogHelper.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Extensions.Http.Logging
     {
         private static readonly LogDefineOptions s_skipEnabledCheckLogDefineOptions = new LogDefineOptions() { SkipEnabledCheck = true };
         private static readonly bool s_disableUriRedaction = GetDisableUriRedactionSettingValue();
-
         private static class EventIds
         {
             public static readonly EventId RequestStart = new EventId(100, "RequestStart");
@@ -31,6 +30,8 @@ namespace Microsoft.Extensions.Http.Logging
             public static readonly EventId RequestPipelineRequestHeader = new EventId(102, "RequestPipelineRequestHeader");
             public static readonly EventId RequestPipelineResponseHeader = new EventId(103, "RequestPipelineResponseHeader");
         }
+
+        public static readonly Func<string, bool> ShouldRedactHeaderValue = (header) => true;
 
         private static readonly Action<ILogger, HttpMethod, string?, Exception?> _requestStart = LoggerMessage.Define<HttpMethod, string?>(
             LogLevel.Information,

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LogHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LogHelper.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Http.Logging
     {
         private static readonly LogDefineOptions s_skipEnabledCheckLogDefineOptions = new LogDefineOptions() { SkipEnabledCheck = true };
         private static readonly bool s_disableUriRedaction = GetDisableUriRedactionSettingValue();
+
         private static class EventIds
         {
             public static readonly EventId RequestStart = new EventId(100, "RequestStart");

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Extensions.Http.Logging
         private readonly ILogger _logger;
         private readonly HttpClientFactoryOptions? _options;
 
-        private static readonly Func<string, bool> _shouldNotRedactHeaderValue = (header) => false;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingHttpMessageHandler"/> class with a specified logger.
         /// </summary>
@@ -55,7 +53,7 @@ namespace Microsoft.Extensions.Http.Logging
 
             async Task<HttpResponseMessage> Core(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
             {
-                Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? _shouldNotRedactHeaderValue;
+                Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? LogHelper.ShouldRedactHeaderValue;
 
                 // Not using a scope here because we always expect this to be at the end of the pipeline, thus there's
                 // not really anything to surround.

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Extensions.Http.Logging
         private readonly ILogger _logger;
         private readonly HttpClientFactoryOptions? _options;
 
-        private static readonly Func<string, bool> _shouldNotRedactHeaderValue = (header) => false;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingScopeHttpMessageHandler"/> class with a specified logger.
         /// </summary>
@@ -56,7 +54,7 @@ namespace Microsoft.Extensions.Http.Logging
             {
                 var stopwatch = ValueStopwatch.StartNew();
 
-                Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? _shouldNotRedactHeaderValue;
+                Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? LogHelper.ShouldRedactHeaderValue;
 
                 using (_logger.BeginRequestPipelineScope(request, out string? formattedUri))
                 {

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
@@ -77,12 +77,12 @@ namespace Microsoft.Extensions.Http.Logging
                     m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
-	                """
-	                Request Headers:
-	                Authorization: *
-	                Cache-Control: *
-	                """),
-	                message.Message);
+	            """
+	            Request Headers:
+	            Authorization: *
+	            Cache-Control: *
+	            """),
+	            message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -91,12 +91,12 @@ namespace Microsoft.Extensions.Http.Logging
                     m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
-	                """
-	                Response Headers:
-	                X-Sensitive: *
-	                Y-Non-Sensitive: *
-	                """),
-	                message.Message);
+	            """
+	            Response Headers:
+	            X-Sensitive: *
+	            Y-Non-Sensitive: *
+	            """),
+	            message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -105,12 +105,12 @@ namespace Microsoft.Extensions.Http.Logging
                     m.LoggerName == OuterLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
-	                """
-	                Response Headers:
-	                X-Sensitive: *
-	                Y-Non-Sensitive: *
-	                """),
-	                message.Message);
+	            """
+	            Response Headers:
+	            X-Sensitive: *
+	            Y-Non-Sensitive: *
+	            """),
+	            message.Message);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Http.Logging
             public static readonly EventId RequestPipelineResponseHeader = new EventId(103, "RequestPipelineResponseHeader");
         }
 
-                [Fact]
+        [Fact]
         public async Task RedactLoggedHeadersNotCalled_AllValuesAreRedactedBeforeLogging()
         {
             // Arrange
@@ -63,10 +63,12 @@ namespace Microsoft.Extensions.Http.Logging
                     m.LoggerName == OuterLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
-@"Request Headers:
-Authorization: *
-Cache-Control: *
-"), message.Message);
+                """
+                Request Headers:
+                Authorization: *
+                Cache-Control: *
+                """),
+                message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -75,10 +77,12 @@ Cache-Control: *
                     m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
-@"Request Headers:
-Authorization: *
-Cache-Control: *
-"), message.Message);
+	                """
+	                Request Headers:
+	                Authorization: *
+	                Cache-Control: *
+	                """),
+	                message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -87,10 +91,12 @@ Cache-Control: *
                     m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
-@"Response Headers:
-X-Sensitive: *
-Y-Non-Sensitive: *
-"), message.Message);
+	                """
+	                Response Headers:
+	                X-Sensitive: *
+	                Y-Non-Sensitive: *
+	                """),
+	                message.Message);
 
             message = Assert.Single(messages.Where(m =>
             {
@@ -99,10 +105,12 @@ Y-Non-Sensitive: *
                     m.LoggerName == OuterLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
-@"Response Headers:
-X-Sensitive: *
-Y-Non-Sensitive: *
-"), message.Message);
+	                """
+	                Response Headers:
+	                X-Sensitive: *
+	                Y-Non-Sensitive: *
+	                """),
+	                message.Message);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/RedactedLogValueIntegrationTest.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Extensions.Http.Logging
 {
     public class RedactedLogValueIntegrationTest
     {
+        private const string OuterLoggerName = "System.Net.Http.HttpClient.test.LogicalHandler";
+        private const string InnerLoggerName = "System.Net.Http.HttpClient.test.ClientHandler";
+
         private static class EventIds
         {
             public static readonly EventId RequestHeader = new EventId(102, "RequestHeader");
@@ -23,6 +26,83 @@ namespace Microsoft.Extensions.Http.Logging
 
             public static readonly EventId RequestPipelineRequestHeader = new EventId(102, "RequestPipelineRequestHeader");
             public static readonly EventId RequestPipelineResponseHeader = new EventId(103, "RequestPipelineResponseHeader");
+        }
+
+                [Fact]
+        public async Task RedactLoggedHeadersNotCalled_AllValuesAreRedactedBeforeLogging()
+        {
+            // Arrange
+            var sink = new TestSink();
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging();
+            serviceCollection.AddSingleton<ILoggerFactory>(new TestLoggerFactory(sink, enabled: true));
+
+            // Act
+            serviceCollection
+                .AddHttpClient("test")
+                .ConfigurePrimaryHttpMessageHandler(() => new TestMessageHandler());
+
+            // Assert
+            var services = serviceCollection.BuildServiceProvider();
+
+            var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("test");
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com");
+            request.Headers.Authorization = new AuthenticationHeaderValue("fake", "secret value");
+            request.Headers.CacheControl = new CacheControlHeaderValue() { NoCache = true, };
+
+            await client.SendAsync(request);
+
+            var messages = sink.Writes.ToArray();
+
+            var message = Assert.Single(messages.Where(m =>
+            {
+                return
+                    m.EventId == EventIds.RequestPipelineRequestHeader &&
+                    m.LoggerName == OuterLoggerName;
+            }));
+            Assert.StartsWith(LineEndingsHelper.Normalize(
+@"Request Headers:
+Authorization: *
+Cache-Control: *
+"), message.Message);
+
+            message = Assert.Single(messages.Where(m =>
+            {
+                return
+                    m.EventId == EventIds.RequestHeader &&
+                    m.LoggerName == InnerLoggerName;
+            }));
+            Assert.StartsWith(LineEndingsHelper.Normalize(
+@"Request Headers:
+Authorization: *
+Cache-Control: *
+"), message.Message);
+
+            message = Assert.Single(messages.Where(m =>
+            {
+                return
+                    m.EventId == EventIds.ResponseHeader &&
+                    m.LoggerName == InnerLoggerName;
+            }));
+            Assert.StartsWith(LineEndingsHelper.Normalize(
+@"Response Headers:
+X-Sensitive: *
+Y-Non-Sensitive: *
+"), message.Message);
+
+            message = Assert.Single(messages.Where(m =>
+            {
+                return
+                    m.EventId == EventIds.RequestPipelineResponseHeader &&
+                    m.LoggerName == OuterLoggerName;
+            }));
+            Assert.StartsWith(LineEndingsHelper.Normalize(
+@"Response Headers:
+X-Sensitive: *
+Y-Non-Sensitive: *
+"), message.Message);
         }
 
         [Fact]
@@ -58,7 +138,7 @@ namespace Microsoft.Extensions.Http.Logging
             {
                 return
                     m.EventId == EventIds.RequestPipelineRequestHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
+                    m.LoggerName == OuterLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
@@ -70,7 +150,7 @@ Cache-Control: no-cache
             {
                 return
                     m.EventId == EventIds.RequestHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
+                    m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
@@ -82,7 +162,7 @@ Cache-Control: no-cache
             {
                 return
                     m.EventId == EventIds.ResponseHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
+                    m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:
@@ -94,7 +174,7 @@ Y-Non-Sensitive: innocuous value
             {
                 return
                     m.EventId == EventIds.RequestPipelineResponseHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
+                    m.LoggerName == OuterLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:
@@ -139,7 +219,7 @@ Y-Non-Sensitive: innocuous value
             {
                 return
                     m.EventId == EventIds.RequestPipelineRequestHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
+                    m.LoggerName == OuterLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
@@ -151,7 +231,7 @@ Cache-Control: no-cache
             {
                 return
                     m.EventId == EventIds.RequestHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
+                    m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Request Headers:
@@ -163,7 +243,7 @@ Cache-Control: no-cache
             {
                 return
                     m.EventId == EventIds.ResponseHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.ClientHandler";
+                    m.LoggerName == InnerLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:
@@ -175,7 +255,7 @@ Y-Non-Sensitive: innocuous value
             {
                 return
                     m.EventId == EventIds.RequestPipelineResponseHeader &&
-                    m.LoggerName == "System.Net.Http.HttpClient.test.LogicalHandler";
+                    m.LoggerName == OuterLoggerName;
             }));
             Assert.StartsWith(LineEndingsHelper.Normalize(
 @"Response Headers:


### PR DESCRIPTION
Only affects the default case; if the sensitive headers were ever specified by `RedactLoggedHeaders`, the behavior is unchanged.