### PR TITLE
[LoongArch64] Add proj to generate nupkg runtime.linux-loongarch64.runtime.native.System.IO.Ports

### DIFF
--- a/src/libraries/System.IO.Ports/pkg/runtime.linux-loongarch64.runtime.native.System.IO.Ports.proj
+++ b/src/libraries/System.IO.Ports/pkg/runtime.linux-loongarch64.runtime.native.System.IO.Ports.proj
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="runtime.native.System.IO.Ports.props" />
+</Project>


### PR DESCRIPTION
There is missing the generation of runtime.linux-loongarch64.runtime.native.System.IO.Ports nupkg on LoongArch. Add this for fix it.

@shushanhf 