### PR TITLE
Grab back some performance in `RuntimeTypeHandle::GetElementType`

### DIFF
--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -409,17 +409,17 @@ FCIMPL1(ReflectClassBaseObject *, RuntimeTypeHandle::GetElementType, ReflectClas
     TypeHandle typeHandle = refType->GetType();
     TypeHandle typeReturn;
 
-    if (typeHandle.IsArray())
+    if (!typeHandle.IsTypeDesc())
     {
+        if (!typeHandle.AsMethodTable()->IsArray())
+            return NULL;
+
         typeReturn = typeHandle.GetArrayElementTypeHandle();
     }
     else
     {
-        if (!typeHandle.IsTypeDesc())
-            return 0;
-
         if (typeHandle.IsGenericVariable())
-            return 0;
+            return NULL;
 
         typeReturn = typeHandle.AsTypeDesc()->GetTypeParam();
     }


### PR DESCRIPTION
It appears that after https://github.com/dotnet/runtime/pull/105965, the compiler is no longer inlining `TypeHandle::IsArray` for this code path. This deconstructs that use and reclaims the performance.

Fixes #106708 