### PR TITLE
Make host tests enable test-only behaviour for nethost before first use

### DIFF
--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -89,7 +89,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61131", TestPlatforms.OSX)]
         [InlineData(true, false, true, false)]
         [InlineData(true, false, true, true)]
         [InlineData(true, false, false, false)]
@@ -183,7 +182,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61131", TestPlatforms.OSX)]
         [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         [InlineData("{0}", false, true)]
         [InlineData("{0}\n", false, true)]
@@ -249,7 +247,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61131", TestPlatforms.OSX)]
         [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_HasNoDefaultInstallationPath()
         {
@@ -280,7 +277,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61131", TestPlatforms.OSX)]
         [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_ArchitectureSpecificPathIsPickedOverDefaultPath()
         {

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -338,22 +338,23 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [Fact]
         public void TestOnlyDisabledByDefault()
         {
-            // Intentionally not enabling test-only behavior. This test validates that even if the test-only env. variable is set
-            // it will not take effect on its own by default.
-            // To make sure the test is reliable, copy the product binary again into the test folder where we run it from.
-            // This is to make sure that we're using the unmodified product binary. If some previous test
-            // enabled test-only product behavior on the binary and didn't correctly cleanup, this test would fail.
-            File.Copy(
-                Binaries.NetHost.FilePath,
-                sharedState.NethostPath,
-                overwrite: true);
+            using (TestArtifact artifact = TestArtifact.Create(nameof(TestOnlyDisabledByDefault)))
+            {
+                // Copy the native host and unmodified nethost product binary into a new test folder
+                string nativeHostPath = Path.Combine(artifact.Location, Path.GetFileName(sharedState.NativeHostPath));
+                File.Copy(sharedState.NativeHostPath, nativeHostPath);
 
-            Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
-                .EnableTracingAndCaptureOutputs()
-                .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, sharedState.ValidInstallRoot)
-                .DotNetRoot(null)
-                .Execute()
-                .Should().NotHaveStdErrContaining($"Using global install location [{sharedState.ValidInstallRoot}] as runtime location.");
+                // Intentionally not enabling test-only behavior. This test validates that even if the test-only env. variable is set
+                // it will not take effect on its own by default.
+                File.Copy(Binaries.NetHost.FilePath, Path.Combine(artifact.Location, Binaries.NetHost.FileName));
+
+                Command.Create(nativeHostPath, GetHostFxrPath)
+                    .EnableTracingAndCaptureOutputs()
+                    .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, sharedState.ValidInstallRoot)
+                    .DotNetRoot(null)
+                    .Execute()
+                    .Should().NotHaveStdErrContaining($"Using global install location [{sharedState.ValidInstallRoot}] as runtime location.");
+            }
         }
 
         public class SharedTestState : SharedTestStateBase

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
@@ -35,6 +35,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             File.Copy(
                 Binaries.NetHost.FilePath,
                 NethostPath);
+
+            // Enable test-only behaviour for nethost. We always do this - even for tests that don't need the behaviour.
+            // On macOS with system integrity protection enabled, if a code-signed binary is loaded, modified (test-only
+            // behaviour rewrites part of the binary), and loaded again, the process will crash (Code Signature Invalid).
+            // We don't bother disabling it later, as we just delete the containing folder after tests run.
+            _ = TestOnlyProductBehavior.Enable(NethostPath);
         }
 
         public Command CreateNativeHostCommand(IEnumerable<string> args, string dotNetRoot)

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
@@ -32,9 +32,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             // user-friendly way of linking against nethost (instead of dlopen/LoadLibrary and dlsym/GetProcAddress).
             // On Windows, we can delay load through a linker option, but on other platforms load is required on start.
             NethostPath = Path.Combine(Path.GetDirectoryName(NativeHostPath), Binaries.NetHost.FileName);
-            File.Copy(
-                Binaries.NetHost.FilePath,
-                NethostPath);
+            File.Copy(Binaries.NetHost.FilePath, NethostPath);
 
             // Enable test-only behaviour for nethost. We always do this - even for tests that don't need the behaviour.
             // On macOS with system integrity protection enabled, if a code-signed binary is loaded, modified (test-only


### PR DESCRIPTION
On macOS with system integrity protection enabled, if a code-signed binary is loaded in a process, modified, and loaded again in another process, the second run will crash with Code Signature Invalid).

Enabling test-only behaviour modifies the binary (re-writes a placeholder value). The nethost tests were enabling/disabling test-only behaviour for the same `nethost` binary used by all the tests. This change updates the tests to just always enable it before any use of the binary.

Fixes https://github.com/dotnet/runtime/issues/61131

cc @dotnet/appmodel @AaronRobinsonMSFT 