### PR TITLE
[release/8.0] ComponentModel threading fixes

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -253,6 +253,7 @@
                       SetTargetFramework="TargetFramework=netstandard2.0"
                       OutputItemType="Analyzer" />
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.ComponentModel" />

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Threading;
 
 namespace System.ComponentModel
 {
@@ -16,10 +18,11 @@ namespace System.ComponentModel
         internal const string PropertyDescriptorPropertyTypeMessage = "PropertyDescriptor's PropertyType cannot be statically discovered.";
 
         private TypeConverter? _converter;
-        private Dictionary<object, EventHandler?>? _valueChangedHandlers;
+        private ConcurrentDictionary<object, EventHandler?>? _valueChangedHandlers;
         private object?[]? _editors;
         private Type[]? _editorTypes;
         private int _editorCount;
+        private object? _syncObject;
 
         /// <summary>
         /// Initializes a new instance of the <see cref='System.ComponentModel.PropertyDescriptor'/> class with the specified name and
@@ -48,6 +51,8 @@ namespace System.ComponentModel
         protected PropertyDescriptor(MemberDescriptor descr, Attribute[]? attrs) : base(descr, attrs)
         {
         }
+
+        private object SyncObject => LazyInitializer.EnsureInitialized(ref _syncObject);
 
         /// <summary>
         /// When overridden in a derived class, gets the type of the
@@ -124,10 +129,11 @@ namespace System.ComponentModel
             ArgumentNullException.ThrowIfNull(component);
             ArgumentNullException.ThrowIfNull(handler);
 
-            _valueChangedHandlers ??= new Dictionary<object, EventHandler?>();
-
-            EventHandler? h = _valueChangedHandlers.GetValueOrDefault(component, defaultValue: null);
-            _valueChangedHandlers[component] = (EventHandler?)Delegate.Combine(h, handler);
+            lock (SyncObject)
+            {
+                _valueChangedHandlers ??= new ConcurrentDictionary<object, EventHandler?>(concurrencyLevel: 1, capacity: 0);
+                _valueChangedHandlers.AddOrUpdate(component, handler, (k, v) => (EventHandler?)Delegate.Combine(v, handler));
+            }
         }
 
         /// <summary>
@@ -392,15 +398,18 @@ namespace System.ComponentModel
 
             if (_valueChangedHandlers != null)
             {
-                EventHandler? h = _valueChangedHandlers.GetValueOrDefault(component, defaultValue: null);
-                h = (EventHandler?)Delegate.Remove(h, handler);
-                if (h != null)
+                lock (SyncObject)
                 {
-                    _valueChangedHandlers[component] = h;
-                }
-                else
-                {
-                    _valueChangedHandlers.Remove(component);
+                    EventHandler? h = _valueChangedHandlers.GetValueOrDefault(component, defaultValue: null);
+                    h = (EventHandler?)Delegate.Remove(h, handler);
+                    if (h != null)
+                    {
+                        _valueChangedHandlers[component] = h;
+                    }
+                    else
+                    {
+                        _valueChangedHandlers.Remove(component, out EventHandler? _);
+                    }
                 }
             }
         }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -23,7 +24,7 @@ namespace System.ComponentModel
     internal sealed partial class ReflectTypeDescriptionProvider : TypeDescriptionProvider
     {
         // ReflectedTypeData contains all of the type information we have gathered for a given type.
-        private Dictionary<Type, ReflectedTypeData>? _typeData;
+        private readonly ConcurrentDictionary<Type, ReflectedTypeData> _typeData = new ConcurrentDictionary<Type, ReflectedTypeData>();
 
         // This is the signature we look for when creating types that are generic, but
         // want to know what type they are dealing with. Enums are a good example of this;
@@ -293,7 +294,6 @@ namespace System.ComponentModel
 
             return obj ?? Activator.CreateInstance(objectType, args);
         }
-
 
         /// <summary>
         /// Helper method to create editors and type converters. This checks to see if the
