### PR TITLE
Remove `BaseDomain::CreateSizedRefHandle`

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1058,31 +1058,6 @@ void SystemDomain::LazyInitFrozenObjectsHeap()
     RETURN;
 }
 
-// Only called when EE is suspended.
-DWORD SystemDomain::GetTotalNumSizedRefHandles()
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    SystemDomain* sysDomain = SystemDomain::System();
-    DWORD dwTotalNumSizedRefHandles = 0;
-    if (sysDomain)
-    {
-        AppDomain* pAppDomain = ::GetAppDomain();
-        if (pAppDomain && pAppDomain->IsActive())
-        {
-            dwTotalNumSizedRefHandles += pAppDomain->GetNumSizedRefHandles();
-        }
-    }
-
-    return dwTotalNumSizedRefHandles;
-}
-
 void SystemDomain::LoadBaseSystemClasses()
 {
     STANDARD_VM_CONTRACT;

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -93,8 +93,6 @@ SPTR_IMPL(SystemDomain, SystemDomain, m_pSystemDomain);
 // Base Domain Statics
 CrstStatic          BaseDomain::m_MethodTableExposedClassObjectCrst;
 
-int                 BaseDomain::m_iNumberOfProcessors = 0;
-
 // System Domain Statics
 GlobalStringLiteralMap*  SystemDomain::m_pGlobalStringLiteralMap = NULL;
 FrozenObjectHeapManager* SystemDomain::m_FrozenObjectHeapManager = NULL;
@@ -482,12 +480,6 @@ void BaseDomain::Init()
     // Initialize the domain locks
     //
     m_crstLoaderAllocatorReferences.Init(CrstLoaderAllocatorReferences);
-
-    m_dwSizedRefHandles = 0;
-    // For server GC this value indicates the number of GC heaps used in circular order to allocate sized
-    // ref handles. It must not exceed the array size allocated by the handle table (see getNumberOfSlots
-    // in objecthandle.cpp). We might want to use GetNumberOfHeaps if it were accessible here.
-    m_iNumberOfProcessors = min(GetCurrentProcessCpuCount(), GetTotalProcessorCount());
 }
 
 #undef LOADERHEAP_PROFILE_COUNTER

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -591,13 +591,6 @@ protected:
     // Protects allocation of slot IDs for thread statics
     static CrstStatic m_MethodTableExposedClassObjectCrst;
 
-
-public:
-    DWORD GetNumSizedRefHandles()
-    {
-        return 0;
-    }
-
 #ifdef DACCESS_COMPILE
 public:
     virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags, bool enumThis) = 0;
@@ -2090,10 +2083,7 @@ inline static BOOL IsUnderDomainLock() { LIMITED_METHOD_CONTRACT; return m_Syste
             WRAPPER_NO_CONTRACT;
         }
     };
-#endif // DACCESS_COMPILE
-
-public:
-    DWORD GetTotalNumSizedRefHandles();
+#endif // !DACCESS_COMPILE
 
 #ifdef DACCESS_COMPILE
 public:

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -546,23 +546,6 @@ public:
         return ::CreateWeakInteriorHandle(m_handleStore, object, pInteriorPointerLocation);
     }
 
-    OBJECTHANDLE CreateSizedRefHandle(OBJECTREF object)
-    {
-        WRAPPER_NO_CONTRACT;
-        OBJECTHANDLE h;
-        if (GCHeapUtilities::IsServerHeap())
-        {
-            h = ::CreateSizedRefHandle(m_handleStore, object, m_dwSizedRefHandles % m_iNumberOfProcessors);
-        }
-        else
-        {
-            h = ::CreateSizedRefHandle(m_handleStore, object);
-        }
-
-        InterlockedIncrement((LONG*)&m_dwSizedRefHandles);
-        return h;
-    }
-
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
     OBJECTHANDLE CreateRefcountedHandle(OBJECTREF object)
     {
@@ -608,30 +591,11 @@ protected:
     // Protects allocation of slot IDs for thread statics
     static CrstStatic m_MethodTableExposedClassObjectCrst;
 
-private:
-    // I have yet to figure out an efficient way to get the number of handles
-    // of a particular type that's currently used by the process without
-    // spending more time looking at the handle table code. We know that
-    // our only customer (asp.net) in Dev10 is not going to create many of
-    // these handles so I am taking a shortcut for now and keep the sizedref
-    // handle count on the AD itself.
-    DWORD m_dwSizedRefHandles;
-
-    static int m_iNumberOfProcessors;
 
 public:
-    // Called by DestroySizedRefHandle
-    void DecNumSizedRefHandles()
-    {
-        WRAPPER_NO_CONTRACT;
-        LONG result;
-        result = InterlockedDecrement((LONG*)&m_dwSizedRefHandles);
-        _ASSERTE(result >= 0);
-    }
-
     DWORD GetNumSizedRefHandles()
     {
-        return m_dwSizedRefHandles;
+        return 0;
     }
 
 #ifdef DACCESS_COMPILE

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1605,7 +1605,7 @@ uint32_t GCToEEInterface::GetTotalNumSizedRefHandles()
 {
     LIMITED_METHOD_CONTRACT;
 
-    return SystemDomain::System()->GetTotalNumSizedRefHandles();
+    return 0;
 }
 
 NormalizedTimer analysisTimer;


### PR DESCRIPTION
`BaseDomain::CreateSizedRefHandle` appears to be dead code. Remove it and the associated members for tracking counts.

cc @jkotas @AaronRobinsonMSFT 