### PR TITLE
[PERF] Fix runtime-wasm-perf pipeline prereq install failure

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -78,6 +78,7 @@ jobs:
           export NODE_MAJOR=18 &&
           echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list &&
           sudo apt-get update &&
+          sudo apt autoremove -y &&
           sudo apt-get install nodejs -y &&
           test -n "$(V8Version)" &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&


### PR DESCRIPTION
Fix runtime-wasm-perf pipeline runs that are failing due to a package conflict between node and libnode72:amd64 12.22.9~dfsg-1ubuntu3.6. This is fixed by running sudo apt autoremove -y before installing nodejs to remove the libnode72 package.
Run with example failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=795729&view=results
Example failure: 
```
Preparing to unpack .../nodejs_18.20.4-1nodesource1_amd64.deb ...
Unpacking nodejs (18.20.4-1nodesource1) ...
dpkg: error processing archive /var/cache/apt/archives/nodejs_18.20.4-1nodesource1_amd64.deb (--unpack):
 trying to overwrite '/usr/share/systemtap/tapset/node.stp', which is also in package libnode72:amd64 12.22.9~dfsg-1ubuntu3.6
Errors were encountered while processing:
 /var/cache/apt/archives/nodejs_18.20.4-1nodesource1_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```