### PR TITLE
Remove `BaseDomain`

### DIFF
--- a/src/coreclr/debug/daccess/dacfn.cpp
+++ b/src/coreclr/debug/daccess/dacfn.cpp
@@ -616,9 +616,10 @@ DacInstantiateClassByVTable(TADDR addr, ULONG32 minSize, bool throwEx)
     // Sanity check that the object we're returning is big enough to fill the PTR type it's being
     // accessed with.
     // If this is not true, it means the type being marshalled isn't a sub-type (or the same type)
-    // as the PTR type it's being used as.  For example, trying to marshal an instance of a SystemDomain
-    // object into a PTR_AppDomain will cause this ASSERT to fire (because both SystemDomain and AppDomain
-    // derived from BaseDomain, and SystemDomain is smaller than AppDomain).
+    // as the PTR type it's being used as. For example, trying to marshal an AssemblyLoaderAllocator
+    // into a PTR_GlobalLoaderAllocator will cause this ASSERT to fire (because AssemblyLoaderAllocator
+    // and GlobalLoaderAllocator derived from LoaderAllocator and AssemblyLoaderAllocator is smaller
+    // than GlobalLoaderAllocator).
     _ASSERTE_MSG(size >= minSize, "DAC coding error: Attempt to instantiate a VPTR from an object that is too small");
 
     inst = g_dacImpl->m_instances.Alloc(addr, size, DAC_VPTR);

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -282,9 +282,9 @@
 //
 //     extern ThreadStore* g_pThreadStore;
 //     ThreadStore* g_pThreadStore = &StaticStore;
-//     class SystemDomain : public BaseDomain {
+//     class CodeVersionManager {
 //         ...
-//         ArrayListStatic m_appDomainIndexList;
+//         static BOOL s_HasNonDefaultILVersions;
 //         ...
 //     }
 //
@@ -304,9 +304,9 @@
 //     GPTR_DECL(ThreadStore, g_pThreadStore);
 //     GPTR_IMPL_INIT(ThreadStore, g_pThreadStore, &StaticStore);
 //
-//     class SystemDomain : public BaseDomain {
+//     class CodeVersionManager {
 //         ...
-//         SVAL_DECL(ArrayListStatic; m_appDomainIndexList);
+//         SVAL_DECL(BOOL, s_HasNonDefaultILVersions);
 //         ...
 //     }
 //
@@ -994,7 +994,7 @@ public:
     __DPtrBase() = default;
 
     explicit __DPtrBase(__TPtrBase ptr) : __TPtrBase(ptr.GetAddr()) {}
-    
+
     // construct const from non-const
     __DPtrBase(__DPtrBase<typename std::remove_const<type>::type, DPtrTemplate> const & rhs) : __DPtrBase(rhs.GetAddr()) {}
 
@@ -2205,9 +2205,7 @@ public: name(int dummy) : base(dummy) {}
 
 // helper macro to make the vtables unique for DAC
 #define VPTR_UNIQUE(unique) virtual int MakeVTableUniqueForDAC() { return unique; }
-#define VPTR_UNIQUE_BaseDomain                          (100000)
-#define VPTR_UNIQUE_SystemDomain                        (VPTR_UNIQUE_BaseDomain + 1)
-#define VPTR_UNIQUE_ComMethodFrame                      (VPTR_UNIQUE_SystemDomain + 1)
+#define VPTR_UNIQUE_ComMethodFrame                      (100000)
 #define VPTR_UNIQUE_RedirectedThreadFrame               (VPTR_UNIQUE_ComMethodFrame + 1)
 #define VPTR_UNIQUE_HijackFrame                         (VPTR_UNIQUE_RedirectedThreadFrame + 1)
 
@@ -2319,10 +2317,10 @@ public: name(int dummy) : base(dummy) {}
 //             pMD = dac_cast<PTR_MethodDesc>(pInstMD)
 //
 //   - (D|V)PTR of one encapsulated pointer type to a (D|V)PTR of
