### PR TITLE
[release/9.0][Workloads] Update the net8/9 component resources

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -40,31 +40,58 @@
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
-      <_ComponentResources Include="microsoft-net-runtime-mono-tooling" Title=".NET 8.0 Shared Mobile Build Tools"
+      <_ComponentResources Include="microsoft-net-runtime-mono-tooling" Title=".NET 9.0 Shared Mobile Build Tools"
                           Description="Shared build tasks for mobile platform development."/>
-      <_ComponentResources Include="wasm-tools" Title=".NET 8.0 WebAssembly Build Tools"
+      <_ComponentResources Include="wasm-tools" Title=".NET 9.0 WebAssembly Build Tools"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
-      <_ComponentResources Include="wasm-experimental" Title=".NET 8.0 WebAssembly Experimental Tools"
+      <_ComponentResources Include="wasm-experimental" Title=".NET 9.0 WebAssembly Experimental Tools"
                           Description=".NET 8.0 WebAssembly experimental tooling"/>
-      <_ComponentResources Include="wasi-experimental" Title=".NET 8.0 Wasi Experimental"
-                          Description=".NET 8.0 Experimental SDK and tooling for WASI"/>
-      <_ComponentResources Include="microsoft-net-runtime-android" Title=".NET 8.0 Android Build Tools"
+      <_ComponentResources Include="wasi-experimental" Title=".NET 9.0 Wasi Experimental"
+                          Description=".NET 9.0 Experimental SDK and tooling for WASI"/>
+      <_ComponentResources Include="microsoft-net-runtime-android" Title=".NET 9.0 Android Build Tools"
                           Description="Build tools for Android compilation and native linking."/>
-      <_ComponentResources Include="microsoft-net-runtime-android-aot" Title=".NET 8.0 Android Build Tools (AoT)"
+      <_ComponentResources Include="microsoft-net-runtime-android-aot" Title=".NET 9.0 Android Build Tools (AoT)"
                           Description="Build tools for Android ahead-of-time (AoT) compilation and native linking."/>
-      <_ComponentResources Include="microsoft-net-runtime-ios" Title=".NET 8.0 iOS Build Tools"
+      <_ComponentResources Include="microsoft-net-runtime-ios" Title=".NET 9.0 iOS Build Tools"
                           Description="Build tools for iOS compilation and native linking."/>
-      <_ComponentResources Include="microsoft-net-runtime-tvos" Title=".NET 8.0 tvOS Build Tools"
+      <_ComponentResources Include="microsoft-net-runtime-tvos" Title=".NET 9.0 tvOS Build Tools"
                           Description="Build tools for tvOS compilation and native linking."/>
-      <_ComponentResources Include="microsoft-net-runtime-maccatalyst" Title=".NET 8.0 Mac Catalyst Build Tools"
+      <_ComponentResources Include="microsoft-net-runtime-maccatalyst" Title=".NET 9.0 Mac Catalyst Build Tools"
                           Description="Build tools for Mac Catalyst compilation and native linking."/>
-      <_ComponentResources Include="runtimes-ios" Title=".NET 8.0 iOS Runtimes"
+      <_ComponentResources Include="runtimes-ios" Title=".NET 9.0 iOS Runtimes"
+                          Description=".NET 9.0 runtime components for iOS execution."/>
+      <_ComponentResources Include="runtimes-tvos" Title=".NET 9.0 tvOS Build Tools"
+                          Description=".NET 9.0 runtime components for tvOS execution."/>
+      <_ComponentResources Include="runtimes-maccatalyst" Title=".NET 9.0 Mac Catalyst Build Tools"
+                          Description=".NET 9.0 runtime components for Mac Catalyst execution."/>
+      <_ComponentResources Include="runtimes-windows" Title=".NET 9.0 Windows Runtimes"
+                          Description=".NET 9.0 runtime components for Windows execution."/>
+
+      <_ComponentResources Include="microsoft-net-runtime-mono-tooling-net8" Title=".NET 8.0 Shared Mobile Build Tools"
+                          Description="Shared build tasks for mobile platform development."/>
+      <_ComponentResources Include="wasm-tools-net8" Title=".NET 8.0 WebAssembly Build Tools"
+                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
+      <_ComponentResources Include="wasm-experimental-net8" Title=".NET 8.0 WebAssembly Experimental Tools"
+                          Description=".NET 8.0 WebAssembly experimental tooling"/>
+      <_ComponentResources Include="wasi-experimental-net8" Title=".NET 8.0 Wasi Experimental"
+                          Description=".NET 8.0 Experimental SDK and tooling for WASI"/>
+      <_ComponentResources Include="microsoft-net-runtime-android-net8" Title=".NET 8.0 Android Build Tools"
+                          Description="Build tools for Android compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-android-aot-net8" Title=".NET 8.0 Android Build Tools (AoT)"
+                          Description="Build tools for Android ahead-of-time (AoT) compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-ios-net8" Title=".NET 8.0 iOS Build Tools"
+                          Description="Build tools for iOS compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-tvos-net8" Title=".NET 8.0 tvOS Build Tools"
+                          Description="Build tools for tvOS compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-maccatalyst-net8" Title=".NET 8.0 Mac Catalyst Build Tools"
+                          Description="Build tools for Mac Catalyst compilation and native linking."/>
+      <_ComponentResources Include="runtimes-ios-net8" Title=".NET 8.0 iOS Runtimes"
                           Description=".NET 8.0 runtime components for iOS execution."/>
-      <_ComponentResources Include="runtimes-tvos" Title=".NET 8.0 tvOS Build Tools"
+      <_ComponentResources Include="runtimes-tvos-net8" Title=".NET 8.0 tvOS Build Tools"
                           Description=".NET 8.0 runtime components for tvOS execution."/>
-      <_ComponentResources Include="runtimes-maccatalyst" Title=".NET 8.0 Mac Catalyst Build Tools"
+      <_ComponentResources Include="runtimes-maccatalyst-net8" Title=".NET 8.0 Mac Catalyst Build Tools"
                           Description=".NET 8.0 runtime components for Mac Catalyst execution."/>
-      <_ComponentResources Include="runtimes-windows" Title=".NET 8.0 Windows Runtimes"
+      <_ComponentResources Include="runtimes-windows-net8" Title=".NET 8.0 Windows Runtimes"
                           Description=".NET 8.0 runtime components for Windows execution."/>
 
       <_ComponentResources Include="microsoft-net-runtime-mono-tooling-net7" Title=".NET 7.0 Shared Mobile Build Tools"


### PR DESCRIPTION
backport of https://github.com/dotnet/runtime/pull/106989 to [release/9.0]