### PR TITLE
SPMI: Always enable venv for coreclr_tests.run collection

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -593,6 +593,7 @@ jobs:
 
       - script: $(PythonSetupScript)
         displayName: Enable python venv
+        condition: always()
 
       - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py merge-mch -log_level DEBUG -pattern $(MchFilesLocation)$(CollectionName).$(CollectionType)*.mch -output_mch_path $(MergedMchFileLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch
         displayName: 'Merge $(CollectionName)-$(CollectionType) SuperPMI collections'


### PR DESCRIPTION
Otherwise if the Helix run failed (because of a failing test) we won't run this step, which will cause the next steps to fail. This is currently happening for collections internally. The other places where we enable Python venv already have this `condition: always()`.