### PR TITLE
Expose QUIC TLS details on QuicConnection.

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -31,6 +31,7 @@ namespace System.Net.Quic
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public System.Net.Security.TlsCipherSuite NegotiatedCipherSuite { get { throw null; } }
+        public System.Security.Authentication.SslProtocols SslProtocol { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
         public string TargetHostName { get { throw null; } }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -29,6 +29,8 @@ namespace System.Net.Quic
         public static bool IsSupported { get { throw null; } }
         public System.Net.IPEndPoint LocalEndPoint { get { throw null; } }
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
+        [System.CLSCompliantAttribute(false)]
+        public System.Net.Security.TlsCipherSuite NegotiatedCipherSuite { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
         public string TargetHostName { get { throw null; } }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -287,6 +287,24 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// </summary>
     public SslApplicationProtocol NegotiatedApplicationProtocol => _negotiatedApplicationProtocol;
 
+    /// <summary>
+    /// Negotiated TLS cipher suite
+    /// </summary>
+    [CLSCompliant(false)]
+    public TlsCipherSuite NegotiatedCipherSuite
+    {
+        get
+        {
+            QUIC_HANDSHAKE_INFO info;
+            unsafe
+            {
+                MsQuicHelpers.GetMsQuicParameter(_handle, QUIC_PARAM_TLS_HANDSHAKE_INFO, (uint)sizeof(QUIC_HANDSHAKE_INFO), (byte*)&info);
+            }
+
+            return (TlsCipherSuite)info.CipherSuite;
+        }
+    }
+
     /// <inheritdoc />
     public override string ToString() => _handle.ToString();
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Channels;
@@ -217,6 +218,10 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// Set when CONNECTED is received.
     /// </summary>
     private TlsCipherSuite _negotiatedCipherSuite;
+    /// <summary>
+    /// Set when CONNECTED is received.
+    /// </summary>
+    private SslProtocols _negotiatedSslProtocol;
 
     /// <summary>
     /// Will contain TLS secret after CONNECTED event is received and store it into SSLKEYLOGFILE.
@@ -296,6 +301,11 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// </summary>
     [CLSCompliant(false)]
     public TlsCipherSuite NegotiatedCipherSuite => _negotiatedCipherSuite;
+
+    /// <summary>
+    /// Gets a <see cref="System.Security.Authentication.SslProtocols"/> value that indicates the security protocol used to authenticate this connection.
+    /// </summary>
+    public SslProtocols SslProtocol => _negotiatedSslProtocol;
 
     /// <inheritdoc />
     public override string ToString() => _handle.ToString();
@@ -626,6 +636,11 @@ public sealed partial class QuicConnection : IAsyncDisposable
             QUIC_CIPHER_SUITE.TLS_AES_256_GCM_SHA384 => TlsCipherSuite.TLS_AES_256_GCM_SHA384,
             QUIC_CIPHER_SUITE.TLS_CHACHA20_POLY1305_SHA256 => TlsCipherSuite.TLS_CHACHA20_POLY1305_SHA256,
             _ => default
+        };
+        _negotiatedSslProtocol = info.TlsProtocolVersion switch
+        {
+            QUIC_TLS_PROTOCOL_VERSION.TLS_1_3 => SslProtocols.Tls13,
+            _ => SslProtocols.None
         };
 
         QuicAddr remoteAddress = MsQuicHelpers.GetMsQuicParameter<QuicAddr>(_handle, QUIC_PARAM_CONN_REMOTE_ADDRESS);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicInteropTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicInteropTests.cs
@@ -70,5 +70,17 @@ namespace System.Net.Quic.Tests
                 Assert.False(settings.Equals((QUIC_SETTINGS)boxed), $"Member {member.Name} is not compared.");
             }
         }
