### PR TITLE
Fix thread static cleanup paths

### DIFF
--- a/src/coreclr/vm/loaderallocator.hpp
+++ b/src/coreclr/vm/loaderallocator.hpp
@@ -264,6 +264,8 @@ class SegmentedHandleIndexStack
 
 public:
 
+    ~SegmentedHandleIndexStack();
+    
     // Push the value to the stack. If the push cannot be done due to OOM, return false;
     inline bool Push(DWORD value);
 

--- a/src/coreclr/vm/loaderallocator.inl
+++ b/src/coreclr/vm/loaderallocator.inl
@@ -208,6 +208,19 @@ inline DWORD SegmentedHandleIndexStack::Pop()
     return m_TOSSegment->m_data[--m_TOSIndex];
 }
 
+inline SegmentedHandleIndexStack::~SegmentedHandleIndexStack()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    while (m_TOSSegment != NULL)
+    {
+        Segment* prevSegment = m_TOSSegment->m_prev;
+        delete m_TOSSegment;
+        m_TOSSegment = prevSegment;
+    }
+    m_freeSegment = NULL;
+}
+
 inline bool SegmentedHandleIndexStack::IsEmpty()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -457,6 +457,7 @@ void FreeThreadStaticData(Thread* pThread)
         pThreadLocalData->cNonCollectibleTlsData = 0;
 
         pOldInFlightData = pThreadLocalData->pInFlightData;
+        pThreadLocalData->pInFlightData = NULL;
         _ASSERTE(pThreadLocalData->pThread == pThread);
         pThreadLocalData->pThread = NULL;
     }

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -304,7 +304,7 @@ public:
 
 #ifndef DACCESS_COMPILE
     void Set(TLSIndex index, PTR_MethodTable pMT, bool isGCStatic);
-    bool FindClearedIndex(uint8_t whenClearedMarkerToAvoid, TLSIndex* pIndex);
+    bool FindClearedIndex(TLSIndex* pIndex);
     void Clear(TLSIndex index, uint8_t whenCleared);
 #endif // !DACCESS_COMPILE
 


### PR DESCRIPTION
- Do not destroy GC handles while holding the spin lock
- Free the pLoaderHandle array when the thread is terminated

Fixes #104449 