### PR TITLE
Fix reporting illegal instruction exception

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -326,6 +326,9 @@ namespace System.Runtime
                 ExceptionIDs.NullReference => new NullReferenceException(),
                 ExceptionIDs.OutOfMemory => new OutOfMemoryException(),
                 ExceptionIDs.Overflow => new OverflowException(),
+#pragma warning disable CS0618 // ExecutionEngineException is obsolete
+                ExceptionIDs.IllegalInstruction => new ExecutionEngineException("Illegal instruction"),
+#pragma warning restore CS0618
                 _ => null
             };
 #endif
@@ -445,6 +448,7 @@ namespace System.Runtime
 
             STATUS_DATATYPE_MISALIGNMENT = 0x80000002u,
             STATUS_ACCESS_VIOLATION = 0xC0000005u,
+            STATUS_ILLEGAL_INSTRUCTION = 0xC000001Du,
             STATUS_INTEGER_DIVIDE_BY_ZERO = 0xC0000094u,
             STATUS_INTEGER_OVERFLOW = 0xC0000095u,
         }
@@ -599,6 +603,10 @@ namespace System.Runtime
 
                 case (uint)HwExceptionCode.STATUS_INTEGER_OVERFLOW:
                     exceptionId = ExceptionIDs.Overflow;
+                    break;
+
+                case (uint)HwExceptionCode.STATUS_ILLEGAL_INSTRUCTION:
+                    exceptionId = ExceptionIDs.IllegalInstruction;
                     break;
 
                 default:

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -328,8 +328,8 @@ namespace System.Runtime
                 ExceptionIDs.Overflow => new OverflowException(),
 #pragma warning disable CS0618 // ExecutionEngineException is obsolete
                 ExceptionIDs.IllegalInstruction => new ExecutionEngineException("Illegal instruction: Attempted to execute an instruction code not defined by the processor."),
-                ExceptionIDs.PrivilegedInstruction => new ExecutionEngineException("Privileged instruction: Attempted to execute an instruction code that cannot be executed in user mode.");
-                ExceptionIDs.InPageError => new ExecutionEngineException("In page error: Attempted to access a memory page that is not present, and the system is unable to load the page. For example, this exception might occur if a network connection is lost while running a program over a network.");
+                ExceptionIDs.PrivilegedInstruction => new ExecutionEngineException("Privileged instruction: Attempted to execute an instruction code that cannot be executed in user mode."),
+                ExceptionIDs.InPageError => new ExecutionEngineException("In page error: Attempted to access a memory page that is not present, and the system is unable to load the page. For example, this exception might occur if a network connection is lost while running a program over a network."),
 #pragma warning restore CS0618
                 _ => null
             };

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -327,7 +327,9 @@ namespace System.Runtime
                 ExceptionIDs.OutOfMemory => new OutOfMemoryException(),
                 ExceptionIDs.Overflow => new OverflowException(),
 #pragma warning disable CS0618 // ExecutionEngineException is obsolete
-                ExceptionIDs.IllegalInstruction => new ExecutionEngineException("Illegal instruction"),
+                ExceptionIDs.IllegalInstruction => new ExecutionEngineException("Illegal instruction: Attempted to execute an instruction code not defined by the processor."),
+                ExceptionIDs.PrivilegedInstruction => new ExecutionEngineException("Privileged instruction: Attempted to execute an instruction code that cannot be executed in user mode.");
+                ExceptionIDs.InPageError => new ExecutionEngineException("In page error: Attempted to access a memory page that is not present, and the system is unable to load the page. For example, this exception might occur if a network connection is lost while running a program over a network.");
 #pragma warning restore CS0618
                 _ => null
             };
@@ -448,9 +450,11 @@ namespace System.Runtime
 
             STATUS_DATATYPE_MISALIGNMENT = 0x80000002u,
             STATUS_ACCESS_VIOLATION = 0xC0000005u,
+            STATUS_IN_PAGE_ERROR = 0xC0000006u,
             STATUS_ILLEGAL_INSTRUCTION = 0xC000001Du,
             STATUS_INTEGER_DIVIDE_BY_ZERO = 0xC0000094u,
             STATUS_INTEGER_OVERFLOW = 0xC0000095u,