+
+        [Fact]
+        public void MsQuicCipherSuites_MapTo_TlsCipherSuite()
+        {
+            foreach (QUIC_CIPHER_SUITE msQuicCipherSuite in Enum.GetValues<QUIC_CIPHER_SUITE>())
+            {
+                // both QUIC_CIPHER_SUITE and TlsCipherSuite members use the IANA identifiers of the TLS cipher suites, check that their values match
+                TlsCipherSuite cipherSuite = (TlsCipherSuite)msQuicCipherSuite;
+                // if same numerical value maps to the same enum member, the ToString() should be the same
+                Assert.Equal(msQuicCipherSuite.ToString(), cipherSuite.ToString());
+            }
+        }
     }
 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,10 +48,13 @@ namespace System.Net.Quic.Tests
                 // https://github.com/microsoft/msquic/issues/3813
                 Assert.Equal(clientConnection.LocalEndPoint, serverConnection.RemoteEndPoint);
             }
-            Assert.Equal(ApplicationProtocol.ToString(), clientConnection.NegotiatedApplicationProtocol.ToString());
-            Assert.Equal(ApplicationProtocol.ToString(), serverConnection.NegotiatedApplicationProtocol.ToString());
             Assert.Equal(options.ClientAuthenticationOptions.TargetHost, clientConnection.TargetHostName);
             Assert.Equal(options.ClientAuthenticationOptions.TargetHost, serverConnection.TargetHostName);
+
+            Assert.Equal(clientConnection.NegotiatedCipherSuite, serverConnection.NegotiatedCipherSuite);
+            Assert.True(clientConnection.NegotiatedCipherSuite ==  TlsCipherSuite.TLS_AES_128_GCM_SHA256 ||
+                        clientConnection.NegotiatedCipherSuite == TlsCipherSuite.TLS_AES_256_GCM_SHA384 ||
+                        clientConnection.NegotiatedCipherSuite == TlsCipherSuite.TLS_CHACHA20_POLY1305_SHA256);
         }
 
         private static async Task<QuicStream> OpenAndUseStreamAsync(QuicConnection c)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,9 +53,12 @@ namespace System.Net.Quic.Tests
             Assert.Equal(options.ClientAuthenticationOptions.TargetHost, serverConnection.TargetHostName);
 
             Assert.Equal(clientConnection.NegotiatedCipherSuite, serverConnection.NegotiatedCipherSuite);
-            Assert.True(clientConnection.NegotiatedCipherSuite ==  TlsCipherSuite.TLS_AES_128_GCM_SHA256 ||
+            Assert.True(clientConnection.NegotiatedCipherSuite == TlsCipherSuite.TLS_AES_128_GCM_SHA256 ||
                         clientConnection.NegotiatedCipherSuite == TlsCipherSuite.TLS_AES_256_GCM_SHA384 ||
                         clientConnection.NegotiatedCipherSuite == TlsCipherSuite.TLS_CHACHA20_POLY1305_SHA256);
+
+            Assert.Equal(clientConnection.SslProtocol, serverConnection.SslProtocol);
+            Assert.Equal(SslProtocols.Tls13, clientConnection.SslProtocol); // only TLS 1.3 is defined for QUIC at the moment
         }
 
         private static async Task<QuicStream> OpenAndUseStreamAsync(QuicConnection c)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -49,6 +49,9 @@ namespace System.Net.Quic.Tests
                 // https://github.com/microsoft/msquic/issues/3813
                 Assert.Equal(clientConnection.LocalEndPoint, serverConnection.RemoteEndPoint);
             }
+            Assert.Equal(ApplicationProtocol.ToString(), clientConnection.NegotiatedApplicationProtocol.ToString());
+            Assert.Equal(ApplicationProtocol.ToString(), serverConnection.NegotiatedApplicationProtocol.ToString());
+
             Assert.Equal(options.ClientAuthenticationOptions.TargetHost, clientConnection.TargetHostName);
             Assert.Equal(options.ClientAuthenticationOptions.TargetHost, serverConnection.TargetHostName);
 


### PR DESCRIPTION
Alternative to #106368
Implements #70184.

Since TLS state is dropped by MsQuic after handshake since it is no longer needed, we need to retrieve TLS info during the CONNECTED event (as we do for negotiated ALPN)

cc: @wfurt 