### PR TITLE
Empty slice fix

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
@@ -527,8 +526,7 @@ namespace System.Numerics.Tensors
                 if (Rank > TensorShape.MaxInlineRank)
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                    curIndexes = curIndexesArray;
-                    curIndexes = curIndexes.Slice(0, Rank);
+                    curIndexes = curIndexesArray.AsSpan(0, Rank);
                 }
                 else
                 {
@@ -575,8 +573,7 @@ namespace System.Numerics.Tensors
                 if (Rank > TensorShape.MaxInlineRank)
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                    curIndexes = curIndexesArray;
-                    curIndexes = curIndexes.Slice(0, Rank);
+                    curIndexes = curIndexesArray.AsSpan(0, Rank);
                 }
                 else
                 {
@@ -663,14 +660,10 @@ namespace System.Numerics.Tensors
             if (Rank > TensorShape.MaxInlineRank)
             {
                 lengthsArray = ArrayPool<nint>.Shared.Rent(Rank);
-                lengths = lengthsArray;
-                lengths = lengths.Slice(0, Rank);
-                lengthsArray = null;
+                lengths = lengthsArray.AsSpan(0, Rank);
 
                 offsetsArray = ArrayPool<nint>.Shared.Rent(Rank);
-                offsets = offsetsArray;
-                offsets = offsets.Slice(0, Rank);
-                offsetsArray = null;
+                offsets = offsetsArray.AsSpan(0, Rank);
             }
             else
             {
@@ -687,21 +680,21 @@ namespace System.Numerics.Tensors
             }
 
             // When we have an empty Tensor and someone wants to slice all of it, we should return an empty Tensor.
-            if (TensorSpanHelpers.CalculateTotalLength(Lengths) == 0)
+            if (FlattenedLength == 0)
             {
                 for (int i = 0; i < offsets.Length; i++)
                 {
-                    if (offsets[i] != 0 || lengths[i] != 0)
+                    if (lengths[i] > Lengths[i])
                         ThrowHelper.ThrowIndexOutOfRangeException();
                 }
-                toReturn = new ReadOnlyTensorSpan<T>(ref _reference, lengths, _shape.Strides, _shape._memoryLength);
+                toReturn = new TensorSpan<T>(ref _reference, lengths, _shape.Strides, _shape._memoryLength); ;
             }
             else
             {
                 nint index = 0;
                 for (int i = 0; i < offsets.Length; i++)
                 {
-                    if (offsets[i] < 0 || offsets[i] >= Lengths[i])
+                    if ((nuint)offsets[i] >= (nuint)Lengths[i])
                         ThrowHelper.ThrowIndexOutOfRangeException();
 
                     index += Strides[i] * (offsets[i]);
@@ -735,8 +728,7 @@ namespace System.Numerics.Tensors
                 if (Rank > TensorShape.MaxInlineRank)
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                    curIndexes = curIndexesArray;
-                    curIndexes = curIndexes.Slice(0, Rank);
+                    curIndexes = curIndexesArray.AsSpan(0, Rank);
                 }
                 else
                 {
@@ -776,8 +768,7 @@ namespace System.Numerics.Tensors
             if (Rank > TensorShape.MaxInlineRank)
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                curIndexes = curIndexesArray;
-                curIndexes = curIndexes.Slice(0, Rank);
+                curIndexes = curIndexesArray.AsSpan(0, Rank);
             }
             else
             {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -679,32 +679,27 @@ namespace System.Numerics.Tensors
                 (offsets[i], lengths[i]) = ranges[i].GetOffsetAndLength(Lengths[i]);
             }
 
-            // When we have an empty Tensor and someone wants to slice all of it, we should return an empty Tensor.
-            if (FlattenedLength == 0)
+            // FlattenedLength is computed everytime so using a local to cache the value.
+            nint flattenedLength = FlattenedLength;
+            nint index = 0;
+            for (int i = 0; i < offsets.Length; i++)
             {
-                for (int i = 0; i < offsets.Length; i++)
-                {
-                    if (lengths[i] > Lengths[i])
-                        ThrowHelper.ThrowIndexOutOfRangeException();
-                }
-                toReturn = new TensorSpan<T>(ref _reference, lengths, _shape.Strides, _shape._memoryLength); ;
-            }
-            else
-            {
-                nint index = 0;
-                for (int i = 0; i < offsets.Length; i++)
-                {
-                    if ((nuint)offsets[i] >= (nuint)Lengths[i])
-                        ThrowHelper.ThrowIndexOutOfRangeException();
-
-                    index += Strides[i] * (offsets[i]);
-                }
-
-                if (index >= _shape._memoryLength || index < 0)
+                // When flattenedLength is 0, at least 1 of the Lengths will be 0 and so will the offset which would trigger this exception even though its valid.
+                // To counteract this we specifically check for the case where the offset is 0 and skip the check.
+                if ((nuint)offsets[i] != 0 && (nuint)offsets[i] >= (nuint)Lengths[i])
                     ThrowHelper.ThrowIndexOutOfRangeException();
 
-                toReturn = new ReadOnlyTensorSpan<T>(ref Unsafe.Add(ref _reference, index), lengths, _shape.Strides, _shape._memoryLength - index);
+                if (lengths[i] > Lengths[i])
+                    ThrowHelper.ThrowIndexOutOfRangeException();
+
+                if (flattenedLength != 0)
+                    index += Strides[i] * (offsets[i]);
             }
+
+            if ((index >= _shape._memoryLength || index < 0) && flattenedLength != 0)
+                ThrowHelper.ThrowIndexOutOfRangeException();
+
+            toReturn = new ReadOnlyTensorSpan<T>(ref Unsafe.Add(ref _reference, index), lengths, _shape.Strides, _shape._memoryLength - index);
 
             if (offsetsArray != null)
                 ArrayPool<nint>.Shared.Return(offsetsArray);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -655,17 +655,30 @@ namespace System.Numerics.Tensors
             if (ranges.Length != Lengths.Length)
                 throw new ArgumentOutOfRangeException(nameof(ranges), "Number of dimensions to slice does not equal the number of dimensions in the span");
 
+            ReadOnlyTensorSpan<T> toReturn;
             scoped Span<nint> lengths;
             scoped Span<nint> offsets;
+            nint[]? lengthsArray;
+            nint[]? offsetsArray;
             if (Rank > TensorShape.MaxInlineRank)
             {
-                lengths = stackalloc nint[Rank];
-                offsets = stackalloc nint[Rank];
+                lengthsArray = ArrayPool<nint>.Shared.Rent(Rank);
+                lengths = lengthsArray;
+                lengths = lengths.Slice(0, Rank);
+                lengthsArray = null;
+
+                offsetsArray = ArrayPool<nint>.Shared.Rent(Rank);
+                offsets = offsetsArray;
+                offsets = offsets.Slice(0, Rank);
+                offsetsArray = null;
             }
             else
             {
-                lengths = new nint[Rank];
-                offsets = new nint[Rank];
+                lengths = stackalloc nint[Rank];
+                offsets = stackalloc nint[Rank];
+
+                lengthsArray = null;
+                offsetsArray = null;
             }
 
             for (int i = 0; i < ranges.Length; i++)
@@ -673,16 +686,39 @@ namespace System.Numerics.Tensors
                 (offsets[i], lengths[i]) = ranges[i].GetOffsetAndLength(Lengths[i]);
             }
 
-            nint index = 0;
-            for (int i = 0; i < offsets.Length; i++)
+            // When we have an empty Tensor and someone wants to slice all of it, we should return an empty Tensor.
+            if (TensorSpanHelpers.CalculateTotalLength(Lengths) == 0)
             {
-                index += Strides[i] * (offsets[i]);
+                for (int i = 0; i < offsets.Length; i++)
+                {
+                    if (offsets[i] != 0 || lengths[i] != 0)
+                        ThrowHelper.ThrowIndexOutOfRangeException();
+                }
+                toReturn = new ReadOnlyTensorSpan<T>(ref _reference, lengths, _shape.Strides, _shape._memoryLength);
+            }
+            else
+            {
+                nint index = 0;
+                for (int i = 0; i < offsets.Length; i++)
+                {
+                    if (offsets[i] < 0 || offsets[i] >= Lengths[i])
+                        ThrowHelper.ThrowIndexOutOfRangeException();
+
+                    index += Strides[i] * (offsets[i]);
+                }
+
+                if (index >= _shape._memoryLength || index < 0)
+                    ThrowHelper.ThrowIndexOutOfRangeException();
+
+                toReturn = new ReadOnlyTensorSpan<T>(ref Unsafe.Add(ref _reference, index), lengths, _shape.Strides, _shape._memoryLength - index);
             }
 
-            if (index >= _shape._memoryLength || index < 0)
-                ThrowHelper.ThrowIndexOutOfRangeException();
+            if (offsetsArray != null)
+                ArrayPool<nint>.Shared.Return(offsetsArray);
+            if (lengthsArray != null)
+                ArrayPool<nint>.Shared.Return(lengthsArray);
 
-            return new ReadOnlyTensorSpan<T>(ref Unsafe.Add(ref _reference, index), lengths, _shape.Strides, _shape._memoryLength - index);
+            return toReturn;
         }
 
         /// <summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -527,6 +527,7 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
