### PR TITLE
[cdac] Change Module data descriptor for lookup maps

### DIFF
--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -25,7 +25,8 @@ record struct ModuleLookupTables(
     TargetPointer MemberRefToDesc,
     TargetPointer MethodDefToDesc,
     TargetPointer TypeDefToMethodTable,
-    TargetPointer TypeRefToMethodTable);
+    TargetPointer TypeRefToMethodTable,
+    TargetPointer MethodDefToILCodeVersioningState);
 
 internal struct EcmaMetadataSchema
 {
@@ -130,6 +131,7 @@ Data descriptors used:
 | `Module` | `TypeRefToMethodTableMap` | Mapping table |
 | `DynamicMetadata` | `Size` | Size of the dynamic metadata blob (as a 32bit uint) |
 | `DynamicMetadata` | `Data` | Start of dynamic metadata data array |
+| `ModuleLookupMap` | `TableData` | Start of the mapping table's data |
 
 ``` csharp
 ModuleHandle GetModuleHandle(TargetPointer modulePointer)
@@ -215,6 +217,8 @@ ModuleLookupTables GetLookupTables(ModuleHandle handle)
         MemberRefToDescMap: target.ReadPointer(handle.Address + /* Module::MemberRefToDescMap */),
         MethodDefToDescMap: target.ReadPointer(handle.Address + /* Module::MethodDefToDescMap */),
         TypeDefToMethodTableMap: target.ReadPointer(handle.Address + /* Module::TypeDefToMethodTableMap */),
-        TypeRefToMethodTableMap: target.ReadPointer(handle.Address + /* Module::TypeRefToMethodTableMap */));
+        TypeRefToMethodTableMap: target.ReadPointer(handle.Address + /* Module::TypeRefToMethodTableMap */),
+        MethodDefToILCodeVersioningState: target.ReadPointer(handle.Address + /*
+        Module::MethodDefToILCodeVersioningState */));
 }
 ```

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -227,7 +227,7 @@ CDAC_TYPE_FIELD(Module, /*pointer*/, MemberRefToDescMap, cdac_data<Module>::Memb
 CDAC_TYPE_FIELD(Module, /*pointer*/, MethodDefToDescMap, cdac_data<Module>::MethodDefToDescMap)
 CDAC_TYPE_FIELD(Module, /*pointer*/, TypeDefToMethodTableMap, cdac_data<Module>::TypeDefToMethodTableMap)
 CDAC_TYPE_FIELD(Module, /*pointer*/, TypeRefToMethodTableMap, cdac_data<Module>::TypeRefToMethodTableMap)
-CDAC_TYPE_FIELD(Module, /*pointer*/, MethodDefToILCodeVersioningState, cdac_data<Module>::MethodDefToILCodeVersioningState)
+CDAC_TYPE_FIELD(Module, /*pointer*/, MethodDefToILCodeVersioningStateMap, cdac_data<Module>::MethodDefToILCodeVersioningStateMap)
 CDAC_TYPE_END(Module)
 
 CDAC_TYPE_BEGIN(ModuleLookupMap)

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -227,7 +227,12 @@ CDAC_TYPE_FIELD(Module, /*pointer*/, MemberRefToDescMap, cdac_data<Module>::Memb
 CDAC_TYPE_FIELD(Module, /*pointer*/, MethodDefToDescMap, cdac_data<Module>::MethodDefToDescMap)
 CDAC_TYPE_FIELD(Module, /*pointer*/, TypeDefToMethodTableMap, cdac_data<Module>::TypeDefToMethodTableMap)
 CDAC_TYPE_FIELD(Module, /*pointer*/, TypeRefToMethodTableMap, cdac_data<Module>::TypeRefToMethodTableMap)
+CDAC_TYPE_FIELD(Module, /*pointer*/, MethodDefToILCodeVersioningState, cdac_data<Module>::MethodDefToILCodeVersioningState)
 CDAC_TYPE_END(Module)
+
+CDAC_TYPE_BEGIN(ModuleLookupMap)
+CDAC_TYPE_FIELD(ModuleLookupMap, /*pointer*/, TableData, offsetof(LookupMapBase, pTable))
+CDAC_TYPE_END(ModuleLookupMap)
 
 // RuntimeTypeSystem
 

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1647,7 +1647,7 @@ struct cdac_data<Module>
     static constexpr size_t MethodDefToDescMap = offsetof(Module, m_MethodDefToDescMap);
     static constexpr size_t TypeDefToMethodTableMap = offsetof(Module, m_TypeDefToMethodTableMap);
     static constexpr size_t TypeRefToMethodTableMap = offsetof(Module, m_TypeRefToMethodTableMap);
-    static constexpr size_t MethodDefToILCodeVersioningState = offsetof(Module, m_ILCodeVersioningStateMap);
+    static constexpr size_t MethodDefToILCodeVersioningStateMap = offsetof(Module, m_ILCodeVersioningStateMap);
 };
 
 //

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1641,12 +1641,13 @@ struct cdac_data<Module>
     static constexpr size_t DynamicMetadata = offsetof(Module, m_pDynamicMetadata);
 
     // Lookup map pointers
-    static constexpr size_t FieldDefToDescMap = offsetof(Module, m_FieldDefToDescMap) + offsetof(LookupMap<PTR_FieldDesc>, pTable);
-    static constexpr size_t ManifestModuleReferencesMap = offsetof(Module, m_ManifestModuleReferencesMap) + offsetof(LookupMap<PTR_Module>, pTable);
-    static constexpr size_t MemberRefToDescMap = offsetof(Module, m_MemberRefMap) + offsetof(LookupMap<TADDR>, pTable);
-    static constexpr size_t MethodDefToDescMap = offsetof(Module, m_MethodDefToDescMap) + offsetof(LookupMap<PTR_MethodDesc>, pTable);
-    static constexpr size_t TypeDefToMethodTableMap = offsetof(Module, m_TypeDefToMethodTableMap) + offsetof(LookupMap<PTR_MethodTable>, pTable);
-    static constexpr size_t TypeRefToMethodTableMap = offsetof(Module, m_TypeRefToMethodTableMap) + offsetof(LookupMap<PTR_TypeRef>, pTable);
+    static constexpr size_t FieldDefToDescMap = offsetof(Module, m_FieldDefToDescMap);
+    static constexpr size_t ManifestModuleReferencesMap = offsetof(Module, m_ManifestModuleReferencesMap);
+    static constexpr size_t MemberRefToDescMap = offsetof(Module, m_MemberRefMap);
+    static constexpr size_t MethodDefToDescMap = offsetof(Module, m_MethodDefToDescMap);
+    static constexpr size_t TypeDefToMethodTableMap = offsetof(Module, m_TypeDefToMethodTableMap);
+    static constexpr size_t TypeRefToMethodTableMap = offsetof(Module, m_TypeRefToMethodTableMap);
+    static constexpr size_t MethodDefToILCodeVersioningState = offsetof(Module, m_ILCodeVersioningStateMap);
 };
 
 //

--- a/src/native/managed/cdacreader/src/Contracts/Loader.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Loader.cs
@@ -29,7 +29,8 @@ internal record struct ModuleLookupTables(
     TargetPointer MemberRefToDesc,
     TargetPointer MethodDefToDesc,
     TargetPointer TypeDefToMethodTable,
-    TargetPointer TypeRefToMethodTable);
+    TargetPointer TypeRefToMethodTable,
+    TargetPointer MethodDefToILCodeVersioningState);
 
 internal struct EcmaMetadataSchema
 {

--- a/src/native/managed/cdacreader/src/Contracts/Loader_1.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Loader_1.cs
@@ -96,6 +96,6 @@ internal readonly struct Loader_1 : ILoader
             module.MethodDefToDescMap,
             module.TypeDefToMethodTableMap,
             module.TypeRefToMethodTableMap,
-            module.MethodDefToILCodeVersioningState);
+            module.MethodDefToILCodeVersioningStateMap);
     }
 }

