### PR TITLE
Bump Microsoft.Private.Intellisense version to 9.0.0-preview-20240830.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -209,7 +209,7 @@
     <CompilerPlatformTestingMicrosoftVisualBasicVersion>10.2.0</CompilerPlatformTestingMicrosoftVisualBasicVersion>
     <CompilerPlatformTestingMicrosoftVisualStudioCompositionVersion>17.0.46</CompilerPlatformTestingMicrosoftVisualStudioCompositionVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>8.0.0-preview-20230918.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>9.0.0-preview-20240830.1</MicrosoftPrivateIntellisenseVersion>
     <!-- Mono Cecil -->
     <MicrosoftDotNetCecilVersion>0.11.5-alpha.24419.1</MicrosoftDotNetCecilVersion>
     <!-- ILCompiler -->


### PR DESCRIPTION
@dotnet/runtime-infrastructure @dotnet/area-infrastructure-libraries PTAL

This package versiopn was freshly updated today:
https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet9-transport/NuGet/Microsoft.Private.Intellisense/overview/9.0.0-preview-20240830.1

More updates will come in the next weeks.

Will backport to `release/9.0`.