### PR TITLE
Fix Type System Equivalence Checks

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.TypeEquivalence.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.TypeEquivalence.cs
@@ -80,12 +80,12 @@ namespace Internal.TypeSystem.Ecma
                     if (this.HasCustomAttribute("System.Runtime.InteropServices", "ImportedFromTypeLibAttribute") || this.HasCustomAttribute("System.Runtime.InteropServices", "PrimaryInteropAssemblyAttribute"))
                     {
                         // This type has a TypeIdentifier attribute if it has an appropriate shape to be considered type equivalent
+                        if (!TypeHasCharacteristicsRequiredToBeTypeEquivalent)
+                            return null;
+
+                        _data = ComputeTypeIdentifierFromGuids();
+                        return _data;
                     }
-
-                    if (!TypeHasCharacteristicsRequiredToBeTypeEquivalent)
-                        return null;
-
-                    _data = ComputeTypeIdentifierFromGuids();
                 }
 
                 return null;


### PR DESCRIPTION
Fixes issue #96242.

This is the initial draft of the solution to address the aforementioned issue. Debugging through Crossgen2 and the compiler for ReadyToRun, we found that on Windows, we were computing and using type identifiers from Guid's, whether there is interop or not. As far as we're concerned, outside of those scenarios we shouldn't need to be doing those checks.

So, initially I want to ask for your guidance more than direct review feedback. Are we approaching this the right way? Is this the right solution? Starting this as draft since this discussion is needed beforehand.

@davidwrighton @jkotas @MichalStrehovsky 