### PR TITLE
Change BuildWithFactoryReadDirect to not use RSA+MD5

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/KeyBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/KeyBagTests.cs
@@ -29,7 +29,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa2.TrySignData(
                         keyBag.Pkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1,
                         out int sigLen));
 
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                     Assert.True(rsa.VerifyData(
                         keyBag.Pkcs8PrivateKey.Span,
                         sig,
-                        HashAlgorithmName.MD5,
+                        HashAlgorithmName.SHA256,
                         RSASignaturePadding.Pkcs1));
                 }
             }


### PR DESCRIPTION
This changes a test that was missed from using RSA+MD5 to using RSA+SHA256, since the test is not exercising any MD5-specific behavior.

Contributes to https://github.com/dotnet/runtime/issues/106489