### PR TITLE
JIT: Remove implicit fallthrough assert in bool optimizer

### DIFF
--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1327,7 +1327,6 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
         assert(m_b2->KindIs(BBJ_COND));
         assert(m_b1->TrueTargetIs(m_b2->GetTrueTarget()));
         assert(m_b1->FalseTargetIs(m_b2));
-        assert(!m_b2->IsLast());
 
         // We now reach B2's false target via B1 false.
         //


### PR DESCRIPTION
Fixes #106487 ([comment](https://github.com/dotnet/runtime/issues/106487#issuecomment-2291885976)). I did a quick search for other asserts checking if a block is or isn't the last block, and none of them seem to be based on any fallthrough assumption, like the removed one was.

@dotnet/jit-contrib PTAL, thanks!