### PR TITLE
Reorder asserts in `TypeBuilderState`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -355,10 +355,10 @@ namespace Internal.Runtime.TypeLoader
                     else
                     {
                         Debug.Assert(TypeBeingBuilt.RetrieveRuntimeTypeHandleIfPossible() ||
-                             TypeBeingBuilt.IsTemplateCanonical() ||
                              (TypeBeingBuilt is PointerType) ||
                              (TypeBeingBuilt is ByRefType) ||
-                             (TypeBeingBuilt is FunctionPointerType));
+                             (TypeBeingBuilt is FunctionPointerType) ||
+                             TypeBeingBuilt.IsTemplateCanonical());
                         _instanceGCLayout = s_emptyLayout;
                     }
                 }


### PR DESCRIPTION
A newly added System.Reflection.Metadata test does `typeof(Nullable<>).MakeByRefType()`.

We:

1. Actually attemt to build a `MethodTable` for this. I guess it's fine to make a `MethodTable` for it.
2. Hit an assert because we're trying to obtain a type loader template for this.

Address 2 by reordering asserts so that we never try to look for template types of pointers/byrefs/function pointers.

Cc @dotnet/ilc-contrib 