### PR TITLE
Exclude non windows platform for the large array test

### DIFF
--- a/src/tests/GC/LargeMemory/Regressions/largearraytest.csproj
+++ b/src/tests/GC/LargeMemory/Regressions/largearraytest.csproj
@@ -2,6 +2,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!--
+        Test unsupported outside of windows
+        On platform other than Windows, this test could get killed by the OOM killer
+        instead of having a proper OutOfMemoryException.
+    -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="largearraytest.cs" />


### PR DESCRIPTION
The test case is expecting `OutOfMemoryException` and do not consider that as a failure, but on non-windows platform, it is being killed by the OOM killer instead, causing the test case to fail.

Fixes https://github.com/dotnet/runtime/issues/100382