-//     another type, i.e., PTR_AppDomain <-> PTR_BaseDomain
-//     Syntax: with PTR_AppDomain pAD, PTR_BaseDomain pBD
-//             dac_cast<PTR_AppDomain>(pBD)
-//             dac_cast<PTR_BaseDomain>(pAD)
+//     another type, i.e., PTR_Module <-> PTR_ModuleBase
+//     Syntax: with PTR_Module pModule, PTR_Module pModuleBase
+//             dac_cast<PTR_Module>(pModuleBase)
+//             dac_cast<PTR_ModuleBase>(pModule)
 //
 // Example comparisons of some old and new syntax, where
 //    h is a host pointer, such as "Foo *h;"

--- a/src/coreclr/inc/vptr_list.h
+++ b/src/coreclr/inc/vptr_list.h
@@ -21,9 +21,6 @@ VPTR_CLASS(EditAndContinueModule)
 VPTR_CLASS(Module)
 VPTR_CLASS(ReflectionModule)
 
-VPTR_CLASS(AppDomain)
-VPTR_CLASS(SystemDomain)
-
 VPTR_CLASS(PrecodeStubManager)
 VPTR_CLASS(StubLinkStubManager)
 VPTR_CLASS(ThePreStubManager)

--- a/src/coreclr/utilcode/ex.cpp
+++ b/src/coreclr/utilcode/ex.cpp
@@ -174,7 +174,7 @@ BOOL Exception::IsTerminal()
         GC_NOTRIGGER;
         NOTHROW;
 
-        // CLRException::GetHR() can eventually call BaseDomain::CreateHandle(),
+        // CLRException::GetHR() can eventually call AppDomain::CreateHandle(),
         // which can indirectly cause a lock if we get a miss in the handle table
         // cache (TableCacheMissOnAlloc).  Since CLRException::GetHR() is virtual,
         // SCAN won't find this for you (though 40 minutes of one of the sql stress

--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -337,7 +337,7 @@ RangeList::RangeListBlock::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         _ASSERTE( size < UINT32_MAX );    // ranges should be less than 4gig!
 
         // We can't be sure this entire range is mapped.  For example, the code:StubLinkStubManager
-        // keeps track of all ranges in the code:BaseDomain::m_pStubHeap LoaderHeap, and
+        // keeps track of all ranges in the code:LoaderAllocator::m_pStubHeap LoaderHeap, and
         // code:LoaderHeap::UnlockedReservePages adds a range for the entire reserved region, instead
         // of updating the RangeList when pages are committed.  But in that case, the committed region of
         // memory will be enumerated by the LoaderHeap anyway, so it's OK if this fails

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -4473,7 +4473,7 @@ AppDomain::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, bool enumThis)
     if (enumThis)
     {
         //sizeof(AppDomain) == 0xeb0
-        DAC_ENUM_VTHIS();
+        DAC_ENUM_DTHIS();
         EMEM_OUT(("MEM: %p AppDomain\n", dac_cast<TADDR>(this)));
     }
 
@@ -4504,7 +4504,7 @@ SystemDomain::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, bool enumThis)
     SUPPORTS_DAC;
     if (enumThis)
     {
-        DAC_ENUM_VTHIS();
+        DAC_ENUM_DTHIS();
         EMEM_OUT(("MEM: %p SystemAppomain\n", dac_cast<TADDR>(this)));
     }
 

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -35,7 +35,6 @@
 
 #include "codeversion.h"
 
-class BaseDomain;
 class SystemDomain;
 class AppDomain;
 class GlobalStringLiteralMap;
@@ -435,47 +434,6 @@ public:
     __newLimit.Activate();                                                              \
     __newLimit.SetLoadLevel(newLimit);
 
