### PR TITLE
[wasm] Add option for both .NET 8 & 9 in current templates

### DIFF
--- a/src/mono/wasm/templates/templates/browser/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/browser/.template.config/template.json
@@ -43,6 +43,11 @@
           "choice": "net9.0",
           "description": "Target net9.0",
           "displayName": ".NET 9.0"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0",
+          "displayName": ".NET 8.0"
         }
       ],
       "defaultValue": "net9.0",

--- a/src/mono/wasm/templates/templates/console/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/console/.template.config/template.json
@@ -24,6 +24,11 @@
           "choice": "net9.0",
           "description": "Target net9.0",
           "displayName": ".NET 9.0"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0",
+          "displayName": ".NET 8.0"
         }
       ],
       "defaultValue": "net9.0",

--- a/src/mono/wasm/templates/templates/wasi-console/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/wasi-console/.template.config/template.json
@@ -24,6 +24,11 @@
           "choice": "net9.0",
           "description": "Target net9.0",
           "displayName": ".NET 9.0"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0",
+          "displayName": ".NET 8.0"
         }
       ],
       "defaultValue": "net9.0",


### PR DESCRIPTION
- Once .NET 9 version of templates is installed, VS ignores .NET 8 version (any of `wasm-experimental-net8` or `wasm-experimental` in .NET 8 SDK or directly templates pack)
- This change adds a workaround so that templates contain both .NET 8 & 9 TFM
- Verified manually