### PR TITLE
PersistedAssemblyBuilder: fix IL reference tokens to another generated assembly members

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -212,7 +212,7 @@ namespace System.Reflection.Emit
             // Get the parent class's default constructor and add it to the IL
             ConstructorInfo? con;
             if (_typeParent!.IsConstructedGenericType &&
-                (_typeParent.GetGenericTypeDefinition() is TypeBuilderImpl || ModuleBuilderImpl.ContainsTypeBuilder(_typeParent.GetGenericArguments())))
+                (_typeParent.GetGenericTypeDefinition() is TypeBuilderImpl || _module.ContainsTypeBuilder(_typeParent.GetGenericArguments())))
             {
                 // When TypeBuilder involved need to construct the parent constructor using TypeBuilder.GetConstructor() static method
                 con = GetConstructor(_typeParent, _typeParent.GetGenericTypeDefinition().GetConstructor(


### PR DESCRIPTION
A generated assembly member tokens will not populated properly until its saved. Therefore we reserve Blob for such tokens and fill-in during `assembly.Save()` operation. As per this design current code reserves tokens in case the IL referencing TypeBuilder, FieldBuilder, MethodBuilder, ConstructorBuilder or generic type parameter references TypeBuilder. This caused a bug when  members are refenced from another generated assembly, tokens are reserved as it was in the same assembly instead it should have reference tokens to that assembly

The fix basically involves checking if the referenced member is in a same module, that is pretty much adding another check `&& Equals(member.Module)` and make the static methods instance in order to use the `Equals(object)` instance method of the module

Fixes https://github.com/dotnet/runtime/issues/107658