### PR TITLE
[cdac] Remove extra [] in array type name

### DIFF
--- a/src/native/managed/cdacreader/src/Legacy/TypeNameBuilder.cs
+++ b/src/native/managed/cdacreader/src/Legacy/TypeNameBuilder.cs
@@ -588,7 +588,6 @@ internal struct TypeNameBuilder
             }
             TypeString.Append(']');
         }
-        TypeString.Append("[]");
     }
 
     private static ReadOnlySpan<char> TypeNameReservedChars()


### PR DESCRIPTION
We were appending an extra `[]` to the end of the type name for multi-dimensional or non-zero-based arrays.

Examples:
```diff
// int[,]
-System.Int32[,][]
+System.Int32[,]
// long[,,]
-System.Int64[,,][]
+System.Int64[,,]
// Array.CreateInstance(typeof(uint), [5], [1])
-System.UInt32<*>[]
+System.UInt32<*>
// ulong[,][]
-System.UInt64[][,][]
+System.UInt64[][,]
```