### PR TITLE
Make missing framework error message list other architectures that were found

### DIFF
--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class ApplyPatchesSettings :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
@@ -6,6 +6,8 @@ using Microsoft.DotNet.Cli.Build.Framework;
 using System;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class ComplexHierarchies :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.Settings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.Settings.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         public static Func<TestSettings, TestSettings> RollForwardSetting(
             SettingLocation location,
             string value,
-            string frameworkReferenceName = MicrosoftNETCoreApp)
+            string frameworkReferenceName = Constants.MicrosoftNETCoreApp)
         {
             if (value == null || location == SettingLocation.None)
             {
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         public static Func<TestSettings, TestSettings> RollForwardOnNoCandidateFxSetting(
             SettingLocation location,
             int? value,
-            string frameworkReferenceName = MicrosoftNETCoreApp)
+            string frameworkReferenceName = Constants.MicrosoftNETCoreApp)
         {
             if (!value.HasValue || location == SettingLocation.None)
             {
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         public static Func<TestSettings, TestSettings> ApplyPatchesSetting(
             SettingLocation location,
             bool? value,
-            string frameworkReferenceName = MicrosoftNETCoreApp)
+            string frameworkReferenceName = Constants.MicrosoftNETCoreApp)
         {
             if (!value.HasValue || location == SettingLocation.None)
             {

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -11,8 +11,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public abstract partial class FrameworkResolutionBase
     {
-        protected const string MicrosoftNETCoreApp = "Microsoft.NETCore.App";
-
         public static class ResolvedFramework
         {
             public const string NotFound = "[not found]";
@@ -23,7 +21,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             DotNetCli dotnet,
             TestApp app,
             TestSettings settings,
-            Action<CommandResult> resultAction = null,
             bool? multiLevelLookup = false)
         {
             using (DotNetCliExtensions.DotNetCliCustomizer dotnetCustomizer = settings.DotnetCustomizer == null ? null : dotnet.Customize())
@@ -52,8 +49,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .MultilevelLookup(multiLevelLookup)
                     .Environment(settings.Environment)
                     .Execute();
-
-                resultAction?.Invoke(result);
 
                 return result;
             }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FxVersionCLI.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FxVersionCLI.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class FXVersionCLI :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class IncludedFrameworksSettings :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
@@ -215,6 +216,50 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .And.HaveStdErrContaining(expectedOutput)
                 .And.HaveStdErrContaining("https://aka.ms/dotnet/app-launch-failed")
                 .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
+        }
+
+        [Fact]
+        public void FrameworkResolutionError_ListOtherArchitectures()
+        {
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNetMainHive.GreatestVersionHostFxrFilePath))
+            using (var otherArchArtifact = TestArtifact.Create("otherArch"))
+            {
+                string requestedVersion = "9999.9.9";
+                string[] otherArchs = ["arm64", "x64", "x86"];
+                var installLocations = new (string, string)[otherArchs.Length];
+                for (int i = 0; i < otherArchs.Length; i++)
+                {
+                    string arch = otherArchs[i];
+
+                    // Create a .NET install with Microsoft.NETCoreApp at the registered location
+                    var dotnet = new DotNetBuilder(otherArchArtifact.Location, TestContext.BuiltDotNet.BinPath, arch)
+                        .AddMicrosoftNETCoreAppFrameworkMockHostPolicy(requestedVersion)
+                        .Build();
+                    installLocations[i] = (arch, dotnet.BinPath);
+                }
+
+                registeredInstallLocationOverride.SetInstallLocation(installLocations);
+
+                CommandResult result = RunTest(
+                    new TestSettings()
+                        .WithRuntimeConfigCustomizer(c => c.WithFramework(MicrosoftNETCoreApp, requestedVersion))
+                        .WithEnvironment(TestOnlyEnvironmentVariables.RegisteredConfigLocation, registeredInstallLocationOverride.PathValueOverride),
+                    multiLevelLookup: null);
+
+                result.ShouldFailToFindCompatibleFrameworkVersion(MicrosoftNETCoreApp, requestedVersion)
+                    .And.HaveStdErrContaining("The following frameworks for other architectures were found:");
+
+                // Error message should list framework found for other architectures
+                foreach ((string arch, string path) in installLocations)
+                {
+                    if (arch == TestContext.BuildArchitecture)
+                        continue;
+
+                    string expectedPath = System.Text.RegularExpressions.Regex.Escape(Path.Combine(path, "shared", MicrosoftNETCoreApp));
+                    result.Should()
+                        .HaveStdErrMatching($@"{arch}\s*{requestedVersion} at \[{expectedPath}\]", System.Text.RegularExpressions.RegexOptions.Multiline);
+                }
+            }
         }
 
         private CommandResult RunTest(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, bool? multiLevelLookup = true)

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardAndRollForwardOnNoCandidateFxSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardAndRollForwardOnNoCandidateFxSettings.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class RollForwardAndRollForwardOnNoCandidateFxSettings :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardMultipleFrameworks.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardMultipleFrameworks.cs
@@ -6,6 +6,8 @@ using Microsoft.DotNet.Cli.Build.Framework;
 using System;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class RollForwardMultipleFrameworks :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
-using System;
 using Xunit;
+
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxMultipleFrameworks.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxMultipleFrameworks.cs
@@ -6,6 +6,8 @@ using Microsoft.DotNet.Cli.Build.Framework;
 using System;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class RollForwardOnNoCandidateFxMultipleFrameworks :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class RollForwardOnNoCandidateFxSettings :

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardPreReleaseOnly.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardPreReleaseOnly.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     /// <summary>

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseAndPreRelease.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseAndPreRelease.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     /// <summary>

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseOnly.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseOnly.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     /// <summary>

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardSettings.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
+using static Microsoft.DotNet.CoreSetup.Test.Constants;
+
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     public class RollForwardSettings :

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.DotNet.CoreSetup.Test
 {
     public static class Constants
@@ -82,8 +84,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public static class TestOnlyEnvironmentVariables
         {
             public const string DefaultInstallPath = "_DOTNET_TEST_DEFAULT_INSTALL_PATH";
-            public const string RegistryPath = "_DOTNET_TEST_REGISTRY_PATH";
             public const string GloballyRegisteredPath = "_DOTNET_TEST_GLOBALLY_REGISTERED_PATH";
+
+            public static string RegisteredConfigLocation = OperatingSystem.IsWindows() ? RegistryPath : InstallLocationPath;
+            public const string RegistryPath = "_DOTNET_TEST_REGISTRY_PATH";
             public const string InstallLocationPath = "_DOTNET_TEST_INSTALL_LOCATION_PATH";
         }
 

--- a/src/native/corehost/fxr/fx_resolver.cpp
+++ b/src/native/corehost/fxr/fx_resolver.cpp
@@ -540,7 +540,7 @@ StatusCode fx_resolver_t::resolve_frameworks_for_app(
                 _X("Architecture: %s"),
                 app_display_name,
                 get_current_arch_name());
-            display_missing_framework_error(resolution_failure.missing.get_fx_name(), resolution_failure.missing.get_fx_version(), pal::string_t(), dotnet_root, app_config.get_is_multilevel_lookup_disabled());
+            display_missing_framework_error(resolution_failure.missing.get_fx_name(), resolution_failure.missing.get_fx_version(), dotnet_root, app_config.get_is_multilevel_lookup_disabled());
             break;
         case StatusCode::FrameworkCompatFailure:
             display_incompatible_framework_error(resolution_failure.incompatible_higher.get_fx_version(), resolution_failure.incompatible_lower);

--- a/src/native/corehost/fxr/fx_resolver.h
+++ b/src/native/corehost/fxr/fx_resolver.h
@@ -64,7 +64,6 @@ private:
     static void display_missing_framework_error(
         const pal::string_t& fx_name,
         const pal::string_t& fx_version,
-        const pal::string_t& fx_dir,
         const pal::string_t& dotnet_root,
         bool disable_multilevel_lookup);
     static void display_incompatible_framework_error(

--- a/src/native/corehost/fxr/install_info.cpp
+++ b/src/native/corehost/fxr/install_info.cpp
@@ -31,7 +31,7 @@ bool install_info::print_environment(const pal::char_t* leading_whitespace)
     return found_any;
 }
 
-bool install_info::print_other_architectures(const pal::char_t* leading_whitespace)
+bool install_info::enumerate_other_architectures(std::function<void(pal::architecture, const pal::string_t&, bool)> callback)
 {
     bool found_any = false;
     for (uint32_t i = 0; i < static_cast<uint32_t>(pal::architecture::__last); ++i)
@@ -47,13 +47,22 @@ bool install_info::print_other_architectures(const pal::char_t* leading_whitespa
         {
             found_any = true;
             remove_trailing_dir_separator(&install_location);
+            callback(arch, install_location, is_registered);
+        }
+    }
+
+    return found_any;
+}
+
+bool install_info::print_other_architectures(const pal::char_t* leading_whitespace)
+{
+    return enumerate_other_architectures(
+        [&](pal::architecture arch, const pal::string_t& install_location, bool is_registered)
+        {
             trace::println(_X("%s%-5s [%s]"), leading_whitespace, get_arch_name(arch), install_location.c_str());
             if (is_registered)
             {
                 trace::println(_X("%s  registered at [%s]"), leading_whitespace, pal::get_dotnet_self_registered_config_location(arch).c_str());
             }
-        }
-    }
-
-    return found_any;
+        });
 }

--- a/src/native/corehost/fxr/install_info.h
+++ b/src/native/corehost/fxr/install_info.h
@@ -5,9 +5,11 @@
 #define __INSTALL_INFO_H__
 
 #include "pal.h"
+#include <functional>
 
 namespace install_info
 {
+    bool enumerate_other_architectures(std::function<void(pal::architecture, const pal::string_t&, bool)> callback);
     bool print_environment(const pal::char_t* leading_whitespace);
     bool print_other_architectures(const pal::char_t* leading_whitespace);
 };

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -10,13 +10,6 @@
 #include <runtime_version.h>
 #include <minipal/utils.h>
 
-#if defined(_WIN32)
-#define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=798306")
-#elif defined(TARGET_OSX)
-#define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=2063366")
-#else
-#define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=2063370")
-#endif
 #define DOTNET_CORE_DOWNLOAD_URL _X("https://aka.ms/dotnet/download")
 #define DOTNET_CORE_APPLAUNCH_URL _X("https://aka.ms/dotnet-core-applaunch")
 


### PR DESCRIPTION
When erroring on a missing framework, check if there are versions of the framework for other architectures and list them for the user.

Example:
```diff
You must install or update .NET to run this application.

App: C:\repos\helloworld\bin\Debug\net8.0\helloworld.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '8.0.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  9.0.0-preview.6.24327.7 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

+The following frameworks for other architectures were found:
+  x86
+    8.0.5 at [C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App]
+    9.0.0-preview.6.24327.7 at [C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=8.0.0&arch=x64&rid=win-x64&os=win10
```

Fixes https://github.com/dotnet/runtime/issues/51102

cc @dotnet/appmodel @AaronRobinsonMSFT 