--- a/src/native/managed/cdacreader/src/Contracts/Loader_1.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Loader_1.cs
@@ -95,6 +95,7 @@ internal readonly struct Loader_1 : ILoader
             module.MemberRefToDescMap,
             module.MethodDefToDescMap,
             module.TypeDefToMethodTableMap,
-            module.TypeRefToMethodTableMap);
+            module.TypeRefToMethodTableMap,
+            module.MethodDefToILCodeVersioningState);
     }
 }

--- a/src/native/managed/cdacreader/src/Data/Module.cs
+++ b/src/native/managed/cdacreader/src/Data/Module.cs
@@ -30,6 +30,7 @@ internal sealed class Module : IData<Module>
         MethodDefToDescMap = target.ReadPointer(address + (ulong)type.Fields[nameof(MethodDefToDescMap)].Offset);
         TypeDefToMethodTableMap = target.ReadPointer(address + (ulong)type.Fields[nameof(TypeDefToMethodTableMap)].Offset);
         TypeRefToMethodTableMap = target.ReadPointer(address + (ulong)type.Fields[nameof(TypeRefToMethodTableMap)].Offset);
+        MethodDefToILCodeVersioningState = target.ReadPointer(address + (ulong)type.Fields[nameof(MethodDefToILCodeVersioningState)].Offset);
     }
 
     public TargetPointer Assembly { get; init; }
