### PR TITLE
[wasi] Include version error message when missing WASI SDK

### DIFF
--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -101,7 +101,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_ToolchainMissingErrorMessage Condition="'$(WASI_SDK_PATH)' == '' or !Exists('$(WASI_SDK_PATH)/VERSION24')">Could not find wasi-sdk. Install wasi-sdk and set %24(WASI_SDK_PATH) . It can be obtained from https://github.com/WebAssembly/wasi-sdk/releases</_ToolchainMissingErrorMessage>
+      <_ToolchainMissingErrorMessage Condition="'$(WASI_SDK_PATH)' == '' or !Exists('$(WASI_SDK_PATH)/VERSION24')">Could not find wasi-sdk version 24 or newer. Install wasi-sdk and set %24(WASI_SDK_PATH) . It can be obtained from https://github.com/WebAssembly/wasi-sdk/releases</_ToolchainMissingErrorMessage>
       <_ToolchainMissingErrorMessage Condition="'$(_ToolchainMissingErrorMessage)' == '' and '$(_ToolchainMissingPaths)' != ''">Using WASI_SDK_PATH=$(WASI_SDK_PATH), cannot find $(_ToolchainMissingPaths) .</_ToolchainMissingErrorMessage>
       <_IsToolchainMissing Condition="'$(_ToolchainMissingErrorMessage)' != ''">true</_IsToolchainMissing>
     </PropertyGroup>


### PR DESCRIPTION
Before
```
PS WasiConsole> $env:WASI_SDK_PATH="/Users/marekfisera/Bin/wasi-sdk-21.0/"
PS WasiConsole90> dotnet publish
Restore complete (0,3s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  WasiConsole90 failed with 1 error(s) (0,2s) → bin/Release/net9.0/wasi-wasm/publish/
    /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/9.0.0-preview.7.24405.7/Sdk/WasiApp.targets(116,5): error : Could not find wasi-sdk. Install wasi-sdk and set $(WASI_SDK_PATH) . It can be obtained from https://github.com/WebAssembly/wasi-sdk/releases SDK is required for building native files.
```

After
```
PS WasiConsole90> dotnet publish
Restore complete (0,3s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  WasiConsole90 failed with 1 error(s) (0,2s) → bin/Release/net9.0/wasi-wasm/publish/
    /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/9.0.0-preview.7.24405.7/Sdk/WasiApp.targets(116,5): error : Could not find wasi-sdk version 24 or newer. Install wasi-sdk and set $(WASI_SDK_PATH) . It can be obtained from https://github.com/WebAssembly/wasi-sdk/releases SDK is required for building native files.
```