### PR TITLE
Fix sbyte overflow in TypeName parsing

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParser.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParser.cs
@@ -194,7 +194,7 @@ namespace System.Reflection.Metadata
             {
                 while (TryParseNextDecorator(ref capturedBeforeProcessing, out int parsedModifier))
                 {
-                    result = new(fullName: null, assemblyName, elementOrGenericType: result, rankOrModifier: (sbyte)parsedModifier);
+                    result = new(fullName: null, assemblyName, elementOrGenericType: result, rankOrModifier: parsedModifier);
                 }
             }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParserHelpers.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParserHelpers.cs
@@ -11,9 +11,9 @@ namespace System.Reflection.Metadata
 {
     internal static class TypeNameParserHelpers
     {
-        internal const sbyte SZArray = -1;
-        internal const sbyte Pointer = -2;
-        internal const sbyte ByRef = -3;
+        internal const int SZArray = -1;
+        internal const int Pointer = -2;
+        internal const int ByRef = -3;
         private const char EscapeCharacter = '\\';
 #if NET8_0_OR_GREATER
         private static readonly SearchValues<char> s_endOfFullTypeNameDelimitersSearchValues = SearchValues.Create("[]&*,+\\");

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeNameTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeNameTests.cs
@@ -705,6 +705,18 @@ namespace System.Reflection.Metadata.Tests
             Assert.Equal("bool", parsed.GetGenericArguments()[1].Name);
         }
 
+        [Fact]
+        public void ArrayRank_SByteOverflow()
+        {
+            const string Input = "WeDontEnforceAnyMaxArrayRank[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]";
+
+            TypeName typeName = TypeName.Parse(Input.AsSpan());
+
+            Assert.Equal(Input, typeName.FullName);
+            Assert.True(typeName.IsArray);
+            Assert.Equal(128, typeName.GetArrayRank());
+        }
+
         [Theory]
         [InlineData(typeof(int))]
         [InlineData(typeof(int?))]


### PR DESCRIPTION
discovered by the Fuzzer in https://github.com/dotnet/runtime/pull/107206#issuecomment-2322633811