### PR TITLE
Normalize `--` and case for options in src/tests/build.sh like we do in eng/build(-commons).sh

### DIFF
--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -176,7 +176,9 @@ __RepoRootDir="$(cd "$__ProjectRoot"/../..; pwd -P)"
 __TargetArch=
 
 handle_arguments_local() {
-    case "$1" in
+    opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
+
+    case "$opt" in
         skipmanaged|-skipmanaged)
             __SkipManaged=1
             __BuildTestWrappers=0

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -230,7 +230,7 @@ handle_arguments_local() {
             __Priority=1
             ;;
 
-        allTargets|-allTargets)
+        alltargets|-alltargets)
             __UnprocessedBuildArgs+=("/p:CLRTestBuildAllTargets=allTargets")
             ;;
 


### PR DESCRIPTION
I lost a decent amount of time trying to puzzle out why cross builds weren't working for tests like they did for everything else, and the problem came down to `--` not working for `tests/build.sh` like it does elsewhere. This is made worse by the usage helptext for regular `build.sh` telling you to use i.e. `--cross`, so it's not obvious that you're screwing up unless you carefully read the cross build documentation and see the single `-` there.