### PR TITLE
Disable test that validates specific copy constructor counts on JitStress

### DIFF
--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
@@ -12,6 +12,7 @@ namespace CopyConstructorMarshaler
     public class CopyConstructorMarshaler
     {
         [Fact]
+        [SkipOnCoreClr("Exact copy constructor counts may differ in JIT stress modes.", RuntimeTestModes.JitStress)]
         public static int TestEntryPoint()
         {
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
@@ -12,57 +12,6 @@ namespace CopyConstructorMarshaler
     public class CopyConstructorMarshaler
     {
         [Fact]
-        [SkipOnCoreClr("Exact copy constructor counts may differ in JIT stress modes.", RuntimeTestModes.JitStress)]
-        public static int TestEntryPoint()
-        {
-            if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
-            {
-                return 100;
-            }
-
-            try
-            {
-                Assembly ijwNativeDll = Assembly.Load("IjwCopyConstructorMarshaler");
-                Type testType = ijwNativeDll.GetType("TestClass");
-                object testInstance = Activator.CreateInstance(testType);
-                MethodInfo testMethod = testType.GetMethod("PInvokeNumCopies");
-
-                // On x86, we will copy in the IL stub to the final arg slot.
-                int platformExtra = 0;
-                if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
-                {
-                    platformExtra = 1;
-                }
-
-                // PInvoke will copy once. Once from the managed to native parameter.
-                Assert.Equal(1 + platformExtra, (int)testMethod.Invoke(testInstance, null));
-
-                testMethod = testType.GetMethod("ReversePInvokeNumCopies");
-
-                // Reverse PInvoke will copy 2 times. One from the same path as the PInvoke,
-                // and one from the reverse P/Invoke call.
-                Assert.Equal(2 + platformExtra, (int)testMethod.Invoke(testInstance, null));
-
-                testMethod = testType.GetMethod("PInvokeNumCopiesDerivedType");
-
-                // PInvoke will copy once from the managed to native parameter.
-                Assert.Equal(1 + platformExtra, (int)testMethod.Invoke(testInstance, null));
-
-                testMethod = testType.GetMethod("ReversePInvokeNumCopiesDerivedType");
-
-                // Reverse PInvoke will copy 2 times. One from the same path as the PInvoke,
-                // and one from the reverse P/Invoke call.
-                Assert.Equal(2 + platformExtra, (int)testMethod.Invoke(testInstance, null));
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-                return 101;
-            }
-            return 100;
-        }
-
-        [Fact]
         public static void CopyConstructorsInArgumentStackSlots()
         {
             Assembly ijwNativeDll = Assembly.Load("IjwCopyConstructorMarshaler");

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/IjwCopyConstructorMarshaler.cpp
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/IjwCopyConstructorMarshaler.cpp
@@ -171,107 +171,10 @@ namespace ExposedThisUnsafeValueType
 }
 
 #pragma managed
-class A
-{
-    int copyCount;
-
-public:
-    A()
-    :copyCount(0)
-    {};
-
-    A(A& other)
-    :copyCount(other.copyCount + 1)
-    {}
-
-    int GetCopyCount()
-    {
-        return copyCount;
-    }
-};
-
-class B : public A
-{
-    int bCopyCount;
-
-public:
-    B()
-    :A(),
-    bCopyCount(0)
-    {};
-
-    B(B& other)
-    :A(other),
-    bCopyCount(other.bCopyCount + 1)
-    {}
-
-    int GetBCopyCount()
-    {
-        return bCopyCount;
-    }
-};
-
-int Managed_GetCopyCount(A a)
-{
-    return a.GetCopyCount();
-}
-
-int Managed_GetCopyCount(B b)
-{
-    return b.GetBCopyCount();
-}
-
-#pragma unmanaged
-
-int GetCopyCount(A a)
-{
-    return a.GetCopyCount();
-}
-
-int GetCopyCount_ViaManaged(A a)
-{
-    return Managed_GetCopyCount(a);
-}
-
-int GetCopyCount(B b)
-{
-    return b.GetBCopyCount();
-}
-
-int GetCopyCount_ViaManaged(B b)
-{
-    return Managed_GetCopyCount(b);
-}
-
-#pragma managed
 
 public ref class TestClass
 {
 public:
-    int PInvokeNumCopies()
-    {
-        A a;
-        return GetCopyCount(a);
-    }
-
-    int PInvokeNumCopiesDerivedType()
-    {
-        B b;
-        return GetCopyCount(b);
-    }
-
-    int ReversePInvokeNumCopies()
-    {
-        A a;
-        return GetCopyCount_ViaManaged(a);
-    }
-
-    int ReversePInvokeNumCopiesDerivedType()
-    {
-        B b;
-        return GetCopyCount_ViaManaged(b);
-    }
-
     int ExposedThisCopyConstructorScenario()
     {
         return ExposedThis::RunScenario();


### PR DESCRIPTION
JitStress can decide to treat a type as an "unsafe buffer" type, which will introduce an extra copy constructor call on the reverse P/Invoke for validity.

Disable the test that validates copy constructor counts in JitStress as a result.

Fixes https://github.com/dotnet/runtime/issues/106848