### PR TITLE
Skip static constructors in DynamicallyAccessedMembersBinder

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -177,7 +177,7 @@ namespace ILCompiler.Dataflow
                 foreach (var method in type.GetMethods())
                 {
                     // Ignore constructors as those are not considered methods from a reflection's point of view
-                    if (method.IsConstructor)
+                    if (method.IsConstructor || method.IsStaticConstructor)
                         continue;
 
                     // Ignore private methods on a base type - those are completely ignored by reflection


### PR DESCRIPTION
Noticed by accident.

Cc @dotnet/ilc-contrib 