### PR TITLE
Improve error message when running `dotnet app.exe`

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -53,13 +53,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         public void ComponentWithNoDependenciesCaseChangedOnAsm()
         {
             // Scenario: change the case of the first letter of component.AppDll file name
+            // Resolution should be based on what is in the .deps.json
 
             // Changing the casing of the first letter of a dependent assembly have different behavior in the 3 platforms
             // Wisely the product code stays out of casing on dependent assemblies choosing the 1st assembly
             // Linux: we fail
-            // Windows and Mac, probing succeeds but
-            // Windows: probing returns the original name
-            // Mac: probing return the new name including 2 assembly probing with the original and new name, and the changed deps file
+            // Windows and Mac, resolution succeeds but
+            // Windows: uses original name and deps file as component info, resolution returns the original name
+            // Mac: uses chanegd name and changed deps file as component info, resolution returns the original name
 
             var component = sharedTestState.ComponentWithNoDependencies.Copy();
 
@@ -89,7 +90,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 sharedTestState.RunComponentResolutionTest(component)
                     .Should().Pass()
                     .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
-                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}{changeFile}{Path.PathSeparator}]")
+                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}]")
                     .And.HaveStdErrContaining($"app_root='{component.Location}{Path.DirectorySeparatorChar}'")
                     .And.HaveStdErrContaining($"deps='{changeDepsFile}'")
                     .And.HaveStdErrContaining($"mgd_app='{changeFile}'");
@@ -107,15 +108,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         [Fact]
         public void ComponentWithNoDependenciesCaseChangedOnDepsAndAsm()
         {
-
             // Scenario: change the case of the first letter of component.AppDll and component.DepsJson file names
+            // Resolution should be based on what is in the .deps.json
 
             // Changing the casing of the first letter of a dependent assembly have different behavior in the 3 platforms
             // Wisely the product code stays out of casing on dependent assemblies choosing the 1st assembly
             // Linux: we fail
-            // Windows and Mac, probing succeeds but
+            // Windows and Mac, resolution succeeds but
             // Windows: probing returns the original name
-            // Mac: probing return the new name including 2 assembly probing with the original and new name, and the changed deps file
+            // Windows: uses original name and deps file as component info, resolution returns the original name
+            // Mac: uses chanegd name and changed deps file as component info, resolution returns the original name
 
             var component = sharedTestState.ComponentWithNoDependencies.Copy();
 
@@ -146,7 +148,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 sharedTestState.RunComponentResolutionTest(component)
                     .Should().Pass()
                     .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
-                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}{changeFile}{Path.PathSeparator}]")
+                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}]")
                     .And.HaveStdErrContaining($"app_root='{component.Location}{Path.DirectorySeparatorChar}'")
                     .And.HaveStdErrContaining($"deps='{changeDepsFile}'")
                     .And.HaveStdErrContaining($"mgd_app='{changeFile}'");
@@ -164,8 +166,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         [Fact]
         public void ComponentWithNoDependenciesNoDepsCaseChangedOnAsm()
         {
-
             // Scenario: change the case of the first letter of component.AppDll file name and delete component.DepsJson file
+            // Resolution should be based on what is in the app-local directory
 
             // Changing the casing of the first letter of a dependent assembly have different behavior in the 3 platforms
             // Wisely the product code stays out of casing on dependent assemblies choosing the 1st assembly
@@ -194,7 +196,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 sharedTestState.RunComponentResolutionTest(component)
                     .Should().Pass()
                     .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
-                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}{changeFile}{Path.PathSeparator}]")
+                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{changeFile}{Path.PathSeparator}]")
                     .And.HaveStdErrContaining($"app_root='{component.Location}{Path.DirectorySeparatorChar}'")
                     .And.HaveStdErrContaining($"deps='{component.DepsJson}'")
                     .And.HaveStdErrContaining($"mgd_app='{component.AppDll}'");

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -1062,7 +1062,7 @@ int fx_muxer_t::handle_cli(
         trace::error(
             _X("The command could not be loaded, possibly because:\n")
             _X("  * You intended to execute a .NET application:\n")
-            _X("      The application '%s' does not exist.\n")
+            _X("      The application '%s' does not exist or is not a managed .dll or .exe.\n")
             _X("  * You intended to execute a .NET SDK command:"),
             app_candidate.c_str());
         resolver.print_resolution_error(host_info.dotnet_root, _X("      "));

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -513,20 +513,6 @@ bool deps_resolver_t::resolve_tpa_list(
     // we cannot determine what assemblies are framework assemblies, and what assemblies are app-local assemblies.
     if (m_host_mode != host_mode_t::libhost)
     {
-        // First add managed assembly to the TPA.
-        // TODO: Remove: the deps should contain the managed DLL.
-        // Workaround for: csc.deps.json doesn't have the csc.dll
-
-        // If this is a single-file bundle, app.dll is expected to be within the bundle, unless it is explicitly excluded from the bundle.
-        // In all other cases, add its path to the TPA list.
-        pal::string_t managed_app_name = get_filename(m_managed_app);
-        if (!bundle::info_t::is_single_file_bundle() ||
-            bundle::runner_t::app()->probe(managed_app_name) == nullptr)
-        {
-            deps_asset_t asset(get_filename_without_ext(m_managed_app), managed_app_name, version_t(), version_t());
-            add_tpa_asset(asset, m_managed_app, &items);
-        }
-
         // Add the app's entries
         const auto& deps_entries = get_app_deps().get_entries(deps_entry_t::asset_types::runtime);
         for (const auto& entry : deps_entries)


### PR DESCRIPTION
Stop explicitly adding app passed on command line to TPA. This was an old workaround that should no longer be needed (the .deps.json - including for csc - has the app assembly). Having this explicitly added would fail with a confusing message about the deps.json and mismatched file extensions if a user did `dotnet app.exe`. This change makes it so that we end up showing the same error as if the user tried to do an Assembly.Load on an app.exe that is not a managed assembly. This also makes the failure message match the case where there was no .deps.json.

Fixes https://github.com/dotnet/runtime/issues/37749

Before:
```
Error:
  An assembly specified in the application dependencies manifest (helloworld.deps.json) has already been found but with a different file extension:
    package: 'helloworld', version: '1.0.0'
    path: 'helloworld.dll'
    previously found assembly: 'C:\repos\helloworld\bin\Debug\net8.0\helloworld.exe'
```
After:
```
Unhandled exception. System.BadImageFormatException: Bad IL format. The format of the file 'C:\repos\helloworld\bin\Debug\net8.0\helloworld.exe' is invalid.
```

cc @dotnet/appmodel @AaronRobinsonMSFT 