### PR TITLE
Add callback-based Encode to AsnWriter

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.macOS.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.macOS.cs
@@ -170,24 +170,17 @@ namespace System.Security.Cryptography
                     hasPrivateKey = false;
                 }
 
-                byte[] rented = CryptoPool.Rent(keyWriter.GetEncodedLength());
-
-                if (!keyWriter.TryEncode(rented, out int written))
-                {
-                    Debug.Fail("TryEncode failed with a pre-allocated buffer");
-                    throw new InvalidOperationException();
-                }
-
-                // Explicitly clear the inner buffer
-                keyWriter.Reset();
-
                 try
                 {
-                    return Interop.AppleCrypto.ImportEphemeralKey(rented.AsSpan(0, written), hasPrivateKey);
+                    return keyWriter.Encode(hasPrivateKey, static (hasPrivateKey, encoded) =>
+                    {
+                        return Interop.AppleCrypto.ImportEphemeralKey(encoded, hasPrivateKey);
+                    });
                 }
                 finally
                 {
-                    CryptoPool.Return(rented, written);
+                    // Explicitly clear the inner buffer
+                    keyWriter.Reset();
                 }
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.macOS.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.macOS.cs
@@ -64,24 +64,17 @@ namespace System.Security.Cryptography
         {
             AsnWriter keyWriter = EccKeyFormatHelper.WriteECPrivateKey(parameters);
 
-            byte[] rented = CryptoPool.Rent(keyWriter.GetEncodedLength());
-
-            if (!keyWriter.TryEncode(rented, out int written))
-            {
-                Debug.Fail("TryEncode failed with a pre-allocated buffer");
-                throw new InvalidOperationException();
-            }
-
-            // Explicitly clear the inner buffer
-            keyWriter.Reset();
-
             try
             {
-                return Interop.AppleCrypto.ImportEphemeralKey(rented.AsSpan(0, written), true);
+                return keyWriter.Encode(static encoded =>
+                {
+                    return Interop.AppleCrypto.ImportEphemeralKey(encoded, true);
+                });
             }
             finally
             {
-                CryptoPool.Return(rented, written);
+                // Explicitly clear the inner buffer
+                keyWriter.Reset();
             }
         }
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -434,7 +434,11 @@ namespace System.Security.Cryptography
                         AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
                         spki.Encode(writer);
 
-                        SafeRsaHandle key = Interop.AndroidCrypto.DecodeRsaSubjectPublicKeyInfo(writer.Encode());
+                        SafeRsaHandle key = writer.Encode(static (encoded) =>
+                        {
+                            return Interop.AndroidCrypto.DecodeRsaSubjectPublicKeyInfo(encoded);
+                        });
+
                         if (key is null || key.IsInvalid)
                         {
                             key?.Dispose();

--- a/src/libraries/System.Formats.Asn1/ref/System.Formats.Asn1.cs
+++ b/src/libraries/System.Formats.Asn1/ref/System.Formats.Asn1.cs
@@ -160,7 +160,7 @@ namespace System.Formats.Asn1
         public bool EncodedValueEquals(System.ReadOnlySpan<byte> other) { throw null; }
 #if NET9_0_OR_GREATER
         public TReturn Encode<TReturn>(System.Func<System.ReadOnlySpan<byte>, TReturn> encodeCallback) { throw null; }
-        public TReturn Encode<TState, TReturn>(TState state, System.Func<TState, System.ReadOnlySpan<byte>, TReturn> encodeCallback) { throw null; }
+        public TReturn Encode<TState, TReturn>(TState state, System.Func<TState, System.ReadOnlySpan<byte>, TReturn> encodeCallback) where TState : allows ref struct { throw null; }
 #endif
         public int GetEncodedLength() { throw null; }
         public void PopOctetString(System.Formats.Asn1.Asn1Tag? tag = default(System.Formats.Asn1.Asn1Tag?)) { }

--- a/src/libraries/System.Formats.Asn1/ref/System.Formats.Asn1.cs
+++ b/src/libraries/System.Formats.Asn1/ref/System.Formats.Asn1.cs
@@ -158,6 +158,10 @@ namespace System.Formats.Asn1
         public int Encode(System.Span<byte> destination) { throw null; }
         public bool EncodedValueEquals(System.Formats.Asn1.AsnWriter other) { throw null; }
         public bool EncodedValueEquals(System.ReadOnlySpan<byte> other) { throw null; }
+#if NET9_0_OR_GREATER
+        public TReturn Encode<TReturn>(System.Func<System.ReadOnlySpan<byte>, TReturn> encodeCallback) { throw null; }
+        public TReturn Encode<TState, TReturn>(TState state, System.Func<TState, System.ReadOnlySpan<byte>, TReturn> encodeCallback) { throw null; }
+#endif
         public int GetEncodedLength() { throw null; }
         public void PopOctetString(System.Formats.Asn1.Asn1Tag? tag = default(System.Formats.Asn1.Asn1Tag?)) { }
         public void PopSequence(System.Formats.Asn1.Asn1Tag? tag = default(System.Formats.Asn1.Asn1Tag?)) { }

--- a/src/libraries/System.Formats.Asn1/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Asn1/src/Resources/Strings.resx
@@ -105,6 +105,9 @@
   <data name="AsnWriter_EncodeUnbalancedStack" xml:space="preserve">
     <value>Encode cannot be called while a Sequence, Set-Of, or Octet String is still open.</value>
   </data>
+  <data name="AsnWriter_ModifyingWhileEncoding" xml:space="preserve">
+    <value>The AsnWriter cannot be written to while performing the Encode callback.</value>
+  </data>
   <data name="AsnWriter_PopWrongTag" xml:space="preserve">
     <value>Cannot pop the requested tag as it is not currently in progress.</value>
   </data>

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -199,6 +199,71 @@ namespace System.Formats.Asn1
             return _buffer.AsSpan(0, _offset).ToArray();
         }
 
