### PR TITLE
Fixed dependency injection event source tests randomly failing.

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
             if (data.PayloadNames is { } names &&
                 data.Payload is { } payload &&
-                names.IndexOf(propName) is var index and >= 0 &&
+                names.IndexOf(propName) is int index and >= 0 &&
                 payload[index] is T value)
             {
                 result = value;


### PR DESCRIPTION
* Filtered events in the listener by the service provider hash. This prevents events from other test classes impacting the event source tests.
* Reused the listener to improve performance.

Fixes #35753