### PR TITLE
[GC] Allow distribute_free_regions to decommit and redistribute

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -13419,13 +13419,14 @@ void gc_heap::distribute_free_regions()
 
         ptrdiff_t balance = total_num_free_regions[kind] + num_huge_region_units_to_consider[kind] - total_budget_in_region_units[kind];
 
+        // first check if we should decommit any regions
         if ((balance > 0)
 #ifdef BACKGROUND_GC
             && (!background_running_p() || (settings.condemned_generation == max_generation))
 #endif
             )
         {
-            // Ignore young huge regions if they are contributing to a surplus.
+            // ignore young huge regions when determining how much to decommit
             num_regions_to_decommit[kind] =
                 max(static_cast<ptrdiff_t>(0),
                     (balance - static_cast<ptrdiff_t>(num_young_huge_region_units_to_consider[kind])));


### PR DESCRIPTION
In #105521, the number of regions to be decommitted can be reduced, but the budgets weren't updated to include the new regions.  This was fine for huge regions, which just sit in the global free list anyway, and it (sort of) works in release builds (though some regions may end up decommitted anyway if they are still in the surplus list at the end of distribution), but it isn't the intended behavior and can trigger a debug assertion that the surplus list is empty.

This change (a subset of #106168), restructures distribute_free_regions so that instead of "decommit or adjust budgets", we first decommit and adjust the remaining balance.  Then we adjust budgets based on the new value.