+                    curIndexes.Clear();
                 }
                 else
                 {
@@ -574,6 +575,7 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
+                    curIndexes.Clear();
                 }
                 else
                 {
@@ -661,9 +663,11 @@ namespace System.Numerics.Tensors
             {
                 lengthsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 lengths = lengthsArray.AsSpan(0, Rank);
+                lengths.Clear();
 
                 offsetsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 offsets = offsetsArray.AsSpan(0, Rank);
+                offsets.Clear();
             }
             else
             {
@@ -724,6 +728,7 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
+                    curIndexes.Clear();
                 }
                 else
                 {
@@ -764,6 +769,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
+                curIndexes.Clear();
             }
             else
             {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -527,13 +527,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
-                    curIndexes.Clear();
                 }
                 else
                 {
                     curIndexesArray = null;
                     curIndexes = stackalloc nint[Rank];
                 }
+                curIndexes.Clear();
 
                 nint copiedValues = 0;
                 TensorSpan<T> slice = destination.Slice(_shape.Lengths);
@@ -575,13 +575,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
-                    curIndexes.Clear();
                 }
                 else
                 {
                     curIndexesArray = null;
                     curIndexes = stackalloc nint[Rank];
                 }
+                curIndexes.Clear();
 
                 nint copiedValues = 0;
                 TensorSpan<T> slice = destination.Slice(_shape.Lengths);
