### PR TITLE
Update size of LDAP `BerVal.bv_len` struct on unix

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Interop.Ldap.cs
@@ -183,18 +183,18 @@ namespace System.DirectoryServices.Protocols
     internal sealed class BerVal
     {
 #if TARGET_UNIX
-        public IntPtr bv_len;
+        public nint bv_len;
 #else
         public int bv_len;
 #endif
-        public IntPtr bv_val = IntPtr.Zero;
+        public nint bv_val = nint.Zero;
 
 #if NET
         [CustomMarshaller(typeof(BerVal), MarshalMode.ManagedToUnmanagedIn, typeof(PinningMarshaller))]
         internal static unsafe class PinningMarshaller
         {
 #if TARGET_UNIX
-            public static ref IntPtr GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<IntPtr>() : ref managed.bv_len);
+            public static ref nint GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<nint>() : ref managed.bv_len);
 #else
             public static ref int GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<int>() : ref managed.bv_len);
 #endif

--- a/src/libraries/Common/src/Interop/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Interop.Ldap.cs
@@ -182,22 +182,14 @@ namespace System.DirectoryServices.Protocols
     [StructLayout(LayoutKind.Sequential)]
     internal sealed class BerVal
     {
-#if TARGET_UNIX
-        public nint bv_len;
-#else
-        public int bv_len;
-#endif
+        public CLong bv_len;
         public nint bv_val = nint.Zero;
 
 #if NET
         [CustomMarshaller(typeof(BerVal), MarshalMode.ManagedToUnmanagedIn, typeof(PinningMarshaller))]
         internal static unsafe class PinningMarshaller
         {
-#if TARGET_UNIX
-            public static ref nint GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<nint>() : ref managed.bv_len);
-#else
-            public static ref int GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<int>() : ref managed.bv_len);
-#endif
+            public static ref CLong GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<CLong>() : ref managed.bv_len);
 
             // All usages in our currently supported scenarios will always go through GetPinnableReference
             public static int* ConvertToUnmanaged(BerVal _) => throw new UnreachableException();

