### PR TITLE
Add debugger display to CancellationTokenSource

### DIFF
--- a/src/libraries/Common/tests/System/Diagnostics/DebuggerAttributes.cs
+++ b/src/libraries/Common/tests/System/Diagnostics/DebuggerAttributes.cs
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -276,6 +273,21 @@ namespace System.Diagnostics
                 }
             }
             return null;
+        }
+
+        internal static void ValidateDebuggerDisplayAttribute_CancellationTokenSource()
+        {
+            var cts = new CancellationTokenSource();
+            string display = ValidateDebuggerDisplayReferences(cts);
+            Debug.Assert(display == "IsCancellationRequested = False, IsDisposed = False");
+
+            cts.Cancel();
+            display = ValidateDebuggerDisplayReferences(cts);
+            Debug.Assert(display == "IsCancellationRequested = True, IsDisposed = False");
+
+            cts.Dispose();
+            display = ValidateDebuggerDisplayReferences(cts);
+            Debug.Assert(display == "IsCancellationRequested = True, IsDisposed = True");
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -22,6 +19,7 @@ namespace System.Threading
     /// concurrently from multiple threads.
     /// </para>
     /// </remarks>
+    [DebuggerDisplay("IsCancellationRequested = {IsCancellationRequested}, Disposed = {_disposed}")]
     public class CancellationTokenSource : IDisposable
     {
         /// <summary>A <see cref="CancellationTokenSource"/> that's already canceled.</summary>


### PR DESCRIPTION
Fixes #105698

Add `DebuggerDisplayAttribute` to `CancellationTokenSource` to show cancellation and disposal status.

- **CancellationTokenSource.cs**
  - Add `DebuggerDisplayAttribute` to the `CancellationTokenSource` class.
  - Display the cancellation status in the `DebuggerDisplayAttribute`.
  - Display the disposal status in the `DebuggerDisplayAttribute`.

- **DebuggerAttributes.cs**
  - Add a test method to validate the `DebuggerDisplayAttribute` for `CancellationTokenSource`.
  - Ensure the test method checks the cancellation status.
  - Ensure the test method checks the disposal status.

