### PR TITLE
Fix stack overflow handling with SuperPMI

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -621,8 +621,7 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
 
         // If the failure address is at most one page above or below the stack pointer,
         // we have a stack overflow.
-        bool isStackOverflow = (failureAddress - (sp - GetVirtualPageSize())) < 2 * GetVirtualPageSize();
-        if (isStackOverflow)
+        if ((failureAddress - (sp - GetVirtualPageSize())) < 2 * GetVirtualPageSize())
         {
             if (GetCurrentPalThread())
             {
@@ -652,8 +651,7 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
                 PROCAbort(SIGSEGV, siginfo);
             }
         }
-
-        if (!isStackOverflow)
+        else
         {
             // Now that we know the SIGSEGV didn't happen due to a stack overflow, execute the common
             // hardware signal handler on the original stack.


### PR DESCRIPTION
When SuperPMI shared library is loaded last, its SIGSEGV handler is the first one that's executed. But since there is no coreclr runtime handler installed for it, it returns from the SwitchStackAndExecuteHandler in case of SIGSEGV. The remaining code in the SIGSEGV handler was not expecting that and thought that there was no stack overflow and attempted to run the hardware exception handler on the original stack of the thread, which obviously crashed since the original stack overflowed.
The fix is to make sure that we only call the previously registered signal handler in this case.

Close #84911