### PR TITLE
Optimize write barriers for server gc on arm64

### DIFF
--- a/src/coreclr/vm/arm64/patchedcode.S
+++ b/src/coreclr/vm/arm64/patchedcode.S
@@ -47,11 +47,15 @@ LEAF_END JIT_PatchedCodeStart, _TEXT
 //         if you add more trashed registers.
 //
 WRITE_BARRIER_ENTRY JIT_ByRefWriteBarrier
-
     ldr  x15, [x13], 8
     b C_FUNC(JIT_CheckedWriteBarrier)
-
 WRITE_BARRIER_END JIT_ByRefWriteBarrier
+
+
+WRITE_BARRIER_ENTRY JIT_ByRefWriteBarrier_SVR64
+    ldr  x15, [x13], 8
+    b C_FUNC(JIT_CheckedWriteBarrier_SVR64)
+WRITE_BARRIER_END JIT_ByRefWriteBarrier_SVR64
 
 //-----------------------------------------------------------------------------
 // Simple WriteBarriers
@@ -75,13 +79,66 @@ WRITE_BARRIER_ENTRY JIT_CheckedWriteBarrier
     cmp  x14,  x12
     ccmp x14,  x17, #0x2, hs
     bhs  LOCAL_LABEL(NotInHeap)
-
     b C_FUNC(JIT_WriteBarrier)
-
 LOCAL_LABEL(NotInHeap):
     str  x15, [x14], 8
     ret  lr
 WRITE_BARRIER_END JIT_CheckedWriteBarrier
+
+
+WRITE_BARRIER_ENTRY JIT_CheckedWriteBarrier_SVR64
+    ldr  x12,  LOCAL_LABEL(wbs_lowest_address)
+    ldr  x17,  LOCAL_LABEL(wbs_highest_address)
+    cmp  x14,  x12
+    ccmp x14,  x17, #0x2, hs
+    bhs  LOCAL_LABEL(NotInHeap_SVR64)
+    b C_FUNC(JIT_WriteBarrier_SVR64)
+LOCAL_LABEL(NotInHeap_SVR64):
+    str  x15, [x14], 8
+    ret  lr
+WRITE_BARRIER_END JIT_CheckedWriteBarrier_SVR64
+
+
+.macro INSERT_WRITE_BARRIER_CHECK suffix
+    #ifdef WRITE_BARRIER_CHECK
+        // Update GC Shadow Heap
+
+        // Do not perform the work if g_GCShadow is 0
+        ldr  x12, LOCAL_LABEL(wbs_GCShadow)
+        cbz  x12, LOCAL_LABEL(ShadowUpdateEnd_\suffix)
+
+        // Compute address of shadow heap location:
+        //   pShadow = g_GCShadow + (x14 - g_lowest_address)
+        ldr  x17, LOCAL_LABEL(wbs_lowest_address)
+        sub  x17, x14, x17
+        add  x12, x17, x12
+
+        // if (pShadow >= g_GCShadowEnd) goto end
+        ldr  x17, LOCAL_LABEL(wbs_GCShadowEnd)
+        cmp  x12, x17
+        bhs  LOCAL_LABEL(ShadowUpdateEnd_\suffix)
+
+        // *pShadow = x15
+        str  x15, [x12]
+
+        // Ensure that the write to the shadow heap occurs before the read from the GC heap so that race
+        // conditions are caught by INVALIDGCVALUE.
+        dmb  ish
+
+        // if ([x14] == x15) goto end
+        ldr  x17, [x14]
+        cmp  x17, x15
+        beq LOCAL_LABEL(ShadowUpdateEnd_\suffix)
+
+        // *pShadow = INVALIDGCVALUE (0xcccccccd)
+        movz x17, #0xcccd
+        movk x17, #0xcccc, LSL #16
+        str  x17, [x12]
+
+    LOCAL_LABEL(ShadowUpdateEnd_\suffix):
+    #endif
+.endm
+
 
 //-----------------------------------------------------------------------------
 // void JIT_WriteBarrier(Object** dst, Object* src)
@@ -101,43 +158,7 @@ WRITE_BARRIER_END JIT_CheckedWriteBarrier
 WRITE_BARRIER_ENTRY JIT_WriteBarrier
     stlr  x15, [x14]
 
