### PR TITLE
[release/6.0] ComponentModel threading fixes

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -240,6 +240,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.ComponentModel" />

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -25,12 +26,23 @@ namespace System.ComponentModel
         // lock on it for thread safety. It is used from nearly
         // every call to this class, so it will be created soon after
         // class load anyway.
-        private static readonly WeakHashtable s_providerTable = new WeakHashtable();     // mapping of type or object hash to a provider list
-        private static readonly Hashtable s_providerTypeTable = new Hashtable();         // A direct mapping from type to provider.
+        private static readonly WeakHashtable s_providerTable = new WeakHashtable();
 
-        private static readonly Hashtable s_defaultProviderInitialized = new Hashtable(); // A table of type -> object to track DefaultTypeDescriptionProviderAttributes.
-                                                                                          // A value of `null` indicates initialization is in progress.
-                                                                                          // A value of s_initializedDefaultProvider indicates the provider is initialized.
+        // This lock object protects access to several thread-unsafe areas below, and is a single lock object to prevent deadlocks.
+        // - During s_providerTypeTable access.
+        // - To act as a mutex for CheckDefaultProvider() when it needs to create the default provider, which may re-enter the above case.
+        // - For cache access in the ReflectTypeDescriptionProvider class which may re-enter the above case.
+        // - For logic added by consumers, such as custom provider, constructor and property logic, which may re-enter the above cases in unexpected ways.
+        internal static readonly object s_commonSyncObject = new object();
+
+        // A direct mapping from type to provider.
+        private static readonly Dictionary<Type, TypeDescriptionNode> s_providerTypeTable = new Dictionary<Type, TypeDescriptionNode>();
+
+        // Tracks DefaultTypeDescriptionProviderAttributes.
+        // A value of `null` indicates initialization is in progress.
+        // A value of s_initializedDefaultProvider indicates the provider is initialized.
+        private static readonly Dictionary<Type, object?> s_defaultProviderInitialized = new Dictionary<Type, object?>();
+
         private static readonly object s_initializedDefaultProvider = new object();
 
         private static WeakHashtable? s_associationTable;
@@ -199,7 +211,7 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 // Get the root node, hook it up, and stuff it back into
                 // the provider cache.
@@ -235,7 +247,7 @@ namespace System.ComponentModel
 
             // Get the root node, hook it up, and stuff it back into
             // the provider cache.
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 refreshNeeded = s_providerTable.ContainsKey(instance);
                 TypeDescriptionNode node = NodeFor(instance, true);
@@ -310,10 +322,7 @@ namespace System.ComponentModel
                 return;
             }
 
-            // Lock on s_providerTable even though s_providerTable is not modified here.
-            // Using a single lock prevents deadlocks since other methods that call into or are called
-            // by this method also lock on s_providerTable and the ordering of the locks may be different.
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 AddDefaultProvider(type);
             }
@@ -321,7 +330,7 @@ namespace System.ComponentModel
 
         /// <summary>
         /// Add the default provider, if it exists.
