### PR TITLE
Remove `BaseDomain` use in `LoaderAllocator` and event tracing helpers

### DIFF
--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -753,7 +753,7 @@ namespace ETW
         static VOID IterateCollectibleLoaderAllocator(AssemblyLoaderAllocator *pLoaderAllocator, DWORD enumerationOptions);
         static VOID IterateAssembly(Assembly *pAssembly, DWORD enumerationOptions);
         static VOID IterateModule(Module *pModule, DWORD enumerationOptions);
-        static VOID EnumerationHelper(Module *moduleFilter, AppDomain *domainFilter, DWORD enumerationOptions);
+        static VOID EnumerationHelper(Module *moduleFilter, DWORD enumerationOptions);
         static DWORD GetEnumerationOptionsFromRuntimeKeywords();
     public:
         typedef union _EnumerationStructs

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -749,7 +749,7 @@ namespace ETW
 #ifdef FEATURE_EVENT_TRACE
         static VOID SendThreadRundownEvent();
         static VOID SendGCRundownEvent();
-        static VOID IterateAppDomain(AppDomain * pAppDomain, DWORD enumerationOptions);
+        static VOID IterateAppDomain(DWORD enumerationOptions);
         static VOID IterateCollectibleLoaderAllocator(AssemblyLoaderAllocator *pLoaderAllocator, DWORD enumerationOptions);
         static VOID IterateAssembly(Assembly *pAssembly, DWORD enumerationOptions);
         static VOID IterateModule(Module *pModule, DWORD enumerationOptions);
@@ -837,7 +837,7 @@ namespace ETW
         static VOID SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL bFireDomainModuleEvents=FALSE);
         static ULONG SendModuleRange(_In_ Module *pModule, _In_ DWORD dwEventOptions);
         static VOID SendAssemblyEvent(Assembly *pAssembly, DWORD dwEventOptions);
-        static VOID SendDomainEvent(AppDomain *pDomain, DWORD dwEventOptions, LPCWSTR wszFriendlyName=NULL);
+        static VOID SendDomainEvent(DWORD dwEventOptions, LPCWSTR wszFriendlyName=NULL);
     public:
         typedef union _LoaderStructs
         {
@@ -875,23 +875,23 @@ namespace ETW
 
         }LoaderStructs;
 
-        static VOID DomainLoadReal(AppDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName=NULL);
+        static VOID DomainLoadReal(_In_opt_ LPWSTR wszFriendlyName=NULL);
 
-        static VOID DomainLoad(AppDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName = NULL)
+        static VOID DomainLoad(_In_opt_ LPWSTR wszFriendlyName = NULL)
         {
             if (ETW_PROVIDER_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER))
             {
-                DomainLoadReal(pDomain, wszFriendlyName);
+                DomainLoadReal(wszFriendlyName);
             }
         }
 
-        static VOID DomainUnload(AppDomain *pDomain);
+        static VOID DomainUnload();
         static VOID CollectibleLoaderAllocatorUnload(AssemblyLoaderAllocator *pLoaderAllocator);
         static VOID ModuleLoad(Module *pModule, LONG liReportedSharedModule);
 #else
     public:
