### PR TITLE
Move TLS tests to unsupported list

### DIFF
--- a/src/tests/JIT/Directed/tls/mutualrecurthd-tls.ilproj
+++ b/src/tests/JIT/Directed/tls/mutualrecurthd-tls.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- Test relies on tls support see #2441 -->
-    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Directed/tls/test-tls.ilproj
+++ b/src/tests/JIT/Directed/tls/test-tls.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- Test relies on tls support see #2441 -->
-    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-EJIT/v1-m10/b07847/b07847.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-EJIT/v1-m10/b07847/b07847.ilproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- Test relies on tls support see #2441 -->
-    <DisableProjectBuild>true</DisableProjectBuild>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BadImageFormatExceptionTest.cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b03689/b03689.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b03689/b03689.ilproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- Test relies on tls support see #2441 -->
-    <DisableProjectBuild>true</DisableProjectBuild>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BadImageFormatExceptionTest.cs" />
   </ItemGroup>
 </Project>

--- a/tests/testsUnsupportedOutsideWindows.txt
+++ b/tests/testsUnsupportedOutsideWindows.txt
@@ -1,3 +1,0 @@
-src/tests/JIT/Directed/tls/mutualrecurthd-tls.ilproj
-src/tests/JIT/Directed/tls/test-tls.ilproj
-src/tests/JIT/Regression/CLR-x86-EJIT/v1-m10/b07847/b07847.ilproj

--- a/tests/testsUnsupportedOutsideWindows.txt
+++ b/tests/testsUnsupportedOutsideWindows.txt
@@ -1,0 +1,3 @@
+src/tests/JIT/Directed/tls/mutualrecurthd-tls.ilproj
+src/tests/JIT/Directed/tls/test-tls.ilproj
+src/tests/JIT/Regression/CLR-x86-EJIT/v1-m10/b07847/b07847.ilproj


### PR DESCRIPTION
Fixes #4852

Move tests that fail with `System.BadImageFormatException` to `tests/testsUnsupportedOutsideWindows.txt`.

* Add `src/tests/JIT/Directed/tls/mutualrecurthd-tls.ilproj` to the list.
* Add `src/tests/JIT/Directed/tls/test-tls.ilproj` to the list.
* Add `src/tests/JIT/Regression/CLR-x86-EJIT/v1-m10/b07847/b07847.ilproj` to the list.
