### PR TITLE
Ignore SYSLIB0057 obsoletion in wasm websocket tests

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/wasm/System.Net.WebSockets.Client.Wasm.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/wasm/System.Net.WebSockets.Client.Wasm.Tests.csproj
@@ -5,6 +5,7 @@
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <TargetFramework>$(NetCoreAppCurrent)-browser</TargetFramework>
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    <NoWarn>$(NoWarn);SYSLIB0057</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">


### PR DESCRIPTION
Fixes #106472.

This uses the same strategy as e.g. System.Net.Security tests.