### PR TITLE
Allow un-examining in PipeReader.AdvanceTo(...)

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -447,30 +447,7 @@ namespace System.IO.Pipelines
 
         internal void AdvanceReader(in SequencePosition consumed)
         {
-            // If the reader is completed
-            if (_readerCompletion.IsCompleted)
-            {
-                ThrowHelper.ThrowInvalidOperationException_NoReadingAllowed();
-            }
-
-            long examinedIndex = consumed.GetInteger();
-            BufferSegment? examinedSegment = (BufferSegment?)consumed.GetObject();
-            if (examinedSegment != null &&
-                // Avoid the lock if we're examining the entire segment, don't need to look at the last examined index in that case
-                examinedSegment.Length - examinedIndex > 0)
-            {
-                lock (SyncObj)
-                {
-                    // If the last examined index is further than the consumed pointer, let's use the last examined index
-
-                    // _lastExaminedIndex includes the RunningIndex so we remove that to calculate how many bytes we're examining
-                    examinedIndex = Math.Max(examinedIndex, _lastExaminedIndex - examinedSegment.RunningIndex);
-                }
-            }
-
-            // TODO: Use new SequenceMarshal.TryGetReadOnlySequenceSegment to get the correct data
-            // directly casting only works because the type value in ReadOnlySequenceSegment is 0
-            AdvanceReader((BufferSegment?)consumed.GetObject(), consumed.GetInteger(), examinedSegment, (int)examinedIndex);
+            AdvanceReader(consumed, consumed);
         }
 
         internal void AdvanceReader(in SequencePosition consumed, in SequencePosition examined)
@@ -481,8 +458,6 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowInvalidOperationException_NoReadingAllowed();
             }
 
-            // TODO: Use new SequenceMarshal.TryGetReadOnlySequenceSegment to get the correct data
-            // directly casting only works because the type value in ReadOnlySequenceSegment is 0
             AdvanceReader((BufferSegment?)consumed.GetObject(), consumed.GetInteger(), (BufferSegment?)examined.GetObject(), examined.GetInteger());
         }
 
@@ -509,13 +484,10 @@ namespace System.IO.Pipelines
 
                 if (examinedSegment != null && _lastExaminedIndex >= 0)
                 {
+                    // This can be negative resulting in _unconsumedBytes increasing, this should be safe because we've already checked that
+                    // examined >= consumed above, so we can't get into a state where we un-examine too much
                     long examinedBytes = BufferSegment.GetLength(_lastExaminedIndex, examinedSegment, examinedIndex);
                     long oldLength = _unconsumedBytes;
-
-                    if (examinedBytes < 0)
-                    {
-                        ThrowHelper.ThrowInvalidOperationException_InvalidExaminedPosition();
-                    }
 
                     _unconsumedBytes -= examinedBytes;
 
@@ -528,6 +500,8 @@ namespace System.IO.Pipelines
                     if (oldLength >= ResumeWriterThreshold &&
                         _unconsumedBytes < ResumeWriterThreshold)
                     {
+                        // Should only release backpressure if we made forward progress
+                        Debug.Assert(examinedBytes > 0);
                         _writerAwaitable.Complete(out completionData);
                     }
                 }
@@ -593,7 +567,7 @@ namespace System.IO.Pipelines
                 // but only if writer is not completed yet
                 if (examinedEverything && !_writerCompletion.IsCompleted)
                 {
-                    Debug.Assert(_writerAwaitable.IsCompleted, "PipeWriter.FlushAsync is isn't completed and will deadlock");
+                    Debug.Assert(_writerAwaitable.IsCompleted, "PipeWriter.FlushAsync isn't completed and will deadlock");
 
                     _readerAwaitable.SetUncompleted();
                 }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -84,9 +84,10 @@ namespace System.IO.Pipelines
         /// <param name="consumed">Marks the extent of the data that has been successfully processed.</param>
         /// <remarks>The memory for the consumed data will be released and no longer available.
         /// The <see cref="System.IO.Pipelines.ReadResult.Buffer" /> previously returned from <see cref="System.IO.Pipelines.PipeReader.ReadAsync(System.Threading.CancellationToken)" /> must not be accessed after this call.