@@ -663,11 +663,9 @@ namespace System.Numerics.Tensors
             {
                 lengthsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 lengths = lengthsArray.AsSpan(0, Rank);
-                lengths.Clear();
 
                 offsetsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 offsets = offsetsArray.AsSpan(0, Rank);
-                offsets.Clear();
             }
             else
             {
@@ -677,6 +675,8 @@ namespace System.Numerics.Tensors
                 lengthsArray = null;
                 offsetsArray = null;
             }
+            lengths.Clear();
+            offsets.Clear();
 
             for (int i = 0; i < ranges.Length; i++)
             {
@@ -686,18 +686,13 @@ namespace System.Numerics.Tensors
             // FlattenedLength is computed everytime so using a local to cache the value.
             nint flattenedLength = FlattenedLength;
             nint index = 0;
-            for (int i = 0; i < offsets.Length; i++)
+
+            if (flattenedLength != 0)
             {
-                // When flattenedLength is 0, at least 1 of the Lengths will be 0 and so will the offset which would trigger this exception even though its valid.
-                // To counteract this we specifically check for the case where the offset is 0 and skip the check.
-                if ((nuint)offsets[i] != 0 && (nuint)offsets[i] >= (nuint)Lengths[i])
-                    ThrowHelper.ThrowIndexOutOfRangeException();
-
-                if (lengths[i] > Lengths[i])
-                    ThrowHelper.ThrowIndexOutOfRangeException();
-
-                if (flattenedLength != 0)
+                for (int i = 0; i < offsets.Length; i++)
+                {
                     index += Strides[i] * (offsets[i]);
+                }
             }
 
             if ((index >= _shape._memoryLength || index < 0) && flattenedLength != 0)
@@ -728,13 +723,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
-                    curIndexes.Clear();
                 }
                 else
                 {
                     curIndexesArray = null;
                     curIndexes = stackalloc nint[Rank];
                 }
+                curIndexes.Clear();
 
                 nint copiedValues = 0;
                 while (copiedValues < _shape.FlattenedLength)
@@ -769,13 +764,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
-                curIndexes.Clear();
             }
             else
             {
                 curIndexesArray = null;
                 curIndexes = stackalloc nint[Rank];
             }
