### PR TITLE
Make acquiring the loader module for a FnPtrTypeDesc a simple operation instead of a complex algorithm

### DIFF
--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -284,6 +284,7 @@ CDAC_TYPE_INDETERMINATE(FnPtrTypeDesc)
 CDAC_TYPE_FIELD(FnPtrTypeDesc, /*uint32*/, NumArgs, cdac_data<FnPtrTypeDesc>::NumArgs)
 CDAC_TYPE_FIELD(FnPtrTypeDesc, /*uint32*/, CallConv, cdac_data<FnPtrTypeDesc>::CallConv)
 CDAC_TYPE_FIELD(FnPtrTypeDesc, /*uint32*/, RetAndArgTypes, cdac_data<FnPtrTypeDesc>::RetAndArgTypes)
+CDAC_TYPE_FIELD(FnPtrTypeDesc, /*pointer*/, LoaderModule, cdac_data<FnPtrTypeDesc>::LoaderModule)
 CDAC_TYPE_END(FnPtrTypeDesc)
 
 CDAC_TYPE_BEGIN(DynamicMetadata)

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -2695,7 +2695,7 @@ TypeHandle ClassLoader::CreateTypeHandleForTypeKey(const TypeKey* pKey, AllocMem
         DWORD numArgs = pKey->GetNumArgs();
         BYTE* mem = (BYTE*) pamTracker->Track(pLoaderModule->GetAssembly()->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(FnPtrTypeDesc)) + S_SIZE_T(sizeof(TypeHandle)) * S_SIZE_T(numArgs)));
 
-        typeHnd = TypeHandle(new(mem)  FnPtrTypeDesc(pKey->GetCallConv(), numArgs, pKey->GetRetAndArgTypes()));
+        typeHnd = TypeHandle(new(mem)  FnPtrTypeDesc(pKey->GetCallConv(), numArgs, pKey->GetRetAndArgTypes(), pLoaderModule));
     }
     else
     {

--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -74,16 +74,7 @@ PTR_Module TypeDesc::GetLoaderModule()
     }
     else
     {
-        PTR_Module retVal = NULL;
-        BOOL fFail = FALSE;
-
-        _ASSERTE(GetInternalCorElementType() == ELEMENT_TYPE_FNPTR);
-        PTR_FnPtrTypeDesc asFnPtr = dac_cast<PTR_FnPtrTypeDesc>(this);
-        if (!fFail)
-        {
-            retVal = ClassLoader::ComputeLoaderModuleForFunctionPointer(asFnPtr->GetRetAndArgTypesPointer(), asFnPtr->GetNumArgs()+1);
-        }
-        return retVal;
+        return dac_cast<PTR_FnPtrTypeDesc>(this)->GetLoaderModule();
     }
 }
 

--- a/src/coreclr/vm/typedesc.h
+++ b/src/coreclr/vm/typedesc.h
@@ -416,7 +416,7 @@ class FnPtrTypeDesc : public TypeDesc
 public:
 #ifndef DACCESS_COMPILE
     FnPtrTypeDesc(BYTE callConv, DWORD numArgs, TypeHandle * retAndArgTypes, PTR_Module pLoaderModule)
-        : TypeDesc(ELEMENT_TYPE_FNPTR), m_NumArgs(numArgs), m_CallConv(callConv), m_pLoaderModule(pLoaderModule)
+        : TypeDesc(ELEMENT_TYPE_FNPTR), m_pLoaderModule(pLoaderModule), m_NumArgs(numArgs), m_CallConv(callConv)
     {
         LIMITED_METHOD_CONTRACT;
         for (DWORD i = 0; i <= numArgs; i++)
@@ -483,14 +483,14 @@ public:
 #endif //DACCESS_COMPILE
 
 protected:
+    // LoaderModule of the TypeDesc
+    PTR_Module m_pLoaderModule;
+
     // Number of arguments
     DWORD m_NumArgs;
 
     // Calling convention (actually just a single byte)
     DWORD m_CallConv;
-
-    // LoaderModule of the TypeDesc
-    PTR_Module m_pLoaderModule;
 
     // Return type first, then argument types
     TypeHandle m_RetAndArgTypes[1];

--- a/src/coreclr/vm/typedesc.h
+++ b/src/coreclr/vm/typedesc.h
@@ -415,8 +415,8 @@ class FnPtrTypeDesc : public TypeDesc
 
 public:
 #ifndef DACCESS_COMPILE
-    FnPtrTypeDesc(BYTE callConv, DWORD numArgs, TypeHandle * retAndArgTypes)
-        : TypeDesc(ELEMENT_TYPE_FNPTR), m_NumArgs(numArgs), m_CallConv(callConv)
+    FnPtrTypeDesc(BYTE callConv, DWORD numArgs, TypeHandle * retAndArgTypes, PTR_Module pLoaderModule)
+        : TypeDesc(ELEMENT_TYPE_FNPTR), m_NumArgs(numArgs), m_CallConv(callConv), m_pLoaderModule(pLoaderModule)
     {
         LIMITED_METHOD_CONTRACT;
         for (DWORD i = 0; i <= numArgs; i++)
@@ -469,6 +469,8 @@ public:
     BOOL IsExternallyVisible() const;
 #endif //DACCESS_COMPILE
 
+    PTR_Module GetLoaderModule() const { LIMITED_METHOD_DAC_CONTRACT; return m_pLoaderModule; }
+
 #ifdef DACCESS_COMPILE
     static ULONG32 DacSize(TADDR addr)
     {
@@ -487,6 +489,9 @@ protected:
     // Calling convention (actually just a single byte)
     DWORD m_CallConv;
 
+    // LoaderModule of the TypeDesc
+    PTR_Module m_pLoaderModule;
+
     // Return type first, then argument types
     TypeHandle m_RetAndArgTypes[1];
 
@@ -499,6 +504,7 @@ struct cdac_data<FnPtrTypeDesc>
     static constexpr size_t NumArgs = offsetof(FnPtrTypeDesc, m_NumArgs);
     static constexpr size_t RetAndArgTypes = offsetof(FnPtrTypeDesc, m_RetAndArgTypes);
     static constexpr size_t CallConv = offsetof(FnPtrTypeDesc, m_CallConv);
+    static constexpr size_t LoaderModule = offsetof(FnPtrTypeDesc, m_pLoaderModule);
 };
 
 #endif // TYPEDESC_H


### PR DESCRIPTION
Add the loader module as a simple field instead of requiring the logic to compute a loader module from first principles.