### PR TITLE
Fix invalid handle bug happening when `TypeBuilder` type used in exception catch clause

### DIFF
--- a/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
+++ b/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
@@ -479,7 +479,6 @@ namespace System.Reflection.Emit
     {
         public PersistedAssemblyBuilder(System.Reflection.AssemblyName name, System.Reflection.Assembly coreAssembly, System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder>? assemblyAttributes = null) { }
         public override string? FullName { get { throw null; } }
-        public override bool IsDynamic { get { throw null; } }
         public override System.Reflection.Module ManifestModule { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Defining a dynamic assembly requires dynamic code.")]
         protected override System.Reflection.Emit.ModuleBuilder DefineDynamicModuleCore(string name) { throw null; }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -357,6 +357,7 @@ namespace System.Reflection.Emit
                 if (il != null)
                 {
                     FillMemberReferences(il);
+                    il.AddExceptionBlocks();
                     StandaloneSignatureHandle signature = il.LocalCount == 0 ? default :
                         _metadataBuilder.AddStandaloneSignature(_metadataBuilder.GetOrAddBlob(MetadataSignatureHelper.GetLocalSignature(il.Locals, this)));
                     offset = AddMethodBody(method, il, signature, methodBodyEncoder);

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/PersistedAssemblyBuilder.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/PersistedAssemblyBuilder.cs
@@ -202,7 +202,5 @@ namespace System.Reflection.Emit
         public override Module ManifestModule => _module ?? throw new InvalidOperationException(SR.InvalidOperation_AModuleRequired);
 
         public override AssemblyName GetName(bool copiedName) => (AssemblyName)_assemblyName.Clone();
-
-        public override bool IsDynamic => true;
     }
 }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/PersistedAssemblyBuilder.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/PersistedAssemblyBuilder.cs
@@ -202,5 +202,7 @@ namespace System.Reflection.Emit
         public override Module ManifestModule => _module ?? throw new InvalidOperationException(SR.InvalidOperation_AModuleRequired);
 
         public override AssemblyName GetName(bool copiedName) => (AssemblyName)_assemblyName.Clone();
+
+        public override bool IsDynamic => true;
     }
 }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -1077,6 +1077,157 @@ internal class Dummy
         }
 
         [Fact]
