### PR TITLE
[cDAC] Fix getting instantiation type handles for generic subclasses

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -333,6 +333,7 @@ The contract additionally depends on these data descriptors
 | `FnPtrTypeDesc` | `NumArgs` | Number of arguments to the function described by the `TypeDesc` |
 | `FnPtrTypeDesc` | `CallConv` | Lower 8 bits is the calling convention bit as extracted by the signature that defines this `TypeDesc` |
 | `FnPtrTypeDesc` | `RetAndArgTypes` | Pointer to an array of TypeHandle addresses. This length of this is 1 more than `NumArgs` |
+| `GenericsDictInfo` | `NumDicts` | Number of instantiation dictionaries, including inherited ones, in this `GenericsDictInfo` |
 | `GenericsDictInfo` | `NumTypeArgs` | Number of type arguments in the type or method instantiation described by this `GenericsDictInfo` |
 
 

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -266,7 +266,8 @@ CDAC_TYPE_END(ArrayClass)
 
 CDAC_TYPE_BEGIN(GenericsDictInfo)
 CDAC_TYPE_INDETERMINATE(GenericsDictInfo)
-CDAC_TYPE_FIELD(GenericsDictInfo, /*uint16*/, NumTypeArgs, cdac_data<GenericsDictInfo>::NumTypeArgs)
+CDAC_TYPE_FIELD(GenericsDictInfo, /*uint16*/, NumDicts, offsetof(GenericsDictInfo, m_wNumDicts))
+CDAC_TYPE_FIELD(GenericsDictInfo, /*uint16*/, NumTypeArgs, offsetof(GenericsDictInfo, m_wNumTyPars))
 CDAC_TYPE_END(GenericsDictInfo)
 
 CDAC_TYPE_BEGIN(TypeDesc)

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -293,15 +293,8 @@ struct GenericsDictInfo
 
     // Number of type parameters (NOT including those of superclasses).
     WORD   m_wNumTyPars;
-    template<typename T> friend struct ::cdac_data;
 };  // struct GenericsDictInfo
 typedef DPTR(GenericsDictInfo) PTR_GenericsDictInfo;
-
-template<>
-struct cdac_data<GenericsDictInfo>
-{
-    static constexpr size_t NumTypeArgs = offsetof(GenericsDictInfo, m_wNumTyPars);
-};
 
 // These various statics structures exist directly before the MethodTableAuxiliaryData
 

--- a/src/native/managed/cdacreader/src/Data/GenericsDictInfo.cs
+++ b/src/native/managed/cdacreader/src/Data/GenericsDictInfo.cs
@@ -10,8 +10,10 @@ internal class GenericsDictInfo : IData<GenericsDictInfo>
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.GenericsDictInfo);
 
+        NumDicts = target.Read<ushort>(address + (ulong)type.Fields[nameof(NumDicts)].Offset);
         NumTypeArgs = target.Read<ushort>(address + (ulong)type.Fields[nameof(NumTypeArgs)].Offset);
     }
 
+    public ushort NumDicts { get; init; }
     public ushort NumTypeArgs { get; init; }
 }


### PR DESCRIPTION
We were always using the first instantiation dictionary when getting the type handles for the instantiation of a type. For types with inherited ones, we'd end up with the base class dictionary instead of the specific type.

- Add GenericsDictInfo::NumDicts to the data descriptor
- Update the `RuntimeTypeSystem` contract implementation to use the last dictionary (the one for the specific type)

This was observed via an incorrect method table name - for example, `Test<int>` where `class Test<T> : List<string>` would use the dictionary for `List<string>` and end up reporting the method table name as `Test<string>`