### PR TITLE
[WASI] fix response header conversion and event loop

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/WasiHttpHandler/WasiHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/WasiHttpHandler/WasiHttpHandler.cs
@@ -54,8 +54,6 @@ namespace System.Net.Http
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var response = new HttpResponseMessage((HttpStatusCode)incomingResponse.Status());
-                WasiHttpInterop.ConvertResponseHeaders(incomingResponse, response);
-
 
                 // request body could be still streaming after response headers are received and started streaming response
                 // we will leave scope of this method
@@ -63,6 +61,7 @@ namespace System.Net.Http
                 // unless we know that we are not streaming anymore
                 incomingStream = new WasiInputStream(this, incomingResponse.Consume());// passing self ownership, passing body ownership
                 response.Content = new StreamContent(incomingStream); // passing incomingStream ownership to SendAsync() caller
+                WasiHttpInterop.ConvertResponseHeaders(incomingResponse, response);
 
                 return response;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/WasiHttpHandler/WasiHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/WasiHttpHandler/WasiHttpHandler.cs
@@ -54,6 +54,7 @@ namespace System.Net.Http
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var response = new HttpResponseMessage((HttpStatusCode)incomingResponse.Status());
+                response.RequestMessage = request;
 
                 // request body could be still streaming after response headers are received and started streaming response
                 // we will leave scope of this method


### PR DESCRIPTION
This addresses two issues:

- In `WasiHttpHandler`, we were setting `response.Content` after calling `WasiHttpInterop.ConvertResponseHeaders`, which had the effect of removing any content headers we had previously added.  The fix is to call `WasiHttpInterop.ConvertResponseHeaders` _after_ setting `response.Content`.

- In `WasiEventLoop`, we were calling `wasi:io/poll#poll` regardless of whether any tasks had been canceled during the call to `ThreadPoolWorkQueue.Dispatch`. That meant the application was not given a chance to quit the event loop promptly, e.g. when tasks are still pending, but the the task(s) the app actually _cares_ about have completed.  The fix is to return without polling if we detect one or more tasks have been canceled.  The app can always keep looping if it's not ready to exit.