### PR TITLE
Track generic instantiations in ILLink

### DIFF
--- a/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
@@ -54,7 +54,7 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		public static bool IsHoistedLocal (FieldDefinition field)
+		public static bool IsHoistedLocal (FieldReference field)
 		{
 			if (CompilerGeneratedNames.IsLambdaDisplayClass (field.DeclaringType.Name))
 				return true;

--- a/src/tools/illink/src/linker/Linker.Dataflow/FieldReferenceValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FieldReferenceValue.cs
@@ -5,8 +5,8 @@ using Mono.Cecil;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	public partial record FieldReferenceValue (FieldDefinition FieldDefinition)
-		: ReferenceValue (FieldDefinition.FieldType)
+	public partial record FieldReferenceValue (FieldReference Field)
+		: ReferenceValue (Field.FieldType)
 	{
 		public override SingleValue DeepCopy () => this;
 	}

--- a/src/tools/illink/src/linker/Linker.Dataflow/FieldValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FieldValue.cs
@@ -4,10 +4,9 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared.DataFlow;
+using Mono.Cecil;
 using Mono.Linker;
 using FieldReference = Mono.Cecil.FieldReference;
-using TypeReference = Mono.Cecil.TypeReference;
-
 
 namespace ILLink.Shared.TrimAnalysis
 {
@@ -19,8 +18,7 @@ namespace ILLink.Shared.TrimAnalysis
 	{
 		public FieldValue (FieldReference fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
-			var staticType = fieldToLoad.FieldType;
-			StaticType = staticType == null ? null : new (staticType);
+			StaticType = fieldToLoad.FieldType.InflateFrom (fieldToLoad.DeclaringType as IGenericInstance);
 			Field = fieldToLoad;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}

--- a/src/tools/illink/src/linker/Linker.Dataflow/FieldValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FieldValue.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared.DataFlow;
 using Mono.Linker;
-using FieldDefinition = Mono.Cecil.FieldDefinition;
+using FieldReference = Mono.Cecil.FieldReference;
 using TypeReference = Mono.Cecil.TypeReference;
 
 
@@ -17,14 +17,15 @@ namespace ILLink.Shared.TrimAnalysis
 	/// </summary>
 	internal sealed partial record FieldValue
 	{
-		public FieldValue (TypeReference? staticType, FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		public FieldValue (FieldReference fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
+			var staticType = fieldToLoad.FieldType;
 			StaticType = staticType == null ? null : new (staticType);
 			Field = fieldToLoad;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}
 
-		public readonly FieldDefinition Field;
+		public readonly FieldReference Field;
 
 		public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; }
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -707,7 +707,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 #pragma warning disable CA1822 // Mark members as static - Should be an instance method for consistency
 		internal partial MethodReturnValue GetMethodReturnValue (MethodProxy method, bool isNewObj, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
-			=> MethodReturnValue.Create (method.Definition, isNewObj, dynamicallyAccessedMemberTypes);
+			=> MethodReturnValue.Create (method, isNewObj, dynamicallyAccessedMemberTypes);
 #pragma warning restore CA1822 // Mark members as static
 
 		internal partial MethodReturnValue GetMethodReturnValue (MethodProxy method, bool isNewObj)

--- a/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -68,8 +68,11 @@ namespace ILLink.Shared.TrimAnalysis
 			return DynamicallyAccessedMemberTypes.None;
 		}
 
-		public DynamicallyAccessedMemberTypes GetFieldAnnotation (FieldDefinition field)
+		public DynamicallyAccessedMemberTypes GetFieldAnnotation (FieldReference fieldRef)
 		{
+			if (_context.TryResolve (fieldRef) is not FieldDefinition field)
+				return DynamicallyAccessedMemberTypes.None;
+
 			if (GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out var annotation))
 				return annotation.Annotation;
 
@@ -748,11 +751,11 @@ namespace ILLink.Shared.TrimAnalysis
 		}
 
 		// Trimming dataflow value creation. Eventually more of these should be shared.
-		internal SingleValue GetFieldValue (FieldDefinition field)
+		internal SingleValue GetFieldValue (FieldReference field)
 			=> field.Name switch {
 				"EmptyTypes" when field.DeclaringType.IsTypeOf (WellKnownType.System_Type) => ArrayValue.Create (0, field.DeclaringType),
 				"Empty" when field.DeclaringType.IsTypeOf (WellKnownType.System_String) => new KnownStringValue (string.Empty),
-				_ => new FieldValue (field.FieldType, field, GetFieldAnnotation (field))
+				_ => new FieldValue (field, GetFieldAnnotation (field))
 			};
 
 		internal SingleValue GetTypeValueFromGenericArgument (TypeReference genericArgument)

--- a/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -24,7 +24,6 @@ namespace ILLink.Shared.TrimAnalysis
 		readonly MarkStep _markStep;
 		readonly ReflectionMarker _reflectionMarker;
 		readonly MethodDefinition _callingMethodDefinition;
-		readonly MethodReference _calledMethodReference;
 
 		public HandleCallAction (
 			LinkContext context,
@@ -32,8 +31,7 @@ namespace ILLink.Shared.TrimAnalysis
 			MarkStep markStep,
 			ReflectionMarker reflectionMarker,
 			in DiagnosticContext diagnosticContext,
-			MethodDefinition callingMethodDefinition,
-			MethodReference calledMethodReference)
+			MethodDefinition callingMethodDefinition)
 		{
 			_context = context;
 			_operation = operation;
@@ -44,7 +42,6 @@ namespace ILLink.Shared.TrimAnalysis
 			_callingMethodDefinition = callingMethodDefinition;
 			_annotations = context.Annotations.FlowAnnotations;
 			_requireDynamicallyAccessedMembersAction = new (reflectionMarker, diagnosticContext);
-			_calledMethodReference = calledMethodReference;
 		}
 
 		private partial bool TryHandleIntrinsic (
@@ -55,7 +52,6 @@ namespace ILLink.Shared.TrimAnalysis
 			out MultiValue? methodReturnValue)
 		{
 			MultiValue? maybeMethodReturnValue = methodReturnValue = null;
-			Debug.Assert (calledMethod.Method == _calledMethodReference);
 
 			switch (intrinsicId) {
 			case IntrinsicId.None: {
@@ -77,7 +73,7 @@ namespace ILLink.Shared.TrimAnalysis
 				break;
 
 			case IntrinsicId.Array_Empty: {
-					AddReturnValue (ArrayValue.Create (0, ((GenericInstanceMethod) _calledMethodReference).GenericArguments[0]));
+					AddReturnValue (ArrayValue.Create (0, ((GenericInstanceMethod) calledMethod.Method).GenericArguments[0]));
 				}
 				break;
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -55,7 +55,7 @@ namespace ILLink.Shared.TrimAnalysis
 			out MultiValue? methodReturnValue)
 		{
 			MultiValue? maybeMethodReturnValue = methodReturnValue = null;
-			Debug.Assert (calledMethod.Method == _context.Resolve (_calledMethodReference));
+			Debug.Assert (calledMethod.Method == _calledMethodReference);
 
 			switch (intrinsicId) {
 			case IntrinsicId.None: {

--- a/src/tools/illink/src/linker/Linker.Dataflow/HoistedLocalKey.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/HoistedLocalKey.cs
@@ -13,9 +13,9 @@ namespace Mono.Linker.Dataflow
 	// or local functions).
 	public readonly struct HoistedLocalKey : IEquatable<HoistedLocalKey>
 	{
-		readonly FieldDefinition Field;
+		readonly FieldReference Field;
 
-		public HoistedLocalKey (FieldDefinition field)
+		public HoistedLocalKey (FieldReference field)
 		{
 			Debug.Assert (CompilerGeneratedState.IsHoistedLocal (field));
 			Field = field;

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -1057,9 +1057,9 @@ namespace Mono.Linker.Dataflow
 			int curBasicBlock,
 			ref InterproceduralState ipState)
 		{
-			if (_context.TryResolve (calledMethod) is MethodDefinition calledMethodDefinition) {
+			if (MethodProxy.TryCreate (calledMethod, _context, out MethodProxy? calledMethodProxy)) {
 				// We resolved the method and can put the ref/out values into the arguments
-				foreach (var parameter in calledMethodDefinition.GetParameters ()) {
+				foreach (var parameter in calledMethodProxy.Value.GetParameters ()) {
 					if (parameter.GetReferenceKind () is not (ReferenceKind.Ref or ReferenceKind.Out))
 						continue;
 					var newByRefValue = _context.Annotations.FlowAnnotations.GetMethodParameterValue (parameter);

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -866,7 +866,7 @@ namespace Mono.Linker.Dataflow
 					StoreMethodLocalValue (locals, source, localReference.LocalDefinition, curBasicBlock);
 					break;
 				case FieldReferenceValue fieldReference
-				when GetFieldValue (fieldReference.FieldDefinition).AsSingleValue () is FieldValue fieldValue:
+				when GetFieldValue (fieldReference.Field).AsSingleValue () is FieldValue fieldValue:
 					HandleStoreField (method, fieldValue, operation, source, parameterIndex);
 					break;
 				case ParameterReferenceValue parameterReference
@@ -897,7 +897,7 @@ namespace Mono.Linker.Dataflow
 
 		}
 
-		protected abstract MultiValue GetFieldValue (FieldDefinition field);
+		protected abstract MultiValue GetFieldValue (FieldReference field);
 
 		private void ScanLdfld (
 			Instruction operation,
@@ -911,7 +911,7 @@ namespace Mono.Linker.Dataflow
 
 			bool isByRef = code == Code.Ldflda || code == Code.Ldsflda;
 
-			FieldDefinition? field = _context.TryResolve ((FieldReference) operation.Operand);
+			FieldReference field = (FieldReference) operation.Operand;
 			if (field == null) {
 				PushUnknown (currentStack);
 				return;
@@ -1016,9 +1016,9 @@ namespace Mono.Linker.Dataflow
 				case FieldReferenceValue fieldReferenceValue:
 					dereferencedValue = MultiValue.Union (
 						dereferencedValue,
-						CompilerGeneratedState.IsHoistedLocal (fieldReferenceValue.FieldDefinition)
-							? interproceduralState.GetHoistedLocal (new HoistedLocalKey (fieldReferenceValue.FieldDefinition))
-							: GetFieldValue (fieldReferenceValue.FieldDefinition));
+						CompilerGeneratedState.IsHoistedLocal (fieldReferenceValue.Field)
+							? interproceduralState.GetHoistedLocal (new HoistedLocalKey (fieldReferenceValue.Field))
+							: GetFieldValue (fieldReferenceValue.Field));
 					break;
 				case ParameterReferenceValue parameterReferenceValue:
 					dereferencedValue = MultiValue.Union (

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodProxy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodProxy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Mono.Cecil;
 using Mono.Linker;
 
@@ -10,11 +11,28 @@ namespace ILLink.Shared.TypeSystemProxy
 {
 	internal readonly partial struct MethodProxy : IEquatable<MethodProxy>
 	{
-		public MethodProxy (MethodDefinition method) => Method = method;
+		public static bool TryCreate (MethodReference method, ITryResolveMetadata resolver, [NotNullWhen (true)] out MethodProxy? methodProxy)
+		{
+			if (resolver.TryResolve (method) is not MethodDefinition methodDef) {
+				methodProxy = null;
+				return false;
+			}
 
-		public static implicit operator MethodProxy (MethodDefinition method) => new (method);
+			methodProxy = new MethodProxy (method, methodDef);
+			return true;
+		}
 
-		public readonly MethodDefinition Method;
+		private MethodProxy (MethodReference method, MethodDefinition methodDef)
+		{
+			Method = method;
+			Definition = methodDef;
+		}
+
+		public static implicit operator MethodProxy (MethodDefinition method) => new (method, method);
+
+		public readonly MethodReference Method;
+
+		internal MethodDefinition Definition { get; }
 
 		public string Name { get => Method.Name; }
 
@@ -38,9 +56,9 @@ namespace ILLink.Shared.TypeSystemProxy
 		/// <summary>
 		/// Use only when iterating over all parameters. When wanting to index, use GetParameters(ParameterIndex)
 		/// </summary>
-		internal partial ParameterProxyEnumerable GetParameters () => Method.GetParameters ();
+		internal partial ParameterProxyEnumerable GetParameters () => Definition.GetParameters ();
 
-		internal partial ParameterProxy GetParameter (ParameterIndex index) => Method.GetParameter (index);
+		internal partial ParameterProxy GetParameter (ParameterIndex index) => Definition.GetParameter (index);
 
 		internal partial bool HasGenericParameters () => Method.HasGenericParameters;
 
@@ -59,9 +77,9 @@ namespace ILLink.Shared.TypeSystemProxy
 			return builder.ToImmutableArray ();
 		}
 
-		internal partial bool IsConstructor () => Method.IsConstructor;
+		internal partial bool IsConstructor () => Definition.IsConstructor;
 
-		internal partial bool IsStatic () => Method.IsStatic;
+		internal partial bool IsStatic () => Definition.IsStatic;
 
 		internal partial bool HasImplicitThis () => Method.HasImplicitThis ();
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodProxy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodProxy.cs
@@ -40,25 +40,25 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		internal partial bool IsDeclaredOnType (string fullTypeName) => Method.IsDeclaredOnType (fullTypeName);
 
-		internal partial bool HasMetadataParameters () => Method.HasMetadataParameters ();
+		internal partial bool HasMetadataParameters () => Definition.HasMetadataParameters ();
 
 		/// <summary>
 		/// Gets the number of entries in the 'Parameters' section of a method's metadata (i.e. excludes the implicit 'this' from the count)
 		/// </summary>
-		internal partial int GetMetadataParametersCount () => Method.GetMetadataParametersCount ();
+		internal partial int GetMetadataParametersCount () => Definition.GetMetadataParametersCount ();
 
 		/// <summary>
 		/// Returns the number of parameters that are passed to the method in IL (including the implicit 'this' parameter).
 		/// In pseudocode: <code>method.HasImplicitThis() ? 1 + MetadataParametersCount : MetadataParametersCount;</code>
 		/// </summary>
-		internal partial int GetParametersCount () => Method.GetParametersCount ();
+		internal partial int GetParametersCount () => Definition.GetParametersCount ();
 
 		/// <summary>
 		/// Use only when iterating over all parameters. When wanting to index, use GetParameters(ParameterIndex)
 		/// </summary>
 		internal partial ParameterProxyEnumerable GetParameters ()
 		{
-			return new ParameterProxyEnumerable (0, GetParametersCount (), this);
+			return new ParameterProxyEnumerable (0, Definition.GetParametersCount (), this);
 		}
 
 		internal partial ParameterProxy GetParameter (ParameterIndex index) => Definition.GetParameter (index);

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodProxy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodProxy.cs
@@ -56,7 +56,10 @@ namespace ILLink.Shared.TypeSystemProxy
 		/// <summary>
 		/// Use only when iterating over all parameters. When wanting to index, use GetParameters(ParameterIndex)
 		/// </summary>
-		internal partial ParameterProxyEnumerable GetParameters () => Definition.GetParameters ();
+		internal partial ParameterProxyEnumerable GetParameters ()
+		{
+			return new ParameterProxyEnumerable (0, GetParametersCount (), this);
+		}
 
 		internal partial ParameterProxy GetParameter (ParameterIndex index) => Definition.GetParameter (index);
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodReturnValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodReturnValue.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared.DataFlow;
+using ILLink.Shared.TypeSystemProxy;
 using Mono.Cecil;
 using Mono.Linker.Dataflow;
 using TypeReference = Mono.Cecil.TypeReference;
@@ -17,11 +18,11 @@ namespace ILLink.Shared.TrimAnalysis
 	/// </summary>
 	internal partial record MethodReturnValue
 	{
-		public static MethodReturnValue Create (MethodDefinition method, bool isNewObj, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		public static MethodReturnValue Create (MethodProxy method, bool isNewObj, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
-			Debug.Assert (!isNewObj || method.IsConstructor, "isNewObj can only be true for constructors");
-			var staticType = isNewObj ? method.DeclaringType : method.ReturnType;
-			return new MethodReturnValue (staticType, method, dynamicallyAccessedMemberTypes);
+			Debug.Assert (!isNewObj || method.Definition.IsConstructor, "isNewObj can only be true for constructors");
+			var staticType = isNewObj ? method.Method.DeclaringType : method.Method.ReturnType;
+			return new MethodReturnValue (staticType, method.Definition, dynamicallyAccessedMemberTypes);
 		}
 
 		private MethodReturnValue (TypeReference? staticType, MethodDefinition method, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodReturnValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodReturnValue.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared.DataFlow;
 using ILLink.Shared.TypeSystemProxy;
 using Mono.Cecil;
+using Mono.Linker;
 using Mono.Linker.Dataflow;
 using TypeReference = Mono.Cecil.TypeReference;
 
@@ -21,7 +22,8 @@ namespace ILLink.Shared.TrimAnalysis
 		public static MethodReturnValue Create (MethodProxy method, bool isNewObj, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Debug.Assert (!isNewObj || method.Definition.IsConstructor, "isNewObj can only be true for constructors");
-			var staticType = isNewObj ? method.Method.DeclaringType : method.Method.ReturnType;
+			var methodRef = method.Method;
+			var staticType = isNewObj ? methodRef.DeclaringType : methodRef.ReturnType.InflateFrom (methodRef as IGenericInstance ?? methodRef.DeclaringType as IGenericInstance);
 			return new MethodReturnValue (staticType, method.Definition, dynamicallyAccessedMemberTypes);
 		}
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/ParameterProxy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ParameterProxy.cs
@@ -43,7 +43,7 @@ namespace ILLink.Shared.TypeSystemProxy
 		public ICustomAttributeProvider GetCustomAttributeProvider ()
 		{
 			if (IsImplicitThis)
-				return Method.Method;
+				return Method.Definition;
 #pragma warning disable RS0030 // MethodReference.Parameters is banned -- this class provides wrappers to use
 			return Method.Method.Parameters[MetadataIndex];
 #pragma warning restore RS0030 // Do not used banned APIs

--- a/src/tools/illink/src/linker/Linker.Dataflow/ParameterProxy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ParameterProxy.cs
@@ -29,8 +29,10 @@ namespace ILLink.Shared.TypeSystemProxy
 				if (IsImplicitThis)
 					return Method.Method.DeclaringType;
 #pragma warning disable RS0030 // MethodReference.Parameters is banned -- this class provides wrappers to use
-				return Method.Method.Parameters[MetadataIndex].ParameterType;
-#pragma warning restore RS0030 // Do not used banned APIs
+				var method = Method.Method;
+				var genericInstance = method as IGenericInstance ?? method.DeclaringType as IGenericInstance;
+				return method.Parameters[MetadataIndex].ParameterType.InflateFrom (genericInstance);
+#pragma warning restore RS0030 // Do not use banned APIs
 			}
 		}
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/ParameterProxy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ParameterProxy.cs
@@ -38,7 +38,7 @@ namespace ILLink.Shared.TypeSystemProxy
 
 #pragma warning disable RS0030 // MethodReference.Parameters is banned -- this class provides wrappers to use
 		public partial string GetDisplayName () => IsImplicitThis ? "this"
-			: !string.IsNullOrEmpty (Method.Method.Parameters[MetadataIndex].Name) ? Method.Method.Parameters[MetadataIndex].Name
+			: !string.IsNullOrEmpty (Method.Definition.Parameters[MetadataIndex].Name) ? Method.Definition.Parameters[MetadataIndex].Name
 			: $"#{Index}";
 #pragma warning restore RS0030 // Do not used banned APIs
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMarker.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMarker.cs
@@ -118,9 +118,12 @@ namespace Mono.Linker.Dataflow
 			_markStep.MarkTypeVisibleToReflection (type, type, new DependencyInfo (dependencyKind, origin.Provider), origin);
 		}
 
-		internal void MarkMethod (in MessageOrigin origin, MethodDefinition method, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		internal void MarkMethod (in MessageOrigin origin, MethodReference methodRef, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
 		{
 			if (!_enabled)
+				return;
+
+			if (_context.TryResolve (methodRef) is not MethodDefinition method)
 				return;
 
 			_markStep.MarkMethodVisibleToReflection (method, new DependencyInfo (dependencyKind, origin.Provider), origin);

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -168,19 +168,22 @@ namespace Mono.Linker.Dataflow
 			MarkStep markStep)
 		{
 			var origin = diagnosticContext.Origin;
-			var calledMethodDefinition = context.TryResolve (calledMethod);
-			Debug.Assert (calledMethodDefinition != null);
+			if (!MethodProxy.TryCreate (calledMethod, context, out MethodProxy? calledMethodProxy)) {
+				Debug.Fail ("Should only be called for resolvable methods");
+				return UnknownValue.Instance;
+			}
+			var calledMethodDefinition = calledMethodProxy.Value.Definition;
 			var callingMethodDefinition = origin.Provider as MethodDefinition;
 			Debug.Assert (callingMethodDefinition != null);
 
 			bool requiresDataFlowAnalysis = context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (calledMethodDefinition);
 			bool isNewObj = operation.OpCode.Code == Code.Newobj;
-			var annotatedMethodReturnValue = context.Annotations.FlowAnnotations.GetMethodReturnValue (calledMethodDefinition, isNewObj);
+			var annotatedMethodReturnValue = context.Annotations.FlowAnnotations.GetMethodReturnValue (calledMethodProxy.Value, isNewObj);
 			Debug.Assert (requiresDataFlowAnalysis || annotatedMethodReturnValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.None);
 
 			var handleCallAction = new HandleCallAction (context, operation, markStep, reflectionMarker, diagnosticContext, callingMethodDefinition, calledMethod);
-			var intrinsicId = Intrinsics.GetIntrinsicIdForMethod (calledMethodDefinition);
-			if (!handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, intrinsicId, out MultiValue methodReturnValue))
+			var intrinsicId = Intrinsics.GetIntrinsicIdForMethod (calledMethodProxy.Value);
+			if (!handleCallAction.Invoke (calledMethodProxy.Value, instanceValue, argumentValues, intrinsicId, out MultiValue methodReturnValue))
 				throw new NotImplementedException ($"Unhandled intrinsic: {intrinsicId}");
 			return methodReturnValue;
 		}

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -91,7 +91,7 @@ namespace Mono.Linker.Dataflow
 		MethodParameterValue GetMethodParameterValue (ParameterProxy parameter, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 			=> _annotations.GetMethodParameterValue (parameter, dynamicallyAccessedMemberTypes);
 
-		protected override MultiValue GetFieldValue (FieldDefinition field) => _annotations.GetFieldValue (field);
+		protected override MultiValue GetFieldValue (FieldReference field) => _annotations.GetFieldValue (field);
 
 		protected override MethodReturnValue GetReturnValue (MethodDefinition method) => _annotations.GetMethodReturnValue (method, isNewObj: false);
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -181,7 +181,7 @@ namespace Mono.Linker.Dataflow
 			var annotatedMethodReturnValue = context.Annotations.FlowAnnotations.GetMethodReturnValue (calledMethodProxy.Value, isNewObj);
 			Debug.Assert (requiresDataFlowAnalysis || annotatedMethodReturnValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.None);
 
-			var handleCallAction = new HandleCallAction (context, operation, markStep, reflectionMarker, diagnosticContext, callingMethodDefinition, calledMethod);
+			var handleCallAction = new HandleCallAction (context, operation, markStep, reflectionMarker, diagnosticContext, callingMethodDefinition);
 			var intrinsicId = Intrinsics.GetIntrinsicIdForMethod (calledMethodProxy.Value);
 			if (!handleCallAction.Invoke (calledMethodProxy.Value, instanceValue, argumentValues, intrinsicId, out MultiValue methodReturnValue))
 				throw new NotImplementedException ($"Unhandled intrinsic: {intrinsicId}");

--- a/src/tools/illink/src/linker/Linker/MemberReferenceExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/MemberReferenceExtensions.cs
@@ -18,16 +18,12 @@ namespace Mono.Linker
 			case MethodReference method:
 				return method.GetDisplayName ();
 
-			case IMemberDefinition memberDef:
-				var sb = new StringBuilder ();
-				if (memberDef.DeclaringType != null)
-					sb.Append (memberDef.DeclaringType.GetDisplayName ()).Append ('.');
-				sb.Append (memberDef.Name);
-				return sb.ToString ();
-
 			default:
-				Debug.Assert (false, "The display name should not use cecil's signature format.");
-				return member.FullName;
+				var sb = new StringBuilder ();
+				if (member.DeclaringType != null)
+					sb.Append (member.DeclaringType.GetDisplayName ()).Append ('.');
+				sb.Append (member.Name);
+				return sb.ToString ();
 			}
 		}
 

--- a/src/tools/illink/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -111,7 +111,7 @@ namespace Mono.Linker
 		{
 			if (method.GetParametersCount () <= (int) index || (int) index < 0)
 				return null;
-			return new (new (method), index);
+			return new (method, index);
 		}
 
 		/// <summary>
@@ -131,8 +131,7 @@ namespace Mono.Linker
 		/// </summary>
 		internal static ParameterProxyEnumerable GetParameters (this MethodDefinition method)
 		{
-			int implicitThisOffset = method.HasImplicitThis () ? 1 : 0;
-			return new ParameterProxyEnumerable (0, method.Parameters.Count + implicitThisOffset, method);
+			return new ParameterProxyEnumerable (0, method.GetParametersCount (), method);
 		}
 
 		/// <summary>

--- a/src/tools/illink/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/MethodReferenceExtensions.cs
@@ -87,10 +87,10 @@ namespace Mono.Linker
 		public static TypeReference GetInflatedParameterType (this MethodReference method, int parameterIndex)
 		{
 #pragma warning disable RS0030 // MethodReference.Parameters is banned -- it's best to leave this as is for now
-			if (method.DeclaringType is GenericInstanceType genericInstance)
-				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.Parameters[parameterIndex].ParameterType);
-
-			return method.Parameters[parameterIndex].ParameterType;
+			IGenericInstance? genericInstance = method as IGenericInstance ?? method.DeclaringType as IGenericInstance;
+			if (genericInstance is null)
+				return method.Parameters[parameterIndex].ParameterType;
+			return TypeReferenceExtensions.InflateGenericType (genericInstance, method.Parameters[parameterIndex].ParameterType);
 #pragma warning restore RS0030 // Do not used banned APIs
 		}
 

--- a/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
@@ -155,7 +155,7 @@ namespace Mono.Linker
 					return;
 				// Get all explicit interfaces of this type
 				foreach (var iface in type.Interfaces) {
-					var interfaceType = iface.InterfaceType.InflateFrom (typeRef);
+					var interfaceType = iface.InterfaceType.InflateFrom (typeRef as IGenericInstance);
 					if (!firstImplementationChain.Any (i => TypeReferenceEqualityComparer.AreEqual (i.Item1, interfaceType, Context))) {
 						firstImplementationChain.Add ((interfaceType, pathToType.Append (iface).ToList ()));
 					}
@@ -163,7 +163,7 @@ namespace Mono.Linker
 
 				// Recursive interfaces after all direct interfaces to preserve Inherit/Implement tree order
 				foreach (var iface in type.Interfaces) {
-					var ifaceDirectlyOnType = iface.InterfaceType.InflateFrom (typeRef);
+					var ifaceDirectlyOnType = iface.InterfaceType.InflateFrom (typeRef as IGenericInstance);
 					AddRecursiveInterfaces (ifaceDirectlyOnType, pathToType.Append (iface), firstImplementationChain, Context);
 				}
 			}

--- a/src/tools/illink/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/TypeReferenceExtensions.cs
@@ -176,6 +176,7 @@ namespace Mono.Linker
 
 		public static TypeReference InflateGenericType (IGenericInstance genericInstanceProvider, TypeReference typeToInflate)
 		{
+			Debug.Assert (genericInstanceProvider is GenericInstanceType or GenericInstanceMethod);
 			if (typeToInflate is ArrayType arrayType) {
 				var inflatedElementType = InflateGenericType (genericInstanceProvider, arrayType.ElementType);
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
@@ -304,6 +304,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			static void GenericOutParameter<T> (out T value) => value = default;
 
+			[UnexpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101734")]
 			static void TestGenericMethodOutParameter ()
 			{
 				GenericOutParameter (out Annotated value);
@@ -326,6 +327,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				Generic<Annotated>.ReturnType ().GetType ().RequiresPublicFields ();
 			}
 
+			[UnexpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101734")]
 			static void TestGenericClassOutParameter ()
 			{
 				Generic<Annotated>.OutParameter (out var value);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
@@ -320,6 +320,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				public static T field;
 
 				public static T Property { get; }
+
+				public class Nested {
+					public static T ReturnType () => default;
+
+					public static void OutParameter (out T value) => value = default;
+
+					public static T field;
+
+					public static T Property { get; }
+				}
 			}
 
 			static void TestGenericClassReturnType ()
@@ -344,6 +354,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				Generic<Annotated>.Property.GetType ().RequiresPublicFields ();
 			}
 
+			static void TestNestedGenericClassReturnType ()
+			{
+				Generic<Annotated>.Nested.ReturnType ().GetType ().RequiresPublicFields ();
+			}
+
+			[UnexpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101734")]
+			static void TestNestedGenericClassOutParameter ()
+			{
+				Generic<Annotated>.Nested.OutParameter (out var value);
+				value.GetType ().RequiresPublicFields ();
+			}
+
+			static void TestNestedGenericClassField ()
+			{
+				Generic<Annotated>.Nested.field.GetType ().RequiresPublicFields ();
+			}
+
+			static void TestNestedGenericClassProperty ()
+			{
+				Generic<Annotated>.Nested.Property.GetType ().RequiresPublicFields ();
+			}
+
 			public static void Test ()
 			{
 				TestGenericMethodReturnType ();
@@ -352,6 +384,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestGenericClassOutParameter ();
 				TestGenericClassField ();
 				TestGenericClassProperty ();
+				TestNestedGenericClassReturnType ();
+				TestNestedGenericClassOutParameter ();
+				TestNestedGenericClassField ();
+				TestNestedGenericClassProperty ();
 			}
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
@@ -20,6 +20,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			EnumTypeSatisfiesPublicFields.Test ();
 			EnumConstraintSatisfiesPublicFields.Test ();
 			InstantiatedTypeParameterAsSource.Test ();
+			EnumerationOverInstances.Test ();
 		}
 
 		class SealedConstructorAsSource
@@ -349,6 +350,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestGenericClassOutParameter ();
 				TestGenericClassField ();
 				TestGenericClassProperty ();
+			}
+		}
+
+		class EnumerationOverInstances
+		{
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			class AnnotatedBase
+			{
+			}
+
+			class Derived : AnnotatedBase
+			{
+				public void Method () { }
+			}
+
+			static IEnumerable<AnnotatedBase> GetInstances () => new AnnotatedBase[] { new Derived () };
+
+			public static void Test ()
+			{
+				foreach (var instance in GetInstances ()) {
+					instance.GetType ().GetMethod ("Method");
+				}
 			}
 		}
 	}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1400,8 +1400,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptMember (".ctor()")]
 			class Derived : AnnotatedBase
 			{
-				// https://github.com/dotnet/runtime/issues/93719
-				// [Kept]
+				[Kept]
 				public void Method () { }
 			}
 
@@ -1409,7 +1408,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			static IEnumerable<AnnotatedBase> GetInstances () => new AnnotatedBase[] { new Derived () };
 
 			[Kept]
-			[UnexpectedWarning ("IL2075", nameof (Type.GetType), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93719")]
+			[UnexpectedWarning ("IL2075", nameof (Type.GetType), Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93719")]
 			public static void Test ()
 			{
 				foreach (var instance in GetInstances ()) {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1408,7 +1408,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			static IEnumerable<AnnotatedBase> GetInstances () => new AnnotatedBase[] { new Derived () };
 
 			[Kept]
-			[UnexpectedWarning ("IL2075", nameof (Type.GetType), Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93719")]
 			public static void Test ()
 			{
 				foreach (var instance in GetInstances ()) {


### PR DESCRIPTION
This changes ILLink's `MethodProxy`, `MethodReturnValue`, `ParameterProxy` (which provides the static type of `MethodParameterValue`), and `FieldValue` to track generic instantiations, whenever they refer to instantiated generic methods, or methods/fields on instantiated generic types.

To support this, the proxy types now store `MethodReference`/`FieldReference` instead of `MethodDefinition`/`FieldDefinition`. The cecil object model doesn't automatically "inflate" parameter/return-value/field types, so this includes logic to do the generic substitution in our proxy types.

`MethodProxy` provides information that's only available on cecil's `MethodDefinition`, so it has been changed to store both a `MethodReference` and the resolved `MethodDefinition`.

The logic to inflate generic types is extended to include support for types that use method generic parameters.

It may be helpful to review commit-by-commit.

Fixes https://github.com/dotnet/runtime/issues/105345
Fixes https://github.com/dotnet/runtime/issues/93719