### PR TITLE
Add missing exception log for ILogger extension methods

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -418,7 +419,12 @@ namespace Microsoft.Extensions.Logging
 
         private static string MessageFormatter(FormattedLogValues state, Exception? error)
         {
-            return state.ToString();
+            if (error == null)
+            {
+                return state.ToString();
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", state, Environment.NewLine, error);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerExtensionsTest.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(0, trace.EventId);
             Assert.Equal(_exception, trace.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 trace.Formatter(trace.State, trace.Exception));
 
             Assert.True(sink.Writes.TryTake(out var information));
@@ -509,7 +509,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(0, information.EventId);
             Assert.Equal(_exception, information.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 information.Formatter(information.State, information.Exception));
 
             Assert.True(sink.Writes.TryTake(out var warning));
@@ -517,7 +517,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(0, warning.EventId);
             Assert.Equal(_exception, warning.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 warning.Formatter(warning.State, warning.Exception));
 
             Assert.True(sink.Writes.TryTake(out var error));
@@ -525,7 +525,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(0, error.EventId);
             Assert.Equal(_exception, error.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 error.Formatter(error.State, error.Exception));
 
             Assert.True(sink.Writes.TryTake(out var critical));
@@ -533,7 +533,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(0, critical.EventId);
             Assert.Equal(_exception, critical.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 critical.Formatter(critical.State, critical.Exception));
 
             Assert.True(sink.Writes.TryTake(out var debug));
@@ -541,7 +541,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(0, debug.EventId);
             Assert.Equal(_exception, debug.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 debug.Formatter(debug.State, debug.Exception));
         }
 
@@ -573,7 +573,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(1, trace.EventId);
             Assert.Equal(_exception, trace.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 trace.Formatter(trace.State, trace.Exception));
 
             Assert.True(sink.Writes.TryTake(out var information));
@@ -582,7 +582,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(2, information.EventId);
             Assert.Equal(_exception, information.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 information.Formatter(information.State, information.Exception));
 
             Assert.True(sink.Writes.TryTake(out var warning));
@@ -591,7 +591,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(3, warning.EventId);
             Assert.Equal(_exception, warning.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 warning.Formatter(warning.State, warning.Exception));
 
             Assert.True(sink.Writes.TryTake(out var error));
@@ -600,7 +600,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(4, error.EventId);
             Assert.Equal(_exception, error.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 error.Formatter(error.State, error.Exception));
 
             Assert.True(sink.Writes.TryTake(out var critical));
@@ -609,7 +609,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(5, critical.EventId);
             Assert.Equal(_exception, critical.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 critical.Formatter(critical.State, critical.Exception));
 
             Assert.True(sink.Writes.TryTake(out var debug));
@@ -618,7 +618,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(6, debug.EventId);
             Assert.Equal(_exception, debug.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 debug.Formatter(debug.State, debug.Exception));
         }
 
@@ -848,7 +848,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(0, write.EventId);
             Assert.Equal(_exception, write.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 write.Formatter(write.State, write.Exception));
         }
 
@@ -879,7 +879,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(eventId, write.EventId);
             Assert.Equal(_exception, write.Exception);
             Assert.Equal(
-                "Test 1",
+                $"Test 1{Environment.NewLine}{_exception}",
                 write.Formatter(write.State, write.Exception));
         }
 


### PR DESCRIPTION
Fixes dotnet/dotnet-api-docs#10318 

This adds the exception as part of the final log string when using any of the `LogTrace`/`LogDebug`/`LogInformation`/`LogWarning`/`LogError`/`LogCritical` extension methods which take in an `Exception?` parameter. 

Since 2016, using the common overloads like `logger.LogError(Exception? exception, string? message, params object?[] args)` on most `ILogger` implementations has led to some confusion as the `exception` is not added to the final log message. This has cost many hours in debugging the reason for the missing logs, forcing many to have to add the exception as part of the `message` or `args` parameters instead.

The formatting of the exception log is as it was initially before this bug was introduced (in [this commit](https://github.com/aspnet/Logging/commit/4528bdbc2816a8b5f933d9c6cf2da806ce4a72ea#diff-5b60005d2d3d01ca51f37a85a0b875cf1c8aafabfc37bd557bd465b87c1d3800L820)).