### PR TITLE
[release/6.0-staging][android] Bump to win 11 helix queue

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -32,7 +32,7 @@ jobs:
 
     # Android arm64
     - ${{ if in(parameters.platform, 'Android_arm64') }}:
-      - Windows.10.Amd64.Android.Open
+      - Windows.11.Amd64.Android.Open
 
     # Android x64
     - ${{ if in(parameters.platform, 'Android_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -96,7 +96,7 @@ jobs:
     - ${{ if in(parameters.platform, 'Android_x86', 'Android_x64') }}:
       - Ubuntu.1804.Amd64.Android.29.Open
     - ${{ if in(parameters.platform, 'Android_arm', 'Android_arm64') }}:
-      - Windows.10.Amd64.Android.Open
+      - Windows.11.Amd64.Android.Open
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'MacCatalyst_arm64', 'iOSSimulator_arm64') }}:


### PR DESCRIPTION
Backport of #96139 to release/6.0-staging.

Same as https://github.com/dotnet/runtime/pull/96634 just for the 6.0 branch. Dnceng would like to remove this old Helix queue.

## Customer Impact
None, this is an infrastructure change

## Testing
CI testing.

## Risk
None.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.