### PR TITLE
[wasm] Increase jiterpreter limits

### DIFF
--- a/src/mono/browser/runtime/jiterpreter-support.ts
+++ b/src/mono/browser/runtime/jiterpreter-support.ts
@@ -20,7 +20,7 @@ export const maxFailures = 2,
     shortNameBase = 36,
     // NOTE: This needs to be big enough to hold the maximum module size since there's no auto-growth
     //  support yet. If that becomes a problem, we should just make it growable
-    blobBuilderCapacity = 16 * 1024;
+    blobBuilderCapacity = 24 * 1024;
 
 // uint16
 export declare interface MintOpcodePtr extends NativePointer {

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -170,14 +170,14 @@ DEFINE_INT(jiterpreter_interp_entry_trampoline_hit_count, "jiterpreter-interp-en
 DEFINE_INT(jiterpreter_interp_entry_queue_flush_threshold, "jiterpreter-interp-entry-queue-flush-threshold", 3000, "Flush the interp_entry JIT queue after an unJITted call site has this many hits")
 // In degenerate cases the jiterpreter could end up generating lots of WASM, so shut off jitting once it reaches this limit
 // Each wasm byte likely maps to multiple bytes of native code, so it's important for this limit not to be too high
-DEFINE_INT(jiterpreter_wasm_bytes_limit, "jiterpreter-wasm-bytes-limit", 6 * 1024 * 1024, "Disable jiterpreter code generation once this many bytes of WASM have been generated")
+DEFINE_INT(jiterpreter_wasm_bytes_limit, "jiterpreter-wasm-bytes-limit", 8 * 1024 * 1024, "Disable jiterpreter code generation once this many bytes of WASM have been generated")
 DEFINE_INT(jiterpreter_table_size, "jiterpreter-table-size", 6 * 1024, "Size of the jiterpreter trace function table")
 // In real-world scenarios these tables can fill up at this size, but making them bigger causes startup time
 //  to bloat to an unacceptable degree. In practice this is still better than nothing.
 // FIXME: In the future if we find a way to reduce the number of unique tables we can raise this constant
 DEFINE_INT(jiterpreter_aot_table_size, "jiterpreter-aot-table-size", 3 * 1024, "Size of the jiterpreter AOT trampoline function tables")
-DEFINE_INT(jiterpreter_max_module_size, "jiterpreter-max-module-size", 4080, "Size limit for jiterpreter generated WASM modules")
-DEFINE_INT(jiterpreter_max_switch_size, "jiterpreter-max-switch-size", 24, "Size limit for jiterpreter switch opcodes (0 to disable)")
+DEFINE_INT(jiterpreter_max_module_size, "jiterpreter-max-module-size", 16384, "Size limit for jiterpreter generated WASM modules")
+DEFINE_INT(jiterpreter_max_switch_size, "jiterpreter-max-switch-size", 128, "Jump table size limit for jiterpreter switch opcodes (0 to disable)")
 #endif // HOST_BROWSER
 
 #if defined(TARGET_WASM) || defined(TARGET_IOS)  || defined(TARGET_TVOS) || defined (TARGET_MACCAT)


### PR DESCRIPTION
* Raise module size limit to 16KB (from past testing this is a good compromise value that can actually reduce number of traces compiled and time spent compiling them)
* Raise total wasm bytes limit a bit since the modules are now bigger
* Raise switch case limit to 128, so switch statements over the 7-bit ASCII character range can be jitted. I expect this to improve text parsing performance; it might be worth raising it to 256.