-        static VOID DomainLoad(AppDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName=NULL) {};
-        static VOID DomainUnload(AppDomain *pDomain) {};
+        static VOID DomainLoad(_In_opt_ LPWSTR wszFriendlyName=NULL) {};
+        static VOID DomainUnload() {};
         static VOID CollectibleLoaderAllocatorUnload(AssemblyLoaderAllocator *pLoaderAllocator) {};
         static VOID ModuleLoad(Module *pModule, LONG liReportedSharedModule) {};
 #endif // FEATURE_EVENT_TRACE

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -902,7 +902,7 @@ namespace ETW
     {
         friend class ETW::EnumerationLog;
 #ifdef FEATURE_EVENT_TRACE
-        static VOID SendEventsForJitMethods(AppDomain *pDomainFilter, LoaderAllocator *pLoaderAllocatorFilter, DWORD dwEventOptions);
+        static VOID SendEventsForJitMethods(BOOL getCodeVersionIds, LoaderAllocator *pLoaderAllocatorFilter, DWORD dwEventOptions);
         static VOID SendEventsForJitMethodsHelper(
             LoaderAllocator *pLoaderAllocatorFilter,
             DWORD dwEventOptions,

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -689,7 +689,6 @@ class Module;
 class Assembly;
 class MethodDesc;
 class MethodTable;
-class BaseDomain;
 class AppDomain;
 class SString;
 class CrawlFrame;
@@ -750,12 +749,11 @@ namespace ETW
 #ifdef FEATURE_EVENT_TRACE
         static VOID SendThreadRundownEvent();
         static VOID SendGCRundownEvent();
-        static VOID IterateDomain(BaseDomain *pDomain, DWORD enumerationOptions);
         static VOID IterateAppDomain(AppDomain * pAppDomain, DWORD enumerationOptions);
         static VOID IterateCollectibleLoaderAllocator(AssemblyLoaderAllocator *pLoaderAllocator, DWORD enumerationOptions);
         static VOID IterateAssembly(Assembly *pAssembly, DWORD enumerationOptions);
         static VOID IterateModule(Module *pModule, DWORD enumerationOptions);
-        static VOID EnumerationHelper(Module *moduleFilter, BaseDomain *domainFilter, DWORD enumerationOptions);
+        static VOID EnumerationHelper(Module *moduleFilter, AppDomain *domainFilter, DWORD enumerationOptions);
         static DWORD GetEnumerationOptionsFromRuntimeKeywords();
     public:
         typedef union _EnumerationStructs
@@ -839,7 +837,7 @@ namespace ETW
         static VOID SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL bFireDomainModuleEvents=FALSE);
         static ULONG SendModuleRange(_In_ Module *pModule, _In_ DWORD dwEventOptions);
         static VOID SendAssemblyEvent(Assembly *pAssembly, DWORD dwEventOptions);
-        static VOID SendDomainEvent(BaseDomain *pBaseDomain, DWORD dwEventOptions, LPCWSTR wszFriendlyName=NULL);
+        static VOID SendDomainEvent(AppDomain *pDomain, DWORD dwEventOptions, LPCWSTR wszFriendlyName=NULL);
     public:
         typedef union _LoaderStructs
         {
@@ -877,9 +875,9 @@ namespace ETW
 
         }LoaderStructs;
 
-        static VOID DomainLoadReal(BaseDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName=NULL);
+        static VOID DomainLoadReal(AppDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName=NULL);
 
-        static VOID DomainLoad(BaseDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName = NULL)
+        static VOID DomainLoad(AppDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName = NULL)
         {
             if (ETW_PROVIDER_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER))
             {
@@ -892,7 +890,7 @@ namespace ETW
         static VOID ModuleLoad(Module *pModule, LONG liReportedSharedModule);
 #else
     public:
-        static VOID DomainLoad(BaseDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName=NULL) {};
+        static VOID DomainLoad(AppDomain *pDomain, _In_opt_ LPWSTR wszFriendlyName=NULL) {};
         static VOID DomainUnload(AppDomain *pDomain) {};
         static VOID CollectibleLoaderAllocatorUnload(AssemblyLoaderAllocator *pLoaderAllocator) {};
         static VOID ModuleLoad(Module *pModule, LONG liReportedSharedModule) {};
@@ -904,7 +902,7 @@ namespace ETW
     {
         friend class ETW::EnumerationLog;
 #ifdef FEATURE_EVENT_TRACE
-        static VOID SendEventsForJitMethods(BaseDomain *pDomainFilter, LoaderAllocator *pLoaderAllocatorFilter, DWORD dwEventOptions);
+        static VOID SendEventsForJitMethods(AppDomain *pDomainFilter, LoaderAllocator *pLoaderAllocatorFilter, DWORD dwEventOptions);
         static VOID SendEventsForJitMethodsHelper(
             LoaderAllocator *pLoaderAllocatorFilter,
             DWORD dwEventOptions,

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2014,7 +2014,7 @@ private:
 
         m_pDelayedUnloadListOfLoaderAllocators=NULL;
 
-        m_GlobalAllocator.Init(this);
+        m_GlobalAllocator.Init();
     }
 #endif
 
@@ -2022,7 +2022,6 @@ private:
     PTR_Assembly    m_pSystemAssembly;  // Single assembly (here for quicker reference);
 
     GlobalLoaderAllocator m_GlobalAllocator;
-
 
     InlineSString<100>  m_BaseLibrary;
 

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -456,7 +456,7 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
 
             // Some of the initialization functions are not virtual. Call through the derived class
             // to prevent calling the base class version.
-            pCollectibleLoaderAllocator->Init(pDomain);
+            pCollectibleLoaderAllocator->Init();
 
             // Setup the managed proxy now, but do not actually transfer ownership to it.
             // Once everything is setup and nothing can fail anymore, the ownership will be

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -1205,7 +1205,7 @@ extern "C" INT_PTR QCALLTYPE AssemblyNative_InitializeAssemblyLoadContext(INT_PT
                 GCX_PREEMP();
                 // Some of the initialization functions are not virtual. Call through the derived class
                 // to prevent calling the base class version.
-                loaderAllocator->Init(pCurDomain);
+                loaderAllocator->Init();
                 loaderAllocator->InitVirtualCallStubManager();
 
                 // Setup the managed proxy now, but do not actually transfer ownership to it.

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -559,7 +559,7 @@ HRESULT CorHost2::CreateAppDomainWithManager(
 
     BEGIN_EXTERNAL_ENTRYPOINT(&hr);
 
-    AppDomain* pDomain = SystemDomain::System()->DefaultDomain();
+    AppDomain* pDomain = AppDomain::GetCurrentDomain();
 
     pDomain->SetFriendlyName(wszFriendlyName);
 

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -563,7 +563,7 @@ HRESULT CorHost2::CreateAppDomainWithManager(
 
     pDomain->SetFriendlyName(wszFriendlyName);
 
-    ETW::LoaderLog::DomainLoad(pDomain, (LPWSTR)wszFriendlyName);
+    ETW::LoaderLog::DomainLoad((LPWSTR)wszFriendlyName);
 
     if (dwFlags & APPDOMAIN_IGNORE_UNHANDLED_EXCEPTIONS)
         pDomain->SetIgnoreUnhandledExceptions();

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -1926,7 +1926,7 @@ VOID ETW::EnumerationLog::ModuleRangeRundown()
                                          TRACE_LEVEL_INFORMATION,
                                          CLR_PERFTRACK_PRIVATE_KEYWORD))
         {
-            ETW::EnumerationLog::EnumerationHelper(NULL, NULL, ETW::EnumerationLog::EnumerationStructs::ModuleRangeLoadPrivate);
+            ETW::EnumerationLog::EnumerationHelper(NULL, ETW::EnumerationLog::EnumerationStructs::ModuleRangeLoadPrivate);
         }
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
 }
@@ -2037,7 +2037,7 @@ VOID ETW::EnumerationLog::StartRundown()
                 enumerationOptions |= ETW::EnumerationLog::EnumerationStructs::JittedMethodRichDebugInfo;
             }
 
-            ETW::EnumerationLog::EnumerationHelper(NULL, NULL, enumerationOptions);
+            ETW::EnumerationLog::EnumerationHelper(NULL, enumerationOptions);
 
             if (bIsThreadingRundownEnabled)
             {
@@ -2124,9 +2124,8 @@ VOID ETW::EnumerationLog::EnumerateForCaptureState()
         {
             DWORD enumerationOptions = GetEnumerationOptionsFromRuntimeKeywords();
 
-            // Send unload events for all remaining domains, including shared domain and
-            // default domain.
-            ETW::EnumerationLog::EnumerationHelper(NULL /* module filter */, NULL /* domain filter */, enumerationOptions);
+            // Send unload events for all remaining modules
+            ETW::EnumerationLog::EnumerationHelper(NULL /* module filter */, enumerationOptions);
 
             // Send thread created events for all currently active threads, if requested
             if (ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context,
@@ -2227,7 +2226,7 @@ VOID ETW::EnumerationLog::EndRundown()
                 enumerationOptions |= ETW::EnumerationLog::EnumerationStructs::JittedMethodRichDebugInfo;
             }
 
-            ETW::EnumerationLog::EnumerationHelper(NULL, NULL, enumerationOptions);
+            ETW::EnumerationLog::EnumerationHelper(NULL, enumerationOptions);
 
             if (bIsThreadingRundownEnabled)
             {
@@ -3009,7 +3008,7 @@ VOID ETW::LoaderLog::DomainUnload(AppDomain *pDomain)
                 enumerationOptions |= ETW::EnumerationLog::EnumerationStructs::TypeUnload;
             }
 
-            ETW::EnumerationLog::EnumerationHelper(NULL, pDomain, enumerationOptions);
+            ETW::EnumerationLog::EnumerationHelper(NULL, enumerationOptions);
         }
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
 }
@@ -3873,7 +3872,7 @@ VOID ETW::LoaderLog::ModuleLoad(Module *pModule, LONG liReportedSharedModule)
                 if(bTraceFlagLoaderSet || bTraceFlagPerfTrackSet)
                     ETW::LoaderLog::SendModuleEvent(pModule, ETW::EnumerationLog::EnumerationStructs::DomainAssemblyModuleLoad | ETW::EnumerationLog::EnumerationStructs::ModuleRangeLoad);
 
-                ETW::EnumerationLog::EnumerationHelper(pModule, NULL, enumerationOptions);
+                ETW::EnumerationLog::EnumerationHelper(pModule, enumerationOptions);
             }
 
             // we want to report domainmodule events whenever they are loaded in any AppDomain
@@ -3910,9 +3909,8 @@ VOID ETW::EnumerationLog::ProcessShutdown()
         {
             DWORD enumerationOptions = GetEnumerationOptionsFromRuntimeKeywords();
 
-            // Send unload events for all remaining domains, including shared domain and
-            // default domain.
-            ETW::EnumerationLog::EnumerationHelper(NULL /* module filter */, NULL /* domain filter */, enumerationOptions);
+            // Send unload events for all remaining modules
+            ETW::EnumerationLog::EnumerationHelper(NULL /* module filter */, enumerationOptions);
         }
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
 }
