### PR TITLE
Remove unused freebsd elf32/elf64 header references

### DIFF
--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -25,11 +25,6 @@
 #include <mono/metadata/debug-internals.h>
 #include <mono/metadata/abi-details.h>
 
-#ifndef HOST_WIN32
-#include <external/libunwind/include/remote/freebsd-elf32.h>
-#include <external/libunwind/include/remote/freebsd-elf64.h>
-#endif
-
 #include <mono/utils/freebsd-dwarf.h>
 
 #define DW_AT_MIPS_linkage_name 0x2007

--- a/src/mono/mono/utils/CMakeLists.txt
+++ b/src/mono/mono/utils/CMakeLists.txt
@@ -217,12 +217,6 @@ endif()
 
 set(utils_sources "${utils_platform_sources};${utils_arch_sources};${utils_common_sources}")
 
-set(utils_sources
-    ${utils_sources}
-    ${CLR_SRC_NATIVE_DIR}/external/libunwind/include/remote/freebsd-elf_common.h
-    ${CLR_SRC_NATIVE_DIR}/external/libunwind/include/remote/freebsd-elf32.h
-    ${CLR_SRC_NATIVE_DIR}/external/libunwind/include/remote/freebsd-elf64.h)
-
 if(ENABLE_DTRACE)
     find_program(DTRACE dtrace)
     if(TARGET_OSX)


### PR DESCRIPTION
It doesn't make sense to require the freebsd-specific headers on non-FreeBSD platforms. In fact, on my testing, the headers aren't even used. And just break or do the wrong things when system libunwind is used.