### PR TITLE
Work around F# ildasm/ilasm round-trip test failure

### DIFF
--- a/src/tests/JIT/Directed/tailcall/mutual_recursion.fsproj
+++ b/src/tests/JIT/Directed/tailcall/mutual_recursion.fsproj
@@ -8,6 +8,9 @@
 
     <!-- Test is slow enough to time out under GC stress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+
+    <!-- Work around test failure https://github.com/dotnet/runtime/issues/106601 -->
+    <RealSig>false</RealSig>
   </PropertyGroup>
   <PropertyGroup>
     <Optimize>True</Optimize>


### PR DESCRIPTION
An F# compiler change caused significant generated IL change and an ildasm/ilasm round-trip test failure. Adding
`<RealSig>false</RealSig>` reverts to the previous F# codegen and fixes the problem.

Tracking: https://github.com/dotnet/runtime/issues/106601