### PR TITLE
[mini] Don't use Unwind Backtrace on android-amd64

### DIFF
--- a/src/mono/mono/mini/mini-amd64.h
+++ b/src/mono/mono/mini/mini-amd64.h
@@ -493,7 +493,7 @@ typedef struct {
 // FIXME: Doesn't work on windows
 //#define MONO_ARCH_HAVE_INIT_MRGCTX 1
 
-#if defined(TARGET_OSX) || defined(__linux__)
+#if defined(TARGET_OSX) || (defined(__linux__) && !defined(TARGET_ANDROID))
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
Match what we do for other android RIDs.

The _Unwind_Backtrace support is only used when llvmonly mode is enabled, which is not something that we do for Android, AFAIK