### PR TITLE
JIT: don't create vector constants from relocatable constants

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8962,8 +8962,18 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeIndir* ind)
         assert(prevData.IsStore());
         assert(currData.IsStore());
 
-        // For now, only constants are supported for data.
+        // For now, only non-relocatable constants are supported for data.
         if (!prevData.value->OperIsConst() || !currData.value->OperIsConst())
+        {
+            return;
+        }
+
+        if (prevData.value->IsCnsIntOrI() && prevData.value->AsIntCon()->ImmedValNeedsReloc(comp))
+        {
+            return;
+        }
+
+        if (currData.value->IsCnsIntOrI() && currData.value->AsIntCon()->ImmedValNeedsReloc(comp))
         {
             return;
         }


### PR DESCRIPTION
We can't represent relocations in data currently.

Fixes #107396.