### PR TITLE
Enable all AVX-512 ISA's in Crossgen2 and ILC When Supported

### DIFF
--- a/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
+++ b/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
@@ -369,6 +369,12 @@ namespace ILCompiler
 
                 if (_supportedInstructionSets.Contains("avx512vbmi"))
                     _supportedInstructionSets.Add("avx512vbmi_vl");
+
+                // Having AVX10V1 and any AVX-512 instruction sets enabled,
+                // automatically implies AVX10V1-V512 as well.
+
+                if (_supportedInstructionSets.Contains("avx10v1"))
+                    _supportedInstructionSets.Add("avx10v1_v512");
             }
 
             foreach (string supported in _supportedInstructionSets)

--- a/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
+++ b/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 using Internal.TypeSystem;
 using Internal.JitInterface;
@@ -333,11 +334,42 @@ namespace ILCompiler
             {
                 unsupportedInstructionSets.AddInstructionSet(instructionSetConversion[unsupported]);
             }
+
             unsupportedInstructionSets.ExpandInstructionSetByReverseImplication(_architecture);
             unsupportedInstructionSets.Set64BitInstructionSetVariants(_architecture);
 
             if ((_architecture == TargetArchitecture.X86) || (_architecture == TargetArchitecture.ARM))
                 unsupportedInstructionSets.Set64BitInstructionSetVariantsUnconditionally(_architecture);
+
+            // While it's possible to enable individual AVX-512 ISA's, it is not
+            // optimal to do so, since they aren't totally functional this way,
+            // plus it is extremely rare to encounter hardware that doesn't support
+            // all of them. So, here we ensure that we are enabling all the ISA's
+            // if one is specified in the Crossgen2 or ILC command-lines.
+            //
+            // For more information, check this Github comment:
+            // https://github.com/dotnet/runtime/issues/106450#issuecomment-2299504035
+
+            if (_supportedInstructionSets.Any(iSet => iSet.Contains("avx512")))
+            {
+                // We can simply try adding all of the AVX-512 ISA's here,
+                // since SortedSet just ignores the value if it is already present.
+
+                _supportedInstructionSets.Add("avx512f");
+                _supportedInstructionSets.Add("avx512f_vl");
+                _supportedInstructionSets.Add("avx512bw");
+                _supportedInstructionSets.Add("avx512bw_vl");
+                _supportedInstructionSets.Add("avx512cd");
+                _supportedInstructionSets.Add("avx512cd_vl");
+                _supportedInstructionSets.Add("avx512dq");
+                _supportedInstructionSets.Add("avx512dq_vl");
+
+                // If AVX-512VBMI is specified, then we have to include its VL
+                // counterpart as well.
+
+                if (_supportedInstructionSets.Contains("avx512vbmi"))
+                    _supportedInstructionSets.Add("avx512vbmi_vl");
+            }
 
             foreach (string supported in _supportedInstructionSets)
             {

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
-using System.Text;
 
 using ILCompiler;
 
@@ -118,27 +116,6 @@ namespace System.CommandLine
             }
             else if (instructionSet != null)
             {
-                // While it's possible to enable individual AVX-512 ISA's, it is not
-                // optimal to do so, since they aren't totally functional this way,
-                // plus it is extremely rare to encounter hardware that doesn't support
-                // all of them. So, here we ensure that we are enabling all the ISA's
-                // if one is specified in the Crossgen2 or ILC command-lines.
-                //
-                // For more information, check this Github comment:
-                // https://github.com/dotnet/runtime/issues/106450#issuecomment-2299504035
-
-                if (instructionSet.Contains("avx512f", StringComparison.OrdinalIgnoreCase)
-                    || instructionSet.Contains("avx512f_vl", StringComparison.OrdinalIgnoreCase)
-                    || instructionSet.Contains("avx512bw", StringComparison.OrdinalIgnoreCase)
-                    || instructionSet.Contains("avx512bw_vl", StringComparison.OrdinalIgnoreCase)
-                    || instructionSet.Contains("avx512cd", StringComparison.OrdinalIgnoreCase)
-                    || instructionSet.Contains("avx512cd_vl", StringComparison.OrdinalIgnoreCase)
-                    || instructionSet.Contains("avx512dq", StringComparison.OrdinalIgnoreCase)
-                    || instructionSet.Contains("avx512dq_vl", StringComparison.OrdinalIgnoreCase))
-                {
-                    instructionSet = EnsureFullAvx512InstructionSet(instructionSet);
-                }
-
                 List<string> instructionSetParams = new List<string>();
                 string[] instructionSetParamsInput = instructionSet.Split(',');
 
@@ -159,8 +136,6 @@ namespace System.CommandLine
 
                     instructionSetParams.Add(instructionSet);
                 }
-
-                Dictionary<string, bool> instructionSetSpecification = new Dictionary<string, bool>();
 
                 foreach (string instructionSetSpecifier in instructionSetParams)
                 {
@@ -276,40 +251,6 @@ namespace System.CommandLine
                 InstructionSetSupportBuilder.GetNonSpecifiableInstructionSetsForArch(targetArchitecture),
                 targetArchitecture,
                 flags);