-#ifdef WRITE_BARRIER_CHECK
-    // Update GC Shadow Heap
-
-    // Do not perform the work if g_GCShadow is 0
-    ldr  x12, LOCAL_LABEL(wbs_GCShadow)
-    cbz  x12, LOCAL_LABEL(ShadowUpdateEnd)
-
-    // Compute address of shadow heap location:
-    //   pShadow = g_GCShadow + (x14 - g_lowest_address)
-    ldr  x17, LOCAL_LABEL(wbs_lowest_address)
-    sub  x17, x14, x17
-    add  x12, x17, x12
-
-    // if (pShadow >= g_GCShadowEnd) goto end
-    ldr  x17, LOCAL_LABEL(wbs_GCShadowEnd)
-    cmp  x12, x17
-    bhs  LOCAL_LABEL(ShadowUpdateEnd)
-
-    // *pShadow = x15
-    str  x15, [x12]
-
-    // Ensure that the write to the shadow heap occurs before the read from the GC heap so that race
-    // conditions are caught by INVALIDGCVALUE.
-    dmb  ish
-
-    // if ([x14] == x15) goto end
-    ldr  x17, [x14]
-    cmp  x17, x15
-    beq LOCAL_LABEL(ShadowUpdateEnd)
-
-    // *pShadow = INVALIDGCVALUE (0xcccccccd)
-    movz x17, #0xcccd
-    movk x17, #0xcccc, LSL #16
-    str  x17, [x12]
-
-LOCAL_LABEL(ShadowUpdateEnd):
-#endif
+    INSERT_WRITE_BARRIER_CHECK
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     // Update the write watch table if necessary
@@ -189,6 +210,63 @@ LOCAL_LABEL(Exit):
     add  x14, x14, 8
     ret  lr
 WRITE_BARRIER_END JIT_WriteBarrier
+
+
+//-----------------------------------------------------------------------------
+// void JIT_WriteBarrier_SVR64(Object** dst, Object* src)
+//   Exactly the same as JIT_WriteBarrier, but without the "Is gen0" check.
+//   SVR GC has multiple heaps, so it cannot provide one single
+//   ephemeral region to bounds check against, so we just skip the
+//   bounds checking all together and do our card table update unconditionally.
+//
+WRITE_BARRIER_ENTRY JIT_WriteBarrier_SVR64
+    stlr  x15, [x14]
+
+    INSERT_WRITE_BARRIER_CHECK SVR64
+
+#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+    // Update the write watch table if necessary
+    ldr  x12, LOCAL_LABEL(wbs_sw_ww_table)
+    cbz  x12, LOCAL_LABEL(CheckCardTable_SVR64)
+    add  x12, x12, x14, lsr #0xc  // SoftwareWriteWatch::AddressToTableByteIndexShift
+    ldrb w17, [x12]
+    cbnz x17, LOCAL_LABEL(CheckCardTable_SVR64)
+    mov  w17, #0xFF
+    strb w17, [x12]
+#endif
+
+LOCAL_LABEL(CheckCardTable_SVR64):
+    // Check if we need to update the card table
+    ldr  x12, LOCAL_LABEL(wbs_card_table)
+    add  x15, x12, x14, lsr #11
+    ldrb w12, [x15]
+    cmp  x12, 0xFF
+    beq  LOCAL_LABEL(Exit_SVR64)
+
+    // Update the card table
+    mov  x12, 0xFF
+    strb w12, [x15]
+
+#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
+    // Check if we need to update the card bundle table
+    ldr  x12, LOCAL_LABEL(wbs_card_bundle_table)
+    add  x15, x12, x14, lsr #21
+    ldrb w12, [x15]
+    cmp  x12, 0xFF
+    beq  LOCAL_LABEL(Exit_SVR64)
+
+    // Update the card bundle
+    mov  x12, 0xFF
+    strb w12, [x15]
+#endif
+
+LOCAL_LABEL(Exit_SVR64):
+    // Increment by 8 to implement JIT_ByRefWriteBarrier contract.
+    // TODO: Consider duplicating the logic to get rid of this redundant 'add'
+    // for JIT_WriteBarrier/JIT_CheckedWriteBarrier
+    add  x14, x14, 8
+    ret  lr
+WRITE_BARRIER_END JIT_WriteBarrier_SVR64
 
     // Begin patchable literal pool
     .balign 64  // Align to power of two at least as big as patchable literal pool so that it fits optimally in cache line

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -6020,6 +6020,12 @@ EXTERN_C void JIT_CheckedWriteBarrier_End();
 EXTERN_C void JIT_ByRefWriteBarrier_End();
 #endif // TARGET_X86
 
