### PR TITLE
[release/8.0-staging][infra][android] Fix Android helix queue name

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Android x64
     - ${{ if in(parameters.platform, 'android_x64') }}:
-      - Ubuntu.2004.Amd64.Android.29.Open
+      - Ubuntu.2204.Amd64.Android.29.Open
 
     # Browser wasm
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -99,7 +99,7 @@ jobs:
 
     # Android
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
-      - Ubuntu.2004.Amd64.Android.29.Open
+      - Ubuntu.2204.Amd64.Android.29.Open
     - ${{ if in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm64') }}:
       - Windows.11.Amd64.Android.Open
 


### PR DESCRIPTION
The Android emulator queue name was changed to `Ubuntu.2004.Amd64.Android.29.Open` in https://github.com/dotnet/runtime/pull/103393 but there is no such queue on helix, causing the Android x64 jobs to fail: `error : Helix API does not contain an entry for Ubuntu.2004.Amd64.Android.29.Open`

Changing to `Ubuntu.2204.Amd64.Android.29.Open`.