### PR TITLE
Fix metrics size regression

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -7,6 +7,9 @@
       <method signature="System.Boolean IsEnabled(System.Diagnostics.Tracing.EventLevel,System.Diagnostics.Tracing.EventKeywords)" body="stub" value="false" />
       <method signature="System.Boolean IsEnabled(System.Diagnostics.Tracing.EventLevel,System.Diagnostics.Tracing.EventKeywords,System.Diagnostics.Tracing.EventChannel)" body="stub" value="false" />
     </type>
+    <type fullname="System.Diagnostics.Tracing.EventSource" feature="System.Diagnostics.Metrics.Meter.IsSupported" featurevalue="false">
+      <method signature="System.Boolean get_IsMeterSupported()" body="stub" value="false" />
+    </type>
     <type fullname="System.Diagnostics.StackTrace" feature="System.Diagnostics.StackTrace.IsSupported" featurevalue="false">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -230,6 +230,11 @@ namespace System.Diagnostics.Tracing
         private static bool InitializeIsSupported() =>
             AppContext.TryGetSwitch("System.Diagnostics.Tracing.EventSource.IsSupported", out bool isSupported) ? isSupported : true;
 
+        internal static bool IsMeterSupported { get; } = InitializeIsMeterSupported();
+
+        private static bool InitializeIsMeterSupported() =>
+            AppContext.TryGetSwitch("System.Diagnostics.Metrics.Meter.IsSupported", out bool isSupported) ? isSupported : true;
+
 #if FEATURE_EVENTSOURCE_XPLAT
 #pragma warning disable CA1823 // field is used to keep listener alive
         private static readonly EventListener? persistent_Xplat_Listener = IsSupported ? XplatEventLogger.InitializePersistentListener() : null;
@@ -3831,7 +3836,7 @@ namespace System.Diagnostics.Tracing
             // Functionally we could preregister NativeRuntimeEventSource and RuntimeEventSource as well, but it may not provide
             // much benefit. The main benefit for MetricsEventSource is that the app may never use it and it defers
             // pulling the System.Diagnostics.DiagnosticSource assembly into the process until it is needed.
-            if (AppContext.TryGetSwitch("System.Diagnostics.Metrics.Meter.IsSupported", out bool isSupported) ? isSupported : true)
+            if (IsMeterSupported)
             {
                 const string name = "System.Diagnostics.Metrics";
                 Guid id = new Guid("20752bc4-c151-50f5-f27b-df92d8af5a61");


### PR DESCRIPTION
When adding the startup init for runtime metrics recently I only used a dynamic check for the System.Diagnostics.Metrics.Meter.IsSupported AppContext flag. This had the right runtime behavior but couldn't be statically analyzed by ILLink so size was larger than necessary. Using a property the linker can be aware of should allow the code to be trimmed once again.