### PR TITLE
Improve code coverage for System.Security.Cryptography.Xml

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
 using Xunit;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    public class CanonicalXmlEntityReferenceTests
+    {
+        [Fact]
+        public void Write_WritesExpectedOutput()
+        {
+            var xmlDocument = new XmlDocument();
+            var entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
+            var stringBuilder = new StringBuilder();
+            var anc = new AncestralNamespaceContextManager();
+
+            entityReference.Write(stringBuilder, DocPosition.InsideRootElement, anc);
+
+            Assert.Equal("<!ENTITY entity SYSTEM \"entity\">", stringBuilder.ToString());
+        }
+
+        [Fact]
+        public void WriteHash_WritesExpectedHash()
+        {
+            var xmlDocument = new XmlDocument();
+            var entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
+            var hashAlgorithm = SHA256.Create();
+            var anc = new AncestralNamespaceContextManager();
+
+            entityReference.WriteHash(hashAlgorithm, DocPosition.InsideRootElement, anc);
+
+            var expectedHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes("<!ENTITY entity SYSTEM \"entity\">"));
+            Assert.Equal(expectedHash, hashAlgorithm.Hash);
+        }
+
+        [Fact]
+        public void IsInNodeSet_GetSet_ReturnsExpected()
+        {
+            var xmlDocument = new XmlDocument();
+            var entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
+
+            Assert.True(entityReference.IsInNodeSet);
+
+            entityReference.IsInNodeSet = false;
+            Assert.False(entityReference.IsInNodeSet);
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
@@ -8,7 +8,7 @@ namespace System.Security.Cryptography.Xml.Tests
     public static class CanonicalXmlEntityReferenceTests
     {
         [Fact]
-        public void Write_WritesExpectedOutput()
+        public static void Write_WritesExpectedOutput()
         {
             var xmlDocument = new XmlDocument();
             var entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        public void WriteHash_WritesExpectedHash()
+        public static void WriteHash_WritesExpectedHash()
         {
             XmlDocument xmlDocument = new XmlDocument();
             CanonicalXmlEntityReference entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
@@ -35,7 +35,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        public void IsInNodeSet_GetSet_ReturnsExpected()
+        public static void IsInNodeSet_GetSet_ReturnsExpected()
         {
             var xmlDocument = new XmlDocument();
             var entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);

--- a/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.Xml.Tests
 {
-    public class CanonicalXmlEntityReferenceTests
+    public static class CanonicalXmlEntityReferenceTests
     {
         [Fact]
         public void Write_WritesExpectedOutput()
@@ -23,14 +23,14 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void WriteHash_WritesExpectedHash()
         {
-            var xmlDocument = new XmlDocument();
-            var entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
-            var hashAlgorithm = SHA256.Create();
+            XmlDocument xmlDocument = new XmlDocument();
+            CanonicalXmlEntityReference entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
+            using SHA256 hashAlgorithm = SHA256.Create();
             var anc = new AncestralNamespaceContextManager();
 
             entityReference.WriteHash(hashAlgorithm, DocPosition.InsideRootElement, anc);
 
-            var expectedHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes("<!ENTITY entity SYSTEM \"entity\">"));
+            byte[] expectedHash = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes("<!ENTITY entity SYSTEM \"entity\">"));
             Assert.Equal(expectedHash, hashAlgorithm.Hash);
         }
 

--- a/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
 using Xunit;
@@ -23,8 +22,8 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public static void WriteHash_WritesExpectedHash()
         {
-            XmlDocument xmlDocument = new XmlDocument();
-            CanonicalXmlEntityReference entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
+            var xmlDocument = new XmlDocument();
+            var entityReference = new CanonicalXmlEntityReference("entity", xmlDocument, true);
             using SHA256 hashAlgorithm = SHA256.Create();
             var anc = new AncestralNamespaceContextManager();
 

--- a/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/CanonicalXmlEntityReferenceTests.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
 using Xunit;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -6,8 +6,9 @@
 // Author:
 //  Atsushi Enomoto  <atsushi@ximian.com>
 //
-// Copyright (C) 2006 Novell, Inc (http://www.novell.com)using System.Collections;
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
 
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -1,4 +1,13 @@
-using System.Collections;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// EncryptedXmlTest.cs
+//
+// Author:
+//  Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)using System.Collections;
+
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptionMethodTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptionMethodTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Security.Cryptography.Xml;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    public class EncryptionMethodTest
+    {
+        [Fact]
+        public void GetXml_ReturnsExpectedXml()
+        {
+            var encryptionMethod = new EncryptionMethod("http://www.w3.org/2001/04/xmlenc#aes256-cbc");
+            var xmlElement = encryptionMethod.GetXml();
+            Assert.Equal("<EncryptionMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#aes256-cbc\" />", xmlElement.OuterXml);
+        }
+
+        [Fact]
+        public void LoadXml_ValidXml_Success()
+        {
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<EncryptionMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#aes256-cbc\" />");
+            var encryptionMethod = new EncryptionMethod();
+            encryptionMethod.LoadXml(xmlDocument.DocumentElement);
+            Assert.Equal("http://www.w3.org/2001/04/xmlenc#aes256-cbc", encryptionMethod.KeyAlgorithm);
+        }
+
+        [Fact]
+        public void LoadXml_InvalidXml_ThrowsException()
+        {
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<InvalidXml></InvalidXml>");
+            var encryptionMethod = new EncryptionMethod();
+            Assert.Throws<XmlException>(() => encryptionMethod.LoadXml(xmlDocument.DocumentElement));
+        }
+
+        [Fact]
+        public void KeyAlgorithm_SetGet_ReturnsExpected()
+        {
+            var encryptionMethod = new EncryptionMethod();
+            encryptionMethod.KeyAlgorithm = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+            Assert.Equal("http://www.w3.org/2001/04/xmlenc#aes256-cbc", encryptionMethod.KeyAlgorithm);
+        }
+
+        [Fact]
+        public void KeySize_SetGet_ReturnsExpected()
+        {
+            var encryptionMethod = new EncryptionMethod();
+            encryptionMethod.KeySize = 256;
+            Assert.Equal(256, encryptionMethod.KeySize);
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptionMethodTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptionMethodTest.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void GetXml_ReturnsExpectedXml()
         {
-            var encryptionMethod = new EncryptionMethod("http://www.w3.org/2001/04/xmlenc#aes256-cbc");
+            EncryptionMethod encryptionMethod = new EncryptionMethod("http://www.w3.org/2001/04/xmlenc#aes256-cbc");
             var xmlElement = encryptionMethod.GetXml();
             Assert.Equal("<EncryptionMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#aes256-cbc\" />", xmlElement.OuterXml);
         }

--- a/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoClauseTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoClauseTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    public class KeyInfoClauseTests
+    {
+        [Fact]
+        public void LoadXml_ValidXml_Success()
+        {
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<KeyInfo><KeyName>Test</KeyName></KeyInfo>");
+            var keyInfoClause = new TestKeyInfoClause();
+            keyInfoClause.LoadXml(xmlDocument.DocumentElement);
+            Assert.Equal("Test", keyInfoClause.KeyName);
+        }
+
+        [Fact]
+        public void LoadXml_InvalidXml_ThrowsException()
+        {
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<InvalidXml></InvalidXml>");
+            var keyInfoClause = new TestKeyInfoClause();
+            Assert.Throws<XmlException>(() => keyInfoClause.LoadXml(xmlDocument.DocumentElement));
+        }
+
+        [Fact]
+        public void GetXml_ReturnsExpectedXml()
+        {
+            var keyInfoClause = new TestKeyInfoClause { KeyName = "Test" };
+            var xmlElement = keyInfoClause.GetXml();
+            Assert.Equal("<KeyInfo><KeyName>Test</KeyName></KeyInfo>", xmlElement.OuterXml);
+        }
+
+        private class TestKeyInfoClause : KeyInfoClause
+        {
+            public string KeyName { get; set; }
+
+            public override XmlElement GetXml()
+            {
+                var xmlDocument = new XmlDocument();
+                var keyInfoElement = xmlDocument.CreateElement("KeyInfo");
+                var keyNameElement = xmlDocument.CreateElement("KeyName");
+                keyNameElement.InnerText = KeyName;
+                keyInfoElement.AppendChild(keyNameElement);
+                return keyInfoElement;
+            }
+
+            public override void LoadXml(XmlElement element)
+            {
+                if (element.Name != "KeyInfo")
+                {
+                    throw new XmlException("Invalid XML element");
+                }
+
+                var keyNameElement = element["KeyName"];
+                if (keyNameElement == null)
+                {
+                    throw new XmlException("Missing KeyName element");
+                }
+
+                KeyName = keyNameElement.InnerText;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoClauseTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoClauseTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Xml;
 using Xunit;
 
@@ -9,9 +8,9 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void LoadXml_WithValidKeyNameXml_SetsKeyNameValue()
         {
-            XmlDocument xmlDocument = new XmlDocument();
+            var xmlDocument = new XmlDocument();
             xmlDocument.LoadXml("<KeyInfo><KeyName>MyKey</KeyName></KeyInfo>");
-            KeyInfoName keyInfoName = new KeyInfoName();
+            var keyInfoName = new KeyInfoName();
             keyInfoName.LoadXml(xmlDocument.DocumentElement);
 
             Assert.Equal("MyKey", keyInfoName.Value);
@@ -30,7 +29,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void GetXml_ReturnsExpectedXml()
         {
             var keyInfoClause = new TestKeyInfoClause { KeyName = "Test" };
-            var xmlElement = keyInfoClause.GetXml();
+            XmlElement xmlElement = keyInfoClause.GetXml();
             Assert.Equal("<KeyInfo><KeyName>Test</KeyName></KeyInfo>", xmlElement.OuterXml);
         }
 
@@ -41,8 +40,8 @@ namespace System.Security.Cryptography.Xml.Tests
             public override XmlElement GetXml()
             {
                 var xmlDocument = new XmlDocument();
-                var keyInfoElement = xmlDocument.CreateElement("KeyInfo");
-                var keyNameElement = xmlDocument.CreateElement("KeyName");
+                XmlElement keyInfoElement = xmlDocument.CreateElement("KeyInfo");
+                XmlElement keyNameElement = xmlDocument.CreateElement("KeyName");
                 keyNameElement.InnerText = KeyName;
                 keyInfoElement.AppendChild(keyNameElement);
                 return keyInfoElement;
@@ -55,7 +54,7 @@ namespace System.Security.Cryptography.Xml.Tests
                     throw new XmlException("Invalid XML element");
                 }
 
-                var keyNameElement = element["KeyName"];
+                XmlElement keyNameElement = element["KeyName"];
                 if (keyNameElement == null)
                 {
                     throw new XmlException("Missing KeyName element");

--- a/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoClauseTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoClauseTests.cs
@@ -7,13 +7,14 @@ namespace System.Security.Cryptography.Xml.Tests
     public class KeyInfoClauseTests
     {
         [Fact]
-        public void LoadXml_ValidXml_Success()
+        public void LoadXml_WithValidKeyNameXml_SetsKeyNameValue()
         {
-            var xmlDocument = new XmlDocument();
-            xmlDocument.LoadXml("<KeyInfo><KeyName>Test</KeyName></KeyInfo>");
-            var keyInfoClause = new TestKeyInfoClause();
-            keyInfoClause.LoadXml(xmlDocument.DocumentElement);
-            Assert.Equal("Test", keyInfoClause.KeyName);
+            XmlDocument xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<KeyInfo><KeyName>MyKey</KeyName></KeyInfo>");
+            KeyInfoName keyInfoName = new KeyInfoName();
+            keyInfoName.LoadXml(xmlDocument.DocumentElement);
+
+            Assert.Equal("MyKey", keyInfoName.Value);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SymmetricKeyWrapTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SymmetricKeyWrapTest.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    public class SymmetricKeyWrapTest
+    {
+        [Fact]
+        public void WrapKey_AES128()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 128;
+                byte[] keyToWrap = new byte[16];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(aes, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(aes, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_AES192()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 192;
+                byte[] keyToWrap = new byte[24];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(aes, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(aes, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_AES256()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 256;
+                byte[] keyToWrap = new byte[32];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(aes, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(aes, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_TripleDES()
+        {
+            using (TripleDES tripleDES = TripleDES.Create())
+            {
+                byte[] keyToWrap = new byte[24];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(tripleDES, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(tripleDES, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_InvalidAlgorithm()
+        {
+            using (SymmetricAlgorithm algorithm = new InvalidSymmetricAlgorithm())
+            {
+                byte[] keyToWrap = new byte[16];
+                Assert.Throws<CryptographicException>(() => SymmetricKeyWrap.WrapKey(algorithm, keyToWrap));
+            }
+        }
+
+        private class InvalidSymmetricAlgorithm : SymmetricAlgorithm
+        {
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -10,6 +10,7 @@
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CngKeyWrapper.cs"
              Link="TestCommon\System\Security\Cryptography\CngKeyWrapper.cs" />
     <Compile Include="AssertCrypto.cs" />
+    <Compile Include="CanonicalXmlEntityReferenceTests.cs" />
     <Compile Include="CipherDataTests.cs" />
     <Compile Include="DataObjectTest.cs" />
     <Compile Include="DataObjectTests.cs" />
@@ -22,6 +23,7 @@
     <Compile Include="EncryptionPropertyCollectionTest.cs" />
     <Compile Include="EncryptionPropertyTest.cs" />
     <Compile Include="SignedXml_Helpers.cs" />
+    <Compile Include="KeyInfoClauseTests.cs" />
     <Compile Include="KeyInfoNameTest.cs" />
     <Compile Include="KeyInfoNodeTest.cs" />
     <Compile Include="KeyInfoRetrievalMethodTest.cs" />
@@ -55,8 +57,6 @@
     <Compile Include="XmlDsigXsltTransformTest.cs" />
     <Compile Include="XmlLicenseEncryptedRef.cs" />
     <Compile Include="XmlLicenseTransformTest.cs" />
-    <Compile Include="CanonicalXmlEntityReferenceTests.cs" />
-    <Compile Include="KeyInfoClauseTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="KeyInfo_ArbitraryElements.cs" />

--- a/src/libraries/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -55,6 +55,8 @@
     <Compile Include="XmlDsigXsltTransformTest.cs" />
     <Compile Include="XmlLicenseEncryptedRef.cs" />
     <Compile Include="XmlLicenseTransformTest.cs" />
+    <Compile Include="CanonicalXmlEntityReferenceTests.cs" />
+    <Compile Include="KeyInfoClauseTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="KeyInfo_ArbitraryElements.cs" />


### PR DESCRIPTION
Fixes #20508

Add tests for `KeyInfoClause` and `CanonicalXmlEntityReference` to improve code coverage.

* **KeyInfoClauseTests.cs**
  - Add a new test class `KeyInfoClauseTests`.
  - Add a test method `LoadXml_ValidXml_Success` to test loading valid XML.
  - Add a test method `LoadXml_InvalidXml_ThrowsException` to test loading invalid XML.
  - Add a test method `GetXml_ReturnsExpectedXml` to test getting XML from `KeyInfoClause`.

* **CanonicalXmlEntityReferenceTests.cs**
  - Add a new test class `CanonicalXmlEntityReferenceTests`.
  - Add a test method `Write_WritesExpectedOutput` to test writing canonical XML.
  - Add a test method `WriteHash_WritesExpectedHash` to test writing hash of canonical XML.
  - Add a test method `IsInNodeSet_GetSet_ReturnsExpected` to test getting and setting `IsInNodeSet`.

