### PR TITLE
Fix Enum field type bug found when underlying type is set from assembly loaded with MLC

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
@@ -303,4 +303,7 @@
   <data name="InvalidOperation_UnmatchingSymScope" xml:space="preserve">
     <value>Unmatching symbol scope.</value>
   </data>
+  <data name="Argument_MustBeEnum" xml:space="preserve">
+    <value>Type provided must be an Enum.</value>
+  </data>
 </root>

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/EnumBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/EnumBuilderImpl.cs
@@ -71,7 +71,7 @@ namespace System.Reflection.Emit
 
         public override Type? ReflectedType => _typeBuilder.ReflectedType;
 
-        public override Type UnderlyingSystemType => GetEnumUnderlyingType();
+        public override Type UnderlyingSystemType => this;
 
         public override Type GetEnumUnderlyingType() => _underlyingField.FieldType;
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -601,7 +601,7 @@ namespace System.Reflection.Emit
             }
 
             EmitOpcode(opcode);
-            UpdateStackSize(GetStackChange(opcode, methodInfo, optionalParameterTypes));
+            UpdateStackSize(GetStackChange(opcode, methodInfo, _moduleBuilder.GetTypeFromCoreAssembly(CoreTypeId.Void), optionalParameterTypes));
             if (optionalParameterTypes == null || optionalParameterTypes.Length == 0)
             {
                 WriteOrReserveToken(_moduleBuilder.TryGetMethodHandle(methodInfo), methodInfo);
@@ -613,12 +613,12 @@ namespace System.Reflection.Emit
             }
         }
 
-        private static int GetStackChange(OpCode opcode, MethodInfo methodInfo, Type[]? optionalParameterTypes)
+        private static int GetStackChange(OpCode opcode, MethodInfo methodInfo, Type voidType, Type[]? optionalParameterTypes)
         {
             int stackChange = 0;
 
             // Push the return value if there is one.
-            if (methodInfo.ReturnType != typeof(void))
+            if (methodInfo.ReturnType != voidType)
             {
                 stackChange++;
             }
@@ -665,7 +665,7 @@ namespace System.Reflection.Emit
                 }
             }
 
-            int stackChange = GetStackChange(returnType, parameterTypes);
+            int stackChange = GetStackChange(returnType, _moduleBuilder.GetTypeFromCoreAssembly(CoreTypeId.Void), parameterTypes);
 
             // Pop off VarArg arguments.
             if (optionalParameterTypes != null)
@@ -685,17 +685,17 @@ namespace System.Reflection.Emit
 
         public override void EmitCalli(OpCode opcode, CallingConvention unmanagedCallConv, Type? returnType, Type[]? parameterTypes)
         {
-            int stackChange = GetStackChange(returnType, parameterTypes);
+            int stackChange = GetStackChange(returnType, _moduleBuilder.GetTypeFromCoreAssembly(CoreTypeId.Void), parameterTypes);
             UpdateStackSize(stackChange);
             Emit(OpCodes.Calli);
             _il.Token(_moduleBuilder.GetSignatureToken(unmanagedCallConv, returnType, parameterTypes));
         }
 
