### PR TITLE
[release/8.0-staging] Fix logging formatting

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -192,32 +192,26 @@ namespace Microsoft.Extensions.Logging
 #if NET8_0_OR_GREATER
         internal string Format<TArg0>(TArg0 arg0)
         {
-            object? arg0String = null;
             return
-                !TryFormatArgumentIfNullOrEnumerable(arg0, ref arg0String) ?
+                !TryFormatArgumentIfNullOrEnumerable(arg0, out object? arg0String) ?
                 string.Format(CultureInfo.InvariantCulture, _format, arg0) :
                 string.Format(CultureInfo.InvariantCulture, _format, arg0String);
         }
 
         internal string Format<TArg0, TArg1>(TArg0 arg0, TArg1 arg1)
         {
-            object? arg0String = null, arg1String = null;
             return
-                !TryFormatArgumentIfNullOrEnumerable(arg0, ref arg0String) &&
-                !TryFormatArgumentIfNullOrEnumerable(arg1, ref arg1String) ?
-                string.Format(CultureInfo.InvariantCulture, _format, arg0, arg1) :
-                string.Format(CultureInfo.InvariantCulture, _format, arg0String ?? arg0, arg1String ?? arg1);
-        }
+                TryFormatArgumentIfNullOrEnumerable(arg0, out object? arg0String) | TryFormatArgumentIfNullOrEnumerable(arg1, out object? arg1String) ?
+                string.Format(CultureInfo.InvariantCulture, _format, arg0String ?? arg0, arg1String ?? arg1) :
+                string.Format(CultureInfo.InvariantCulture, _format, arg0, arg1);
+       }
 
         internal string Format<TArg0, TArg1, TArg2>(TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
-            object? arg0String = null, arg1String = null, arg2String = null;
             return
-                !TryFormatArgumentIfNullOrEnumerable(arg0, ref arg0String) &&
-                !TryFormatArgumentIfNullOrEnumerable(arg1, ref arg1String) &&
-                !TryFormatArgumentIfNullOrEnumerable(arg2, ref arg2String) ?
-                string.Format(CultureInfo.InvariantCulture, _format, arg0, arg1, arg2) :
-                string.Format(CultureInfo.InvariantCulture, _format, arg0String ?? arg0, arg1String ?? arg1, arg2String ?? arg2);
+                TryFormatArgumentIfNullOrEnumerable(arg0, out object? arg0String) | TryFormatArgumentIfNullOrEnumerable(arg1, out object? arg1String) | TryFormatArgumentIfNullOrEnumerable(arg2, out object? arg2String) ?
+                string.Format(CultureInfo.InvariantCulture, _format, arg0String ?? arg0, arg1String ?? arg1, arg2String ?? arg2):
+                string.Format(CultureInfo.InvariantCulture, _format, arg0, arg1, arg2);
         }
 #else
         internal string Format(object? arg0) =>
@@ -259,11 +253,10 @@ namespace Microsoft.Extensions.Logging
 
         private static object FormatArgument(object? value)
         {
-            object? stringValue = null;
-            return TryFormatArgumentIfNullOrEnumerable(value, ref stringValue) ? stringValue : value!;
+            return TryFormatArgumentIfNullOrEnumerable(value, out object? stringValue) ? stringValue : value!;
         }
 
-        private static bool TryFormatArgumentIfNullOrEnumerable<T>(T? value, [NotNullWhen(true)] ref object? stringValue)
+        private static bool TryFormatArgumentIfNullOrEnumerable<T>(T? value, [NotNullWhen(true)] out object? stringValue)
         {
             if (value == null)
             {
@@ -290,6 +283,7 @@ namespace Microsoft.Extensions.Logging
                 return true;
             }
 
+            stringValue = null;
             return false;
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -5,8 +5,8 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>1</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>2</ServicingVersion>
     <PackageDescription>Logging abstractions for Microsoft.Extensions.Logging.
 
 Commonly Used Types:


### PR DESCRIPTION
Backport of #106283 to release/8.0-dtaging

/cc @tarekgh

## Customer Impact

Users of the .NET logging system may encounter incorrect log entries when attempting to log more than one collection argument. Instead of logging the individual values of the collection, the type name of the collection is logged. Examples of this issue can be found at https://github.com/dotnet/runtime/issues/103338.

*This is a regression in .NET 8.0*

## Details

We had some performance improvements in the logging formatting code that caused this regression.

## Testing

Passed the regression tests and added more tests to cover the failing cases.

## Risk

Low. This change only addresses the broken cases in the logging formatting code. It doesn't alter any logic; it simply ensures that collection formatting is corrected.

**IMPORTANT**: If this backport is for a servicing release, please verify that:
- The PR target branch is `release/X.0-staging`, not `release/X.0`.
- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
