### PR TITLE
Propagate RuntimeConfiguration for cross-subset builds

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -587,6 +587,7 @@
       <AdditionalProperties Condition="'%(ProjectToBuild.Category)' == 'tools'">%(AdditionalProperties);Configuration=$(ToolsConfiguration)</AdditionalProperties>
 
       <!-- Propagate configurations for cross-subset builds -->
+      <AdditionalProperties>%(AdditionalProperties);CoreCLRConfiguration=$(CoreCLRConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);LibrariesConfiguration=$(LibrariesConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);HostConfiguration=$(HostConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);TasksConfiguration=$(TasksConfiguration)</AdditionalProperties>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -587,7 +587,7 @@
       <AdditionalProperties Condition="'%(ProjectToBuild.Category)' == 'tools'">%(AdditionalProperties);Configuration=$(ToolsConfiguration)</AdditionalProperties>
 
       <!-- Propagate configurations for cross-subset builds -->
-      <AdditionalProperties>%(AdditionalProperties);CoreCLRConfiguration=$(CoreCLRConfiguration)</AdditionalProperties>
+      <AdditionalProperties>%(AdditionalProperties);RuntimeConfiguration=$(RuntimeConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);LibrariesConfiguration=$(LibrariesConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);HostConfiguration=$(HostConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);TasksConfiguration=$(TasksConfiguration)</AdditionalProperties>


### PR DESCRIPTION
This addresses issues building cross-subset with clr with mixed configurations.

For example, `singlefilehost` is built as part of the `clr` subset, but the `host` subset copies it, embeds the DAC (when necessary) and packages it. When the clr and host configuration  didn't match, this resulted in the host build looking for `singlefilehost` in the wrong location.