### PR TITLE
JIT: update simd base type when combining simd nodes for bitwise ops

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -1430,10 +1430,9 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
         const uint8_t B = 0xCC;
         const uint8_t C = 0xAA;
 
-        var_types   simdType        = node->TypeGet();
-        CorInfoType simdBaseJitType = node->GetSimdBaseJitType();
-        var_types   simdBaseType    = node->GetSimdBaseType();
-        unsigned    simdSize        = node->GetSimdSize();
+        var_types simdType     = node->TypeGet();
+        var_types simdBaseType = node->GetSimdBaseType();
+        unsigned  simdSize     = node->GetSimdSize();
 
         GenTree* op1 = node->Op(1);
         GenTree* op2 = node->Op(2);
@@ -1454,6 +1453,10 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
 
                 bool       userIsScalar = false;
                 genTreeOps userOper     = userIntrin->GetOperForHWIntrinsicId(&isScalar);
+
+                // userIntrin may have re-interpreted the base type
+                //
+                simdBaseType = userIntrin->GetSimdBaseType();
 
                 if (GenTreeHWIntrinsic::OperIsBitwiseHWIntrinsic(userOper))
                 {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106478/Runtime_106478.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106478/Runtime_106478.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+// Reduced from 30.05 KB to 2.35 KB.
+// Further redued by hand
+
+using System;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_106478
+{
+    static Vector512<double> s_v512_double_46 = Vector512.Create(4, -4.971830985915493, -0.9789473684210527, -1.956043956043956, 2, 74.25, 1.0533333333333332, 4.033898305084746);
+    Vector512<int> v512_int_101 = Vector512<int>.Zero;
+    Vector512<int> p_v512_int_125 = Vector512<int>.Zero;
+
+    void Problem()
+    {
+        p_v512_int_125 = v512_int_101& Vector512.AsInt32(s_v512_double_46 ^ Vector512<double>.AllBitsSet);
+    }
+
+    [Fact]
+    public static void Test()
+    {
+        new Runtime_106478().Problem();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106478/Runtime_106478.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106478/Runtime_106478.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If we merge two simd for bitwise ops (eg creating an AndNot), make sure to use the simd base type of the parent (And) node when specializing the operator.

Fixes #106478.