### PR TITLE
Remove FCThrowRes from AssemblyNative::IsDynamic

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -584,9 +584,17 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool FCallIsDynamic(RuntimeAssembly assembly);
+        private static extern bool FCallIsDynamic(IntPtr assembly);
 
-        public override bool IsDynamic => FCallIsDynamic(this);
+        public override bool IsDynamic
+        {
+            get
+            {
+                bool isDynamic = FCallIsDynamic(GetUnderlyingNativeHandle());
+                GC.KeepAlive(this); // We directly pass the native handle above - make sure this object stays alive for the call
+                return isDynamic;
+            }
+        }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetSimpleName")]
         private static partial void GetSimpleName(QCallAssembly assembly, StringHandleOnStack retSimpleName);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -584,13 +584,13 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool FCallIsDynamic(IntPtr assembly);
+        private static extern bool GetIsDynamic(IntPtr assembly);
 
         public override bool IsDynamic
         {
             get
             {
-                bool isDynamic = FCallIsDynamic(GetUnderlyingNativeHandle());
+                bool isDynamic = GetIsDynamic(GetUnderlyingNativeHandle());
                 GC.KeepAlive(this); // We directly pass the native handle above - make sure this object stays alive for the call
                 return isDynamic;
             }

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -513,7 +513,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetForwardedType(QCall::AssemblyHandle 
     END_QCALL;
 }
 
-FCIMPL1(FC_BOOL_RET, AssemblyNative::IsDynamic, Assembly* pAssembly)
+FCIMPL1(FC_BOOL_RET, AssemblyNative::GetIsDynamic, Assembly* pAssembly)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -513,16 +513,16 @@ extern "C" void QCALLTYPE AssemblyNative_GetForwardedType(QCall::AssemblyHandle 
     END_QCALL;
 }
 
-FCIMPL1(FC_BOOL_RET, AssemblyNative::IsDynamic, AssemblyBaseObject* pAssemblyUNSAFE)
+FCIMPL1(FC_BOOL_RET, AssemblyNative::IsDynamic, Assembly* pAssembly)
 {
-    FCALL_CONTRACT;
+    CONTRACTL
+    {
+        FCALL_CHECK;
+        PRECONDITION(CheckPointer(pAssembly));
+    }
+    CONTRACTL_END;
 
-    ASSEMBLYREF refAssembly = (ASSEMBLYREF)ObjectToOBJECTREF(pAssemblyUNSAFE);
-
-    if (refAssembly == NULL)
-        FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
-
-    FC_RETURN_BOOL(refAssembly->GetAssembly()->GetPEAssembly()->IsReflectionEmit());
+    FC_RETURN_BOOL(pAssembly->GetPEAssembly()->IsReflectionEmit());
 }
 FCIMPLEND
 

--- a/src/coreclr/vm/assemblynative.hpp
+++ b/src/coreclr/vm/assemblynative.hpp
@@ -31,7 +31,7 @@ public:
     //
 
     static
-    FCDECL1(FC_BOOL_RET, IsDynamic, Assembly* pAssembly);
+    FCDECL1(FC_BOOL_RET, GetIsDynamic, Assembly* pAssembly);
 };
 
 extern "C" uint32_t QCALLTYPE AssemblyNative_GetAssemblyCount();

--- a/src/coreclr/vm/assemblynative.hpp
+++ b/src/coreclr/vm/assemblynative.hpp
@@ -19,10 +19,6 @@ class CustomAssemblyBinder;
 
 class AssemblyNative
 {
-    friend class Assembly;
-    friend class BaseDomain;
-    friend class DomainAssembly;
-
 public:
 
     static Assembly* LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pImage, bool excludeAppPaths = false);
@@ -35,7 +31,7 @@ public:
     //
 
     static
-    FCDECL1(FC_BOOL_RET, IsDynamic, AssemblyBaseObject * pAssemblyUNSAFE);
+    FCDECL1(FC_BOOL_RET, IsDynamic, Assembly* pAssembly);
 };
 
 extern "C" uint32_t QCALLTYPE AssemblyNative_GetAssemblyCount();

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -222,7 +222,7 @@ FCFuncStart(gCOMModuleHandleFuncs)
 FCFuncEnd()
 
 FCFuncStart(gRuntimeAssemblyFuncs)
-    FCFuncElement("FCallIsDynamic", AssemblyNative::IsDynamic)
+    FCFuncElement("GetIsDynamic", AssemblyNative::GetIsDynamic)
     FCFuncElement("GetManifestModule", AssemblyHandle::GetManifestModule)
     FCFuncElement("GetToken", AssemblyHandle::GetToken)
 FCFuncEnd()


### PR DESCRIPTION
Switch to using the underlying handle and remove the null check/throw in the FCall (which created a helper method frame).