### PR TITLE
Fix loading of cDAC in DAC

### DIFF
--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -13,11 +13,17 @@ namespace
 {
     bool TryLoadCDACLibrary(HMODULE *phCDAC)
     {
-        // Load cdacreader from next to DAC binary
+        // Load cdacreader from next to current module (DAC binary)
         PathString path;
-        if (FAILED(GetClrModuleDirectory(path)))
+        if (WszGetModuleFileName((HMODULE)GetCurrentModuleBase(), path) == 0)
             return false;
 
+        SString::Iterator iter = path.End();
+        if (!path.FindBack(iter, DIRECTORY_SEPARATOR_CHAR_W))
+            return false;
+
+        iter++;
+        path.Truncate(iter);
         path.Append(CDAC_LIB_NAME);
         *phCDAC = CLRLoadLibrary(path.GetUnicode());
         if (*phCDAC == NULL)

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -3241,7 +3241,7 @@ BOOL GetRegistryLongValue(HKEY    hKeyParent,              // Parent key.
                           long    *pValue,                 // Put value here, if found.
                           BOOL    fReadNonVirtualizedKey); // Whether to read 64-bit hive on WOW64
 
-HRESULT GetCurrentModuleFileName(SString& pBuffer);
+HRESULT GetCurrentExecutableFileName(SString& pBuffer);
 
 //*****************************************************************************
 // Retrieve information regarding what registered default debugger

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -3867,6 +3867,7 @@ inline T* InterlockedCompareExchangeT(
 // Returns the directory for clr module. So, if path was for "C:\Dir1\Dir2\Filename.DLL",
 // then this would return "C:\Dir1\Dir2\" (note the trailing backslash).
 HRESULT GetClrModuleDirectory(SString& wszPath);
+void* GetCurrentModuleBase();
 
 namespace Clr { namespace Util
 {

--- a/src/coreclr/utilcode/clrhost.cpp
+++ b/src/coreclr/utilcode/clrhost.cpp
@@ -31,6 +31,13 @@ void* GetClrModuleBase()
 
 void* GetClrModuleBase()
 {
+    return GetCurrentModuleBase();
+}
+
+#endif // DACCESS_COMPILE
+
+void* GetCurrentModuleBase()
+{
     LIMITED_METHOD_CONTRACT;
 
 #if HOST_WINDOWS
@@ -47,8 +54,6 @@ void* GetClrModuleBase()
     return pRet;
 #endif // HOST_WINDOWS
 }
-
-#endif // DACCESS_COMPILE
 
 thread_local int t_CantAllocCount;
 

--- a/src/coreclr/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/utilcode/util_nodependencies.cpp
@@ -144,7 +144,7 @@ BOOL GetRegistryLongValue(HKEY    hKeyParent,
 
 //----------------------------------------------------------------------------
 //
-// GetCurrentModuleFileName - Retrieve the current module's filename
+// GetCurrentExecutableFileName - Retrieve the current executable's filename
 //
 // Arguments:
 //    pBuffer - output string buffer
@@ -155,7 +155,7 @@ BOOL GetRegistryLongValue(HKEY    hKeyParent,
 // Note:
 //
 //----------------------------------------------------------------------------
-HRESULT GetCurrentModuleFileName(SString& pBuffer)
+HRESULT GetCurrentExecutableFileName(SString& pBuffer)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -211,7 +211,7 @@ BOOL IsCurrentModuleFileNameInAutoExclusionList()
     PathString wszAppName;
 
     // Get the appname to look up in the exclusion or inclusion list.
-    if (GetCurrentModuleFileName(wszAppName) != S_OK)
+    if (GetCurrentExecutableFileName(wszAppName) != S_OK)
     {
         // Assume it is not on the exclusion list if we cannot find the module's filename.
         return FALSE;
@@ -380,7 +380,7 @@ HRESULT GetDebuggerSettingInfoWorker(_Out_writes_to_opt_(*pcchDebuggerString, *p
             long iValue;
 
             // Check DebugApplications setting
-            if ((SUCCEEDED(GetCurrentModuleFileName(wzAppName))) &&
+            if ((SUCCEEDED(GetCurrentExecutableFileName(wzAppName))) &&
                 (
                     GetRegistryLongValue(HKEY_LOCAL_MACHINE, kDebugApplicationsPoliciesKey, wzAppName, &iValue, TRUE) ||
                     GetRegistryLongValue(HKEY_LOCAL_MACHINE, kDebugApplicationsKey, wzAppName, &iValue, TRUE) ||

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -451,7 +451,7 @@ void BaseBucketParamsManager::GetAppName(_Out_writes_(maxLength) WCHAR* targetPa
     CONTRACTL_END;
 
     PathString appPath;
-    if (GetCurrentModuleFileName(appPath) == S_OK)
+    if (GetCurrentExecutableFileName(appPath) == S_OK)
     {
         // Get just the module name; remove the path
         const WCHAR* appName = u16_strrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
@@ -479,7 +479,7 @@ void BaseBucketParamsManager::GetAppVersion(_Out_writes_(maxLength) WCHAR* targe
     WCHAR verBuf[23] = {0};
     USHORT major, minor, build, revision;
 
-    if ((GetCurrentModuleFileName(appPath) == S_OK) && SUCCEEDED(DwGetFileVersionInfo(appPath, major, minor, build, revision)))
+    if ((GetCurrentExecutableFileName(appPath) == S_OK) && SUCCEEDED(DwGetFileVersionInfo(appPath, major, minor, build, revision)))
     {
         _snwprintf_s(targetParam,
             maxLength,


### PR DESCRIPTION
When loading the cDAC, we were relying on `GetClrModuleDirectory` in the DAC actually giving us the DAC directory. With https://github.com/dotnet/runtime/pull/106217, it explicitly stores/uses the CLR module base. When we first try to load the cDAC in the DAC, that has not yet been set. The current intent is to actually load from next to the DAC, so switch the logic to look next to the current module for the cDAC instead of using the CLR module directory.

Also renamed `GetCurrentModuleFileName` in utilcode to `GetCurrentExecutableFileName` so that it accurately represents what it does (I tried to use it and was sad).