### PR TITLE
Define a merged runner for the nativeaot subtree and run every test out-of-proc and don't reference the xunit generator

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -464,7 +464,7 @@
 
     <!-- We don't want the out-of-process test marker file to be included in referencing projects, so we don't include it as content. -->
     <WriteLinesToFile
-        Condition="'$(RequiresProcessIsolation)' == 'true' and '$(BuildAsStandalone)' != 'true'"
+        Condition="'$(RequiresProcessIsolation)' == 'true' and '$(BuildAllTestsAsStandalone)' != 'true'"
         File="$(OutputPath)\$(AssemblyName).OutOfProcessTest"
         Lines="OutOfProcessTest"
         Overwrite="true"

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -35,7 +35,7 @@
   <!-- Default priority building values. -->
   <PropertyGroup>
     <DisableProjectBuild Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and '$(BuildAllTestsAsStandalone)' == 'true' and '$(HasMergedInTests)' != 'true'">true</DisableProjectBuild>
-    <OutputType Condition="('$(IsMergedTestRunnerAssembly)' == 'true' and '$(BuildAllTestsAsStandalone)' != 'true') or ('$(RequiresProcessIsolation)' == 'true' and '$(CLRTestKind)' != 'SharedLibrary')">Exe</OutputType>
+    <OutputType Condition="'$(SkipInferOutputType)' != 'true' and (('$(IsMergedTestRunnerAssembly)' == 'true' and '$(BuildAllTestsAsStandalone)' != 'true') or ('$(RequiresProcessIsolation)' == 'true' and '$(CLRTestKind)' != 'SharedLibrary'))">Exe</OutputType>
 
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">SharedLibrary</CLRTestKind>

--- a/src/tests/nativeaot/CustomMain/CustomMain.csproj
+++ b/src/tests/nativeaot/CustomMain/CustomMain.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <CustomNativeMain>true</CustomNativeMain>
     <StaticLibraryPrefix Condition="'$(TargetOS)' != 'windows'">lib</StaticLibraryPrefix>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/CustomMainWithStubExe/CustomMainWithStubExe.csproj
+++ b/src/tests/nativeaot/CustomMainWithStubExe/CustomMainWithStubExe.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <CustomNativeMain>true</CustomNativeMain>
     <NativeLib>Shared</NativeLib>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
+++ b/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
@@ -8,6 +8,8 @@
       Disable for now.
     -->
     <DisableProjectBuild Condition="'$(EnableNativeSanitizers)' != ''">true</DisableProjectBuild>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
+++ b/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
@@ -6,6 +6,8 @@
 
     <!-- Shouldn't need this: https://github.com/dotnet/linker/issues/2618 -->
     <NoWarn>$(NoWarn);IL2050</NoWarn>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
 
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/ControlFlowGuard/ControlFlowGuard.csproj
+++ b/src/tests/nativeaot/SmokeTests/ControlFlowGuard/ControlFlowGuard.csproj
@@ -7,6 +7,8 @@
     <Optimize>true</Optimize>
     <!-- x86 support tracked at https://github.com/dotnet/runtime/issues/99516 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true' or '$(TargetArchitecture)' == 'x86' ">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ControlFlowGuard.cs" />

--- a/src/tests/nativeaot/SmokeTests/Determinism/Determinism.csproj
+++ b/src/tests/nativeaot/SmokeTests/Determinism/Determinism.csproj
@@ -5,6 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- test tries to read files from disk, bundling them into the app isn't easily possible right now -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Determinism.cs" />

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
@@ -9,6 +9,8 @@
     <!-- There are a lot more symbols on sanitized builds, so this test times out -->
     <CLRTestTargetUnsupported Condition="'$(EnableNativeSanitizers)' != ''">true</CLRTestTargetUnsupported>
     <StripSymbols>false</StripSymbols>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
@@ -10,6 +10,8 @@
 
     <!-- Look for MULTIMODULE_BUILD #define for the more specific incompatible parts -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.csproj
+++ b/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.csproj
@@ -6,6 +6,8 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <!-- Test infra issue on apple devices: https://github.com/dotnet/runtime/issues/89917 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Exceptions.cs" />

--- a/src/tests/nativeaot/SmokeTests/FrameworkStrings/Baseline.csproj
+++ b/src/tests/nativeaot/SmokeTests/FrameworkStrings/Baseline.csproj
@@ -4,6 +4,8 @@
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Test infra issue on apple devices: https://github.com/dotnet/runtime/issues/89917 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/nativeaot/SmokeTests/FrameworkStrings/UseSystemResourceKeys.csproj
+++ b/src/tests/nativeaot/SmokeTests/FrameworkStrings/UseSystemResourceKeys.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
     <!-- Test infra issue on apple devices: https://github.com/dotnet/runtime/issues/89917 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);AVX_INTRINSICS;VECTORT128_INTRINSICS</DefineConstants>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx2.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx2.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);AVX2_INTRINSICS;VECTORT256_INTRINSICS</DefineConstants>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx512.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx512.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);AVX512_INTRINSICS;VECTORT256_INTRINSICS</DefineConstants>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx_NoAvx2.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx_NoAvx2.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);AVX_INTRINSICS;VECTORT128_INTRINSICS</DefineConstants>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);BASELINE_INTRINSICS;VECTORT128_INTRINSICS</DefineConstants>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Sse42.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Sse42.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);SSE42_INTRINSICS;VECTORT128_INTRINSICS</DefineConstants>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/MultiModule/Library.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/Library.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IlcMultiModule>true</IlcMultiModule>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library.cs" />

