### PR TITLE
Avoid using OpenThread for out of process SetThreadContext debugging

### DIFF
--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -11211,7 +11211,7 @@ void CordbProcess::HandleSetThreadContextNeeded(DWORD dwThreadId)
     context.ContextFlags = CONTEXT_FULL;
 
     // we originally used GetDataTarget()->GetThreadContext, but 
-    // the ipmlementation uses ShimLocalDataTarget::GetThreadContext which 
+    // the implementation uses ShimLocalDataTarget::GetThreadContext which 
     // depends on OpenThread which might fail with an Access Denied error (see note above)
     BOOL success = ::GetThreadContext(hThread, (CONTEXT*)(&context));
     if (!success)

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -11164,7 +11164,7 @@ void CordbProcess::HandleSetThreadContextNeeded(DWORD dwThreadId)
     // 4. then we can perform the actual SetThreadContext operation
     // 5. lastly, we must resume the thread
     // For the first step of obtaining the thread handle, 
-    // we have previously attempted to use ::OpenThead to get a handle to the thread.
+    // we have previously attempted to use ::OpenThread to get a handle to the thread.
     // However, there are situations where OpenThread can fail with an Access Denied error.
     // From https://github.com/dotnet/runtime/issues/107263, the control-c handler in 
     // Windows causes the process to have higher privileges. 

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -11168,7 +11168,7 @@ void CordbProcess::HandleSetThreadContextNeeded(DWORD dwThreadId)
     // However, there are situations where OpenThread can fail with an Access Denied error.
     // From https://github.com/dotnet/runtime/issues/107263, the control-c handler in 
     // Windows causes the process to have higher privileges. 
-    // We are now using the following approach to acess the thread handle, which is the same
+    // We are now using the following approach to access the thread handle, which is the same
     // approach used by CordbThread::RefreshHandle:
     // 1. Get the thread handle from the DAC
     // 2. Duplicate the handle to the current process


### PR DESCRIPTION
In .NET 9, CET (Control-flow Enforcement Technology) has been enabled by default (see https://github.com/dotnet/runtime/pull/103007).  The debugger has special handling when is CET enabled for breakpoints, stepping, and func-eval (see https://github.com/dotnet/runtime/pull/73572).  A customer reported regression in .NET 9 related to pressing "control-c".  Internally, when a managed control-c handler function is invoked, we try to set thread context out of process and fail to obtain the target thread's handle.  We found that once Control-C is pressed, Windows seems to change the access permissions to the process, causing attempts to retrieve the target thread's handle via to OpenThread to fail (the same happens with a C++ repro).  This PR updates the out-of-proc setthreadcontext handling logic to retrieve the handle using the DAC to workaround the access denied in OpenThread. 

Fixes #107263