### PR TITLE
[mono] Revert "don't define HAS_CUSTOM_BLOCKS on mono (#106764)"

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !MONO && (TARGET_AMD64 || TARGET_ARM64 || (TARGET_32BIT && !TARGET_ARM) || TARGET_LOONGARCH64)
+#if TARGET_AMD64 || TARGET_ARM64 || (TARGET_32BIT && !TARGET_ARM) || TARGET_LOONGARCH64
 // JIT is guaranteed to unroll blocks up to 64 bytes in size
 #define HAS_CUSTOM_BLOCKS
 #endif


### PR DESCRIPTION
This reverts commit 7266021f0e16011c38686618b73f0eb8e37f1644. The commit caused significant improvements for MonoJIT but introduced unexpected regressions for MonoAOT/MonoInterpreter described at https://github.com/dotnet/runtime/issues/107308#issuecomment-2337333734. 

We need to make a proper fix for MonoJIT https://github.com/dotnet/runtime/issues/106822 to mitigate the regressions from https://github.com/dotnet/perf-autofiling-issues/issues/33182.


This needs to be backport to .NET 9 because of https://github.com/dotnet/runtime/pull/106801.
