### PR TITLE
[Tar] Fill in the file size even if the file is empty.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -629,7 +629,7 @@ namespace System.Formats.Tar
                 checksum += FormatNumeric(_gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
             }
 
-            if (_size > 0)
+            if (_size >= 0)
             {
                 checksum += FormatNumeric(_size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -629,7 +629,7 @@ namespace System.Formats.Tar
                 checksum += FormatNumeric(_gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
             }
 
-            if (_size >= 0)
+            if (_dataStream != null && _size >= 0)
             {
                 checksum += FormatNumeric(_size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
             }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -355,9 +355,9 @@ namespace System.Formats.Tar.Tests
         [Fact]
         void Verify_Size_RegularFile_Empty()
         {
-            MemoryStream emptyData = new(0);
-            MemoryStream output = new();
-            TarWriter archive = new(output, TarEntryFormat.Pax);
+            using MemoryStream emptyData = new(0);
+            using MemoryStream output = new();
+            using TarWriter archive = new(output, TarEntryFormat.Pax);
             PaxTarEntry te = new(TarEntryType.RegularFile, "zero_size")
             { DataStream = emptyData };
             archive.WriteEntry(te);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -349,6 +350,21 @@ namespace System.Formats.Tar.Tests
             // Pax BlockDevice: 655 + 1004 + 686 = 2345
             // Gnu BlockDevice: 623 + 1004 + 686 + 1142 = 3455
             return checksum;
+        }
+
+        [Fact]
+        void Verify_Size_RegularFile_Empty()
+        {
+            MemoryStream emptyData = new(0);
+            MemoryStream output = new();
+            TarWriter archive = new(output, TarEntryFormat.Pax);
+            PaxTarEntry te = new(TarEntryType.RegularFile, "zero_size")
+            { DataStream = emptyData };
+            archive.WriteEntry(te);
+            var sizeBuffer = output.GetBuffer()[1148..(1148 + 12)];
+            // we expect ocal zeros
+            byte[] expected = [0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0];
+            Assert.True(sizeBuffer.SequenceEqual(expected));
         }
     }
 }


### PR DESCRIPTION
This matches standard behavior.
See #95354