### PR TITLE
zlib-ng: Change all W3s to W4s

### DIFF
--- a/src/native/external/zlib-ng/CMakeLists.txt
+++ b/src/native/external/zlib-ng/CMakeLists.txt
@@ -183,7 +183,7 @@ elseif(MSVC)
     # (who'd use cmake from an IDE...) but checking for ICC before checking for MSVC should
     # avoid mistakes.
     # /Oi ?
-    set(WARNFLAGS /W3)
+    set(WARNFLAGS /W4)
     set(WARNFLAGS_MAINTAINER /W4)
     set(WARNFLAGS_DISABLE)
     if(BASEARCH_ARM_FOUND)

--- a/src/native/external/zlib-ng/win32/Makefile.a64
+++ b/src/native/external/zlib-ng/win32/Makefile.a64
@@ -23,7 +23,7 @@ LD = link
 AR = lib
 RC = rc
 CP = copy /y
-CFLAGS  = -nologo -MD -W3 -O2 -Oy- -Zi -Fd"zlib" $(LOC)
+CFLAGS  = -nologo -MD -W4 -O2 -Oy- -Zi -Fd"zlib" $(LOC)
 WFLAGS  = \
 	-D_ARM64_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1 \
 	-D_CRT_SECURE_NO_DEPRECATE \

--- a/src/native/external/zlib-ng/win32/Makefile.arm
+++ b/src/native/external/zlib-ng/win32/Makefile.arm
@@ -23,7 +23,7 @@ LD = link
 AR = lib
 RC = rc
 CP = copy /y
-CFLAGS  = -nologo -MD -W3 -O2 -Oy- -Zi -Fd"zlib" $(LOC)
+CFLAGS  = -nologo -MD -W4 -O2 -Oy- -Zi -Fd"zlib" $(LOC)
 WFLAGS  = \
 	-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1 \
 	-D_CRT_SECURE_NO_DEPRECATE \

--- a/src/native/external/zlib-ng/win32/Makefile.msc
+++ b/src/native/external/zlib-ng/win32/Makefile.msc
@@ -23,7 +23,7 @@ LD = link
 AR = lib
 RC = rc
 CP = copy /y
-CFLAGS  = -nologo -MD -W3 -O2 -Oy- -Zi -Fd"zlib" $(LOC)
+CFLAGS  = -nologo -MD -W4 -O2 -Oy- -Zi -Fd"zlib" $(LOC)
 WFLAGS  = \
 	-D_CRT_SECURE_NO_DEPRECATE \
 	-D_CRT_NONSTDC_NO_DEPRECATE \


### PR DESCRIPTION
After the helix machines got updated to Regular Preview VS2022 from 17.11.0 P1.1 to 17.11.0 P2.1, we started seeing multiple CLI log warnings treated as errors in the `windows-arm64 release CrossAOT_Mono crossaot` CI legs.

Example: https://dev.azure.com/dnceng-public/public/_build/results?buildId=777468&view=logs&j=4ebc4b0a-75a3-5501-f077-449e62204024&t=6122ebc2-9677-50d9-2298-0edc58d2e578&l=364

Among the multiple errors, we are seeing one coming from fetchzlibng-build specifically:

> Command line warning D9025: overriding '/W4' with '/W3'

zlib-ng uses /W3 while runtime uses W4. The W4 level is the most verbose, which is what we want.

This would have to be backported to 9.0.

If we take this, I'll also propose the same change in the upstream zlib-ng repo afterwards.

