### PR TITLE
`__ComObject` invoke through reflection fix

### DIFF
--- a/src/tests/Interop/COM/NETClients/Primitives/CallViaReflectionTests.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/CallViaReflectionTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace NetClient
+{
+    using System;
+    using System.Reflection;
+    using Xunit;
+
+    class CallViaReflectionTests
+    {
+        private readonly Server.Contract.Servers.NumericTesting server;
+
+        public CallViaReflectionTests()
+        {
+            this.server = (Server.Contract.Servers.NumericTesting)new Server.Contract.Servers.NumericTestingClass();
+        }
+
+        public void Run()
+        {
+            Console.WriteLine(nameof(CallViaReflectionTests));
+            this.InvokeInstanceMethod();
+        }
+
+        private void InvokeInstanceMethod()
+        {
+            MethodInfo minfo = typeof(Server.Contract.INumericTesting).GetMethod("Add_Int")!;
+            object[] parameters = new object[2] { 10, 20 };
+            int sum = (int)minfo.Invoke(this.server, parameters);
+            Assert.Equal(30, sum);
+        }
+    }
+}

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="ArrayTests.cs" />
+    <Compile Include="CallViaReflectionTests.cs" />
     <Compile Include="ErrorTests.cs" />
     <Compile Include="NumericTests.cs" />
     <Compile Include="StringTests.cs" />

--- a/src/tests/Interop/COM/NETClients/Primitives/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/Program.cs
@@ -40,6 +40,7 @@ namespace NetClient
             new StringTests().Run();
             new ErrorTests().Run();
             new ColorTests().Run();
+            new CallViaReflectionTests().Run();
         }
     }
 }


### PR DESCRIPTION
A regression was introduced that had `__ComObject`
implement `IDynamicInterfaceCastable`. This means
that the order of checks is now important. Made the
order consistent in all places and added a test for this
particular case.

Regression introduced in https://github.com/dotnet/runtime/pull/105965 and found in https://github.com/dotnet/winforms/pull/11916.

/cc @dotnet/interop-contrib 