-        }
-
-        private static string EnsureFullAvx512InstructionSet(string isasStr)
-        {
-            var instructionSetSb = new StringBuilder(isasStr);
-
-            // Since the user can specify any of the AVX-512 instruction sets, or
-            // any possible subset, we have to check for each one individually.
-
-            if (!isasStr.Contains("avx512f", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512f");
-
-            if (!isasStr.Contains("avx512f_vl", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512f_vl");
-
-            if (!isasStr.Contains("avx512bw", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512bw");
-
-            if (!isasStr.Contains("avx512bw_vl", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512bw_vl");
-
-            if (!isasStr.Contains("avx512cd", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512cd");
-
-            if (!isasStr.Contains("avx512cd_vl", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512cd_vl");
-
-            if (!isasStr.Contains("avx512dq", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512dq");
-
-            if (!isasStr.Contains("avx512dq_vl", StringComparison.OrdinalIgnoreCase))
-                instructionSetSb.Append(",avx512dq_vl");
-
-            return instructionSetSb.ToString();
         }
     }
 }

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
+using System.Text;
 
 using ILCompiler;
 
@@ -116,10 +118,31 @@ namespace System.CommandLine
             }
             else if (instructionSet != null)
             {
+                // While it's possible to enable individual AVX-512 ISA's, it is not
+                // optimal to do so, since they aren't totally functional this way,
+                // plus it is extremely rare to encounter hardware that doesn't support
+                // all of them. So, here we ensure that we are enabling all the ISA's
+                // if one is specified in the Crossgen2 or ILC command-lines.
+                //
+                // For more information, check this Github comment:
+                // https://github.com/dotnet/runtime/issues/106450#issuecomment-2299504035
+
+                if (instructionSet.Contains("avx512f", StringComparison.OrdinalIgnoreCase)
+                    || instructionSet.Contains("avx512f_vl", StringComparison.OrdinalIgnoreCase)
+                    || instructionSet.Contains("avx512bw", StringComparison.OrdinalIgnoreCase)
+                    || instructionSet.Contains("avx512bw_vl", StringComparison.OrdinalIgnoreCase)
+                    || instructionSet.Contains("avx512cd", StringComparison.OrdinalIgnoreCase)
+                    || instructionSet.Contains("avx512cd_vl", StringComparison.OrdinalIgnoreCase)
+                    || instructionSet.Contains("avx512dq", StringComparison.OrdinalIgnoreCase)
+                    || instructionSet.Contains("avx512dq_vl", StringComparison.OrdinalIgnoreCase))
+                {
+                    instructionSet = EnsureFullAvx512InstructionSet(instructionSet);
+                }
+
                 List<string> instructionSetParams = new List<string>();
+                string[] instructionSetParamsInput = instructionSet.Split(',');
 
                 // Normalize instruction set format to include implied +.
-                string[] instructionSetParamsInput = instructionSet.Split(',');
                 for (int i = 0; i < instructionSetParamsInput.Length; i++)
                 {
                     instructionSet = instructionSetParamsInput[i].Trim();
@@ -128,14 +151,17 @@ namespace System.CommandLine
                         throw new CommandLineException(string.Format(mustNotBeMessage, ""));
 
                     char firstChar = instructionSet[0];
+
                     if ((firstChar != '+') && (firstChar != '-'))
                     {
-                        instructionSet =  "+" + instructionSet;
+                        instructionSet = "+" + instructionSet;
                     }
+
                     instructionSetParams.Add(instructionSet);
                 }
 
                 Dictionary<string, bool> instructionSetSpecification = new Dictionary<string, bool>();
+
                 foreach (string instructionSetSpecifier in instructionSetParams)
                 {
                     instructionSet = instructionSetSpecifier.Substring(1);
@@ -250,6 +276,40 @@ namespace System.CommandLine
                 InstructionSetSupportBuilder.GetNonSpecifiableInstructionSetsForArch(targetArchitecture),
                 targetArchitecture,
                 flags);
+        }
+
+        private static string EnsureFullAvx512InstructionSet(string isasStr)
+        {
+            var instructionSetSb = new StringBuilder(isasStr);
+
+            // Since the user can specify any of the AVX-512 instruction sets, or
+            // any possible subset, we have to check for each one individually.
+
+            if (!isasStr.Contains("avx512f", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512f");
+
+            if (!isasStr.Contains("avx512f_vl", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512f_vl");
+
+            if (!isasStr.Contains("avx512bw", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512bw");
+
+            if (!isasStr.Contains("avx512bw_vl", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512bw_vl");
+
+            if (!isasStr.Contains("avx512cd", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512cd");
+
+            if (!isasStr.Contains("avx512cd_vl", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512cd_vl");
+
+            if (!isasStr.Contains("avx512dq", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512dq");
+
+            if (!isasStr.Contains("avx512dq_vl", StringComparison.OrdinalIgnoreCase))
+                instructionSetSb.Append(",avx512dq_vl");
+
+            return instructionSetSb.ToString();
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue #106450.

It is possible to specify just a subset of AVX-512 ISA's with the `--instruction-set` flag when running Crossgen2 and/or ILC. While this is not wrong per se, by design, we are expected to enable all of the ISA's or none at all. To protect this condition, an assert was getting fired when running with Debug builds.

This PR adds an enhancement to ensure all the AVX-512 ISA's are enabled when one is requested, and thus complying with the design. More information about this here: https://github.com/dotnet/runtime/pull/86486