### PR TITLE
[cdac] Fix ThreadStoreData finalizer and GC thread

### DIFF
--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -88,8 +88,8 @@ internal readonly struct Thread_1 : IThread
         return new ThreadStoreData(
             threadStore.ThreadCount,
             GetThreadFromLink(threadStore.FirstThreadLink),
-            _target.ReadGlobalPointer(Constants.Globals.FinalizerThread),
-            _target.ReadGlobalPointer(Constants.Globals.GCThread));
+            _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.FinalizerThread)),
+            _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.GCThread)));
     }
 
     ThreadStoreCounts IThread.GetThreadCounts()


### PR DESCRIPTION
Actually read the pointer when populating `ThreadStoreData`