### PR TITLE
Fix docs file names and add validation

### DIFF
--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -11,7 +11,7 @@
     <IntellisensePackageXmlFilePath Condition="'$(IntellisensePackageXmlFilePath)' == '' and Exists($(IntellisensePackageXmlFilePathFromNetFolder))">$(IntellisensePackageXmlFilePathFromNetFolder)</IntellisensePackageXmlFilePath>
     <IntellisensePackageXmlFilePath Condition="'$(IntellisensePackageXmlFilePath)' == '' and Exists($(IntellisensePackageXmlFilePathFromDotNetPlatExtFolder))">$(IntellisensePackageXmlFilePathFromDotNetPlatExtFolder)</IntellisensePackageXmlFilePath>
 
-    <IntermediateDocFileItemFromIntellisensePackage>$(IntermediateOutputPath)$(TargetName).intellisense-package.xml</IntermediateDocFileItemFromIntellisensePackage>
+    <IntermediateDocFileItemFromIntellisensePackage>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', 'intellisense-package', '$(TargetName).xml'))</IntermediateDocFileItemFromIntellisensePackage>
 
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors when the intellisense package xml file is used. -->
     <NoWarn Condition="'$(SkipIntellisenseNoWarnCS1591)' != 'true'">$(NoWarn);CS1591</NoWarn>

--- a/src/libraries/sfx.proj
+++ b/src/libraries/sfx.proj
@@ -69,6 +69,27 @@
           UseHardlinksIfPossible="true" />
   </Target>
 
+  <Target Name="ValidateSharedFramework"
+          AfterTargets="Build">
+    <ItemGroup>
+      <!-- exclude private assemblies from ref-->
+      <_expectedRef Include="@(NetCoreAppLibrary)" Condition="!$([System.String]::new('%(Identity)').StartsWith('System.Private'))" />
+      <_expectedSharedFrameworkFile Include="@(_expectedRefs->'$(MicrosoftNetCoreAppRefPackRefDir)%(Identity).dll')" />
+
+      <!-- exclude the full facades from expected docs since they have no types -->
+      <_expectedDoc Include="@(_expectedRefs)" Exclude="netstandard;@(NetFxReference)" />
+      <_expectedSharedFrameworkFile Include="@(_expectedDoc->'$(MicrosoftNetCoreAppRefPackRefDir)%(Identity).xml')" />
+
+      <!-- exclude CoreLib from expected libs, since it's placed in native -->
+      <_expectedLib Include="@(NetCoreAppLibrary)" Exclude="System.Private.CoreLib" />
+      <_expectedSharedFrameworkFile Include="@(_expectedLib->'$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)%(Identity).dll')" />
+
+      <_missingSharedFrameworkFile Include="@(_expectedSharedFrameworkFile)" Exclude="@(_expectedSharedFrameworkFile->Exists())" />
+    </ItemGroup>
+
+    <Error Text="The shared framework files '@(_missingSharedFrameworkFile)' were missing." Condition="'@(_missingSharedFrameworkFile)' != ''" />
+  </Target>
+
   <Target Name="GetTrimSharedFrameworkAssembliesInputs"
           DependsOnTargets="ResolveProjectReferences">
     <PropertyGroup>


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/106825

The build process does not rename doc files when copying to output.  See issue for details.

I added a target to the project that was copying these to act as a test case so that this doesn't regress again.  It's a bit redundant, but that is what tests are after all - just a different way to state a requirement in a way that's unlikely to regress in the same way as the product.