@@ -45,6 +46,7 @@ internal sealed class Module : IData<Module>
     public TargetPointer MethodDefToDescMap { get; init; }
     public TargetPointer TypeDefToMethodTableMap { get; init; }
     public TargetPointer TypeRefToMethodTableMap { get; init; }
+    public TargetPointer MethodDefToILCodeVersioningState { get; init; }
 
     private TargetPointer _metadataStart = TargetPointer.Null;
     private ulong _metadataSize;

--- a/src/native/managed/cdacreader/src/Data/Module.cs
+++ b/src/native/managed/cdacreader/src/Data/Module.cs
@@ -30,7 +30,7 @@ internal sealed class Module : IData<Module>
         MethodDefToDescMap = target.ReadPointer(address + (ulong)type.Fields[nameof(MethodDefToDescMap)].Offset);
         TypeDefToMethodTableMap = target.ReadPointer(address + (ulong)type.Fields[nameof(TypeDefToMethodTableMap)].Offset);
         TypeRefToMethodTableMap = target.ReadPointer(address + (ulong)type.Fields[nameof(TypeRefToMethodTableMap)].Offset);
-        MethodDefToILCodeVersioningState = target.ReadPointer(address + (ulong)type.Fields[nameof(MethodDefToILCodeVersioningState)].Offset);
+        MethodDefToILCodeVersioningStateMap = target.ReadPointer(address + (ulong)type.Fields[nameof(MethodDefToILCodeVersioningStateMap)].Offset);
     }
 
     public TargetPointer Assembly { get; init; }
@@ -46,7 +46,7 @@ internal sealed class Module : IData<Module>
     public TargetPointer MethodDefToDescMap { get; init; }
     public TargetPointer TypeDefToMethodTableMap { get; init; }
     public TargetPointer TypeRefToMethodTableMap { get; init; }
-    public TargetPointer MethodDefToILCodeVersioningState { get; init; }
+    public TargetPointer MethodDefToILCodeVersioningStateMap { get; init; }
 
     private TargetPointer _metadataStart = TargetPointer.Null;
     private ulong _metadataSize;

--- a/src/native/managed/cdacreader/src/Data/ModuleLookupMap.cs
+++ b/src/native/managed/cdacreader/src/Data/ModuleLookupMap.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal sealed class ModuleLookupMap : IData<ModuleLookupMap>
+{
+    static ModuleLookupMap IData<ModuleLookupMap>.Create(Target target, TargetPointer address) => new ModuleLookupMap(target, address);
+
+    private ModuleLookupMap(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.ModuleLookupMap);
+
+        TableData = target.ReadPointer(address + (ulong)type.Fields[nameof(TableData)].Offset);
+
+    }
+
+    public TargetPointer TableData { get; init; }
+}