-        /// This is equivalent to calling <see cref="System.IO.Pipelines.PipeReader.AdvanceTo(System.SequencePosition,System.SequencePosition)" /> with identical examined and consumed positions.
+        /// This is equivalent to calling <see cref="System.IO.Pipelines.PipeReader.AdvanceTo(System.SequencePosition,System.SequencePosition)" /> with identical examined and consumed positions,
+        /// unless a previous <see cref="PipeReader.AdvanceTo(SequencePosition, SequencePosition)"/> call was made with a further examined index, then it will use the further examined index.
         /// The examined data communicates to the pipeline when it should signal more data is available.
-        /// Because the consumed parameter doubles as the examined parameter, the consumed parameter should be greater than or equal to the examined position in the previous call to `AdvanceTo`. Otherwise, an <see cref="System.InvalidOperationException" /> is thrown.</remarks>
+        /// </remarks>
         public abstract void AdvanceTo(SequencePosition consumed);
 
         /// <summary>Moves forward the pipeline's read cursor to after the consumed data, marking the data as processed, read and examined.</summary>

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -84,8 +84,7 @@ namespace System.IO.Pipelines
         /// <param name="consumed">Marks the extent of the data that has been successfully processed.</param>
         /// <remarks>The memory for the consumed data will be released and no longer available.
         /// The <see cref="System.IO.Pipelines.ReadResult.Buffer" /> previously returned from <see cref="System.IO.Pipelines.PipeReader.ReadAsync(System.Threading.CancellationToken)" /> must not be accessed after this call.
-        /// This is equivalent to calling <see cref="System.IO.Pipelines.PipeReader.AdvanceTo(System.SequencePosition,System.SequencePosition)" /> with identical examined and consumed positions,
-        /// unless a previous <see cref="PipeReader.AdvanceTo(SequencePosition, SequencePosition)"/> call was made with a further examined index, then it will use the further examined index.
+        /// This is equivalent to calling <see cref="System.IO.Pipelines.PipeReader.AdvanceTo(System.SequencePosition,System.SequencePosition)" /> with identical examined and consumed positions.
         /// The examined data communicates to the pipeline when it should signal more data is available.
         /// </remarks>
         public abstract void AdvanceTo(SequencePosition consumed);
@@ -95,8 +94,7 @@ namespace System.IO.Pipelines
         /// <param name="examined">Marks the extent of the data that has been read and examined.</param>
         /// <remarks>The memory for the consumed data will be released and no longer available.
         /// The <see cref="System.IO.Pipelines.ReadResult.Buffer" /> previously returned from <see cref="System.IO.Pipelines.PipeReader.ReadAsync(System.Threading.CancellationToken)" /> must not be accessed after this call.
-        /// The examined data communicates to the pipeline when it should signal more data is available.
-        /// The examined parameter should be greater than or equal to the examined position in the previous call to `AdvanceTo`. Otherwise, an <see cref="System.InvalidOperationException" /> is thrown.</remarks>
+        /// The examined data communicates to the pipeline when it should signal more data is available.</remarks>
         public abstract void AdvanceTo(SequencePosition consumed, SequencePosition examined);
 
         /// <summary>Returns a <see cref="System.IO.Stream" /> representation of the <see cref="System.IO.Pipelines.PipeReader" />.</summary>

--- a/src/libraries/System.IO.Pipelines/tests/BackpressureTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/BackpressureTests.cs
@@ -249,23 +249,23 @@ namespace System.IO.Pipelines.Tests
             ValueTask<FlushResult> flushAsync = writableBuffer.FlushAsync();
 
             ReadResult result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
-            SequencePosition consumed = result.Buffer.GetPosition(2);
+            SequencePosition examined = result.Buffer.GetPosition(2);
             // Examine 2, don't advance consumed
-            _pipe.Reader.AdvanceTo(result.Buffer.Start, consumed);
+            _pipe.Reader.AdvanceTo(result.Buffer.Start, examined);
 
             Assert.False(flushAsync.IsCompleted);
 
             result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
             // Examine 1 which is less than the previous examined index of 2
-            consumed = result.Buffer.GetPosition(1);
-            _pipe.Reader.AdvanceTo(result.Buffer.Start, consumed);
+            examined = result.Buffer.GetPosition(1);
+            _pipe.Reader.AdvanceTo(result.Buffer.Start, examined);
 
             Assert.False(flushAsync.IsCompleted);
 
             // Just make sure we can still release backpressure
             result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
