### PR TITLE
Make `AssemblyBaseObject` store `Assembly` instead of `DomainAssembly`

### DIFF
--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -1590,7 +1590,7 @@ OBJECTREF Assembly::GetExposedObject()
         // Create the assembly object
         GCPROTECT_BEGIN(assemblyObj);
         assemblyObj = (ASSEMBLYREF)AllocateObject(pMT);
-        assemblyObj->SetAssembly(GetDomainAssembly());
+        assemblyObj->SetAssembly(this);
 
         // Attach the reference to the assembly to keep the LoaderAllocator for this collectible type
         // alive as long as a reference to the assembly is kept alive.

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -336,7 +336,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetLocation(QCall::AssemblyHandle pAsse
     END_QCALL;
 }
 
-extern "C" void QCALLTYPE AssemblyNative_GetTypeCore(QCall::AssemblyHandle assemblyHandle,
+extern "C" void QCALLTYPE AssemblyNative_GetTypeCore(QCall::AssemblyHandle pAssembly,
     LPCSTR szTypeName,
     LPCSTR * rgszNestedTypeNames,
     int32_t cNestedTypeNamesLength,
@@ -350,8 +350,6 @@ extern "C" void QCALLTYPE AssemblyNative_GetTypeCore(QCall::AssemblyHandle assem
     CONTRACTL_END;
 
     BEGIN_QCALL;
-
-    Assembly* pAssembly = assemblyHandle->GetAssembly();
 
     TypeHandle th = TypeHandle();
     Module* pManifestModule = pAssembly->GetModule();
@@ -421,7 +419,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetTypeCoreIgnoreCase(QCall::AssemblyHa
 
     BEGIN_QCALL;
 
-    Assembly* pAssembly = assemblyHandle->GetAssembly();
+    Assembly* pAssembly = assemblyHandle;
 
     TypeHandle th = TypeHandle();
     Module* pManifestModule = pAssembly->GetModule();
@@ -499,14 +497,13 @@ extern "C" void QCALLTYPE AssemblyNative_GetForwardedType(QCall::AssemblyHandle 
     LPCSTR pszClassName;
     mdToken mdImpl;
 
-    Assembly * pAsm = pAssembly->GetAssembly();
-    Module *pManifestModule = pAsm->GetModule();
+    Module *pManifestModule = pAssembly->GetModule();
     IfFailThrow(pManifestModule->GetMDImport()->GetExportedTypeProps(mdtExternalType, &pszNameSpace, &pszClassName, &mdImpl, NULL, NULL));
     if (TypeFromToken(mdImpl) == mdtAssemblyRef)
     {
         NameHandle typeName(pszNameSpace, pszClassName);
         typeName.SetTypeToken(pManifestModule, mdtExternalType);
-        TypeHandle typeHnd = pAsm->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
+        TypeHandle typeHnd = pAssembly->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
         {
             GCX_COOP();
             retType.Set(typeHnd.GetManagedClassObject());
@@ -525,7 +522,7 @@ FCIMPL1(FC_BOOL_RET, AssemblyNative::IsDynamic, AssemblyBaseObject* pAssemblyUNS
     if (refAssembly == NULL)
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
-    FC_RETURN_BOOL(refAssembly->GetDomainAssembly()->GetPEAssembly()->IsReflectionEmit());
+    FC_RETURN_BOOL(refAssembly->GetAssembly()->GetPEAssembly()->IsReflectionEmit());
 }
 FCIMPLEND
 
@@ -648,7 +645,7 @@ extern "C" BYTE * QCALLTYPE AssemblyNative_GetResource(QCall::AssemblyHandle pAs
 
     pAssembly->GetPEAssembly()->GetResource(pNameUTF8, length,
                            &pbInMemoryResource, NULL, NULL,
-                           NULL, pAssembly->GetAssembly());
+                           NULL, pAssembly);
 
     END_QCALL;
 
@@ -680,7 +677,7 @@ extern "C" INT32 QCALLTYPE AssemblyNative_GetManifestResourceInfo(QCall::Assembl
     DWORD dwLocation = 0;
 
     if (pAssembly->GetPEAssembly()->GetResource(pNameUTF8, NULL, NULL, &pReferencedAssembly, &pFileName,
-                              &dwLocation, pAssembly->GetAssembly()))
+                              &dwLocation, pAssembly))
     {
         if (pFileName)
             retFileName.Set(pFileName);
@@ -815,10 +812,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetExportedTypes(QCall::AssemblyHandle 
     BEGIN_QCALL;
 
     InlineSArray<TypeHandle, 20> types;
-
-    Assembly * pAsm = pAssembly->GetAssembly();
-
-    IMDInternalImport *pImport = pAsm->GetMDImport();
+    IMDInternalImport *pImport = pAssembly->GetMDImport();
 
     {
         HENUMTypeDefInternalHolder phTDEnum(pImport);
@@ -846,7 +840,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetExportedTypes(QCall::AssemblyHandle 
 
             if (IsTdPublic(dwFlags))
             {
-                TypeHandle typeHnd = ClassLoader::LoadTypeDefThrowing(pAsm->GetModule(), mdTD,
+                TypeHandle typeHnd = ClassLoader::LoadTypeDefThrowing(pAssembly->GetModule(), mdTD,
                                                                       ClassLoader::ThrowIfNotFound,
                                                                       ClassLoader::PermitUninstDefOrRef);
                 types.Append(typeHnd);
@@ -894,8 +888,8 @@ extern "C" void QCALLTYPE AssemblyNative_GetExportedTypes(QCall::AssemblyHandle 
                 IsTdPublic(dwFlags))
             {
                 NameHandle typeName(pszNameSpace, pszClassName);
-                typeName.SetTypeToken(pAsm->GetModule(), mdCT);
-                TypeHandle typeHnd = pAsm->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
+                typeName.SetTypeToken(pAssembly->GetModule(), mdCT);
+                TypeHandle typeHnd = pAssembly->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
 
                 types.Append(typeHnd);
             }
@@ -935,10 +929,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetForwardedTypes(QCall::AssemblyHandle
     BEGIN_QCALL;
 
     InlineSArray<TypeHandle, 8> types;
-
-    Assembly * pAsm = pAssembly->GetAssembly();
-
-    IMDInternalImport *pImport = pAsm->GetMDImport();
+    IMDInternalImport *pImport = pAssembly->GetMDImport();
 
     // enumerate the ExportedTypes table
     {
@@ -964,8 +955,8 @@ extern "C" void QCALLTYPE AssemblyNative_GetForwardedTypes(QCall::AssemblyHandle
             if ((TypeFromToken(mdImpl) == mdtAssemblyRef) && (mdImpl != mdAssemblyRefNil))
             {
                 NameHandle typeName(pszNameSpace, pszClassName);
-                typeName.SetTypeToken(pAsm->GetModule(), mdCT);
-                TypeHandle typeHnd = pAsm->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
+                typeName.SetTypeToken(pAssembly->GetModule(), mdCT);
+                TypeHandle typeHnd = pAssembly->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
 
                 types.Append(typeHnd);
             }
@@ -1005,9 +996,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetManifestResourceNames(QCall::Assembl
 
     BEGIN_QCALL;
 
-    Assembly * pAsm = pAssembly->GetAssembly();
-
-    IMDInternalImport *pImport = pAsm->GetMDImport();
+    IMDInternalImport *pImport = pAssembly->GetMDImport();
 
     HENUMInternalHolder phEnum(pImport);
     phEnum.EnumInit(mdtManifestResource, mdTokenNil);
@@ -1047,9 +1036,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetReferencedAssemblies(QCall::Assembly
 {
     BEGIN_QCALL;
 
-    Assembly * pAsm = pAssembly->GetAssembly();
-
-    IMDInternalImport *pImport = pAsm->GetMDImport();
+    IMDInternalImport *pImport = pAssembly->GetMDImport();
 
     HENUMInternalHolder phEnum(pImport);
     phEnum.EnumInit(mdtAssemblyRef, mdTokenNil);
@@ -1099,7 +1086,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetEntryPoint(QCall::AssemblyHandle pAs
 
     BEGIN_QCALL;
 
-    pMeth = pAssembly->GetAssembly()->GetEntryPoint();
+    pMeth = pAssembly->GetEntryPoint();
     if (pMeth != NULL)
     {
         GCX_COOP();

--- a/src/coreclr/vm/nativelibrarynative.cpp
+++ b/src/coreclr/vm/nativelibrarynative.cpp
@@ -32,11 +32,10 @@ extern "C" INT_PTR QCALLTYPE NativeLibrary_LoadByName(LPCWSTR name, QCall::Assem
     QCALL_CONTRACT;
 
     NATIVE_LIBRARY_HANDLE handle = nullptr;
-    Assembly *pAssembly = callingAssembly->GetAssembly();
 
     BEGIN_QCALL;
 
-    handle = NativeLibrary::LoadLibraryByName(name, pAssembly, hasDllImportSearchPathFlag, dllImportSearchPathFlag, throwOnError);
+    handle = NativeLibrary::LoadLibraryByName(name, callingAssembly, hasDllImportSearchPathFlag, dllImportSearchPathFlag, throwOnError);
 
     END_QCALL;
 

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -278,7 +278,7 @@ TypeHandle Object::GetGCSafeTypeHandleIfPossible() const
 Assembly *AssemblyBaseObject::GetAssembly()
 {
     WRAPPER_NO_CONTRACT;
-    return m_pAssembly->GetAssembly();
+    return m_pAssembly;
 }
 
 STRINGREF AllocateString(SString sstr)
@@ -1489,7 +1489,7 @@ void StackTraceArray::Allocate(size_t size)
     {
         EX_THROW(EEMessageException, (kOverflowException, IDS_EE_ARRAY_DIMENSIONS_EXCEEDED));
     }
-   
+
     SetArray(I1ARRAYREF(AllocatePrimitiveArray(ELEMENT_TYPE_I1, static_cast<DWORD>(raw_size.Value()))));
     SetSize(0);
     SetKeepAliveItemsCount(0);
@@ -1915,7 +1915,7 @@ void ExceptionObject::SetStackTrace(OBJECTREF stackTrace)
 // - if the stack trace was created by the current thread, the arrays are returned as is.
 // - if it was created by another thread, deep copies of the arrays are returned. It is ensured
 //   that both of these arrays are consistent. That means that the stack trace doesn't contain
-//   frames that need keep alive objects and that are not protected by entries in the keep alive 
+//   frames that need keep alive objects and that are not protected by entries in the keep alive
 //   array.
 void ExceptionObject::GetStackTrace(StackTraceArray & stackTrace, PTRARRAYREF * outKeepAliveArray /*= NULL*/) const
 {
@@ -1956,7 +1956,7 @@ void ExceptionObject::GetStackTrace(StackTraceArray & stackTrace, PTRARRAYREF * 
 
         uint32_t keepAliveArrayCapacity = ((*outKeepAliveArray) == NULL) ? 0 : (*outKeepAliveArray)->GetNumComponents();
 
-        // It is possible that another thread was modifying the stack trace array and keep alive array while we were making the copies. 
+        // It is possible that another thread was modifying the stack trace array and keep alive array while we were making the copies.
         // The following sequence of events could have happened:
         // Case 1:
         // * The current thread gets the stack trace array and the keep alive array references using the ExceptionObject::GetStackTraceParts above
@@ -2014,10 +2014,10 @@ void ExceptionObject::GetStackTrace(StackTraceArray & stackTrace, PTRARRAYREF * 
         }
         GCPROTECT_END();
     }
-#endif // DACCESS_COMPILE            
+#endif // DACCESS_COMPILE
 }
 
-// Get the stack trace and the dynamic method array from the stack trace object. 
+// Get the stack trace and the dynamic method array from the stack trace object.
 // If the stack trace was created by another thread, it returns clones of both arrays.
 /* static */
 void ExceptionObject::GetStackTraceParts(OBJECTREF stackTraceObj, StackTraceArray & stackTrace, PTRARRAYREF * outKeepAliveArray /*= NULL*/)

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -1408,7 +1408,7 @@ class AssemblyBaseObject : public Object
     OBJECTREF     m_pModuleEventHandler;   // Delegate for 'resolve module' event
     STRINGREF     m_fullname;              // Slot for storing assemblies fullname
     OBJECTREF     m_pSyncRoot;             // Pointer to loader allocator to keep collectible types alive, and to serve as the syncroot for assembly building in ref.emit
-    DomainAssembly* m_pAssembly;           // Pointer to the Assembly Structure
+    Assembly* m_pAssembly;                 // Pointer to the Assembly Structure
 
   protected:
     AssemblyBaseObject() { LIMITED_METHOD_CONTRACT; }
@@ -1416,16 +1416,10 @@ class AssemblyBaseObject : public Object
 
   public:
 
-    void SetAssembly(DomainAssembly* p)
+    void SetAssembly(Assembly* p)
     {
         LIMITED_METHOD_CONTRACT;
         m_pAssembly = p;
-    }
-
-    DomainAssembly* GetDomainAssembly()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_pAssembly;
     }
 
     Assembly* GetAssembly();

--- a/src/coreclr/vm/qcall.h
+++ b/src/coreclr/vm/qcall.h
@@ -248,15 +248,15 @@ public:
     struct AssemblyHandle
     {
         Object ** m_ppObject;
-        DomainAssembly * m_pAssembly;
+        Assembly * m_pAssembly;
 
-        operator DomainAssembly * ()
+        operator Assembly * ()
         {
             LIMITED_METHOD_CONTRACT;
             return m_pAssembly;
         }
 
-        DomainAssembly * operator->() const
+        Assembly * operator->() const
         {
             LIMITED_METHOD_CONTRACT;
             return m_pAssembly;

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2687,8 +2687,7 @@ FCIMPL1(ReflectModuleBaseObject*, AssemblyHandle::GetManifestModule, AssemblyBas
     if (refAssembly == NULL)
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
-    DomainAssembly *pAssembly = refAssembly->GetDomainAssembly();
-    Assembly* currentAssembly = pAssembly->GetAssembly();
+    Assembly* currentAssembly = refAssembly->GetAssembly();
 
     FC_RETURN_MODULE_OBJECT(currentAssembly->GetModule(), refAssembly);
 }
@@ -2702,10 +2701,8 @@ FCIMPL1(INT32, AssemblyHandle::GetToken, AssemblyBaseObject* pAssemblyUNSAFE) {
     if (refAssembly == NULL)
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
-    DomainAssembly *pAssembly = refAssembly->GetDomainAssembly();
     mdAssembly token = mdAssemblyNil;
-
-    IMDInternalImport *mdImport = pAssembly->GetAssembly()->GetMDImport();
+    IMDInternalImport *mdImport = refAssembly->GetAssembly()->GetMDImport();
 
     if (mdImport != 0)
     {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/104590

cc @jkotas @AaronRobinsonMSFT 