### PR TITLE
[release/9.0] Backport Azure Linux test changes

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -18,7 +18,9 @@ namespace System.Security.Cryptography.Tests
 
         // This would need to be virtualized if there was ever a platform that
         // allowed explicit in ECDH or ECDSA but not the other.
-        public static bool SupportsExplicitCurves { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.ExplicitCurvesSupported;
+        public static bool SupportsExplicitCurves { get; } =
+            EcDiffieHellman.Tests.ECDiffieHellmanFactory.ExplicitCurvesSupported ||
+            EcDiffieHellman.Tests.ECDiffieHellmanFactory.ExplicitCurvesSupportFailOnUseOnly;
 
         public static bool CanDeriveNewPublicKey { get; } = EcDiffieHellman.Tests.ECDiffieHellmanFactory.CanDeriveNewPublicKey;
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 #endif
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
+        bool ExplicitCurvesSupportFailOnUseOnly => PlatformDetection.IsAzureLinux;
         bool CanDeriveNewPublicKey { get; }
         bool SupportsRawDerivation { get; }
         bool SupportsSha3 { get; }
@@ -48,5 +49,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         public static bool SupportsRawDerivation => s_provider.SupportsRawDerivation;
 
         public static bool SupportsSha3 => s_provider.SupportsSha3;
+
+        public static bool ExplicitCurvesSupportFailOnUseOnly => s_provider.ExplicitCurvesSupportFailOnUseOnly;
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
@@ -319,7 +319,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         [Fact]
         public static void TestExplicitCurveImportOnUnsupportedPlatform()
         {
-            if (ECDiffieHellmanFactory.ExplicitCurvesSupported)
+            if (ECDiffieHellmanFactory.ExplicitCurvesSupported || ECDiffieHellmanFactory.ExplicitCurvesSupportFailOnUseOnly)
             {
                 return;
             }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 #endif
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
+        bool ExplicitCurvesSupportFailOnUseOnly => PlatformDetection.IsAzureLinux;
     }
 
     public static partial class ECDsaFactory
@@ -39,5 +40,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         public static bool ExplicitCurvesSupported => s_provider.ExplicitCurvesSupported;
+        public static bool ExplicitCurvesSupportFailOnUseOnly => s_provider.ExplicitCurvesSupportFailOnUseOnly;
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
@@ -8,13 +8,13 @@ namespace System.Security.Cryptography.Rsa.Tests
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class KeyGeneration
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAzureLinux))]
         public static void GenerateMinKey()
         {
             GenerateKey(rsa => GetMin(rsa.LegalKeySizes));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAzureLinux))]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(rsa => GetSecondMin(rsa.LegalKeySizes));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         bool SupportsSha2Oaep { get; }
         bool SupportsPss { get; }
         bool SupportsSha1Signatures { get; }
+        bool SupportsMd5Signatures { get; }
         bool SupportsSha3 { get; }
     }
 
@@ -43,6 +44,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public static bool SupportsPss => s_provider.SupportsPss;
 
         public static bool SupportsSha1Signatures => s_provider.SupportsSha1Signatures;
+        public static bool SupportsMd5Signatures => s_provider.SupportsMd5Signatures;
 
         public static bool SupportsSha3 => s_provider.SupportsSha3;
         public static bool NoSupportsSha3 => !SupportsSha3;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -600,7 +600,11 @@ namespace System.Security.Cryptography.Rsa.Tests
                         yield return new object[] { nameof(HashAlgorithmName.SHA1), rsaParameters };
                     }
 
-                    yield return new object[] { nameof(HashAlgorithmName.MD5), rsaParameters };
+                    if (RSAFactory.SupportsMd5Signatures)
+                    {
+                        yield return new object[] { nameof(HashAlgorithmName.MD5), rsaParameters };
+                    }
+
                     yield return new object[] { nameof(HashAlgorithmName.SHA256), rsaParameters };
                 }
 