-            consumed = result.Buffer.GetPosition(ResumeWriterThreshold + 1);
-            _pipe.Reader.AdvanceTo(consumed, consumed);
+            examined = result.Buffer.GetPosition(ResumeWriterThreshold + 1);
+            _pipe.Reader.AdvanceTo(examined, examined);
 
             Assert.True(flushAsync.IsCompleted);
         }

--- a/src/libraries/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -221,24 +221,6 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task ExaminedLessThanBeforeThrows()
-        {
-            _pipe.Writer.WriteEmpty(10);
-            await _pipe.Writer.FlushAsync();
-
-            ReadResult result = await _pipe.Reader.ReadAsync();
-            _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
-
-            Assert.Equal(0, _pipe.Length);
-
-            _pipe.Writer.WriteEmpty(10);
-            await _pipe.Writer.FlushAsync();
-
-            result = await _pipe.Reader.ReadAsync();
-            Assert.Throws<InvalidOperationException>(() => _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.Start));
-        }
-
-        [Fact]
         public async Task ConsumedGreaterThanExaminedThrows()
         {
             _pipe.Writer.WriteEmpty(10);
@@ -284,10 +266,10 @@ namespace System.IO.Pipelines.Tests
             Memory<byte> buffer = new byte[26];
             Pipe pipe = new(new PipeOptions(minimumSegmentSize: 1));
 
-            var mem = pipe.Writer.GetMemory(14)[..14];
-            buffer[..14].CopyTo(mem);
+            var mem = pipe.Writer.GetMemory(14).Slice(0, 14);
+            buffer.Slice(0, 14).CopyTo(mem);
             pipe.Writer.Advance(14);
-            await pipe.Writer.WriteAsync(buffer[14..]);
+            await pipe.Writer.WriteAsync(buffer.Slice(14));
             ReadResult res = await pipe.Reader.ReadAsync();
             Assert.Equal(res.Buffer.Length, buffer.Length);
         }

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderStreamTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderStreamTests.cs
@@ -38,7 +38,7 @@ namespace System.IO.Pipelines.Tests
             for (int i = 0; i < 2; i++)
             {
                 s.Dispose();
-#if NETCOREAPP
+#if NET
                 await s.DisposeAsync();
 #endif
             }

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -759,7 +759,7 @@ namespace System.IO.Pipelines.Tests
 
         // Regression test: https://github.com/dotnet/runtime/issues/107213
         [Fact]
-        public async Task AdvanceToWithoutExaminedUsesFurthestExaminedIndex()
+        public async Task AdvanceToWithoutExaminedCanUnExamine()
         {
             PipeWriter buffer = _pipe.Writer;
             buffer.Write("Hello Worl"u8.ToArray());
@@ -781,12 +781,62 @@ namespace System.IO.Pipelines.Tests
 
             Assert.Equal("World", Encoding.ASCII.GetString(result.Buffer.ToArray()));
 
-            // Previous examine is at the end of 'Worl', calling AdvanceTo without passing examined will honor the previous examined index
+            // Previous examine is at the end of 'Worl', calling AdvanceTo without passing examined will unexamine (not externally visible)
+            // But more importantly, it will work and not throw that you're unexamining
             _pipe.Reader.AdvanceTo(result.Buffer.Start);
 
             // Double check that ReadAsync is still unblocked and works
             result = await _pipe.Reader.ReadAsync();
             Assert.Equal("World", Encoding.ASCII.GetString(result.Buffer.ToArray()));
+        }
+
+        [Fact]
+        public async Task AdvanceToWithExaminedCanUnExamine()
+        {
+            PipeWriter buffer = _pipe.Writer;
+            buffer.Write("Hello Worl"u8.ToArray());
+            await buffer.FlushAsync();
+
+            bool gotData = _pipe.Reader.TryRead(out ReadResult result);
+            Assert.True(gotData);
+
+            Assert.Equal("Hello Worl", Encoding.ASCII.GetString(result.Buffer.ToArray()));
+
+            // Advance past 'Hello ' and examine everything else
+            _pipe.Reader.AdvanceTo(result.Buffer.GetPosition(6), result.Buffer.End);
+
+            // Write so that the next ReadAsync will be unblocked
+            buffer.Write("d"u8.ToArray());
+            await buffer.FlushAsync();
+
+            result = await _pipe.Reader.ReadAsync();
+
+            Assert.Equal("World", Encoding.ASCII.GetString(result.Buffer.ToArray()));
+
+            // Previous examine is at the end of 'Worl', calling AdvanceTo without passing examined will unexamine (not externally visible)
+            // But more importantly, it will work and not throw that you're unexamining
+            _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.GetPosition(1));
+
+            // Double check that ReadAsync is still unblocked and works
+            result = await _pipe.Reader.ReadAsync();
+            Assert.Equal("World", Encoding.ASCII.GetString(result.Buffer.ToArray()));
+        }
+
+        [Fact]
+        public async Task ExaminedCannotBeBeforeConsumed()
+        {
+            PipeWriter buffer = _pipe.Writer;
+            buffer.Write("Hello World"u8.ToArray());
+            await buffer.FlushAsync();
+
+            bool gotData = _pipe.Reader.TryRead(out ReadResult result);
+            Assert.True(gotData);
+
+            Assert.Equal("Hello World", Encoding.ASCII.GetString(result.Buffer.ToArray()));
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => _pipe.Reader.AdvanceTo(result.Buffer.GetPosition(6), result.Buffer.GetPosition(5)));
+            Assert.Equal("The examined position must be greater than or equal to the consumed position.", ex.Message);
         }
 
         private bool IsTaskWithResult<T>(ValueTask<T> task)

