### PR TITLE
JIT: Fix `emitter::emitSplit` to not create zero-sized method fragment

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3071,6 +3071,14 @@ void emitter::emitSplit(emitLocation*         startLoc,
 
     } // end for loop
 
+    // It's possible to have zero-sized IGs at this point in the emitter.
+    // For example, the JIT may create an IG to align a loop,
+    // but then later walk back this decision after other alignment decisions,
+    // which means it will zero out the new IG.
+    // If a zero-sized IG precedes a populated IG, it will be included in the latter's fragment.
+    // However, if the last IG candidate is a zero-sized IG, splitting would create a zero-sized fragment,
+    // so skip the last split in such cases.
+    // (The last IG in the main method body can be zero-sized if it was created to align a loop in the first funclet.)
     if ((igLastCandidate != nullptr) && (curSize == candidateSize))
     {
         JITDUMP("emitSplit: can't split at last candidate IG%02u because it would create a zero-sized fragment\n",

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3073,10 +3073,6 @@ void emitter::emitSplit(emitLocation*         startLoc,
 
     if ((igLastCandidate != nullptr) && (curSize == candidateSize))
     {
-        // TODO: This scenario may be possible (but very unlikely) when using the default fragment size.
-        // Fixing this would likely require padding out the last fragment to not be zero-sized, and doing the split.
-        // For now, assume this only occurs under stress modes, or when using DOTNET_JitSplitFunctionSize.
-        assert(maxSplitSize != UW_MAX_FRAGMENT_SIZE_BYTES);
         JITDUMP("emitSplit: can't split at last candidate IG%02u because it would create a zero-sized fragment\n",
                 igLastCandidate->igNum);
     }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3071,8 +3071,21 @@ void emitter::emitSplit(emitLocation*         startLoc,
 
     } // end for loop
 
-    splitIfNecessary();
-    assert(curSize < UW_MAX_FRAGMENT_SIZE_BYTES);
+    if ((igLastCandidate != nullptr) && (curSize == candidateSize))
+    {
+        // TODO: This scenario may be possible (but very unlikely) when using the default fragment size.
+        // Fixing this would likely require padding out the last fragment to not be zero-sized, and doing the split.
+        // For now, assume this only occurs under stress modes, or when using DOTNET_JitSplitFunctionSize.
+        assert(maxSplitSize != UW_MAX_FRAGMENT_SIZE_BYTES);
+        JITDUMP("emitSplit: can't split at last candidate IG%02u because it would create a zero-sized fragment\n",
+                igLastCandidate->igNum);
+    }
+    else
+    {
+        splitIfNecessary();
+    }
+
+    assert((curSize > 0) && (curSize < UW_MAX_FRAGMENT_SIZE_BYTES));
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Fixes #106379 ([comment](https://github.com/dotnet/runtime/issues/106379#issuecomment-2338994599)). When considering the final split of a method body, skip the split if it will create a zero-sized fragment at the end of the method. Under stress modes, it's fine to ignore the desired fragment size, but in the rare case where we need to split the last piece of the method and it is exactly 512KB, skipping the split might break ISA invariants around how EH data is reported. This seems terribly unlikely, but I documented this just in case we hit it some day.