### PR TITLE
Fix JsonSchemaExporter support for global UnmappedMemberHandling settings.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -204,7 +204,8 @@ namespace System.Text.Json.Schema
                     List<string>? required = null;
                     JsonSchema? additionalProperties = null;
 
-                    if (typeInfo.UnmappedMemberHandling is JsonUnmappedMemberHandling.Disallow)
+                    JsonUnmappedMemberHandling effectiveUnmappedMemberHandling = typeInfo.UnmappedMemberHandling ?? typeInfo.Options.UnmappedMemberHandling;
+                    if (effectiveUnmappedMemberHandling is JsonUnmappedMemberHandling.Disallow)
                     {
                         additionalProperties = JsonSchema.False;
                     }

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -677,6 +677,24 @@ namespace System.Text.Json.Schema.Tests
                 }
                 """);
 
+            // Global setting for JsonUnmappedMemberHandling.Disallow
+            yield return new TestData<SimplePoco>(
+                Value: new() { String = "string", StringNullable = "string", Int = 42, Double = 3.14, Boolean = true },
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object","null"],
+                    "properties": {
+                        "String": { "type": "string" },
+                        "StringNullable": { "type": ["string", "null"] },
+                        "Int": { "type": "integer" },
+                        "Double": { "type": "number" },
+                        "Boolean": { "type": "boolean" }
+                    },
+                    "additionalProperties": false,
+                }
+                """,
+                SerializerOptions: new() { UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow });
+
             yield return new TestData<PocoWithNullableAnnotationAttributes>(
                 Value: new() { MaybeNull = null!, AllowNull = null, NotNull = null, DisallowNull = null!, NotNullDisallowNull = "str" },
                 ExpectedJsonSchema: """
@@ -1446,7 +1464,8 @@ namespace System.Text.Json.Schema.Tests
             T? Value,
             string ExpectedJsonSchema,
             IEnumerable<T?>? AdditionalValues = null,
-            JsonSchemaExporterOptions? Options = null)
+            JsonSchemaExporterOptions? Options = null,
+            JsonSerializerOptions? SerializerOptions = null)
             : ITestData
         {
             public Type Type => typeof(T);
@@ -1480,6 +1499,8 @@ namespace System.Text.Json.Schema.Tests
             string ExpectedJsonSchema { get; }
 
             JsonSchemaExporterOptions? Options { get; }
+
+            JsonSerializerOptions? SerializerOptions { get; }
 
             IEnumerable<ITestData> GetTestDataForAllValues();
         }

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -46,7 +46,7 @@ namespace System.Text.Json.Schema.Tests
                 : Serializer.DefaultOptions;
 
             JsonNode schema = options.GetJsonSchemaAsNode(testData.Type, testData.Options);
-            JsonNode? instance = JsonSerializer.SerializeToNode(testData.Value, testData.Type, Serializer.DefaultOptions);
+            JsonNode? instance = JsonSerializer.SerializeToNode(testData.Value, testData.Type, options);
             AssertDocumentMatchesSchema(schema, instance);
         }
 

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -29,7 +29,11 @@ namespace System.Text.Json.Schema.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/103694", TestRuntimes.Mono)]
         public void TestTypes_GeneratesExpectedJsonSchema(ITestData testData)
         {
-            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(testData.Type, testData.Options);
+            JsonSerializerOptions options = testData.SerializerOptions is { } opts
+                ? new(opts) { TypeInfoResolver = Serializer.DefaultOptions.TypeInfoResolver }
+                : Serializer.DefaultOptions;
+
+            JsonNode schema = options.GetJsonSchemaAsNode(testData.Type, testData.Options);
             AssertValidJsonSchema(testData.Type, testData.ExpectedJsonSchema, schema);
         }
 
@@ -37,7 +41,11 @@ namespace System.Text.Json.Schema.Tests
         [MemberData(nameof(GetTestDataUsingAllValues))]
         public void TestTypes_SerializedValueMatchesGeneratedSchema(ITestData testData)
         {
-            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(testData.Type, testData.Options);
+            JsonSerializerOptions options = testData.SerializerOptions is { } opts
+                ? new(opts) { TypeInfoResolver = Serializer.DefaultOptions.TypeInfoResolver }
+                : Serializer.DefaultOptions;
+
+            JsonNode schema = options.GetJsonSchemaAsNode(testData.Type, testData.Options);
             JsonNode? instance = JsonSerializer.SerializeToNode(testData.Value, testData.Type, Serializer.DefaultOptions);
             AssertDocumentMatchesSchema(schema, instance);
         }


### PR DESCRIPTION
Fixes a [customer reported issue](https://github.com/dotnet/runtime/issues/107501#issuecomment-2338096340) on use of the global `JsonUnmappedMemberHandling` setting. Should be backported to .NET 9