### PR TITLE
Disable MD5 tests on Azure Linux

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         bool SupportsSha2Oaep { get; }
         bool SupportsPss { get; }
         bool SupportsSha1Signatures { get; }
+        bool SupportsMd5Signatures { get; }
         bool SupportsSha3 { get; }
     }
 
@@ -43,6 +44,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public static bool SupportsPss => s_provider.SupportsPss;
 
         public static bool SupportsSha1Signatures => s_provider.SupportsSha1Signatures;
+        public static bool SupportsMd5Signatures => s_provider.SupportsMd5Signatures;
 
         public static bool SupportsSha3 => s_provider.SupportsSha3;
         public static bool NoSupportsSha3 => !SupportsSha3;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -600,7 +600,11 @@ namespace System.Security.Cryptography.Rsa.Tests
                         yield return new object[] { nameof(HashAlgorithmName.SHA1), rsaParameters };
                     }
 
-                    yield return new object[] { nameof(HashAlgorithmName.MD5), rsaParameters };
+                    if (RSAFactory.SupportsMd5Signatures)
+                    {
+                        yield return new object[] { nameof(HashAlgorithmName.MD5), rsaParameters };
+                    }
+
                     yield return new object[] { nameof(HashAlgorithmName.SHA256), rsaParameters };
                 }
 
@@ -1589,7 +1593,11 @@ namespace System.Security.Cryptography.Rsa.Tests
                 yield return new object[] { HashAlgorithmName.SHA256.Name };
                 yield return new object[] { HashAlgorithmName.SHA384.Name };
                 yield return new object[] { HashAlgorithmName.SHA512.Name };
