### PR TITLE
JIT: fix some asserts that arise when debugging with checked build

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4115,16 +4115,6 @@ _SetMinOpts:
         opts.jitFlags->Clear(JitFlags::JIT_FLAG_TIER1);
         opts.jitFlags->Clear(JitFlags::JIT_FLAG_BBOPT);
         compSwitchedToMinOpts = true;
-
-        // We may have read PGO data. Clear it out because we won't be using it.
-        //
-        fgPgoFailReason  = "method switched to min-opts";
-        fgPgoQueryResult = E_FAIL;
-        fgPgoHaveWeights = false;
-        fgPgoData        = nullptr;
-        fgPgoSchema      = nullptr;
-        fgPgoDisabled    = true;
-        fgPgoDynamic     = false;
     }
 
 #ifdef DEBUG
@@ -4143,6 +4133,10 @@ _SetMinOpts:
 
         lvaEnregEHVars &= compEnregLocals();
         lvaEnregMultiRegVars &= compEnregLocals();
+
+        // Scrub any profile data we might have fetched
+        //
+        fgRemoveProfileData("compiling with minopt");
     }
 
     if (!compIsForInlining())

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6521,6 +6521,8 @@ public:
         return fgIsUsingProfileWeights() ? fgNumProfileRuns : BB_UNITY_WEIGHT_UNSIGNED;
     }
 
+    void fgRemoveProfileData(const char* reason);
+
 //-------- Insert a statement at the start or end of a basic block --------
 
 #ifdef DEBUG


### PR DESCRIPTION
The Tier1 IL may diverge from the Tier0+Instr IL, if the method is modified by a profiler at just the "right" time. Tolerate this by not asserting if there is a mismatch in the Tier0+Instr and Tier1 schemas (instead the JIT will ignore the profile data).

The Tier1 JIT may initially read profile data and then switch over to minopt because of debugger override. If so, completely remove the profile data, so later phases are not confused and hit asserts.

Fixes #106033.