### PR TITLE
[RISC-V] Fix test build failure

### DIFF
--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -42,7 +42,7 @@
         `build -c debug -rc checked`, the corresponding test command is `src/tests/build -checked -p:LibrariesConfiguration=debug`,
         instead of `-debug -p:RuntimeConfiguration=checked`. That forces us to either pass the
         `HostConfiguration=debug` explicitly or fix this disparity; both of which will break the dev workflow.
-        
+
         As a workaround, we will first check if the directory pointed by `HostConfiguration` exists, then check
         `LibrariesConfiguration`.
     -->

--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.csproj
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PublishAot>true</PublishAot>
+    <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
     <LinkerFlavor Condition="'$(CrossBuild)' == 'true' and '$(TargetsLinux)' == 'true'">lld</LinkerFlavor>
     <SysRoot Condition="'$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>


### PR DESCRIPTION
Fix NETSDK1203: Ahead-of-time compilation is not supported for the target runtime identifier 'linux-riscv64'. [/runtime/src/tests/Common/XUnitLogChecker/XUnitLogChecker.csproj]

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung