### PR TITLE
Skip deeply-recursive test in `System.Runtime.Serialization.Xml.ReflectionOnly.Tests` if doing random OSR

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4478,6 +4478,7 @@ public static partial class DataContractSerializerTests
     }
 
     [SkipOnPlatform(TestPlatforms.Browser, "Causes a stack overflow")]
+    [SkipOnCoreClr("Random OSR can cause stack overflow", RuntimeTestModes.JitRandomOnStackReplacement)]
     [Fact]
     public static void DCS_DeeplyLinkedData()
     {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4478,7 +4478,6 @@ public static partial class DataContractSerializerTests
     }
 
     [SkipOnPlatform(TestPlatforms.Browser, "Causes a stack overflow")]
-    [SkipOnCoreClr("Random OSR can cause stack overflow", RuntimeTestModes.JitRandomOnStackReplacement)]
     [Fact]
     public static void DCS_DeeplyLinkedData()
     {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4477,8 +4477,11 @@ public static partial class DataContractSerializerTests
         Assert.NotNull(actual);
     }
 
+    // Random OSR might cause a stack overflow on Windows x64
+    private static bool IsNotWindowsRandomOSR => !PlatformDetection.IsWindows || (Environment.GetEnvironmentVariable("DOTNET_JitRandomOnStackReplacement") == null);
+
     [SkipOnPlatform(TestPlatforms.Browser, "Causes a stack overflow")]
-    [Fact]
+    [ConditionalFact(nameof(IsNotWindowsRandomOSR))]
     public static void DCS_DeeplyLinkedData()
     {
         TypeWithLinkedProperty head = new TypeWithLinkedProperty();

--- a/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
@@ -21,27 +21,28 @@ namespace Xunit
         JitStressRegs = 1 << 2, // DOTNET_JitStressRegs is set.
         JitMinOpts = 1 << 3, // DOTNET_JITMinOpts is set.
         TailcallStress = 1 << 4, // DOTNET_TailcallStress is set.
+        JitRandomOnStackReplacement = 1 << 5, // DOTNET_JitRandomOnStackReplacement is set.
 
         // DisableR2R says to not use ReadyToRun images.
         // This means we JIT everything.
-        DisableR2R = 1 << 5, // DOTNET_ReadyToRun=0
+        DisableR2R = 1 << 6, // DOTNET_ReadyToRun=0
 
         // GCStress3 forces a GC at various locations, typically transitions
         // to/from the VM from managed code.
-        GCStress3 = 1 << 6,  // DOTNET_GCStress includes mode 0x3.
+        GCStress3 = 1 << 7,  // DOTNET_GCStress includes mode 0x3.
 
         // GCStressC forces a GC at every JIT-generated code instruction,
         // including in NGEN/ReadyToRun code.
-        GCStressC = 1 << 7, // DOTNET_GCStress includes mode 0xC.
+        GCStressC = 1 << 8, // DOTNET_GCStress includes mode 0xC.
         AnyGCStress = GCStress3 | GCStressC, // Disable when any GCStress is exercised.
         // TieredCompilation is on by default, but can cause some tests to fail
         // As TieredCompilation is on by default, it does not count as a stress mode for RegularRun.
-        TieredCompilation = 1 << 8, // DOTNET_TieredCompilation (or COMPlus_TieredCompilation) is not set to 0.
+        TieredCompilation = 1 << 9, // DOTNET_TieredCompilation (or COMPlus_TieredCompilation) is not set to 0.
 
         AnyJitStress = JitStress | JitStressRegs | JitMinOpts | TailcallStress, // Disable when any JIT stress mode is exercised.
 
         AnyJitOptimizationStress = AnyJitStress | TieredCompilation, // Disable when any JIT non-full optimization stress mode is exercised.
 
-        HeapVerify = 1 << 9, // DOTNET_HeapVerify (or COMPlus_HeapVerify) is set.
+        HeapVerify = 1 << 10, // DOTNET_HeapVerify (or COMPlus_HeapVerify) is set.
     }
 }

--- a/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
@@ -21,28 +21,27 @@ namespace Xunit
         JitStressRegs = 1 << 2, // DOTNET_JitStressRegs is set.
         JitMinOpts = 1 << 3, // DOTNET_JITMinOpts is set.
         TailcallStress = 1 << 4, // DOTNET_TailcallStress is set.
-        JitRandomOnStackReplacement = 1 << 5, // DOTNET_JitRandomOnStackReplacement is set.
 
         // DisableR2R says to not use ReadyToRun images.
         // This means we JIT everything.
-        DisableR2R = 1 << 6, // DOTNET_ReadyToRun=0
+        DisableR2R = 1 << 5, // DOTNET_ReadyToRun=0
 
         // GCStress3 forces a GC at various locations, typically transitions
         // to/from the VM from managed code.
-        GCStress3 = 1 << 7,  // DOTNET_GCStress includes mode 0x3.
+        GCStress3 = 1 << 6,  // DOTNET_GCStress includes mode 0x3.
 
         // GCStressC forces a GC at every JIT-generated code instruction,
         // including in NGEN/ReadyToRun code.
-        GCStressC = 1 << 8, // DOTNET_GCStress includes mode 0xC.
+        GCStressC = 1 << 7, // DOTNET_GCStress includes mode 0xC.
         AnyGCStress = GCStress3 | GCStressC, // Disable when any GCStress is exercised.
         // TieredCompilation is on by default, but can cause some tests to fail
         // As TieredCompilation is on by default, it does not count as a stress mode for RegularRun.
-        TieredCompilation = 1 << 9, // DOTNET_TieredCompilation (or COMPlus_TieredCompilation) is not set to 0.
+        TieredCompilation = 1 << 8, // DOTNET_TieredCompilation (or COMPlus_TieredCompilation) is not set to 0.
 
         AnyJitStress = JitStress | JitStressRegs | JitMinOpts | TailcallStress, // Disable when any JIT stress mode is exercised.
 
         AnyJitOptimizationStress = AnyJitStress | TieredCompilation, // Disable when any JIT non-full optimization stress mode is exercised.
 
-        HeapVerify = 1 << 10, // DOTNET_HeapVerify (or COMPlus_HeapVerify) is set.
+        HeapVerify = 1 << 9, // DOTNET_HeapVerify (or COMPlus_HeapVerify) is set.
     }
 }


### PR DESCRIPTION
Fixes #100246. Disables test that frequently overflows the stack for OSR stress scenarios (see [comment](https://github.com/dotnet/runtime/issues/100246#issuecomment-2278801505) for discussion).