### PR TITLE
Fix chrome update action is failing 

### DIFF
--- a/eng/testing/BrowserVersions.props
+++ b/eng/testing/BrowserVersions.props
@@ -1,13 +1,13 @@
 <Project>
   <PropertyGroup>
-    <linux_ChromeVersion>128.0.6613.113</linux_ChromeVersion>
-    <linux_ChromeRevision>1331488</linux_ChromeRevision>
-    <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1331503</linux_ChromeBaseSnapshotUrl>
-    <linux_V8Version>12.8.374</linux_V8Version>
-    <win_ChromeVersion>128.0.6613.86</win_ChromeVersion>
-    <win_ChromeRevision>1331488</win_ChromeRevision>
-    <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1331504</win_ChromeBaseSnapshotUrl>
-    <win_V8Version>12.8.374</win_V8Version>
+    <linux_ChromeVersion>126.0.6478.114</linux_ChromeVersion>
+    <linux_ChromeRevision>1300313</linux_ChromeRevision>
+    <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1300316</linux_ChromeBaseSnapshotUrl>
+    <linux_V8Version>12.6.228</linux_V8Version>
+    <win_ChromeVersion>126.0.6478.36</win_ChromeVersion>
+    <win_ChromeRevision>1300313</win_ChromeRevision>
+    <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1300320</win_ChromeBaseSnapshotUrl>
+    <win_V8Version>12.6.228</win_V8Version>
     <linux_FirefoxRevision>125.0.1</linux_FirefoxRevision>
     <linux_GeckoDriverRevision>0.34.0</linux_GeckoDriverRevision>
     <win_FirefoxRevision>125.0.1</win_FirefoxRevision>

--- a/eng/testing/BrowserVersions.props
+++ b/eng/testing/BrowserVersions.props
@@ -1,13 +1,13 @@
 <Project>
   <PropertyGroup>
-    <linux_ChromeVersion>126.0.6478.114</linux_ChromeVersion>
-    <linux_ChromeRevision>1300313</linux_ChromeRevision>
-    <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1300316</linux_ChromeBaseSnapshotUrl>
-    <linux_V8Version>12.6.228</linux_V8Version>
-    <win_ChromeVersion>126.0.6478.36</win_ChromeVersion>
-    <win_ChromeRevision>1300313</win_ChromeRevision>
-    <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1300320</win_ChromeBaseSnapshotUrl>
-    <win_V8Version>12.6.228</win_V8Version>
+    <linux_ChromeVersion>128.0.6613.113</linux_ChromeVersion>
+    <linux_ChromeRevision>1331488</linux_ChromeRevision>
+    <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1331503</linux_ChromeBaseSnapshotUrl>
+    <linux_V8Version>12.8.374</linux_V8Version>
+    <win_ChromeVersion>128.0.6613.86</win_ChromeVersion>
+    <win_ChromeRevision>1331488</win_ChromeRevision>
+    <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1331504</win_ChromeBaseSnapshotUrl>
+    <win_V8Version>12.8.374</win_V8Version>
     <linux_FirefoxRevision>125.0.1</linux_FirefoxRevision>
     <linux_GeckoDriverRevision>0.34.0</linux_GeckoDriverRevision>
     <win_FirefoxRevision>125.0.1</win_FirefoxRevision>

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -38,7 +38,7 @@ test-runner:
 	$(DOTNET) build $(TOP)/src/libraries/Common/tests/WasmTestRunner /p:Configuration=$(CONFIG) $(MSBUILD_ARGS)
 
 build-tasks:
-	$(DOTNET) build $(TOP)/src/tasks/tasks.proj /p:Configuration=$(CONFIG) $(MSBUILD_ARGS)
+	$(DOTNET) build $(TOP)/src/tasks/tasks.proj /p:Configuration=$(CONFIG) /p:TargetOS=browser $(MSBUILD_ARGS)
 
 clean:
 	$(RM) -rf $(BUILDS_OBJ_DIR)


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/107125.

- We were not compiling the `src/tasks/WasmBuildTasks/WasmBuildTasks.csproj` project on `make -C src/mono/wasm build-tasks` that triggers command -> `dotnet.sh build src/tasks/tasks.proj /p:Configuration=Release /p:KeepNativeSymbols=true`

`tasks.proj` was recently cleaned up in https://github.com/dotnet/runtime/pull/104226. Since then it was compiling only:
```
  installer.tasks -> /workspaces/runtime/artifacts/bin/installer.tasks/Release/net9.0/installer.tasks.dll
  Crossgen2Tasks -> /workspaces/runtime/artifacts/bin/Crossgen2Tasks/Release/net9.0/Crossgen2Tasks.dll
  Microsoft.Interop.SourceGeneration -> /workspaces/runtime/artifacts/bin/Microsoft.Interop.SourceGeneration/Release/netstandard2.0/Microsoft.Interop.SourceGeneration.dll
  DownlevelLibraryImportGenerator -> /workspaces/runtime/artifacts/bin/DownlevelLibraryImportGenerator/Release/netstandard2.0/Microsoft.Interop.LibraryImportGenerator.Downlevel.dll
  installer.tasks -> /workspaces/runtime/artifacts/bin/installer.tasks/Release/net472/installer.tasks.dll
```

