### PR TITLE
[PERF] Remove python venv module installation from setup script

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -96,7 +96,6 @@ jobs:
         sudo apt-get remove -y lttng-modules-dkms &&
         sudo apt-get -y install python3-pip &&
         python3 -m pip install --user -U pip &&
-        sudo apt-get -y install python3-venv &&
         python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv &&
         ls -l $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate &&
         export PYTHONPATH= &&


### PR DESCRIPTION
Since python version 3.3, venv has been an included module so we do not need to install it ourselves as we are using newer versions of python. This should also workaround the error we are hitting when trying to install python venv on the Linux Arm64 machines.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2522720&view=results.