### PR TITLE
pal init: Move InitializeFlushProcessWriteBuffers() after VIRTUALInitialize()

### DIFF
--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -359,16 +359,6 @@ Initialize(
             goto CLEANUP0a;
         }
 
-        if (flags & PAL_INITIALIZE_FLUSH_PROCESS_WRITE_BUFFERS)
-        {
-            // Initialize before first thread is created for faster load on Linux
-            if (!InitializeFlushProcessWriteBuffers())
-            {
-                palError = ERROR_PALINIT_INITIALIZE_FLUSH_PROCESS_WRITE_BUFFERS;
-                goto CLEANUP0a;
-            }
-        }
-
         // The gSharedFilesPath is allocated dynamically so its destructor does not get
         // called unexpectedly during cleanup
         gSharedFilesPath = InternalNew<PathCharString>();
@@ -614,6 +604,17 @@ Initialize(
             ERROR("Unable to initialize virtual memory support\n");
             palError = ERROR_PALINIT_VIRTUAL;
             goto CLEANUP10;
+        }
+
+        if (flags & PAL_INITIALIZE_FLUSH_PROCESS_WRITE_BUFFERS)
+        {
+            // Initialize before first thread is created for faster load on Linux
+            if (!InitializeFlushProcessWriteBuffers())
+            {
+                ERROR("Unable to initialize flush process write buffers\n");
+                palError = ERROR_PALINIT_INITIALIZE_FLUSH_PROCESS_WRITE_BUFFERS;
+                goto CLEANUP10;
+            }
         }
 
         if (flags & PAL_INITIALIZE_SYNC_THREAD)


### PR DESCRIPTION
A fixup of commit 27ee590d that's broken on platforms which don't
support membarrier() syscall: GetVirtualPageSize() is called in the
fallback path of InitializeFlushProcessWriteBuffers() and attempts to
mmap() zero bytes.

Move InitializeFlushProcessWriteBuffers() after VIRTUALInitialize() but
before the first thread is created.

Fixes https://github.com/dotnet/runtime/issues/106892
Fixes https://github.com/dotnet/runtime/issues/106722
