### PR TITLE
Fix: SettingsProperty constructor ignores serializeAs parameter if it is not SettingsSerializeAs.Binary

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsProperty.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsProperty.cs
@@ -52,6 +52,10 @@ namespace System.Configuration
                     throw new NotSupportedException(Obsoletions.BinaryFormatterMessage);
                 }
             }
+            else
+            {
+                SerializeAs = serializeAs;
+            }
             Attributes = attributes;
             ThrowOnErrorDeserializing = throwOnErrorDeserializing;
             ThrowOnErrorSerializing = throwOnErrorSerializing;

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="System\Configuration\SettingsManageabilityAttributeTests.cs" />
     <Compile Include="System\Configuration\SettingsPropertyIsReadOnlyExceptionTests.cs" />
     <Compile Include="System\Configuration\SettingsPropertyNotFoundExceptionTests.cs" />
+    <Compile Include="System\Configuration\SettingsPropertyTests.cs" />
     <Compile Include="System\Configuration\SettingsPropertyWrongTypeExceptionTests.cs" />
     <Compile Include="System\Configuration\SmokeTest.cs" />
     <Compile Include="System\Configuration\StringUtilTests.cs" />
@@ -93,7 +94,7 @@
     <Compile Include="System\Configuration\UrlPathTests.cs" />
     <Compile Include="System\Configuration\ValidatiorUtilsTests.cs" />
     <Compile Include="System\Diagnostics\DiagnosticsTestData.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
-    <Compile Include="System\Diagnostics\TraceSourceConfigurationTests.cs"  Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Compile Include="System\Diagnostics\TraceSourceConfigurationTests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <Compile Include="System\Drawing\Configuration\SystemDrawingSectionTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingsPropertyTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingsPropertyTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Configuration;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class SettingsPropertyTests
+    {
+        [Fact]
+        public void SettingsProperty_WithNoArguments()
+        {
+            var settingsProperty = new SettingsProperty("TestName");
+            Assert.Equal("TestName", settingsProperty.Name);
+            Assert.False(settingsProperty.IsReadOnly);
+            Assert.Null(settingsProperty.DefaultValue);
+            Assert.Null(settingsProperty.PropertyType);
+            Assert.Equal(SettingsSerializeAs.String, settingsProperty.SerializeAs);
+            Assert.Null(settingsProperty.Provider);
+            Assert.NotNull(settingsProperty.Attributes);
+            Assert.False(settingsProperty.ThrowOnErrorDeserializing);
+            Assert.False(settingsProperty.ThrowOnErrorSerializing);
+        }
+
+        [Theory]
+        [InlineData(SettingsSerializeAs.String)]
+        [InlineData(SettingsSerializeAs.Xml)]
+        [InlineData(SettingsSerializeAs.ProviderSpecific)]
+        public void SettingsProperty_WithArguments(SettingsSerializeAs serializeAs)
+        {
+            var settingsProperty = new SettingsProperty(
+                "TestName",
+                typeof(string),
+                null,
+                true,
+                "TestDefaultValue",
+                serializeAs,
+                new SettingsAttributeDictionary(),
+                true,
+                false);
+            Assert.Equal("TestName", settingsProperty.Name);
+            Assert.True(settingsProperty.IsReadOnly);
+            Assert.Equal("TestDefaultValue", settingsProperty.DefaultValue);
+            Assert.Equal(typeof(string), settingsProperty.PropertyType);
+            Assert.Equal(serializeAs, settingsProperty.SerializeAs);
+            Assert.Null(settingsProperty.Provider);
+            Assert.NotNull(settingsProperty.Attributes);
+            Assert.True(settingsProperty.ThrowOnErrorDeserializing);
+            Assert.False(settingsProperty.ThrowOnErrorSerializing);
+        }
+    }
+}

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingsPropertyTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingsPropertyTests.cs
@@ -32,13 +32,13 @@ namespace System.ConfigurationTests
             var settingsProperty = new SettingsProperty(
                 "TestName",
                 typeof(string),
-                null,
-                true,
+                provider: null,
+                isReadOnly: true,
                 "TestDefaultValue",
                 serializeAs,
                 new SettingsAttributeDictionary(),
-                true,
-                false);
+                throwOnErrorDeserializing: true,
+                throwOnErrorSerializing: false);
             Assert.Equal("TestName", settingsProperty.Name);
             Assert.True(settingsProperty.IsReadOnly);
             Assert.Equal("TestDefaultValue", settingsProperty.DefaultValue);


### PR DESCRIPTION
As mentioned in the [issue](https://github.com/dotnet/runtime/issues/104732) the `SettingsProperty` constructor ignores `serializeAs` parameter if it is not `SettingsSerializeAs.Binary`, the regression caused by https://github.com/dotnet/runtime/pull/50531 which allows `BinaryFormatter` serialization only when an `AppContext` switch: `System.Configuration.ConfigurationManager.EnableUnsafeBinaryFormatterInPropertyValueSerialization` is set, and throws otherwise.

The current fix is setting the `SerializeAs` property with the `serializeAs` parameter when it is not `SettingsSerializeAs.Binary`, though we might want to remove the `AppContext` switch logic and throw for `SettingsSerializeAs.Binary` as now the `BinaryFormatter` is removed and accessing the property values throws `PlatformNotSupportedException` on serialization even if the switch is on. The related test `SerializeAndDeserializeWithSettingsSerializeAsBinary` now throws PNSE on VS, skipped when run from command line.

Fixes https://github.com/dotnet/runtime/issues/104732