### PR TITLE
Pass $(crossArg) to src/tests/build.sh in Antigen/Fuzzlyn pipelines

### DIFF
--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -40,7 +40,7 @@ extends:
             buildArgs: -s clr+libs -c $(_BuildConfig) -lc Release
             timeoutInMinutes: 360
             postBuildSteps:
-              - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(_BuildConfig) $(archType) generatelayoutonly
+              - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(_BuildConfig) $(archType) $(crossArg) generatelayoutonly
                 displayName: Create Core_Root
                 condition: succeeded()
               - template: /eng/pipelines/coreclr/templates/jit-exploratory-steps.yml


### PR DESCRIPTION
Hopefully fixes https://github.com/dotnet/runtime/pull/103795#issuecomment-2322942441