### PR TITLE
Fix reflection-calling `Set` method on arrays

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
@@ -727,7 +727,7 @@ namespace System
             return rawIndex;
         }
 
-        private unsafe nint GetFlattenedIndex(ReadOnlySpan<int> indices)
+        internal unsafe nint GetFlattenedIndex(ReadOnlySpan<int> indices)
         {
             // Checked by the caller
             Debug.Assert(indices.Length == Rank);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -213,7 +213,7 @@ namespace System.Reflection.Runtime.TypeInfos
                             for (int i = 0; i < rank; i++)
                                 indices[i] = (int)(args[i]);
                             object value = args[rank];
-                            array.SetValue(value, indices);
+                            RuntimeAugments.SetArrayValue(array, indices, value);
                             return null;
                         }
                     );


### PR DESCRIPTION
The test added in #106787 found an issue in the implementation of reflection calls to array `Set` methods. We used to throw the wrong exception type. There were probably other corner case bugs (like what exception is thrown when both element type is wrong and index is out of range and when/how value coercion should happen). This should fix that.

Cc @dotnet/ilc-contrib 