### PR TITLE
Remove unused declarations from clsload.hpp

### DIFF
--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -836,27 +836,6 @@ void ClassLoader::EnsureLoaded(TypeHandle typeHnd, ClassLoadLevel level)
 #endif // DACCESS_COMPILE
 }
 
-/*static*/
-void ClassLoader::TryEnsureLoaded(TypeHandle typeHnd, ClassLoadLevel level)
-{
-    WRAPPER_NO_CONTRACT;
-
-#ifndef DACCESS_COMPILE // Nothing to do for the DAC case
-
-    EX_TRY
-    {
-        ClassLoader::EnsureLoaded(typeHnd, level);
-    }
-    EX_CATCH
-    {
-        // Some type may not load successfully. For eg. generic instantiations
-        // that do not satisfy the constraints of the type arguments.
-    }
-    EX_END_CATCH(RethrowTerminalExceptions);
-
-#endif // DACCESS_COMPILE
-}
-
 /* static */
 TypeHandle ClassLoader::LookupTypeKey(const TypeKey *pKey, EETypeHashTable *pTable)
 {

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -564,11 +564,6 @@ private:
         Module *              pLookInThisModuleOnly,
         Loader::LoadFlag      loadFlag);
 
-    static PTR_Module ComputeLoaderModuleForCompilation(Module *pDefinitionModule,      // the module that declares the generic type or method
-                                                        mdToken token,
-                                                        Instantiation classInst,        // the type arguments to the type (if any)
-                                                        Instantiation methodInst);      // the type arguments to the method (if any)
-
 public:
     void Init(AllocMemTracker *pamTracker);
 
@@ -889,24 +884,7 @@ private:
 
     static void DECLSPEC_NORETURN  ThrowTypeLoadException(const TypeKey *pKey, UINT resIDWhy);
 
-
-    BOOL IsNested(const NameHandle* pName, mdToken *mdEncloser);
-    static BOOL IsNested(ModuleBase *pModude, mdToken typeDefOrRef, mdToken *mdEncloser);
-
 public:
-    // Helpers for FindClassModule()
-    BOOL CompareNestedEntryWithTypeDef(IMDInternalImport *pImport,
-                                       mdTypeDef mdCurrent,
-                                       EEClassHashTable *pClassHash,
-                                       PTR_EEClassHashEntry pEntry);
-    BOOL CompareNestedEntryWithTypeRef(IMDInternalImport *pImport,
-                                       mdTypeRef mdCurrent,
-                                       EEClassHashTable *pClassHash,
-                                       PTR_EEClassHashEntry pEntry);
-    BOOL CompareNestedEntryWithExportedType(IMDInternalImport *pImport,
-                                            mdExportedType mdCurrent,
-                                            EEClassHashTable *pClassHash,
-                                            PTR_EEClassHashEntry pEntry);
 
     //Attempts to find/load/create a type handle but does not throw
     // if used in "find" mode.

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -713,7 +713,6 @@ public:
                                              BOOL *           pfUsesTypeForwarder = NULL);
 
     static void EnsureLoaded(TypeHandle typeHnd, ClassLoadLevel level = CLASS_LOADED);
-    static void TryEnsureLoaded(TypeHandle typeHnd, ClassLoadLevel level = CLASS_LOADED);
 
 public:
     // Look up a class by name


### PR DESCRIPTION
The definition of `ComputeLoaderModuleForCompilation` was removed in https://github.com/dotnet/runtime/pull/57669.
`TryEnsureLoaded` has a definition but seems to be unused.
The definitions of the others were removed in https://github.com/dotnet/runtime/pull/94825.