### PR TITLE
Do not over-align code when JitAlignLoops=0 is set

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6773,12 +6773,10 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
 #endif
 
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64)
-    // For x64/x86/arm64, align methods that are "optimizations enabled" to 32 byte boundaries if
-    // they are larger than 16 bytes and contain a loop.
+    // For x64/x86/arm64, align methods that contain a loop to 32 byte boundaries if
+    // they are larger than 16 bytes and loop alignment is enabled.
     //
-    if (emitComp->opts.OptimizationEnabled() &&
-        (!emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) || comp->IsTargetAbi(CORINFO_NATIVEAOT_ABI)) &&
-        (emitTotalHotCodeSize > 16) && emitComp->fgHasLoops)
+    if (codeGen->ShouldAlignLoops() && (emitTotalHotCodeSize > 16) && emitComp->fgHasLoops)
     {
         codeAlignment = 32;
     }


### PR DESCRIPTION
Simplify the condition for alignment of methods with loop. The check for optimizations, R2R and NativeAOT already guards the `SetAlignLoops` code path, so there's no need to repeat it. Additionally, explicitly disabling loop alignment with `JitAlignLoops=0` should disable the extra method alignment.