### PR TITLE
Fix MD5 failures on Azure Linux in System.Security.Cryptography.Pkcs

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/ShroudedKeyBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/ShroudedKeyBagTests.cs
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa2.TrySignData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1,
                         out int sigLen));
 
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa.VerifyData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1));
                 }
             }
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa2.TrySignData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1,
                         out int sigLen));
 
@@ -86,7 +86,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa.VerifyData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1));
                 }
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
@@ -10,5 +10,8 @@ namespace System.Security.Cryptography.Pkcs.Tests
     {
         public static bool SupportsRsaSha1Signatures { get; } =
             System.Security.Cryptography.Tests.SignatureSupport.CanProduceSha1Signature(RSA.Create());
+
+        public static bool SupportsRsaMd5Signatures { get; } =
+            System.Security.Cryptography.Tests.SignatureSupport.CanProduceMd5Signature(RSA.Create());
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
@@ -198,7 +198,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             signer.CheckSignature(new X509Certificate2Collection(), true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaMd5Signatures))]
         public static void CheckSignature_MD5WithRSA()
         {
             SignedCms cms = new SignedCms();


### PR DESCRIPTION
I missed S.S.C.Pkcs in my pass of "what needs to be fixed on Azure Linux". This addresses a few failures.

Contributes to https://github.com/dotnet/runtime/issues/106489