-        private static int GetStackChange(Type? returnType, Type[]? parameterTypes)
+        private static int GetStackChange(Type? returnType, Type voidType, Type[]? parameterTypes)
         {
             int stackChange = 0;
             // If there is a non-void return type, push one.
-            if (returnType != typeof(void))
+            if (returnType != voidType)
             {
                 stackChange++;
             }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ParameterBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ParameterBuilderImpl.cs
@@ -32,8 +32,6 @@ namespace System.Reflection.Emit
 
         public override void SetConstant(object? defaultValue)
         {
-            Type parameterType = _position == 0 ? _methodBuilder.ReturnType : _methodBuilder.ParameterTypes![_position - 1];
-            FieldBuilderImpl.ValidateDefaultValueType(defaultValue, parameterType);
             _defaultValue = defaultValue;
             _attributes |= ParameterAttributes.HasDefault;
         }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/PropertyBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/PropertyBuilderImpl.cs
@@ -57,7 +57,6 @@ namespace System.Reflection.Emit
         protected override void SetConstantCore(object? defaultValue)
         {
             _containingType.ThrowIfCreated();
-            FieldBuilderImpl.ValidateDefaultValueType(defaultValue, _propertyType);
             _defaultValue = defaultValue;
         }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -305,7 +305,6 @@ namespace System.Reflection.Emit
         {
             ThrowIfCreated();
 
-
             MethodBuilderImpl methodBuilder = new(name, attributes, callingConvention, returnType, returnTypeRequiredCustomModifiers,
                 returnTypeOptionalCustomModifiers, parameterTypes, parameterTypeRequiredCustomModifiers, parameterTypeOptionalCustomModifiers, _module, this);
             _methodDefinitions.Add(methodBuilder);
@@ -616,23 +615,22 @@ namespace System.Reflection.Emit
         public override string? Namespace => _namespace;
         public override Assembly Assembly => _module.Assembly;
         public override Module Module => _module;
-        public override Type UnderlyingSystemType
-        {
-            get
-            {
-                if (IsEnum)
-                {
-                    if (_enumUnderlyingType == null)
-                    {
-                        throw new InvalidOperationException(SR.InvalidOperation_NoUnderlyingTypeOnEnum);
-                    }
+        public override Type UnderlyingSystemType => this;
 
-                    return _enumUnderlyingType;
-                }
-                else
+        public override Type GetEnumUnderlyingType()
+        {
+            if (IsEnum)
+            {
+                if (_enumUnderlyingType == null)
                 {
-                    return this;
+                    throw new InvalidOperationException(SR.InvalidOperation_NoUnderlyingTypeOnEnum);
                 }
+
+                return _enumUnderlyingType;
+            }
+            else
+            {
+                throw new ArgumentException(SR.Argument_MustBeEnum);
             }
         }
         public override bool IsSZArray => false;

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveEnumBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveEnumBuilderTests.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.Emit.Tests
             yield return new object[] { typeof(uint), (uint)1 };
 
             yield return new object[] { typeof(int), 0 };
-            yield return new object[] { typeof(int), 1 };
+            yield return new object[] { typeof(int), Test.Second };
 
             yield return new object[] { typeof(ulong), (ulong)0 };
             yield return new object[] { typeof(ulong), (ulong)1 };

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveEnumBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveEnumBuilderTests.cs
@@ -100,7 +100,7 @@ namespace System.Reflection.Emit.Tests
                 PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(PopulateAssemblyName(), mlc.CoreAssembly);
                 ModuleBuilder mb = ab.DefineDynamicModule("My Module");
                 Type intType = mlc.CoreAssembly.GetType("System.Int32");
-                EnumBuilder enumBuilder = mb.DefineEnum("TestEnum", TypeAttributes.Public, typeof(int));
+                EnumBuilder enumBuilder = mb.DefineEnum("TestEnum", TypeAttributes.Public, intType);
                 FieldBuilder field = enumBuilder.DefineLiteral("Default", 0);
 
                 enumBuilder.CreateTypeInfo();
@@ -118,7 +118,7 @@ namespace System.Reflection.Emit.Tests
 
                 FieldInfo testField = createdEnum.GetField("Default");
                 Assert.Equal(createdEnum, testField.FieldType);
-                Assert.Equal(typeof(int), enumBuilder.GetEnumUnderlyingType());
+                Assert.Equal(intType, enumBuilder.GetEnumUnderlyingType());
                 Assert.Equal(FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, testField.Attributes);
             }
         }


### PR DESCRIPTION
`EnumBuilder.UnderlyingSystemType`, currently [returns](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/EnumBuilderImpl.cs#L74-L76) `GetEnumUnderlyingType()` which returns `_underlyingField.FieldType` underneath. Because [Type.Equals](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Type.cs#L675) checks `UnderlyingSystemType` for equality when the `EnumBuilder` underlying type is set from MLC Core assembly it is causing issue for enum fields defined, for example:
```cs
Type intType = mlc.CoreAssembly.GetType("System.Int32");
EnumBuilder enumBuilder = mb.DefineEnum("TestEnum", TypeAttributes.Public, intType);
FieldBuilder field = enumBuilder.DefineLiteral("Default", 0);
 ```
In this case the `field` type should be `TestEnum`, but it is evaluated to be equal to `System.Int32` when writing the field signature on Save. I think we should not return underlying field type for `EnumBuilder.UnderlyingSystemType`, should probably return the Enum itself instead (runtime enums returns the enum type itself). Though the `EnumBuilder.GetEnumUnderlyingType()` method should keep returning the underlying field type.

Related to https://github.com/dotnet/runtime/pull/105903