### PR TITLE
Ensure that Vector128.CreateSequence works on x86 for non-constant 64-bit inputs

### DIFF
--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -2338,16 +2338,19 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     }
                 }
 
-                if (varTypeIsLong(simdBaseType) && !impStackTop(0).val->OperIsConst())
+                if (varTypeIsLong(simdBaseType))
                 {
-                    // When op2 is a constant, we can skip the multiplication allowing us to always
-                    // generate better code. However, if it isn't then we need to fallback in the
-                    // cases where multiplication isn't supported.
-
-                    if ((simdSize != 64) && !canUseEvexEncoding())
+                    if (!impStackTop(0).val->OperIsConst())
                     {
-                        // TODO-XARCH-CQ: We should support long/ulong multiplication
-                        break;
+                        // When op2 is a constant, we can skip the multiplication allowing us to always
+                        // generate better code. However, if it isn't then we need to fallback in the
+                        // cases where multiplication isn't supported.
+
+                        if ((simdSize != 64) && !canUseEvexEncoding())
+                        {
+                            // TODO-XARCH-CQ: We should support long/ulong multiplication
+                            break;
+                        }
                     }
 
 #if defined(TARGET_X86)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106372/Runtime_106372.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106372/Runtime_106372.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+// Found by Antigen
+// Reduced from 161.42 KB to 874 B.
+// Further reduced by hand.
+//
+// Assert failure(PID 35056 [0x000088f0], Thread: 28500 [0x6f54]): Assertion failed 'unreached' in 'TestClass:Method0():this' during 'Importation' (IL size 116; hash 0x46e9aa75; Tier0)
+//     File: C:\wk\runtime\src\coreclr\jit\gentree.cpp:22552
+//     Image: C:\wk\runtime\artifacts\tests\coreclr\windows.x86.Checked\Tests\Core_Root\corerun.exe
+
+public class Runtime_106372
+{
+    static long s_long_11 = 1;
+
+    public static void TestEntryPoint()
+    {
+        Vector128<long> result = Vector128.CreateSequence(s_long_11, -2);
+        Assert(Vector128.Create(+1L, -1L), result);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106372/Runtime_106372.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106372/Runtime_106372.cs
@@ -20,6 +20,6 @@ public class Runtime_106372
     public static void TestEntryPoint()
     {
         Vector128<long> result = Vector128.CreateSequence(s_long_11, -2);
-        Assert(Vector128.Create(+1L, -1L), result);
+        Assert.Equal(Vector128.Create(+1L, -1L), result);
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106372/Runtime_106372.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106372/Runtime_106372.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This resolves #106372 

The issue was that the x86 path was only exiting for the path we had to do 64-bit multiplication. It did not also exit for the path that needed to do 64-bit broadcast.

Both of these issues are solvable, but is something to handle in the .NET 10 timeframe.