### PR TITLE
Fix GetTargetPath hook point

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -73,7 +73,8 @@
   <!-- Flow the ILLinkSuppressionsXmls item list down to consuming projects, in order for sfx.proj and oob.proj to
        receive the suppression files. -->
   <Target Name="AnnotateTargetPathWithILLinkSuppressionsXmlsProp"
-          AfterTargets="GetTargetPathWithTargetPlatformMoniker">
+          DependsOnTargets="GetTargetPathWithTargetPlatformMoniker"
+          BeforeTargets="GetTargetPath">
     <ItemGroup>
       <TargetPathWithTargetPlatformMoniker ILLinkSuppressionsXmls="@(ILLinkSuppressionsXmls->Metadata('FullPath'))" />
     </ItemGroup>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -66,8 +66,8 @@
 
   <!-- Allow P2Ps to retrieve the DocFileItem path. -->
   <Target Name="AnnotateTargetPathWithTargetPlatformMonikerWithDocFileItem"
-          DependsOnTargets="ChangeDocumentationFileForPackaging"
-          AfterTargets="GetTargetPathWithTargetPlatformMoniker">
+          DependsOnTargets="ChangeDocumentationFileForPackaging;GetTargetPathWithTargetPlatformMoniker"
+          BeforeTargets="GetTargetPath">
     <ItemGroup>
       <TargetPathWithTargetPlatformMoniker DocFileItem="@(DocFileItem)" />
     </ItemGroup>

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -39,8 +39,8 @@
   <!-- Allow P2Ps that target a source project to build against the corresponding ref project. -->
   <Target Name="AnnotateTargetPathWithTargetPlatformMonikerWithReferenceAssembly"
           Condition="'$(AnnotateTargetPathWithContract)' == 'true'"
-          DependsOnTargets="ResolveProjectReferences"
-          AfterTargets="GetTargetPathWithTargetPlatformMoniker">
+          DependsOnTargets="ResolveProjectReferences;GetTargetPathWithTargetPlatformMoniker"
+          BeforeTargets="GetTargetPath">
     <ItemGroup>
       <TargetPathWithTargetPlatformMoniker ReferenceAssembly="@(ResolvedMatchingContract)" />
     </ItemGroup>


### PR DESCRIPTION
I noticed that in some environments, the existing hook point (AfterTargets=GetTargetPathWithTargetPlatformMoniker) doesn't run before `GetTargetPath`. That resulted in some project compiling against the src instead of the ref assembly.

DependsOnTargets + BeforeTargets="GetTargetPath" is is more correct anyway and works as exected.