### PR TITLE
[mono] Re-enable HAS_CUSTOM_BLOCKS for non-amd64 Mono

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !MONO && (TARGET_AMD64 || TARGET_ARM64 || (TARGET_32BIT && !TARGET_ARM) || TARGET_LOONGARCH64)
+#if (TARGET_AMD64 && !MONO) || TARGET_ARM64 || (TARGET_32BIT && !TARGET_ARM) || TARGET_LOONGARCH64
 // JIT is guaranteed to unroll blocks up to 64 bytes in size
 #define HAS_CUSTOM_BLOCKS
 #endif


### PR DESCRIPTION
We've seen a bunch of regressions on WASM, AOT-arm64 and Interp-arm64 microbenchmark after https://github.com/dotnet/runtime/pull/106764. Rather than reverting the PR and loosing the gains on x64 MonoJIT, we can try limiting the change to x64.

Regressions:
- https://github.com/dotnet/runtime/issues/107308