### PR TITLE
String.Contains should throw ArgumentNullException, when Argument is Null

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -28,6 +28,8 @@ namespace System
 
         public bool Contains(string value, StringComparison comparisonType)
         {
+            if (value == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
 #pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'... this is the implementation of Contains!
             return IndexOf(value, comparisonType) >= 0;
 #pragma warning restore CA2249


### PR DESCRIPTION
Updates String.Contains, to check for null before calling String.IndexOf

In the current state, this will cause a NullReferenceException, which is not the desired exception, and does not align with how other methods operate.

Instead- this adds a simple null check, to then throw the correctly expected ArgumentNullException.


Reasoning- My OCD is really bugging me with the inconsistent exception type used for this method.

