### PR TITLE
Fix copying ephemeral keys to keychains

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_macos.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_macos.c
@@ -391,7 +391,7 @@ int32_t AppleCryptoNative_X509CopyWithPrivateKey(SecCertificateRef cert,
     SecKeychainItemRef itemCopy = NULL;
 
     // This only happens with an ephemeral key, so the keychain we're adding it to is temporary.
-    if (status == errSecNoSuchKeychain)
+    if (status == errSecNoSuchKeychain || status == errSecInvalidItemRef)
     {
         status = AddKeyToKeychain(privateKey, targetKeychain, NULL);
     }


### PR DESCRIPTION
Starting on macOS Sequoia, at least in beta, SecKeychainitemCopyKeychain no longer returns errSecNoSuchKeychain for ephemeral keys. Instead, it returns errSecInvalidItemRef.

This adds the error code in the handling logic for when we need to add an ephemeral key to the target keychain.

Fixes #106775

----

With this change, I get a clean run of the S.S.C tests on Sequoia.
<img width="1164" alt="Screenshot 2024-08-26 at 1 00 36 PM" src="https://github.com/user-attachments/assets/96595692-2f2c-4409-a740-6263394ba501">