-// A BaseDomain much basic information in a code:AppDomain including
-//
-//    * code:#AppdomainHeaps - Heaps for any data structures that will be freed on appdomain unload
-//
-class BaseDomain
-{
-    friend class Assembly;
-    friend class AssemblySpec;
-    friend class AppDomain;
-
-    VPTR_BASE_VTABLE_CLASS(BaseDomain)
-    VPTR_UNIQUE(VPTR_UNIQUE_BaseDomain)
-
-public:
-
-    class AssemblyIterator;
-    friend class AssemblyIterator;
-
-    //****************************************************************************************
-    //
-    // Initialization/shutdown routines for every instance of an BaseDomain.
-
-    BaseDomain() = default;
-    virtual ~BaseDomain() {}
-
-    virtual BOOL IsAppDomain()    { LIMITED_METHOD_DAC_CONTRACT; return FALSE; }
-
-    virtual PTR_AppDomain AsAppDomain()
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(!"Not an AppDomain");
-        return NULL;
-    }
-
-#ifdef DACCESS_COMPILE
-public:
-    virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags, bool enumThis) = 0;
-#endif
-
-};  // class BaseDomain
-
 enum
 {
     ATTACH_ASSEMBLY_LOAD = 0x1,
@@ -687,25 +645,17 @@ const DWORD DefaultADID = 1;
 // Threads are always running in the context of a particular AppDomain.  See
 // file:threads.h#RuntimeThreadLocals for more details.
 //
-// see code:BaseDomain for much of the meat of a AppDomain (heaps locks, etc)
 //     * code:AppDomain.m_Assemblies - is a list of code:Assembly in the appdomain
 //
-class AppDomain : public BaseDomain
+class AppDomain final
 {
-    friend class SystemDomain;
-    friend class AssemblyNative;
-    friend class AssemblySpec;
-    friend class ClassLoader;
-    friend class ThreadNative;
+    friend struct _DacGlobals;
     friend class ClrDataAccess;
-    friend class CheckAsmOffsets;
-
-    VPTR_VTABLE_CLASS(AppDomain, BaseDomain)
 
 public:
 #ifndef DACCESS_COMPILE
     AppDomain();
-    virtual ~AppDomain();
+    ~AppDomain();
     static void Create();
 #endif
 
@@ -729,9 +679,6 @@ public:
 
     // final assembly cleanup
     void ShutdownFreeLoaderAllocators();
-
-    virtual BOOL IsAppDomain() { LIMITED_METHOD_DAC_CONTRACT; return TRUE; }
-    virtual PTR_AppDomain AsAppDomain() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_AppDomain>(this); }
 
     PTR_LoaderAllocator GetLoaderAllocator();
 
@@ -1698,7 +1645,7 @@ public:
 
 #ifdef DACCESS_COMPILE
 public:
-    virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
+    void EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
                                    bool enumThis);
 #endif
 
@@ -1735,14 +1682,12 @@ private:
 // Just a ref holder
 typedef ReleaseHolder<AppDomain> AppDomainRefHolder;
 
-typedef VPTR(class SystemDomain) PTR_SystemDomain;
+typedef DPTR(class SystemDomain) PTR_SystemDomain;
 