+#if NET9_0_OR_GREATER
+        /// <summary>
+        ///   Provides the encoded representation of the data to the specified callback.
+        /// </summary>
+        /// <param name="encodeCallback">
+        ///   The callback that receives the encoded data.
+        /// </param>
+        /// <typeparam name="TReturn">
+        ///   The type of the return value.
+        /// </typeparam>
+        /// <returns>
+        ///   Returns the value returned from <paramref name="encodeCallback" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="encodeCallback"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   A <see cref="PushSequence"/> or <see cref="PushSetOf"/> has not been closed via
+        ///   <see cref="PopSequence"/> or <see cref="PopSetOf"/>.
+        /// </exception>
+        public TReturn Encode<TReturn>(Func<ReadOnlySpan<byte>, TReturn> encodeCallback)
+        {
+            if (encodeCallback is null)
+                throw new ArgumentNullException(nameof(encodeCallback));
+
+            ReadOnlySpan<byte> encoded = EncodeAsSpan();
+            return encodeCallback(encoded);
+        }
+
+        /// <summary>
+        ///   Provides the encoded representation of the data to the specified callback.
+        /// </summary>
+        /// <param name="encodeCallback">
+        ///   The callback that receives the encoded data.
+        /// </param>
+        /// <param name="state">
+        ///   The state to pass to <paramref name="encodeCallback" />.
+        /// </param>
+        /// <typeparam name="TState">
+        ///   The type of the state.
+        /// </typeparam>
+        /// <typeparam name="TReturn">
+        ///   The type of the return value.
+        /// </typeparam>
+        /// <returns>
+        ///   Returns the value returned from <paramref name="encodeCallback" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="encodeCallback"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   A <see cref="PushSequence"/> or <see cref="PushSetOf"/> has not been closed via
+        ///   <see cref="PopSequence"/> or <see cref="PopSetOf"/>.
+        /// </exception>
+        public TReturn Encode<TState, TReturn>(TState state, Func<TState, ReadOnlySpan<byte>, TReturn> encodeCallback)
+            where TState : allows ref struct
+        {
+            if (encodeCallback is null)
+                throw new ArgumentNullException(nameof(encodeCallback));
+
+            ReadOnlySpan<byte> encoded = EncodeAsSpan();
+            return encodeCallback(state, encoded);
+        }
+#endif
+
         private ReadOnlySpan<byte> EncodeAsSpan()
         {
             if ((_nestingStack?.Count ?? 0) != 0)

--- a/src/libraries/System.Formats.Asn1/tests/Writer/Asn1WriterTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/Asn1WriterTests.cs
@@ -16,6 +16,18 @@ namespace System.Formats.Asn1.Tests.Writer
             Assert.Equal(expectedHex, encoded.ByteArrayToHex());
             Assert.Equal(expectedSize, encoded.Length);
 
+#if NET9_0_OR_GREATER
+            string hexEncoded = writer.Encode(Convert.ToHexString);
+            Assert.Equal(expectedHex, hexEncoded);
+
+            object state = new();
+            hexEncoded = writer.Encode(state, (object callbackState, ReadOnlySpan<byte> encoded) => {
+                Assert.Same(state, callbackState);
+                return Convert.ToHexString(encoded);
+            });
+            Assert.Equal(expectedHex, hexEncoded);
+#endif
+
             // Now verify TryEncode's boundary conditions.
             byte[] encoded2 = new byte[encoded.Length + 3];
             encoded2[0] = 255;

--- a/src/libraries/System.Formats.Asn1/tests/Writer/PushPopSetOf.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/PushPopSetOf.cs
@@ -465,6 +465,18 @@ namespace System.Formats.Asn1.Tests.Writer
             Assert.Throws<InvalidOperationException>(() => writer.TryEncode(buf, out written));
             Assert.Throws<InvalidOperationException>(() => writer.EncodedValueEquals(buf));
             Assert.Equal(-5, written);
+
+#if NET9_0_OR_GREATER
+            Assert.Throws<InvalidOperationException>(() => writer.Encode<object>(_ => {
+                Assert.Fail("Callback should not have been called.");
+                return null;
+            }));
+
+            Assert.Throws<InvalidOperationException>(() => writer.Encode<object, object>(null, (_, _) => {
+                Assert.Fail("Callback should not have been called.");
+                return null;
+            }));
+#endif
         }
 
         [Theory]

