### PR TITLE
Fix published crossgen2 crash

### DIFF
--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <LibrariesConfiguration>Release</LibrariesConfiguration>
+    <LibrariesConfiguration Condition="'$(LibrariesConfiguration)' == ''">$(Configuration)</LibrariesConfiguration>
     <InstallV8ForTests>false</InstallV8ForTests>
   </PropertyGroup>
 


### PR DESCRIPTION
If test is built as Debug or Checked without `LibrariesConfiguration`, `LibrariesConfiguration` is set to default `Release` configuration.
So when it builds crossgen2, it uses debug c/c++ codes with non-debug libraries. It makes some mismatching and crossgen2 crashes in some tests.
For example, `ParentMethodTableOffset` in `MethodTable` has different values in `methodtable.h` and `RuntimeHelpers.CoreCLR.cs` because debug mode has `debug_m_szClassName` field and release mode doesn't have.

cc @dotnet/samsung