### PR TITLE
Split the HostApplicationBuilder configuration.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostApplicationBuilder.cs
@@ -21,10 +21,11 @@ public interface IHostApplicationBuilder
     IDictionary<object, object> Properties { get; }
 
     /// <summary>
-    /// Gets the set of key/value configuration properties.
+    /// Gets the set of key/value application configuration properties.
     /// </summary>
     /// <remarks>
     /// This can be mutated by adding more configuration sources, which will update its current view.
+    /// Changing the application configuration properties will not affect host properties such as the <see cref="Environment"/>.
     /// </remarks>
     IConfigurationManager Configuration { get; }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
@@ -47,8 +47,6 @@ namespace Microsoft.Extensions.Hosting
         public HostApplicationBuilderSettings() { }
         public string? ApplicationName { get { throw null; } set { } }
         public string[]? Args { get { throw null; } set { } }
-        public Microsoft.Extensions.Configuration.ConfigurationManager? HostConfiguration { get { throw null; } set { } }
-        [System.Obsolete($"Use {nameof(HostConfiguration)} instead.")]
         public Microsoft.Extensions.Configuration.ConfigurationManager? Configuration { get { throw null; } set { } }
         public string? ContentRootPath { get { throw null; } set { } }
         public bool DisableDefaults { get { throw null; } set { } }

--- a/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Extensions.Hosting
         public HostApplicationBuilderSettings() { }
         public string? ApplicationName { get { throw null; } set { } }
         public string[]? Args { get { throw null; } set { } }
+        public Microsoft.Extensions.Configuration.ConfigurationManager? HostConfiguration { get { throw null; } set { } }
+        [System.Obsolete($"Use {nameof(HostConfiguration)} instead.")]
         public Microsoft.Extensions.Configuration.ConfigurationManager? Configuration { get { throw null; } set { } }
         public string? ContentRootPath { get { throw null; } set { } }
         public bool DisableDefaults { get { throw null; } set { } }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Host.cs
@@ -106,6 +106,10 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="settings">Controls the initial configuration and other settings for constructing the <see cref="HostApplicationBuilder"/>.</param>
         /// <returns>The initialized <see cref="HostApplicationBuilder"/>.</returns>
         public static HostApplicationBuilder CreateEmptyApplicationBuilder(HostApplicationBuilderSettings? settings)
-            => new HostApplicationBuilder(settings, empty: true);
+        {
+            settings ??= new();
+            settings.DisableDefaults = true;
+            return new HostApplicationBuilder(settings);
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.Hosting
 
         private static void InitializeHostConfiguration(HostApplicationBuilderSettings settings, out ConfigurationManager hostConfiguration)
         {
-            hostConfiguration = settings.HostConfiguration ?? new();
+            hostConfiguration = settings.Configuration ?? new();
 
             if (!settings.DisableDefaults)
             {
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.Hosting
         /// <remarks>
         /// This can be mutated by adding more configuration sources, which will update its current view.
         /// Changing the application configuration properties will not affect host properties such as the <see cref="Environment"/>.
-        /// Use the <see cref="HostApplicationBuilderSettings.HostConfiguration"/> to affect the host properties.
+        /// Use the <see cref="HostApplicationBuilderSettings.Configuration"/> to affect the host properties.
         /// </remarks>
         public ConfigurationManager Configuration { get; } = new();
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -45,15 +44,10 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// Set up the configuration for the builder itself. This will be used to initialize
         /// the <see cref="HostApplicationBuilder.Environment"/> through the use of <see cref="HostDefaults"/> keys.
+        /// The configuration is also added to the <see cref="HostApplicationBuilder.Configuration"/>.
         /// Disposing the built <see cref="IHost"/> disposes the <see cref="ConfigurationManager"/>.
         /// </summary>
-        public ConfigurationManager? HostConfiguration { get; set; }
-
-        /// <summary>
-        /// Obsolete name for the <see cref="HostConfiguration"/>.
-        /// </summary>
-        [Obsolete($"Use {nameof(HostConfiguration)} instead.")]
-        public ConfigurationManager? Configuration { get => HostConfiguration; set => HostConfiguration = value; }
+        public ConfigurationManager? Configuration { get; set; }
 
         /// <summary>
         /// The environment name.

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -42,11 +43,17 @@ namespace Microsoft.Extensions.Hosting
         public string[]? Args { get; set; }
 
         /// <summary>
-        /// Initial configuration sources to be added to the <see cref="HostApplicationBuilder.Configuration"/>. These sources can influence
-        /// the <see cref="HostApplicationBuilder.Environment"/> through the use of <see cref="HostDefaults"/> keys. Disposing the built
-        /// <see cref="IHost"/> disposes the <see cref="ConfigurationManager"/>.
+        /// Set up the configuration for the builder itself. This will be used to initialize
+        /// the <see cref="HostApplicationBuilder.Environment"/> through the use of <see cref="HostDefaults"/> keys.
+        /// Disposing the built <see cref="IHost"/> disposes the <see cref="ConfigurationManager"/>.
         /// </summary>
-        public ConfigurationManager? Configuration { get; set; }
+        public ConfigurationManager? HostConfiguration { get; set; }
+
+        /// <summary>
+        /// Obsolete name for the <see cref="HostConfiguration"/>.
+        /// </summary>
+        [Obsolete($"Use {nameof(HostConfiguration)} instead.")]
+        public ConfigurationManager? Configuration { get => HostConfiguration; set => HostConfiguration = value; }
 
         /// <summary>
         /// The environment name.

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 var builder = createBuilder(new HostApplicationBuilderSettings
                 {
                     DisableDefaults = disableDefaults,
-                    HostConfiguration = config,
+                    Configuration = config,
                 });
 
                 Assert.Equal("AppA", builder.Configuration[HostDefaults.ApplicationKey]);
@@ -358,7 +358,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 var builder = createBuilder(new HostApplicationBuilderSettings
                 {
                     DisableDefaults = disableDefaults,
-                    HostConfiguration = config,
+                    Configuration = config,
                     ApplicationName = "AppB",
                     EnvironmentName = "EnvB",
                     ContentRootPath = tempPath,
@@ -428,7 +428,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
-                HostConfiguration = config,
+                Configuration = config,
             });
 
             config.AddInMemoryCollection(new KeyValuePair<string, string>[]
@@ -488,7 +488,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
-                HostConfiguration = config
+                Configuration = config
             });
 
             Assert.Equal("MyProjectReference", builder.Environment.ApplicationName);
@@ -518,7 +518,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
-                HostConfiguration = config
+                Configuration = config
             });
 
             Assert.Equal("testParameterValue", builder.Configuration["testParameterKey"]);


### PR DESCRIPTION
* Renamed the HostApplicationBuilderSettings.Configuration to HostConfiguration and marking the old property obsolete.
* Included the host configuration in the app configuration analogous to how HostBuilder does.
* Updated the documentation of the Configuration properties to reflect this logic change.

Fixes #97930