### PR TITLE
Allow preinitializing spans created from arrays

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -612,6 +612,12 @@ namespace ILCompiler
 
                                 instance = new ReadOnlySpanValue(readOnlySpanElementType, bytes, byteOffset, byteLength);
                             }
+                            else if (readOnlySpanElementType != null && ctorSig.Length == 1 && ctorSig[0].IsArray
+                                && ctorParameters[1] is ArrayInstance spanArrayInstance
+                                && spanArrayInstance.TryGetReadOnlySpan(out ReadOnlySpanValue arraySpan))
+                            {
+                                instance = arraySpan;
+                            }
                             else
                             {
                                 if (owningType.IsValueType)
@@ -2927,6 +2933,18 @@ namespace ILCompiler
                 }
 
                 builder.EmitBytes(_data);
+            }
+
+            public bool TryGetReadOnlySpan(out ReadOnlySpanValue value)
+            {
+                var parameterType = ((ArrayType)Type).ParameterType as MetadataType;
+                if (parameterType != null)
+                {
+                    value = new ReadOnlySpanValue(parameterType, _data, 0, _data.Length);
+                    return true;
+                }
+                value = null;
+                return false;
             }
 
             public bool IsKnownImmutable => _elementCount == 0;

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -1111,6 +1111,31 @@ class TestSpan
         }
     }
 
+    class ArrayAlloc
+    {
+        public static byte FirstByte;
+        public static byte LastByte;
+        public static char FirstChar;
+        public static char LastChar;
+
+        static ArrayAlloc()
+        {
+            byte[] a1 = new byte[8];
+            Span<byte> s1 = a1;
+            s1.Slice(0, 1)[0] = 42;
+            s1.Slice(s1.Length - 1, 1)[0] = 100;
+            FirstByte = a1[0];
+            LastByte = a1[7];
+
+            char[] a2 = new char[8];
+            Span<char> s2 = a2;
+            s2.Slice(0, 1)[0] = 'H';
+            s2.Slice(s2.Length - 1, 1)[0] = '!';
+            FirstChar = a2[0];
+            LastChar = a2[7];
+        }
+    }
+
     public static void Run()
     {
         Assert.IsPreinitialized(typeof(StackAlloc));
@@ -1118,6 +1143,12 @@ class TestSpan
         Assert.AreEqual(100, StackAlloc.LastByte);
         Assert.AreEqual('H', StackAlloc.FirstChar);
         Assert.AreEqual('!', StackAlloc.LastChar);
+
+        Assert.IsPreinitialized(typeof(ArrayAlloc));
+        Assert.AreEqual(42, ArrayAlloc.FirstByte);
+        Assert.AreEqual(100, ArrayAlloc.LastByte);
+        Assert.AreEqual('H', ArrayAlloc.FirstChar);
+        Assert.AreEqual('!', ArrayAlloc.LastChar);
     }
 }
 


### PR DESCRIPTION
Fixes #107541.

Cc @dotnet/ilc-contrib 