### PR TITLE
Extend timeout when waiting for service status

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Hosting
             { }
         }
 
-        public static TimeSpan WaitForStatusTimeout { get; set; } = TimeSpan.FromSeconds(30);
+        public static TimeSpan WaitForStatusTimeout { get; set; } = TimeSpan.FromMinutes(3);
 
         public new void WaitForStatus(ServiceControllerStatus desiredStatus) =>
             WaitForStatus(desiredStatus, WaitForStatusTimeout);


### PR DESCRIPTION
Fix #103548

Wait for up to 3 minutes for the service status to change.

These tests were timing out in the JIT stress pipeline.  Give them more time for the service to start up before failing.

cc @JulieLeeMSFT @mikelle-rogers 