### PR TITLE
[PERF] For slow perf runs, change release/9.0 to only be on schedule and main to only be batched.

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -32,7 +32,6 @@ schedules:
   displayName: Every night at 2:30AM
   branches:
     include:
-    - main
     - release/9.0
   always: true
 

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -11,7 +11,6 @@ trigger:
   branches:
     include:
     - main
-    - release/9.0
   paths:
     include:
     - '*'
@@ -34,6 +33,7 @@ schedules:
   branches:
     include:
     - main
+    - release/9.0
   always: true
 
 extends:


### PR DESCRIPTION
Currently each run of perf-slow causes ~6 hours of work items to be queued onto our ampere queues. With release/9.0 now also triggering batched on commits in addition to main it is causing the ampere queues to be backed up considerably. With this change it should significantly help reduce the wait times for the ampere queue as this is affecting the dotnet-performance pipeline which needs to run scenario workloads on the ampere machines as well.