### PR TITLE
[wasm] Clean up some FIXMEs in the jiterpreter

### DIFF
--- a/src/mono/browser/runtime/jiterpreter.ts
+++ b/src/mono/browser/runtime/jiterpreter.ts
@@ -851,18 +851,6 @@ function generate_wasm (
         // Get the exported trace function
         const fn = traceInstance.exports[traceName];
 
-        // FIXME: Before threading can be supported, we will need to ensure that
-        //  once we assign a function pointer index to a given trace, the trace is
-        //  broadcast to all the JS workers and compiled + installed at the appropriate
-        //  index in every worker's function pointer table. This also means that we
-        //  would need to fill empty slots with a dummy function when growing the table
-        //  so that any erroneous ENTERs will skip the opcode instead of crashing due
-        //  to calling a null function pointer.
-        // Table grow operations will need to be synchronized between workers somehow,
-        //  probably by storing the table size in a volatile global or something so that
-        //  we know the range of indexes available to us and can ensure that threads
-        //  independently jitting traces will not stomp on each other and all threads
-        //  have a globally consistent view of which function pointer maps to each trace.
         rejected = false;
 
         let idx: number;
@@ -995,7 +983,6 @@ export function mono_interp_tier_prepare_jiterpreter (
     if (!mostRecentOptions)
         mostRecentOptions = getOptions();
 
-    // FIXME: We shouldn't need this check
     if (!mostRecentOptions.enableTraces)
         return JITERPRETER_NOT_JITTED;
     else if (mostRecentOptions.wasmBytesLimit <= getCounter(JiterpCounter.BytesGenerated))

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7657,7 +7657,8 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 		MINT_IN_CASE(MINT_LDLOCA_S)
 			LOCAL_VAR (ip [1], gpointer) = locals + ip [2];
-			ip += 3;
+			// ip[3] reserved for size data for jiterpreter
+			ip += 4;
 			MINT_IN_BREAK;
 
 #define MOV(argtype1,argtype2) \

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -128,7 +128,11 @@ OPDEF(MINT_MOV_8_2, "mov.8.2", 5, 0, 0, MintOpPair2)
 OPDEF(MINT_MOV_8_3, "mov.8.3", 7, 0, 0, MintOpPair3)
 OPDEF(MINT_MOV_8_4, "mov.8.4", 9, 0, 0, MintOpPair4)
 
-OPDEF(MINT_LDLOCA_S, "ldloca.s", 3, 1, 0, MintOpUShortInt)
+// NOTE: We reserve an extra ushort at the end of this specifically to communicate information
+//  to the jiterpreter about how large the local is so that invalidation can be correct.
+// FIXME: genmintops.py is way too simple to handle this having a different size on different targets,
+//  so it's got a size of 4 everywhere.
+OPDEF(MINT_LDLOCA_S, "ldloca.s", 4, 1, 0, MintOpUShortInt)
 
 OPDEF(MINT_LDIND_I1, "ldind.i1", 3, 1, 1, MintOpNoArgs)
 OPDEF(MINT_LDIND_U1, "ldind.u1", 3, 1, 1, MintOpNoArgs)
@@ -838,7 +842,7 @@ OPDEF(MINT_INTRINS_WIDEN_ASCII_TO_UTF16, "intrins_widen_ascii_to_utf16", 5, 1, 3
 OPDEF(MINT_METADATA_UPDATE_LDFLDA, "metadata_update.ldflda", 5, 1, 1, MintOpTwoShorts)
 
 // This ifdef is fine because genmintops.py is generating output for HOST_BROWSER
-#if HOST_BROWSER
+#ifdef HOST_BROWSER
 OPDEF(MINT_TIER_PREPARE_JITERPRETER, "tier_prepare_jiterpreter", 4, 0, 0, MintOpShortAndInt)
 OPDEF(MINT_TIER_NOP_JITERPRETER, "tier_nop_jiterpreter", 4, 0, 0, MintOpShortAndInt)
 OPDEF(MINT_TIER_ENTER_JITERPRETER, "tier_enter_jiterpreter", 4, 0, 0, MintOpShortAndInt)

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -9241,6 +9241,12 @@ opcode_emit:
 		} else if (opcode == MINT_LDLOCA_S) {
 			// This opcode receives a local but it is not viewed as a sreg since we don't load the value
 			*ip++ = GINT_TO_UINT16 (get_var_offset (td, ins->sregs [0]));
+
+#if HOST_BROWSER
+			// We reserve an extra 2 bytes at the end of ldloca_s so the jiterpreter knows how large
+			//  the var is when taking its address so that it can invalidate a properly sized range.
+			*ip++ = GINT_TO_UINT16 (td->vars [ins->sregs [0]].size);
+#endif
 		}
 
 		int left = interp_get_ins_length (ins) - GPTRDIFF_TO_INT(ip - start_ip);


### PR DESCRIPTION
This PR cleans up some FIXMEs in the jiterpreter. 

One of them was a note about a correctness issue, so I fix that by flowing through size information along with LDLOCA_S interpreter opcodes.