### PR TITLE
Remove ArrayClass::m_ElementType - get type from the type handle on MethodTable

### DIFF
--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -337,7 +337,6 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
         pClass->SetInternalCorElementType(arrayKind);
         pClass->SetAttrClass (tdPublic | tdSerializable | tdSealed);  // This class is public, serializable, sealed
         pClass->SetRank (Rank);
-        pClass->SetArrayElementType (elemType);
         pClass->SetMethodTable (pMT);
 
         // Fill In the method table
@@ -658,9 +657,8 @@ public:
             hiddenArgIdx = 0;
         }
 #endif
-
-        ArrayClass *pcls = (ArrayClass*)(pMT->GetClass());
-        if(pcls->GetArrayElementType() == ELEMENT_TYPE_CLASS)
+        CorElementType sigElementType = pMT->GetArrayElementType();
+        if(sigElementType == ELEMENT_TYPE_CLASS || sigElementType == ELEMENT_TYPE_ARRAY)
         {
             // Type Check
             if(m_pMD->GetArrayFuncIndex() == ArrayMethodDesc::ARRAY_FUNC_SET)

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -658,7 +658,7 @@ public:
         }
 #endif
         CorElementType sigElementType = pMT->GetArrayElementType();
-        if(sigElementType == ELEMENT_TYPE_CLASS || sigElementType == ELEMENT_TYPE_ARRAY)
+        if (CorTypeInfo::IsObjRef(sigElementType))
         {
             // Type Check
             if(m_pMD->GetArrayFuncIndex() == ArrayMethodDesc::ARRAY_FUNC_SET)

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -1953,7 +1953,6 @@ private:
 
     DAC_ALIGNAS(EEClass) // Align the first member to the alignment of the base class
     unsigned char   m_rank;
-    CorElementType  m_ElementType;// Cache of element type in m_ElementTypeHnd
 
 public:
     DWORD GetRank() {
@@ -1968,16 +1967,6 @@ public:
         _ASSERTE((Rank <= MAX_RANK) && (Rank <= (unsigned char)(-1)));
         m_rank = (unsigned char)Rank;
     }
-
-    CorElementType GetArrayElementType() {
-        LIMITED_METHOD_CONTRACT;
-        return m_ElementType;
-    }
-    void SetArrayElementType(CorElementType ElementType) {
-        LIMITED_METHOD_CONTRACT;
-        m_ElementType = ElementType;
-    }
-
 
     // Allocate a new MethodDesc for the methods we add to this class
     void InitArrayMethodDesc(

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -402,7 +402,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
 #endif
 
 #ifdef FEATURE_DOUBLE_ALIGNMENT_HINT
-    if ((pArrayMT->GetArrayElementType() == ELEMENT_TYPE_R8) &&
+    if ((pArrayMT->GetArrayElementTypeHandle() == CoreLibBinder::GetElementType(ELEMENT_TYPE_R8)) &&
         ((DWORD)cElements >= g_pConfig->GetDoubleArrayToLargeObjectHeapThreshold()))
     {
         STRESS_LOG2(LF_GC, LL_INFO10, "Allocating double MD array of size %d and length %d to large object heap\n", totalSize, cElements);
@@ -425,7 +425,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
     else
     {
 #ifdef FEATURE_DOUBLE_ALIGNMENT_HINT
-        if (pArrayMT->GetArrayElementType() == ELEMENT_TYPE_R8)
+        if (pArrayMT->GetArrayElementTypeHandle() == CoreLibBinder::GetElementType(ELEMENT_TYPE_R8))
         {
             flags |= GC_ALLOC_ALIGN8;
         }
@@ -497,7 +497,7 @@ OBJECTREF TryAllocateFrozenSzArray(MethodTable* pArrayMT, INT32 cElements)
 
     // FrozenObjectHeapManager doesn't yet support objects with a custom alignment,
     // so we give up on arrays of value types requiring 8 byte alignment on 32bit platforms.
-    if ((DATA_ALIGNMENT < sizeof(double)) && (pArrayMT->GetArrayElementType() == ELEMENT_TYPE_R8))
+    if ((DATA_ALIGNMENT < sizeof(double)) && (pArrayMT->GetArrayElementTypeHandle() == CoreLibBinder::GetElementType(ELEMENT_TYPE_R8)))
     {
         return NULL;
     }
@@ -665,7 +665,7 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
 #endif
 
 #ifdef FEATURE_DOUBLE_ALIGNMENT_HINT
-    if ((pArrayMT->GetArrayElementType() == ELEMENT_TYPE_R8) &&
+    if ((pArrayMT->GetArrayElementTypeHandle() == CoreLibBinder::GetElementType(ELEMENT_TYPE_R8)) &&
         (cElements >= g_pConfig->GetDoubleArrayToLargeObjectHeapThreshold()))
     {
         STRESS_LOG2(LF_GC, LL_INFO10, "Allocating double MD array of size %d and length %d to large object heap\n", totalSize, cElements);

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -2783,7 +2783,11 @@ public:
     }
 
     // The following methods are only valid for the method tables for array types.
-    CorElementType GetArrayElementType();
+    CorElementType GetArrayElementType()
+    {
+        return GetArrayElementTypeHandle().GetSignatureCorElementType();
+    }
+
     DWORD GetRank();
 
     TypeHandle GetArrayElementTypeHandle()

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -300,15 +300,6 @@ inline BOOL MethodTable::IsValueType()
 }
 
 //==========================================================================================
-inline CorElementType MethodTable::GetArrayElementType()
-{
-    WRAPPER_NO_CONTRACT;
-
-    _ASSERTE (IsArray());
-    return dac_cast<PTR_ArrayClass>(GetClass())->GetArrayElementType();
-}
-
-//==========================================================================================
 inline DWORD MethodTable::GetRank()
 {
     LIMITED_METHOD_DAC_CONTRACT;

--- a/src/tests/baseservices/invalid_operations/Arrays.cs
+++ b/src/tests/baseservices/invalid_operations/Arrays.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+
+using Xunit;
+
+public class Arrays
+{
+    private class TestClass { }
+
+    [Fact]
+    public static void TypeMismatch_ArrayElement()
+    {
+        Console.WriteLine($"Running {nameof(TypeMismatch_ArrayElement)}...");
+        TestClass[][] arr = new TestClass[1][];
+        MethodInfo arraySet = typeof(object[][]).GetMethod("Set");
+        Exception e = Assert.Throws<TargetInvocationException>(() => arraySet.Invoke(arr, [0, new object[] { new object() }]));
+        Assert.IsType<ArrayTypeMismatchException>(e.InnerException);
+    }
+
+    [Fact]
+    public static void TypeMismatch_MultidimensionalArrayElement()
+    {
+        Console.WriteLine($"Running {nameof(TypeMismatch_MultidimensionalArrayElement)}...");
+        TestClass[][,] arr = new TestClass[1][,];
+        MethodInfo arraySet = typeof(object[][,]).GetMethod("Set");
+        Exception e = Assert.Throws<TargetInvocationException>(() => arraySet.Invoke(arr, [0, new object[1,1] { {new object()} }]));
+        Assert.IsType<ArrayTypeMismatchException>(e.InnerException);
+    }
+
+    [Fact]
+    public static void TypeMismatch_ClassElement()
+    {
+        Console.WriteLine($"Running {nameof(TypeMismatch_ClassElement)}...");
+        {
+            TestClass[] arr = new TestClass[1];
+            MethodInfo arraySet = typeof(object[]).GetMethod("Set");
+            Exception e = Assert.Throws<TargetInvocationException>(() => arraySet.Invoke(arr, [0, new object()]));
+            Assert.IsType<ArrayTypeMismatchException>(e.InnerException);
+        }
+        {
+            TestClass[,] arr = new TestClass[1,1];
+            MethodInfo arraySet = typeof(object[,]).GetMethod("Set");
+            Exception e = Assert.Throws<TargetInvocationException>(() => arraySet.Invoke(arr, [0, 0, new object()]));
+            Assert.IsType<ArrayTypeMismatchException>(e.InnerException);
+        }
+    }
+}

--- a/src/tests/baseservices/invalid_operations/Arrays.cs
+++ b/src/tests/baseservices/invalid_operations/Arrays.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 
 using Xunit;
 
+[ConditionalClass(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsMonoInterpreter))]
 public class Arrays
 {
     private class TestClass { }

--- a/src/tests/baseservices/invalid_operations/Arrays.cs
+++ b/src/tests/baseservices/invalid_operations/Arrays.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 using Xunit;
 
-[ConditionalClass(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsMonoInterpreter))]
+[ActiveIssue("https://github.com/dotnet/runtime/issues/107110", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsMonoInterpreter))]
 public class Arrays
 {
     private class TestClass { }

--- a/src/tests/baseservices/invalid_operations/InvalidOperations.csproj
+++ b/src/tests/baseservices/invalid_operations/InvalidOperations.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ManagedPointers.cs" />
+    <Compile Include="Arrays.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />


### PR DESCRIPTION
`ArrayClass::m_ElementType` held a cached version of `MethodTable::m_ElementTypeHnd.GetSignatureCorElementType()`. This removes that member and makes `MethodTable::GetArrayElementType` (and therefore `ArrayBase::GetArrayElementType`) use the type handle to get the element type instead.

This also fixes an issue where we were not always emitting a type check in array functions on arrays with elements that were object references. The added tests validate that these cases now result in an `ArrayTypeMismatchException` for mismatched element types.

https://github.com/dotnet/runtime/pull/106718#discussion_r1725220897

cc @jkotas @davidwrighton @AaronRobinsonMSFT 