@@ -5564,17 +5562,12 @@ VOID ETW::EnumerationLog::IterateModule(Module *pModule, DWORD enumerationOption
 //
 // Arguments:
 //      * moduleFilter - if non-NULL, events from only moduleFilter module are reported
-//      * domainFilter - if non-NULL, events from only domainFilter domain are reported
 //      * enumerationOptions - Flags from ETW::EnumerationLog::EnumerationStructs which
 //          describe which events should be sent.
 //
-// Notes:
-//     * if all filter args are NULL, events from all domains are reported
-//
-//
 
 // static
-VOID ETW::EnumerationLog::EnumerationHelper(Module *moduleFilter, AppDomain *domainFilter, DWORD enumerationOptions)
+VOID ETW::EnumerationLog::EnumerationHelper(Module *moduleFilter, DWORD enumerationOptions)
 {
     CONTRACTL {
         THROWS;
@@ -5607,18 +5600,7 @@ VOID ETW::EnumerationLog::EnumerationHelper(Module *moduleFilter, AppDomain *dom
     }
     else
     {
-        if(domainFilter)
-        {
-            ETW::EnumerationLog::IterateAppDomain(domainFilter, enumerationOptions);
-        }
-        else
-        {
-            AppDomain *pDomain = AppDomain::GetCurrentDomain();
-            if (pDomain != NULL)
-            {
-                ETW::EnumerationLog::IterateAppDomain(pDomain, enumerationOptions);
-            }
-        }
+        ETW::EnumerationLog::IterateAppDomain(AppDomain::GetCurrentDomain(), enumerationOptions);
     }
 }
 

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1732,7 +1732,7 @@ void AssemblyLoaderAllocator::Init()
     // GC mode, in case the caller requires that
     m_dependentHandleToNativeObjectSetCrst.Init(CrstLeafLock, CRST_UNSAFE_ANYMODE);
 
-    LoaderAllocator::Init(NULL);
+    LoaderAllocator::Init(NULL /*pExecutableHeapMemory*/);
     if (IsCollectible())
     {
         // TODO: the ShuffleThunkCache should really be using the m_pStubHeap, however the unloadability support

--- a/src/coreclr/vm/loaderallocator.hpp
+++ b/src/coreclr/vm/loaderallocator.hpp
@@ -360,8 +360,6 @@ public:
     BYTE *GetVSDHeapInitialBlock(DWORD *pSize);
     BYTE *GetCodeHeapInitialBlock(const BYTE * loAddr, const BYTE * hiAddr, DWORD minimumSize, DWORD *pSize);
 
-    BaseDomain *m_pDomain;
-
     // ExecutionManager caches
     void * m_pLastUsedCodeHeap;
     void * m_pLastUsedDynamicCodeHeap;
@@ -735,9 +733,8 @@ public:
 
     LoaderAllocator(bool collectible);
     virtual ~LoaderAllocator();
-    BaseDomain *GetDomain() { LIMITED_METHOD_CONTRACT; return m_pDomain; }
     virtual BOOL CanUnload() = 0;
-    void Init(BaseDomain *pDomain, BYTE *pExecutableHeapMemory = NULL);
+    void Init(BYTE *pExecutableHeapMemory);
     void Terminate();
     virtual void ReleaseManagedAssemblyLoadContext() {}
 
@@ -887,7 +884,7 @@ protected:
     LoaderAllocatorID m_Id;
 
 public:
-    void Init(BaseDomain *pDomain);
+    void Init();
     GlobalLoaderAllocator() : LoaderAllocator(false), m_Id(LAT_Global, (void*)1) { LIMITED_METHOD_CONTRACT;};
     virtual LoaderAllocatorID* Id();
     virtual BOOL CanUnload();
@@ -913,7 +910,7 @@ public:
         , m_binderToRelease(NULL)
 #endif
     { LIMITED_METHOD_CONTRACT; }
-    void Init(AppDomain *pAppDomain);
+    void Init();
     virtual BOOL CanUnload();
 
     void AddDomainAssembly(DomainAssembly *pDomainAssembly)

--- a/src/coreclr/vm/loaderallocator.inl
+++ b/src/coreclr/vm/loaderallocator.inl
@@ -24,9 +24,9 @@ inline bool LoaderAllocator::IsExposedObjectLive()
     return !ObjectHandleIsNull(m_hLoaderAllocatorObjectHandle);
 }
 
-inline void GlobalLoaderAllocator::Init(BaseDomain *pDomain)
+inline void GlobalLoaderAllocator::Init()
 {
-    LoaderAllocator::Init(pDomain, m_ExecutableHeapInstance);
+    LoaderAllocator::Init(m_ExecutableHeapInstance);
 }
 
 inline BOOL LoaderAllocatorID::Equals(LoaderAllocatorID *pId)


### PR DESCRIPTION
- Remove `BaseDomain` member on `LoaderAllocator`
  - Add asserts in functions using `AppDomain` that the loader allocator is collectible and the type is `LAT_Assembly` (so `AssemblyLoaderAllocator` which always had `AppDomain`)
- Remove unnecessary `BaseDomain`/`AppDomain` parameters from event tracing helpers
  - They were always being called with the current app domain

cc @jkotas @AaronRobinsonMSFT 