### PR TITLE
Add FreeBSD as valid test host.

### DIFF
--- a/src/coreclr/scripts/coreclr_arguments.py
+++ b/src/coreclr/scripts/coreclr_arguments.py
@@ -65,7 +65,7 @@ class CoreclrArguments:
 
         self.valid_arches = ["x64", "x86", "arm", "arm64", "loongarch64", "riscv64", "wasm"]
         self.valid_build_types = ["Debug", "Checked", "Release"]
-        self.valid_host_os = ["windows", "osx", "linux", "illumos", "solaris", "haiku", "browser", "android", "wasi"]
+        self.valid_host_os = ["windows", "osx", "linux", "illumos", "solaris", "haiku", "freebsd", "browser", "android", "wasi"]
 
         self.__initialize__(args)
 
@@ -175,7 +175,7 @@ class CoreclrArguments:
     def provide_default_host_os():
         """ Return a string representing the current host operating system.
 
-            Returns one of: linux, osx, windows, illumos, solaris, haiku
+            Returns one of: linux, osx, windows, illumos, solaris, haiku, freebsd
         """
 
         if sys.platform == "linux" or sys.platform == "linux2":
@@ -189,6 +189,8 @@ class CoreclrArguments:
             return 'illumos' if is_illumos else 'solaris'
         elif sys.platform == "haiku":
             return "haiku"
+        elif sys.platform.startswith("freebsd"):
+            return "freebsd"
         else:
             print("Unknown OS: %s" % sys.platform)
             sys.exit(1)

--- a/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
@@ -67,6 +67,7 @@ namespace TestLibrary
 
         public static bool IsWindows => OperatingSystem.IsWindows();
         public static bool IsLinux => OperatingSystem.IsLinux();
+        public static bool IsFreeBSD => OperatingSystem.IsFreeBSD();
         public static bool IsMacOSX => OperatingSystem.IsMacOS();
         public static bool IsWindows7 => IsWindows && Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 1;
         public static bool IsWindowsNanoServer => (!IsWindowsIoTCore && GetInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -150,7 +150,7 @@ namespace Profiler.Tests
             {
                 profilerName = $"{ProfilerName}.dll";
             }
-            else if (TestLibrary.Utilities.IsLinux)
+            else if ((TestLibrary.Utilities.IsLinux) || (TestLibrary.Utilities.IsFreeBSD))
             {
                 profilerName = $"lib{ProfilerName}.so";
             }

--- a/src/tests/profiler/eventpipe/reverse_startup.cs
+++ b/src/tests/profiler/eventpipe/reverse_startup.cs
@@ -125,7 +125,7 @@ namespace ReverseStartupTests
             {
                 profilerName = "Profiler.dll";
             }
-            else if (TestLibrary.Utilities.IsLinux)
+            else if ((TestLibrary.Utilities.IsLinux) || (TestLibrary.Utilities.IsFreeBSD))
             {
                 profilerName = "libProfiler.so";
             }

--- a/src/tests/profiler/unittest/releaseondetach.cs
+++ b/src/tests/profiler/unittest/releaseondetach.cs
@@ -23,7 +23,7 @@ namespace Profiler.Tests
             {
                 profilerName = "Profiler.dll";
             }
-            else if (TestLibrary.Utilities.IsLinux)
+            else if ((TestLibrary.Utilities.IsLinux) || (TestLibrary.Utilities.IsFreeBSD))
             {
                 profilerName = "libProfiler.so";
             }

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -607,7 +607,7 @@ def setup_coredump_generation(host_os):
     """
     global coredump_pattern
 
-    if host_os == "osx":
+    if host_os == "osx" or "freebsd":
         coredump_pattern = subprocess.check_output("sysctl -n kern.corefile", shell=True).rstrip()
     elif host_os == "linux":
         with open("/proc/sys/kernel/core_pattern", "r") as f:
@@ -683,7 +683,7 @@ def print_info_from_coredump_file(host_os, arch, coredump_name, executable_name)
 
     command = ""
 
-    if host_os == "osx":
+    if host_os == "osx" or "freebsd":
         command = "lldb -c %s -b -o 'bt all' -o 'disassemble -b -p'" % coredump_name
     elif host_os == "linux":
         command = "gdb --batch -ex \"thread apply all bt full\" -ex \"disassemble /r $pc\" -ex \"quit\" %s %s" % (executable_name, coredump_name)


### PR DESCRIPTION
This adds missing FreeBSD case to `coreclr_arguments.py` as a valid test host and adds FreeBSD to `run.py` 
Creates `TestLibrary.Utilities.IsFreeBSD` where needed for the remaining tests