### PR TITLE
[wasm] Performance sample - remove public nugets and clean up

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Common/GetNugetConfigTask.cs
+++ b/src/mono/sample/wasm/browser-bench/Common/GetNugetConfigTask.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class GetNugetConfigTask : Task
+{
+    [Required]
+    public string InputFile { get; set; }
+
+    [Required]
+    public string ArtifactsDir { get; set; }
+
+    [Required]
+    public string Configuration { get; set; }
+
+    [Output]
+    public string NugetConfigContent { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            XDocument doc = XDocument.Load(InputFile);
+            XElement packageSources = doc.Root.Element("packageSources");
+
+            if (packageSources == null)
+            {
+                packageSources = new XElement("packageSources");
+                doc.Root.Add(packageSources);
+            }
+
+            XElement newSource = new XElement("add",
+                new XAttribute("key", "nuget-local"),
+                new XAttribute("value", Path.Combine(ArtifactsDir, "packages", Configuration, "Shipping"))
+            );
+
+            packageSources.Add(newSource);
+
+            NugetConfigContent = doc.ToString();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex);
+            return false;
+        }
+    }
+}

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -17,29 +17,22 @@
     <WasmExtraFilesToDeploy Include="frame-main.js" />
     <WasmExtraFilesToDeploy Include="style.css" />
     <Compile Remove="Console/Console.cs" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
+  <UsingTask TaskName="GetNugetConfigTask" AssemblyFile="$(OutputPath)Wasm.Browser.Bench.Sample.dll" />
+
+  <Target Name="SetNugetConfigContent" BeforeTargets="PrepareBlazorTemplate;BuildBlazorFrame">
+    <GetNugetConfigTask 
+      InputFile="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/nuget9.config" 
+      ArtifactsDir="$(ArtifactsDir)" 
+      Configuration="$(Configuration)">
+      <Output TaskParameter="NugetConfigContent" PropertyName="NugetConfigContent"/>
+    </GetNugetConfigTask>
+  </Target>
 
   <PropertyGroup>
-    <NugetConfigContent>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
-&lt;configuration&gt;
-  &lt;!-- Don't use any higher level config files. --&gt;
-  &lt;fallbackPackageFolders&gt;
-    &lt;clear /&gt;
-  &lt;/fallbackPackageFolders&gt;
-  &lt;packageSources&gt;
-    &lt;clear /&gt;
-    &lt;add key=&quot;nuget-local&quot; value=&quot;$(ArtifactsDir)packages/$(Configuration)/Shipping/&quot; /&gt;
-    &lt;add key=&quot;dotnet8&quot; value=&quot;https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json&quot; /&gt;
-    &lt;add key=&quot;dotnet9&quot; value=&quot;https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json&quot; /&gt;
-    &lt;add key=&quot;nuget.org&quot;  value=&quot;https://api.nuget.org/v3/index.json&quot; protocolVersion=&quot;3&quot; /&gt;
-  &lt;/packageSources&gt;
-    &lt;disabledPackageSources&gt;
-    &lt;clear /&gt;
-  &lt;/disabledPackageSources&gt;
-&lt;/configuration&gt;
-    </NugetConfigContent>
     <NugetPackagesPath>$(MSBuildThisFileDirectory)nugetPackages</NugetPackagesPath>
   </PropertyGroup>
 

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -23,7 +23,7 @@
   <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
   <UsingTask TaskName="GetNugetConfigTask" AssemblyFile="$(OutputPath)Wasm.Browser.Bench.Sample.dll" />
 
-  <Target Name="SetNugetConfigContent" BeforeTargets="PrepareBlazorTemplate;BuildBlazorFrame">
+  <Target Name="SetNugetConfigContent">
     <GetNugetConfigTask 
       InputFile="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/nuget9.config" 
       ArtifactsDir="$(ArtifactsDir)" 
@@ -48,7 +48,7 @@
     <MakeDir Directories="$(NugetPackagesPath)" />
   </Target>
 
-  <Target Name="PrepareBlazorTemplate" Condition="!Exists('$(MonoProjectRoot)sample/wasm/blazor-frame/blazor')">
+  <Target Name="PrepareBlazorTemplate" Condition="!Exists('$(MonoProjectRoot)sample/wasm/blazor-frame/blazor')" DependsOnTargets="SetNugetConfigContent">
     <ItemGroup>
         <OverrideFiles Include="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/WasmOverridePacks.targets" />
         <OverrideFiles Include="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/Blazor.Directory.Build.targets" />
@@ -80,7 +80,7 @@
         DestinationFolder="$(MSBuildThisFileDirectory)/bin/$(Configuration)/AppBundle/blazor-template/%(RecursiveDir)" />
   </Target>
 
-  <Target Name="PrepareBrowserTemplate" Condition="!Exists('$(MonoProjectRoot)sample/wasm/browser-frame/browser-frame')">
+  <Target Name="PrepareBrowserTemplate" Condition="!Exists('$(MonoProjectRoot)sample/wasm/browser-frame/browser-frame')" DependsOnTargets="SetNugetConfigContent">
     <ItemGroup>
         <OverrideFiles Include="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/WasmOverridePacks.targets" />
         <OverrideFiles Include="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/Blazor.Directory.Build.targets" />


### PR DESCRIPTION
Follow-up for https://github.com/dotnet/runtime/pull/104806.

- Removes "nuget-org" from perf sample
- Removes embedded xml from msbuild file
- Makes `src/mono/wasm/Wasm.Build.Tests/data/nuget*.config` the only place to edit in case we want to change sources.
- Requires updating `nuget9.config` name when the release version changes.

Tested locally.