--- a/src/libraries/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
+++ b/src/libraries/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
@@ -25,6 +25,7 @@
     <Compile Include="PipeCompletionCallbacksTests.cs" />
     <Compile Include="PipeOptionsTests.cs" />
     <Compile Include="PipeReaderWriterFacts.cs" />
+    <Compile Include="PipeReaderStreamTests.cs" />
     <Compile Include="PipePoolTests.cs" />
     <Compile Include="PipeResetTests.cs" />
     <Compile Include="PipeTest.cs" />
@@ -51,7 +52,6 @@
     <Compile Include="PipeResetTests.nonnetstandard.cs" />
     <Compile Include="PipePoolTests.nonnetstandard.cs" />
     <Compile Include="PipeWriterStreamTests.nonnetstandard.cs" />
-    <Compile Include="PipeReaderStreamTests.nonnetstandard.cs" />
     <Compile Include="PipeReaderWriterStreamTests.nonnetstandard.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
+++ b/src/libraries/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
@@ -44,9 +44,9 @@
     <Compile Include="StreamPipeWriterTests.cs" />
     <Compile Include="Infrastructure\ThrowAfterNWritesStream.cs" />
     <Compile Include="UnflushedBytesTests.cs" />
+    <Compile Include="PipeLengthTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <Compile Include="PipeLengthTests.cs" />
     <Compile Include="BufferSegmentPoolTest.cs" />
     <Compile Include="PipeReaderWriterFacts.nonnetstandard.cs" />
     <Compile Include="PipeResetTests.nonnetstandard.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/107213

Changes `PipeReader.AdvanceTo(...)` to allow un-examining as long as the examine index is `>= consumed`. This allows code that might look at parts of the `Pipe`, and then pass the `Pipe` on, to work better.

A specific example is when examining some of the `Pipe` (`pipeReader.AdvanceTo(buffer.Start, buffer.End)`) and then creating a `Stream` via `PipeReader.AsStream()` and doing a zero-byte read on the `Stream`.

