### PR TITLE
Make host error message include pointer to architecture for Windows library load failure with ERROR_BAD_EXE_FORMAT

### DIFF
--- a/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
+++ b/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
@@ -125,8 +125,6 @@ hostfxr_resolver_t::hostfxr_resolver_t(const pal::string_t& app_root)
     else
     {
         trace::error(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, m_fxr_path.c_str());
-        trace::error(_X("  - Installing .NET prerequisites might help resolve this problem."));
-        trace::error(_X("     %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
         m_status_code = StatusCode::CoreHostLibLoadFailure;
     }
 }

--- a/src/native/corehost/fxr_resolver.h
+++ b/src/native/corehost/fxr_resolver.h
@@ -59,8 +59,6 @@ int load_fxr_and_get_delegate(hostfxr_delegate_type type, THostPathToConfigCallb
         if (!pal::load_library(&fxr_path, &fxr))
         {
             trace::error(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, fxr_path.c_str());
-            trace::error(_X("  - Installing .NET prerequisites might help resolve this problem."));
-            trace::error(_X("     %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
             return StatusCode::CoreHostLibLoadFailure;
         }
     }


### PR DESCRIPTION
Check for `ERROR_BAD_EXE_FORMAT` and include a pointer towards architecture mismatch in the error message. This is only on Windows - we don't have a good way of detecting this on non-Windows - dlopen will fail and the host will just print the message from dlerror.

This also removes the comment/link to install .NET prerequisites. I don't think there's anything there that would be helpful for the case of we found the library, but the operating system call to load it failed.

Example:
```diff
- Failed to load the dll from [C:\Program Files (x86)\dotnet\host\fxr\9.0.0-preview.6.24327.7\hostfxr.dll], HRESULT: 0x800700C1
+ Failed to load [C:\Program Files (x86)\dotnet\host\fxr\9.0.0-preview.6.24327.7\hostfxr.dll], HRESULT: 0x800700C1
+  - Ensure the library matches the current process architecture: x64
The library hostfxr.dll was found, but loading it from C:\Program Files (x86)\dotnet\host\fxr\9.0.0-preview.6.24327.7\hostfxr.dll failed
-  - Installing .NET prerequisites might help resolve this problem.
-     https://go.microsoft.com/fwlink/?linkid=798306
```

Fixes https://github.com/dotnet/runtime/issues/3745

cc @dotnet/appmodel @AaronRobinsonMSFT 