### PR TITLE
[wasm] Include .NET version in templates package id

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
@@ -44,6 +44,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- When changing 'NetVersion', also change Microsoft.NET.Runtime.WebAssembly.Templates.csproj 'PackageId' -->
       <_WorkloadManifestValues Include="NetVersion" Value="net9" /> <!-- NetCurrent -->
       <_WorkloadManifestValues Include="WorkloadVersion" Value="$(PackageVersion)" />
       <_WorkloadManifestValues Include="PackageVersion" Value="$(PackageVersion)" />

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -206,10 +206,7 @@
     },
     "Microsoft.NET.Runtime.WebAssembly.Templates.${NetVersion}": {
       "kind": "template",
-      "version": "${PackageVersion}",
-      "alias-to": {
-          "any": "Microsoft.NET.Runtime.WebAssembly.Templates"
-      }
+      "version": "${PackageVersion}"
     },
     "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.android-arm": {
       "kind": "framework",

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -16,6 +16,7 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <IsPackable>true</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <!-- TODO: Add package readme -->
     <EnableDefaultPackageReadmeFile>false</EnableDefaultPackageReadmeFile>
   </PropertyGroup>

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net9</PackageId>
+    <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net$(MajorVersion)</PackageId>
     <Title>WebAssembly Templates</Title>
     <Authors>Microsoft</Authors>
     <Description>Templates to create WebAssembly projects.</Description>

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net$(MajorVersion)</PackageId>
+    <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net9</PackageId>
     <Title>WebAssembly Templates</Title>
     <Authors>Microsoft</Authors>
     <Description>Templates to create WebAssembly projects.</Description>

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates</PackageId>
+    <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net9</PackageId>
     <Title>WebAssembly Templates</Title>
     <Authors>Microsoft</Authors>
     <Description>Templates to create WebAssembly projects.</Description>


### PR DESCRIPTION
- Dotnet CLI does support having one package id with multiple versions and it picks templates from both.
- Visual Studio doesn't support having one package id with multiple versions.
- For .NET 8 the package id will remain `Microsoft.NET.Runtime.WebAssembly.Templates`.
- For .NET 9 the package id will be `Microsoft.NET.Runtime.WebAssembly.Templates.net9`.
- ~~For future versions the package id computed based on `$(MajorVersion)` property~~ Once we target workload for .NET 10, we can compute the package id dynamically