### PR TITLE
[mono][debugger] Fix evaluate method in a struct that doesn't need extra_space

### DIFF
--- a/src/mono/browser/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -841,5 +841,16 @@ namespace DebuggerTests
                await RuntimeEvaluateAndCheck(
                    ("myVar.MyMethod()", TNumber(10)));
            });
+        
+        // https://github.com/dotnet/runtime/issues/106311
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task EvaluateOnValueTypeWithoutExtraSpace() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateOnValueTypeWithoutExtraSpace", "run", 3, "DebuggerTests.EvaluateOnValueTypeWithoutExtraSpace.run",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateOnValueTypeWithoutExtraSpace:run'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               await RuntimeEvaluateAndCheck(
+                   ("f1.DistSquaredXY(f2)", TNumber(2)));
+           });
     }
 }

--- a/src/mono/browser/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/browser/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -2291,4 +2291,27 @@ namespace DebuggerTests
             myVar.MyMethod();
         }
     }
+
+    public struct EvaluateOnValueTypeWithoutExtraSpace
+    {
+        public double X;
+        public double Y;
+        public double Z;
+        public EvaluateOnValueTypeWithoutExtraSpace(float InX, float InY, float InZ)
+        {
+            X = InX; Y = InY; Z = InZ;
+        }
+        public double DistSquaredXY(in EvaluateOnValueTypeWithoutExtraSpace B) // the keyword "in" here is crucial, with it the crash produced
+        {
+            double DX = X - B.X;
+            double DY = Y - B.Y;
+            return DX * DX + DY * DY;
+        }
+        public static void run()
+        {
+            EvaluateOnValueTypeWithoutExtraSpace f1 = new EvaluateOnValueTypeWithoutExtraSpace(1, 1, 1);
+            EvaluateOnValueTypeWithoutExtraSpace f2 = new EvaluateOnValueTypeWithoutExtraSpace(2, 2, 2);
+            Console.WriteLine("pause here");
+        }
+    }
 }

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5696,8 +5696,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 {
 	ErrorCode err;
 
-	if (m_type_is_byref (t)) {
-		g_assert (extra_space != NULL && *extra_space != NULL);
+	if (m_type_is_byref (t) && extra_space != NULL && *extra_space != NULL) {
 		*(guint8**)addr = *extra_space; //assign the extra_space allocated for byref fields to the addr
 		guint8 *buf_int = buf;
 		addr = *(guint8**)addr; //dereference the pointer as it's a byref field


### PR DESCRIPTION
Fixes #106311 