### PR TITLE
Fix HashSet copy constructor handling of instances that have fallen back to the randomized hashcode generator.

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.NonGeneric.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.NonGeneric.Tests.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public static class HashSet_NonGeneric_Tests
+    {
+        [Fact]
+        public static void HashSet_CopyConstructor_ShouldWorkWithRandomizedEffectiveComparer()
+        {
+            HashSet<string> set = CreateCopyWithRandomizedComparer(new HashSet<string>() { "a", "b" });
+            Assert.True(set.Contains("a"));
+
+            HashSet<string> copiedSet = new(set);
+            Assert.True(copiedSet.Contains("a"));
+
+            static HashSet<string> CreateCopyWithRandomizedComparer(HashSet<string> set)
+            {
+                // To reproduce the bug, we need a HashSet<string> instance that has fallen back to
+                // the randomized comparer. This typically happens when there are many collisions but
+                // it can also happen when the set is serialized and deserialized via ISerializable.
+                // For consistent results and to avoid brute forcing collisions, use the latter approach.
+
+                SerializationInfo info = new(typeof(HashSet<string>), new FormatterConverter());
+                StreamingContext context = new(StreamingContextStates.All);
+                set.GetObjectData(info, context);
+  
+                HashSet<string> copiedSet = (HashSet<string>)Activator.CreateInstance(typeof(HashSet<string>), BindingFlags.NonPublic | BindingFlags.Instance, null, [info, context], null);
+                copiedSet.OnDeserialization(null);
+                return copiedSet;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
-                      Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj" Private="true" SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
   </ItemGroup>
   <ItemGroup>
     <RdXmlFile Include="default.rd.xml" />
@@ -34,6 +32,7 @@
     <Compile Include="$(CommonTestPath)System\EnumTypes.cs" Link="Common\System\EnumTypes.cs" />
     <Compile Include="$(CommonTestPath)System\ObjectCloner.cs" Link="Common\System\ObjectCloner.cs" />
     <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs" Link="Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs" />
+    <Compile Include="Generic\HashSet\HashSet.NonGeneric.Tests.cs" />
     <Compile Include="Generic\ReadOnlySet\ReadOnlySetTests.cs" />
     <!-- Generic tests -->
     <Compile Include="Generic\SortedSet\SortedSet.TreeSubSet.Tests.cs" />


### PR DESCRIPTION
Fix #107222.