### PR TITLE
[ILStrip] Fix passing assemblies using relative path

### DIFF
--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -127,13 +127,14 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
         try
         {
-            if(!AssemblyStripper.AssemblyStripper.TryStripAssembly(assemblyFile, outputPath))
+            if (!AssemblyStripper.AssemblyStripper.TryStripAssembly(assemblyFile, outputPath))
             {
                 Log.LogMessage(MessageImportance.Low, $"[ILStrip] Skipping {assemblyFile} because it is not a managed assembly.");
             }
             else
             {
-                _processedAssemblies.GetOrAdd(assemblyItem.ItemSpec, GetTrimmedAssemblyItem(assemblyItem, outputPath, assemblyFile));
+                var fullPath = assemblyItem.GetMetadata("FullPath");
+                _processedAssemblies.GetOrAdd(fullPath, GetTrimmedAssemblyItem(assemblyItem, outputPath, assemblyFile));
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Continuation of fix for: https://github.com/dotnet/runtime/issues/101967

https://github.com/dotnet/runtime/pull/106267 allowed ILStrip to gracefully handle unmanaged assemblies. Part of the fix included surfacing a new task output `UpdatedAssemblies`. This output is intended to be used by xamarin-macios in its MobileILStrip task. 

While completing the fix on xamarin-macios side we have discovered that the `UpdatedAssemblies` output is not populated when assemblies are passed using relative paths, which caused some of the xamarin-macios tests to fail. This PR solves this issue. The fix is structured in a way to only affect the scenario enabled by https://github.com/dotnet/runtime/pull/106267. It should not have any effect on other ILStrip applications. 

We will need to backport this to net9.

### Testing:
I did verify the fix locally by injecting the resulting dll into xamarin-macios and running the failing test.