### PR TITLE
Update `MethodTable::IsDynamicStatics` and `DacpMethodTableData::bIsDynamic` to return 0/1 instead of flag value

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2113,7 +2113,9 @@ ClrDataAccess::GetMethodTableData(CLRDATA_ADDRESS mt, struct DacpMethodTableData
             _ASSERTE(MTData->dwAttrClass == mtDataLocal.dwAttrClass);
             _ASSERTE(MTData->bContainsPointers == mtDataLocal.bContainsPointers);
             _ASSERTE(MTData->bIsShared == mtDataLocal.bIsShared);
-            _ASSERTE(MTData->bIsDynamic == mtDataLocal.bIsDynamic);
+            _ASSERTE(MTData->bIsDynamic == mtDataLocal.bIsDynamic
+                // DAC returns the flag value instead of 0 or 1
+                || (MTData->bIsDynamic != FALSE && mtDataLocal.bIsDynamic != FALSE));
         }
 #endif
     }

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2113,9 +2113,7 @@ ClrDataAccess::GetMethodTableData(CLRDATA_ADDRESS mt, struct DacpMethodTableData
             _ASSERTE(MTData->dwAttrClass == mtDataLocal.dwAttrClass);
             _ASSERTE(MTData->bContainsPointers == mtDataLocal.bContainsPointers);
             _ASSERTE(MTData->bIsShared == mtDataLocal.bIsShared);
-            _ASSERTE(MTData->bIsDynamic == mtDataLocal.bIsDynamic
-                // DAC returns the flag value instead of 0 or 1
-                || (MTData->bIsDynamic != FALSE && mtDataLocal.bIsDynamic != FALSE));
+            _ASSERTE(MTData->bIsDynamic == mtDataLocal.bIsDynamic);
         }
 #endif
     }
@@ -2162,7 +2160,7 @@ ClrDataAccess::GetMethodTableDataImpl(CLRDATA_ADDRESS mt, struct DacpMethodTable
         MTData->dwAttrClass = pMT->GetAttrClass();
         MTData->bContainsPointers = pMT->ContainsGCPointers();
         MTData->bIsShared = FALSE;
-        MTData->bIsDynamic = pMT->IsDynamicStatics();
+        MTData->bIsDynamic = pMT->IsDynamicStatics() ? TRUE : FALSE;
     }
     return S_OK;
 }

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -2567,10 +2567,10 @@ public:
     inline PTR_BYTE GetNonGCThreadStaticsBasePointer(PTR_Thread pThread);
     inline PTR_BYTE GetGCThreadStaticsBasePointer(PTR_Thread pThread);
 
-    inline DWORD IsDynamicStatics()
+    inline BOOL IsDynamicStatics()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        return GetFlag(enum_flag_DynamicStatics);
+        return GetFlag(enum_flag_DynamicStatics) == enum_flag_DynamicStatics;
     }
 
     inline void SetDynamicStatics()


### PR DESCRIPTION
`MethodTable::IsDynamicStatics` just gets the flag
https://github.com/dotnet/runtime/blob/c88c31b3dff2e0f027379d947414fbced8c4b911/src/coreclr/vm/methodtable.h#L2570-L2574

So if it is set, it returns the flag value (0x2)

DAC just sets `DacpMethodTableData::bIsDynamic` to `MethodTable::IsDynamicStatics`.

Change both to return TRUE/FALSE instead of the flag value. Per https://github.com/dotnet/runtime/pull/106504#issuecomment-2292310285, this was the behaviour until somewhat recently.