### PR TITLE
Remove Helper Method Frames from debugdebugger

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
@@ -11,14 +11,14 @@ namespace System.Diagnostics
 {
     public static partial class Debugger
     {
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "DebugDebugger_Break")]
+        private static partial void BreakInternal();
+
         // Break causes a breakpoint to be signalled to an attached debugger.  If no debugger
         // is attached, the user is asked if they want to attach a debugger. If yes, then the
         // debugger is launched.
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void Break() => BreakInternal();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern void BreakInternal();
 
         // Launch launches & attaches a debugger to the process. If a debugger is already attached,
         // nothing happens.

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
@@ -30,9 +30,9 @@ namespace System.Diagnostics
 
         private void BuildStackFrame(int skipFrames, bool needFileInfo)
         {
-            StackFrameHelper StackF = new StackFrameHelper(null);
+            StackFrameHelper StackF = new StackFrameHelper();
 
-            StackF.InitializeSourceInfo(0, needFileInfo, null);
+            StackF.InitializeSourceInfo(needFileInfo, null);
 
             int iNumOfFrames = StackF.GetNumberOfFrames();
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
@@ -13,7 +13,6 @@ namespace System.Diagnostics
     // VM\DebugDebugger.h. The binder will catch some of these layout problems.
     internal sealed class StackFrameHelper
     {
-        private Thread? targetThread;
         private int[]? rgiOffset;
         private int[]? rgiILOffset;
 
@@ -48,9 +47,8 @@ namespace System.Diagnostics
         [ThreadStatic]
         private static int t_reentrancy;
 
-        public StackFrameHelper(Thread? target)
+        public StackFrameHelper()
         {
-            targetThread = target;
             rgMethodHandle = null;
             rgiMethodToken = null;
             rgiOffset = null;
@@ -85,9 +83,9 @@ namespace System.Diagnostics
         // done by GetStackFramesInternal (on Windows for old PDB format).
         //
 
-        internal void InitializeSourceInfo(int iSkip, bool fNeedFileInfo, Exception? exception)
+        internal void InitializeSourceInfo(bool fNeedFileInfo, Exception? exception)
         {
-            StackTrace.GetStackFramesInternal(this, iSkip, fNeedFileInfo, exception);
+            StackTrace.GetStackFramesInternal(this, fNeedFileInfo, exception);
 
             if (!fNeedFileInfo)
                 return;

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackTrace.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackTrace.CoreCLR.cs
@@ -10,10 +10,10 @@ namespace System.Diagnostics
     public partial class StackTrace
     {
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "StackTrace_GetStackFramesInternal")]
-        private static partial void GetStackFramesInternal(ObjectHandleOnStack sfh, int iSkip, [MarshalAs(UnmanagedType.Bool)] bool fNeedFileInfo, ObjectHandleOnStack e);
+        private static partial void GetStackFramesInternal(ObjectHandleOnStack sfh, [MarshalAs(UnmanagedType.Bool)] bool fNeedFileInfo, ObjectHandleOnStack e);
 
-        internal static void GetStackFramesInternal(StackFrameHelper sfh, int iSkip, bool fNeedFileInfo, Exception? e)
-            => GetStackFramesInternal(ObjectHandleOnStack.Create(ref sfh), iSkip, fNeedFileInfo, ObjectHandleOnStack.Create(ref e));
+        internal static void GetStackFramesInternal(StackFrameHelper sfh, bool fNeedFileInfo, Exception? e)
+            => GetStackFramesInternal(ObjectHandleOnStack.Create(ref sfh), fNeedFileInfo, ObjectHandleOnStack.Create(ref e));
 
         internal static int CalculateFramesToSkip(StackFrameHelper StackF, int iNumFrames)
         {
@@ -61,9 +61,9 @@ namespace System.Diagnostics
         {
             _methodsToSkip = skipFrames;
 
-            StackFrameHelper StackF = new StackFrameHelper(null);
+            StackFrameHelper StackF = new StackFrameHelper();
 
-            StackF.InitializeSourceInfo(0, fNeedFileInfo, e);
+            StackF.InitializeSourceInfo(fNeedFileInfo, e);
 
             _numOfFrames = StackF.GetNumberOfFrames();
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackTrace.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackTrace.CoreCLR.cs
@@ -3,13 +3,17 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Diagnostics
 {
     public partial class StackTrace
     {
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern void GetStackFramesInternal(StackFrameHelper sfh, int iSkip, bool fNeedFileInfo, Exception? e);
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "StackTrace_GetStackFramesInternal")]
+        private static partial void GetStackFramesInternal(ObjectHandleOnStack sfh, int iSkip, [MarshalAs(UnmanagedType.Bool)] bool fNeedFileInfo, ObjectHandleOnStack e);
+
+        internal static void GetStackFramesInternal(StackFrameHelper sfh, int iSkip, bool fNeedFileInfo, Exception? e)
+            => GetStackFramesInternal(ObjectHandleOnStack.Create(ref sfh), iSkip, fNeedFileInfo, ObjectHandleOnStack.Create(ref e));
 
         internal static int CalculateFramesToSkip(StackFrameHelper StackF, int iNumFrames)
         {

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -3707,7 +3707,6 @@ void DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, Dac
     DebugStackTrace::GetStackFramesData stackFramesData;
 
     stackFramesData.pDomain = NULL;
-    stackFramesData.skip = 0;
     stackFramesData.NumFramesRequested = 0;
 
     DebugStackTrace::GetStackFramesFromException(&objRef, &stackFramesData);

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -3720,7 +3720,7 @@ void DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, Dac
 
         for (INT32 index = 0; index < dacStackFramesLength; ++index)
         {
-            DebugStackTrace::DebugStackTraceElement const& currentElement = stackFramesData.pElements[index];
+            DebugStackTrace::Element const& currentElement = stackFramesData.pElements[index];
             DacExceptionCallStackData& currentFrame = dacStackFrames[index];
 
             AppDomain* pDomain = AppDomain::GetCurrentDomain();

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -8849,7 +8849,7 @@ void Debugger::SendUserBreakpoint(Thread * thread)
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
 
         PRECONDITION(thread != NULL);
         PRECONDITION(thread == ::GetThreadNULLOk());

--- a/src/coreclr/dlls/mscorrc/mscorrc.rc
+++ b/src/coreclr/dlls/mscorrc/mscorrc.rc
@@ -468,7 +468,6 @@ BEGIN
     IDS_EE_INVALID_CA                       "Invalid custom attribute provided."
 
     IDS_EE_THREAD_CANNOT_GET                "Unable to retrieve thread information."
-    IDS_EE_THREAD_BAD_STATE                 "Thread in invalid state."
     IDS_EE_THREAD_ABORT_WHILE_SUSPEND       "Thread is suspended; attempting to abort."
     IDS_EE_NOVARIANTRETURN                  "PInvoke restriction: cannot return variants."
 

--- a/src/coreclr/dlls/mscorrc/resource.h
+++ b/src/coreclr/dlls/mscorrc/resource.h
@@ -233,7 +233,6 @@
 #define IDS_EE_INVALID_CA                       0x1a10
 
 #define IDS_EE_THREAD_CANNOT_GET                0x1a15
-#define IDS_EE_THREAD_BAD_STATE                 0x1a1b
 #define IDS_EE_THREAD_ABORT_WHILE_SUSPEND       0x1a1c
 
 #define IDS_EE_NOVARIANTRETURN                  0x1a1d

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -761,7 +761,6 @@ DEFINE_METHOD(SAFE_HANDLE,          DISPOSE_BOOL,           Dispose,            
 DEFINE_CLASS(SECURITY_EXCEPTION,    Security,               SecurityException)
 
 DEFINE_CLASS_U(Diagnostics,                StackFrameHelper,   StackFrameHelper)
-DEFINE_FIELD_U(targetThread,               StackFrameHelper,   targetThread)
 DEFINE_FIELD_U(rgiOffset,                  StackFrameHelper,   rgiOffset)
 DEFINE_FIELD_U(rgiILOffset,                StackFrameHelper,   rgiILOffset)
 DEFINE_FIELD_U(dynamicMethods,             StackFrameHelper,   dynamicMethods)

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -40,12 +40,12 @@
 //    Else if a native debugger is attached, this should send a native break event (kernel32!DebugBreak)
 //    Else, this should invoke Watson.
 //
-FCIMPL0(void, DebugDebugger::Break)
+extern "C" void QCALLTYPE DebugDebugger_Break()
 {
-    FCALL_CONTRACT;
+    QCALL_CONTRACT;
 
 #ifdef DEBUGGING_SUPPORTED
-    HELPER_METHOD_FRAME_BEGIN_0();
+    BEGIN_QCALL;
 
 #ifdef _DEBUG
     {
@@ -73,21 +73,17 @@ FCIMPL0(void, DebugDebugger::Break)
         // No managed debugger, but a native debug is attached. Explicitly fire a native user breakpoint.
         // Don't rely on Watson support since that may have a different policy.
 
-        // Toggle to preemptive before firing the debug event. This allows the debugger to suspend this
+        // Confirm we're in preemptive before firing the debug event. This allows the debugger to suspend this
         // thread at the debug event.
-        GCX_PREEMP();
+        _ASSERTE(!GetThread()->PreemptiveGCDisabled());
 
         // This becomes an unmanaged breakpoint, such as int 3.
         DebugBreak();
     }
-    else
-    {
-    }
 
-    HELPER_METHOD_FRAME_END();
+    END_QCALL;
 #endif // DEBUGGING_SUPPORTED
 }
-FCIMPLEND
 
 extern "C" BOOL QCALLTYPE DebugDebugger_Launch()
 {

--- a/src/coreclr/vm/debugdebugger.h
+++ b/src/coreclr/vm/debugdebugger.h
@@ -35,7 +35,6 @@ class StackFrameHelper : public Object
     // Modifying the order or fields of this object may require other changes to the
     // classlib definition of the StackFrameHelper class.
 public:
-    THREADBASEREF targetThread;
     I4ARRAYREF rgiOffset;
     I4ARRAYREF rgiILOffset;
     PTRARRAYREF dynamicMethods;
@@ -108,10 +107,8 @@ public:
 
 public:
 
-    struct GetStackFramesData {
-
-        // Used for the integer-skip version
-        INT32   skip;
+    struct GetStackFramesData
+    {
         INT32   NumFramesRequested;
         INT32   cElementsAllocated;
         INT32   cElements;
@@ -120,17 +117,15 @@ public:
         AppDomain *pDomain;
         BOOL fDoWeHaveAnyFramesFromForeignStackTrace;
 
-
-        GetStackFramesData() :  skip(0),
-                                NumFramesRequested (0),
-                                cElementsAllocated(0),
-                                cElements(0),
-                                pElements(NULL),
-                                TargetThread((THREADBASEREF)(TADDR)NULL)
+        GetStackFramesData()
+            : NumFramesRequested (0)
+            , cElementsAllocated(0)
+            , cElements(0)
+            , pElements(NULL)
+            , TargetThread((THREADBASEREF)(TADDR)NULL)
+            , fDoWeHaveAnyFramesFromForeignStackTrace(FALSE)
         {
             LIMITED_METHOD_CONTRACT;
-            fDoWeHaveAnyFramesFromForeignStackTrace = FALSE;
-
         }
 
         ~GetStackFramesData()
@@ -144,7 +139,6 @@ public:
 
 extern "C" void QCALLTYPE StackTrace_GetStackFramesInternal(
     QCall::ObjectHandleOnStack stackFrameHelper,
-    INT32 iSkip,
     BOOL fNeedFileInfo,
     QCall::ObjectHandleOnStack exception);
 

--- a/src/coreclr/vm/debugdebugger.h
+++ b/src/coreclr/vm/debugdebugger.h
@@ -21,17 +21,13 @@ class DebugDebugger
 public:
     static FCDECL0(FC_BOOL_RET, IsDebuggerAttached);
 
-    // receives a custom notification object from the target and sends it to the RS via
-    // code:Debugger::SendCustomDebuggerNotification
-    static FCDECL1(void, CustomNotification, Object * dataUNSAFE);
-
     static FCDECL0(FC_BOOL_RET, IsLogging);
 };
 
 extern "C" void QCALLTYPE DebugDebugger_Break();
 extern "C" BOOL QCALLTYPE DebugDebugger_Launch();
 extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWSTR pwzMessage);
-
+extern "C" void QCALLTYPE DebugDebugger_CustomNotification(QCall::ObjectHandleOnStack data);
 
 class StackFrameHelper : public Object
 {

--- a/src/coreclr/vm/debugdebugger.h
+++ b/src/coreclr/vm/debugdebugger.h
@@ -84,12 +84,7 @@ typedef StackFrameHelper* STACKFRAMEHELPERREF;
 class DebugStackTrace
 {
 public:
-
-#ifndef DACCESS_COMPILE
-// the DAC directly uses the GetStackFramesData and DebugStackTraceElement types
-private:
-#endif // DACCESS_COMPILE
-    struct DebugStackTraceElement {
+    struct Element {
         DWORD dwOffset;     // native offset
         DWORD dwILOffset;
         MethodDesc *pFunc;
@@ -120,7 +115,7 @@ public:
         INT32   NumFramesRequested;
         INT32   cElementsAllocated;
         INT32   cElements;
-        DebugStackTraceElement* pElements;
+        Element* pElements;
         THREADBASEREF   TargetThread;
         AppDomain *pDomain;
         BOOL fDoWeHaveAnyFramesFromForeignStackTrace;
@@ -144,28 +139,14 @@ public:
         }
     };
 
-    static FCDECL4(void,
-                   GetStackFramesInternal,
-                   StackFrameHelper* pStackFrameHelper,
-                   INT32 iSkip,
-                   FC_BOOL_ARG fNeedFileInfo,
-                   Object* pException
-                  );
-
     static void GetStackFramesFromException(OBJECTREF * e, GetStackFramesData *pData, PTRARRAYREF * pDynamicMethodArray = NULL);
-
-#ifndef DACCESS_COMPILE
-// the DAC directly calls GetStackFramesFromException
-private:
-#endif
-
-    static void GetStackFramesHelper(Frame *pStartFrame, void* pStopStack, GetStackFramesData *pData);
-
-    static void GetStackFrames(Frame *pStartFrame, void* pStopStack, GetStackFramesData *pData);
-
-    static StackWalkAction GetStackFramesCallback(CrawlFrame* pCf, VOID* data);
-
 };
+
+extern "C" void QCALLTYPE StackTrace_GetStackFramesInternal(
+    QCall::ObjectHandleOnStack stackFrameHelper,
+    INT32 iSkip,
+    BOOL fNeedFileInfo,
+    QCall::ObjectHandleOnStack exception);
 
 extern "C" MethodDesc* QCALLTYPE StackFrame_GetMethodDescFromNativeIP(LPVOID ip);
 

--- a/src/coreclr/vm/debugdebugger.h
+++ b/src/coreclr/vm/debugdebugger.h
@@ -19,7 +19,6 @@
 class DebugDebugger
 {
 public:
-    static FCDECL0(void, Break);
     static FCDECL0(FC_BOOL_RET, IsDebuggerAttached);
 
     // receives a custom notification object from the target and sends it to the RS via
@@ -29,6 +28,7 @@ public:
     static FCDECL0(FC_BOOL_RET, IsLogging);
 };
 
+extern "C" void QCALLTYPE DebugDebugger_Break();
 extern "C" BOOL QCALLTYPE DebugDebugger_Launch();
 extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWSTR pwzMessage);
 

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -68,7 +68,6 @@ FCFuncStart(gStringFuncs)
 FCFuncEnd()
 
 FCFuncStart(gDiagnosticsDebugger)
-    FCFuncElement("BreakInternal", DebugDebugger::Break)
     FCFuncElement("get_IsAttached", DebugDebugger::IsDebuggerAttached)
     FCFuncElement("IsLogging", DebugDebugger::IsLogging)
     FCFuncElement("CustomNotification", DebugDebugger::CustomNotification)

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -72,10 +72,6 @@ FCFuncStart(gDiagnosticsDebugger)
     FCFuncElement("IsLogging", DebugDebugger::IsLogging)
 FCFuncEnd()
 
-FCFuncStart(gDiagnosticsStackTrace)
-    FCFuncElement("GetStackFramesInternal", DebugStackTrace::GetStackFramesInternal)
-FCFuncEnd()
-
 FCFuncStart(gEnvironmentFuncs)
     FCFuncElement("get_CurrentManagedThreadId", JIT_GetCurrentManagedThreadId)
     FCFuncElement("get_TickCount", SystemNative::GetTickCount)
@@ -513,7 +509,6 @@ FCClassElement("RuntimeType", "System", gSystem_RuntimeType)
 FCClassElement("RuntimeTypeHandle", "System", gCOMTypeHandleFuncs)
 
 FCClassElement("Signature", "System", gSignatureNative)
-FCClassElement("StackTrace", "System.Diagnostics", gDiagnosticsStackTrace)
 FCClassElement("Stream", "System.IO", gStreamFuncs)
 FCClassElement("String", "System", gStringFuncs)
 FCClassElement("StubHelpers", "System.StubHelpers", gStubHelperFuncs)

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -70,7 +70,6 @@ FCFuncEnd()
 FCFuncStart(gDiagnosticsDebugger)
     FCFuncElement("get_IsAttached", DebugDebugger::IsDebuggerAttached)
     FCFuncElement("IsLogging", DebugDebugger::IsLogging)
-    FCFuncElement("CustomNotification", DebugDebugger::CustomNotification)
 FCFuncEnd()
 
 FCFuncStart(gDiagnosticsStackTrace)

--- a/src/coreclr/vm/eventreporter.cpp
+++ b/src/coreclr/vm/eventreporter.cpp
@@ -632,7 +632,6 @@ void ReportExceptionStackHelper(OBJECTREF exObj, EventReporter& reporter, SmallS
 
     DebugStackTrace::GetStackFramesData stackFramesData;
     stackFramesData.pDomain = NULL;
-    stackFramesData.skip = 0;
     stackFramesData.NumFramesRequested = 0;
 
     DebugStackTrace::GetStackFramesFromException(&(gc.exObj), &stackFramesData);

--- a/src/coreclr/vm/i386/jitinterfacex86.cpp
+++ b/src/coreclr/vm/i386/jitinterfacex86.cpp
@@ -96,25 +96,6 @@ extern "C" void STDCALL WriteBarrierAssert(BYTE* ptr, Object* obj)
 
 #endif // _DEBUG
 
-FCDECL1(Object*, JIT_New, CORINFO_CLASS_HANDLE typeHnd_);
-
-
-HCIMPL1(Object*, AllocObjectWrapper, MethodTable *pMT)
-{
-    CONTRACTL
-    {
-        FCALL_CHECK;
-    }
-    CONTRACTL_END;
-
-    OBJECTREF newObj = NULL;
-    HELPER_METHOD_FRAME_BEGIN_RET_0();    // Set up a frame
-    newObj = AllocateObject(pMT);
-    HELPER_METHOD_FRAME_END();
-    return OBJECTREFToObject(newObj);
-}
-HCIMPLEND
-
 /*********************************************************************/
 #ifndef UNIX_X86_ABI
 extern "C" void* g_TailCallFrameVptr;
@@ -360,6 +341,8 @@ void JIT_TrialAlloc::EmitNoAllocCode(CPUSTUBLINKER *psl, Flags flags)
         psl->Emit32(0xFFFFFFFF);
     }
 }
+
+FCDECL1(Object*, JIT_New, CORINFO_CLASS_HANDLE typeHnd_);
 
 void *JIT_TrialAlloc::GenAllocSFast(Flags flags)
 {

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -140,6 +140,7 @@ static const Entry s_QCall[] =
     DllImportEntry(RuntimeModule_GetFullyQualifiedName)
     DllImportEntry(RuntimeModule_GetTypes)
     DllImportEntry(RuntimeFieldHandle_GetRVAFieldInfo)
+    DllImportEntry(StackTrace_GetStackFramesInternal)
     DllImportEntry(StackFrame_GetMethodDescFromNativeIP)
     DllImportEntry(ModuleBuilder_GetStringConstant)
     DllImportEntry(ModuleBuilder_GetTypeRef)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -86,6 +86,7 @@ static const Entry s_QCall[] =
     DllImportEntry(DebugDebugger_Break)
     DllImportEntry(DebugDebugger_Launch)
     DllImportEntry(DebugDebugger_Log)
+    DllImportEntry(DebugDebugger_CustomNotification)
     DllImportEntry(Delegate_BindToMethodName)
     DllImportEntry(Delegate_BindToMethodInfo)
     DllImportEntry(Delegate_InitializeVirtualCallStub)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -83,6 +83,7 @@ static const Entry s_QCall[] =
     DllImportEntry(CustomAttribute_CreateCustomAttributeInstance)
     DllImportEntry(CustomAttribute_CreatePropertyOrFieldData)
     DllImportEntry(Enum_GetValuesAndNames)
+    DllImportEntry(DebugDebugger_Break)
     DllImportEntry(DebugDebugger_Launch)
     DllImportEntry(DebugDebugger_Log)
     DllImportEntry(Delegate_BindToMethodName)

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -4267,12 +4267,6 @@ struct cdac_data<ThreadStore>
     static constexpr size_t DeadCount = offsetof(ThreadStore, m_DeadThreadCount);
 };
 
-struct TSSuspendHelper {
-    static void SetTrap() { ThreadStore::IncrementTrapReturningThreads(); }
-    static void UnsetTrap() { ThreadStore::DecrementTrapReturningThreads(); }
-};
-typedef StateHolder<TSSuspendHelper::SetTrap, TSSuspendHelper::UnsetTrap> TSSuspendHolder;
-
 typedef StateHolder<ThreadStore::LockThreadStore,ThreadStore::UnlockThreadStore> ThreadStoreLockHolder;
 
 


### PR DESCRIPTION
Each commit contains a single functions from the diagnostic space. This PR is best reviewed by each commit.

Removed unused JIT Helper for x86.

Ran diagnostics tests and confirmed no failures.