### PR TITLE
Make `DomainAssembly` create its `Assembly` in its constructor and remove separate allocate load level

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1070,7 +1070,7 @@ void SystemDomain::LoadBaseSystemClasses()
 
         // Only partially load the system assembly. Other parts of the code will want to access
         // the globals in this function before finishing the load.
-        m_pSystemAssembly = DefaultDomain()->LoadDomainAssembly(NULL, m_pSystemPEAssembly, FILE_LOAD_POST_ALLOCATE)->GetAssembly();
+        m_pSystemAssembly = DefaultDomain()->LoadDomainAssembly(NULL, m_pSystemPEAssembly, FILE_LOAD_BEFORE_TYPE_LOAD)->GetAssembly();
 
         // Set up binder for CoreLib
         CoreLibBinder::AttachModule(m_pSystemAssembly->GetModule());
@@ -2045,8 +2045,7 @@ static const char *fileLoadLevelName[] =
 {
     "CREATE",                             // FILE_LOAD_CREATE
     "BEGIN",                              // FILE_LOAD_BEGIN
-    "ALLOCATE",                           // FILE_LOAD_ALLOCATE
-    "POST_ALLOCATE",                      // FILE_LOAD_POST_ALLOCATE
+    "BEFORE_TYPE_LOAD",                   // FILE_LOAD_BEFORE_TYPE_LOAD
     "EAGER_FIXUPS",                       // FILE_LOAD_EAGER_FIXUPS
     "DELIVER_EVENTS",                     // FILE_LOAD_DELIVER_EVENTS
     "VTABLE FIXUPS",                      // FILE_LOAD_VTABLE_FIXUPS
@@ -2113,7 +2112,6 @@ BOOL FileLoadLock::CompleteLoadLevel(FileLoadLevel level, BOOL success)
 #ifndef DACCESS_COMPILE
         switch(level)
         {
-            case FILE_LOAD_ALLOCATE:
             case FILE_LOAD_DELIVER_EVENTS:
             case FILE_LOADED:
             case FILE_ACTIVE: // The timing of stress logs is not critical, so even for the FILE_ACTIVE stage we need not do it while the m_pList lock is held.

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -378,6 +378,9 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
     // the loader allocator objects.
     NewHolder<LoaderAllocator> pLoaderAllocator;
 
+    AllocMemTracker amTracker;
+    AllocMemTracker *pamTracker = &amTracker;
+
     Assembly *pRetVal = NULL;
 
     // First, we set up a pseudo-manifest file for the assembly.
@@ -477,7 +480,7 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
         }
 
         // Create a domain assembly
-        pDomainAssembly = new DomainAssembly(pPEAssembly, pLoaderAllocator);
+        pDomainAssembly = new DomainAssembly(pPEAssembly, pLoaderAllocator, pamTracker);
         pAssem = pDomainAssembly->GetAssembly();
         pAssem->m_isDynamic = true;
         if (pDomainAssembly->IsCollectible())
@@ -518,6 +521,7 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
         // Cannot fail after this point
 
         pDomainAssembly.SuppressRelease();
+        pamTracker->SuppressRelease();
 
         // Once we reach this point, the loader allocator lifetime is controlled by the Assembly object.
         if (createdNewAssemblyLoaderAllocator)

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4473,24 +4473,6 @@ VOID Module::EnsureActive()
 
 #include <optdefault.h>
 
-
-#ifndef DACCESS_COMPILE
-
-VOID Module::EnsureAllocated()
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    GetDomainAssembly()->EnsureAllocated();
-}
-
-#endif // !DACCESS_COMPILE
-
 CHECK Module::CheckActivated()
 {
     CONTRACTL

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -948,7 +948,6 @@ public:
 
 #ifndef DACCESS_COMPILE
     VOID EnsureActive();
-    VOID EnsureAllocated();
 #endif
 
     CHECK CheckActivated();

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -69,7 +69,10 @@ DomainAssembly::DomainAssembly(PEAssembly* pPEAssembly, LoaderAllocator* pLoader
         assemblyHolder.SuppressRelease();
     }
 
-    SetAssembly(pAssembly);
+    m_pAssembly = pAssembly;
+    m_pModule = pAssembly->GetModule();
+
+    pAssembly->SetDomainAssembly(this);
 
     // Creating the Assembly should have ensured the PEAssembly is loaded
     _ASSERT(GetPEAssembly()->IsLoaded());
@@ -496,19 +499,6 @@ void DomainAssembly::Activate()
 #endif
 
     RETURN;
-}
-
-void DomainAssembly::SetAssembly(Assembly* pAssembly)
-{
-    STANDARD_VM_CONTRACT;
-
-    _ASSERTE(pAssembly->GetModule()->GetPEAssembly()==m_pPEAssembly);
-    _ASSERTE(m_pAssembly == NULL);
-
-    m_pAssembly = pAssembly;
-    m_pModule = pAssembly->GetModule();
-
-    pAssembly->SetDomainAssembly(this);
 }
 
 void DomainAssembly::Begin()

--- a/src/coreclr/vm/domainassembly.h
+++ b/src/coreclr/vm/domainassembly.h
@@ -251,7 +251,7 @@ public:
     friend class Module;
     friend class FileLoadLock;
 