--- a/src/libraries/Common/src/Interop/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Interop.Ldap.cs
@@ -182,14 +182,22 @@ namespace System.DirectoryServices.Protocols
     [StructLayout(LayoutKind.Sequential)]
     internal sealed class BerVal
     {
+#if TARGET_UNIX
+        public IntPtr bv_len;
+#else
         public int bv_len;
+#endif
         public IntPtr bv_val = IntPtr.Zero;
 
 #if NET
         [CustomMarshaller(typeof(BerVal), MarshalMode.ManagedToUnmanagedIn, typeof(PinningMarshaller))]
         internal static unsafe class PinningMarshaller
         {
+#if TARGET_UNIX
+            public static ref IntPtr GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<IntPtr>() : ref managed.bv_len);
+#else
             public static ref int GetPinnableReference(BerVal managed) => ref (managed is null ? ref Unsafe.NullRef<int>() : ref managed.bv_len);
+#endif
 
             // All usages in our currently supported scenarios will always go through GetPinnableReference
             public static int* ConvertToUnmanaged(BerVal _) => throw new UnreachableException();

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -10,20 +10,19 @@
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
     <PackageDescription>Provides the methods defined in the Lightweight Directory Access Protocol (LDAP) version 3 (V3) and Directory Services Markup Language (DSML) version 2.0 (V2) standards.</PackageDescription>
+    <!-- CS3016: Arrays as attribute arguments is not CLS-compliant -->
+    <NoWarn>$(NoWarn);CS3016</NoWarn>
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>
 
     <!-- TODO https://github.com/dotnet/runtime/issues/90400: Annotate for nullable reference types -->
     <Nullable>disable</Nullable>
-
-    <!-- CS3016: Arrays as attribute arguments is not CLS-compliant -->
-    <NoWarn>$(NoWarn);nullable;CS3016</NoWarn>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' == ''">SR.DirectoryServicesProtocols_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
-    <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'linux' or '$(TargetPlatformIdentifier)' == 'osx'">$(DefineConstants);TARGET_UNIX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -16,8 +16,7 @@
     <Nullable>disable</Nullable>
 
     <!-- CS3016: Arrays as attribute arguments is not CLS-compliant -->
-    <!-- CA2020: Prevent behavioral change caused by built-in operators of IntPtr/UIntPtr -->
-    <NoWarn>$(NoWarn);nullable;CS3016;CA2020</NoWarn>
+    <NoWarn>$(NoWarn);nullable;CS3016</NoWarn>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -10,19 +10,21 @@
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
     <PackageDescription>Provides the methods defined in the Lightweight Directory Access Protocol (LDAP) version 3 (V3) and Directory Services Markup Language (DSML) version 2.0 (V2) standards.</PackageDescription>
-    <!-- CS3016: Arrays as attribute arguments is not CLS-compliant -->
-    <NoWarn>$(NoWarn);CS3016</NoWarn>
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>
 
     <!-- TODO https://github.com/dotnet/runtime/issues/90400: Annotate for nullable reference types -->
     <Nullable>disable</Nullable>
-    <NoWarn>$(NoWarn);nullable</NoWarn>
+
+    <!-- CS3016: Arrays as attribute arguments is not CLS-compliant -->
+    <!-- CA2020: Prevent behavioral change caused by built-in operators of IntPtr/UIntPtr -->
+    <NoWarn>$(NoWarn);nullable;CS3016;CA2020</NoWarn>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' == ''">SR.DirectoryServicesProtocols_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'linux' or '$(TargetPlatformIdentifier)' == 'osx'">$(DefineConstants);TARGET_UNIX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -128,7 +128,7 @@ namespace System.DirectoryServices.Protocols
                 passwordPtr = LdapPal.StringToPtr(passwd);
                 BerVal passwordBerval = new BerVal
                 {
-                    bv_len = MemoryMarshal.CreateReadOnlySpanFromNullTerminated((byte*)passwordPtr).Length,
+                    bv_len = new CLong(MemoryMarshal.CreateReadOnlySpanFromNullTerminated((byte*)passwordPtr).Length),
                     bv_val = passwordPtr,
                 };
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/SafeHandles.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/SafeHandles.Linux.cs
@@ -65,7 +65,7 @@ namespace System.DirectoryServices.Protocols
             // In Linux if bv_val is null ber_init will segFault instead of returning IntPtr.Zero.
             // In Linux if bv_len is 0 ber_init returns a valid pointer which will then fail when trying to use it,
             // so we fail early by throwing exception if this is the case.
-            if (value.bv_val == IntPtr.Zero || value.bv_len == 0)
+            if (value.bv_val == IntPtr.Zero || value.bv_len.Value == 0)
             {
                 throw new BerConversionException();
             }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.cs
@@ -269,15 +269,15 @@ namespace System.DirectoryServices.Protocols
                     Marshal.PtrToStructure(flattenptr, binaryValue);
                 }
 
-                if (binaryValue == null || binaryValue.bv_len == 0)
+                if (binaryValue == null || binaryValue.bv_len.Value == 0)
                 {
                     encodingResult = Array.Empty<byte>();
                 }
                 else
                 {
-                    encodingResult = new byte[binaryValue.bv_len];
+                    encodingResult = new byte[binaryValue.bv_len.Value];
 
-                    Marshal.Copy(binaryValue.bv_val, encodingResult, 0, (int)binaryValue.bv_len);
+                    Marshal.Copy(binaryValue.bv_val, encodingResult, 0, (int)binaryValue.bv_len.Value);
                 }
             }
             finally
@@ -315,12 +315,12 @@ namespace System.DirectoryServices.Protocols
 
             if (value == null)
             {
-                berValue.bv_len = 0;
+                berValue.bv_len = new CLong(0);
                 berValue.bv_val = IntPtr.Zero;
             }
             else
             {
-                berValue.bv_len = value.Length;
+                berValue.bv_len = new CLong(value.Length);
                 berValue.bv_val = Marshal.AllocHGlobal(value.Length);
                 Marshal.Copy(value, 0, berValue.bv_val, value.Length);
             }
@@ -499,8 +499,8 @@ namespace System.DirectoryServices.Protocols
                     {
                         Marshal.PtrToStructure(result, binaryValue);
 
-                        byteArray = new byte[binaryValue.bv_len];
-                        Marshal.Copy(binaryValue.bv_val, byteArray, 0, (int)binaryValue.bv_len);
+                        byteArray = new byte[binaryValue.bv_len.Value];
+                        Marshal.Copy(binaryValue.bv_val, byteArray, 0, (int)binaryValue.bv_len.Value);
                     }
                 }
                 else
