### PR TITLE
Avoid compiler crash when `UsageBasedMetadataGenerationOptions.CompleteTypesOnly` is specified

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -77,9 +77,11 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         try
                         {
-                            // Make sure we're not adding a method to the dependency graph that is going to
-                            // cause trouble down the line. This entire type would not actually load on CoreCLR anyway.
-                            LibraryRootProvider.CheckCanGenerateMethod(method);
+                            // Spot check by parsing signature.
+                            // Previously we had LibraryRootProvider.CheckCanGenerateMethod(method) here, but that one
+                            // expects fully instantiated types and methods. We operate on definitions here.
+                            // This is not as thorough as it could be. This option is unsupported anyway.
+                            _ = method.Signature;
                         }
                         catch (TypeSystemException)
                         {


### PR DESCRIPTION
Fixes #106439.

This is an unsupported flag that allows generating unusable metadata for type members that would have been trimmed. This is useful when troubleshooting trimming issues for people who ignore trimming warnings because it converts random `NullReferenceException` (e.g. `GetMethod` returned null and the program didn't check for it) into "Foo.Bar wasn't generated" exceptions.

Because this isn't tested, we regressed this. The code that checks whether it's possible to generate the metadata for the member at all stopped working for uninstantiated generics. This check is needed to deal with invalid input IL.

Cc @dotnet/ilc-contrib 