### PR TITLE
[mono][ci] Include PDBs from runtime pack when building on Helix if required

### DIFF
--- a/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
+++ b/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
@@ -109,8 +109,8 @@
           Condition="'$(UsePortableRuntimePack)' == 'true'">
 
     <ItemGroup>
-      <_RuntimePackFiles Condition="%(_AppleUsedRuntimePackFiles.Extension) == '.dll' and %(_AppleUsedRuntimePackFiles.FileName) != 'System.Private.CoreLib'" Include="@(_AppleUsedRuntimePackFiles->'$(MicrosoftNetCoreAppRuntimePackLibDir)%(FileName)%(Extension)')" />
-      <_RuntimePackFiles Condition="%(_AppleUsedRuntimePackFiles.Extension) != '.dll' or %(_AppleUsedRuntimePackFiles.FileName) == 'System.Private.CoreLib'" Include="@(_AppleUsedRuntimePackFiles->'$(MicrosoftNetCoreAppRuntimePackNativeDir)%(FileName)%(Extension)')" />
+      <_RuntimePackFiles Condition="(%(_AppleUsedRuntimePackFiles.Extension) == '.dll' or %(_AppleUsedRuntimePackFiles.Extension) == '.pdb') and %(_AppleUsedRuntimePackFiles.FileName) != 'System.Private.CoreLib'" Include="@(_AppleUsedRuntimePackFiles->'$(MicrosoftNetCoreAppRuntimePackLibDir)%(FileName)%(Extension)')" />
+      <_RuntimePackFiles Condition="(%(_AppleUsedRuntimePackFiles.Extension) != '.dll' and %(_AppleUsedRuntimePackFiles.Extension) != '.pdb') or %(_AppleUsedRuntimePackFiles.FileName) == 'System.Private.CoreLib'" Include="@(_AppleUsedRuntimePackFiles->'$(MicrosoftNetCoreAppRuntimePackNativeDir)%(FileName)%(Extension)')" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_RuntimePackFiles)"


### PR DESCRIPTION
## Description

This is a follow-up to PR that complements the fix introduced in: https://github.com/dotnet/runtime/pull/107079 
It now properly includes PDB files from the runtime pack if required (DebuggerSupport=true) from: 
https://github.com/dotnet/runtime/blob/c53a9115e3fcbe7ab2c7b5588a5ce2c8a018d788/eng/testing/tests.ioslike.targets#L95-L98

---
Fixes https://github.com/dotnet/runtime/issues/107309