### PR TITLE
[cdac] Make GetObjectData for arrays use canonical method table when getting the element type

### DIFF
--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -440,10 +440,13 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface2, 
                 // Update the size to include the array components
                 data->Size += numComponents * data->dwComponentSize;
 
-                // Get the type of the array elements
+                // Get the type handle of the array elements
                 TypeHandle element = runtimeTypeSystemContract.GetTypeParam(handle);
                 data->ElementTypeHandle = element.Address;
-                data->ElementType = (uint)runtimeTypeSystemContract.GetSignatureCorElementType(element);
+
+                // Get the element type from the canonical method table - see MethodTable::GetArrayElementType for coreclr equivalent
+                TypeHandle canonical = runtimeTypeSystemContract.GetTypeHandle(runtimeTypeSystemContract.GetCanonicalMethodTable(handle));
+                data->ElementType = (uint)runtimeTypeSystemContract.GetSignatureCorElementType(runtimeTypeSystemContract.GetTypeParam(canonical));
 
                 // Validate the element type handles for arrays of arrays
                 while (runtimeTypeSystemContract.IsArray(element, out _))


### PR DESCRIPTION
When getting the element type for an array, cDAC was just getting the CorElementType of the element type handle. However, there are cases where that does not match the element type on the class for the array's canonical method table - for example, arrays of multi-dimensional or non-zero-based arrays. This changes the cDAC to use the canonical method table when getting the element type - matching the DAC (which uses `MethodTable::GetArrayElementType`).