### PR TITLE
Don't define HAS_CUSTOM_BLOCKS on mono

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if TARGET_AMD64 || TARGET_ARM64 || (TARGET_32BIT && !TARGET_ARM) || TARGET_LOONGARCH64
+#if !MONO && (TARGET_AMD64 || TARGET_ARM64 || (TARGET_32BIT && !TARGET_ARM) || TARGET_LOONGARCH64)
 // JIT is guaranteed to unroll blocks up to 64 bytes in size
 #define HAS_CUSTOM_BLOCKS
 #endif


### PR DESCRIPTION
Fixes https://github.com/dotnet/perf-autofiling-issues/issues/33182 regressions