@@ -1589,7 +1593,11 @@ namespace System.Security.Cryptography.Rsa.Tests
                 yield return new object[] { HashAlgorithmName.SHA256.Name };
                 yield return new object[] { HashAlgorithmName.SHA384.Name };
                 yield return new object[] { HashAlgorithmName.SHA512.Name };
-                yield return new object[] { HashAlgorithmName.MD5.Name };
+
+                if (RSAFactory.SupportsMd5Signatures)
+                {
+                    yield return new object[] { HashAlgorithmName.MD5.Name };
+                }
 
                 if (RSAFactory.SupportsSha1Signatures)
                 {

--- a/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
@@ -5,14 +5,17 @@ namespace System.Security.Cryptography.Tests
 {
     internal static class SignatureSupport
     {
-        internal static bool CanProduceSha1Signature(AsymmetricAlgorithm algorithm)
+        internal static bool CanProduceSha1Signature(AsymmetricAlgorithm algorithm) => CanProduceSignature(algorithm, HashAlgorithmName.SHA1);
+        internal static bool CanProduceMd5Signature(AsymmetricAlgorithm algorithm) => CanProduceSignature(algorithm, HashAlgorithmName.MD5);
+
+        private static bool CanProduceSignature(AsymmetricAlgorithm algorithm, HashAlgorithmName hashAlgorithmName)
         {
             using (algorithm)
             {
 #if NETFRAMEWORK
                 return true;
 #else
-                // We expect all non-Linux platforms to support SHA1 signatures, currently.
+                // We expect all non-Linux platforms to support any signatures, currently.
                 if (!OperatingSystem.IsLinux())
                 {
                     return true;
@@ -23,7 +26,7 @@ namespace System.Security.Cryptography.Tests
                     case ECDsa ecdsa:
                         try
                         {
-                            ecdsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1);
+                            ecdsa.SignData(Array.Empty<byte>(), hashAlgorithmName);
                             return true;
                         }
                         catch (CryptographicException)
@@ -33,7 +36,7 @@ namespace System.Security.Cryptography.Tests
                     case RSA rsa:
                         try
                         {
-                            rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                            rsa.SignData(Array.Empty<byte>(), hashAlgorithmName, RSASignaturePadding.Pkcs1);
                             return true;
                         }
                         catch (CryptographicException)

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -34,6 +34,7 @@ namespace System
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
         public static bool IsQemuLinux => IsLinux && Environment.GetEnvironmentVariable("DOTNET_RUNNING_UNDER_QEMU") != null;
         public static bool IsNotQemuLinux => !IsQemuLinux;
+        public static bool IsNotAzureLinux => !IsAzureLinux;
 
         // OSX family
         public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -28,6 +28,7 @@ namespace System
         public static bool IsFedora => IsDistroAndVersion("fedora");
         public static bool IsLinuxBionic => IsBionic();
         public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();
+        public static bool IsAzureLinux => IsDistroAndVersionOrHigher("azurelinux", 3);
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;

--- a/src/libraries/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -37,6 +37,8 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         public bool SupportsSha1Signatures => true;
 
+        public bool SupportsMd5Signatures => true;
+
         public bool SupportsSha3 { get; } = SHA3_256.IsSupported; // If SHA3_256 is supported, assume 384 and 512 are, too.
     }
 

--- a/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
@@ -156,9 +156,12 @@ namespace System.Security.Cryptography.Csp.Tests
 
         public static IEnumerable<object[]> AlgorithmIdentifiers()
         {
-            yield return new object[] { "MD5", MD5.Create() };
-            yield return new object[] { "MD5", typeof(MD5) };
-            yield return new object[] { "MD5", "1.2.840.113549.2.5" };
+            if (RSAFactory.SupportsMd5Signatures)
+            {
+                yield return new object[] { "MD5", MD5.Create() };
+                yield return new object[] { "MD5", typeof(MD5) };
+                yield return new object[] { "MD5", "1.2.840.113549.2.5" };
+            }
 
             if (RSAFactory.SupportsSha1Signatures)
             {

--- a/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class RSACryptoServiceProviderProvider : IRSAProvider
     {
         private bool? _supportsSha1Signatures;
+        private bool? _supportsMd5Signatures;
 
         public RSA Create() => new RSACryptoServiceProvider();
 
@@ -23,6 +24,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public bool SupportsPss => false;
 
         public bool SupportsSha1Signatures => _supportsSha1Signatures ??= SignatureSupport.CanProduceSha1Signature(Create());
+        public bool SupportsMd5Signatures => _supportsMd5Signatures ??= SignatureSupport.CanProduceMd5Signature(Create());
 
         public bool SupportsSha3 => false;
     }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
@@ -50,7 +50,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             get
             {
-                return true;
+                return !PlatformDetection.IsAzureLinux;
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -8,6 +8,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class RSAOpenSslProvider : IRSAProvider
     {
         private bool? _supportsSha1Signatures;
+        private bool? _supportsMd5Signatures;
 
         public RSA Create() => new RSAOpenSsl();
 
@@ -22,6 +23,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         public bool SupportsPss => true;
 
         public bool SupportsSha1Signatures => _supportsSha1Signatures ??= SignatureSupport.CanProduceSha1Signature(Create());
+        public bool SupportsMd5Signatures => _supportsMd5Signatures ??= SignatureSupport.CanProduceMd5Signature(Create());
 
         public bool SupportsSha3 => SHA3_256.IsSupported; // If SHA3_256 is supported, assume 384 and 512 are, too.
     }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/ShroudedKeyBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/ShroudedKeyBagTests.cs
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa2.TrySignData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1,
                         out int sigLen));
 
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa.VerifyData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1));
                 }
             }
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa2.TrySignData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1,
                         out int sigLen));
 
