### PR TITLE
[mono] Add missing return mono_type_to_load_membase

### DIFF
--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -420,6 +420,7 @@ mono_type_to_load_membase (MonoCompile *cfg, MonoType *type)
 	case MONO_TYPE_VALUETYPE:
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return OP_LOADX_MEMBASE;
+		return OP_LOADV_MEMBASE;
 	case MONO_TYPE_TYPEDBYREF:
 		return OP_LOADV_MEMBASE;
 	case MONO_TYPE_GENERICINST:


### PR DESCRIPTION
There was a missing return for `MONO_TYPE_VALUETYPE` in `mono_type_to_load_membase`. It works correctly even without this fix but only by coincidence because the following case is `MONO_TYPE_TYPEDBYREF` which returns the same `OP_LOADV_MEMBASE` op code.