### PR TITLE
Code cleanup: Remove TODO in assertionprop regarding optVNConstantPropOnJTrue removin trees twice

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -6482,9 +6482,6 @@ Compiler::fgWalkResult Compiler::optVNBasedFoldCurStmt(BasicBlock* block,
         return WALK_CONTINUE;
     }
 
-    // TODO https://github.com/dotnet/runtime/issues/10450:
-    // at that moment stmt could be already removed from the stmt list.
-
     optAssertionProp_Update(newTree, tree, stmt);
 
     JITDUMP("After VN-based fold of [%06u]:\n", tree->gtTreeID);


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/10450 was closed as not reproducible because JIT no longer does any incremental ref count updates. So, this PR removes the TODO comment that is no longer relevant.