@@ -540,7 +540,7 @@ namespace System.DirectoryServices.Protocols
 
                         if (byteArray != null)
                         {
-                            managedBervalArray[i].bv_len = byteArray.Length;
+                            managedBervalArray[i].bv_len = new CLong(byteArray.Length);
                             managedBervalArray[i].bv_val = Marshal.AllocHGlobal(byteArray.Length);
                             Marshal.Copy(byteArray, 0, managedBervalArray[i].bv_val, byteArray.Length);
                         }
@@ -607,8 +607,8 @@ namespace System.DirectoryServices.Protocols
                             BerVal ber = new BerVal();
                             Marshal.PtrToStructure(tempPtr, ber);
 
-                            byte[] berArray = new byte[ber.bv_len];
-                            Marshal.Copy(ber.bv_val, berArray, 0, (int)ber.bv_len);
+                            byte[] berArray = new byte[ber.bv_len.Value];
+                            Marshal.Copy(ber.bv_val, berArray, 0, (int)ber.bv_len.Value);
 
                             binaryList.Add(berArray);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.cs
@@ -277,7 +277,7 @@ namespace System.DirectoryServices.Protocols
                 {
                     encodingResult = new byte[binaryValue.bv_len];
 
-                    Marshal.Copy(binaryValue.bv_val, encodingResult, 0, binaryValue.bv_len);
+                    Marshal.Copy(binaryValue.bv_val, encodingResult, 0, (int)binaryValue.bv_len);
                 }
             }
             finally
@@ -500,7 +500,7 @@ namespace System.DirectoryServices.Protocols
                         Marshal.PtrToStructure(result, binaryValue);
 
                         byteArray = new byte[binaryValue.bv_len];
-                        Marshal.Copy(binaryValue.bv_val, byteArray, 0, binaryValue.bv_len);
+                        Marshal.Copy(binaryValue.bv_val, byteArray, 0, (int)binaryValue.bv_len);
                     }
                 }
                 else
@@ -608,7 +608,7 @@ namespace System.DirectoryServices.Protocols
                             Marshal.PtrToStructure(tempPtr, ber);
 
                             byte[] berArray = new byte[ber.bv_len];
-                            Marshal.Copy(ber.bv_val, berArray, 0, ber.bv_len);
+                            Marshal.Copy(ber.bv_val, berArray, 0, (int)ber.bv_len);
 
                             binaryList.Add(berArray);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
@@ -757,7 +757,7 @@ namespace System.DirectoryServices.Protocols
                 if (value != null)
                 {
                     _directoryControlValue = new byte[value.bv_len];
-                    Marshal.Copy(value.bv_val, _directoryControlValue, 0, value.bv_len);
+                    Marshal.Copy(value.bv_val, _directoryControlValue, 0, (int)value.bv_len);
                 }
             }
             finally

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
@@ -756,8 +756,8 @@ namespace System.DirectoryServices.Protocols
                 _directoryControlValue = null;
                 if (value != null)
                 {
-                    _directoryControlValue = new byte[value.bv_len];
-                    Marshal.Copy(value.bv_val, _directoryControlValue, 0, (int)value.bv_len);
+                    _directoryControlValue = new byte[value.bv_len.Value];
+                    Marshal.Copy(value.bv_val, _directoryControlValue, 0, (int)value.bv_len.Value);
                 }
             }
             finally

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -629,7 +629,7 @@ namespace System.DirectoryServices.Protocols
 
                     berValuePtr = new BerVal
                     {
-                        bv_len = byteArray.Length,
+                        bv_len = new CLong(byteArray.Length),
                         bv_val = Marshal.AllocHGlobal(byteArray.Length)
                     };
                     Marshal.Copy(byteArray, 0, berValuePtr.bv_val, byteArray.Length);