Code that would have thrown in this case will now work. The few [examples](https://github.com/dotnet/aspnetcore/issues/27585) we found of the original "examined position cannot be less than the previously examined position" exception have all been in cases where this fix would have made changing our code to avoid the exception unnecessary.

### Analyzing other PipeReader implementations

##### ASP.NET Core (Kestrel)

Kestrel has 1 PipeReader impementation: [HttpRequestPipeReader](https://github.com/dotnet/aspnetcore/blob/2d8ffa65e666a5e099bc0c400a5805669afa3f43/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestPipeReader.cs)

This is the type application developers can interact with. Internally it calls into different implementations depending on what version of Http the request is using. Most implementations look fine, the main interesting effect this change will have is on the tracking of how many bytes have been looked at for the case of flow control
https://github.com/dotnet/aspnetcore/blob/226b1c67495ad29a5d08be5a72d4f4e5a465220d/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs#L304
This can now return a negative value, which is then passed on to Http2 flow control. The flow control code looks like it can handle negative values and even calls it out as a scenario
https://github.com/dotnet/aspnetcore/blob/226b1c67495ad29a5d08be5a72d4f4e5a465220d/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/FlowControl.cs#L36-L39

##### Nerdbank.Streams

The [Nerdbank.Streams](https://github.com/dotnet/Nerdbank.Streams) repo has a couple `PipeReader` implementations
https://github.com/dotnet/Nerdbank.Streams/blob/886a3b356f355ab84c915e1325bba20129c6f599/src/Nerdbank.Streams/StreamPipeReader.cs#L78
and
https://github.com/dotnet/Nerdbank.Streams/blob/886a3b356f355ab84c915e1325bba20129c6f599/src/Nerdbank.Streams/NestedPipeReader.cs#L36
both of which look like they'll continue working as expected with this change.

##### Pipelines.Sockets.Unofficial

[MemoryMappedPipeReader](https://github.com/mgravell/Pipelines.Sockets.Unofficial/blob/6703efc310131037ee55b3136ff0d2d9e0df1e3f/src/Pipelines.Sockets.Unofficial/MemoryMappedPipeReader.cs#L130) looks like it will continue working as expected with this change.

-------------------------------

<details>

<summary>Original change</summary>

### Core change

Changes `PipeReader.AdvanceTo(SequencePosition consumed)` to choose between the internal examined index and `consumed` depending on which one is further advanced. This allows code that might look at parts of the `Pipe`, and then pass the `Pipe` on, to work better.

A specific example is when examining some of the `Pipe` (`pipeReader.AdvanceTo(buffer.Start, buffer.End)`) and then creating a `Stream` via `PipeReader.AsStream()` and doing a zero-byte read on the `Stream`.

This would technically be a **behavior breaking change**, but I believe it's mostly additive, so shouldn't break anyone unless they were relying on seeing an `InvalidOperationException` in this specific case.

### Analyzing other PipeReader implementations

##### ASP.NET Core (Kestrel)

In order to fix the original issue we have to at a minimum change [DuplexPipeStream](https://github.com/dotnet/aspnetcore/blob/3586ac9dd9e75e1c0159c85704d357bce9b25fd0/src/Shared/ServerInfrastructure/DuplexPipeStream.cs#L148) to call `AdvanceTo(consumed)`, right now it explicitly calls `AdvanceTo(consumed, consumed)`.

There is also [HttpRequestPipeReader](https://github.com/dotnet/aspnetcore/blob/2d8ffa65e666a5e099bc0c400a5805669afa3f43/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestPipeReader.cs#L28) which calls [MessageBody.AdvanceTo(consumed)](https://github.com/dotnet/aspnetcore/blob/2d8ffa65e666a5e099bc0c400a5805669afa3f43/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs#L54) and that ends up calling `MessageBody.AdvanceTo(consumed, consumed)` which has multiple implementations, many of which call `AdvanceTo(consumed, examined)` on an underlying [PipeReader](https://github.com/dotnet/aspnetcore/blob/3586ac9dd9e75e1c0159c85704d357bce9b25fd0/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs#L39). The `HttpRequestPipeReader` is used in user app code, so isn't as urgent to update if we go this route.

##### Nerdbank.Streams

The [Nerdbank.Streams](https://github.com/dotnet/Nerdbank.Streams) repo has a couple `PipeReader` implementations that would diverge in behavior
https://github.com/dotnet/Nerdbank.Streams/blob/886a3b356f355ab84c915e1325bba20129c6f599/src/Nerdbank.Streams/StreamPipeReader.cs#L78
and
https://github.com/dotnet/Nerdbank.Streams/blob/886a3b356f355ab84c915e1325bba20129c6f599/src/Nerdbank.Streams/NestedPipeReader.cs#L36
The `NestedPipeReader` one is the more immediately interesting one as it wraps a `PipeReader` and would end up calling `AdvanceTo(consumed, consumed)` which ends up missing this change.

##### Pipelines.Sockets.Unofficial

[MemoryMappedPipeReader](https://github.com/mgravell/Pipelines.Sockets.Unofficial/blob/6703efc310131037ee55b3136ff0d2d9e0df1e3f/src/Pipelines.Sockets.Unofficial/MemoryMappedPipeReader.cs#L130) behavior would diverge.

### Alternative design

We could attempt to do a fix that's targeted specifically to `PipeReaderStream`. One silly idea is to always set examined to 1 less than the end of the read buffer (unless consuming the entire buffer) which would make it so we never run into using an examined index less than the internal examined index, and would let any future read calls to complete immediately since there is at least 1 "new" byte to read.

</details>