### PR TITLE
Add lld in dependency script

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -23,14 +23,14 @@ case "$os" in
         if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then
             apt update
 
-            apt install -y build-essential gettext locales cmake llvm clang lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
+            apt install -y build-essential gettext locales cmake llvm clang lld lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
                 libssl-dev libkrb5-dev zlib1g-dev
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
         elif [ "$ID" = "fedora" ]; then
             dnf install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel zlib-devel lttng-ust-devel
         elif [ "$ID" = "alpine" ]; then
-            apk add build-base cmake bash curl clang llvm-dev krb5-dev lttng-ust-dev icu-dev zlib-dev openssl-dev
+            apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev zlib-dev openssl-dev
         else
             echo "Unsupported distro. distro: $ID"
             exit 1


### PR DESCRIPTION
Cross build requires either multitarget linker (like lld) or target specific one (bfd/gold from binutils). Since we are installing lld on Fedora, lets sync Deb and Alpine.