### PR TITLE
Revert "Avoid taking lock for empty bucket in ConcurrentDictionary.TryRemove …"

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -443,57 +443,52 @@ namespace System.Collections.Concurrent
                 object[] locks = tables._locks;
                 ref Node? bucket = ref GetBucketAndLock(tables, hashcode, out uint lockNo);
 
-                // Do a hot read on number of items stored in the bucket.  If it's empty, we can avoid
-                // taking the lock and fail fast.
-                if (tables._countPerLock[lockNo] != 0)
+                lock (locks[lockNo])
                 {
-                    lock (locks[lockNo])
+                    // If the table just got resized, we may not be holding the right lock, and must retry.
+                    // This should be a rare occurrence.
+                    if (tables != _tables)
                     {
-                        // If the table just got resized, we may not be holding the right lock, and must retry.
-                        // This should be a rare occurrence.
-                        if (tables != _tables)
+                        tables = _tables;
+                        if (!ReferenceEquals(comparer, tables._comparer))
                         {
-                            tables = _tables;
-                            if (!ReferenceEquals(comparer, tables._comparer))
-                            {
-                                comparer = tables._comparer;
-                                hashcode = GetHashCode(comparer, key);
-                            }
-                            continue;
+                            comparer = tables._comparer;
+                            hashcode = GetHashCode(comparer, key);
                         }
+                        continue;
+                    }
 
-                        Node? prev = null;
-                        for (Node? curr = bucket; curr is not null; curr = curr._next)
+                    Node? prev = null;
+                    for (Node? curr = bucket; curr is not null; curr = curr._next)
+                    {
+                        Debug.Assert((prev is null && curr == bucket) || prev!._next == curr);
+
+                        if (hashcode == curr._hashcode && NodeEqualsKey(comparer, curr, key))
                         {
-                            Debug.Assert((prev is null && curr == bucket) || prev!._next == curr);
-
-                            if (hashcode == curr._hashcode && NodeEqualsKey(comparer, curr, key))
+                            if (matchValue)
                             {
-                                if (matchValue)
+                                bool valuesMatch = EqualityComparer<TValue>.Default.Equals(oldValue, curr._value);
+                                if (!valuesMatch)
                                 {
-                                    bool valuesMatch = EqualityComparer<TValue>.Default.Equals(oldValue, curr._value);
-                                    if (!valuesMatch)
-                                    {
-                                        value = default;
-                                        return false;
-                                    }
+                                    value = default;
+                                    return false;
                                 }
-
-                                if (prev is null)
-                                {
-                                    Volatile.Write(ref bucket, curr._next);
-                                }
-                                else
-                                {
-                                    prev._next = curr._next;
-                                }
-
-                                value = curr._value;
-                                tables._countPerLock[lockNo]--;
-                                return true;
                             }
-                            prev = curr;
+
+                            if (prev is null)
+                            {
+                                Volatile.Write(ref bucket, curr._next);
+                            }
+                            else
+                            {
+                                prev._next = curr._next;
+                            }
+
+                            value = curr._value;
+                            tables._countPerLock[lockNo]--;
+                            return true;
                         }
+                        prev = curr;
                     }
                 }
 


### PR DESCRIPTION
This reverts commit 252018c3d3fffdb592413cf61d5b80cf751e0a59. That change was considered safe within the context of TryRemove, in that it doesn't affect the behavior of TryRemove in isolation. But it's definitely confusing in conjunction with other APIs, where with no other concurrent removals, you could call ContainsKey, have it return true, and then have TryRemove return false.

https://github.com/dotnet/runtime/issues/107525

We should backport this to at least release/9.0 if not also release/8.0.

Best reviewed without whitespace:
https://github.com/dotnet/runtime/pull/107653/files?w=1