+#if defined(TARGET_ARM64) && defined(TARGET_UNIX)
+EXTERN_C void JIT_WriteBarrier_SVR64_End();
+EXTERN_C void JIT_CheckedWriteBarrier_SVR64_End();
+EXTERN_C void JIT_ByRefWriteBarrier_SVR64_End();
+#endif
+
 #if defined(TARGET_AMD64) && defined(_DEBUG)
 EXTERN_C void JIT_WriteBarrier_Debug();
 EXTERN_C void JIT_WriteBarrier_Debug_End();
@@ -6068,6 +6074,11 @@ bool IsIPInMarkedJitHelper(UINT_PTR uControlPc)
     CHECK_RANGE(JIT_WriteBarrier)
     CHECK_RANGE(JIT_CheckedWriteBarrier)
     CHECK_RANGE(JIT_ByRefWriteBarrier)
+#if defined(TARGET_ARM64) && defined(TARGET_UNIX)
+    CHECK_RANGE(JIT_WriteBarrier_SVR64)
+    CHECK_RANGE(JIT_CheckedWriteBarrier_SVR64)
+    CHECK_RANGE(JIT_ByRefWriteBarrier_SVR64)
+#endif
 #if !defined(TARGET_ARM64) && !defined(TARGET_LOONGARCH64) && !defined(TARGET_RISCV64)
     CHECK_RANGE(JIT_StackProbe)
 #endif // !TARGET_ARM64 && !TARGET_LOONGARCH64 && !TARGET_RISCV64

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -390,6 +390,15 @@ extern "C"
 #endif // TARGET_ARM64
 };
 
+#if defined(TARGET_ARM64) && defined(TARGET_UNIX)
+extern "C"
+{
+    void JIT_WriteBarrier_SVR64();
+    void JIT_CheckedWriteBarrier_SVR64();
+    void JIT_ByRefWriteBarrier_SVR64();
+}
+#endif
+
 /*********************************************************************/
 /*********************************************************************/
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1115,6 +1115,18 @@ void InitThreadManager()
         ETW::MethodLog::StubInitialized((ULONGLONG)GetWriteBarrierCodeLocation((void*)JIT_CheckedWriteBarrier), W("@CheckedWriteBarrier"));
         SetJitHelperFunction(CORINFO_HELP_ASSIGN_BYREF, GetWriteBarrierCodeLocation((void*)JIT_ByRefWriteBarrier));
         ETW::MethodLog::StubInitialized((ULONGLONG)GetWriteBarrierCodeLocation((void*)JIT_ByRefWriteBarrier), W("@ByRefWriteBarrier"));
+#if defined(TARGET_ARM64) && defined(TARGET_UNIX)
+        if (GCHeapUtilities::IsServerHeap())
+        {
+            SetJitHelperFunction(CORINFO_HELP_ASSIGN_REF, GetWriteBarrierCodeLocation((void*)JIT_WriteBarrier_SVR64));
+            ETW::MethodLog::StubInitialized((ULONGLONG)GetWriteBarrierCodeLocation((void*)JIT_WriteBarrier_SVR64), W("@WriteBarrier_SVR64"));
+            SetJitHelperFunction(CORINFO_HELP_CHECKED_ASSIGN_REF, GetWriteBarrierCodeLocation((void*)JIT_CheckedWriteBarrier_SVR64));
+            ETW::MethodLog::StubInitialized((ULONGLONG)GetWriteBarrierCodeLocation((void*)JIT_CheckedWriteBarrier_SVR64), W("@CheckedWriteBarrier_SVR64"));
+            SetJitHelperFunction(CORINFO_HELP_ASSIGN_BYREF, GetWriteBarrierCodeLocation((void*)JIT_ByRefWriteBarrier_SVR64));
+            ETW::MethodLog::StubInitialized((ULONGLONG)GetWriteBarrierCodeLocation((void*)JIT_ByRefWriteBarrier_SVR64), W("@ByRefWriteBarrier_SVR64"));
+        }
+#endif
+
 #endif // TARGET_ARM64 || TARGET_ARM || TARGET_LOONGARCH64 || TARGET_RISCV64
 
     }


### PR DESCRIPTION
Introduce ServerGC-specific write barriers on arm64. The only difference in them is removed "is gen0" check:
```diff
-    // Branch to Exit if the reference is not in the Gen0 heap
-    ldr  x12, LOCAL_LABEL(wbs_ephemeral_low)
-    ldr  x17, LOCAL_LABEL(wbs_ephemeral_high)
-    cmp  x15, x12
-    ccmp x15, x17, #0x2, hs
-    bhs  LOCAL_LABEL(Exit)
```
since server gc has multiple heaps and this check doesn't work. Copied from x64 which has `JIT_WriteBarrier_SVR64`

I'll add windows and NAOT support if this is approved as the right thing to do