### PR TITLE
Mark NoBackwardTimeZones as ConditionalFact

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -3169,7 +3169,7 @@ namespace System.Tests
             Assert.Equal(new TimeSpan(2, 0, 0), customTimeZone.GetUtcOffset(new DateTime(2021, 3, 10, 2, 0, 0)));
         }
 
-        [Fact]
+        [ConditionalFact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/64111", TestPlatforms.Linux)]
         public static void NoBackwardTimeZones()
         {


### PR DESCRIPTION
Otherwise the test will fail instead of be skipped when a SkipTestException is raised.