### PR TITLE
Relax PNSE expectation for OSSL providers on Apple platforms

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/OpenSslNamedKeysTests.manual.cs
+++ b/src/libraries/System.Security.Cryptography/tests/OpenSslNamedKeysTests.manual.cs
@@ -100,7 +100,21 @@ namespace System.Security.Cryptography.Tests
         [ConditionalFact(nameof(ProvidersNotSupported))]
         public static void ProvidersNotSupported_ThrowsPlatformNotSupported()
         {
-            Assert.Throws<PlatformNotSupportedException>(() => SafeEvpPKeyHandle.OpenKeyFromProvider(Tpm2ProviderName, AnyProviderKeyUri));
+            try
+            {
+                using SafeEvpPKeyHandle key = SafeEvpPKeyHandle.OpenKeyFromProvider("default", NonExistingEngineOrProviderKeyName);
+                Assert.Fail("We expected an exception to be thrown");
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Expected
+            }
+            catch (CryptographicException) when (PlatformDetection.IsApplePlatform)
+            {
+                // Our tests detect providers using PlatformDetection.IsOpenSsl3 which is always false for Apple platforms.
+                // Product on the other hand does feature detection and that might end up working
+                // in which case we should still throw any CryptographicException because the keyUri does not exist.
+            }
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.OpenSslPresentOnSystem))]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/106794

(or at least should as I don't have OSX to repro this specific issue)

This is relaxing expectations on when PNSE should happen - specifically on Apple platforms we will also allow  - I suspect some OSX-es on our CI have OpenSSL installed but our test PlatformDetection might not detect that correctly (currently `IsOpenSsl3` is always false for any Apple platform). Product does the feature detection by checking API presence and therefore discrepancy is possible.