### PR TITLE
Code cleanup: remove TODO-ASG with zero diff quirk in lclmorph

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1829,7 +1829,6 @@ private:
             else
             {
                 node->ChangeOper(GT_LCL_VAR);
-                node->gtFlags &= (GTF_NODE_MASK | GTF_DONT_CSE); // TODO-ASG-Cleanup: delete this zero-diff quirk.
             }
             node->AsLclVar()->SetLclNum(fieldLclNum);
             node->gtType = fieldType;


### PR DESCRIPTION
Remove TODO comment because ASG work is done. 
```
//node->gtFlags &= (GTF_NODE_MASK | GTF_DONT_CSE); // TODO-ASG-Cleanup: delete this zero-diff quirk.

```
SPMI replay is clean, and asmdiffs has more improvements and regressions look fine. 
