### PR TITLE
Remove explicit dependency on System.Buffers from System.Formats.Asn1

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System.Formats.Asn1.csproj
+++ b/src/libraries/System.Formats.Asn1/src/System.Formats.Asn1.csproj
@@ -64,7 +64,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
System.Formats.Asn1 depends on System.Memory >=4.5.5 and System.Buffers >=4.5.1, but System.Memory 4.5.5 already depends on System.Buffers >=4.5.1, so the explicit dependency should not be needed, right...?