### PR TITLE
Remove vestigial ReadOnlySequence.SequenceType.Empty

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -651,7 +651,7 @@ namespace System.Buffers
             MultiSegment = 0x00,
             Array = 0x1,
             MemoryManager = 0x2,
-            String = 0x3
+            String = 0x3,
         }
     }
 

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -651,8 +651,7 @@ namespace System.Buffers
             MultiSegment = 0x00,
             Array = 0x1,
             MemoryManager = 0x2,
-            String = 0x3,
-            Empty = 0x4
+            String = 0x3
         }
     }
 


### PR DESCRIPTION
This should be just a simple cleanup. `GetSequenceType()` can only return 4 unique values since it only looks at 2 bits. `ReadOnlySequence<T>.Empty` is `SequenceType.Array`.

I did some digging, and it looks like @benaadams introduced `SequenceType.Empty` when a null `_startObject` indicated an empty ROS which is no longer the case. https://github.com/dotnet/corefx/pull/27455