--- a/src/libraries/System.Formats.Asn1/tests/Writer/SimpleWriterTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/SimpleWriterTests.cs
@@ -247,6 +247,38 @@ namespace System.Formats.Asn1.Tests.Writer
             Assert.Equal(1024, buffer?.Length);
         }
 
+#if NET9_0_OR_GREATER
+        [Fact]
+        public static void Encode_Callback_NoModifications()
+        {
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+
+            writer.Encode(writer, static (writer, encoded) =>
+            {
+                writer.Encode(writer, static (writer, encoded) =>
+                {
+                    Assert.Throws<InvalidOperationException>(() => writer.WriteNull());
+                    return (object)null;
+                });
+
+                Assert.Throws<InvalidOperationException>(() => writer.WriteNull());
+                return (object)null;
+            });
+
+            writer.Encode(writer, static (writer, encoded) =>
+            {
+                writer.Encode(writer, static (writer, encoded) =>
+                {
+                    Assert.Throws<InvalidOperationException>(() => writer.Reset());
+                    return (object)null;
+                });
+
+                Assert.Throws<InvalidOperationException>(() => writer.Reset());
+                return (object)null;
+            });
+        }
+#endif
+
         private static byte[]? PeekRawBuffer(AsnWriter writer)
         {
             FieldInfo bufField = typeof(AsnWriter).GetField("_buffer", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/libraries/System.Formats.Asn1/tests/Writer/SimpleWriterTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/SimpleWriterTests.cs
@@ -49,6 +49,18 @@ namespace System.Formats.Asn1.Tests.Writer
             Assert.Equal(0, written);
             Assert.True(writer.EncodedValueEquals(ReadOnlySpan<byte>.Empty));
 
+#if NET9_0_OR_GREATER
+            writer.Encode<object>(encoded => {
+                Assert.Equal(0, encoded.Length);
+                return null;
+            });
+
+            writer.Encode<object, object>(null, (_, encoded) => {
+                Assert.Equal(0, encoded.Length);
+                return null;
+            });
+#endif
+
             Span<byte> negativeTest = stackalloc byte[] { 5, 0 };
             Assert.False(writer.EncodedValueEquals(negativeTest));
         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -653,7 +653,15 @@ namespace System.Security.Cryptography.Pkcs
                     {
                         writer.PopSetOf();
 
+#if NET9_0_OR_GREATER
+                        writer.Encode(hasher, static (hasher, encoded) =>
+                        {
+                            hasher.AppendData(encoded);
+                            return (object?)null;
+                        });
+#else
                         hasher.AppendData(writer.Encode());
+#endif
                     }
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -890,7 +890,7 @@ namespace System.Security.Cryptography.X509Certificates
             };
 
             certificate.Encode(writer);
-            X509Certificate2 ret = X509CertificateLoader.LoadCertificate(writer.Encode());
+            X509Certificate2 ret = writer.Encode(X509CertificateLoader.LoadCertificate);
             CryptoPool.Return(normalizedSerial);
             return ret;
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.CdpExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.CdpExtension.cs
@@ -108,8 +108,10 @@ namespace System.Security.Cryptography.X509Certificates
             // CRLDistributionPoints
             writer.PopSequence();
 
-            byte[] encoded = writer.Encode();
-            return new X509Extension(Oids.CrlDistributionPointsOid, encoded, critical);
+            return writer.Encode(critical, static (critical, encoded) =>
+            {
+                return new X509Extension(Oids.CrlDistributionPointsOid, encoded, critical);
+            });
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509Encoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509Encoder.cs
@@ -280,8 +280,11 @@ namespace System.Security.Cryptography.X509Certificates
             DSAOpenSsl dsa = new DSAOpenSsl();
             try
             {
-                dsa.ImportSubjectPublicKeyInfo(writer.Encode(), out _);
-                return dsa;
+                return writer.Encode(dsa, static (dsa, encoded) =>
+                {
+                    dsa.ImportSubjectPublicKeyInfo(encoded, out _);
+                    return dsa;
+                });
             }
             catch (Exception)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/SubjectAlternativeNameBuilder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/SubjectAlternativeNameBuilder.cs
@@ -77,10 +77,10 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
-            return new X509Extension(
-                Oids.SubjectAltName,
-                writer.Encode(),
-                critical);
+            return writer.Encode(critical, static (critical, encoded) =>
+            {
+                return new X509Extension(Oids.SubjectAltName, encoded, critical);
+            });
         }
 
         private void AddGeneralName(GeneralNameAsn generalName)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedNameBuilder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedNameBuilder.cs
