### PR TITLE
[release/9.0][no-merge][testing][Android] Run runtime and libraries tests on different Android API version

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -46,7 +46,18 @@ jobs:
 
     # Android x64
     - ${{ if in(parameters.platform, 'android_x64') }}:
+      - Ubuntu.2204.Amd64.Android.21.Open
+      - Ubuntu.2204.Amd64.Android.22.Open
+      - Ubuntu.2204.Amd64.Android.23.Open
+      - Ubuntu.2204.Amd64.Android.24.Open
+      - Ubuntu.2204.Amd64.Android.25.Open
+      - Ubuntu.2204.Amd64.Android.26.Open
+      - Ubuntu.2204.Amd64.Android.27.Open
+      - Ubuntu.2204.Amd64.Android.28.Open
       - Ubuntu.2204.Amd64.Android.29.Open
+      - Ubuntu.2204.Amd64.Android.30.Open
+      - Ubuntu.2204.Amd64.Android.31.Open
+      - Ubuntu.2204.Amd64.Android.32.Open
 
     # Browser wasm
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -38,7 +38,7 @@ jobs:
       nameSuffix: AllSubsets_Mono_RuntimeTests
       runtimeVariant: minijit
       buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
+      timeoutInMinutes: 1800
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -77,7 +77,7 @@ jobs:
       nameSuffix: AllSubsets_Mono_RuntimeTests_Interp
       runtimeVariant: monointerpreter
       buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
+      timeoutInMinutes: 1800
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -111,7 +111,7 @@ jobs:
       nameSuffix: AllSubsets_Mono
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg)
-      timeoutInMinutes: 180
+      timeoutInMinutes: 1800
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/libraries/helix.yml

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -95,7 +95,19 @@ jobs:
 
     # Android
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
+      - Ubuntu.2204.Amd64.Android.21.Open
+      - Ubuntu.2204.Amd64.Android.22.Open
+      - Ubuntu.2204.Amd64.Android.23.Open
+      - Ubuntu.2204.Amd64.Android.24.Open
+      - Ubuntu.2204.Amd64.Android.25.Open
+      - Ubuntu.2204.Amd64.Android.26.Open
+      - Ubuntu.2204.Amd64.Android.27.Open
+      - Ubuntu.2204.Amd64.Android.28.Open
       - Ubuntu.2204.Amd64.Android.29.Open
+      - Ubuntu.2204.Amd64.Android.30.Open
+    - ${{ if in(parameters.platform, 'Android_x64') }}: # there's no x86 emulator image anymore since Android 31
+      - Ubuntu.2204.Amd64.Android.31.Open
+      - Ubuntu.2204.Amd64.Android.32.Open
     - ${{ if in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64') }}:
       - Windows.11.Amd64.Android.Open
 

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -3,7 +3,22 @@
 # point the pipeline in azdo UI to this, and thus avoid any scheduled
 # triggers
 
-trigger: none
+trigger: 
+  branches:
+    include:
+    - release/*.*
+  paths:
+    include:
+    - '*'
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*.*
+  paths:
+    include:
+    - '*'
 
 variables:
   - template: /eng/pipelines/common/variables.yml


### PR DESCRIPTION
Description https://github.com/dotnet/runtime/issues/106717

couldn't run`runtime-androidemulator` pipeline on servicing, ran `runtime-extra-platforms` instead