### PR TITLE
Fix zlib-ng compilation on Raspberry Pi ARM32

### DIFF
--- a/src/native/external/zlib-ng.cmake
+++ b/src/native/external/zlib-ng.cmake
@@ -13,6 +13,8 @@ set(Z_PREFIX ON)
 
 # TODO: Turn back on when Linux kernels with proper RISC-V extension detection (>= 6.5) are more commonplace
 set(WITH_RVV OFF)
+# We don't support ARMv6 and the check works incorrectly when compiling for ARMv7 w/ Thumb instruction set
+set(WITH_ARMV6 OFF)
 
 # 'aligned_alloc' is not available in browser/wasi, yet it is set by zlib-ng/CMakeLists.txt.
 if (CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)


### PR DESCRIPTION
Fixes #106584

Note that we don't lose any optimized code paths since NEON is enabled:
```
  -- The following features have been enabled:
  
   * CMAKE_BUILD_TYPE, Build type: DEBUG (selected)
   * ACLE_CRC, Support ACLE optimized CRC hash generation, using "-march=armv8-a+crc"
   * NEON_ADLER32, Support NEON instructions in adler32, using "-mfpu=neon"
   * NEON_SLIDEHASH, Support NEON instructions in slide_hash, using "-mfpu=neon"
   * WITH_GZFILEOP, Compile with support for gzFile related functions
   * ZLIB_COMPAT, Compile with zlib compatible API
   * WITH_SANITIZER, Enable sanitizer support
   * WITH_GTEST, Build gtest_zlib
   * WITH_OPTIM, Build with optimisation
   * WITH_NEW_STRATEGIES, Use new strategies
   * WITH_ACLE, Build with ACLE
   * WITH_NEON, Build with NEON intrinsics
```

On the unsupported ARMv6 Mono builds the system Zlib is used instead.