### PR TITLE
[mono][llvm] Fix alignment of local vars

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/LazyTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/LazyTests.cs
@@ -385,7 +385,6 @@ namespace System.Tests
             Assert.False(lazy.IsValueCreated);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void EnsureInitialized_SimpleRefTypes()
         {
@@ -417,7 +416,6 @@ namespace System.Tests
             Assert.Equal(strTemplate, d);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void EnsureInitialized_SimpleRefTypes_Invalid()
         {
@@ -430,7 +428,6 @@ namespace System.Tests
             Assert.Throws<MissingMemberException>(() => LazyInitializer.EnsureInitialized(ref ndc));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void EnsureInitialized_ComplexRefTypes()
         {
@@ -487,7 +484,6 @@ namespace System.Tests
             Assert.Null(LazyInitializer.EnsureInitialized(ref e, ref einit, ref elock, () => { initCount++; return null; }));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void EnsureInitialized_ComplexRefTypes_Invalid()
         {
@@ -498,7 +494,6 @@ namespace System.Tests
             Assert.Throws<MissingMemberException>(() => LazyInitializer.EnsureInitialized(ref ndc, ref ndcInit, ref ndcLock));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void LazyInitializerComplexValueTypes()
         {
@@ -553,7 +548,6 @@ namespace System.Tests
             VerifyLazy(lazyObject, 123, hasValue: true, isValueCreated: true);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void EnsureInitialized_FuncInitializationWithoutTrackingBool_Uninitialized()
         {
@@ -565,7 +559,6 @@ namespace System.Tests
             Assert.NotNull(syncLock);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void EnsureInitialized_FuncInitializationWithoutTrackingBool_Initialized()
         {
@@ -577,7 +570,6 @@ namespace System.Tests
             Assert.Null(syncLock);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/105251", TestPlatforms.tvOS)]
         [Fact]
         public static void EnsureInitializer_FuncInitializationWithoutTrackingBool_Null()
         {

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -2978,10 +2978,10 @@ build_named_alloca (EmitContext *ctx, MonoType *t, char const *name)
 
 	g_assert (!mini_is_gsharedvt_variable_type (t));
 
-	if (mini_class_is_simd (ctx->cfg, k))
-		align = mono_class_value_size (k, NULL);
+	if (mini_class_is_simd (ctx->cfg, k) && !m_type_is_byref (t))
+		align = mono_class_value_size (k, NULL); // FIXME mono_type_size should report correct alignment
 	else
-		align = mono_class_min_align (k);
+		mono_type_size (t, &align);
 
 	/* Sometimes align is not a power of 2 */
 	while (mono_is_power_of_two (align) == -1)


### PR DESCRIPTION
klass->min_align specifies the alignment required by the class fields. For example a class/struct containing an int64 will require a minimum alignment of 8 byte for its storage, while a a class/struct containing an int8 will require a 1 byte alignment. `build_named_alloca` is used to allocate storage for a local var of a certain type so using `klass->min_align` is incorrect. We should use `mono_type_size` instead, as this is used throughout the runtime for this purpose. A var of object type should have the alignment `sizeof (gpointer)` since it is a pointer, completely unrelated to the class field layout.

Should fix https://github.com/dotnet/runtime/issues/105251