### PR TITLE
[cdac] Fix building of method signature names for class type variables

### DIFF
--- a/src/native/managed/cdacreader/src/Legacy/SigFormat.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SigFormat.cs
@@ -227,9 +227,9 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy
 
                     case CorElementType.Var:
                         int varIndex = signature.ReadCompressedInteger();
-                        if (methodInstantiation.Length > varIndex)
+                        if (typeInstantiation.Length > varIndex)
                         {
-                            AddType(target, stringBuilder, methodInstantiation[varIndex]);
+                            AddType(target, stringBuilder, typeInstantiation[varIndex]);
                         }
                         else
                         {

--- a/src/native/managed/cdacreader/src/Legacy/TypeNameBuilder.cs
+++ b/src/native/managed/cdacreader/src/Legacy/TypeNameBuilder.cs
@@ -149,6 +149,12 @@ internal struct TypeNameBuilder
             if (!th.IsNull)
             {
                 typeInstantiationSigFormat = runtimeTypeSystem.GetInstantiation(th);
+                if (typeInstantiationSigFormat.IsEmpty && runtimeTypeSystem.IsArray(th, out _))
+                {
+                    // For arrays, fill in the instantiation with the element type handle
+                    // See MethodTable::GetArrayInstantiation for coreclr equivalent
+                    typeInstantiationSigFormat = new[] { runtimeTypeSystem.GetTypeParam(th) };
+                }
             }
 
             SigFormat.AppendSigFormat(target, stringBuilder, signature, reader, null, null, null, typeInstantiationSigFormat, runtimeTypeSystem.GetGenericMethodInstantiation(method), true);


### PR DESCRIPTION
- Use type instantiation (instead of method) for formatting signature with class type variables
- Handle creating instantiation for arrays to pass to signature formatting helper

Examples:
```diff
-System.Collections.Generic.Dictionary`2[[System.Int32, System.Private.CoreLib],[System.UInt64, System.Private.CoreLib]].Add(!!0, !!1)
+System.Collections.Generic.Dictionary`2[[System.Int32, System.Private.CoreLib],[System.UInt64, System.Private.CoreLib]].Add(Int32, UInt64)

-System.Object[].Set(Int32, !!0)
+System.Object[].Set(Int32, System.Object)
```