### PR TITLE
Don't vectorize division for integer types

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
@@ -69,7 +69,8 @@ namespace System.Numerics.Tensors
         /// <summary>x / y</summary>
         internal readonly struct DivideOperator<T> : IBinaryOperator<T> where T : IDivisionOperators<T, T, T>
         {
-            public static bool Vectorizable => true;
+            public static bool Vectorizable => typeof(T) == typeof(float)
+                                            || typeof(T) == typeof(double);
             public static T Invoke(T x, T y) => x / y;
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => x / y;
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => x / y;


### PR DESCRIPTION
This will improve some, but not all cases for https://github.com/dotnet/runtime/issues/105204 by ensuring its not significantly slower than scalar for arbitrary inputs.

For constant divisors, it is likely to still be slower than a for loop. For example `x / 2` may still be slower than `x >> 1` because we can't introspect it to be a constant for the more complex call site.