### PR TITLE
Disable stackoverflowtester test for osx-x64

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -421,6 +421,9 @@
 
     <!-- OSX x64 on CoreCLR Runtime -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsOSX)' == 'true' and '$(TargetArchitecture)' == 'x64' and '$(RuntimeFlavor)' == 'coreclr' ">
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">
+            <Issue>https://github.com/dotnet/runtime/issues/84911</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/simple/ParallelCrashMainThread/*">
             <Issue>https://github.com/dotnet/runtime/issues/80356</Issue>
         </ExcludeList>


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/84911