@@ -86,7 +86,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa.VerifyData(
                         keyBag.EncryptedPkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1));
                 }
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
@@ -10,5 +10,8 @@ namespace System.Security.Cryptography.Pkcs.Tests
     {
         public static bool SupportsRsaSha1Signatures { get; } =
             System.Security.Cryptography.Tests.SignatureSupport.CanProduceSha1Signature(RSA.Create());
+
+        public static bool SupportsRsaMd5Signatures { get; } =
+            System.Security.Cryptography.Tests.SignatureSupport.CanProduceMd5Signature(RSA.Create());
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
@@ -198,7 +198,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             signer.CheckSignature(new X509Certificate2Collection(), true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaMd5Signatures))]
         public static void CheckSignature_MD5WithRSA()
         {
             SignedCms cms = new SignedCms();

--- a/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
@@ -478,6 +478,11 @@ namespace System.Security.Cryptography.Tests
                 // CryptoKit is supported on macOS 10.15+, which is our minimum target. On iOS/tvOS, it was added in 13.0 but we can expect that version in our testing environments.
                 expectedIsSupported = true;
             }
+            else if (PlatformDetection.IsAzureLinux)
+            {
+                // Though Azure Linux uses OpenSSL, they build OpenSSL without ChaCha20-Poly1305.
+                expectedIsSupported = false;
+            }
             else if (PlatformDetection.OpenSslPresentOnSystem && PlatformDetection.IsOpenSslSupported)
             {
                 const int OpenSslChaChaMinimumVersion = 0x1_01_00_00_F; //major_minor_fix_patch_status

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Unix.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         {
             get
             {
-                if (PlatformDetection.IsApplePlatform)
+                if (PlatformDetection.IsApplePlatform || PlatformDetection.IsAzureLinux)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Unix.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             get
             {
-                if (PlatformDetection.IsApplePlatform)
+                if (PlatformDetection.IsApplePlatform || PlatformDetection.IsAzureLinux)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
@@ -10,6 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     {
         private bool? _supports384PrivateKey;
         private bool? _supportsSha1Signatures;
+        private bool? _supportsMd5Signatures;
 
         public RSA Create() => RSA.Create();
 
@@ -41,6 +42,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         public bool SupportsSha1Signatures => _supportsSha1Signatures ??= SignatureSupport.CanProduceSha1Signature(Create());
+        public bool SupportsMd5Signatures => _supportsMd5Signatures ??= SignatureSupport.CanProduceMd5Signature(Create());
 
         public bool SupportsLargeExponent => true;
 

--- a/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
@@ -14,6 +14,8 @@ namespace System.Security.Cryptography.Tests
         protected abstract byte[] Expand(HashAlgorithmName hash, byte[] prk, int outputLength, byte[] info);
         protected abstract byte[] DeriveKey(HashAlgorithmName hash, byte[] ikm, int outputLength, byte[] salt, byte[] info);
 
+        internal static bool MD5Supported => !PlatformDetection.IsBrowser && !PlatformDetection.IsAzureLinux;
+
         [Theory]
         [MemberData(nameof(GetHkdfTestCases))]
         public void ExtractTests(HkdfTestCase test)
@@ -22,9 +24,8 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(test.Prk, prk);
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(MD5Supported))]
         [MemberData(nameof(GetHkdfTestCases))]
-        [SkipOnPlatform(TestPlatforms.Browser, "MD5 is not supported on Browser")]
         public void ExtractTamperHashTests(HkdfTestCase test)
         {
             byte[] prk = Extract(HashAlgorithmName.MD5, 128 / 8, test.Ikm, test.Salt);
@@ -257,7 +258,7 @@ namespace System.Security.Cryptography.Tests
             yield return new object[] { HashAlgorithmName.SHA256, 256 / 8 - 1 };
             yield return new object[] { HashAlgorithmName.SHA512, 512 / 8 - 1 };
 
-            if (!PlatformDetection.IsBrowser)
+            if (MD5Supported)
             {
                 yield return new object[] { HashAlgorithmName.MD5, 128 / 8 - 1 };
             }

--- a/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
@@ -9,12 +9,12 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    [ConditionalClass(typeof(HmacMD5Tests.Traits), nameof(HmacMD5Tests.Traits.IsSupported))]
     public class HmacMD5Tests : Rfc2202HmacTests<HmacMD5Tests.Traits>
     {
         public sealed class Traits : IHmacTrait
         {
-            public static bool IsSupported => true;
+            public static bool IsSupported => !PlatformDetection.IsAzureLinux && !PlatformDetection.IsBrowser;
             public static int HashSizeInBytes => HMACMD5.HashSizeInBytes;
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
+++ b/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
@@ -95,7 +95,7 @@ namespace System.Security.Cryptography.Tests
         public static bool IsSupported => TKmacTrait.IsSupported;
         public static bool IsNotSupported => !IsSupported;
         public static KeySizes? PlatformKeySizeRequirements { get; } =
-            PlatformDetection.IsOpenSslSupported ? new KeySizes(4, 512, 1) : null;
+            PlatformDetection.IsOpenSslSupported && !PlatformDetection.IsAzureLinux ? new KeySizes(4, 512, 1) : null;
 
         public static int? PlatformMaxOutputSize { get; } = PlatformDetection.IsOpenSslSupported ? 0xFFFFFF / 8 : null;
         public static int? PlatformMaxCustomizationStringSize { get; } = PlatformDetection.IsOpenSslSupported ? 512 : null;


### PR DESCRIPTION
Backport of #106554, #106698, #106565, and #106835 to release/9.0

/cc @bartonjs @jeffhandley 

## Customer Impact

- [ ] Customer reported
- [x] Found internally

These are test-only changes to react to Azure Linux 3.0. Azure Linux 3.0 disables certain cryptographic algorithms that we have unit tests for. This pull request disables those tests when run on Azure Linux.

## Regression

- [ ] Yes
- [x] No

## Testing

Existing tests continue to pass on other Linux distributions. The test changes were validated against Azure Linux 3.0 locally.

## Risk

None. Test only changes.