### PR TITLE
Use RoundtripKind in new IXmlSerializable tests

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.Internal.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.Internal.cs
@@ -38,7 +38,7 @@ public static partial class XmlSerializerTests
     {
         var dClass = new XmlSerializableDerivedClass() { AttributeString = "derivedIXmlSerTest", DateTimeValue = DateTime.Parse("Dec 31, 1999"), BoolValue = true };
 
-        var expectedXml = WithXmlHeader(@$"<BaseIXmlSerializable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:type=""DerivedIXmlSerializable"" AttributeString=""derivedIXmlSerTest"" DateTimeValue=""12/31/1999 12:00:00 AM"" BoolValue=""True"" xmlns=""{XmlSerializableBaseClass.XmlNamespace}"" />");
+        var expectedXml = WithXmlHeader(@$"<BaseIXmlSerializable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:type=""DerivedIXmlSerializable"" AttributeString=""derivedIXmlSerTest"" DateTimeValue=""1999-12-31T00:00:00"" BoolValue=""True"" xmlns=""{XmlSerializableBaseClass.XmlNamespace}"" />");
         var fromBase = SerializeAndDeserialize(dClass, expectedXml, () => new XmlSerializer(typeof(XmlSerializableBaseClass), new Type[] { typeof(XmlSerializableDerivedClass) }));
         Assert.Equal(dClass.AttributeString, fromBase.AttributeString);
         Assert.StrictEqual(dClass.DateTimeValue, fromBase.DateTimeValue);
@@ -46,7 +46,7 @@ public static partial class XmlSerializerTests
 
         // Derived class does not apply XmlRoot attribute to force itself to be emitted with the base class element name, so update expected xml accordingly.
         // Since we can't smartly emit xsi:type during serialization though, it is still there even though it isn't needed.
-        expectedXml = WithXmlHeader(@"<DerivedIXmlSerializable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:type=""DerivedIXmlSerializable"" AttributeString=""derivedIXmlSerTest"" DateTimeValue=""12/31/1999 12:00:00 AM"" BoolValue=""True"" />");
+        expectedXml = WithXmlHeader(@"<DerivedIXmlSerializable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:type=""DerivedIXmlSerializable"" AttributeString=""derivedIXmlSerTest"" DateTimeValue=""1999-12-31T00:00:00"" BoolValue=""True"" />");
         var fromDerived = SerializeAndDeserialize(dClass, expectedXml, () => new XmlSerializer(typeof(XmlSerializableDerivedClass)));
         Assert.Equal(dClass.AttributeString, fromDerived.AttributeString);
         Assert.StrictEqual(dClass.DateTimeValue, fromDerived.DateTimeValue);

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1169,7 +1169,7 @@ public class XmlSerializableBaseClass : IXmlSerializable
     public virtual void WriteXml(XmlWriter writer)
     {
         writer.WriteAttributeString("AttributeString", AttributeString);
-        writer.WriteAttributeString("DateTimeValue", DateTimeValue.ToString());
+        writer.WriteAttributeString("DateTimeValue", XmlConvert.ToString(DateTimeValue, XmlDateTimeSerializationMode.RoundtripKind));
     }
 
     public virtual void ReadXml(XmlReader reader)
@@ -1177,7 +1177,7 @@ public class XmlSerializableBaseClass : IXmlSerializable
         if (reader.MoveToAttribute("AttributeString"))
             AttributeString = reader.Value;
         if (reader.MoveToAttribute("DateTimeValue"))
-            DateTimeValue = DateTime.Parse(reader.Value);
+            DateTimeValue = XmlConvert.ToDateTime(reader.Value, XmlDateTimeSerializationMode.RoundtripKind);
     }
 
     public XmlSchema? GetSchema() => null;


### PR DESCRIPTION
DateTime in our new IXmlSerializable tests should use RoundtripKind to avoid culture issues on different OS's. This was causing failures on OS's in our "community" runs (like Alpine Linux which uses an unexpected character sequence for spacing in DateTime - #98664 and #96022) which format DateTime differently than our "expected" string.