### PR TITLE
JIT: Disallow separate CSE candidates for struct `GT_COMMA`s

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_106380/Runtime_106380.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106380/Runtime_106380.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+// Reduced from 24.98 KB to 779 B.
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using Xunit;
+
+public class Runtime_106380
+{
+    static Vector64<uint> s_v64_uint_23 = Vector64<uint>.AllBitsSet;
+    Vector64<uint> v64_uint_74 = Vector64.Create((uint)2, 2);
+    private void Method0()
+    {
+        unchecked
+        {
+            AdvSimd.MaxPairwise(v64_uint_74 += Vector64.ConditionalSelect(Vector64<uint>.Zero, s_v64_uint_23, s_v64_uint_23) & v64_uint_74, v64_uint_74 += (s_v64_uint_23 ^ v64_uint_74)& (s_v64_uint_23 = v64_uint_74));
+            return;
+        }
+    }
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        new Runtime_106380().Method0();
+    }
+}
+
+/*
+Environment:
+
+set DOTNET_TieredCompilation=0
+
+Assert failure(PID 13404 [0x0000345c], Thread: 5136 [0x1410]): Assertion failed 'type != TYP_VOID' in 'TestClass:Method0():this' during 'Optimize Valnum CSEs' (IL size 111; hash 0x46e9aa75; FullOpts)
+    File: C:\wk\runtime\src\coreclr\jit\gentree.cpp:8388
+    Image: C:\aman\Core_Root\corerun.exe
+*/

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106380/Runtime_106380.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106380/Runtime_106380.cs
@@ -22,7 +22,10 @@ public class Runtime_106380
     [Fact]
     public static void TestEntryPoint()
     {
-        new Runtime_106380().Method0();
+        if (AdvSimd.IsSupported)
+        {
+            new Runtime_106380().Method0();
+        }
     }
 }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106380/Runtime_106380.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106380/Runtime_106380.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
CSE normally creates candidates based on the normal VN of trees.
However, there is an exception for `GT_COMMA` nodes, where the
`GT_COMMA` itself creates a candidate with its op1 exceptions, while the
op2 then creates the usual "normal VN" candidate.

This can be problematic for `TYP_STRUCT` typed trees. In the JIT we do
not have a first class representation for `TYP_STRUCT` temporaries,
meaning that these always are restricted in what their immediate user
is. `gtNewTempStore` thus needs special logic to keep this invariant
satisfied; one of those special cases is that for `GT_COMMA`, instead of
creating the store with the comma as the source, we sink the store into
the `op2` recursively so that we end up with the store immediately next
to the node that produces the struct value. This is ok since we are
storing to a new local anyway, so there can't be interference with the
op1's of the commas we skipped into.

This, however, causes problems for CSE with the `GT_COMMA` special case
above. If we end up CSE'ing the outer comma we will create a definition
that is sunk into `op2` of the comma. If that `op2` is itself as `COMMA`
that was a CSE candidate, then once we get to that candidate it no
longer has an IR shape that produces a value, and we thus cannot create
a CSE definition. The fix is to avoid creating separate CSE candidates
for struct-typed commas.

Fix #106380

#91586 is a better long term solution. I think to make that happen we should allow struct temporaries in HIR/LIR and have lowering figure out how to insert proper locals when it sees interference for struct LIR edges. That should be much better since there are many `varTypeIsStruct(x)` trees that actually do have first class handling in the backend, for example multi-reg and SIMD nodes.