### PR TITLE
Improved handling of ReadOnlySpan<char> in Write and WriteLine

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -133,7 +133,7 @@ namespace System.IO
         {
             if (buffer != null)
             {
-                Write(buffer, 0, buffer.Length);
+                Write(new ReadOnlySpan<char>(buffer));
             }
         }
 
@@ -152,23 +152,16 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             }
 
-            for (int i = 0; i < count; i++) Write(buffer[index + i]);
+            Write(new ReadOnlySpan<char>(buffer, index, count));
         }
 
         // Writes a span of characters to the text stream.
         //
         public virtual void Write(ReadOnlySpan<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
-
-            try
+            for (int i = 0; i < buffer.Length; i++)
             {
-                buffer.CopyTo(new Span<char>(array));
-                Write(array, 0, buffer.Length);
-            }
-            finally
-            {
-                ArrayPool<char>.Shared.Return(array);
+                Write(buffer[i]);
             }
         }
 
@@ -363,17 +356,8 @@ namespace System.IO
 
         public virtual void WriteLine(ReadOnlySpan<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
-
-            try
-            {
-                buffer.CopyTo(new Span<char>(array));
-                WriteLine(array, 0, buffer.Length);
-            }
-            finally
-            {
-                ArrayPool<char>.Shared.Return(array);
-            }
+            Write(buffer);
+            WriteLine();
         }
 
         // Writes the text representation of a boolean followed by a line


### PR DESCRIPTION
# Reason For Change

Performance improvement

## Compatibility  

No APIs were changed, and neither was their behavior, only the internal implementation was modified.

## Details

Before this change, the implementation of the `TextWriter` class which is used by `System.Console` and many other types,
used a rather crude workaround for writing `ReadOnlySpan<char>`, and in detail: Those API's rented a buffer from the array pool, writing it to the buffer, and then called the `Char[], int index, int count` overload, which in turn just iterates through the indexes and prints each `char`.

This is completely redundant as an array is not necessary at all, which means those methods did additional work just to acquire the array, while increasing the work of the `ArrayPool<char>.Shared`.

The new implementation changes the `ReadOnlySpan<char>` overload to directly iterate its characters and print each one (Same as the `char[]` overload), Without requiring any rented array.

This change also enabled to improve the other overloads, such as:

* `Char[], index, count` -> now just creates a `ReadOnlySpan<char>` slice and forwards it to the `ReadOnlySpan<char>` overload.
* `Char[]` -> does the same, previously it called the `Char[], index, count` overload with 0 and length, which is redundant now.
* `WriteLine(ReadOnlySpan<char>)` -> now directly calls the `Write` overload followed by and empty `WriteLine()`.

These changes reduce the amount of code in the class, improve maintainability and performance. 
And their benefits cascade all over.

For example, even the `Write(StringBuilder?)` method, used to call the `Write(ReadOnlySpan<char>` for each chunk of the `StringBuilder` which as pointed above required renting an array to write each chunk, essentially doubling the memory usage for the `StringBuilder`. After the `Write` optimization above, each chunk is written directly, for long `StringBuilder`s this should significantly improve performance.