### PR TITLE
Fix KMAC tests on Azure Linux

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
+++ b/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
@@ -95,7 +95,7 @@ namespace System.Security.Cryptography.Tests
         public static bool IsSupported => TKmacTrait.IsSupported;
         public static bool IsNotSupported => !IsSupported;
         public static KeySizes? PlatformKeySizeRequirements { get; } =
-            PlatformDetection.IsOpenSslSupported ? new KeySizes(4, 512, 1) : null;
+            PlatformDetection.IsOpenSslSupported && !PlatformDetection.IsAzureLinux ? new KeySizes(4, 512, 1) : null;
 
         public static int? PlatformMaxOutputSize { get; } = PlatformDetection.IsOpenSslSupported ? 0xFFFFFF / 8 : null;
         public static int? PlatformMaxCustomizationStringSize { get; } = PlatformDetection.IsOpenSslSupported ? 512 : null;


### PR DESCRIPTION
This is part 2 of a series of pull requests that will be needed to get a green test run on Azure Linux.

KMAC for SCOSSL does not have a minimum key size.

[They kept](https://github.com/microsoft/SymCrypt-OpenSSL/blob/81bfe457ed2e757f2806fa7fdbbb06257c5e81f8/SymCryptProvider/src/mac/p_scossl_kmac.c#L14-L15) the max output size and max customization string, so those are unaffected. Only the key size is (even though SymCrypt on Windows does not have output or customization string limits).

This is done separately from other AZL changes because KMAC is new in .NET 9, and won't be back ported to .NET 8 or older.

This brings the failure count down to 298.

Contributes to https://github.com/dotnet/runtime/issues/106489

