### PR TITLE
Track that kmov instructions may write to GPR register

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2789,7 +2789,14 @@ bool emitter::emitInsCanOnlyWriteSSE2OrAVXReg(instrDesc* id)
             // These SSE instructions write to a general purpose integer register.
             return false;
         }
-
+        case INS_kmovb_gpr:
+        case INS_kmovw_gpr:
+        case INS_kmovd_gpr:
+        case INS_kmovq_gpr:
+        {
+            // These kmov writes to a general purpose integer register
+            return !isGeneralRegister(id->idReg1());
+        }
         default:
         {
             return true;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106545/Runtime_106545.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106545/Runtime_106545.cs
@@ -8,7 +8,10 @@ Assertion failed '(emitThisGCrefRegs & regMask) == 0' in 'TestClass:Method4(shor
 
     File: D:\a\_work\1\s\src\coreclr\jit\emitxarch.cpp Line: 1498
 */
+using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using Xunit;
 
 public class Runtime_106545

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106545/Runtime_106545.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106545/Runtime_106545.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+Found by Fuzzlyn
+
+Assertion failed '(emitThisGCrefRegs & regMask) == 0' in 'TestClass:Method4(short,System.Runtime.Intrinsics.Vector512`1[long],byref,short,byref,byref,TestClass+S1,byref):byte:this' during 'Emit code' (IL size 47; hash 0x0a275b75; FullOpts)
+
+    File: D:\a\_work\1\s\src\coreclr\jit\emitxarch.cpp Line: 1498
+*/
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_106545
+{   
+    Vector512<byte> v512_byte_97 = Vector512.CreateScalar((byte)1);
+
+    public ulong Method0()
+    {
+        v512_byte_97 = Vector512<byte>.AllBitsSet;
+        return (0 - Vector512.ExtractMostSignificantBits(v512_byte_97));
+    }
+    
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        if (Avx2.IsSupported)
+        {
+            new Runtime_106545().Method0();
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_106545/Runtime_106545.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_106545/Runtime_106545.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There were several `kmov*` instructions missing from method `emitInsCanOnlyWriteSSE2OrAVXReg`. 

Closes: https://github.com/dotnet/runtime/issues/106545