### PR TITLE
Add missing compile item in System.Net.WebSockets.Client.Wasm.Tests.csproj

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/wasm/System.Net.WebSockets.Client.Wasm.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/wasm/System.Net.WebSockets.Client.Wasm.Tests.csproj
@@ -34,12 +34,14 @@
              Link="Common\System\Net\Configuration.WebSockets.cs" />
     <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs"
              Link="Common\System\Net\EventSourceTestLogging.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Http\GenericLoopbackServer.cs"
+             Link="Common\System\Net\Http\GenericLoopbackServer.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackProxyServer.cs"
              Link="Common\System\Net\Http\LoopbackProxyServer.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs"
              Link="Common\System\Net\Http\LoopbackServer.cs" />
-    <Compile Include="$(CommonTestPath)System\Net\Http\GenericLoopbackServer.cs"
-             Link="Common\System\Net\Http\GenericLoopbackServer.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Http\TestHelper.cs"
+             Link="Common\System\Net\Http\TestHelper.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
              Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
     <Compile Include="..\ClientWebSocketTestBase.cs" />


### PR DESCRIPTION
Fixes:

```
C:\git\runtime3> .\dotnet.cmd build src\libraries\System.Net.WebSockets.Client\tests\wasm\System.Net.WebSockets.Client.Wasm.Tests.csproj /bl

  Determining projects to restore...
  All projects are up-to-date for restore.
  TestUtilities -> C:\git\runtime3\artifacts\bin\TestUtilities\Debug\net8.0\TestUtilities.dll
C:\git\runtime3\src\libraries\Common\tests\System\Net\Http\GenericLoopbackServer.cs(15,23): error CS0234: The type or namespace name 'Functional' does not exist in the
 namespace 'System.Net.Http' (are you missing an assembly reference?) [C:\git\runtime3\src\libraries\System.Net.WebSockets.Client\tests\wasm\System.Net.WebSockets.Clie
nt.Wasm.Tests.csproj]
C:\git\runtime3\src\libraries\Common\tests\System\Net\Http\GenericLoopbackServer.cs(26,68): error CS0103: The name 'TestHelper' does not exist in the current context [
C:\git\runtime3\src\libraries\System.Net.WebSockets.Client\tests\wasm\System.Net.WebSockets.Client.Wasm.Tests.csproj]
```

This wasn't caught before because there is no CI validation for building tests for all configurations: https://github.com/dotnet/runtime/pull/106474