### PR TITLE
Fix TreatWarningsAsErrors for linux

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -329,7 +329,7 @@ foreach ($argument in $PSBoundParameters.Keys)
 }
 
 if ($env:TreatWarningsAsErrors -eq 'false') {
-  $arguments += " -warnAsError 0"
+  $arguments += " -warnAsError `$false"
 }
 
 # disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -550,7 +550,7 @@ if [[ "$os" == "wasi" ]]; then
 fi
 
 if [[ "${TreatWarningsAsErrors:-}" == "false" ]]; then
-    arguments="$arguments -warnAsError 0"
+    arguments="$arguments -warnAsError false"
 fi
 
 # disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211


### PR DESCRIPTION
Building with the env var TreatWarningsAsErrors=false on linux gives:
```
/.nuget/packages/microsoft.net.compilers.toolset/4.12.0-2.24408.4/tasks/netcore/Microsoft.CSharp.Core.targets(160,10): error MSB4030: "0" is an invalid value for the "TreatWarningsAsErrors" parameter of the "Csc" task. The "TreatWarningsAsErrors" parameter is of type "System.Boolean".
```

`0` isn't a valid value for `TreatWarningsAsErrors` which should be a boolean. It worked on windows because powershell accepts `0` as a boolean. I'm updating the `ps1` script too for clarity.
