### PR TITLE
Disable mutual_recursion F# test under GC stress

### DIFF
--- a/src/tests/JIT/Directed/tailcall/mutual_recursion.fsproj
+++ b/src/tests/JIT/Directed/tailcall/mutual_recursion.fsproj
@@ -5,6 +5,9 @@
 
     <!-- Not even printf is AOT compatible in F# -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
+
+    <!-- Test is slow enough to time out under GC stress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <Optimize>True</Optimize>


### PR DESCRIPTION
This test started timing out under GC stress with preview 7 due to degraded IL codegen from fsc. I opened https://github.com/dotnet/fsharp/issues/17607 about that.
In the mean time, disable the test under GC stress.

Fix #106603