### PR TITLE
Stop referencing S.R.Metadata directly

### DIFF
--- a/src/coreclr/tools/ILVerify/ILVerify.csproj
+++ b/src/coreclr/tools/ILVerify/ILVerify.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" Condition="'$(EnableDiaSymReaderUse)' == 'true'" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Should fix #106983.

This was added in #101666 to address a point in time issue. It should not be needed anymore.

@dotnet/ilc-contrib or @dotnet/crossgen-contrib for review