+            STATUS_PRIVILEGED_INSTRUCTION = 0xC0000096u,
         }
         [StructLayout(LayoutKind.Explicit, Size = AsmOffsets.SIZEOF__PAL_LIMITED_CONTEXT)]
         public struct PAL_LIMITED_CONTEXT
@@ -607,6 +611,14 @@ namespace System.Runtime
 
                 case (uint)HwExceptionCode.STATUS_ILLEGAL_INSTRUCTION:
                     exceptionId = ExceptionIDs.IllegalInstruction;
+                    break;
+
+                case (uint)HwExceptionCode.STATUS_IN_PAGE_ERROR:
+                    exceptionId = ExceptionIDs.InPageError;
+                    break;
+
+                case (uint)HwExceptionCode.STATUS_PRIVILEGED_INSTRUCTION:
+                    exceptionId = ExceptionIDs.PrivilegedInstruction;
                     break;
 
                 default:

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionIDs.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionIDs.cs
@@ -22,5 +22,6 @@ namespace System.Runtime
         DataMisaligned = 10,
         EntrypointNotFound = 11,
         AmbiguousImplementation = 12,
+        IllegalInstruction = 13,
     }
 }

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionIDs.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionIDs.cs
@@ -23,5 +23,7 @@ namespace System.Runtime
         EntrypointNotFound = 11,
         AmbiguousImplementation = 12,
         IllegalInstruction = 13,
+        PrivilegedInstruction = 14,
+        InPageError = 15,
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ExceptionIDs.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ExceptionIDs.cs
@@ -17,5 +17,6 @@ namespace System.Runtime
         DataMisaligned = 10,
         EntrypointNotFound = 11,
         AmbiguousImplementation = 12,
+        IllegalInstruction = 13,
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ExceptionIDs.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ExceptionIDs.cs
@@ -18,5 +18,7 @@ namespace System.Runtime
         EntrypointNotFound = 11,
         AmbiguousImplementation = 12,
         IllegalInstruction = 13,
+        PrivilegedInstruction = 14,
+        InPageError = 15,
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -96,6 +96,11 @@ namespace System
                         FailFast("Access Violation: Attempted to read or write protected memory. This is often an indication that other memory is corrupt. The application will be terminated since this platform does not support throwing an AccessViolationException.");
                         return null;
 
+#pragma warning disable CS0618 // ExecutionEngineException is obsolete
+                    case ExceptionIDs.IllegalInstruction:
+                        return new ExecutionEngineException("Illegal instruction");
+#pragma warning restore CS0618
+
                     case ExceptionIDs.DataMisaligned:
                         return new DataMisalignedException();
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -96,10 +96,9 @@ namespace System
                         FailFast("Access Violation: Attempted to read or write protected memory. This is often an indication that other memory is corrupt. The application will be terminated since this platform does not support throwing an AccessViolationException.");
                         return null;
 
-#pragma warning disable CS0618 // ExecutionEngineException is obsolete
                     case ExceptionIDs.IllegalInstruction:
-                        return new ExecutionEngineException("Illegal instruction");
-#pragma warning restore CS0618
+                        FailFast("Illegal instruction.");
+                        return null;
 
                     case ExceptionIDs.DataMisaligned:
                         return new DataMisalignedException();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -97,7 +97,15 @@ namespace System
                         return null;
 
                     case ExceptionIDs.IllegalInstruction:
-                        FailFast("Illegal instruction.");
+                        FailFast("Illegal instruction: Attempted to execute an instruction code not defined by the processor.");
+                        return null;
+
+                    case ExceptionIDs.PrivilegedInstruction:
+                        FailFast("Privileged instruction: Attempted to execute an instruction code that cannot be executed in user mode.");
+                        return null;
+
+                    case ExceptionIDs.InPageError:
+                        FailFast("In page error: Attempted to access a memory page that is not present, and the system is unable to load the page. For example, this exception might occur if a network connection is lost while running a program over a network.");
                         return null;
 
                     case ExceptionIDs.DataMisaligned:


### PR DESCRIPTION
The new EH (like NativeAOT) was not recognizing illegal instruction as valid hardware exceptions, so the reported error and stack trace were unusable to determine the error cause.

This change adds proper reporting of this hardware exception.

Close #107145