### PR TITLE
Don't use WeakReferences in the BF round trip test

### DIFF
--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/BasicObjectTests.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/BasicObjectTests.cs
@@ -14,6 +14,14 @@ public class BasicObjectTests : Common.BasicObjectTests<FormattedObjectSerialize
     [MemberData(nameof(SerializableObjects))]
     public void BasicObjectsRoundTripAndMatch(object value, TypeSerializableValue[] _)
     {
+        if (value is WeakReference || (value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition() == typeof(WeakReference<>)))
+        {
+            // We can root the provided value, but we can't root the deserialized value:
+            // GC can free the target of WeakReference after it gets deserialized,
+            // but before it gets returned from BinaryFormatter.Deserialize.
+            return;
+        }
+
         // We need to round trip through the BinaryFormatter as a few objects in tests remove
         // serialized data on deserialization.
         BinaryFormatter formatter = new();


### PR DESCRIPTION
In #105072 I've tried to fix #104905 by rooting the argument provided to the test method.

It turned out to be incomplete, as this test performs a full round trip (serialize -> deserialize) and I was not rooting the deserialized weak reference target:

https://github.com/dotnet/runtime/blob/b57996248009cc88df2a2d15364f540056dd9269/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/FormattedObject/BasicObjectTests.cs#L23

I could try to do that by doing sth like this:

```cs
object bfdeserialized = formatter.Deserialize(serialized);
object? root = bfdeserialized is WeakReference weakReference ? weakReference.Target : null;
// rest of the test
GC.KeepAlive(root);
```

But in theory GC could free the `WeakReference` target after it got deserialized by BF, but before returned from `BinaryFormatter.Deserialize`. Since this test was flaky for a while and I don't ever want to hear about it, I propose to simply don't test weak references for this particular scenario (it's used by other tests so no worries)

fixes #104905