@@ -695,7 +695,7 @@ namespace System.DirectoryServices.Protocols
                     {
                         berValuePtr = new BerVal()
                         {
-                            bv_len = val.Length,
+                            bv_len = new CLong(val.Length),
                             bv_val = Marshal.AllocHGlobal(val.Length)
                         };
                         Marshal.Copy(val, 0, berValuePtr.bv_val, val.Length);
@@ -1222,7 +1222,7 @@ namespace System.DirectoryServices.Protocols
                             // Get the control type.
                             ldctl_oid = LdapPal.StringToPtr(((DirectoryControl)controlList[i]).Type),
 
-                            // Get the control cricality.
+                            // Get the control criticality.
                             ldctl_iscritical = ((DirectoryControl)controlList[i]).IsCritical
                         };
 
@@ -1234,7 +1234,7 @@ namespace System.DirectoryServices.Protocols
                             // Treat the control value as null.
                             managedControls[i].ldctl_value = new BerVal
                             {
-                                bv_len = 0,
+                                bv_len = new CLong(0),
                                 bv_val = IntPtr.Zero
                             };
                         }
@@ -1242,10 +1242,10 @@ namespace System.DirectoryServices.Protocols
                         {
                             managedControls[i].ldctl_value = new BerVal
                             {
-                                bv_len = byteControlValue.Length,
+                                bv_len = new CLong(byteControlValue.Length),
                                 bv_val = Marshal.AllocHGlobal(sizeof(byte) * byteControlValue.Length)
                             };
-                            Marshal.Copy(byteControlValue, 0, managedControls[i].ldctl_value.bv_val, (int)managedControls[i].ldctl_value.bv_len);
+                            Marshal.Copy(byteControlValue, 0, managedControls[i].ldctl_value.bv_val, (int)managedControls[i].ldctl_value.bv_len.Value);
                         }
                     }
                 }
@@ -1330,13 +1330,13 @@ namespace System.DirectoryServices.Protocols
 
                             berValues[j] = new BerVal()
                             {
-                                bv_len = byteArray.Length,
+                                bv_len = new CLong(byteArray.Length),
                                 bv_val = Marshal.AllocHGlobal(byteArray.Length)
                             };
 
                             // need to free the memory allocated on the heap when we are done
                             ptrToFree.Add(berValues[j].bv_val);
-                            Marshal.Copy(byteArray, 0, berValues[j].bv_val, (int)berValues[j].bv_len);
+                            Marshal.Copy(byteArray, 0, berValues[j].bv_val, (int)berValues[j].bv_len.Value);
                         }
                     }
 
@@ -1485,10 +1485,10 @@ namespace System.DirectoryServices.Protocols
                                     {
                                         val = new BerVal();
                                         Marshal.PtrToStructure(requestValue, val);
-                                        if (val.bv_len != 0 && val.bv_val != IntPtr.Zero)
+                                        if (val.bv_len.Value != 0 && val.bv_val != IntPtr.Zero)
                                         {
-                                            requestValueArray = new byte[val.bv_len];
-                                            Marshal.Copy(val.bv_val, requestValueArray, 0, (int)val.bv_len);
+                                            requestValueArray = new byte[val.bv_len.Value];
+                                            Marshal.Copy(val.bv_val, requestValueArray, 0, (int)val.bv_len.Value);
                                         }
                                     }
 
@@ -1806,10 +1806,10 @@ namespace System.DirectoryServices.Protocols
                         BerVal bervalue = new BerVal();
                         Marshal.PtrToStructure(tempPtr, bervalue);
                         byte[] byteArray;
-                        if (bervalue.bv_len > 0 && bervalue.bv_val != IntPtr.Zero)
+                        if (bervalue.bv_len.Value > 0 && bervalue.bv_val != IntPtr.Zero)
                         {
-                            byteArray = new byte[bervalue.bv_len];
-                            Marshal.Copy(bervalue.bv_val, byteArray, 0, (int)bervalue.bv_len);
+                            byteArray = new byte[bervalue.bv_len.Value];
+                            Marshal.Copy(bervalue.bv_val, byteArray, 0, (int)bervalue.bv_len.Value);
                             attribute.Add(byteArray);
                         }
 
@@ -1944,8 +1944,8 @@ namespace System.DirectoryServices.Protocols
             Debug.Assert(control.ldctl_oid != IntPtr.Zero);
             string controlType = LdapPal.PtrToString(control.ldctl_oid);
 
