### PR TITLE
[mono][tvos] Do not treat assembly.pdb/xml files as native files to bundle when AOTing on Helix

### DIFF
--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -71,6 +71,7 @@
       <BundleFiles Condition="'%(AppleAssembliesToBundle._IsNative)' != 'true'"
                    Include="@(AppleAssembliesToBundle)"         TargetDir="publish\%(AppleAssembliesToBundle.RecursiveDir)" />
       <BundleFiles Include="@(AppleNativeFilesToBundle)"        TargetDir="publish\%(AppleNativeFilesToBundle.RecursiveDir)" />
+      <BundleFiles Include="@(_SatelliteAssemblies)"            TargetDir="publish\%(_SatelliteAssemblies.RecursiveDir)" />
       <BundleFiles Include="$(RuntimeConfigFilePath)"           TargetDir="publish" />
 
       <BundleFiles Include="$(MonoProjectRoot)\msbuild\apple\data\*" TargetDir="publish" />

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -93,8 +93,7 @@
 
     <ItemGroup Condition="'$(DebuggerSupport)' == 'true'">
       <!-- Add any pdb files, if available -->
-      <_BundlePdbFiles Include="$([System.IO.Path]::ChangeExtension('%(AppleAssembliesToBundle.Identity)', '.pdb'))" />
-      <BundleFiles Include="@(_BundlePdbFiles)" TargetDir="publish" Condition="Exists(%(_BundlePdbFiles.Identity))" />
+      <BundleFiles Include="@(ApplePdbsToBundle)" TargetDir="publish" Condition="Exists(%(ApplePdbsToBundle.Identity))" />
     </ItemGroup>
 
     <Copy SourceFiles="@(BundleFiles)"         DestinationFolder="$(BundleDir)%(TargetDir)" />
@@ -213,7 +212,10 @@
         <_IsNative>false</_IsNative>
       </AppleAssembliesToBundle>
 
-      <AppleNativeFilesToBundle Include="$(PublishDir)\**\*.*" Exclude="$(PublishDir)\*.dll" />
+      <ApplePdbsToBundle Include="$([System.IO.Path]::ChangeExtension('%(AppleAssembliesToBundle.Identity)', '.pdb'))" />
+      <AppleXmlsToBundle Include="$([System.IO.Path]::ChangeExtension('%(AppleAssembliesToBundle.Identity)', '.xml'))" />
+
+      <AppleNativeFilesToBundle Include="$(PublishDir)\**\*.*" Exclude="@(AppleAssembliesToBundle);@(ApplePdbsToBundle);@(AppleXmlsToBundle);@(_SatelliteAssemblies)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Description

In https://github.com/dotnet/runtime/pull/106737 we switched from using package to project references in libraries tests for a number of dependencies. This affected iOS/tvOS CI testing, more specifically AOTing and test app bundling on Helix, causing builds to fail due to missing files. The root cause of failure were assumptions in MSBuild targets that perform collection and packaging of build artifacts to be transferred to Helix machines which assumed that files like: `System.Runtime.Serialization.Formatters.pdb` can only appear in the runtime pack output folder. This is not true anymore as this file will appear in the output folder of the test being built since it is now a project reference. (details described in: https://github.com/dotnet/runtime/issues/107029#issuecomment-2314770611).

## Changes

The issue has been fixed by excluding all `assembly.dll/.pdb/.xml` from `AppleNativeFilesToBundle` to correct the assumption and slightly clean-up the implementation. Pdbs are properly included only if `DebuggerSupport` feature switch is enabled for a particular test and are transferred to Helix for AOTing accordingly. 
As a side note, builds on Helix always used assemblies from the current build of the runtime pack.

---
Fixes https://github.com/dotnet/runtime/issues/107029