### PR TITLE
JIT: Handle memory conservatively in handler blocks in VN

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11007,7 +11007,13 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 
             ValueNum              newMemoryVN;
             FlowGraphNaturalLoop* loop = m_blockToLoop->GetLoop(blk);
-            if ((loop != nullptr) && (loop->GetHeader() == blk))
+            if (bbIsHandlerBeg(blk))
+            {
+                // We do not model memory SSA faithfully for handling (in particular, we do not model that
+                // the handler may see memory states from intermediate points in the enclosed blocks)
+                newMemoryVN = vnStore->VNForExpr(blk, TYP_HEAP);
+            }
+            else if ((loop != nullptr) && (loop->GetHeader() == blk))
             {
                 newMemoryVN = fgMemoryVNForLoopSideEffects(memoryKind, blk, loop);
             }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_86112/Runtime_86112.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_86112/Runtime_86112.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_86112
+{
+    static int _intStatic;
+
+    [Fact]
+    public static int Problem()
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Throw()
+        {
+            _intStatic = 1;
+            throw new Exception();
+        }
+
+        _intStatic = 2;
+
+        try
+        {
+            Throw();
+            _intStatic = 2;
+        }
+        catch (Exception)
+        {
+            if (_intStatic == 2)
+            {
+                return 101;
+            }
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_86112/Runtime_86112.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_86112/Runtime_86112.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
SSA does not model memory SSA faithfully inside try clauses. To model it
faithfully we would need to make all intermediate memory states in the
try block visible to the handler block. Doing so would require teaching
SSA about all nodes that define memory, and introduce a bunch of new
memory SSA states for EH constructs.

Instead of doing that this PR makes VN treat any handler block with
multiple incoming memory states (meaning that memory changed during the
try) conservatively. The diffs seem small enough; we can consider a more
elaborate fix in .NET 10.

Fix #86112