+            curIndexes.Clear();
 
             nint copiedValues = 0;
             while (copiedValues < _shape.FlattenedLength)

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -398,8 +398,7 @@ namespace System.Numerics.Tensors
             if (tensors[0].Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(tensors[0].Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, tensors[0].Rank);
+                curIndex = curIndexArray.AsSpan(0, tensors[0].Rank);
             }
             else
             {
@@ -503,8 +502,7 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, right.Rank);
+                curIndex = curIndexArray.AsSpan(0, right.Rank);
             }
             else
             {
@@ -559,8 +557,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
             }
             else
             {
@@ -604,8 +601,7 @@ namespace System.Numerics.Tensors
             if (broadcastedLeft.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
             }
             else
             {
@@ -643,8 +639,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
             }
             else
             {
@@ -688,9 +683,7 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -727,9 +720,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -874,9 +865,7 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, right.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -934,9 +923,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -994,9 +981,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1083,9 +1068,7 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, right.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1143,9 +1126,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1203,9 +1184,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1247,9 +1226,7 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1286,9 +1263,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1325,9 +1300,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1370,9 +1343,7 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1409,9 +1380,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1448,9 +1417,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1494,9 +1461,7 @@ namespace System.Numerics.Tensors
             if (broadcastedLeft.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1533,9 +1498,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1572,9 +1535,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1618,9 +1579,7 @@ namespace System.Numerics.Tensors
             if (broadcastedLeft.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1657,9 +1616,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1696,9 +1653,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1786,9 +1741,7 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, right.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1846,9 +1799,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1906,9 +1857,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -1995,9 +1944,7 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, right.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2055,9 +2002,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2115,9 +2060,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2160,9 +2103,7 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2199,9 +2140,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2238,9 +2177,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2284,9 +2221,7 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2323,9 +2258,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2362,9 +2295,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2407,9 +2338,7 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2446,9 +2375,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2485,9 +2412,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2530,9 +2455,7 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, broadcastedRight.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2569,9 +2492,7 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, x.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -2608,9 +2529,7 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray;
-                curIndex = curIndex.Slice(0, y.Rank);
-            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
             else
             {
                 curIndexArray = null;
@@ -6746,9 +6665,7 @@ namespace System.Numerics.Tensors
                 if (input.Lengths.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
-                    curIndex = curIndexArray;
-                    curIndex = curIndex.Slice(0, input.Rank);
-                }
+                    curIndex = curIndexArray.AsSpan(0, input.Rank);                }
                 else
                 {
                     curIndexArray = null;
@@ -6798,9 +6715,7 @@ namespace System.Numerics.Tensors
                 if (input.Lengths.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
-                    curIndex = curIndexArray;
-                    curIndex = curIndex.Slice(0, input.Rank);
-                }
+                    curIndex = curIndexArray.AsSpan(0, input.Rank);                }
                 else
                 {
                     curIndexArray = null;
@@ -6850,9 +6765,7 @@ namespace System.Numerics.Tensors
                 if (input.Lengths.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
-                    curIndex = curIndexArray;
-                    curIndex = curIndex.Slice(0, input.Rank);
-                }
+                    curIndex = curIndexArray.AsSpan(0, input.Rank);                }
                 else
                 {
                     curIndexArray = null;
@@ -6914,9 +6827,7 @@ namespace System.Numerics.Tensors
                 if (newSize.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(newSize.Length);
-                    curIndex = curIndexArray;
-                    curIndex = curIndex.Slice(0, newSize.Length);
-                }
+                    curIndex = curIndexArray.AsSpan(0, newSize.Length);                }
                 else
                 {
                     curIndexArray = null;

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -399,13 +399,14 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(tensors[0].Rank);
                 curIndex = curIndexArray.AsSpan(0, tensors[0].Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[tensors[0].Rank];
             }
+            curIndex.Clear();
+
             nint srcIndex;
             nint copyLength;
 
@@ -504,13 +505,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
                 curIndex = curIndexArray.AsSpan(0, right.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[right.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < left.FlattenedLength; i++)
             {
@@ -560,13 +561,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -605,13 +606,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -644,13 +645,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -689,13 +690,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Lengths.Length];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -728,13 +729,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -875,13 +876,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
                 curIndex = curIndexArray.AsSpan(0, right.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[right.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < left.FlattenedLength; i++)
             {
@@ -935,13 +936,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -995,13 +996,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -1084,13 +1085,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
                 curIndex = curIndexArray.AsSpan(0, right.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[right.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < left.FlattenedLength; i++)
             {
@@ -1144,13 +1145,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -1204,13 +1205,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -1248,13 +1249,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Lengths.Length];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -1287,13 +1288,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -1326,13 +1327,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -1371,13 +1372,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Lengths.Length];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -1410,13 +1411,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -1449,13 +1450,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -1495,13 +1496,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -1534,13 +1535,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -1573,13 +1574,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -1619,13 +1620,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -1658,13 +1659,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -1697,13 +1698,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -1787,13 +1788,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
                 curIndex = curIndexArray.AsSpan(0, right.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[right.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < left.FlattenedLength; i++)
             {
@@ -1847,13 +1848,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -1907,13 +1908,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -1996,13 +1997,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
                 curIndex = curIndexArray.AsSpan(0, right.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[right.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < left.FlattenedLength; i++)
             {
@@ -2056,13 +2057,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -2116,13 +2117,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -2161,13 +2162,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Lengths.Length];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -2200,13 +2201,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -2239,13 +2240,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -2285,13 +2286,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Lengths.Length];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -2324,13 +2325,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -2363,13 +2364,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i <= y.FlattenedLength; i++)
             {
@@ -2408,13 +2409,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Lengths.Length];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -2447,13 +2448,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -2486,13 +2487,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -2531,13 +2532,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[broadcastedRight.Lengths.Length];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < broadcastedLeft.FlattenedLength; i++)
             {
@@ -2570,13 +2571,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[x.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < x.FlattenedLength; i++)
             {
@@ -2609,13 +2610,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
                 curIndex = curIndexArray.AsSpan(0, y.Rank);
-                curIndex.Clear();
             }
             else
             {
                 curIndexArray = null;
                 curIndex = stackalloc nint[y.Rank];
             }
+            curIndex.Clear();
 
             for (int i = 0; i < y.FlattenedLength; i++)
             {
@@ -6757,13 +6758,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
                     curIndex = curIndexArray.AsSpan(0, input.Rank);
-                    curIndex.Clear();
                 }
                 else
                 {
                     curIndexArray = null;
                     curIndex = stackalloc nint[input.Lengths.Length];
                 }
+                curIndex.Clear();
 
                 int copiedValues = 0;
                 nint rowLength = input.Lengths[^1];
@@ -6809,13 +6810,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
                     curIndex = curIndexArray.AsSpan(0, input.Rank);
-                    curIndex.Clear();
                 }
                 else
                 {
                     curIndexArray = null;
                     curIndex = stackalloc nint[input.Lengths.Length];
                 }
+                curIndex.Clear();
 
                 int copiedValues = 0;
                 nint rowLength = input.Lengths[^1];
@@ -6861,13 +6862,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
                     curIndex = curIndexArray.AsSpan(0, input.Rank);
-                    curIndex.Clear();
                 }
                 else
                 {
                     curIndexArray = null;
                     curIndex = stackalloc nint[input.Lengths.Length];
                 }
+                curIndex.Clear();
 
                 int copiedValues = 0;
                 nint rowLength = input.Lengths[^1];
@@ -6925,13 +6926,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(newSize.Length);
                     curIndex = curIndexArray.AsSpan(0, newSize.Length);
-                    curIndex.Clear();
                 }
                 else
                 {
                     curIndexArray = null;
                     curIndex = stackalloc nint[newSize.Length];
                 }
+                curIndex.Clear();
 
                 int outputOffset = 0;
                 // neither row contiguous

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -399,6 +399,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(tensors[0].Rank);
                 curIndex = curIndexArray.AsSpan(0, tensors[0].Rank);
+                curIndex.Clear();
             }
             else
             {
@@ -503,6 +504,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
                 curIndex = curIndexArray.AsSpan(0, right.Rank);
+                curIndex.Clear();
             }
             else
             {
@@ -558,6 +560,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
             }
             else
             {
@@ -602,6 +605,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
                 curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
             }
             else
             {
@@ -640,6 +644,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
                 curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
             }
             else
             {
@@ -683,7 +688,9 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -720,7 +727,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -865,7 +874,9 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -923,7 +934,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -981,7 +994,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1068,7 +1083,9 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1126,7 +1143,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1184,7 +1203,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1226,7 +1247,9 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1263,7 +1286,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1300,7 +1325,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1343,7 +1370,9 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1380,7 +1409,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1417,7 +1448,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1461,7 +1494,9 @@ namespace System.Numerics.Tensors
             if (broadcastedLeft.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1498,7 +1533,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1535,7 +1572,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1579,7 +1618,9 @@ namespace System.Numerics.Tensors
             if (broadcastedLeft.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Rank);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1616,7 +1657,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1653,7 +1696,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1741,7 +1786,9 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1799,7 +1846,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1857,7 +1906,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -1944,7 +1995,9 @@ namespace System.Numerics.Tensors
             if (right.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(right.Rank);
-                curIndex = curIndexArray.AsSpan(0, right.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, right.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2002,7 +2055,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2060,7 +2115,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2103,7 +2160,9 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2140,7 +2199,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2177,7 +2238,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2221,7 +2284,9 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2258,7 +2323,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2295,7 +2362,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2338,7 +2407,9 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2375,7 +2446,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2412,7 +2485,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2455,7 +2530,9 @@ namespace System.Numerics.Tensors
             if (broadcastedRight.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(broadcastedRight.Lengths.Length);
-                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, broadcastedRight.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2492,7 +2569,9 @@ namespace System.Numerics.Tensors
             if (x.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(x.Rank);
-                curIndex = curIndexArray.AsSpan(0, x.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, x.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2529,7 +2608,9 @@ namespace System.Numerics.Tensors
             if (y.Rank > TensorShape.MaxInlineRank)
             {
                 curIndexArray = ArrayPool<nint>.Shared.Rent(y.Rank);
-                curIndex = curIndexArray.AsSpan(0, y.Rank);            }
+                curIndex = curIndexArray.AsSpan(0, y.Rank);
+                curIndex.Clear();
+            }
             else
             {
                 curIndexArray = null;
@@ -2599,9 +2680,12 @@ namespace System.Numerics.Tensors
                 if (outTensor.Rank > 6)
                 {
                     indicesArray = ArrayPool<nint>.Shared.Rent(outTensor.Rank);
-                    indexes = indicesArray;
+                    indexes = indicesArray.AsSpan(0, outTensor.Rank);
+                    indexes.Clear();
+
                     permutedIndicesArray = ArrayPool<nint>.Shared.Rent(outTensor.Rank);
-                    permutedIndices = permutedIndicesArray;
+                    permutedIndices = permutedIndicesArray.AsSpan(0, outTensor.Rank);
+                    permutedIndices.Clear();
                 }
                 else
                 {
@@ -2879,9 +2963,12 @@ namespace System.Numerics.Tensors
                 if (tensor.Rank > 6)
                 {
                     oIndicesArray = ArrayPool<nint>.Shared.Rent(tensor.Rank);
-                    oIndices = oIndicesArray;
+                    oIndices = oIndicesArray.AsSpan(0, tensor.Rank);
+                    oIndices.Clear();
+
                     iIndicesArray = ArrayPool<nint>.Shared.Rent(tensor.Rank);
-                    iIndices = iIndicesArray;
+                    iIndices = iIndicesArray.AsSpan(0, tensor.Rank);
+                    iIndices.Clear();
                 }
                 else
                 {
@@ -3013,9 +3100,12 @@ namespace System.Numerics.Tensors
             if (tensor.Rank > 6)
             {
                 oIndicesArray = ArrayPool<nint>.Shared.Rent(tensor.Rank);
-                oIndices = oIndicesArray;
+                oIndices = oIndicesArray.AsSpan(0, tensor.Rank);
+                oIndices.Clear();
+
                 iIndicesArray = ArrayPool<nint>.Shared.Rent(tensor.Rank);
-                iIndices = iIndicesArray;
+                iIndices = iIndicesArray.AsSpan(0, tensor.Rank);
+                iIndices.Clear();
             }
             else
             {
@@ -3349,7 +3439,8 @@ namespace System.Numerics.Tensors
             if (tensor.Rank > 6)
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(tensor.Rank);
-                curIndexes = curIndexesArray;
+                curIndexes = curIndexesArray.AsSpan(0, tensor.Rank);
+                curIndexes.Clear();
             }
             else
             {
@@ -6665,7 +6756,9 @@ namespace System.Numerics.Tensors
                 if (input.Lengths.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
-                    curIndex = curIndexArray.AsSpan(0, input.Rank);                }
+                    curIndex = curIndexArray.AsSpan(0, input.Rank);
+                    curIndex.Clear();
+                }
                 else
                 {
                     curIndexArray = null;
@@ -6715,7 +6808,9 @@ namespace System.Numerics.Tensors
                 if (input.Lengths.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
-                    curIndex = curIndexArray.AsSpan(0, input.Rank);                }
+                    curIndex = curIndexArray.AsSpan(0, input.Rank);
+                    curIndex.Clear();
+                }
                 else
                 {
                     curIndexArray = null;
@@ -6765,7 +6860,9 @@ namespace System.Numerics.Tensors
                 if (input.Lengths.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(input.Lengths.Length);
-                    curIndex = curIndexArray.AsSpan(0, input.Rank);                }
+                    curIndex = curIndexArray.AsSpan(0, input.Rank);
+                    curIndex.Clear();
+                }
                 else
                 {
                     curIndexArray = null;
@@ -6827,7 +6924,9 @@ namespace System.Numerics.Tensors
                 if (newSize.Length > TensorShape.MaxInlineRank)
                 {
                     curIndexArray = ArrayPool<nint>.Shared.Rent(newSize.Length);
-                    curIndex = curIndexArray.AsSpan(0, newSize.Length);                }
+                    curIndex = curIndexArray.AsSpan(0, newSize.Length);
+                    curIndex.Clear();
+                }
                 else
                 {
                     curIndexArray = null;

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 using EditorBrowsableAttribute = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
@@ -510,8 +509,7 @@ namespace System.Numerics.Tensors
             if (Rank > TensorShape.MaxInlineRank)
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                curIndexes = curIndexesArray;
-                curIndexes = curIndexes.Slice(0, Rank);
+                curIndexes = curIndexesArray.AsSpan(0, Rank);
             }
             else
             {
@@ -560,8 +558,7 @@ namespace System.Numerics.Tensors
             if (Rank > TensorShape.MaxInlineRank)
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                curIndexes = curIndexesArray;
-                curIndexes = curIndexes.Slice(0, Rank);
+                curIndexes = curIndexesArray.AsSpan(0, Rank);
             }
             else
             {
@@ -603,8 +600,7 @@ namespace System.Numerics.Tensors
                 if (Rank > TensorShape.MaxInlineRank)
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                    curIndexes = curIndexesArray;
-                    curIndexes = curIndexes.Slice(0, Rank);
+                    curIndexes = curIndexesArray.AsSpan(0, Rank);
                 }
                 else
                 {
@@ -698,14 +694,10 @@ namespace System.Numerics.Tensors
             if (Rank > TensorShape.MaxInlineRank)
             {
                 lengthsArray = ArrayPool<nint>.Shared.Rent(Rank);
-                lengths = lengthsArray;
-                lengths = lengths.Slice(0, Rank);
-                lengthsArray = null;
+                lengths = lengthsArray.AsSpan(0, Rank);
 
                 offsetsArray = ArrayPool<nint>.Shared.Rent(Rank);
-                offsets = offsetsArray;
-                offsets = offsets.Slice(0, Rank);
-                offsetsArray = null;
+                offsets = offsetsArray.AsSpan(0, Rank);
             }
             else
             {
@@ -722,21 +714,21 @@ namespace System.Numerics.Tensors
             }
 
             // When we have an empty Tensor and someone wants to slice all of it, we should return an empty Tensor.
-            if (TensorSpanHelpers.CalculateTotalLength(Lengths) == 0)
+            if (FlattenedLength == 0)
             {
                 for (int i = 0; i < offsets.Length; i++)
                 {
-                    if (offsets[i] != 0 || lengths[i] != 0)
+                    if (lengths[i] > Lengths[i])
                         ThrowHelper.ThrowIndexOutOfRangeException();
                 }
-                toReturn = new TensorSpan<T>(ref _reference, lengths, _shape.Strides, _shape._memoryLength);
+                toReturn = new TensorSpan<T>(ref _reference, lengths, _shape.Strides, _shape._memoryLength); ;
             }
             else
             {
                 nint index = 0;
                 for (int i = 0; i < offsets.Length; i++)
                 {
-                    if (offsets[i] < 0 || offsets[i] >= Lengths[i])
+                    if ((nuint)offsets[i] >= (nuint)Lengths[i])
                         ThrowHelper.ThrowIndexOutOfRangeException();
 
                     index += Strides[i] * (offsets[i]);
@@ -788,8 +780,7 @@ namespace System.Numerics.Tensors
             if (Rank > TensorShape.MaxInlineRank)
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                curIndexes = curIndexesArray;
-                curIndexes = curIndexes.Slice(0, Rank);
+                curIndexes = curIndexesArray.AsSpan(0, Rank);
             }
             else
             {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
@@ -510,13 +510,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
-                curIndexes.Clear();
             }
             else
             {
                 curIndexesArray = null;
                 curIndexes = stackalloc nint[Rank];
             }
+            curIndexes.Clear();
 
             nint clearedValues = 0;
             while (clearedValues < _shape.FlattenedLength)
@@ -560,13 +560,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
-                curIndexes.Clear();
             }
             else
             {
                 curIndexesArray = null;
                 curIndexes = stackalloc nint[Rank];
             }
+            curIndexes.Clear();
 
             nint copiedValues = 0;
             TensorSpan<T> slice = destination.Slice(_shape.Lengths);
@@ -603,13 +603,13 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
-                    curIndexes.Clear();
                 }
                 else
                 {
                     curIndexesArray = null;
                     curIndexes = stackalloc nint[Rank];
                 }
+                curIndexes.Clear();
 
                 nint copiedValues = 0;
                 TensorSpan<T> slice = destination.Slice(_shape.Lengths);
@@ -698,11 +698,9 @@ namespace System.Numerics.Tensors
             {
                 lengthsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 lengths = lengthsArray.AsSpan(0, Rank);
-                lengths.Clear();
 
                 offsetsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 offsets = offsetsArray.AsSpan(0, Rank);
-                offsets.Clear();
             }
             else
             {
@@ -712,6 +710,8 @@ namespace System.Numerics.Tensors
                 lengthsArray = null;
                 offsetsArray = null;
             }
+            lengths.Clear();
+            offsets.Clear();
 
             for (int i = 0; i < ranges.Length; i++)
             {
@@ -722,18 +722,13 @@ namespace System.Numerics.Tensors
             // FlattenedLength is computed everytime so using a local to cache the value.
             nint flattenedLength = FlattenedLength;
             nint index = 0;
-            for (int i = 0; i < offsets.Length; i++)
+
+            if (flattenedLength != 0)
             {
-                // When flattenedLength is 0, at least 1 of the Lengths will be 0 and so will the offset which would trigger this exception even though its valid.
-                // To counteract this we specifically check for the case where the offset is 0 and skip the check.
-                if ((nuint)offsets[i] != 0 && (nuint)offsets[i] >= (nuint)Lengths[i])
-                    ThrowHelper.ThrowIndexOutOfRangeException();
-
-                if (lengths[i] > Lengths[i])
-                    ThrowHelper.ThrowIndexOutOfRangeException();
-
-                if (flattenedLength != 0)
+                for (int i = 0; i < offsets.Length; i++)
+                {
                     index += Strides[i] * (offsets[i]);
+                }
             }
 
             if ((index >= _shape._memoryLength || index < 0) && flattenedLength != 0)
@@ -782,13 +777,13 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
-                curIndexes.Clear();
             }
             else
             {
                 curIndexesArray = null;
                 curIndexes = stackalloc nint[Rank];
             }
+            curIndexes.Clear();
 
             nint copiedValues = 0;
             while (copiedValues < _shape.FlattenedLength)

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpan.cs
@@ -510,6 +510,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
+                curIndexes.Clear();
             }
             else
             {
@@ -559,6 +560,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
+                curIndexes.Clear();
             }
             else
             {
@@ -601,6 +603,7 @@ namespace System.Numerics.Tensors
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                     curIndexes = curIndexesArray.AsSpan(0, Rank);
+                    curIndexes.Clear();
                 }
                 else
                 {
@@ -695,9 +698,11 @@ namespace System.Numerics.Tensors
             {
                 lengthsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 lengths = lengthsArray.AsSpan(0, Rank);
+                lengths.Clear();
 
                 offsetsArray = ArrayPool<nint>.Shared.Rent(Rank);
                 offsets = offsetsArray.AsSpan(0, Rank);
+                offsets.Clear();
             }
             else
             {
@@ -777,6 +782,7 @@ namespace System.Numerics.Tensors
             {
                 curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
                 curIndexes = curIndexesArray.AsSpan(0, Rank);
+                curIndexes.Clear();
             }
             else
             {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace System.Numerics.Tensors

--- a/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
@@ -980,7 +980,50 @@ namespace System.Numerics.Tensors.Tests
         public static void ReadOnlyTensorSpanSliceTest()
         {
             // Make sure slicing an empty TensorSpan works
-            new TensorSpan<double>(Array.Empty<double>()).Slice(new NRange[] { .. });
+            TensorSpan<int> emptyTensorSpan = new TensorSpan<int>(Array.Empty<int>()).Slice(new NRange[] { .. });
+            Assert.Equal([0], emptyTensorSpan.Lengths);
+            Assert.Equal(1, emptyTensorSpan.Rank);
+            Assert.Equal(0, emptyTensorSpan.FlattenedLength);
+
+            // Make sure slicing a multi-dimensional empty TensorSpan works
+            int[,] empty2dArray = new int[2, 0];
+            emptyTensorSpan = new TensorSpan<int>(empty2dArray);
+            TensorSpan<int> slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { .., .. });
+            Assert.Equal([2, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(2, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { 0..1, .. });
+            Assert.Equal([1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(2, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            // Make sure slicing a multi-dimensional empty TensorSpan works
+            int[,,,] empty4dArray = new int[2, 5, 1, 0];
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { .., .., .., .. });
+            Assert.Equal([2, 5, 1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { 0..1, .., .., .. });
+            Assert.Equal([1, 5, 1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { 0..1, 2..3, .., .. });
+            Assert.Equal([1, 1, 1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            empty4dArray = new int[2, 0, 1, 5];
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { .., .., .., .. });
+            Assert.Equal([2, 0, 1, 5], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
 
             int[] a = [1, 2, 3, 4, 5, 6, 7, 8, 9];
             int[] results = new int[9];

--- a/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
@@ -979,6 +979,9 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public static void ReadOnlyTensorSpanSliceTest()
         {
+            // Make sure slicing an empty TensorSpan works
+            new TensorSpan<double>(Array.Empty<double>()).Slice(new NRange[] { .. });
+
             int[] a = [1, 2, 3, 4, 5, 6, 7, 8, 9];
             int[] results = new int[9];
             ReadOnlyTensorSpan<int> spanInt = a.AsTensorSpan(3, 3);

--- a/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
@@ -1705,7 +1705,50 @@ namespace System.Numerics.Tensors.Tests
         public static void TensorSpanSliceTest()
         {
             // Make sure slicing an empty TensorSpan works
-            new TensorSpan<double>(Array.Empty<double>()).Slice(new NRange[] { .. });
+            TensorSpan<int> emptyTensorSpan = new TensorSpan<int>(Array.Empty<int>()).Slice(new NRange[] { .. });
+            Assert.Equal([0], emptyTensorSpan.Lengths);
+            Assert.Equal(1, emptyTensorSpan.Rank);
+            Assert.Equal(0, emptyTensorSpan.FlattenedLength);
+
+            // Make sure slicing a multi-dimensional empty TensorSpan works
+            int[,] empty2dArray = new int[2, 0];
+            emptyTensorSpan = new TensorSpan<int>(empty2dArray);
+            TensorSpan<int> slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { .. , .. });
+            Assert.Equal([2, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(2, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { 0..1, .. });
+            Assert.Equal([1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(2, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            // Make sure slicing a multi-dimensional empty TensorSpan works
+            int[,,,] empty4dArray = new int[2, 5, 1, 0];
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { .., .., .., .. });
+            Assert.Equal([2, 5, 1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { 0..1, .., .., .. });
+            Assert.Equal([1, 5, 1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { 0..1, 2..3, .., .. });
+            Assert.Equal([1, 1, 1, 0], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
+
+            empty4dArray = new int[2, 0, 1, 5];
+            emptyTensorSpan = new TensorSpan<int>(empty4dArray);
+            slicedEmptyTensorSpan = emptyTensorSpan.Slice(new NRange[] { .., .., .., .. });
+            Assert.Equal([2, 0, 1, 5], slicedEmptyTensorSpan.Lengths);
+            Assert.Equal(4, slicedEmptyTensorSpan.Rank);
+            Assert.Equal(0, slicedEmptyTensorSpan.FlattenedLength);
 
             int[] a = [1, 2, 3, 4, 5, 6, 7, 8, 9];
             int[] results = new int[9];

--- a/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
@@ -1704,6 +1704,9 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public static void TensorSpanSliceTest()
         {
+            // Make sure slicing an empty TensorSpan works
+            new TensorSpan<double>(Array.Empty<double>()).Slice(new NRange[] { .. });
+
             int[] a = [1, 2, 3, 4, 5, 6, 7, 8, 9];
             int[] results = new int[9];
             TensorSpan<int> spanInt = a.AsTensorSpan(3, 3);


### PR DESCRIPTION
Fixes #106536. When slicing an empty `Tensor`,  you should be able to ask for `..` and get back an empty tensor. This PR enables this behavior.