--- a/src/tests/nativeaot/SmokeTests/MultiModule/Library.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/Library.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IlcMultiModule>true</IlcMultiModule>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library.cs" />

--- a/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
@@ -7,6 +7,8 @@
     <!-- This test always runs as multimodule. It's not supported if we don't have framework object files. -->
     <CLRTestTargetUnsupported Condition="'$(BuildNativeAotFrameworkObjects)' != 'true'">true</CLRTestTargetUnsupported>
     <IlcMultiModule>true</IlcMultiModule>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MultiModule.cs" />

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.csproj
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.csproj
@@ -10,6 +10,8 @@
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
     <!-- Test infra issue on apple devices: https://github.com/dotnet/runtime/issues/89917 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvoke.cs" />

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.csproj
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.csproj
@@ -16,6 +16,8 @@
       with system C++ runtime library (-lstdc++).
     -->
     <LinkStandardCPlusPlusLibrary>true</LinkStandardCPlusPlusLibrary>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.csproj
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.csproj
@@ -10,6 +10,8 @@
 
     <!-- Look for MULTIMODULE_BUILD #define for the more specific incompatible parts -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Reflection.cs" />

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection_FromUsage.csproj
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection_FromUsage.csproj
@@ -15,6 +15,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
 
     <IlcTrimMetadata>false</IlcTrimMetadata>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Reflection.cs" />

--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NativeLib>Shared</NativeLib>
+    <BuildAsStandalone>false</BuildAsStandalone>
     <!-- Unable to compile a project with the Library output type for apple mobile devices -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
 
@@ -12,7 +13,7 @@
          not even from stack trace mapping data -->
     <StackTraceSupport>false</StackTraceSupport>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <SkipInferOutputType>true</SkipInferOutputType>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
@@ -11,6 +11,8 @@
     <!-- Regression test for https://github.com/dotnet/runtime/issues/105330: make sure the UnmanagedCallersOnly are completely unreferenced,
          not even from stack trace mapping data -->
     <StackTraceSupport>false</StackTraceSupport>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata.csproj
+++ b/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata.csproj
@@ -7,6 +7,8 @@
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
     <!-- Tracking issue: https://github.com/dotnet/runtime/issues/90460 -->
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' == 'tvos' and '$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StackTraceMetadata.cs" />

--- a/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata_Stripped.csproj
+++ b/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata_Stripped.csproj
@@ -9,6 +9,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
     <DefineConstants>$(DefineConstants);STRIPPED</DefineConstants>
     <StackTraceSupport>false</StackTraceSupport>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StackTraceMetadata.cs" />

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library.cs" />

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library.cs" />

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ShimLibrary.cs" />

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ShimLibrary.cs" />

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/TrimmingBehaviors.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/TrimmingBehaviors.csproj
@@ -7,6 +7,8 @@
 
     <!-- We don't run the scanner in optimized builds -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
@@ -8,6 +8,8 @@
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <NoWarn>$(NoWarn);IL3050;IL3054</NoWarn>
 
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicThreading.cs" />

--- a/src/tests/nativeaot/SmokeTests/Win32Resources/Win32Resources.csproj
+++ b/src/tests/nativeaot/SmokeTests/Win32Resources/Win32Resources.csproj
@@ -5,6 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <Win32Resource>test.res</Win32Resource>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Win32Resources.cs" />

--- a/src/tests/nativeaot/StartupHook/StartupHook.csproj
+++ b/src/tests/nativeaot/StartupHook/StartupHook.csproj
@@ -5,6 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StartupHookSupport>true</StartupHookSupport>
     <NoWarn>$(NoWarn);IL2026</NoWarn>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StartupHook.cs" />

--- a/src/tests/nativeaot/nativeaot.csproj
+++ b/src/tests/nativeaot/nativeaot.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-      <MergedWrapperProjectReference Include="**/*.??proj" />
+      <MergedWrapperProjectReference Include="*/**/*.??proj" Exclude="*/**/Library.csproj" />
     </ItemGroup>
   
     <Import Project="$(TestSourceDir)MergedTestRunner.targets" />

--- a/src/tests/nativeaot/nativeaot.csproj
+++ b/src/tests/nativeaot/nativeaot.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+      <MergedWrapperProjectReference Include="**/*.??proj" />
+    </ItemGroup>
+  
+    <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
+  </Project>
+  


### PR DESCRIPTION
This is a very simplistic port to the merged runner infrastructure just so we can get the last few directories onto it to enable removing the old infrastructure.

I've validated locally that all of the tests actually run with this change.