### PR TITLE
Define a merged runner for the profiler tests

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1687,21 +1687,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/ContextualReflection/ContextualReflection/**">
             <Issue>https://github.com/dotnet/runtime/issues/34072</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/**">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/elt/slowpatheltenter/*">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/elt/slowpatheltleave/*">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/unittest/metadatagetdispenser/**">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/rejit/rejit/rejit.sh">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/**">
             <Issue>These tests are not supposed to be run with mono.</Issue>
         </ExcludeList>

--- a/src/tests/profiler/Directory.Build.targets
+++ b/src/tests/profiler/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+  <!-- SDK Style projects auto-magically include this file. -->
+  <Import Project="..\Directory.Build.targets" />
+
+  <PropertyGroup Condition="'$(IsMergedTestRunnerAssembly)' != 'true'">
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+  </PropertyGroup>
+</Project>

--- a/src/tests/profiler/profiler.csproj
+++ b/src/tests/profiler/profiler.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Profiler APIs aren't supported on mobile platforms -->
+    <DisableProjectBuild Condition="'$(TargetsMobile)' == 'true'">true</DisableProjectBuild>
+    <!-- Profiler APIs aren't supported on Mono -->
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <MergedWrapperProjectReference Include="*/**/*.csproj" Exclude="common/**/*.csproj;unittest/unloadlibrary.csproj" />
+  </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
+</Project>


### PR DESCRIPTION
Define a merged runner that invokes each test as an out-of-proc test.

In combination with #107167, this gets us to the point where every test group has been moved to the merged model.