### PR TITLE
Fix error check for CipherUpdate

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OpenSslCipherLite.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OpenSslCipherLite.cs
@@ -139,11 +139,11 @@ namespace System.Security.Cryptography
 
         private int CipherUpdate(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Interop.Crypto.EvpCipherUpdate(
+            CheckBoolReturn(Interop.Crypto.EvpCipherUpdate(
                 _ctx,
                 output,
                 out int bytesWritten,
-                input);
+                input));
 
             return bytesWritten;
         }

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -157,13 +157,19 @@ int32_t CryptoNative_EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding)
 int32_t
 CryptoNative_EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl)
 {
+    assert(outl != NULL);
     ERR_clear_error();
 
-    int outLength;
+    int outLength = 0;
     int32_t ret = EVP_CipherUpdate(ctx, out, &outLength, in, inl);
+
     if (ret == SUCCESS)
     {
         *outl = outLength;
+    }
+    else
+    {
+        *outl = 0;
     }
 
     return ret;


### PR DESCRIPTION
We weren't checking the return value for `CipherUpdate`, so add the return value check. While we are here, make sure `outl` is always set when the native shim function exits.

There is currently no known way to hit this or write a test for it, as the inputs to `CipherUpdate` are checked up-front and handled appropriately.