### PR TITLE
Fix RidAssetResolution test to open shared framework file with read share access

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NET.HostModel
             if (_resourceData == null)
                 ThrowExceptionForInvalidUpdate();
 
-            using var module = new PEReader(File.Open(peFile, FileMode.Open, FileAccess.Read, FileShare.Read));
+            using var module = new PEReader(File.OpenRead(peFile));
             var moduleResources = new ResourceData(module);
             _resourceData.CopyResourcesFrom(moduleResources);
             return this;

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
@@ -602,7 +602,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         {
             IReadOnlyList<RuntimeFallbacks> fallbacks;
             string depsJson = Path.Combine(TestContext.BuiltDotNet.GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
-            using (FileStream fileStream = File.Open(depsJson, FileMode.Open))
+            using (FileStream fileStream = File.OpenRead(depsJson))
             using (DependencyContextJsonReader reader = new DependencyContextJsonReader())
             {
                 fallbacks = reader.Read(fileStream).RuntimeGraph;

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/ResourceUpdaterTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/ResourceUpdaterTests.cs
@@ -183,7 +183,7 @@ public class ResourceUpdaterTests
         tempFile.Stream.Seek(0, SeekOrigin.Begin);
 
         using (var modified = new PEReader(tempFile.Stream, PEStreamOptions.LeaveOpen))
-        using (var assembly = new PEReader(File.Open(Assembly.GetExecutingAssembly().Location, FileMode.Open, FileAccess.Read, FileShare.Read)))
+        using (var assembly = new PEReader(File.OpenRead(Assembly.GetExecutingAssembly().Location)))
         {
             var modifiedReader = new ResourceData(modified);
             var assemblyReader = new ResourceData(assembly);


### PR DESCRIPTION
The `RidAssetResolution` test was reading Microsoft.NETCoreApp.deps.json in a non-shareable way, which could result in other tests failing when trying to run an application (since that reads the .deps.json). This changes the test to open with `FileShare.Read` by going through `File.OpenRead`.

The other two I just switched to `File.OpenRead` from `File.Open` with the equivalent arguments for consistency with the rest of HostModel and host tests.

Fixes #103743

cc @dotnet/appmodel @AaronRobinsonMSFT 