### PR TITLE
Fix string case-insensitive comparisons in Globalization invariant mode

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/InvariantModeCasing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/InvariantModeCasing.cs
@@ -215,7 +215,7 @@ namespace System.Globalization
                     continue;
                 }
 
-                return (int)codePointA - (int)codePointB;
+                return (int)aUpper - (int)bUpper;
             }
 
             return lengthA - lengthB;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/Invariant/InvariantMode.cs
@@ -1257,5 +1257,18 @@ namespace System.Globalization.Tests
 
             return memoryStream.ToArray();
         }
+
+        [Fact]
+        public void TestChainStringComparisons()
+        {
+            var s1 = "бал";
+            var s2 = "Бан";
+            var s3 = "Д";
+
+            // If s1 < s2 and s2 < s3, then s1 < s3
+            Assert.True(string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase) < 0);
+            Assert.True(string.Compare(s2, s3, StringComparison.OrdinalIgnoreCase) < 0);
+            Assert.True(string.Compare(s1, s3, StringComparison.OrdinalIgnoreCase) < 0);
+        }
     }
 }


### PR DESCRIPTION
This issue addressing https://github.com/dotnet/runtime/issues/106828.

In Globalization invariant mode when comparing string with case insensitive option, should satisfy the rule: if s1 < s2 and s2 < s3, then s1 < s3. The change here is fixing the string comparison to ensure this rule. 