-        /// For threading, this is always called under a 'lock (s_providerTable)'.
+        /// For threading, this is always called under a 'lock (s_commonSyncObject)'.
         /// </summary>
         private static void AddDefaultProvider(Type type)
         {
@@ -1564,7 +1573,7 @@ namespace System.ComponentModel
 
                     if (searchType == typeof(object) || baseType == null)
                     {
-                        lock (s_providerTable)
+                        lock (s_commonSyncObject)
                         {
                             node = (TypeDescriptionNode?)s_providerTable[searchType];
 
@@ -1580,7 +1589,7 @@ namespace System.ComponentModel
                     else if (createDelegator)
                     {
                         node = new TypeDescriptionNode(new DelegatingTypeDescriptionProvider(baseType));
-                        lock (s_providerTable)
+                        lock (s_commonSyncObject)
                         {
                             s_providerTypeTable[searchType] = node;
                         }
@@ -1672,7 +1681,7 @@ namespace System.ComponentModel
         /// </summary>
         private static void NodeRemove(object key, TypeDescriptionProvider provider)
         {
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 TypeDescriptionNode? head = (TypeDescriptionNode?)s_providerTable[key];
                 TypeDescriptionNode? target = head;
@@ -2195,7 +2204,7 @@ namespace System.ComponentModel
             {
                 Type type = component.GetType();
 
-                lock (s_providerTable)
+                lock (s_commonSyncObject)
                 {
                     // ReflectTypeDescritionProvider is only bound to object, but we
                     // need go to through the entire table to try to find custom
@@ -2279,7 +2288,7 @@ namespace System.ComponentModel
 
             bool found = false;
 
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 // ReflectTypeDescritionProvider is only bound to object, but we
                 // need go to through the entire table to try to find custom
@@ -2344,7 +2353,7 @@ namespace System.ComponentModel
             // each of these levels.
             Hashtable? refreshedTypes = null;
 
-            lock (s_providerTable)
+            lock (s_commonSyncObject)
             {
                 // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
                 IDictionaryEnumerator e = s_providerTable.GetEnumerator();

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -28,13 +28,21 @@ namespace System.ComponentModel.Tests
             var component = new DescriptorTestComponent();
             var properties = TypeDescriptor.GetProperties(component.GetType());
             PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
-            var handlerWasCalled = false;
-            EventHandler valueChangedHandler = (_, __) => handlerWasCalled = true;
+            int handlerCalledCount = 0;
 
-            propertyDescriptor.AddValueChanged(component, valueChangedHandler);
-            propertyDescriptor.SetValue(component, int.MaxValue);
+            EventHandler valueChangedHandler1 = (_, __) => handlerCalledCount++;
+            EventHandler valueChangedHandler2 = (_, __) => handlerCalledCount++;
 
-            Assert.True(handlerWasCalled);
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler1);
+
+            // Add case.
+            propertyDescriptor.SetValue(component, int.MaxValue); // Add to delegate.
+            Assert.Equal(1, handlerCalledCount);
+
+
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler2);
+            propertyDescriptor.SetValue(component, int.MaxValue);  // Update delegate.
+            Assert.Equal(3, handlerCalledCount);
         }
 
         [Fact]
@@ -42,15 +50,25 @@ namespace System.ComponentModel.Tests
         {
             var component = new DescriptorTestComponent();
             var properties = TypeDescriptor.GetProperties(component.GetType());
-            var handlerWasCalled = false;
-            EventHandler valueChangedHandler = (_, __) => handlerWasCalled = true;
+            int handlerCalledCount = 0;
+
+            EventHandler valueChangedHandler1 = (_, __) => handlerCalledCount++;
+            EventHandler valueChangedHandler2 = (_, __) => handlerCalledCount++;
+
             PropertyDescriptor propertyDescriptor = properties.Find(nameof(component.Property), false);
 
-            propertyDescriptor.AddValueChanged(component, valueChangedHandler);
-            propertyDescriptor.RemoveValueChanged(component, valueChangedHandler);
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler1);
+            propertyDescriptor.AddValueChanged(component, valueChangedHandler2);
             propertyDescriptor.SetValue(component, int.MaxValue);
+            Assert.Equal(2, handlerCalledCount);
 
-            Assert.False(handlerWasCalled);
+            propertyDescriptor.SetValue(component, int.MaxValue);
+            Assert.Equal(4, handlerCalledCount);
+
+            propertyDescriptor.RemoveValueChanged(component, valueChangedHandler1);
+            propertyDescriptor.RemoveValueChanged(component, valueChangedHandler2);
+            propertyDescriptor.SetValue(component, int.MaxValue);
+            Assert.Equal(4, handlerCalledCount);
         }
 
         [Fact]


### PR DESCRIPTION
Backport of #104407 and #103835 to release/6.0.

See also https://github.com/dotnet/runtime/pull/107353 for the 8.0 port.

## Customer Impact
Fixes various threading issues with TypeDescriptor and PropertyDescriptor.

## Regression
Yes; a [previous servicing fix](https://github.com/dotnet/runtime/pull/101306) caused concurrency issues with:
- Dictionary\hashtable concurrency issues reported in https://github.com/dotnet/runtime/issues/104221 and https://github.com/dotnet/runtime/issues/103823 and this port addresses those by using `ConcurrentDictionary`.
- A rare deadlock could occur as reported in https://github.com/dotnet/runtime/issues/103265.

## Testing
The 9.0 tests that were added are ported here.

## Risk
Low; the fixes have been in 9.0 for several months with no reported regressions.
