### PR TITLE
Make the TimeProvider timer test reliable

### DIFF
--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -104,13 +104,13 @@ namespace Tests.System
 
         public static IEnumerable<object[]> TimersProvidersData()
         {
-            yield return new object[] { TimeProvider.System, 6000 };
-            yield return new object[] { new FastClock(),     3000 };
+            yield return new object[] { TimeProvider.System, 1200 }; // At least 4-periods of of 300ms
+            yield return new object[] { new FastClock(),     600  }; // At least 4-periods of of 150ms. fast clock cut time by half
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(TimersProvidersData))]
-        public void TestProviderTimer(TimeProvider provider, int MaxMilliseconds)
+        public void TestProviderTimer(TimeProvider provider, int minMilliseconds)
         {
             TimerState state = new TimerState();
 
@@ -122,8 +122,6 @@ namespace Tests.System
                                     {
                                         s.Counter++;
 
-                                        s.TotalTicks += DateTimeOffset.UtcNow.Ticks - s.UtcNow.Ticks;
-
                                         switch (s.Counter)
                                         {
                                             case 2:
@@ -132,12 +130,11 @@ namespace Tests.System
                                                 break;
 
                                             case 4:
+                                                s.Stopwatch.Stop();
                                                 s.TokenSource.Cancel();
                                                 s.Timer.Dispose();
                                                 break;
                                         }
-
-                                        s.UtcNow = DateTimeOffset.UtcNow;
                                     }
                                 },
                             state,
@@ -148,7 +145,7 @@ namespace Tests.System
 
             Assert.Equal(4, state.Counter);
             Assert.Equal(400, state.Period);
-            Assert.True(MaxMilliseconds >= state.TotalTicks / TimeSpan.TicksPerMillisecond, $"The total fired periods {state.TotalTicks / TimeSpan.TicksPerMillisecond}ms expected not exceeding the expected max {MaxMilliseconds}");
+            Assert.True(minMilliseconds <= state.Stopwatch.ElapsedMilliseconds, $"The total fired periods {state.Stopwatch.ElapsedMilliseconds}ms expected to be greater then the expected min {minMilliseconds}ms");
         }
 
         [Fact]
@@ -459,17 +456,16 @@ namespace Tests.System
             {
                 Counter = 0;
                 Period = 300;
-                TotalTicks = 0;
-                UtcNow = DateTimeOffset.UtcNow;
                 TokenSource = new CancellationTokenSource();
+                Stopwatch = new Stopwatch ();
+                Stopwatch.Start();
             }
 
             public CancellationTokenSource TokenSource { get; set; }
             public int Counter { get; set; }
             public int Period { get; set; }
-            public DateTimeOffset UtcNow { get; set; }
             public ITimer Timer { get; set; }
-            public long TotalTicks { get; set; }
+            public Stopwatch Stopwatch { get; set; }
         };
 
         // Clock that speeds up the reported time


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/103459