### PR TITLE
Bump Windows MsQuic version to 2.4.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -218,7 +218,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>9.0.0-rc.1.24373.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.3.6</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.3</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>9.0.0-alpha.1.24167.3</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>19.0.0-alpha.1.24401.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>


### PR DESCRIPTION
This makes sure the new MsQuic is bundled with .NET Runtime on Windows in next .NET 9 release