### PR TITLE
Bump versioning to .NET 10

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,8 @@
     <SdkBandVersionForWorkload_FromRuntimeVersions>$(SdkBandVersion)$(WorkloadVersionSuffix)</SdkBandVersionForWorkload_FromRuntimeVersions>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->
-    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <!-- Temporarily hard-code to 9.0.0.0. We can't version forward the Assembly Version without updating the TFM in dotnet/runtime. -->
+    <AssemblyVersion>9.0.0.0</AssemblyVersion>
     <!-- Opt-in/out repo features -->
     <UsingToolIbcOptimization>false</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,16 +1,16 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>9.0.0</ProductVersion>
+    <ProductVersion>10.0.0</ProductVersion>
     <!-- File version numbers -->
-    <MajorVersion>9</MajorVersion>
+    <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>9.0.100</SdkBandVersion>
     <PackageVersionNet8>8.0.8</PackageVersionNet8>
     <PackageVersionNet7>7.0.20</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet8)').Build),25))</PackageVersionNet6>
-    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>


### PR DESCRIPTION

Here's what we did last year: https://github.com/dotnet/runtime/pull/90558/files?diff=unified&w=1

We will need to make Version.Details.xml changes after emsdk and arcade update their darc versions.

### IMPORTANT!

Do not merge until after the RC1 snap.
