### PR TITLE
wasm-mt: Fix Environment.ProcessorCount ILLink substitution to 1

### DIFF
--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -139,6 +139,7 @@
 
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml" Condition="Exists('$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml')" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.iOS.xml" Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" />
+    <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.wasm.singlethread.xml" Condition="'$(Platform)' == 'wasm' and '$(FeatureWasmManagedThreads)' != 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.Intrinsics.x86.xml" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.Intrinsics.Vectors.xml" />
 

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.wasm.singlethread.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.wasm.singlethread.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Environment">
+      <method signature="System.Int32 get_ProcessorCount()" body="stub" value="1" />
+    </type>
+  </assembly>
+</linker>

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.wasm.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.wasm.xml
@@ -1,8 +1,5 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
-    <type fullname="System.Environment">
-      <method signature="System.Int32 get_ProcessorCount()" body="stub" value="1" />
-    </type>
     <type fullname="System.Runtime.CompilerServices.RuntimeFeature">
       <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="false" />
     </type>


### PR DESCRIPTION
On multi-threaded wasm we shouldn't be hardcoding the processor count to 1, we can rely on the runtime to report the correct value.