### PR TITLE
JIT: Allow stack allocate objects in loops

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -377,7 +377,6 @@ bool ObjectAllocator::MorphAllocObjNodes()
     for (BasicBlock* const block : comp->Blocks())
     {
         const bool basicBlockHasNewObj       = block->HasFlag(BBF_HAS_NEWOBJ);
-        const bool basicBlockHasBackwardJump = block->HasFlag(BBF_BACKWARD_JUMP);
 #ifndef DEBUG
         if (!basicBlockHasNewObj)
         {
@@ -436,11 +435,6 @@ bool ObjectAllocator::MorphAllocObjNodes()
                 if (!IsObjectStackAllocationEnabled())
                 {
                     onHeapReason = "[object stack allocation disabled]";
-                    canStack     = false;
-                }
-                else if (basicBlockHasBackwardJump)
-                {
-                    onHeapReason = "[alloc in loop]";
                     canStack     = false;
                 }
                 else if (!CanAllocateLclVarOnStack(lclNum, clsHnd, &onHeapReason))

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -376,7 +376,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
 
     for (BasicBlock* const block : comp->Blocks())
     {
-        const bool basicBlockHasNewObj       = block->HasFlag(BBF_HAS_NEWOBJ);
+        const bool basicBlockHasNewObj = block->HasFlag(BBF_HAS_NEWOBJ);
 #ifndef DEBUG
         if (!basicBlockHasNewObj)
         {

--- a/src/coreclr/jit/objectalloc.h
+++ b/src/coreclr/jit/objectalloc.h
@@ -65,7 +65,10 @@ private:
     unsigned int MorphAllocObjNodeIntoStackAlloc(
         GenTreeAllocObj* allocObj, CORINFO_CLASS_HANDLE clsHnd, bool isValueClass, BasicBlock* block, Statement* stmt);
     struct BuildConnGraphVisitorCallbackData;
-    bool CanLclVarEscapeViaParentStack(ArrayStack<GenTree*>* parentStack, unsigned int lclNum);
+    bool CanLclVarEscapeViaParentStack(ArrayStack<GenTree*>* parentStack,
+                                       unsigned int          lclNum,
+                                       bool                  hasBackwardJump,
+                                       BitSetShortLongRep    lclsInPreds);
     void UpdateAncestorTypes(GenTree* tree, ArrayStack<GenTree*>* parentStack, var_types newType);
 
     static const unsigned int s_StackAllocMaxSize = 0x2000U;


### PR DESCRIPTION
Unlike stackalloc, stack allocated objects have no difference than using `struct` directly, and objects that don't escape from a loop are likely to be promoted later. Allow stack allocate objects in loops to get rid of more boxes. 
Inspired from https://devblogs.microsoft.com/java/improving-openjdk-scalar-replacement-part-1-3.

```cs
class Test
{
    public static int CompositeChecksum(string[] messages)
    {
        int checksum = 0;
        foreach (var msg in messages)
        {
            var m = new Message(msg);
            int cs = m.Checksum();
            checksum += cs;
        }
        return checksum;
    }
}

class Message(string content)
{
    public string Content = content;

    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public int Checksum()
    {
        int chks = 0;
        for (int i = 0; i < Content.Length; i++)
        {
            chks += Content[i];
        }
        return chks;
    }
}
```

New codegen for `CompositeChecksum`:

```asm
; Assembly listing for method Program+Foo:CompositeChecksum(System.String[]):int (Tier1)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; Tier1 code
; optimized code
; optimized using Dynamic PGO
; rsp based frame
; fully interruptible
; with Dynamic PGO: fgCalledCount is 46
; 1 inlinees with PGO data; 2 single block inlinees; 0 inlinees without PGO data
; Final local variable assignments
;
;  V00 arg0         [V00,T08] (  3,  3.00)     ref  ->  rcx         class-hnd single-def <System.String[]>
;  V01 loc0         [V01,T05] (  4,  6.00)     int  ->  rax
;  V02 loc1         [V02,T09] (  3,  2.67)     ref  ->  rcx         class-hnd exact single-def <System.String[]>
;* V03 loc2         [V03,T12] (  0,  0   )     int  ->  zero-ref
;* V04 loc3         [V04    ] (  0,  0   )     int1084  ->
zero-ref
;# V05 OutArgs      [V05    ] (  1,  1   )  struct ( 0) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
;* V06 tmp1         [V06    ] (  0,  0   )    long  ->  zero-ref    class-hnd exact "NewObj constructor temp" <Program+Message>
;* V07 tmp2         [V07    ] (  0,  0   )     ref  ->  zero-ref    class-hnd exact "Inlining Arg" <System.String>
;  V08 tmp3         [V08,T02] (  4, 24   )     int  ->  r10         "Inline stloc first use temp"
;* V09 tmp4         [V09,T11] (  0,  0   )     int  ->  zero-ref    "Inline stloc first use temp"
;* V10 tmp5         [V10    ] (  0,  0   )  struct (16) zero-ref    do-not-enreg[SF] "stack allocated ref class temp" <Program+Message>
;* V11 tmp6         [V11    ] (  0,  0   )    long  ->  zero-ref    "V10.[000..008)"
;  V12 tmp7         [V12,T06] (  3,  5.67)     ref  ->   r8         "V10.[008..016)"
;  V13 cse0         [V13,T07] (  3,  5.67)     int  ->   r9         "CSE #01: aggressive"
;  V14 cse1         [V14,T10] (  3,  2.67)     int  ->  rdx         "CSE #02: aggressive"
;  V15 rat0         [V15,T03] (  4,  6.67)   byref  ->  rcx         "Strength reduced derived IV"
;  V16 rat1         [V16,T04] (  4,  6.67)     int  ->  rdx         "Trip count IV"
;  V17 rat2         [V17,T00] (  4, 31.67)   byref  ->   r8         "Strength reduced derived IV"
;  V18 rat3         [V18,T01] (  4, 31.67)     int  ->   r9         "Trip count IV"
;
; Lcl frame size = 0

G_M27921_IG01:  ;; offset=0x0000
                                                ;; size=0 bbWeight=1.00 PerfScore 0.00
G_M27921_IG02:  ;; offset=0x0000
       xor      eax, eax
       mov      edx, dword ptr [rcx+0x08]
       test     edx, edx
       jle      SHORT G_M27921_IG08
                                                ;; size=9 bbWeight=1.00 PerfScore 3.50
G_M27921_IG03:  ;; offset=0x0009
       add      rcx, 16
                                                ;; size=4 bbWeight=0.67 PerfScore 0.17
G_M27921_IG04:  ;; offset=0x000D
       mov      r8, gword ptr [rcx]
       xor      r10d, r10d
       mov      r9d, dword ptr [r8+0x08]
       test     r9d, r9d
       jle      SHORT G_M27921_IG07
                                                ;; size=15 bbWeight=2 PerfScore 11.00
G_M27921_IG05:  ;; offset=0x001C
       add      r8, 12
       align    [0 bytes for IG06]
                                                ;; size=4 bbWeight=1.67 PerfScore 0.42
G_M27921_IG06:  ;; offset=0x0020
       movzx    r11, word  ptr [r8]
       add      r10d, r11d
       add      r8, 2
       dec      r9d
       jne      SHORT G_M27921_IG06
                                                ;; size=16 bbWeight=10 PerfScore 37.50
G_M27921_IG07:  ;; offset=0x0030
       add      eax, r10d
       add      rcx, 8
       dec      edx
       jne      SHORT G_M27921_IG04
                                                ;; size=11 bbWeight=2.00 PerfScore 3.50
G_M27921_IG08:  ;; offset=0x003B
       ret
                                                ;; size=1 bbWeight=1.00 PerfScore 1.00

; Total bytes of code 60, prolog size 0, PerfScore 57.08, instruction count 22, allocated bytes for code 60 (MethodHash=8fa792ee) for method Program+Foo:CompositeChecksum(System.String[]):int (Tier1)
```