@@ -833,18 +833,11 @@ namespace System.ComponentModel
         {
             List<Type> typeList = new List<Type>();
 
-            lock (TypeDescriptor.s_commonSyncObject)
+            foreach (KeyValuePair<Type, ReflectedTypeData> kvp in _typeData)
             {
-                Dictionary<Type, ReflectedTypeData>? typeData = _typeData;
-                if (typeData != null)
+                if (kvp.Key.Module == module && kvp.Value!.IsPopulated)
                 {
-                    foreach (KeyValuePair<Type, ReflectedTypeData> kvp in typeData)
-                    {
-                        if (kvp.Key.Module == module && kvp.Value!.IsPopulated)
-                        {
-                            typeList.Add(kvp.Key);
-                        }
-                    }
+                    typeList.Add(kvp.Key);
                 }
             }
 
@@ -889,9 +882,7 @@ namespace System.ComponentModel
         /// </summary>
         private ReflectedTypeData? GetTypeData([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, bool createIfNeeded)
         {
-            ReflectedTypeData? td = null;
-
-            if (_typeData != null && _typeData.TryGetValue(type, out td))
+            if (_typeData.TryGetValue(type, out ReflectedTypeData? td))
             {
                 Debug.Assert(td != null);
                 return td;
@@ -899,7 +890,7 @@ namespace System.ComponentModel
 
             lock (TypeDescriptor.s_commonSyncObject)
             {
-                if (_typeData != null && _typeData.TryGetValue(type, out td))
+                if (_typeData.TryGetValue(type, out td))
                 {
                     Debug.Assert(td != null);
                     return td;
@@ -908,7 +899,6 @@ namespace System.ComponentModel
                 if (createIfNeeded)
                 {
                     td = new ReflectedTypeData(type);
-                    _typeData ??= new Dictionary<Type, ReflectedTypeData>();
                     _typeData[type] = td;
                 }
             }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -22,10 +22,8 @@ namespace System.ComponentModel
     /// </summary>
     internal sealed partial class ReflectTypeDescriptionProvider : TypeDescriptionProvider
     {
-        // Hastable of Type -> ReflectedTypeData. ReflectedTypeData contains all
-        // of the type information we have gathered for a given type.
-        //
-        private Hashtable? _typeData;
+        // ReflectedTypeData contains all of the type information we have gathered for a given type.
+        private Dictionary<Type, ReflectedTypeData>? _typeData;
 
         // This is the signature we look for when creating types that are generic, but
         // want to know what type they are dealing with. Enums are a good example of this;
@@ -91,8 +89,6 @@ namespace System.ComponentModel
 
         internal static Guid ExtenderProviderKey { get; } = Guid.NewGuid();
 
-
-        private static readonly object s_internalSyncObject = new object();
         /// <summary>
         /// Creates a new ReflectTypeDescriptionProvider. The type is the
         /// type we will obtain type information for.
@@ -243,7 +239,7 @@ namespace System.ComponentModel
 
             Debug.Assert(table != null, "COMPAT: Editor table should not be null"); // don't throw; RTM didn't so we can't do it either.
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 Hashtable editorTables = EditorTables;
                 if (!editorTables.ContainsKey(editorBaseType))
@@ -429,7 +425,7 @@ namespace System.ComponentModel
                 //
                 if (table == null)
                 {
-                    lock (s_internalSyncObject)
+                    lock (TypeDescriptor.s_commonSyncObject)
                     {
                         table = editorTables[editorBaseType];
                         if (table == null)
@@ -837,20 +833,16 @@ namespace System.ComponentModel
         {
             List<Type> typeList = new List<Type>();
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
-                Hashtable? typeData = _typeData;
+                Dictionary<Type, ReflectedTypeData>? typeData = _typeData;
                 if (typeData != null)
                 {
-                    // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
-                    IDictionaryEnumerator e = typeData.GetEnumerator();
-                    while (e.MoveNext())
+                    foreach (KeyValuePair<Type, ReflectedTypeData> kvp in typeData)
                     {
-                        DictionaryEntry de = e.Entry;
-                        Type type = (Type)de.Key;
-                        if (type.Module == module && ((ReflectedTypeData)de.Value!).IsPopulated)
+                        if (kvp.Key.Module == module && kvp.Value!.IsPopulated)
                         {
-                            typeList.Add(type);
+                            typeList.Add(kvp.Key);
                         }
                     }
                 }
@@ -899,26 +891,24 @@ namespace System.ComponentModel
         {
             ReflectedTypeData? td = null;
 
-            if (_typeData != null)
+            if (_typeData != null && _typeData.TryGetValue(type, out td))
             {
-                td = (ReflectedTypeData?)_typeData[type];
-                if (td != null)
-                {
-                    return td;
-                }
+                Debug.Assert(td != null);
+                return td;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
-                if (_typeData != null)
+                if (_typeData != null && _typeData.TryGetValue(type, out td))
                 {
-                    td = (ReflectedTypeData?)_typeData[type];
+                    Debug.Assert(td != null);
+                    return td;
                 }
 
-                if (td == null && createIfNeeded)
+                if (createIfNeeded)
                 {
                     td = new ReflectedTypeData(type);
-                    _typeData ??= new Hashtable();
+                    _typeData ??= new Dictionary<Type, ReflectedTypeData>();
                     _typeData[type] = td;
                 }
             }
@@ -1006,7 +996,7 @@ namespace System.ComponentModel
                 return attrs;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 attrs = (Attribute[]?)attributeCache[type];
                 if (attrs == null)
@@ -1034,7 +1024,7 @@ namespace System.ComponentModel
                 return attrs;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 attrs = (Attribute[]?)attributeCache[member];
                 if (attrs == null)
@@ -1063,7 +1053,7 @@ namespace System.ComponentModel
                 return events;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 events = (EventDescriptor[]?)eventCache[type];
                 if (events == null)
@@ -1160,7 +1150,7 @@ namespace System.ComponentModel
             ReflectPropertyDescriptor[]? extendedProperties = (ReflectPropertyDescriptor[]?)extendedPropertyCache[providerType];
             if (extendedProperties == null)
             {
-                lock (s_internalSyncObject)
+                lock (TypeDescriptor.s_commonSyncObject)
                 {
                     extendedProperties = (ReflectPropertyDescriptor[]?)extendedPropertyCache[providerType];
 
@@ -1240,7 +1230,7 @@ namespace System.ComponentModel
                 return properties;
             }
 
-            lock (s_internalSyncObject)
+            lock (TypeDescriptor.s_commonSyncObject)
             {
                 properties = (PropertyDescriptor[]?)propertyCache[type];
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -26,12 +27,23 @@ namespace System.ComponentModel
         // lock on it for thread safety. It is used from nearly
         // every call to this class, so it will be created soon after
         // class load anyway.
-        private static readonly WeakHashtable s_providerTable = new WeakHashtable();     // mapping of type or object hash to a provider list
-        private static readonly Hashtable s_providerTypeTable = new Hashtable();         // A direct mapping from type to provider.
+        private static readonly WeakHashtable s_providerTable = new WeakHashtable();
 
-        private static readonly Hashtable s_defaultProviderInitialized = new Hashtable(); // A table of type -> object to track DefaultTypeDescriptionProviderAttributes.
-                                                                                          // A value of `null` indicates initialization is in progress.
-                                                                                          // A value of s_initializedDefaultProvider indicates the provider is initialized.
+        // This lock object protects access to several thread-unsafe areas below, and is a single lock object to prevent deadlocks.
+        // - During s_providerTypeTable access.
+        // - To act as a mutex for CheckDefaultProvider() when it needs to create the default provider, which may re-enter the above case.
+        // - For cache access in the ReflectTypeDescriptionProvider class which may re-enter the above case.
+        // - For logic added by consumers, such as custom provider, constructor and property logic, which may re-enter the above cases in unexpected ways.
+        internal static readonly object s_commonSyncObject = new object();
+
+        // A direct mapping from type to provider.
+        private static readonly Dictionary<Type, TypeDescriptionNode> s_providerTypeTable = new Dictionary<Type, TypeDescriptionNode>();
+
+        // Tracks DefaultTypeDescriptionProviderAttributes.
+        // A value of `null` indicates initialization is in progress.
+        // A value of s_initializedDefaultProvider indicates the provider is initialized.
+        private static readonly Dictionary<Type, object?> s_defaultProviderInitialized = new Dictionary<Type, object?>();
+
         private static readonly object s_initializedDefaultProvider = new object();
 
         private static WeakHashtable? s_associationTable;
@@ -179,7 +191,7 @@ namespace System.ComponentModel
             ArgumentNullException.ThrowIfNull(provider);
             ArgumentNullException.ThrowIfNull(type);
 
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 // Get the root node, hook it up, and stuff it back into
                 // the provider cache.
@@ -209,7 +221,7 @@ namespace System.ComponentModel
 
             // Get the root node, hook it up, and stuff it back into
             // the provider cache.
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 refreshNeeded = s_providerTable.ContainsKey(instance);
                 TypeDescriptionNode node = NodeFor(instance, true);
@@ -270,10 +282,7 @@ namespace System.ComponentModel
                 return;
             }
 
-            // Lock on s_providerTable even though s_providerTable is not modified here.
-            // Using a single lock prevents deadlocks since other methods that call into or are called
-            // by this method also lock on s_providerTable and the ordering of the locks may be different.
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 AddDefaultProvider(type);
             }
@@ -281,7 +290,7 @@ namespace System.ComponentModel
 
         /// <summary>
         /// Add the default provider, if it exists.
-        /// For threading, this is always called under a 'lock (s_providerTable)'.
+        /// For threading, this is always called under a 'lock (s_commonSyncObject)'.
         /// </summary>
         private static void AddDefaultProvider(Type type)
         {
@@ -1484,7 +1493,7 @@ namespace System.ComponentModel
 
                     if (searchType == typeof(object) || baseType == null)
                     {
-                        lock (s_providerTable)
+                        lock (s_commonSyncObject)
                         {
                             node = (TypeDescriptionNode?)s_providerTable[searchType];
 
@@ -1500,7 +1509,7 @@ namespace System.ComponentModel
                     else if (createDelegator)
                     {
                         node = new TypeDescriptionNode(new DelegatingTypeDescriptionProvider(baseType));
-                        lock (s_providerTable)
+                        lock (s_commonSyncObject)
                         {
                             s_providerTypeTable[searchType] = node;
                         }
@@ -1603,7 +1612,7 @@ namespace System.ComponentModel
         /// </summary>
         private static void NodeRemove(object key, TypeDescriptionProvider provider)
         {
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 TypeDescriptionNode? head = (TypeDescriptionNode?)s_providerTable[key];
                 TypeDescriptionNode? target = head;
@@ -2124,7 +2133,7 @@ namespace System.ComponentModel
             {
                 Type type = component.GetType();
 
-                lock (s_providerTable)
+                lock (s_commonSyncObject)
                 {
                     // ReflectTypeDescritionProvider is only bound to object, but we
                     // need go to through the entire table to try to find custom
@@ -2208,7 +2217,7 @@ namespace System.ComponentModel
 
             bool found = false;
 
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 // ReflectTypeDescritionProvider is only bound to object, but we
                 // need go to through the entire table to try to find custom
@@ -2273,7 +2282,7 @@ namespace System.ComponentModel
             // each of these levels.
             Hashtable? refreshedTypes = null;
 
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
                 IDictionaryEnumerator e = s_providerTable.GetEnumerator();

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel.Design;
@@ -37,12 +38,12 @@ namespace System.ComponentModel
         internal static readonly object s_commonSyncObject = new object();
 
         // A direct mapping from type to provider.
-        private static readonly Dictionary<Type, TypeDescriptionNode> s_providerTypeTable = new Dictionary<Type, TypeDescriptionNode>();
+        private static readonly ConcurrentDictionary<Type, TypeDescriptionNode> s_providerTypeTable = new ConcurrentDictionary<Type, TypeDescriptionNode>();
 
         // Tracks DefaultTypeDescriptionProviderAttributes.
         // A value of `null` indicates initialization is in progress.
         // A value of s_initializedDefaultProvider indicates the provider is initialized.
-        private static readonly Dictionary<Type, object?> s_defaultProviderInitialized = new Dictionary<Type, object?>();
+        private static readonly ConcurrentDictionary<Type, object?> s_defaultProviderInitialized = new ConcurrentDictionary<Type, object?>();
 
         private static readonly object s_initializedDefaultProvider = new object();
 
@@ -277,7 +278,7 @@ namespace System.ComponentModel
         /// </summary>
         private static void CheckDefaultProvider(Type type)
         {
-            if (s_defaultProviderInitialized[type] == s_initializedDefaultProvider)
+            if (s_defaultProviderInitialized.TryGetValue(type, out object? provider) && provider == s_initializedDefaultProvider)
             {
                 return;
             }
@@ -304,7 +305,7 @@ namespace System.ComponentModel
 
             // Immediately set this to null to indicate we are in progress setting the default provider for a type.
             // This prevents re-entrance to this method.
-            s_defaultProviderInitialized[type] = null;
+            s_defaultProviderInitialized.TryAdd(type, null);
 
             // Always use core reflection when checking for the default provider attribute.
             // If there is a provider, we probably don't want to build up our own cache state against the type.
@@ -1484,8 +1485,10 @@ namespace System.ComponentModel
 
             while (node == null)
             {
-                node = (TypeDescriptionNode?)s_providerTypeTable[searchType] ??
-                       (TypeDescriptionNode?)s_providerTable[searchType];
+                if (!s_providerTypeTable.TryGetValue(searchType, out node))
+                {
+                    node = (TypeDescriptionNode?)s_providerTable[searchType];
+                }
 
                 if (node == null)
                 {
@@ -1511,7 +1514,7 @@ namespace System.ComponentModel
                         node = new TypeDescriptionNode(new DelegatingTypeDescriptionProvider(baseType));
                         lock (s_commonSyncObject)
                         {
-                            s_providerTypeTable[searchType] = node;
+                            s_providerTypeTable.TryAdd(searchType, node);
                         }
                     }
                     else

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -28,13 +28,21 @@ namespace System.ComponentModel.Tests
             var component = new DescriptorTestComponent();
             var properties = TypeDescriptor.GetProperties(component.GetType());
             PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
-            var handlerWasCalled = false;
-            EventHandler valueChangedHandler = (_, __) => handlerWasCalled = true;
+            int handlerCalledCount = 0;
 
-            propertyDescriptor.AddValueChanged(component, valueChangedHandler);
-            propertyDescriptor.SetValue(component, int.MaxValue);
+            EventHandler valueChangedHandler1 = (_, __) => handlerCalledCount++;
+            EventHandler valueChangedHandler2 = (_, __) => handlerCalledCount++;
 
-            Assert.True(handlerWasCalled);
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler1);
+
+            // Add case.
+            propertyDescriptor.SetValue(component, int.MaxValue); // Add to delegate.
+            Assert.Equal(1, handlerCalledCount);
+
+
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler2);
+            propertyDescriptor.SetValue(component, int.MaxValue);  // Update delegate.
+            Assert.Equal(3, handlerCalledCount);
         }
 
         [Fact]
@@ -42,15 +50,25 @@ namespace System.ComponentModel.Tests
         {
             var component = new DescriptorTestComponent();
             var properties = TypeDescriptor.GetProperties(component.GetType());
-            var handlerWasCalled = false;
-            EventHandler valueChangedHandler = (_, __) => handlerWasCalled = true;
+            int handlerCalledCount = 0;
+
+            EventHandler valueChangedHandler1 = (_, __) => handlerCalledCount++;
+            EventHandler valueChangedHandler2 = (_, __) => handlerCalledCount++;
+
             PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
 
-            propertyDescriptor.AddValueChanged(component, valueChangedHandler);
-            propertyDescriptor.RemoveValueChanged(component, valueChangedHandler);
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler1);
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler2);
             propertyDescriptor.SetValue(component, int.MaxValue);
+            Assert.Equal(2, handlerCalledCount);
 
-            Assert.False(handlerWasCalled);
+            propertyDescriptor.SetValue(component, int.MaxValue);
+            Assert.Equal(4, handlerCalledCount);
+
+            propertyDescriptor.RemoveValueChanged(component, valueChangedHandler1);
+            propertyDescriptor.RemoveValueChanged(component, valueChangedHandler2);
+            propertyDescriptor.SetValue(component, int.MaxValue);
+            Assert.Equal(4, handlerCalledCount);
         }
 
         [Fact]


### PR DESCRIPTION
Backport of #104407 and #103835 to release/8.0

See also https://github.com/dotnet/runtime/pull/107354 for the 6.0 port.

## Customer Impact
Fixes various threading issues with TypeDescriptor and PropertyDescriptor.

## Regression
Yes; a [previous servicing fix](https://github.com/dotnet/runtime/pull/101305) caused concurrency issues with:
- Dictionary\hashtable concurrency issues reported in https://github.com/dotnet/runtime/issues/104221 and https://github.com/dotnet/runtime/issues/103823 and this port addresses those by using `ConcurrentDictionary`.
- A rare deadlock could occur as reported in https://github.com/dotnet/runtime/issues/103265.

## Testing
The 9.0 tests that were added are ported here.

## Risk
Low; the fixes have been in 9.0 for several months with no reported regressions.