+        public void TryCatchWithTypeBuilderException()
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssembly"), typeof(object).Assembly);
+                ModuleBuilder mb = ab.DefineDynamicModule("MyModule");
+                TypeBuilder tb = mb.DefineType("MyType", TypeAttributes.Public);
+                TypeBuilder exceptionType = mb.DefineType("MyException", TypeAttributes.Public, typeof(Exception));
+                MethodBuilder method = tb.DefineMethod("Method", MethodAttributes.Public | MethodAttributes.Static, typeof(int), [typeof(int), typeof(int)]);
+                ILGenerator ilGenerator = method.GetILGenerator();
+                ilGenerator.BeginExceptionBlock();
+                ilGenerator.Emit(OpCodes.Ldarg_0);
+                ilGenerator.Emit(OpCodes.Ldarg_1);
+                ilGenerator.Emit(OpCodes.Add);
+                ilGenerator.BeginCatchBlock(exceptionType);
+                ilGenerator.Emit(OpCodes.Ldc_I4_0);
+                ilGenerator.EndExceptionBlock();
+                ilGenerator.Emit(OpCodes.Ret);
+                tb.CreateType();
+                exceptionType.CreateType();
+                ab.Save(file.Path);
+
+                using (MetadataLoadContext mlc = new MetadataLoadContext(new CoreMetadataAssemblyResolver()))
+                {
+                    Assembly assemblyFromDisk = mlc.LoadFromAssemblyPath(file.Path);
+                    Type typeFromDisk = assemblyFromDisk.Modules.First().GetType("MyType");
+                    MethodBody body = typeFromDisk.GetMethod("Method").GetMethodBody();
+                    Assert.Equal(1, body.ExceptionHandlingClauses.Count);
+                    Assert.Equal("MyException", body.ExceptionHandlingClauses[0].CatchType.FullName);
+                    Assert.Equal(ExceptionHandlingClauseOptions.Clause, body.ExceptionHandlingClauses[0].Flags);
+                }
+            }
+        }
+
+        [Fact]
+        public void TryMultipleCatchFinallyBlocks()
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder tb);
+                MethodBuilder method = tb.DefineMethod("Method", MethodAttributes.Public | MethodAttributes.Static, typeof(int), [typeof(int), typeof(int)]);
+                FieldBuilder fb = tb.DefineField("Field", typeof(int), FieldAttributes.Public | FieldAttributes.Static);
+                Type dBZException = typeof(DivideByZeroException);
+                TypeBuilder myExceptionType = ab.GetDynamicModule("MyModule").DefineType("MyException", TypeAttributes.Public, typeof(Exception));
+                myExceptionType.CreateType();
+                Type exception = typeof(Exception);
+                Type overflowException = typeof(OverflowException);
+                ILGenerator ilGenerator = method.GetILGenerator();
+                LocalBuilder local = ilGenerator.DeclareLocal(typeof(int));
+                Label exBlock = ilGenerator.BeginExceptionBlock();
+                Label check100 = ilGenerator.DefineLabel();
+                Label leave = ilGenerator.DefineLabel();
+                ilGenerator.Emit(OpCodes.Ldarg_0);
+                ilGenerator.Emit(OpCodes.Ldarg_1);
+                ilGenerator.Emit(OpCodes.Div);
+                ilGenerator.Emit(OpCodes.Stloc_0);
+                ilGenerator.Emit(OpCodes.Ldloc_0);
+                ilGenerator.Emit(OpCodes.Brtrue, check100);
+                ilGenerator.ThrowException(myExceptionType);
+                ilGenerator.MarkLabel(check100);
+                ilGenerator.Emit(OpCodes.Ldarg_1);
+                ilGenerator.Emit(OpCodes.Ldc_I4, 100);
+                ilGenerator.Emit(OpCodes.Bne_Un, leave);
+                ilGenerator.ThrowException(overflowException);
+                ilGenerator.MarkLabel(leave);
+                ilGenerator.BeginCatchBlock(dBZException);
+                ilGenerator.EmitWriteLine("Error: division by zero");
+                ilGenerator.Emit(OpCodes.Ldc_I4_M1);
+                ilGenerator.Emit(OpCodes.Stloc_0);
+                ilGenerator.BeginCatchBlock(myExceptionType);
+                ilGenerator.EmitWriteLine("Error: MyException");
+                ilGenerator.Emit(OpCodes.Ldc_I4_S, 2);
+                ilGenerator.Emit(OpCodes.Stloc_0);
+                ilGenerator.BeginCatchBlock(exception);
+                ilGenerator.EmitWriteLine("Error: generic Exception");
+                ilGenerator.Emit(OpCodes.Ldc_I4_S, 3);
+                ilGenerator.Emit(OpCodes.Stloc_0);
+                ilGenerator.BeginFinallyBlock();
+                ilGenerator.EmitWriteLine("Finally block");
+                ilGenerator.Emit(OpCodes.Ldc_I4_S, 30);
+                ilGenerator.Emit(OpCodes.Stsfld, fb);
+                ilGenerator.EndExceptionBlock();
+                ilGenerator.Emit(OpCodes.Ldloc_0);
+                ilGenerator.Emit(OpCodes.Ret);
+                tb.CreateType();
+                ab.Save(file.Path);
+
+                TestAssemblyLoadContext tlc = new TestAssemblyLoadContext();
+                Assembly assemblyFromDisk = tlc.LoadFromAssemblyPath(file.Path);
+                Type typeFromDisk = assemblyFromDisk.GetType("MyType");
+                MethodInfo methodFromDisk = typeFromDisk.GetMethod("Method");
+                MethodBody body = methodFromDisk.GetMethodBody();
+                Assert.Equal(4, body.ExceptionHandlingClauses.Count);
+                Assert.Equal(ExceptionHandlingClauseOptions.Clause, body.ExceptionHandlingClauses[0].Flags);
+                Assert.Equal(ExceptionHandlingClauseOptions.Clause, body.ExceptionHandlingClauses[1].Flags);
+                Assert.Equal(ExceptionHandlingClauseOptions.Clause, body.ExceptionHandlingClauses[2].Flags);
+                Assert.Equal(ExceptionHandlingClauseOptions.Finally, body.ExceptionHandlingClauses[3].Flags);
+                Assert.Equal(dBZException.FullName, body.ExceptionHandlingClauses[0].CatchType.FullName);
+                Assert.Equal("MyException", body.ExceptionHandlingClauses[1].CatchType.FullName);
+                Assert.Equal(exception.FullName, body.ExceptionHandlingClauses[2].CatchType.FullName);
+/*
+public class MyException : Exception { }
+
+public class MyType
+{
+    public static int Field;
+    public static int Method(int a, int b)
+    {
+        int res;
+        try{
+            res = a/b;
+            if (res == 0)
+                throw new MyException();
+            if (b == 100)
+                throw new OverflowException();
+        }
+        catch(DivideByZeroException)
+        {
+            Console.WriteLine("Divide by zero caught");
+            res = -1;
+        }
+        catch(MyException)
+        {
+            Console.WriteLine("MyException caught");
+            res = 2;
+        }
+        catch(Exception)
+        {
+            Console.WriteLine("Divide by zero!");
+            res = 3;
+        }
+        finally
+        {
+            Console.WriteLine("Finally block");
+            Field = 30;
+        }
+        return res;
+    }
+}*/
+                FieldInfo field = typeFromDisk.GetField("Field");
+                Assert.Equal(0, field.GetValue(null));
+                Assert.Equal(5, methodFromDisk.Invoke(null, new object[] { 50, 10 }));
+                Assert.Equal(30, field.GetValue(null));
+                Assert.Equal(-1, methodFromDisk.Invoke(null, new object[] { 1, 0 }));
+                Assert.Equal(2, methodFromDisk.Invoke(null, new object[] { 0, 1 }));
+                Assert.Equal(3, methodFromDisk.Invoke(null, new object[] { 1000, 100 }));
+                tlc.Unload();
+            }
+        }
+
+        [Fact]
         public void TryMultipleCatchBlocks()
         {
             using (TempFile file = TempFile.Create())


### PR DESCRIPTION
PersistedAssemblyBuilder's `ILGenerator` cannot handle catch block with newly created `TypeBuilder` exception type, because the `TypeBuilder` token is not valid when `ILGenerator.BeginCatchBlock(Type? exceptionType)` called and the handle will not be populated properly until the assembly saved into a file or stream.

The current solution for handling unpopulated tokens: `BlobBuilder.ReserveBytes(int)` will not work for this case as `ControlFlowBuilder.AddCatchRegion(...)` validates and reserves the exception type handle, not writes the token into BLOB directly

So instead of adding exception handler blocks directly into the `ControlFlowBuilder` instance collecting them into a list and adding them to the `ControlFlowBuilder` during Save where all tokens will be populated. 

Alternative solution: tried to fill valid `TypeBuilder` handles using reflection, but it's getting very messy, need to access and manipulate private/internal members of `ControlFlowBuilder`.

Fixes https://github.com/dotnet/runtime/issues/106485