### PR TITLE
Fix CrossGen2SynthesizePgo on Windows

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -127,7 +127,7 @@ IF NOT "%RunningIlasmRoundTrip%"=="" (
 
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(SynthesizedPgoIncompatible)' == 'true'"><![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-IF NOT "%CrossGen2SynthesizePgo"=="" (
+IF NOT "%CrossGen2SynthesizePgo%"=="" (
   ECHO SKIPPING EXECUTION BECAUSE CrossGen2SynthesizePgo IS SET
   popd
   Exit /b 0


### PR DESCRIPTION
Due to an apparent typo, The CrossGen2SynthesizePgo test flag simply always skipped tests on Windows, instead of just skipping tests when synthesize pgo testing was enabled.