### PR TITLE
Disable IOCP config var test

### DIFF
--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1342,6 +1342,7 @@ namespace System.Threading.ThreadPools.Tests
         [ConditionalTheory(nameof(IsThreadingAndRemoteExecutorSupported), nameof(UsePortableThreadPool))]
         [MemberData(nameof(IOCompletionPortCountConfigVarTest_Args))]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/106371")]
         public static void IOCompletionPortCountConfigVarTest(int ioCompletionPortCount)
         {
             // Avoid contaminating the main process' environment


### PR DESCRIPTION
The test is still failing occasionally. A simplified version is failing more frequently locally, needs further investigation to determine the cause.

Tracking: https://github.com/dotnet/runtime/issues/106371