### PR TITLE
Fix incorrect handle type array/count when FEATURE_SIZED_REF_HANDLES is not defined

### DIFF
--- a/src/coreclr/gc/objecthandle.cpp
+++ b/src/coreclr/gc/objecthandle.cpp
@@ -1105,7 +1105,7 @@ void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, 
 
     // promote objects pointed to by strong handles
     // during ephemeral GCs we also want to promote the ones pointed to by sizedref handles.
-    uint32_t types[2] = {
+    uint32_t types[] = {
         HNDTYPE_STRONG,
 #ifdef FEATURE_SIZED_REF_HANDLES
         HNDTYPE_SIZEDREF


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/107381

Regression from https://github.com/dotnet/runtime/pull/107326 - without `FEATURE_SIZED_REF_HANDLES` defined, this was incorrectly passing an array of two handle types - HNDTYPE_STRONG and HNDTYPE_WEAK_SHORT (0) - when promoting objects pointed to by strong handles.