-class SystemDomain : public BaseDomain
+class SystemDomain final
 {
+    friend struct _DacGlobals;
     friend class ClrDataAccess;
-
-    VPTR_VTABLE_CLASS(SystemDomain, BaseDomain)
-    VPTR_UNIQUE(VPTR_UNIQUE_SystemDomain)
 
 public:
     static PTR_LoaderAllocator GetGlobalLoaderAllocator();
@@ -2066,7 +2011,7 @@ inline static BOOL IsUnderDomainLock() { LIMITED_METHOD_CONTRACT; return m_Syste
 
 #ifdef DACCESS_COMPILE
 public:
-    virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
+    void EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
                                    bool enumThis);
 #endif
 

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -47,7 +47,6 @@ class FramedMethodFrame;
 class Module;
 struct DeclActionInfo;
 class ComCallMethodDesc;
-class BaseDomain;
 class ZapNode;
 struct ArgLocDesc;
 

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -23,10 +23,8 @@
 #include "cordbpriv.h"
 #include "assemblyspec.hpp"
 
-class BaseDomain;
 class AppDomain;
 class DomainAssembly;
-class DomainModule;
 class SystemDomain;
 class ClassLoader;
 class AssemblyNative;
@@ -45,13 +43,11 @@ class FriendAssemblyDescriptor;
 //
 class Assembly
 {
-    friend class BaseDomain;
     friend class SystemDomain;
     friend class ClassLoader;
     friend class AssemblyNative;
     friend class AssemblySpec;
     friend class NDirect;
-    friend class AssemblyNameNative;
     friend class ClrDataAccess;
 
 private:

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -52,7 +52,6 @@ class EEStringData;
 class MethodDescChunk;
 class SigTypeContext;
 class Assembly;
-class BaseDomain;
 class AppDomain;
 class SystemDomain;
 class Module;

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -101,14 +101,13 @@ using std::min;
 
 typedef VPTR(class LoaderAllocator)     PTR_LoaderAllocator;
 typedef DPTR(PTR_LoaderAllocator)       PTR_PTR_LoaderAllocator;
-typedef VPTR(class AppDomain)           PTR_AppDomain;
+typedef DPTR(class AppDomain)           PTR_AppDomain;
 typedef DPTR(class ArrayBase)           PTR_ArrayBase;
 typedef DPTR(class Assembly)            PTR_Assembly;
 typedef DPTR(class AssemblyBaseObject)  PTR_AssemblyBaseObject;
 typedef DPTR(class AssemblyLoadContextBaseObject) PTR_AssemblyLoadContextBaseObject;
 typedef DPTR(class AssemblyBinder)      PTR_AssemblyBinder;
 typedef DPTR(class AssemblyNameBaseObject) PTR_AssemblyNameBaseObject;
-typedef VPTR(class BaseDomain)          PTR_BaseDomain;
 typedef DPTR(class ClassLoader)         PTR_ClassLoader;
 typedef DPTR(class ComCallMethodDesc)   PTR_ComCallMethodDesc;
 typedef DPTR(class CLRToCOMCallMethodDesc) PTR_CLRToCOMCallMethodDesc;

--- a/src/coreclr/vm/contractimpl.h
+++ b/src/coreclr/vm/contractimpl.h
@@ -120,7 +120,6 @@ public:
 struct DispatchTokenFat
 {
     friend struct DispatchToken;
-    friend class BaseDomain;
 
   private:
     UINT32 m_typeId;

--- a/src/coreclr/vm/genericdict.h
+++ b/src/coreclr/vm/genericdict.h
@@ -45,7 +45,6 @@
 
 class TypeHandleList;
 class Module;
-class BaseDomain;
 class SigTypeContext;
 class SigBuilder;
 
@@ -182,7 +181,7 @@ public:
 class Dictionary
 {
 private:
-    // First N entries are generic instantiations arguments. 
+    // First N entries are generic instantiations arguments.
     // The rest of the open array are normal pointers (no optional indirection) and may be NULL.
     DictionaryEntry m_pEntries[1];
 

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -29,7 +29,6 @@ class MethodDesc;
 class FramedMethodFrame;
 class Module;
 class ComCallMethodDesc;
-class BaseDomain;
 
 // CPU-dependent functions
 Stub * GenerateInitPInvokeFrameHelper();

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -447,9 +447,9 @@ MethodDesc* ILStubCache::InsertStubMethodDesc(MethodDesc *pMD, ILStubHashBlob* p
 //
 // JIT'ed IL stubs
 //
-//    - The ILStubCache is per-BaseDomain
+//    - The ILStubCache is per-LoaderAllocator
 //
-//    - Each BaseDomain's ILStubCache will lazily create a "minimal MethodTable" to
+//    - Each LoaderAllocator's ILStubCache will lazily create a "minimal MethodTable" to
 //      serve as the home for IL stub MethodDescs
 //
 //    - The created MethodTables will use the Module belonging to one of the
@@ -463,10 +463,7 @@ MethodDesc* ILStubCache::InsertStubMethodDesc(MethodDesc *pMD, ILStubHashBlob* p
 //
 // It's important to point out that the Module we latch onto here has no knowledge
 // of the MethodTable that we've just "added" to it.  There only exists a "back
-// pointer" to the Module from the MethodTable itself.  So we're really only using
-// that module to answer the question of what BaseDomain the MethodTable lives in.
-// So as long as the BaseDomain for that module is the same as the BaseDomain the
-// ILStubCache lives in, I think we have a fairly consistent story here.
+// pointer" to the Module from the MethodTable itself.
 //
 // We're relying on the fact that a VASigCookie may only mention types within the
 // corresponding module used to qualify the signature and the fact that interop
@@ -475,14 +472,7 @@ MethodDesc* ILStubCache::InsertStubMethodDesc(MethodDesc *pMD, ILStubHashBlob* p
 // ELEMENT_TYPE_INTERNAL, which may refer to any type.
 //
 // We can only access E_T_INTERNAL through LCG, which does not permit referring
-// to types in other BaseDomains.
-//
-//
-// Places for improvement:
-//
-//    - allow NGEN'ing of CALLI pinvoke and vararg pinvoke
-//
-//    - pre-populate the per-BaseDomain cache with IL stubs from  NGEN'ed image
+// to types in other AppDomains.
 //
 
 MethodDesc* ILStubCache::GetStubMethodDesc(

--- a/src/coreclr/vm/instmethhash.h
+++ b/src/coreclr/vm/instmethhash.h
@@ -26,7 +26,7 @@ class AllocMemTracker;
 // Each persisted Module has an InstMethodHashTable used for such methods that
 // were ngen'ed into that module. See ceeload.hpp for more information about ngen modules.
 //
-// Methods created at runtime are placed in an InstMethHashTable in BaseDomain.
+// Methods created at runtime are placed in an InstMethHashTable in Module.
 //
 // Keys are always derivable from the data stored in the table (MethodDesc)
 //

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -45,7 +45,7 @@ void MulticoreJitCodeStorage::Init()
     CONTRACTL
     {
         THROWS;
-        MODE_ANY;   // called from BaseDomain::Init which is MODE_ANY
+        MODE_ANY;   // called from SystemDomain::Attach which is MODE_ANY
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -77,7 +77,6 @@ void ErectWriteBarrierForMT(MethodTable **dst, MethodTable *ref);
 
 class MethodTable;
 class Thread;
-class BaseDomain;
 class Assembly;
 class DomainAssembly;
 class AssemblyNative;

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -27,7 +27,6 @@ class MethodTable;
 class EEClass;
 class Module;
 class Assembly;
-class BaseDomain;
 class MethodDesc;
 class TypeKey;
 class TypeHandleList;

--- a/src/coreclr/vm/typehash.h
+++ b/src/coreclr/vm/typehash.h
@@ -15,10 +15,7 @@
 // This hash table is used by class loaders to look up constructed types:
 // arrays, pointers and instantiations of user-defined generic types.
 //
-// Each persisted module structure has an EETypeHashTable used for constructed types that
-// were ngen'ed into that module. See ceeload.hpp for more information about ngen modules.
-//
-// Types created at runtime are placed in an EETypeHashTable in BaseDomain.
+// Types created at runtime are placed in an EETypeHashTable in Module.
 //
 // Keys are derivable from the data stored in the table (TypeHandle)
 // - for an instantiated type, the typedef module, typedef token, and instantiation


### PR DESCRIPTION
The `BaseDomain` concept is no longer useful now that we don't have shared domains or multiple app domains. It has been gutted enough and usages moved to directly use `AppDomain` or `SystemDomain` that it can just be removed now. With this change, `AppDomain` and `SystemDomain` are separate classes with no shared base.

cc @jkotas @AaronRobinsonMSFT 