### PR TITLE
Fix passing targetRID into sourcebuild job

### DIFF
--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -126,5 +126,5 @@ extends:
         parameters:
           platforms:
           - name: Linux_x64
-            targetRid: linux-x64
+            targetRID: linux-x64
             container: SourceBuild_linux_x64

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -574,7 +574,7 @@ extends:
         parameters:
           platforms:
           - name: Linux_x64
-            targetRid: linux-x64
+            targetRID: linux-x64
             container: SourceBuild_linux_x64
 
       #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1857,11 +1857,11 @@ extends:
           parameters:
             platforms:
               - name: CentOS8
-                targetRid: centos.8-x64
+                targetRID: centos.8-x64
                 nonPortable: true
                 container: SourceBuild_centos_x64
               - name: NonexistentRID
                 baseOS: linux
-                targetRid: banana.24-x64
+                targetRID: banana.24-x64
                 nonPortable: true
                 container: SourceBuild_centos_x64


### PR DESCRIPTION
I noticed we weren't actually passing the `/p:TargetRid` parameter into the sourcebuild jobs because we used the wrong casing for the yml variable, it needs to be `targetRID` instead of `targetRid`.

I looked at all the repos in the dotnet org and runtime is the only one that is affected.