### PR TITLE
Use the typical `MethodTable` not instantiated on the declaration for constraint validation

### DIFF
--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1294,7 +1294,7 @@ namespace
         Instantiation targetMethodInst;
         if (targetType->HasInstantiation())
         {
-            declClassInst = declaration->GetMethodTable()->GetInstantiation();
+            declClassInst = declaration->GetMethodTable()->GetTypicalMethodTable()->GetInstantiation();
             targetClassInst = targetType->GetTypicalMethodTable()->GetInstantiation();
         }
         if (targetMethod->HasMethodInstantiation())


### PR DESCRIPTION
Fixes #107132 