### PR TITLE
Enable CommittedUsage event for segments

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3220,7 +3220,7 @@ void gc_heap::fire_pevents()
 // because EE is not suspended then. On entry it's fired after the GCStart event, on exit it's fire before the GCStop event.
 void gc_heap::fire_committed_usage_event()
 {
-#if defined(FEATURE_EVENT_TRACE) && defined(USE_REGIONS)
+#ifdef FEATURE_EVENT_TRACE
     if (!EVENT_ENABLED (GCMarkWithType)) return;
 
     size_t total_committed = 0;
@@ -3235,11 +3235,18 @@ void gc_heap::fire_committed_usage_event()
                             new_committed_by_oh);
 
     size_t total_committed_in_use = new_committed_by_oh[soh] + new_committed_by_oh[loh] + new_committed_by_oh[poh];
+#ifdef USE_REGIONS
     size_t total_committed_in_global_decommit = committed_decommit;
     size_t total_committed_in_free = committed_free;
     size_t total_committed_in_global_free = new_committed_by_oh[recorded_committed_free_bucket] - total_committed_in_free - total_committed_in_global_decommit;
+#else
+    assert (committed_decommit == 0);
+    assert (committed_free == 0);
+    size_t total_committed_in_global_decommit = 0;
+    size_t total_committed_in_free = 0;
+    size_t total_committed_in_global_free = 0;
+#endif //USE_REGIONS
     size_t total_bookkeeping_committed = committed_bookkeeping;
-
     GCEventFireCommittedUsage_V1 (
         (uint64_t)total_committed_in_use,
         (uint64_t)total_committed_in_global_decommit,
@@ -3247,7 +3254,7 @@ void gc_heap::fire_committed_usage_event()
         (uint64_t)total_committed_in_global_free,
         (uint64_t)total_bookkeeping_committed
     );
-#endif //FEATURE_EVENT_TRACE && USE_REGIONS
+#endif //FEATURE_EVENT_TRACE
 }
 
 inline BOOL

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3245,6 +3245,7 @@ void gc_heap::fire_committed_usage_event()
     size_t total_committed_in_global_decommit = 0;
     size_t total_committed_in_free = 0;
     size_t total_committed_in_global_free = 0;
+    // For segments, bookkeeping committed does not include mark array
 #endif //USE_REGIONS
     size_t total_bookkeeping_committed = committed_bookkeeping;
     GCEventFireCommittedUsage_V1 (

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3248,6 +3248,7 @@ void gc_heap::fire_committed_usage_event()
     // For segments, bookkeeping committed does not include mark array
 #endif //USE_REGIONS
     size_t total_bookkeeping_committed = committed_bookkeeping;
+
     GCEventFireCommittedUsage_V1 (
         (uint64_t)total_committed_in_use,
         (uint64_t)total_committed_in_global_decommit,

--- a/src/coreclr/gc/gcevent_serializers.h
+++ b/src/coreclr/gc/gcevent_serializers.h
@@ -101,9 +101,10 @@ struct EventSerializationTraits<uint16_t>
     static void Serialize(const uint16_t& value, uint8_t** buffer)
     {
 #if defined(BIGENDIAN)
-        **((uint16_t**)buffer) = ByteSwap16(value);
+        uint16_t swapped = ByteSwap16(value);
+        memcpy(*buffer, &swapped, sizeof(uint16_t));
 #else
-        **((uint16_t**)buffer) = value;
+        memcpy(*buffer, &value, sizeof(uint16_t));
 #endif // BIGENDIAN
         *buffer += sizeof(uint16_t);
     }
@@ -120,9 +121,10 @@ struct EventSerializationTraits<uint32_t>
     static void Serialize(const uint32_t& value, uint8_t** buffer)
     {
 #if defined(BIGENDIAN)
-        **((uint32_t**)buffer) = ByteSwap32(value);
+        uint32_t swapped = ByteSwap32(value);
+        memcpy(*buffer, &swapped, sizeof(uint32_t));
 #else
-        **((uint32_t**)buffer) = value;
+        memcpy(*buffer, &value, sizeof(uint32_t));
 #endif // BIGENDIAN
         *buffer += sizeof(uint32_t);
     }
@@ -139,9 +141,10 @@ struct EventSerializationTraits<uint64_t>
     static void Serialize(const uint64_t& value, uint8_t** buffer)
     {
 #if defined(BIGENDIAN)
-        **((uint32_t**)buffer) = ByteSwap64(value);
+        uint64_t swapped = ByteSwap64(value);
+        memcpy(*buffer, &swapped, sizeof(uint64_t));
 #else
-        **((uint64_t**)buffer) = value;
+        memcpy(*buffer, &value, sizeof(uint64_t));
 #endif // BIGENDIAN
         *buffer += sizeof(uint64_t);
     }
@@ -157,7 +160,7 @@ struct EventSerializationTraits<float>
 {
     static void Serialize(const float& value, uint8_t** buffer)
     {
-        **((float**)buffer) = value;
+        memcpy(*buffer, &value, sizeof(float));
         *buffer += sizeof(float);
     }
 


### PR DESCRIPTION
Since we have got the commit accounting right, we can take advantage of it to fire the `CommittedUsage` event. This will allow us to make meaningful comparison between segments and regions with respect to committed memory usage.