### PR TITLE
JIT: random partial compilation stress mode

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -539,6 +539,7 @@ jobs:
             scenarios:
             - jitosr_stress
             - jitpartialcompilation_pgo
+            - jitpartialcompilation_pgo_stress_random
             - jitoptrepeat
             - jitoldlayout
           ${{ else }}:
@@ -548,6 +549,7 @@ jobs:
             - jit_stress_splitting
             - jitpartialcompilation
             - jitpartialcompilation_pgo
+            - jitpartialcompilation_pgo_stress_random
             - jitobjectstackallocation
             - jitphysicalpromotion_only
             - jitphysicalpromotion_full

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -683,6 +683,9 @@ RELEASE_CONFIG_INTEGER(TC_OnStackReplacement_InitialCounter, W("TC_OnStackReplac
 // Enable partial compilation for Tier0 methods
 RELEASE_CONFIG_INTEGER(TC_PartialCompilation, W("TC_PartialCompilation"), 0)
 
+// If partial compilation is enabled, use random heuristic for patchpoint placement
+CONFIG_INTEGER(JitRandomPartialCompilation, W("JitRandomPartialCompilation"), 0)
+
 // Patchpoint strategy:
 // 0 - backedge sources
 // 1 - backedge targets

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -70,6 +70,7 @@
       DOTNET_JitRandomGuardedDevirtualization;
       DOTNET_JitRandomEdgeCounts;
       DOTNET_JitRandomOnStackReplacement;
+      DOTNET_JitRandomPartialComplation;
       DOTNET_JitRandomlyCollect64BitCounts;
       DOTNET_JitStressModeNames;
       DOTNET_JitGuardedDevirtualizationMaxTypeChecks;
@@ -225,6 +226,7 @@
     <TestEnvironment Include="jit_stress_splitting" JitFakeProcedureSplitting="1" JitStressProcedureSplitting="1" />
     <TestEnvironment Include="jitpartialcompilation" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
     <TestEnvironment Include="jitpartialcompilation_pgo" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />
+    <TestEnvironment Include="jitpartialcompilation_pgo_stress_random" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" JitRandomPartialCompilation="1" />
     <TestEnvironment Include="jitobjectstackallocation" JitObjectStackAllocation="1" TieredCompilation="0" />
     <TestEnvironment Include="jitphysicalpromotion_only" JitStressModeNames="STRESS_NO_OLD_PROMOTION" TieredCompilation="0" />
     <TestEnvironment Include="jitphysicalpromotion_full" JitStressModeNames="STRESS_PHYSICAL_PROMOTION_COST STRESS_NO_OLD_PROMOTION" TieredCompilation="0" />

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -226,7 +226,7 @@
     <TestEnvironment Include="jit_stress_splitting" JitFakeProcedureSplitting="1" JitStressProcedureSplitting="1" />
     <TestEnvironment Include="jitpartialcompilation" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
     <TestEnvironment Include="jitpartialcompilation_pgo" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />
-    <TestEnvironment Include="jitpartialcompilation_pgo_stress_random" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" JitRandomPartialCompilation="1" />
+    <TestEnvironment Include="jitpartialcompilation_pgo_stress_random" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" JitRandomPartialCompilation="15" />
     <TestEnvironment Include="jitobjectstackallocation" JitObjectStackAllocation="1" TieredCompilation="0" />
     <TestEnvironment Include="jitphysicalpromotion_only" JitStressModeNames="STRESS_NO_OLD_PROMOTION" TieredCompilation="0" />
     <TestEnvironment Include="jitphysicalpromotion_full" JitStressModeNames="STRESS_PHYSICAL_PROMOTION_COST STRESS_NO_OLD_PROMOTION" TieredCompilation="0" />


### PR DESCRIPTION
When JitRandomPartialCompilation is nonzero, allow partial compilation patchpoints at the start of randomly chosen patchpoint-eligible blocks.

Enable this stress mode in the jit-experimental pipeline.