-    DomainAssembly(PEAssembly* pPEAssembly, LoaderAllocator* pLoaderAllocator);
+    DomainAssembly(PEAssembly* pPEAssembly, LoaderAllocator* pLoaderAllocator, AllocMemTracker* memTracker);
 
     BOOL DoIncrementalLoad(FileLoadLevel targetLevel);
     void ClearLoading() { LIMITED_METHOD_CONTRACT; m_loading = FALSE; }

--- a/src/coreclr/vm/domainassembly.h
+++ b/src/coreclr/vm/domainassembly.h
@@ -35,15 +35,13 @@ enum FileLoadLevel
 
     FILE_LOAD_CREATE,
     FILE_LOAD_BEGIN,
-    FILE_LOAD_ALLOCATE,
-    FILE_LOAD_POST_ALLOCATE,
+    FILE_LOAD_BEFORE_TYPE_LOAD,
     FILE_LOAD_EAGER_FIXUPS,
     FILE_LOAD_DELIVER_EVENTS,
     FILE_LOAD_VTABLE_FIXUPS,
     FILE_LOADED,                    // Loaded by not yet active
     FILE_ACTIVE                     // Fully active (constructors run & security checked)
 };
-
 
 enum NotificationStatus
 {
@@ -186,13 +184,6 @@ public:
         return EnsureLoadLevel(FILE_ACTIVE);
     }
 
-    // Ensure that an assembly has reached at least the Allocated state.  Throw if not.
-    void EnsureAllocated()
-    {
-        WRAPPER_NO_CONTRACT;
-        return EnsureLoadLevel(FILE_LOAD_ALLOCATE);
-    }
-
     // EnsureLoadLevel is a generic routine used to ensure that the file is not in a delay loaded
     // state (unless it needs to be.)  This should be used when a particular level of loading
     // is required for an operation.  Note that deadlocks are tolerated so the level may be one
@@ -268,8 +259,7 @@ public:
 
 #ifndef DACCESS_COMPILE
     void Begin();
-    void Allocate();
-    void PostAllocate();
+    void BeforeTypeLoad();
     void EagerFixups();
     void VtableFixups();
     void DeliverSyncEvents();

--- a/src/coreclr/vm/domainassembly.h
+++ b/src/coreclr/vm/domainassembly.h
@@ -273,7 +273,6 @@ public:
 
     // This should be used to permanently set the load to fail. Do not use with transient conditions
     void SetError(Exception *ex);
-    void SetAssembly(Assembly* pAssembly);
 
     void SetProfilerNotified() { LIMITED_METHOD_CONTRACT; m_notifyflags|= PROFILER_NOTIFIED; }
     void SetDebuggerNotified() { LIMITED_METHOD_CONTRACT; m_notifyflags|=DEBUGGER_NOTIFIED; }

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1260,8 +1260,6 @@ MethodTableBuilder::BuildMethodTableThrowing(
     }
     CONTRACTL_END;
 
-    pModule->EnsureAllocated();
-
     // The following structs, defined as private members of MethodTableBuilder, contain the necessary local
     // parameters needed for BuildMethodTable Look at the struct definitions for a detailed list of all
     // parameters available to BuildMethodTableThrowing.

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -290,7 +290,7 @@ void SigPointer::ConvertToInternalExactlyOne(Module* pSigModule, SigTypeContext 
                     uint8_t required;
                     IfFailThrowBF(GetByte(&required), BFA_BAD_COMPLUS_SIG, pSigModule);
                     pSigBuilder->AppendByte(required);
-                    
+
                     // this check is not functional in DAC and provides no security against a malicious dump
                     // the DAC is prepared to receive an invalid type handle
 #ifndef DACCESS_COMPILE
@@ -2360,11 +2360,11 @@ BOOL SigPointer::HasCustomModifier(Module *pModule, LPCSTR szModName, CorElement
             uint8_t required;
             if (FAILED(sp.GetByte(&required)))
                 return FALSE;
-            
+
             void* typeHandle;
             if (FAILED(sp.GetPointer(&typeHandle)))
                 return FALSE;
-            
+
             TypeHandle type = TypeHandle::FromPtr(typeHandle);
             tk = type.GetCl();
             lookupModule = type.GetModule();
@@ -3272,11 +3272,6 @@ BOOL IsTypeDefEquivalent(mdToken tk, Module *pModule)
         // 4. Type is externally visible (i.e. public)
         if (!IsTypeDefExternallyVisible(tk, pModule, dwAttrType))
             return FALSE;
-
-        // since the token has not been loaded yet,
-        // its module might be not fully initialized in this domain
-        // take care of that possibility
-        pModule->EnsureAllocated();
 
         // 6. If type is nested, nesting type must be equivalent.
         if (IsTdNested(dwAttrType))


### PR DESCRIPTION
There is no logical distinction between creating a `DomainAssembly` and an `Assembly` now. Making `DomainAssembly` create the `Assembly` as soon as it is constructed should make it so that we can switch assorted things that currently store/use `DomainAssembly` to `Assembly`, since they will be created at the same time.

Contributes to https://github.com/dotnet/runtime/issues/104590

cc @jkotas @AaronRobinsonMSFT 