### PR TITLE
[cdac] Fix getting array function type in RuntimeTypeSystem.IsArrayMethod

### DIFF
--- a/src/native/managed/cdacreader/src/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdacreader/src/Contracts/RuntimeTypeSystem_1.cs
@@ -698,14 +698,15 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             return false;
         }
 
-        int arrayMethodIndex = methodDesc.Slot - GetNumVtableSlots(GetTypeHandle(methodDesc.MethodTable));
+        MethodTable methodTable = _methodTables[GetTypeHandle(methodDesc.MethodTable).Address];
+        int arrayMethodIndex = methodDesc.Slot - methodTable.NumVirtuals;
 
         functionType = arrayMethodIndex switch
         {
             0 => ArrayFunctionType.Get,
             1 => ArrayFunctionType.Set,
             2 => ArrayFunctionType.Address,
-            > 3 => ArrayFunctionType.Constructor,
+            >= 3 => ArrayFunctionType.Constructor,
             _ => throw new InvalidOperationException()
         };
 

--- a/src/native/managed/cdacreader/src/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdacreader/src/Contracts/RuntimeTypeSystem_1.cs
@@ -698,6 +698,16 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             return false;
         }
 
+        // To get the array function index, subtract the number of virtuals from the method's slot
+        // The array vtable looks like:
+        //    System.Object vtable
+        //    System.Array vtable
+        //    type[] vtable
+        //    Get
+        //    Set
+        //    Address
+        //    .ctor        // possibly more
+        // See ArrayMethodDesc for details in coreclr
         MethodTable methodTable = _methodTables[GetTypeHandle(methodDesc.MethodTable).Address];
         int arrayMethodIndex = methodDesc.Slot - methodTable.NumVirtuals;
 

--- a/src/native/managed/cdacreader/src/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdacreader/src/Contracts/RuntimeTypeSystem_1.cs
@@ -708,9 +708,8 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         //    Address
         //    .ctor        // possibly more
         // See ArrayMethodDesc for details in coreclr
-        MethodTable methodTable = _methodTables[GetTypeHandle(methodDesc.MethodTable).Address];
+        MethodTable methodTable = GetOrCreateMethodTable(methodDesc);
         int arrayMethodIndex = methodDesc.Slot - methodTable.NumVirtuals;
-
         functionType = arrayMethodIndex switch
         {
             0 => ArrayFunctionType.Get,
@@ -779,5 +778,12 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         }
 
         return AsDynamicMethodDesc(methodDesc).IsILStub;
+    }
+
+    private MethodTable GetOrCreateMethodTable(MethodDesc methodDesc)
+    {
+        // Ensures that the method table is valid, created, and cached
+        _ = GetTypeHandle(methodDesc.MethodTable);
+        return _methodTables[methodDesc.MethodTable];
     }
 }


### PR DESCRIPTION
- Array method index should be the slot minus the number of virtuals, not the number of slots
- Constructor index should include 3, not just greater than