### PR TITLE
[JIT] Allow side-effects for the first test in switch recognition

### DIFF
--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -50,17 +50,19 @@ PhaseStatus Compiler::optSwitchRecognition()
 //    constant test? e.g. JTRUE(EQ/NE(X, CNS)).
 //
 // Arguments:
-//    block        - The block to check
-//    trueEdge     - [out] The successor edge taken if X == CNS
-//    falseEdge    - [out] The successor edge taken if X != CNS
-//    isReversed   - [out] True if the condition is reversed (GT_NE)
-//    variableNode - [out] The variable node (X in the example above)
-//    cns          - [out] The constant value (CNS in the example above)
+//    block            - The block to check
+//    allowSideEffects - is variableNode allowed to have side-effects (COMMA)?
+//    trueEdge         - [out] The successor edge taken if X == CNS
+//    falseEdge        - [out] The successor edge taken if X != CNS
+//    isReversed       - [out] True if the condition is reversed (GT_NE)
+//    variableNode     - [out] The variable node (X in the example above)
+//    cns              - [out] The constant value (CNS in the example above)
 //
 // Return Value:
 //    True if the block represents a constant test, false otherwise
 //
 bool IsConstantTestCondBlock(const BasicBlock* block,
+                             bool              allowSideEffects,
                              BasicBlock**      trueTarget,
                              BasicBlock**      falseTarget,
                              bool*             isReversed,
@@ -89,7 +91,15 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
             if ((op1->IsCnsIntOrI() && !op1->IsIconHandle()) ^ (op2->IsCnsIntOrI() && !op2->IsIconHandle()))
             {
                 // TODO: relax this to support any side-effect free expression
-                if (!op1->OperIs(GT_LCL_VAR) && !op2->OperIs(GT_LCL_VAR))
+
+                if (allowSideEffects)
+                {
+                    if (!op1->gtEffectiveVal()->OperIs(GT_LCL_VAR) && !op2->gtEffectiveVal()->OperIs(GT_LCL_VAR))
+                    {
+                        return false;
+                    }
+                }
+                else if (!op1->OperIs(GT_LCL_VAR) && !op2->OperIs(GT_LCL_VAR))
                 {
                     return false;
                 }
@@ -148,7 +158,7 @@ bool Compiler::optSwitchDetectAndConvert(BasicBlock* firstBlock)
     // and then try to accumulate as many constant test blocks as possible. Once we hit
     // a block that doesn't match the pattern, we start processing the accumulated blocks.
     bool isReversed = false;
-    if (IsConstantTestCondBlock(firstBlock, &trueTarget, &falseTarget, &isReversed, &variableNode, &cns))
+    if (IsConstantTestCondBlock(firstBlock, true, &trueTarget, &falseTarget, &isReversed, &variableNode, &cns))
     {
         if (isReversed)
         {
@@ -185,8 +195,8 @@ bool Compiler::optSwitchDetectAndConvert(BasicBlock* firstBlock)
             }
 
             // Inspect secondary blocks
-            if (IsConstantTestCondBlock(currBb, &currTrueTarget, &currFalseTarget, &isReversed, &currVariableNode,
-                                        &currCns))
+            if (IsConstantTestCondBlock(currBb, false, &currTrueTarget, &currFalseTarget, &isReversed,
+                                        &currVariableNode, &currCns))
             {
                 if (currTrueTarget != trueTarget)
                 {
@@ -194,7 +204,7 @@ bool Compiler::optSwitchDetectAndConvert(BasicBlock* firstBlock)
                     return optSwitchConvert(firstBlock, testValueIndex, testValues, falseLikelihood, variableNode);
                 }
 
-                if (!GenTree::Compare(currVariableNode, variableNode))
+                if (!GenTree::Compare(currVariableNode, variableNode->gtEffectiveVal()))
                 {
                     // A different variable node is used, stop searching and process what we already have.
                     return optSwitchConvert(firstBlock, testValueIndex, testValues, falseLikelihood, variableNode);
@@ -324,7 +334,7 @@ bool Compiler::optSwitchConvert(
     BasicBlock* blockIfTrue  = nullptr;
     BasicBlock* blockIfFalse = nullptr;
     bool        isReversed   = false;
-    const bool  isTest       = IsConstantTestCondBlock(lastBlock, &blockIfTrue, &blockIfFalse, &isReversed);
+    const bool  isTest       = IsConstantTestCondBlock(lastBlock, false, &blockIfTrue, &blockIfFalse, &isReversed);
     assert(isTest);
 
     assert(firstBlock->TrueTargetIs(blockIfTrue));

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -90,8 +90,6 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
             // We're looking for "X EQ/NE CNS" or "CNS EQ/NE X" pattern
             if ((op1->IsCnsIntOrI() && !op1->IsIconHandle()) ^ (op2->IsCnsIntOrI() && !op2->IsIconHandle()))
             {
-                // TODO: relax this to support any side-effect free expression
-
                 if (allowSideEffects)
                 {
                     if (!op1->gtEffectiveVal()->OperIs(GT_LCL_VAR) && !op2->gtEffectiveVal()->OperIs(GT_LCL_VAR))

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -345,7 +345,7 @@ bool Compiler::optSwitchConvert(
     firstBlock->lastStmt()->GetRootNode()->ChangeOper(GT_SWITCH);
 
     // The root node is now SUB(nodeToTest, minValue) if minValue != 0
-    GenTree* switchValue = gtCloneExpr(nodeToTest);
+    GenTree* switchValue = nodeToTest;
     if (minValue != 0)
     {
         switchValue =


### PR DESCRIPTION
```cs
static void Test(char ch)
{
    if (ch == '\r' || ch == '\n' || ch == '\t' || ch == ' ')
    {
        Console.WriteLine("special symbol");
    }
}
```
Codegen diff:
```diff
; Assembly listing for method Proga:Test(ushort) (FullOpts)
       push     rbx
       sub      rsp, 32
       movzx    rbx, cx
-      cmp      ebx, 13  ;; this "ch == '\r'" is supposed to be part of the bit-test below
-      je       SHORT G_M18843_IG05
       cmp      ebx, 32
       ja       SHORT G_M18843_IG06
-      mov      eax, 0xFFFFF9FF
+      mov      eax, 0xFFFFD9FF
       bt       rax, rbx
       jb       SHORT G_M18843_IG06
G_M18843_IG05:
       mov      rcx, 0x2127BF35718      ; 'special symbol'
       call     [System.Console:WriteLine(System.String)]
G_M18843_IG06:
       nop      
       add      rsp, 32
       pop      rbx
       ret      
```

JIT IR before the switch recognition:
```

---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight   [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1    [000..005)-> BB05(0.5),BB02(0.5)     ( cond )                     i
BB02 [0001]  1       BB01                  0.50 [005..00A)-> BB05(0.5),BB03(0.5)     ( cond )                     i
BB03 [0002]  1       BB02                  0.50 [00A..00F)-> BB05(0.5),BB04(0.5)     ( cond )                     i
BB04 [0003]  1       BB03                  0.50 [00F..014)-> BB06(0.5),BB05(0.5)     ( cond )                     i
BB05 [0004]  4       BB01,BB02,BB03,BB04   0.50 [014..01E)-> BB06(1)                 (always)                     i hascall gcsafe
BB06 [0005]  2       BB04,BB05             1    [01E..01F)                           (return)                     i
---------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------ BB01 [0000] [000..005) -> BB05(0.5),BB02(0.5) (cond), preds={} succs={BB02,BB05}

***** BB01 [0000]
STMT00000 ( 0x000[E-] ... 0x003 )
N008 (  8,  9) [000003] -A---+-----                         *  JTRUE     void   $VN.Void
N007 (  6,  7) [000002] JA---+-N---                         \--*  EQ        int    $101
N005 (  4,  5) [000026] -A---------                            +--*  COMMA     int    $100
N003 (  3,  4) [000024] DA---------                            |  +--*  STORE_LCL_VAR int    V02 cse0         d:1 $VN.Void
N002 (  3,  4) [000019] -----+-----                            |  |  \--*  CAST      int <- ushort <- int $100
N001 (  2,  2) [000000] -----+-----                            |  |     \--*  LCL_VAR   int    V00 arg0         u:1 $80
N004 (  1,  1) [000025] -----------                            |  \--*  LCL_VAR   int    V02 cse0         u:1 $100
N006 (  1,  1) [000001] -----+-----                            \--*  CNS_INT   int    13 $43

------------ BB02 [0001] [005..00A) -> BB05(0.5),BB03(0.5) (cond), preds={BB01} succs={BB03,BB05}

***** BB02 [0001]
STMT00003 ( 0x005[E-] ... 0x008 )
N004 (  5,  5) [000010] -----+-----                         *  JTRUE     void   $VN.Void
N003 (  3,  3) [000009] J----+-N---                         \--*  EQ        int    $102
N001 (  1,  1) [000027] -----------                            +--*  LCL_VAR   int    V02 cse0         u:1 $100
N002 (  1,  1) [000008] -----+-----                            \--*  CNS_INT   int    10 $42

------------ BB03 [0002] [00A..00F) -> BB05(0.5),BB04(0.5) (cond), preds={BB02} succs={BB04,BB05}

***** BB03 [0002]
STMT00004 ( 0x00A[E-] ... 0x00D )
N004 (  5,  5) [000014] -----+-----                         *  JTRUE     void   $VN.Void
N003 (  3,  3) [000013] J----+-N---                         \--*  EQ        int    $103
N001 (  1,  1) [000028] -----------                            +--*  LCL_VAR   int    V02 cse0         u:1 $100
N002 (  1,  1) [000012] -----+-----                            \--*  CNS_INT   int    9 $44

------------ BB04 [0003] [00F..014) -> BB06(0.5),BB05(0.5) (cond), preds={BB03} succs={BB05,BB06}

***** BB04 [0003]
STMT00005 ( 0x00F[E-] ... 0x012 )
N004 (  5,  5) [000018] -----+-----                         *  JTRUE     void   $VN.Void
N003 (  3,  3) [000017] N----+-N-U-                         \--*  NE        int    $104
N001 (  1,  1) [000029] -----------                            +--*  LCL_VAR   int    V02 cse0         u:1 $100
N002 (  1,  1) [000016] -----+-----                            \--*  CNS_INT   int    32 $45

------------ BB05 [0004] [014..01E) -> BB06(1) (always), preds={BB01,BB02,BB03,BB04} succs={BB06}

***** BB05 [0004]
STMT00001 ( 0x014[E-] ... 0x019 )
N002 ( 17, 16) [000005] --CXG+-----                         *  CALL      void   System.Console:WriteLine(System.String) $VN.Void
N001 (  3, 10) [000023] H----+----- arg0 in rcx             \--*  CNS_INT(h) ref     'special symbol' $140

------------ BB06 [0005] [01E..01F) (return), preds={BB04,BB05} succs={}

***** BB06 [0005]
STMT00002 ( 0x01E[E-] ... 0x01E )
N001 (  0,  0) [000006] -----+-----                         *  RETURN    void   $VN.Void

-------------------------------------------------------------------------------------------------------------------
```

We used to give up on `BB01` due to `COMMA`, but in fact we shouldn't since we preserve the first block for the resulting `switch`.

Alternative fix: run "remove all commas" phase 🙂 `SplitTreesRemoveCommas`