### PR TITLE
[wasi][windows] Enable the wasi-aot-library tests on windows

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -870,6 +870,7 @@ extends:
             - browser_wasm
             - browser_wasm_win
             - wasi_wasm
+            - wasi_wasm_win
           nameSuffix: _Smoke_AOT
           runAOT: true
           shouldRunSmokeOnly: true


### PR DESCRIPTION
Enabling, see the comment: https://github.com/dotnet/runtime/issues/101533#issuecomment-2296027295.