### PR TITLE
Enable xUnit verbose logging on System.IO.Tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.Tests/System.IO.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/System.IO.Tests.csproj
@@ -5,10 +5,10 @@
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <XunitShowProgress>true</XunitShowProgress>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)' == 'browser' and '$(WasmEnableThreads)' == 'true'">
     <WasmXHarnessMaxParallelThreads>1</WasmXHarnessMaxParallelThreads>
-    <XunitShowProgress>true</XunitShowProgress>
     <!-- VSF is emulated on the UI thread and all calls are slow because they are marshaled -->
     <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
   </PropertyGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/100558 in an attempt to visualize which test is causing OOM (error 137).