### PR TITLE
Remove RefOnly optional msbuild switch

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -196,8 +196,6 @@
     <SubsetName Include="Libs.Native" Description="The native libraries used in the shared framework." />
     <SubsetName Include="Libs.Sfx" Description="The managed shared framework libraries." />
     <SubsetName Include="Libs.Oob" Description="The managed out-of-band libraries." />
-    <SubsetName Include="Libs.Ref" OnDemand="true" Description="The managed reference libraries." />
-    <SubsetName Include="Libs.Src" OnDemand="true" Description="The managed implementation libraries." />
     <SubsetName Include="Libs.PreTest" Description="Test assets which are necessary to run tests." />
     <SubsetName Include="Libs.Tests" OnDemand="true" Description="The test projects. Note that building this doesn't execute tests: you must also pass the '-test' argument." />
 
@@ -481,20 +479,16 @@
     <ProjectToBuild Include="$(SharedNativeRoot)libs\build-native.proj" Category="libs" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(_subset.Contains('+libs.ref+')) or $(_subset.Contains('+libs.src+')) or $(_subset.Contains('+libs.sfx+'))">
+  <ItemGroup Condition="$(_subset.Contains('+libs.sfx+'))">
     <ProjectToBuild Include="$(LibrariesProjectRoot)sfx.proj"
                     Category="libs"
                     Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or
                                '$(BuildTargetFramework)' == '' or
-                               '$(BuildAllConfigurations)' == 'true'">
-      <AdditionalProperties Condition="$(_subset.Contains('+libs.ref+'))">%(AdditionalProperties);RefOnly=true</AdditionalProperties>
-    </ProjectToBuild>
+                               '$(BuildAllConfigurations)' == 'true'" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(_subset.Contains('+libs.ref+')) or $(_subset.Contains('+libs.src+')) or $(_subset.Contains('+libs.oob+'))">
-    <ProjectToBuild Include="$(LibrariesProjectRoot)oob.proj" Category="libs">
-      <AdditionalProperties Condition="$(_subset.Contains('+libs.ref+'))">%(AdditionalProperties);RefOnly=true</AdditionalProperties>
-    </ProjectToBuild>
+  <ItemGroup Condition="$(_subset.Contains('+libs.oob+'))">
+    <ProjectToBuild Include="$(LibrariesProjectRoot)oob.proj" Category="libs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+mono.wasmruntime+'))">

--- a/src/libraries/oob.proj
+++ b/src/libraries/oob.proj
@@ -22,13 +22,6 @@
     <ProjectReference Include="oob-gen.proj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
-  <!-- Support building reference projects only. -->
-  <ItemGroup Condition="'$(RefOnly)' == 'true'">
-    <ProjectReference Remove="@(ProjectReference)" />
-    <ProjectReference Include="sfx-ref.proj" OutputItemType="SharedFrameworkAssembly" />
-    <ProjectReference Include="oob-ref.proj" />
-  </ItemGroup>
-
   <Target Name="GetTrimOOBAssembliesInputs"
           DependsOnTargets="ResolveProjectReferences">
     <PropertyGroup>
@@ -47,7 +40,7 @@
 
   <Target Name="TrimOOBAssemblies"
           AfterTargets="Build"
-          Condition="'$(RefOnly)' != 'true' and '@(OOBAssembly)' != ''"
+          Condition="'@(OOBAssembly)' != ''"
           DependsOnTargets="GetTrimOOBAssembliesInputs;PrepareForAssembliesTrim"
           Inputs="$(ILLinkTasksAssembly);@(OOBAssemblyToTrim);@(OOBAssemblyReference);@(OOBLibrarySuppressionsXml)"
           Outputs="$(OOBAssembliesTrimMarkerFile)">

--- a/src/libraries/sfx-ref.proj
+++ b/src/libraries/sfx-ref.proj
@@ -17,12 +17,4 @@
                                System.Private.CoreLib\ref\System.Private.CoreLib.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RefOnly)' == 'true'">
-    <ProjectReference Include="shims\*\src\*.csproj" />
-    <ReferenceShimProject Include="shims\*\ref\*.csproj" />
-    <ProjectReference Include="@(ReferenceShimProject)" />
-    <!-- Omit projects which depend on source projects to be built. -->
-    <ProjectReference Remove="@(ReferenceShimProject->'shims\%(Filename)\src\%(Filename)%(Extension)')" />
-  </ItemGroup>
-
 </Project>

--- a/src/libraries/sfx.proj
+++ b/src/libraries/sfx.proj
@@ -14,11 +14,8 @@
   <ItemGroup>
     <!-- The sfx ref projects must be built first as sfx src projects don't use P2Ps to reference each other. Instead the
          references are defined manually via Reference items, therefore the reference assemblies must exist before that. -->
-    <ProjectReference Include="sfx-ref.proj">
-      <OutputItemType Condition="'$(RefOnly)' == 'true'">SharedFrameworkAssembly</OutputItemType>
-    </ProjectReference>
-     <!-- The RefOnly condition exists to support building the reference source projects only. -->
-    <ProjectReference Include="sfx-src.proj" OutputItemType="SharedFrameworkAssembly" Condition="'$(RefOnly)' != 'true'" />
+    <ProjectReference Include="sfx-ref.proj" />
+    <ProjectReference Include="sfx-src.proj" OutputItemType="SharedFrameworkAssembly" />
     <ProjectReference Include="sfx-gen.proj" OutputItemType="SharedFrameworkAnalyzerAssembly" />
   </ItemGroup>
 
@@ -61,8 +58,7 @@
 
   <!-- Copy the intellisense file to the targeting pack directory. -->
   <Target Name="CopyDocumentationFiles"
-          AfterTargets="Build"
-          Condition="'$(RefOnly)' != 'true'">
+          AfterTargets="Build">
     <ItemGroup>
       <DocumentationFileToCopy Include="@(SharedFrameworkAssembly->WithMetadataValue('IsPrivateAssembly', 'false')->Metadata('DocFileItem'))" />
     </ItemGroup>
@@ -89,7 +85,6 @@
   <Target Name="TrimSharedFrameworkAssemblies"
           AfterTargets="Build"
           DependsOnTargets="ResolveProjectReferences;GetTrimSharedFrameworkAssembliesInputs;PrepareForAssembliesTrim"
-          Condition="'$(RefOnly)' != 'true'"
           Inputs="@(SharedFrameworkAssembly);@(SharedFrameworkSuppressionsXml);$(ILLinkTasksAssembly)"
           Outputs="$(SharedFrameworkAssembliesTrimMarkerFile)">
     <Message Text="$(MSBuildProjectName) -> Trimming $(OutputRID) shared framework assemblies with ILLinker..." Importance="high" />


### PR DESCRIPTION
This changes removes support for the /p:RefOnly=true msbuild switch and the libs.ref and the libs.src subsets.

The former allowed to only build the reference assemblies of the sfx and/or oob libraries. This isn't possible anymore now that we remove reference source projects for libraries that don't need them anymore.

This switch was never documented and isn't used afaik.

The removal of the two libs subsets is happening for the same reason. Now that projects start removing the reference source projects, the split between and ref and src doesn't work anymore. Those subsets were listed by the subsets help description but aren't used anymore.