-            byte[] bytes = new byte[control.ldctl_value.bv_len];
-            Marshal.Copy(control.ldctl_value.bv_val, bytes, 0, (int)control.ldctl_value.bv_len);
+            byte[] bytes = new byte[control.ldctl_value.bv_len.Value];
+            Marshal.Copy(control.ldctl_value.bv_val, bytes, 0, (int)control.ldctl_value.bv_len.Value);
 
             bool criticality = control.ldctl_iscritical;
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -1245,7 +1245,7 @@ namespace System.DirectoryServices.Protocols
                                 bv_len = byteControlValue.Length,
                                 bv_val = Marshal.AllocHGlobal(sizeof(byte) * byteControlValue.Length)
                             };
-                            Marshal.Copy(byteControlValue, 0, managedControls[i].ldctl_value.bv_val, managedControls[i].ldctl_value.bv_len);
+                            Marshal.Copy(byteControlValue, 0, managedControls[i].ldctl_value.bv_val, (int)managedControls[i].ldctl_value.bv_len);
                         }
                     }
                 }
@@ -1336,7 +1336,7 @@ namespace System.DirectoryServices.Protocols
 
                             // need to free the memory allocated on the heap when we are done
                             ptrToFree.Add(berValues[j].bv_val);
-                            Marshal.Copy(byteArray, 0, berValues[j].bv_val, berValues[j].bv_len);
+                            Marshal.Copy(byteArray, 0, berValues[j].bv_val, (int)berValues[j].bv_len);
                         }
                     }
 
@@ -1488,7 +1488,7 @@ namespace System.DirectoryServices.Protocols
                                         if (val.bv_len != 0 && val.bv_val != IntPtr.Zero)
                                         {
                                             requestValueArray = new byte[val.bv_len];
-                                            Marshal.Copy(val.bv_val, requestValueArray, 0, val.bv_len);
+                                            Marshal.Copy(val.bv_val, requestValueArray, 0, (int)val.bv_len);
                                         }
                                     }
 
@@ -1809,7 +1809,7 @@ namespace System.DirectoryServices.Protocols
                         if (bervalue.bv_len > 0 && bervalue.bv_val != IntPtr.Zero)
                         {
                             byteArray = new byte[bervalue.bv_len];
-                            Marshal.Copy(bervalue.bv_val, byteArray, 0, bervalue.bv_len);
+                            Marshal.Copy(bervalue.bv_val, byteArray, 0, (int)bervalue.bv_len);
                             attribute.Add(byteArray);
                         }
 
@@ -1945,7 +1945,7 @@ namespace System.DirectoryServices.Protocols
             string controlType = LdapPal.PtrToString(control.ldctl_oid);
 
             byte[] bytes = new byte[control.ldctl_value.bv_len];
-            Marshal.Copy(control.ldctl_value.bv_val, bytes, 0, control.ldctl_value.bv_len);
+            Marshal.Copy(control.ldctl_value.bv_val, bytes, 0, (int)control.ldctl_value.bv_len);
 
             bool criticality = control.ldctl_iscritical;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/106412.

We will likely backport to v9.

Testing was performed locally using WSL; the original issue was repro'd (linux+AOT), fixed and verified. The LDAP `DirectoryServicesProtocolsTests` were also run locally.

The `bv_len` field changed from `Int32` to `CLong` which on unix is effectively `IntPtr` in order to support both 32- and 64-bit platforms. Although not specifically tested yet, this is based on:
- The [openldap mirror on GitHub](https://github.com/openldap/openldap/blob/c9ab732ec18e32c58643e44a45233a6ed87830b6/include/lber.h#L213) uses the type `ber_len_t` and from https://www.man7.org/linux/man-pages/man3/ber_len_t.3.html:
_ber_len_t is an unsigned integer of at least 32 bits used to represent a length.  It is commonly equivalent to a size_t._
- From source, `LBER_LEN_T`  [maps to `ber_len_t`](https://github.com/openldap/openldap/blob/c9ab732ec18e32c58643e44a45233a6ed87830b6/include/lber_types.hin#L55) which is a [C long](https://github.com/openldap/openldap/blob/c9ab732ec18e32c58643e44a45233a6ed87830b6/configure.ac#L2264) which is 32-bits on 32-bit platforms.