### PR TITLE
JIT: Fix x86 VectorT_ToScalar(long) when SSE41 not available

### DIFF
--- a/src/coreclr/jit/simdashwintrinsic.cpp
+++ b/src/coreclr/jit/simdashwintrinsic.cpp
@@ -593,6 +593,18 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
             break;
         }
 
+#if defined(TARGET_X86)
+        case NI_VectorT_ToScalar:
+        {
+            if (varTypeIsLong(simdBaseType) && !compOpportunisticallyDependsOn(InstructionSet_SSE41))
+            {
+                return nullptr;
+            }
+
+            break;
+        }
+#endif // TARGET_X86
+
 #if defined(TARGET_XARCH)
         case NI_VectorT_GetElement:
         {
@@ -889,14 +901,6 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 
                 return op1;
             }
-
-#if defined(TARGET_X86)
-            if ((intrinsic == NI_VectorT_ToScalar) && varTypeIsLong(simdBaseType) &&
-                !compOpportunisticallyDependsOn(InstructionSet_SSE41))
-            {
-                return nullptr;
-            }
-#endif // TARGET_X86
 
             argType = JITtype2varType(strip(info.compCompHnd->getArgType(sig, argList, &argClass)));
             op1     = getArgForHWIntrinsic(argType, argClass);

--- a/src/coreclr/jit/simdashwintrinsic.cpp
+++ b/src/coreclr/jit/simdashwintrinsic.cpp
@@ -890,6 +890,14 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
                 return op1;
             }
 
+#if defined(TARGET_X86)
+            if ((intrinsic == NI_VectorT_ToScalar) && varTypeIsLong(simdBaseType) &&
+                !compOpportunisticallyDependsOn(InstructionSet_SSE41))
+            {
+                return nullptr;
+            }
+#endif // TARGET_X86
+
             argType = JITtype2varType(strip(info.compCompHnd->getArgType(sig, argList, &argClass)));
             op1     = getArgForHWIntrinsic(argType, argClass);
 
@@ -993,6 +1001,8 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 #if defined(TARGET_X86)
                     if (varTypeIsLong(simdBaseType))
                     {
+                        // We should have verified SSE41 was available above.
+                        assert(compIsaSupportedDebugOnly(InstructionSet_SSE41));
                         op2 = gtNewIconNode(0);
                         return gtNewSimdGetElementNode(retType, op1, op2, simdBaseJitType, simdSize);
                     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106143/Runtime_106143.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106143/Runtime_106143.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_106431
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static T M<T>(Vector<T> x) => (x + x).ToScalar();
+    
+    [Fact]
+    public static int Test()
+    {
+        ulong x = M(new Vector<ulong>(1));
+        return (int)x + 98;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106143/Runtime_106143.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106143/Runtime_106143.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When handling VectorT_ToScalar(long) on x86, ensure SSE41 is available; if not, resort to the software fallback.

Fixes #106143.