### PR TITLE
[apple-mobile] Disable TLSWitLoadedDlls for Apple mobile due to missing native libs

### DIFF
--- a/src/tests/JIT/Directed/tls/TestTLSWithLoadedDlls.csproj
+++ b/src/tests/JIT/Directed/tls/TestTLSWithLoadedDlls.csproj
@@ -4,6 +4,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
     <NativeAotIncompatible>true</NativeAotIncompatible>
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/92129 -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Disable TLSWitLoadedDlls tests for Apple mobile due to missing native libs https://github.com/dotnet/runtime/issues/92129.

This is likely the cause of JIT_Directed failures happening since 08/08/2024 https://dev.azure.com/dnceng-public/public/_build/results?buildId=769464&view=results. The tests were introduced in https://github.com/dotnet/runtime/pull/106052 and the failures didn't get caught because the tests are run only on `runtime-extra-platforms` pipeline.