-                yield return new object[] { HashAlgorithmName.MD5.Name };
+
+                if (RSAFactory.SupportsMd5Signatures)
+                {
+                    yield return new object[] { HashAlgorithmName.MD5.Name };
+                }
 
                 if (RSAFactory.SupportsSha1Signatures)
                 {

--- a/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
@@ -5,14 +5,17 @@ namespace System.Security.Cryptography.Tests
 {
     internal static class SignatureSupport
     {
-        internal static bool CanProduceSha1Signature(AsymmetricAlgorithm algorithm)
+        internal static bool CanProduceSha1Signature(AsymmetricAlgorithm algorithm) => CanProduceSignature(algorithm, HashAlgorithmName.SHA1);
+        internal static bool CanProduceMd5Signature(AsymmetricAlgorithm algorithm) => CanProduceSignature(algorithm, HashAlgorithmName.MD5);
+
+        private static bool CanProduceSignature(AsymmetricAlgorithm algorithm, HashAlgorithmName hashAlgorithmName)
         {
             using (algorithm)
             {
 #if NETFRAMEWORK
                 return true;
 #else
-                // We expect all non-Linux platforms to support SHA1 signatures, currently.
+                // We expect all non-Linux platforms to support any signatures, currently.
                 if (!OperatingSystem.IsLinux())
                 {
                     return true;
@@ -23,7 +26,7 @@ namespace System.Security.Cryptography.Tests
                     case ECDsa ecdsa:
                         try
                         {
-                            ecdsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1);
+                            ecdsa.SignData(Array.Empty<byte>(), hashAlgorithmName);
                             return true;
                         }
                         catch (CryptographicException)
@@ -33,7 +36,7 @@ namespace System.Security.Cryptography.Tests
                     case RSA rsa:
                         try
                         {
-                            rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                            rsa.SignData(Array.Empty<byte>(), hashAlgorithmName, RSASignaturePadding.Pkcs1);
                             return true;
                         }
                         catch (CryptographicException)

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -28,6 +28,7 @@ namespace System
         public static bool IsFedora => IsDistroAndVersion("fedora");
         public static bool IsLinuxBionic => IsBionic();
         public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();
+        public static bool IsAzureLinux => IsDistroAndVersionOrHigher("azurelinux", 3);
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;

--- a/src/libraries/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -37,6 +37,8 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public bool SupportsSha1Signatures => true;
 
+        public bool SupportsMd5Signatures => true;
+
         public bool SupportsSha3 { get; } = SHA3_256.IsSupported; // If SHA3_256 is supported, assume 384 and 512 are, too.
     }
 

--- a/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
@@ -156,9 +156,12 @@ namespace System.Security.Cryptography.Csp.Tests
 
         public static IEnumerable<object[]> AlgorithmIdentifiers()
         {
-            yield return new object[] { "MD5", MD5.Create() };
-            yield return new object[] { "MD5", typeof(MD5) };
-            yield return new object[] { "MD5", "1.2.840.113549.2.5" };
+            if (RSAFactory.SupportsMd5Signatures)
+            {
+                yield return new object[] { "MD5", MD5.Create() };
+                yield return new object[] { "MD5", typeof(MD5) };
+                yield return new object[] { "MD5", "1.2.840.113549.2.5" };
+            }
 
             if (RSAFactory.SupportsSha1Signatures)
             {

--- a/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class RSACryptoServiceProviderProvider : IRSAProvider
     {
         private bool? _supportsSha1Signatures;
+        private bool? _supportsMd5Signatures;
 
         public RSA Create() => new RSACryptoServiceProvider();
 
@@ -23,6 +24,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public bool SupportsPss => false;
 
         public bool SupportsSha1Signatures => _supportsSha1Signatures ??= SignatureSupport.CanProduceSha1Signature(Create());
+        public bool SupportsMd5Signatures => _supportsMd5Signatures ??= SignatureSupport.CanProduceMd5Signature(Create());
 
         public bool SupportsSha3 => false;
     }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -8,6 +8,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class RSAOpenSslProvider : IRSAProvider
     {
         private bool? _supportsSha1Signatures;
+        private bool? _supportsMd5Signatures;
 
         public RSA Create() => new RSAOpenSsl();
 
@@ -22,6 +23,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public bool SupportsPss => true;
 
         public bool SupportsSha1Signatures => _supportsSha1Signatures ??= SignatureSupport.CanProduceSha1Signature(Create());
+        public bool SupportsMd5Signatures => _supportsMd5Signatures ??= SignatureSupport.CanProduceMd5Signature(Create());
 
         public bool SupportsSha3 => SHA3_256.IsSupported; // If SHA3_256 is supported, assume 384 and 512 are, too.
     }

--- a/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
@@ -10,6 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     {
         private bool? _supports384PrivateKey;
         private bool? _supportsSha1Signatures;
+        private bool? _supportsMd5Signatures;
 
         public RSA Create() => RSA.Create();
 
@@ -41,6 +42,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         public bool SupportsSha1Signatures => _supportsSha1Signatures ??= SignatureSupport.CanProduceSha1Signature(Create());
+        public bool SupportsMd5Signatures => _supportsMd5Signatures ??= SignatureSupport.CanProduceMd5Signature(Create());
 
         public bool SupportsLargeExponent => true;
 

--- a/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
@@ -14,6 +14,8 @@ namespace System.Security.Cryptography.Tests
         protected abstract byte[] Expand(HashAlgorithmName hash, byte[] prk, int outputLength, byte[] info);
         protected abstract byte[] DeriveKey(HashAlgorithmName hash, byte[] ikm, int outputLength, byte[] salt, byte[] info);
 
+        internal static bool MD5Supported => !PlatformDetection.IsBrowser && !PlatformDetection.IsAzureLinux;
+
         [Theory]
         [MemberData(nameof(GetHkdfTestCases))]
         public void ExtractTests(HkdfTestCase test)
@@ -22,9 +24,8 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(test.Prk, prk);
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(MD5Supported))]
         [MemberData(nameof(GetHkdfTestCases))]
-        [SkipOnPlatform(TestPlatforms.Browser, "MD5 is not supported on Browser")]
         public void ExtractTamperHashTests(HkdfTestCase test)
         {
             byte[] prk = Extract(HashAlgorithmName.MD5, 128 / 8, test.Ikm, test.Salt);
@@ -257,7 +258,7 @@ namespace System.Security.Cryptography.Tests
             yield return new object[] { HashAlgorithmName.SHA256, 256 / 8 - 1 };
             yield return new object[] { HashAlgorithmName.SHA512, 512 / 8 - 1 };
 
-            if (!PlatformDetection.IsBrowser)
+            if (MD5Supported)
             {
                 yield return new object[] { HashAlgorithmName.MD5, 128 / 8 - 1 };
             }

--- a/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
@@ -9,13 +9,12 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     [ConditionalClass(typeof(HmacMD5Tests.Traits), nameof(HmacMD5Tests.Traits.IsSupported))]
     public class HmacMD5Tests : Rfc2202HmacTests<HmacMD5Tests.Traits>
     {
         public sealed class Traits : IHmacTrait
         {
-            public static bool IsSupported => !PlatformDetection.IsAzureLinux;
+            public static bool IsSupported => !PlatformDetection.IsAzureLinux && !PlatformDetection.IsBrowser;
             public static int HashSizeInBytes => HMACMD5.HashSizeInBytes;
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
@@ -10,11 +10,12 @@ using Xunit;
 namespace System.Security.Cryptography.Tests
 {
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    [ConditionalClass(typeof(HmacMD5Tests.Traits), nameof(HmacMD5Tests.Traits.IsSupported))]
     public class HmacMD5Tests : Rfc2202HmacTests<HmacMD5Tests.Traits>
     {
         public sealed class Traits : IHmacTrait
         {
-            public static bool IsSupported => true;
+            public static bool IsSupported => !PlatformDetection.IsAzureLinux;
             public static int HashSizeInBytes => HMACMD5.HashSizeInBytes;
         }
 


### PR DESCRIPTION
This is part 1 of a series of pull requests that will be needed to get a green test run on Azure Linux.

This PR focuses on MD5 disabled functionality.

This brings the test failure count down from 355 to 303.

Contributes to https://github.com/dotnet/runtime/issues/106489