--- a/src/native/managed/cdacreader/src/Data/ModuleLookupMap.cs
+++ b/src/native/managed/cdacreader/src/Data/ModuleLookupMap.cs
@@ -12,7 +12,6 @@ internal sealed class ModuleLookupMap : IData<ModuleLookupMap>
         Target.TypeInfo type = target.GetTypeInfo(DataType.ModuleLookupMap);
 
         TableData = target.ReadPointer(address + (ulong)type.Fields[nameof(TableData)].Offset);
-
     }
 
     public TargetPointer TableData { get; init; }

--- a/src/native/managed/cdacreader/src/DataType.cs
+++ b/src/native/managed/cdacreader/src/DataType.cs
@@ -27,6 +27,7 @@ public enum DataType
     ExceptionInfo,
     RuntimeThreadLocals,
     Module,
+    ModuleLookupMap,
     MethodTable,
     EEClass,
     ArrayClass,

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -275,8 +275,8 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface2, 
             data->LoaderAllocator = contract.GetLoaderAllocator(handle);
             data->ThunkHeap = contract.GetThunkHeap(handle);
 
-            Target.TypeInfo looupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
-            ulong tableDataOffset = (ulong)looupMapTypeInfo.Fields[nameof(Data.ModuleLookupMap.TableData)].Offset;
+            Target.TypeInfo lookupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
+            ulong tableDataOffset = (ulong)lookupMapTypeInfo.Fields[nameof(Data.ModuleLookupMap.TableData)].Offset;
 
             Contracts.ModuleLookupTables tables = contract.GetLookupTables(handle);
             data->FieldDefToDescMap = tables.FieldDefToDesc + tableDataOffset;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -275,13 +275,16 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface2, 
             data->LoaderAllocator = contract.GetLoaderAllocator(handle);
             data->ThunkHeap = contract.GetThunkHeap(handle);
 
+            Target.TypeInfo looupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
+            ulong tableDataOffset = (ulong)looupMapTypeInfo.Fields[nameof(Data.ModuleLookupMap.TableData)].Offset;
+
             Contracts.ModuleLookupTables tables = contract.GetLookupTables(handle);
-            data->FieldDefToDescMap = tables.FieldDefToDesc;
-            data->ManifestModuleReferencesMap = tables.ManifestModuleReferences;
-            data->MemberRefToDescMap = tables.MemberRefToDesc;
-            data->MethodDefToDescMap = tables.MethodDefToDesc;
-            data->TypeDefToMethodTableMap = tables.TypeDefToMethodTable;
-            data->TypeRefToMethodTableMap = tables.TypeRefToMethodTable;
+            data->FieldDefToDescMap = tables.FieldDefToDesc + tableDataOffset;
+            data->ManifestModuleReferencesMap = tables.ManifestModuleReferences + tableDataOffset;
+            data->MemberRefToDescMap = tables.MemberRefToDesc + tableDataOffset;
+            data->MethodDefToDescMap = tables.MethodDefToDesc + tableDataOffset;
+            data->TypeDefToMethodTableMap = tables.TypeDefToMethodTable + tableDataOffset;
+            data->TypeRefToMethodTableMap = tables.TypeRefToMethodTable + tableDataOffset;
 
             // Always 0 - .NET no longer has these concepts
             data->dwModuleID = 0;


### PR DESCRIPTION
1. Add the MethodDefToILCodeVersioningState lookup map, too.

2. In future work (for example the SOS GetMethodDescData method) we will need to perform lookups in some of these lookup maps, so we will want the offsets of their Count and Next fields, not just a pointer to the table data.  Change the data descriptor to return the offsets of the LookupMap structs themselves, not their `pTable` member

3. Update SOSDacImpl.GetModuleData implementation to manually add the table data offset to the lookup map addresses that are used by that method.