### PR TITLE
Fix object.GetType dataflow edge case

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
@@ -373,6 +373,11 @@ namespace ILLink.Shared.TrimAnalysis
                 //
                 case IntrinsicId.Object_GetType:
                     {
+                        if (instanceValue.IsEmpty ()) {
+                            AddReturnValue (MultiValueLattice.Top);
+                            break;
+                        }
+
                         foreach (var valueNode in instanceValue.AsEnumerable ())
                         {
                             // Note that valueNode can be statically typed in IL as some generic argument type.

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
@@ -66,6 +66,11 @@ namespace ILLink.Shared.TrimAnalysis
 				break;
 
 			case IntrinsicId.Object_GetType: {
+					if (instanceValue.IsEmpty ()) {
+						AddReturnValue (MultiValueLattice.Top);
+						break;
+					}
+
 					foreach (var valueNode in instanceValue.AsEnumerable ()) {
 						// Note that valueNode can be statically typed as some generic argument type.
 						// For example:

--- a/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -100,6 +100,11 @@ namespace ILLink.Shared.TrimAnalysis
 			// GetType()
 			//
 			case IntrinsicId.Object_GetType: {
+					if (instanceValue.IsEmpty ()) {
+						AddReturnValue (MultiValueLattice.Top);
+						break;
+					}
+
 					foreach (var valueNode in instanceValue.AsEnumerable ()) {
 						// Note that valueNode can be statically typed in IL as some generic argument type.
 						// For example:

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ObjectGetTypeDataflow.cs
@@ -29,16 +29,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class SealedConstructorAsSource
 		{
-			[KeptMember (".ctor()")]
 			public class Base
 			{
 			}
 
-			[KeptMember (".ctor()")]
-			[KeptBaseType (typeof (Base))]
 			public sealed class Derived : Base
 			{
-				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
 				[RequiresUnreferencedCode (nameof (Method))]
 				public void Method () { }
 			}
@@ -50,48 +46,35 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		[Kept]
 		class InstantiatedGenericAsSource
 		{
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			class Generic<T> {
-				[Kept]
 				[ExpectedWarning ("IL2112")]
-				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
 				[RequiresUnreferencedCode (nameof (KeptForMethodParameter))]
 				public void KeptForMethodParameter () {}
 
-				[Kept]
 				[ExpectedWarning ("IL2112")]
-				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
 				[RequiresUnreferencedCode (nameof (KeptForField))]
 				public void KeptForField () {}
 
-				[Kept]
 				[ExpectedWarning ("IL2112")]
-				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
 				[RequiresUnreferencedCode (nameof (KeptJustBecause))]
 				public void KeptJustBecause () {}
 			}
 
-			[Kept]
 			static void TestMethodParameter (Generic<int> instance)
 			{
 				instance.GetType ().GetMethod ("KeptForMethodParameter");
 			}
 
-			[Kept]
 			static Generic<int> field = null;
 
-			[Kept]
 			static void TestField ()
 			{
 				field.GetType ().GetMethod ("KeptForField");
 			}
 
-			[Kept]
 			public static void Test ()
 			{
 				TestMethodParameter (null);
@@ -99,57 +82,45 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		[Kept]
 		class EnumTypeSatisfiesPublicFields
 		{
-			[Kept]
 			static void ParameterType (Enum instance)
 			{
 				instance.GetType ().RequiresPublicFields ();
 			}
 
-			[Kept]
 			class FieldType
 			{
-				[Kept]
 				Enum field;
 
-				[Kept]
 				public FieldType (Enum instance) => field = instance;
 
-				[Kept]
 				public void Test ()
 				{
 					field.GetType ().RequiresPublicFields ();
 				}
 			}
 
-			[KeptMember ("value__")]
 			enum EnumType
 			{
-				[Kept]
 				Value
 			}
 
-			[Kept]
 			static Enum ReturnType ()
 			{
 				return EnumType.Value;
 			}
 
-			[Kept]
 			static void TestReturnType ()
 			{
 				ReturnType ().GetType ().RequiresPublicFields ();
 			}
 
-			[Kept]
 			static void OutParameter (out Enum value)
 			{
 				value = EnumType.Value;
 			}
 
-			[Kept]
 			// Analyzer doesn't assign a value to the out parameter after calling the OutParameter method,
 			// so when it looks up the value of the local 'value', it returns an empty value, and the
 			// GetType intrinsic handling can't see that the out param satisfies the public fields requirement.
@@ -161,7 +132,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				value.GetType ().RequiresPublicFields ();
 			}
 
-			[Kept]
 			public static void Test ()
 			{
 				ParameterType (EnumType.Value);
@@ -171,22 +141,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		[Kept]
 		class EnumConstraintSatisfiesPublicFields
 		{
-			[Kept]
 			static void MethodGenericParameterAsParameter<T> (T instance) where T : Enum
 			{
 				instance.GetType ().RequiresPublicFields ();
 			}
 
-			[Kept]
 			class TypeGenericParameterAsField<T> where T : Enum
 			{
-				[Kept]
 				public static T field;
 
-				[Kept]
 				public static void TestAccessFromType ()
 				{
 					field.GetType ().RequiresPublicFields ();
@@ -198,32 +163,26 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TypeGenericParameterAsField<Enum>.field.GetType ().RequiresPublicFields ();
 			}
 
-			[Kept]
 			class TypeGenericParameterAsParameter<T> where T : Enum
 			{
-				[Kept]
 				public static void Method (T instance)
 				{
 					instance.GetType ().RequiresPublicFields ();
 				}
 
-				[Kept]
 				public static void Test ()
 				{
 					Method (default);
 				}
 			}
 
-			[Kept]
 			class TypeGenericParameterAsReturnType<T> where T : Enum
 			{
-				[Kept]
 				public static T Method ()
 				{
 					return default;
 				}
 
-				[Kept]
 				public static void TestAccessFromType ()
 				{
 					Method ().GetType ().RequiresPublicFields ();
@@ -235,16 +194,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TypeGenericParameterAsReturnType<Enum>.Method ().GetType ().RequiresPublicFields ();
 			}
 
-			[Kept]
 			class TypeGenericParameterAsOutParam<T> where T : Enum
 			{
-				[Kept]
 				public static void Method (out T instance)
 				{
 					instance = default;
 				}
 
-				[Kept]
 				[ExpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101734")]
 				public static void TestAccessFromType ()
 				{
@@ -260,26 +216,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				instance.GetType ().RequiresPublicFields ();
 			}
 
-			[KeptMember ("value__")]
 			enum EnumType
 			{
-				[Kept]
 				Value
 			}
 
-			[Kept]
 			static T MethodGenericParameterAsReturnType<T> () where T : Enum
 			{
 				return default;
 			}
 
-			[Kept]
 			static void TestMethodGenericParameterAsReturnType ()
 			{
 				MethodGenericParameterAsReturnType<Enum> ().GetType ().RequiresPublicFields ();
 			}
 
-			[Kept]
 			public static void Test ()
 			{
 				TypeGenericParameterAsParameter<Enum>.Test ();
@@ -461,7 +412,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class UnknownValue
 		{
-			[KeptMember (".ctor()")]
 			class TestType
 			{
 			}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1526,7 +1526,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[UnexpectedWarning ("IL2072", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/93720")]
+			[UnexpectedWarning ("IL2072", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93720")]
 			static void TestIsInstOf (object o)
 			{
 				if (o is Target t) {
@@ -1535,10 +1535,20 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
+			[ExpectedWarning ("IL2072", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93720")]
+			static void TestIsInstOfMismatch (object o)
+			{
+				if (o is Target t) {
+					t.GetType ().RequiresPublicMethods ();
+				}
+			}
+
+			[Kept]
 			public static void Test ()
 			{
 				var target = new Target ();
 				TestIsInstOf (target);
+				TestIsInstOfMismatch (target);
 			}
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -53,10 +53,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 			DataFlowUnusedGetType.Test ();
 
-			NullValue.Test ();
-			NoValue.Test ();
-			UnknownValue.Test ();
-
 			PrivateMembersOnBaseTypesAppliedToDerived.Test ();
 
 			IsInstOf.Test ();
@@ -1464,60 +1460,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				if (GetBaseInstance ().GetType () is DerivedFromAnnotatedBase) {
 					Console.WriteLine ("Never get here");
 				}
-			}
-		}
-
-		[Kept]
-		class NullValue
-		{
-			[Kept]
-			class TestType
-			{
-			}
-
-			[Kept]
-			[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresAll) + "(Type)", nameof (Object.GetType) + "()")]
-			public static void Test ()
-			{
-				TestType nullInstance = null;
-				// Even though this throws at runtime, we warn about the return value of GetType
-				nullInstance.GetType ().RequiresAll ();
-			}
-		}
-
-		[Kept]
-		class NoValue
-		{
-			[Kept]
-			[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresAll) + "(Type)", nameof (Object.GetType) + "()")]
-			public static void Test ()
-			{
-				Type t = null;
-				Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
-				// Even though the above throws at runtime, we warn about the return value of GetType
-				noValue.GetType ().RequiresAll ();
-			}
-		}
-
-		[Kept]
-		class UnknownValue
-		{
-			[Kept]
-			[KeptMember (".ctor()")]
-			class TestType
-			{
-			}
-
-			[Kept]
-			static TestType GetInstance () => new TestType ();
-
-			[Kept]
-			[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresAll) + "(Type)", nameof (Object.GetType) + "()")]
-			public static void Test ()
-			{
-				TestType unknownValue = GetInstance ();
-				// Should warn about the return value of GetType
-				unknownValue.GetType ().RequiresAll ();
 			}
 		}
 


### PR DESCRIPTION
Partial fix for one of the cases mentioned in https://github.com/dotnet/runtime/issues/106886.

I moved some of the tests to ObjectGetTypeDataflow.cs because ObjectGetType.cs is skipped by native AOT. Fixes an issue I ran into while investigating https://github.com/dotnet/runtime/pull/106215.