### PR TITLE
JIT: fix unused operand marking in LowerHWIntrinsicTernaryLogic

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3927,6 +3927,13 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
                     }
                 }
 
+                // Update the locals to reflect any operand swaps we did above.
+
+                op1 = node->Op(1);
+                op2 = node->Op(2);
+                op3 = node->Op(3);
+                assert(op4 == node->Op(4));
+
                 GenTree* replacementNode = nullptr;
 
                 switch (useFlags)
@@ -3975,7 +3982,7 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
 
                         if (!op1->IsCnsVec())
                         {
-                            node->Op(1)->SetUnusedValue();
+                            op1->SetUnusedValue();
                             op1 = comp->gtNewZeroConNode(simdType);
 
                             BlockRange().InsertBefore(node, op1);
@@ -3984,7 +3991,7 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
 
                         if (!op2->IsCnsVec())
                         {
-                            node->Op(2)->SetUnusedValue();
+                            op2->SetUnusedValue();
                             op2 = comp->gtNewZeroConNode(simdType);
 
                             BlockRange().InsertBefore(node, op2);
@@ -3997,7 +4004,7 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
                     {
                         if (!op1->IsCnsVec())
                         {
-                            node->Op(1)->SetUnusedValue();
+                            op1->SetUnusedValue();
                             op1 = comp->gtNewZeroConNode(simdType);
 
                             BlockRange().InsertBefore(node, op1);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3975,7 +3975,7 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
 
                         if (!op1->IsCnsVec())
                         {
-                            op1->SetUnusedValue();
+                            node->Op(1)->SetUnusedValue();
                             op1 = comp->gtNewZeroConNode(simdType);
 
                             BlockRange().InsertBefore(node, op1);
@@ -3984,7 +3984,7 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
 
                         if (!op2->IsCnsVec())
                         {
-                            op2->SetUnusedValue();
+                            node->Op(2)->SetUnusedValue();
                             op2 = comp->gtNewZeroConNode(simdType);
 
                             BlockRange().InsertBefore(node, op2);
@@ -3997,7 +3997,7 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
                     {
                         if (!op1->IsCnsVec())
                         {
-                            op1->SetUnusedValue();
+                            node->Op(1)->SetUnusedValue();
                             op1 = comp->gtNewZeroConNode(simdType);
 
                             BlockRange().InsertBefore(node, op1);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106480/Runtime_106480.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106480/Runtime_106480.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+// Reduced from 121.36 KB to 3.38 
+// Further redued by hand
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public class Runtime_106480
+{
+    Vector512<ushort> v512_ushort_102 = Vector512<ushort>.AllBitsSet;
+
+    void Problem()
+    {
+        if (Avx512F.IsSupported)
+        {
+            byte byte_126 = 5;
+            Avx512F.TernaryLogic(v512_ushort_102, v512_ushort_102, v512_ushort_102, byte_126);
+        }
+    }
+
+    [Fact]
+    public static void Test()
+    {
+        new Runtime_106480().Problem();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106480/Runtime_106480.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106480/Runtime_106480.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In `LowerHWIntrinsicTernaryLogic` we do some operand swapping and replacing, and were not accounting for this when marking operands as unused.

Fixes #106480.