In the updated form it is compiling:
```
 MonoAOTCompiler -> /workspaces/runtime/artifacts/bin/MonoAOTCompiler/Release/net9.0/MonoAOTCompiler.dll
  AppleAppBuilder -> /workspaces/runtime/artifacts/bin/AppleAppBuilder/Release/net9.0/AppleAppBuilder.dll
  MobileBuildTasks -> /workspaces/runtime/artifacts/bin/MobileBuildTasks/Release/net9.0/MobileBuildTasks.dll
  Microsoft.NET.WebAssembly.Webcil -> /workspaces/runtime/artifacts/bin/Microsoft.NET.WebAssembly.Webcil/Release/net9.0/Microsoft.NET.WebAssembly.Webcil.dll
  AndroidAppBuilder -> /workspaces/runtime/artifacts/bin/AndroidAppBuilder/Release/net9.0/AndroidAppBuilder.dll
  AndroidAppBuilder -> /workspaces/runtime/artifacts/bin/AndroidAppBuilder/Release/net9.0/publish/
  Microsoft.NET.Sdk.WebAssembly.Pack.Tasks -> /workspaces/runtime/artifacts/bin/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/Release/net9.0/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.dll
  AssemblyStripper -> /workspaces/runtime/artifacts/bin/AssemblyStripper/Release/net9.0/AssemblyStripper.dll
  WasmAppBuilder -> /workspaces/runtime/artifacts/bin/WasmAppBuilder/Release/net9.0/WasmAppBuilder.dll
  TestExclusionListTasks -> /workspaces/runtime/artifacts/bin/TestExclusionListTasks/Release/net9.0/TestExclusionListTasks.dll
  Microsoft.Interop.SourceGeneration -> /workspaces/runtime/artifacts/bin/Microsoft.Interop.SourceGeneration/Release/netstandard2.0/Microsoft.Interop.SourceGeneration.dll
  WasmBuildTasks -> /workspaces/runtime/artifacts/bin/WasmBuildTasks/Release/net9.0/WasmBuildTasks.dll
  MonoTargetsTasks -> /workspaces/runtime/artifacts/bin/MonoTargetsTasks/Release/net9.0/MonoTargetsTasks.dll
  WasmBuildTasks -> /workspaces/runtime/artifacts/bin/WasmBuildTasks/Release/net9.0/publish/
  WorkloadBuildTasks -> /workspaces/runtime/artifacts/bin/WorkloadBuildTasks/Release/net9.0/WorkloadBuildTasks.dll
  Crossgen2Tasks -> /workspaces/runtime/artifacts/bin/Crossgen2Tasks/Release/net9.0/Crossgen2Tasks.dll
  installer.tasks -> /workspaces/runtime/artifacts/bin/installer.tasks/Release/net9.0/installer.tasks.dll
  DownlevelLibraryImportGenerator -> /workspaces/runtime/artifacts/bin/DownlevelLibraryImportGenerator/Release/netstandard2.0/Microsoft.Interop.LibraryImportGenerator.Downlevel.dll
  WorkloadBuildTasks -> /workspaces/runtime/artifacts/bin/WorkloadBuildTasks/Release/net8.0/WorkloadBuildTasks.dll
  LibraryBuilder -> /workspaces/runtime/artifacts/bin/LibraryBuilder/Release/net9.0/LibraryBuilder.dll
  MonoAOTCompiler -> /workspaces/runtime/artifacts/bin/MonoAOTCompiler/Release/net472/MonoAOTCompiler.dll
  installer.tasks -> /workspaces/runtime/artifacts/bin/installer.tasks/Release/net472/installer.tasks.dll
  MobileBuildTasks -> /workspaces/runtime/artifacts/bin/MobileBuildTasks/Release/net472/MobileBuildTasks.dll
  AssemblyStripper -> /workspaces/runtime/artifacts/bin/AssemblyStripper/Release/net472/AssemblyStripper.dll
  LibraryBuilder -> /workspaces/runtime/artifacts/bin/LibraryBuilder/Release/net472/LibraryBuilder.dll
  Microsoft.NET.WebAssembly.Webcil -> /workspaces/runtime/artifacts/bin/Microsoft.NET.WebAssembly.Webcil/Release/net472/Microsoft.NET.WebAssembly.Webcil.dll
  MonoTargetsTasks -> /workspaces/runtime/artifacts/bin/MonoTargetsTasks/Release/net472/MonoTargetsTasks.dll
  Microsoft.NET.Sdk.WebAssembly.Pack.Tasks -> /workspaces/runtime/artifacts/bin/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/Release/net472/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.dll
  WasmAppBuilder -> /workspaces/runtime/artifacts/bin/WasmAppBuilder/Release/net472/WasmAppBuilder.dll
```

~~So that we won't wait for the bot's PR, I added the update to the versions in this PR as well.~~
The version update will be done in a separate PR.