### PR TITLE
Fix infinite loop in genCreateAddrMode

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1365,9 +1365,8 @@ AGAIN:
                 {
                     cns += addConst->IconValue();
                     op2 = op2->AsOp()->gtOp1;
+                    goto AGAIN;
                 }
-
-                goto AGAIN;
             }
             break;
 #endif // TARGET_XARCH

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106607/Runtime_106607.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106607/Runtime_106607.il
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime { }
+.assembly extern System.Console { }
+.assembly extern xunit.core { }
+.assembly Runtime_106607 { }
+
+.class Runtime_106607 extends [System.Runtime]System.Object
+{
+  .method public static int32 Main() nooptimization
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .maxstack 8
+    .locals init ([0] int32 num)
+
+    ldc.i4       42
+    stloc.0
+    ldloc.0
+    ldc.i4       1620763441
+    ldc.i4       1453536392
+    add
+    add
+    ldloc.0
+    ldloc.0 
+    sub
+    ldc.i4       152872638
+    ldc.i4.s     31
+    and
+    shl
+    add
+    call  void [System.Console]System.Console::WriteLine(int32)
+
+    ldc.i4 100
+    ret
+  }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106607/Runtime_106607.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106607/Runtime_106607.ilproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/106607

Not sure when exactly this regression was introduced (reproduces on net8 and net7 according to the author, however, this code has not been touched for many years). I wasn't able to create the needed shape in C# (mainly, because Roslyn does constant folding + fixes overshifts even for Debug) so I did it in raw IL.

I presume the culprit in the customer's case is IL obfuscator.