@@ -350,11 +350,7 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
-            byte[] rented = CryptoPool.Rent(_writer.GetEncodedLength());
-            int encoded = _writer.Encode(rented);
-            X500DistinguishedName name = new X500DistinguishedName(rented.AsSpan(0, encoded));
-            CryptoPool.Return(rented, clearSize: 0); // Distinguished Names do not contain sensitive information.
-            return name;
+            return _writer.Encode(static encoded => new X500DistinguishedName(encoded));
         }
 
         private void EncodeComponent(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityKeyIdentifierExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityKeyIdentifierExtension.cs
@@ -245,22 +245,7 @@ namespace System.Security.Cryptography.X509Certificates
                 writer.WriteOctetString(subjectKeyIdentifier, new Asn1Tag(TagClass.ContextSpecific, 0));
             }
 
-            // Most KeyIdentifier values are computed from SHA-1 (20 bytes), which produces a 24-byte
-            // value for this extension.
-            // Let's go ahead and be really generous before moving to redundant array allocation.
-            Span<byte> stackSpan = stackalloc byte[64];
-            scoped ReadOnlySpan<byte> encoded;
-
-            if (writer.TryEncode(stackSpan, out int written))
-            {
-                encoded = stackSpan.Slice(0, written);
-            }
-            else
-            {
-                encoded = writer.Encode();
-            }
-
-            return new X509AuthorityKeyIdentifierExtension(encoded);
+            return writer.Encode(static encoded => new X509AuthorityKeyIdentifierExtension(encoded));
         }
 
         /// <summary>
@@ -343,7 +328,7 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
-            return new X509AuthorityKeyIdentifierExtension(writer.Encode());
+            return writer.Encode(static encoded => new X509AuthorityKeyIdentifierExtension(encoded));
         }
 
 
@@ -444,7 +429,7 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
-            return new X509AuthorityKeyIdentifierExtension(writer.Encode());
+            return writer.Encode(static encoded => new X509AuthorityKeyIdentifierExtension(encoded));
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Android.cs
@@ -155,23 +155,23 @@ namespace System.Security.Cryptography.X509Certificates
                 AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
                 spki.Encode(writer);
 
-                byte[] rented = CryptoPool.Rent(writer.GetEncodedLength());
-
-                int written = writer.Encode(rented);
-
                 DSA dsa = DSA.Create();
                 DSA? toDispose = dsa;
 
                 try
                 {
-                    dsa.ImportSubjectPublicKeyInfo(rented.AsSpan(0, written), out _);
+                    writer.Encode(dsa, static (dsa, encoded) =>
+                    {
+                        dsa.ImportSubjectPublicKeyInfo(encoded, out _);
+                        return (object?)null;
+                    });
+
                     toDispose = null;
                     return dsa;
                 }
                 finally
                 {
                     toDispose?.Dispose();
-                    CryptoPool.Return(rented, written);
                 }
             }
         }


### PR DESCRIPTION
This adds a new callback-based mechanism for `AsnWriter`, and uses it where appropriate through the rest of the libraries.

Closes #75759