### PR TITLE
Move load level tracking and checks from `DomainAssembly` to `Assembly`

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -4425,11 +4425,6 @@ void  DacDbiInterfaceImpl::EnumerateAssembliesInAppDomain(
 
     while (iterator.Next(pDomainAssembly.This()))
     {
-        if (!pDomainAssembly->GetAssembly()->IsVisibleToDebugger())
-        {
-            continue;
-        }
-
         VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
         vmDomainAssembly.SetHostPtr(pDomainAssembly);
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -4425,7 +4425,7 @@ void  DacDbiInterfaceImpl::EnumerateAssembliesInAppDomain(
 
     while (iterator.Next(pDomainAssembly.This()))
     {
-        if (!pDomainAssembly->IsVisibleToDebugger())
+        if (!pDomainAssembly->GetAssembly()->IsVisibleToDebugger())
         {
             continue;
         }
@@ -4454,7 +4454,7 @@ void DacDbiInterfaceImpl::EnumerateModulesInAssembly(
     if (pDomainAssembly->GetModule()->IsVisibleToDebugger())
     {
         // If domain assembly isn't yet loaded, just return
-        if (!pDomainAssembly->IsLoaded())
+        if (!pDomainAssembly->GetAssembly()->IsLoaded())
             return;
 
         VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2859,7 +2859,7 @@ ClrDataAccess::GetAppDomainData(CLRDATA_ADDRESS addr, struct DacpAppDomainData *
 
                 while (i.Next(pDomainAssembly.This()))
                 {
-                    if (pDomainAssembly->IsLoaded())
+                    if (pDomainAssembly->GetAssembly()->IsLoaded())
                     {
                         appdomainData->AssemblyCount++;
                     }
@@ -2978,9 +2978,9 @@ ClrDataAccess::GetAssemblyList(CLRDATA_ADDRESS addr, int count, CLRDATA_ADDRESS 
         {
             while (i.Next(pDomainAssembly.This()) && (n < count))
             {
-                if (pDomainAssembly->IsLoaded())
+                CollectibleAssemblyHolder<Assembly *> pAssembly = pDomainAssembly->GetAssembly();
+                if (pAssembly->IsLoaded())
                 {
-                    CollectibleAssemblyHolder<Assembly *> pAssembly = pDomainAssembly->GetAssembly();
                     // Note: DAC doesn't need to keep the assembly alive - see code:CollectibleAssemblyHolder#CAH_DAC
                     values[n++] = HOST_CDADDR(pAssembly.Extract());
                 }
@@ -2989,7 +2989,7 @@ ClrDataAccess::GetAssemblyList(CLRDATA_ADDRESS addr, int count, CLRDATA_ADDRESS 
         else
         {
             while (i.Next(pDomainAssembly.This()))
-                if (pDomainAssembly->IsLoaded())
+                if (pDomainAssembly->GetAssembly()->IsLoaded())
                     n++;
         }
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -914,7 +914,7 @@ void SystemDomain::Init()
         PreallocateSpecialObjects();
 
         // Finish loading CoreLib now.
-        m_pSystemAssembly->GetDomainAssembly()->EnsureActive();
+        m_pSystemAssembly->EnsureActive();
 
         // Set AwareLock's offset of the holding OS thread ID field into ThreadBlockingInfo's static field. That can be used
         // when doing managed debugging to get the OS ID of the thread holding the lock. The offset is currently not zero, and
@@ -1014,7 +1014,7 @@ void SystemDomain::LoadBaseSystemClasses()
 
         // Only partially load the system assembly. Other parts of the code will want to access
         // the globals in this function before finishing the load.
-        m_pSystemAssembly = DefaultDomain()->LoadDomainAssembly(NULL, m_pSystemPEAssembly, FILE_LOAD_BEFORE_TYPE_LOAD)->GetAssembly();
+        m_pSystemAssembly = DefaultDomain()->LoadDomainAssembly(NULL, m_pSystemPEAssembly, FILE_LOAD_BEFORE_TYPE_LOAD);
 
         // Set up binder for CoreLib
         CoreLibBinder::AttachModule(m_pSystemAssembly->GetModule());
@@ -1888,7 +1888,7 @@ DispIDCache* AppDomain::SetupRefDispIDCache()
 
 #endif // FEATURE_COMINTEROP
 
-FileLoadLock *FileLoadLock::Create(PEFileListLock *pLock, PEAssembly * pPEAssembly, DomainAssembly *pDomainAssembly)
+FileLoadLock *FileLoadLock::Create(PEFileListLock *pLock, PEAssembly * pPEAssembly, Assembly *pAssembly)
 {
     CONTRACTL
     {
@@ -1901,7 +1901,7 @@ FileLoadLock *FileLoadLock::Create(PEFileListLock *pLock, PEAssembly * pPEAssemb
     }
     CONTRACTL_END;
 
-    NewHolder<FileLoadLock> result(new FileLoadLock(pLock, pPEAssembly, pDomainAssembly));
+    NewHolder<FileLoadLock> result(new FileLoadLock(pLock, pPEAssembly, pAssembly));
 
     pLock->AddElement(result);
     result->AddRef(); // Add one ref on behalf of the ListLock's reference. The corresponding Release() happens in FileLoadLock::CompleteLoadLevel.
@@ -1921,10 +1921,10 @@ FileLoadLock::~FileLoadLock()
     ((PEAssembly *) m_data)->Release();
 }
 
-DomainAssembly *FileLoadLock::GetDomainAssembly()
+Assembly *FileLoadLock::GetAssembly()
 {
     LIMITED_METHOD_CONTRACT;
-    return m_pDomainAssembly;
+    return m_pAssembly;
 }
 
 FileLoadLevel FileLoadLock::GetLoadLevel()
@@ -2000,7 +2000,7 @@ BOOL FileLoadLock::CompleteLoadLevel(FileLoadLevel level, BOOL success)
     if (level > m_level)
     {
         // Must complete each level in turn, unless we have an error
-        CONSISTENCY_CHECK(m_pDomainAssembly->IsError() || (level == (m_level+1)));
+        CONSISTENCY_CHECK(m_pAssembly->IsError() || (level == (m_level+1)));
         // Remove the lock from the list if the load is completed
         if (level >= FILE_ACTIVE)
         {
@@ -2014,7 +2014,7 @@ BOOL FileLoadLock::CompleteLoadLevel(FileLoadLevel level, BOOL success)
                     m_pList->Unlink(this);
                 _ASSERTE(fDbgOnly_SuccessfulUnlink);
 
-                m_pDomainAssembly->ClearLoading();
+                m_pAssembly->ClearLoading();
 
                 CONSISTENCY_CHECK(m_dwRefCount >= 2); // Caller (LoadDomainAssembly) should have 1 refcount and m_pList should have another which was acquired in FileLoadLock::Create.
 
@@ -2025,7 +2025,7 @@ BOOL FileLoadLock::CompleteLoadLevel(FileLoadLevel level, BOOL success)
                 // we depend on the DomainAssembly's load level being up to date. Hence we must update the load
                 // level while the m_pList lock is held.
                 if (success)
-                    m_pDomainAssembly->SetLoadLevel(level);
+                    m_pAssembly->SetLoadLevel(level);
             }
 
 
@@ -2037,7 +2037,7 @@ BOOL FileLoadLock::CompleteLoadLevel(FileLoadLevel level, BOOL success)
             m_level = (FileLoadLevel)level;
 
             if (success)
-                m_pDomainAssembly->SetLoadLevel(level);
+                m_pAssembly->SetLoadLevel(level);
         }
 
 #ifndef DACCESS_COMPILE
@@ -2046,7 +2046,7 @@ BOOL FileLoadLock::CompleteLoadLevel(FileLoadLevel level, BOOL success)
             case FILE_LOAD_DELIVER_EVENTS:
             case FILE_LOADED:
             case FILE_ACTIVE: // The timing of stress logs is not critical, so even for the FILE_ACTIVE stage we need not do it while the m_pList lock is held.
-                STRESS_LOG3(LF_CLASSLOADER, LL_INFO100, "Completed Load Level %s for DomainAssembly %p - success = %i\n", fileLoadLevelName[level], m_pDomainAssembly, success);
+                STRESS_LOG3(LF_CLASSLOADER, LL_INFO100, "Completed Load Level %s for Assembly %p - success = %i\n", fileLoadLevelName[level], m_pAssembly, success);
                 break;
             default:
                 break;
@@ -2075,9 +2075,9 @@ void FileLoadLock::SetError(Exception *ex)
     m_cachedHR = ex->GetHR();
 
     LOG((LF_LOADER, LL_WARNING, "LOADER: ***%s*\t!!!Non-transient error 0x%x\n",
-        m_pDomainAssembly->GetSimpleName(), m_cachedHR));
+        m_pAssembly->GetSimpleName(), m_cachedHR));
 
-    m_pDomainAssembly->SetError(ex);
+    m_pAssembly->SetError(ex);
 
     CompleteLoadLevel(FILE_ACTIVE, FALSE);
 }
@@ -2105,10 +2105,10 @@ UINT32 FileLoadLock::Release()
     return count;
 }
 
-FileLoadLock::FileLoadLock(PEFileListLock *pLock, PEAssembly * pPEAssembly, DomainAssembly *pDomainAssembly)
+FileLoadLock::FileLoadLock(PEFileListLock *pLock, PEAssembly * pPEAssembly, Assembly *pAssembly)
   : ListLockEntry(pLock, pPEAssembly, "File load lock"),
     m_level((FileLoadLevel) (FILE_LOAD_CREATE)),
-    m_pDomainAssembly(pDomainAssembly),
+    m_pAssembly(pAssembly),
     m_cachedHR(S_OK)
 {
     WRAPPER_NO_CONTRACT;
@@ -2172,21 +2172,21 @@ void AppDomain::LoadSystemAssemblies()
 // thread has completed the load step.
 //
 
-BOOL AppDomain::IsLoading(DomainAssembly *pFile, FileLoadLevel level)
+BOOL AppDomain::IsLoading(Assembly *pAssembly, FileLoadLevel level)
 {
     // Cheap out
-    if (pFile->GetLoadLevel() < level)
+    if (pAssembly->GetLoadLevel() < level)
     {
         FileLoadLock *pLock = NULL;
         {
             LoadLockHolder lock(this);
 
-            pLock = (FileLoadLock *) lock->FindFileLock(pFile->GetPEAssembly());
+            pLock = (FileLoadLock *) lock->FindFileLock(pAssembly->GetPEAssembly());
 
             if (pLock == NULL)
             {
                 // No thread involved with loading
-                return pFile->GetLoadLevel() >= level;
+                return pAssembly->GetLoadLevel() >= level;
             }
 
             pLock->AddRef();
@@ -2209,16 +2209,16 @@ BOOL AppDomain::IsLoading(DomainAssembly *pFile, FileLoadLevel level)
 
 // CheckLoading is a weaker form of IsLoading, which will not block on
 // other threads waiting for their status.  This is appropriate for asserts.
-CHECK AppDomain::CheckLoading(DomainAssembly *pFile, FileLoadLevel level)
+CHECK AppDomain::CheckLoading(Assembly *pAssembly, FileLoadLevel level)
 {
     // Cheap out
-    if (pFile->GetLoadLevel() < level)
+    if (pAssembly->GetLoadLevel() < level)
     {
         FileLoadLock *pLock = NULL;
 
         LoadLockHolder lock(this);
 
-        pLock = (FileLoadLock *) lock->FindFileLock(pFile->GetPEAssembly());
+        pLock = (FileLoadLock *) lock->FindFileLock(pAssembly->GetPEAssembly());
 
         if (pLock != NULL
             && pLock->CanAcquire(level))
@@ -2275,7 +2275,7 @@ CHECK AppDomain::CheckCanExecuteManagedCode(MethodDesc* pMD)
 
 #endif // !DACCESS_COMPILE
 
-void AppDomain::LoadDomainAssembly(DomainAssembly *pFile,
+void AppDomain::LoadDomainAssembly(Assembly *pAssembly,
                                FileLoadLevel targetLevel)
 {
     CONTRACTL
@@ -2288,26 +2288,26 @@ void AppDomain::LoadDomainAssembly(DomainAssembly *pFile,
     CONTRACTL_END;
 
     // Quick exit if finished
-    if (pFile->GetLoadLevel() >= targetLevel)
+    if (pAssembly->GetLoadLevel() >= targetLevel)
         return;
 
     // Handle the error case
-    pFile->ThrowIfError(targetLevel);
+    pAssembly->ThrowIfError(targetLevel);
 
 
 #ifndef DACCESS_COMPILE
 
-    if (pFile->IsLoading())
+    if (pAssembly->IsLoading())
     {
         GCX_PREEMP();
 
         // Load some more if appropriate
         LoadLockHolder lock(this);
 
-        FileLoadLock* pLockEntry = (FileLoadLock *) lock->FindFileLock(pFile->GetPEAssembly());
+        FileLoadLock* pLockEntry = (FileLoadLock *) lock->FindFileLock(pAssembly->GetPEAssembly());
         if (pLockEntry == NULL)
         {
-            _ASSERTE (!pFile->IsLoading());
+            _ASSERTE (!pAssembly->IsLoading());
             return;
         }
 
@@ -2349,18 +2349,15 @@ Assembly *AppDomain::LoadAssembly(AssemblySpec* pIdentity,
         THROWS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pPEAssembly));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK)); // May be NULL in recursive load case
+        POSTCONDITION(CheckPointer(RETVAL)); // May be NULL in recursive load case
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACT_END;
 
-    DomainAssembly *pAssembly = LoadDomainAssembly(pIdentity, pPEAssembly, targetLevel);
-    PREFIX_ASSUME(pAssembly != NULL);
-
-    RETURN pAssembly->GetAssembly();
+    RETURN LoadDomainAssembly(pIdentity, pPEAssembly, targetLevel);
 }
 
-DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
+Assembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
                                               PEAssembly * pPEAssembly,
                                               FileLoadLevel targetLevel)
 {
@@ -2372,7 +2369,7 @@ DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
         return LoadDomainAssemblyInternal(pSpec, pPEAssembly, targetLevel);
     }
 
-    DomainAssembly* pRetVal = NULL;
+    Assembly* pRetVal = NULL;
     EX_TRY
     {
         pRetVal = LoadDomainAssemblyInternal(pSpec, pPEAssembly, targetLevel);
@@ -2419,11 +2416,11 @@ DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
 }
 
 
-DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
+Assembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
                                               PEAssembly * pPEAssembly,
                                               FileLoadLevel targetLevel)
 {
-    CONTRACT(DomainAssembly *)
+    CONTRACT(Assembly *)
     {
         GC_TRIGGERS;
         THROWS;
@@ -2439,7 +2436,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
     CONTRACT_END;
 
 
-    DomainAssembly * result;
+    Assembly * result;
 
     // Go into preemptive mode since this may take a while.
     GCX_PREEMP();
@@ -2479,7 +2476,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
             {
                 // We are the first one in - create the DomainAssembly
                 registerNewAssembly = true;
-                fileLock = FileLoadLock::Create(lock, pPEAssembly, pDomainAssembly);
+                fileLock = FileLoadLock::Create(lock, pPEAssembly, pDomainAssembly->GetAssembly());
                 pDomainAssembly.SuppressRelease();
                 pamTracker->SuppressRelease();
 
@@ -2507,7 +2504,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
             // Note that if we throw here, we will poison fileLock with an error condition,
             // so it will not be removed until app domain unload.  So there is no need
             // to release our ref count.
-            result = (DomainAssembly *)LoadDomainAssembly(fileLock, targetLevel);
+            result = LoadDomainAssembly(fileLock, targetLevel);
         }
         else
         {
@@ -2529,19 +2526,19 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
     {
         AssemblySpec spec;
         spec.InitializeSpec(result->GetPEAssembly());
-        GetAppDomain()->AddAssemblyToCache(&spec, result);
+        GetAppDomain()->AddAssemblyToCache(&spec, result->GetDomainAssembly());
     }
     else
     {
-        GetAppDomain()->AddAssemblyToCache(pIdentity, result);
+        GetAppDomain()->AddAssemblyToCache(pIdentity, result->GetDomainAssembly());
     }
 
     RETURN result;
 } // AppDomain::LoadDomainAssembly
 
-DomainAssembly *AppDomain::LoadDomainAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel)
+Assembly *AppDomain::LoadDomainAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel)
 {
-    CONTRACT(DomainAssembly *)
+    CONTRACT(Assembly *)
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pLock));
@@ -2552,7 +2549,7 @@ DomainAssembly *AppDomain::LoadDomainAssembly(FileLoadLock *pLock, FileLoadLevel
     }
     CONTRACT_END;
 
-    DomainAssembly *pFile = pLock->GetDomainAssembly();
+    Assembly *pAssembly = pLock->GetAssembly();
 
     // Make sure we release the lock on exit
     FileLoadLockRefHolder lockRef(pLock);
@@ -2560,9 +2557,9 @@ DomainAssembly *AppDomain::LoadDomainAssembly(FileLoadLock *pLock, FileLoadLevel
     // Do a quick out check for the already loaded case.
     if (pLock->GetLoadLevel() >= targetLevel)
     {
-        pFile->ThrowIfError(targetLevel);
+        pAssembly->ThrowIfError(targetLevel);
 
-        RETURN pFile;
+        RETURN pAssembly;
     }
 
     // Initialize a loading queue.  This will hold any loads which are triggered recursively but
@@ -2583,7 +2580,7 @@ DomainAssembly *AppDomain::LoadDomainAssembly(FileLoadLock *pLock, FileLoadLevel
             immediateTargetLevel = limit.GetLoadLevel();
 
         LOG((LF_LOADER, LL_INFO100, "LOADER: ***%s*\t>>>Load initiated, %s/%s\n",
-             pFile->GetSimpleName(),
+             pAssembly->GetSimpleName(),
              fileLoadLevelName[immediateTargetLevel], fileLoadLevelName[targetLevel]));
 
         // Now loop and do the load incrementally to the target level.
@@ -2610,28 +2607,28 @@ DomainAssembly *AppDomain::LoadDomainAssembly(FileLoadLock *pLock, FileLoadLevel
                           || workLevel == FILE_ACTIVE)
                          ? LL_INFO10 : LL_INFO1000,
                          "LOADER: %p:***%s*\t   loading at level %s\n",
-                         this, pFile->GetSimpleName(), fileLoadLevelName[workLevel]));
+                         this, pAssembly->GetSimpleName(), fileLoadLevelName[workLevel]));
 
-                    TryIncrementalLoad(pFile, workLevel, fileLock);
+                    TryIncrementalLoad(pAssembly, workLevel, fileLock);
                 }
             }
 
             if (pLock->GetLoadLevel() == immediateTargetLevel-1)
             {
                 LOG((LF_LOADER, LL_INFO100, "LOADER: ***%s*\t<<<Load limited due to detected deadlock, %s\n",
-                     pFile->GetSimpleName(),
+                     pAssembly->GetSimpleName(),
                      fileLoadLevelName[immediateTargetLevel-1]));
             }
         }
 
         LOG((LF_LOADER, LL_INFO100, "LOADER: ***%s*\t<<<Load completed, %s\n",
-             pFile->GetSimpleName(),
+             pAssembly->GetSimpleName(),
              fileLoadLevelName[pLock->GetLoadLevel()]));
 
     }
 
     // There may have been an error stored on the domain file by another thread, or from a previous load
-    pFile->ThrowIfError(targetLevel);
+    pAssembly->ThrowIfError(targetLevel);
 
     // There are two normal results from the above loop.
     //
@@ -2649,13 +2646,11 @@ DomainAssembly *AppDomain::LoadDomainAssembly(FileLoadLock *pLock, FileLoadLevel
     // (An alternate, and possibly preferable, strategy here would be for all callers to explicitly
     // specify the minimum load level acceptable and throw if not reached.)
 
-    pFile->RequireLoadLevel((FileLoadLevel)(immediateTargetLevel-1));
-
-
-    RETURN pFile;
+    pAssembly->RequireLoadLevel((FileLoadLevel)(immediateTargetLevel-1));
+    RETURN pAssembly;
 }
 
-void AppDomain::TryIncrementalLoad(DomainAssembly *pFile, FileLoadLevel workLevel, FileLoadLockHolder &lockHolder)
+void AppDomain::TryIncrementalLoad(Assembly *pAssembly, FileLoadLevel workLevel, FileLoadLockHolder &lockHolder)
 {
     STANDARD_VM_CONTRACT;
 
@@ -2667,7 +2662,7 @@ void AppDomain::TryIncrementalLoad(DomainAssembly *pFile, FileLoadLevel workLeve
     EX_TRY
     {
         // Do the work
-        BOOL success = pFile->DoIncrementalLoad(workLevel);
+        BOOL success = pAssembly->DoIncrementalLoad(workLevel);
 
         // Complete the level.
         if (pLoadLock->CompleteLoadLevel(workLevel, success) &&
@@ -2675,7 +2670,7 @@ void AppDomain::TryIncrementalLoad(DomainAssembly *pFile, FileLoadLevel workLeve
         {
             lockHolder.Release();
             released = TRUE;
-            pFile->DeliverAsyncEvents();
+            pAssembly->DeliverAsyncEvents();
         };
     }
     EX_HOOK
@@ -2684,7 +2679,7 @@ void AppDomain::TryIncrementalLoad(DomainAssembly *pFile, FileLoadLevel workLeve
 
         //We will cache this error and wire this load to forever fail,
         // unless the exception is transient or the file is loaded OK but just cannot execute
-        if (!pEx->IsTransient() && !pFile->IsLoaded())
+        if (!pEx->IsTransient() && !pAssembly->IsLoaded())
         {
             if (released)
             {
@@ -2705,7 +2700,7 @@ void AppDomain::TryIncrementalLoad(DomainAssembly *pFile, FileLoadLevel workLeve
             }
 
             if (!EEFileLoadException::CheckType(pEx))
-                EEFileLoadException::Throw(pFile->GetPEAssembly(), pEx->GetHR(), pEx);
+                EEFileLoadException::Throw(pAssembly->GetPEAssembly(), pEx->GetHR(), pEx);
         }
 
         // Otherwise, we simply abort this load, and can retry later on.
@@ -2764,7 +2759,7 @@ void AppDomain::SetupSharedStatics()
     SetObjectReference( pEmptyStringHandle, StringObject::GetEmptyString());
 }
 
-DomainAssembly * AppDomain::FindAssembly(PEAssembly * pPEAssembly, FindAssemblyOptions options/* = FindAssemblyOptions_None*/)
+Assembly * AppDomain::FindAssembly(PEAssembly * pPEAssembly, FindAssemblyOptions options/* = FindAssemblyOptions_None*/)
 {
     CONTRACTL
     {
@@ -2779,9 +2774,9 @@ DomainAssembly * AppDomain::FindAssembly(PEAssembly * pPEAssembly, FindAssemblyO
     if (pPEAssembly->HasHostAssembly())
     {
         DomainAssembly * pDA = pPEAssembly->GetHostAssembly()->GetDomainAssembly();
-        if (pDA != nullptr && (pDA->IsLoaded() || (includeFailedToLoad && pDA->IsError())))
+        if (pDA != nullptr && (pDA->GetAssembly()->IsLoaded() || (includeFailedToLoad && pDA->GetAssembly()->IsError())))
         {
-            return pDA;
+            return pDA->GetAssembly();
         }
         return nullptr;
     }
@@ -2798,7 +2793,7 @@ DomainAssembly * AppDomain::FindAssembly(PEAssembly * pPEAssembly, FindAssemblyO
         if (pManifestFile &&
             pManifestFile->Equals(pPEAssembly))
         {
-            return pDomainAssembly.GetValue();
+            return pDomainAssembly.GetValue()->GetAssembly();
         }
     }
     return NULL;
@@ -3596,7 +3591,7 @@ BOOL AppDomain::NotifyDebuggerLoad(int flags, BOOL attaching)
     CollectibleAssemblyHolder<DomainAssembly *> pDomainAssembly;
     while (i.Next(pDomainAssembly.This()))
     {
-        result = (pDomainAssembly->NotifyDebuggerLoad(flags, attaching) ||
+        result = (pDomainAssembly->GetAssembly()->NotifyDebuggerLoad(flags, attaching) ||
                   result);
     }
 
@@ -3619,7 +3614,7 @@ void AppDomain::NotifyDebuggerUnload()
     while (i.Next(pDomainAssembly.This()))
     {
         LOG((LF_CORDB, LL_INFO100, "AD::NDD: Iterating assemblies\n"));
-        pDomainAssembly->NotifyDebuggerUnload();
+        pDomainAssembly->GetAssembly()->NotifyDebuggerUnload();
     }
 }
 #endif // DEBUGGING_SUPPORTED
@@ -4077,7 +4072,8 @@ AppDomain::AssemblyIterator::Next_Unlocked(
             continue;
         }
 
-        if (pDomainAssembly->IsError())
+        Assembly* pAssembly = pDomainAssembly->GetAssembly();
+        if (pAssembly->IsError())
         {
             if (m_assemblyIterationFlags & kIncludeFailedToLoad)
             {
@@ -4090,7 +4086,7 @@ AppDomain::AssemblyIterator::Next_Unlocked(
         // First, reject DomainAssemblies whose load status is not to be included in
         // the enumeration
 
-        if (pDomainAssembly->IsAvailableToProfilers() &&
+        if (pAssembly->IsAvailableToProfilers() &&
             (m_assemblyIterationFlags & kIncludeAvailableToProfilers))
         {
             // The assembly has reached the state at which we would notify profilers,
@@ -4100,7 +4096,7 @@ AppDomain::AssemblyIterator::Next_Unlocked(
             // kIncludeAvailableToProfilers contains some loaded AND loading
             // assemblies.
         }
-        else if (pDomainAssembly->IsLoaded())
+        else if (pAssembly->IsLoaded())
         {
             // A loaded assembly
             if (!(m_assemblyIterationFlags & kIncludeLoaded))
@@ -4138,7 +4134,7 @@ AppDomain::AssemblyIterator::Next_Unlocked(
             // Un-tenured collectible assemblies should not be returned. (This can only happen in a brief
             // window during collectible assembly creation. No thread should need to have a pointer
             // to the just allocated DomainAssembly at this stage.)
-            if (!pDomainAssembly->GetAssembly()->GetModule()->IsTenured())
+            if (!pAssembly->GetModule()->IsTenured())
             {
                 continue; // reject
             }

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -1072,8 +1072,7 @@ public:
 
     BOOL IsLoading(Assembly *pFile, FileLoadLevel level);
 
-    void LoadDomainAssembly(Assembly *pFile,
-                        FileLoadLevel targetLevel);
+    void LoadAssembly(Assembly *pFile, FileLoadLevel targetLevel);
 
     enum FindAssemblyOptions
     {
@@ -1088,33 +1087,27 @@ public:
                            PEAssembly *pPEAssembly,
                            FileLoadLevel targetLevel);
 
-    // this function does not provide caching, you must use LoadDomainAssembly
+    CHECK CheckValidModule(Module *pModule);
+
+    void LoadSystemAssemblies();
+
+private:
+    // this function does not provide caching, you must use LoadAssembly
     // unless the call is guaranteed to succeed or you don't need the caching
     // (e.g. if you will FailFast or tear down the AppDomain anyway)
     // The main point that you should not bypass caching if you might try to load the same file again,
     // resulting in multiple DomainAssembly objects that share the same PEAssembly for ngen image
     //which is violating our internal assumptions
-    Assembly *LoadDomainAssemblyInternal( AssemblySpec* pIdentity,
-                                                PEAssembly *pPEAssembly,
-                                                FileLoadLevel targetLevel);
+    Assembly *LoadAssemblyInternal(AssemblySpec* pIdentity,
+                                   PEAssembly *pPEAssembly,
+                                   FileLoadLevel targetLevel);
 
-    Assembly *LoadDomainAssembly( AssemblySpec* pIdentity,
-                                        PEAssembly *pPEAssembly,
-                                        FileLoadLevel targetLevel);
-
-
-    CHECK CheckValidModule(Module *pModule);
-
-    // private:
-    void LoadSystemAssemblies();
-
-    Assembly *LoadDomainAssembly(FileLoadLock *pLock,
-                               FileLoadLevel targetLevel);
+    Assembly *LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel);
 
     void TryIncrementalLoad(Assembly *pFile, FileLoadLevel workLevel, FileLoadLockHolder &lockHolder);
 
 #ifndef DACCESS_COMPILE // needs AssemblySpec
-
+public:
     //****************************************************************************************
     // Returns and Inserts assemblies into a lookup cache based on the binding information
     // in the AssemblySpec. There can be many AssemblySpecs to a single assembly.
@@ -1124,10 +1117,12 @@ public:
         return m_AssemblyCache.LookupAssembly(pSpec, fThrow);
     }
 
+private:
     PEAssembly* FindCachedFile(AssemblySpec* pSpec, BOOL fThrow = TRUE);
     BOOL IsCached(AssemblySpec *pSpec);
 #endif // DACCESS_COMPILE
 
+public:
     BOOL AddFileToCache(AssemblySpec* pSpec, PEAssembly *pPEAssembly);
     BOOL RemoveFileFromCache(PEAssembly *pPEAssembly);
 
@@ -1137,8 +1132,7 @@ public:
     BOOL AddExceptionToCache(AssemblySpec* pSpec, Exception *ex);
     void AddUnmanagedImageToCache(LPCWSTR libraryName, NATIVE_LIBRARY_HANDLE hMod);
     NATIVE_LIBRARY_HANDLE FindUnmanagedImageInCache(LPCWSTR libraryName);
-    //****************************************************************************************
-    //
+
     // Adds or removes an assembly to the domain.
     void AddAssembly(DomainAssembly * assem);
     void RemoveAssembly(DomainAssembly * pAsm);

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -305,15 +305,15 @@ typedef PEFileListLock::Holder PEFileListLockHolder;
 class FileLoadLock : public ListLockEntry
 {
 private:
-    FileLoadLevel           m_level;
-    DomainAssembly          *m_pDomainAssembly;
-    HRESULT                 m_cachedHR;
+    FileLoadLevel   m_level;
+    Assembly*       m_pAssembly;
+    HRESULT         m_cachedHR;
 
 public:
-    static FileLoadLock *Create(PEFileListLock *pLock, PEAssembly *pPEAssembly, DomainAssembly *pDomainAssembly);
+    static FileLoadLock *Create(PEFileListLock *pLock, PEAssembly *pPEAssembly, Assembly *pAssembly);
 
     ~FileLoadLock();
-    DomainAssembly *GetDomainAssembly();
+    Assembly *GetAssembly();
     FileLoadLevel GetLoadLevel();
 
     // CanAcquire will return FALSE if Acquire will definitely not take the lock due
@@ -340,7 +340,7 @@ public:
 
 private:
 
-    FileLoadLock(PEFileListLock *pLock, PEAssembly *pPEAssembly, DomainAssembly *pDomainAssembly);
+    FileLoadLock(PEFileListLock *pLock, PEAssembly *pPEAssembly, Assembly *pAssembly);
 
     static void HolderLeave(FileLoadLock *pThis);
 
@@ -1068,11 +1068,11 @@ public:
 
     CHECK CheckCanLoadTypes(Assembly *pAssembly);
     CHECK CheckCanExecuteManagedCode(MethodDesc* pMD);
-    CHECK CheckLoading(DomainAssembly *pFile, FileLoadLevel level);
+    CHECK CheckLoading(Assembly *pFile, FileLoadLevel level);
 
-    BOOL IsLoading(DomainAssembly *pFile, FileLoadLevel level);
+    BOOL IsLoading(Assembly *pFile, FileLoadLevel level);
 
-    void LoadDomainAssembly(DomainAssembly *pFile,
+    void LoadDomainAssembly(Assembly *pFile,
                         FileLoadLevel targetLevel);
 
     enum FindAssemblyOptions
@@ -1081,7 +1081,7 @@ public:
         FindAssemblyOptions_IncludeFailedToLoad     = 0x1
     };
 
-    DomainAssembly * FindAssembly(PEAssembly* pPEAssembly, FindAssemblyOptions options = FindAssemblyOptions_None) DAC_EMPTY_RET(NULL);
+    Assembly * FindAssembly(PEAssembly* pPEAssembly, FindAssemblyOptions options = FindAssemblyOptions_None) DAC_EMPTY_RET(NULL);
 
 
     Assembly *LoadAssembly(AssemblySpec* pIdentity,
@@ -1094,11 +1094,11 @@ public:
     // The main point that you should not bypass caching if you might try to load the same file again,
     // resulting in multiple DomainAssembly objects that share the same PEAssembly for ngen image
     //which is violating our internal assumptions
-    DomainAssembly *LoadDomainAssemblyInternal( AssemblySpec* pIdentity,
+    Assembly *LoadDomainAssemblyInternal( AssemblySpec* pIdentity,
                                                 PEAssembly *pPEAssembly,
                                                 FileLoadLevel targetLevel);
 
-    DomainAssembly *LoadDomainAssembly( AssemblySpec* pIdentity,
+    Assembly *LoadDomainAssembly( AssemblySpec* pIdentity,
                                         PEAssembly *pPEAssembly,
                                         FileLoadLevel targetLevel);
 
@@ -1108,10 +1108,10 @@ public:
     // private:
     void LoadSystemAssemblies();
 
-    DomainAssembly *LoadDomainAssembly(FileLoadLock *pLock,
+    Assembly *LoadDomainAssembly(FileLoadLock *pLock,
                                FileLoadLevel targetLevel);
 
-    void TryIncrementalLoad(DomainAssembly *pFile, FileLoadLevel workLevel, FileLoadLockHolder &lockHolder);
+    void TryIncrementalLoad(Assembly *pFile, FileLoadLevel workLevel, FileLoadLockHolder &lockHolder);
 
 #ifndef DACCESS_COMPILE // needs AssemblySpec
 
@@ -1380,7 +1380,7 @@ public:
 private:
     void RaiseLoadingAssemblyEvent(Assembly* pAssembly);
 
-    friend class DomainAssembly;
+    friend class Assembly;
 
 private:
     BOOL RaiseUnhandledExceptionEvent(OBJECTREF *pThrowable, BOOL isTerminating);

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -123,26 +123,25 @@ Assembly::Assembly(PEAssembly* pPEAssembly, DebuggerAssemblyControlFlags debugge
     , m_pModule(NULL)
     , m_pPEAssembly(clr::SafeAddRef(pPEAssembly))
     , m_pFriendAssemblyDescriptor(NULL)
-    , m_isDynamic(false)
-#ifdef FEATURE_COLLECTIBLE_TYPES
-    , m_isCollectible{pLoaderAllocator->IsCollectible()}
-#endif
-    , m_pLoaderAllocator{pLoaderAllocator}
 #ifdef FEATURE_COMINTEROP
     , m_pITypeLib(NULL)
-#endif // FEATURE_COMINTEROP
-#ifdef FEATURE_COMINTEROP
     , m_InteropAttributeStatus(INTEROP_ATTRIBUTE_UNSET)
 #endif
-    , m_debuggerFlags(debuggerFlags)
-    , m_fTerminated(FALSE)
-    , m_hExposedObject{}
+    , m_pLoaderAllocator{pLoaderAllocator}
+#ifdef FEATURE_COLLECTIBLE_TYPES
+    , m_isCollectible{pLoaderAllocator->IsCollectible() != FALSE}
+#endif
+    , m_isDynamic(false)
+    , m_isLoading{true}
+    , m_isTerminated{false}
     , m_level{FILE_LOAD_CREATE}
-    , m_loading{TRUE}
     , m_notifyFlags{NOT_NOTIFIED}
     , m_pError{NULL}
-    , m_fHostAssemblyPublished{FALSE}
-    , m_bDisableActivationCheck{FALSE}
+#ifdef _DEBUG
+    , m_bDisableActivationCheck{false}
+#endif
+    , m_debuggerFlags(debuggerFlags)
+    , m_hExposedObject{}
 {
     CONTRACTL
     {
@@ -231,11 +230,8 @@ Assembly::~Assembly()
 
     if (m_pPEAssembly)
     {
-        if (m_fHostAssemblyPublished)
-        {
-            // Remove association first.
-            UnregisterFromHostAssembly();
-        }
+        // Remove association first.
+        UnregisterFromHostAssembly();
 
         m_pPEAssembly->Release();
     }
@@ -296,7 +292,7 @@ void Assembly::Terminate( BOOL signalProfiler )
 
     STRESS_LOG1(LF_LOADER, LL_INFO100, "Assembly::Terminate (this = 0x%p)\n", reinterpret_cast<void *>(this));
 
-    if (this->m_fTerminated)
+    if (m_isTerminated)
         return;
 
     if (m_pClassLoader != NULL)
@@ -315,7 +311,7 @@ void Assembly::Terminate( BOOL signalProfiler )
     }
 #endif // PROFILING_SUPPORTED
 
-    this->m_fTerminated = TRUE;
+    m_isTerminated = true;
 }
 
 Assembly * Assembly::Create(

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -231,7 +231,10 @@ Assembly::~Assembly()
     if (m_pPEAssembly)
     {
         // Remove association first.
-        UnregisterFromHostAssembly();
+        if (m_level >= FILE_LOAD_BEGIN)
+        {
+            UnregisterFromHostAssembly();
+        }
 
         m_pPEAssembly->Release();
     }

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -155,16 +155,6 @@ private:
     BOOL IsDebuggerNotified() { LIMITED_METHOD_CONTRACT; return m_notifyFlags & DEBUGGER_NOTIFIED; }
     BOOL ShouldNotifyDebugger() { LIMITED_METHOD_CONTRACT; return m_notifyFlags & DEBUGGER_NEEDNOTIFICATION; }
 
-    // CheckLoaded is appropriate for asserts that the assembly can be passively used.
-    CHECK CheckLoaded();
-
-    // Ensure that an assembly has reached at least the IsLoaded state.  Throw if not.
-    void EnsureLoaded()
-    {
-        WRAPPER_NO_CONTRACT;
-        return EnsureLoadLevel(FILE_LOADED);
-    }
-
     // CheckLoadLevel is an assert predicate used to verify the load level of an assembly.
     // deadlockOK indicates that the level is allowed to be one short if we are restricted
     // by loader reentrancy.

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -94,7 +94,6 @@ public:
     void ClearLoading() { LIMITED_METHOD_CONTRACT; m_loading = FALSE; }
     void SetLoadLevel(FileLoadLevel level) { LIMITED_METHOD_CONTRACT; m_level = level; }
 
-    BOOL IsVisibleToDebugger();
     BOOL NotifyDebuggerLoad(int flags, BOOL attaching);
     void NotifyDebuggerUnload();
 

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -159,55 +159,6 @@ private:
     // by loader reentrancy.
     CHECK CheckLoadLevel(FileLoadLevel requiredLevel, BOOL deadlockOK = TRUE) DAC_EMPTY_RET(CHECK::OK());
 
-    class ExInfo
-    {
-        enum
-        {
-            ExType_ClrEx,
-            ExType_HR
-        }
-        m_type;
-        union
-        {
-            Exception* m_pEx;
-            HRESULT    m_hr;
-        };
-
-    public:
-        void Throw()
-        {
-            CONTRACTL
-            {
-                THROWS;
-                GC_TRIGGERS;
-                MODE_ANY;
-            }
-            CONTRACTL_END;
-            if (m_type == ExType_ClrEx)
-            {
-                PAL_CPP_THROW(Exception*, m_pEx->DomainBoundClone());
-            }
-            if (m_type == ExType_HR)
-                ThrowHR(m_hr);
-            _ASSERTE(!"Bad exception type");
-            ThrowHR(E_UNEXPECTED);
-        };
-
-        ExInfo(Exception* pEx)
-        {
-            LIMITED_METHOD_CONTRACT;
-            m_type = ExType_ClrEx;
-            m_pEx = pEx;
-        };
-
-        ~ExInfo()
-        {
-            LIMITED_METHOD_CONTRACT;
-            if (m_type == ExType_ClrEx)
-                delete m_pEx;
-        }
-    };
-
 public:
     void StartUnload();
     void Terminate( BOOL signalProfiler = TRUE );
@@ -575,7 +526,7 @@ private:
     FileLoadLevel   m_level;
     BOOL            m_loading;
     DWORD           m_notifyFlags;
-    ExInfo*         m_pError;
+    Exception*      m_pError;
     BOOL            m_fHostAssemblyPublished;
     BOOL            m_bDisableActivationCheck;
 };

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -170,7 +170,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pIma
     PEAssemblyHolder pPEAssembly(PEAssembly::Open(pAssembly->GetPEImage(), pAssembly));
     bindOperation.SetResult(pPEAssembly.GetValue());
 
-    RETURN pCurDomain->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);
+    RETURN pCurDomain->LoadAssembly(&spec, pPEAssembly, FILE_LOADED);
 }
 
 extern "C" void QCALLTYPE AssemblyNative_LoadFromPath(INT_PTR ptrNativeAssemblyBinder, LPCWSTR pwzILPath, LPCWSTR pwzNIPath, QCall::ObjectHandleOnStack retLoadedAssembly)

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -170,8 +170,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pIma
     PEAssemblyHolder pPEAssembly(PEAssembly::Open(pAssembly->GetPEImage(), pAssembly));
     bindOperation.SetResult(pPEAssembly.GetValue());
 
-    DomainAssembly *pDomainAssembly = pCurDomain->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);
-    RETURN pDomainAssembly->GetAssembly();
+    RETURN pCurDomain->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);
 }
 
 extern "C" void QCALLTYPE AssemblyNative_LoadFromPath(INT_PTR ptrNativeAssemblyBinder, LPCWSTR pwzILPath, LPCWSTR pwzNIPath, QCall::ObjectHandleOnStack retLoadedAssembly)

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -378,7 +378,7 @@ Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel,
         BinderTracing::AssemblyBindOperation bindOperation(this);
         bindOperation.SetResult(domainAssembly->GetPEAssembly(), true /*cached*/);
 
-        pDomain->LoadDomainAssembly(domainAssembly->GetAssembly(), targetLevel);
+        pDomain->LoadAssembly(domainAssembly->GetAssembly(), targetLevel);
         RETURN domainAssembly->GetAssembly();
     }
 

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -838,8 +838,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(UnsafeContains(this, pSpec));
-        POSTCONDITION(UnsafeVerifyLookupAssembly(this, pSpec, pAssembly));
+        POSTCONDITION((!RETVAL) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACT_END;

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -378,7 +378,7 @@ Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel,
         BinderTracing::AssemblyBindOperation bindOperation(this);
         bindOperation.SetResult(domainAssembly->GetPEAssembly(), true /*cached*/);
 
-        pDomain->LoadDomainAssembly(domainAssembly, targetLevel);
+        pDomain->LoadDomainAssembly(domainAssembly->GetAssembly(), targetLevel);
         RETURN domainAssembly->GetAssembly();
     }
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2406,7 +2406,7 @@ Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
     Assembly * pAssembly = LookupAssemblyRef(kAssemblyRef);
     if (pAssembly != NULL)
     {
-        ::GetAppDomain()->LoadDomainAssembly(pAssembly, FILE_LOADED);
+        ::GetAppDomain()->LoadAssembly(pAssembly, FILE_LOADED);
         RETURN pAssembly;
     }
 
@@ -2422,7 +2422,7 @@ Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
         {
             spec.SetBinder(pBinder);
         }
-        pAssembly = GetAppDomain()->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);
+        pAssembly = GetAppDomain()->LoadAssembly(&spec, pPEAssembly, FILE_LOADED);
     }
 
     _ASSERTE(pAssembly != NULL && pAssembly->IsLoaded());

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2300,8 +2300,7 @@ Module::GetAssemblyIfLoaded(
     if ((pAssembly != NULL) && !IsGCThread() && !IsStackWalkerThread())
     {
         _ASSERTE(::GetAppDomain() != NULL);
-        DomainAssembly * pDomainAssembly = pAssembly->GetDomainAssembly();
-        if ((pDomainAssembly == NULL) || !pDomainAssembly->IsLoaded())
+        if (!pAssembly->IsLoaded())
             pAssembly = NULL;
     }
 
@@ -2330,7 +2329,7 @@ Module::GetAssemblyIfLoaded(
 
         DomainAssembly * pDomainAssembly = AppDomain::GetCurrentDomain()->FindCachedAssembly(&spec, FALSE /*fThrow*/);
 
-        if (pDomainAssembly && pDomainAssembly->IsLoaded())
+        if (pDomainAssembly && pDomainAssembly->GetAssembly()->IsLoaded())
             pAssembly = pDomainAssembly->GetAssembly();
 
         // Only store in the rid map if working with the current AppDomain.
@@ -2407,11 +2406,10 @@ Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
     Assembly * pAssembly = LookupAssemblyRef(kAssemblyRef);
     if (pAssembly != NULL)
     {
-        ::GetAppDomain()->LoadDomainAssembly(pAssembly->GetDomainAssembly(), FILE_LOADED);
+        ::GetAppDomain()->LoadDomainAssembly(pAssembly, FILE_LOADED);
         RETURN pAssembly;
     }
 
-    DomainAssembly * pDomainAssembly;
     {
         PEAssemblyHolder pPEAssembly = GetPEAssembly()->LoadAssembly(kAssemblyRef);
         AssemblySpec spec;
@@ -2424,14 +2422,13 @@ Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
         {
             spec.SetBinder(pBinder);
         }
-        pDomainAssembly = GetAppDomain()->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);
+        pAssembly = GetAppDomain()->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);
     }
 
-    pAssembly = pDomainAssembly->GetAssembly();
-    _ASSERTE(pDomainAssembly->IsLoaded() && pAssembly != NULL);
+    _ASSERTE(pAssembly != NULL && pAssembly->IsLoaded());
     _ASSERTE(
-        pDomainAssembly->IsSystem() ||                  // GetAssemblyIfLoaded will not find CoreLib (see AppDomain::FindCachedFile)
-        GetAssemblyIfLoaded(kAssemblyRef, NULL, pDomainAssembly->GetPEAssembly()->GetHostAssembly()->GetBinder()) != NULL);     // GetAssemblyIfLoaded should find all remaining cases
+        pAssembly->IsSystem() ||                  // GetAssemblyIfLoaded will not find CoreLib (see AppDomain::FindCachedFile)
+        GetAssemblyIfLoaded(kAssemblyRef, NULL, pAssembly->GetPEAssembly()->GetHostAssembly()->GetBinder()) != NULL);     // GetAssemblyIfLoaded should find all remaining cases
 
     StoreAssemblyRef(kAssemblyRef, pAssembly);
 
@@ -4458,7 +4455,7 @@ VOID Module::EnsureActive()
         MODE_ANY;
     }
     CONTRACTL_END;
-    GetDomainAssembly()->EnsureActive();
+    GetAssembly()->EnsureActive();
 }
 #endif // DACCESS_COMPILE
 
@@ -4475,10 +4472,10 @@ CHECK Module::CheckActivated()
     CONTRACTL_END;
 
 #ifndef DACCESS_COMPILE
-    DomainAssembly *pDomainAssembly = GetDomainAssembly();
-    CHECK(pDomainAssembly != NULL);
-    PREFIX_ASSUME(pDomainAssembly != NULL);
-    CHECK(pDomainAssembly->CheckActivated());
+    Assembly *pAssembly = GetAssembly();
+    CHECK(pAssembly != NULL);
+    PREFIX_ASSUME(pAssembly != NULL);
+    CHECK(pAssembly->CheckActivated());
 #endif
     CHECK_OK;
 }

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -171,7 +171,7 @@ void Assembly::SetError(Exception *ex)
     }
     CONTRACT_END;
 
-    m_pError = new ExInfo(ex->DomainBoundClone());
+    m_pError = ex->DomainBoundClone();
 
     if (m_pModule)
     {
@@ -203,10 +203,9 @@ void Assembly::ThrowIfError(FileLoadLevel targetLevel)
     }
     CONTRACT_END;
 
-    if (m_level < targetLevel)
+    if (m_level < targetLevel && m_pError != NULL)
     {
-        if (m_pError)
-            m_pError->Throw();
+        PAL_CPP_THROW(Exception*, m_pError->DomainBoundClone());
     }
 
     RETURN;
@@ -650,9 +649,6 @@ BOOL Assembly::NotifyDebuggerLoad(int flags, BOOL attaching)
 
     BOOL result = FALSE;
 
-    if (!IsVisibleToDebugger())
-        return FALSE;
-
     // Debugger Attach is done totally out-of-process. Does not call code in-proc.
     _ASSERTE(!attaching);
 
@@ -691,9 +687,6 @@ BOOL Assembly::NotifyDebuggerLoad(int flags, BOOL attaching)
 void Assembly::NotifyDebuggerUnload()
 {
     LIMITED_METHOD_CONTRACT;
-
-    if (!IsVisibleToDebugger())
-        return;
 
     if (!AppDomain::GetCurrentDomain()->IsDebuggerAttached())
         return;

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -93,7 +93,7 @@ void Assembly::EnsureLoadLevel(FileLoadLevel targetLevel)
     TRIGGERSGC ();
     if (IsLoading())
     {
-        AppDomain::GetCurrentDomain()->LoadDomainAssembly(this, targetLevel);
+        AppDomain::GetCurrentDomain()->LoadAssembly(this, targetLevel);
 
         // Enforce the loading requirement.  Note that we may have a deadlock in which case we
         // may be off by one which is OK.  (At this point if we are short of targetLevel we know

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -221,34 +221,6 @@ CHECK Assembly::CheckNoError(FileLoadLevel targetLevel)
     CHECK_OK;
 }
 
-CHECK Assembly::CheckLoaded()
-{
-    CONTRACTL
-    {
-        INSTANCE_CHECK;
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    CHECK_MSG(CheckNoError(FILE_LOADED), "Assembly load resulted in an error");
-
-    if (IsLoaded())
-        CHECK_OK;
-
-    // CoreLib is allowed to run managed code much earlier than other
-    // assemblies for bootstrapping purposes.  This is because it has no
-    // dependencies, security checks, and doesn't rely on loader notifications.
-
-    if (GetPEAssembly()->IsSystem())
-        CHECK_OK;
-
-    CHECK_MSG(GetPEAssembly()->IsLoaded(), "PEAssembly has not been loaded");
-
-    CHECK_OK;
-}
-
 CHECK Assembly::CheckActivated()
 {
     CONTRACTL

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -245,8 +245,9 @@ CHECK Assembly::CheckActivated()
 
     CHECK_MSG(GetPEAssembly()->IsLoaded(), "PEAssembly has not been loaded");
     CHECK_MSG(IsLoaded(), "Assembly has not been fully loaded");
+#ifdef _DEBUG
     CHECK_MSG(m_bDisableActivationCheck || CheckLoadLevel(FILE_ACTIVE), "File has not had execution verified");
-
+#endif
     CHECK_OK;
 }
 
@@ -405,7 +406,9 @@ void Assembly::Activate()
     if (pMT != NULL)
     {
         pMT->CheckRestore();
+#ifdef _DEBUG
         m_bDisableActivationCheck=TRUE;
+#endif
         pMT->CheckRunClassInitThrowing();
     }
 #ifdef _DEBUG
@@ -435,7 +438,6 @@ void Assembly::Begin()
     }
     // Make it possible to find this DomainAssembly object from associated BINDER_SPACE::Assembly.
     RegisterWithHostAssembly();
-    m_fHostAssemblyPublished = true;
 }
 
 void Assembly::RegisterWithHostAssembly()

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -253,24 +253,6 @@ CHECK Assembly::CheckActivated()
 
 #endif //!DACCESS_COMPILE
 
-// Return true iff the debugger should get notifications about this assembly.
-//
-// Notes:
-//   The debuggee may be stopped while a DomainAssmebly is being initialized.  In this time window,
-//   GetAssembly() may be NULL.  If that's the case, this function has to return FALSE.  Later on, when
-//   the DomainAssembly is fully initialized, this function will return TRUE.  This is the only scenario
-//   where this function is mutable.  In other words, a DomainAssembly can only change from being invisible
-//   to visible, but NOT vice versa.  Once a DomainAssmebly is fully initialized, this function should be
-//   immutable for an instance of a module. That ensures that the debugger gets consistent
-//   notifications about it. It this value mutates, than the debugger may miss relevant notifications.
-BOOL Assembly::IsVisibleToDebugger()
-{
-    WRAPPER_NO_CONTRACT;
-    SUPPORTS_DAC;
-
-    return TRUE;
-}
-
 #ifndef DACCESS_COMPILE
 
 BOOL Assembly::DoIncrementalLoad(FileLoadLevel level)

--- a/src/coreclr/vm/domainassembly.h
+++ b/src/coreclr/vm/domainassembly.h
@@ -78,7 +78,6 @@ public:
     Assembly* GetAssembly()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        CONSISTENCY_CHECK(CheckLoaded());
 
         return m_pAssembly;
     }
@@ -86,21 +85,8 @@ public:
     Module* GetModule()
     {
         LIMITED_METHOD_CONTRACT;
-        CONSISTENCY_CHECK(CheckLoaded());
 
         return m_pModule;
-    }
-
-    IMDInternalImport *GetMDImport()
-    {
-        WRAPPER_NO_CONTRACT;
-        return m_pPEAssembly->GetMDImport();
-    }
-
-    BOOL IsSystem()
-    {
-        WRAPPER_NO_CONTRACT;
-        return GetPEAssembly()->IsSystem();
     }
 
     LPCUTF8 GetSimpleName()
@@ -122,94 +108,6 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_fCollectible;
     }
-
-    // ------------------------------------------------------------
-    // Loading state checks
-    // ------------------------------------------------------------
-
-    // Return the File's load level.  Note that this is the last level actually successfully completed.
-    // Note that this is subtly different than the FileLoadLock's level, which is the last level
-    // which was triggered (but potentially skipped if error or inappropriate.)
-    FileLoadLevel GetLoadLevel() { LIMITED_METHOD_DAC_CONTRACT; return m_level; }
-
-    // Error means that a permanent x-appdomain load error has occurred.
-    BOOL IsError()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        DACCOP_IGNORE(FieldAccess, "No marshalling required");
-        return m_pError != NULL;
-    }
-
-    // Loading means that the load is still being tracked by a FileLoadLock.
-    BOOL IsLoading() { LIMITED_METHOD_CONTRACT; return m_loading; }
-
-    // Loaded means that the file can be used passively.  This includes loading types, reflection, and
-    // jitting.
-    BOOL IsLoaded() { LIMITED_METHOD_DAC_CONTRACT; return m_level >= FILE_LOAD_DELIVER_EVENTS; }
-
-    // Active means that the file can be used actively in the current app domain.  Note that a shared file
-    // may conditionally not be able to be made active on a per app domain basis.
-    BOOL IsActive() { LIMITED_METHOD_CONTRACT; return m_level >= FILE_ACTIVE; }
-
-    // Checks if the load has reached the point where profilers may be notified
-    // about the file. It's important that IF a profiler is notified, THEN this returns
-    // TRUE, otherwise there can be profiler-attach races where the profiler doesn't see
-    // the file via either enumeration or notification. As a result, this begins
-    // returning TRUE just before the profiler is actually notified.  See
-    // code:ProfilerFunctionEnum::Init#ProfilerEnumAssemblies
-    BOOL IsAvailableToProfilers()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        return IsProfilerNotified(); // despite the name, this function returns TRUE just before we notify the profiler
-    }
-
-    // CheckLoaded is appropriate for asserts that the assembly can be passively used.
-    CHECK CheckLoaded();
-
-    // CheckActivated is appropriate for asserts that the assembly can be actively used.  Note that
-    // it is slightly different from IsActive in that it deals with reentrancy cases properly.
-    CHECK CheckActivated();
-
-    // Ensure that an assembly has reached at least the IsLoaded state.  Throw if not.
-    void EnsureLoaded()
-    {
-        WRAPPER_NO_CONTRACT;
-        return EnsureLoadLevel(FILE_LOADED);
-    }
-
-    // Ensure that an assembly has reached at least the IsActive state.  Throw if not.
-    void EnsureActive()
-    {
-        WRAPPER_NO_CONTRACT;
-        return EnsureLoadLevel(FILE_ACTIVE);
-    }
-
-    // EnsureLoadLevel is a generic routine used to ensure that the file is not in a delay loaded
-    // state (unless it needs to be.)  This should be used when a particular level of loading
-    // is required for an operation.  Note that deadlocks are tolerated so the level may be one
-    void EnsureLoadLevel(FileLoadLevel targetLevel) DAC_EMPTY();
-
-    // CheckLoadLevel is an assert predicate used to verify the load level of an assembly.
-    // deadlockOK indicates that the level is allowed to be one short if we are restricted
-    // by loader reentrancy.
-    CHECK CheckLoadLevel(FileLoadLevel requiredLevel, BOOL deadlockOK = TRUE) DAC_EMPTY_RET(CHECK::OK());
-
-    // RequireLoadLevel throws an exception if the domain file isn't loaded enough.  Note
-    // that this is intolerant of deadlock related failures so is only really appropriate for
-    // checks inside the main loading loop.
-    void RequireLoadLevel(FileLoadLevel targetLevel) DAC_EMPTY();
-
-    // Throws if a load error has occurred
-    void ThrowIfError(FileLoadLevel targetLevel) DAC_EMPTY();
-
-    // Checks that a load error has not occurred before the given level
-    CHECK CheckNoError(FileLoadLevel targetLevel) DAC_EMPTY_RET(CHECK::OK());
-
-    // IsNotified means that the profiler API notification has been delivered
-    BOOL IsProfilerNotified() { LIMITED_METHOD_CONTRACT; return m_notifyflags & PROFILER_NOTIFIED; }
-    BOOL IsDebuggerNotified() { LIMITED_METHOD_CONTRACT; return m_notifyflags & DEBUGGER_NOTIFIED; }
-    BOOL ShouldNotifyDebugger() { LIMITED_METHOD_CONTRACT; return m_notifyflags & DEBUGGER_NEEDNOTIFICATION; }
-
 
     // ------------------------------------------------------------
     // Other public APIs
@@ -248,84 +146,8 @@ public:
 
     friend class AppDomain;
     friend class Assembly;
-    friend class Module;
-    friend class FileLoadLock;
 
     DomainAssembly(PEAssembly* pPEAssembly, LoaderAllocator* pLoaderAllocator, AllocMemTracker* memTracker);
-
-    BOOL DoIncrementalLoad(FileLoadLevel targetLevel);
-    void ClearLoading() { LIMITED_METHOD_CONTRACT; m_loading = FALSE; }
-    void SetLoadLevel(FileLoadLevel level) { LIMITED_METHOD_CONTRACT; m_level = level; }
-
-#ifndef DACCESS_COMPILE
-    void Begin();
-    void BeforeTypeLoad();
-    void EagerFixups();
-    void VtableFixups();
-    void DeliverSyncEvents();
-    void DeliverAsyncEvents();
-    void FinishLoad();
-    void Activate();
-
-    void RegisterWithHostAssembly();
-    void UnregisterFromHostAssembly();
-#endif
-
-    // This should be used to permanently set the load to fail. Do not use with transient conditions
-    void SetError(Exception *ex);
-
-    void SetProfilerNotified() { LIMITED_METHOD_CONTRACT; m_notifyflags|= PROFILER_NOTIFIED; }
-    void SetDebuggerNotified() { LIMITED_METHOD_CONTRACT; m_notifyflags|=DEBUGGER_NOTIFIED; }
-    void SetShouldNotifyDebugger() { LIMITED_METHOD_CONTRACT; m_notifyflags|=DEBUGGER_NEEDNOTIFICATION; }
-
-    class ExInfo
-    {
-        enum
-        {
-            ExType_ClrEx,
-            ExType_HR
-        }
-        m_type;
-        union
-        {
-            Exception* m_pEx;
-            HRESULT    m_hr;
-        };
-
-    public:
-        void Throw()
-        {
-            CONTRACTL
-            {
-                THROWS;
-                GC_TRIGGERS;
-                MODE_ANY;
-            }
-            CONTRACTL_END;
-            if (m_type == ExType_ClrEx)
-            {
-                PAL_CPP_THROW(Exception*, m_pEx->DomainBoundClone());
-            }
-            if (m_type == ExType_HR)
-                ThrowHR(m_hr);
-            _ASSERTE(!"Bad exception type");
-            ThrowHR(E_UNEXPECTED);
-        };
-
-        ExInfo(Exception* pEx)
-        {
-            LIMITED_METHOD_CONTRACT;
-            m_type = ExType_ClrEx;
-            m_pEx = pEx;
-        };
-
-        ~ExInfo()
-        {
-            LIMITED_METHOD_CONTRACT;
-            if (m_type == ExType_ClrEx)
-                delete m_pEx;
-        }
-    };
 
 public:
 // ------------------------------------------------------------
@@ -349,10 +171,6 @@ public:
 
     HRESULT GetDebuggingCustomAttributes(DWORD* pdwFlags);
 
-    BOOL IsVisibleToDebugger();
-    BOOL NotifyDebuggerLoad(int flags, BOOL attaching);
-    void NotifyDebuggerUnload();
-
 private:
     // ------------------------------------------------------------
     // Instance data
@@ -366,17 +184,7 @@ private:
     DomainAssembly*             m_NextDomainAssemblyInSameALC;
     PTR_LoaderAllocator         m_pLoaderAllocator;
 
-    FileLoadLevel               m_level;
-    BOOL                        m_loading;
-
-    ExInfo*                     m_pError;
-
-    BOOL                        m_bDisableActivationCheck;
-    BOOL                        m_fHostAssemblyPublished;
-
     DebuggerAssemblyControlFlags    m_debuggerFlags;
-    DWORD                       m_notifyflags;
-    BOOL                        m_fDebuggerUnloadStarted;
 };
 
 #endif  // _DOMAINASSEMBLY_H_

--- a/src/coreclr/vm/eventtrace_bulktype.cpp
+++ b/src/coreclr/vm/eventtrace_bulktype.cpp
@@ -517,10 +517,10 @@ void BulkStaticsLogger::LogAllStatics()
         while (assemblyIter.Next(pDomainAssembly.This()))
         {
             // Make sure the assembly is loaded.
-            if (!pDomainAssembly->IsLoaded())
+            CollectibleAssemblyHolder<Assembly *> pAssembly = pDomainAssembly->GetAssembly();
+            if (!pAssembly->IsLoaded())
                 continue;
 
-            CollectibleAssemblyHolder<Assembly *> pAssembly = pDomainAssembly->GetAssembly();
             // Get the domain module from the module/appdomain pair.
             Module *module = pDomainAssembly->GetModule();
             if (module == NULL)
@@ -531,7 +531,7 @@ void BulkStaticsLogger::LogAllStatics()
                 continue;
 
             // Ensure the module has fully loaded.
-            if (!domainAssembly->IsActive())
+            if (!pAssembly->IsActive())
                 continue;
 
             // Now iterate all types with

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -542,7 +542,7 @@ void LoaderAllocator::GCLoaderAllocators(LoaderAllocator* pOriginalLoaderAllocat
             // Call AssemblyUnloadStarted event
             domainAssemblyIt->GetAssembly()->StartUnload();
             // Notify the debugger
-            domainAssemblyIt->NotifyDebuggerUnload();
+            domainAssemblyIt->GetAssembly()->NotifyDebuggerUnload();
             domainAssemblyIt++;
         }
 

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -237,11 +237,11 @@ FileLoadLevel MulticoreJitManager::GetModuleFileLoadLevel(Module * pModule)
 
     if (pModule != NULL)
     {
-        DomainAssembly * pDomainAssembly = pModule->GetDomainAssembly();
+        Assembly * pAssembly = pModule->GetAssembly();
 
-        if (pDomainAssembly != NULL)
+        if (pAssembly != NULL)
         {
-            level = pDomainAssembly->GetLoadLevel();
+            level = pAssembly->GetLoadLevel();
         }
     }
 

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -497,7 +497,7 @@ PEAssembly* PEAssembly::LoadAssembly(mdAssemblyRef kAssemblyRef)
 
     AssemblySpec spec;
 
-    spec.InitializeSpec(kAssemblyRef, pImport, GetAppDomain()->FindAssembly(this)->GetAssembly());
+    spec.InitializeSpec(kAssemblyRef, pImport, GetAppDomain()->FindAssembly(this));
 
     RETURN GetAppDomain()->BindAssemblySpec(&spec, TRUE);
 }
@@ -538,8 +538,8 @@ BOOL PEAssembly::GetResource(LPCSTR szName, DWORD *cbResource,
     else
     {
         AppDomain* pAppDomain = AppDomain::GetCurrentDomain();
-        DomainAssembly* pParentAssembly = pAppDomain->FindAssembly(this);
-        pAssembly = pAppDomain->RaiseResourceResolveEvent(pParentAssembly->GetAssembly(), szName);
+        Assembly* pParentAssembly = pAppDomain->FindAssembly(this);
+        pAssembly = pAppDomain->RaiseResourceResolveEvent(pParentAssembly, szName);
         if (pAssembly == NULL)
             return FALSE;
         pPEAssembly = pAssembly->GetPEAssembly();

--- a/src/coreclr/vm/profilingenumerators.cpp
+++ b/src/coreclr/vm/profilingenumerators.cpp
@@ -491,8 +491,8 @@ HRESULT IterateAppDomainContainingModule::AddAppDomainContainingModule(AppDomain
     }
     CONTRACTL_END;
 
-    DomainAssembly * pDomainAssembly = m_pModule->GetDomainAssembly();
-    if ((pDomainAssembly != NULL) && (pDomainAssembly->IsAvailableToProfilers()))
+    Assembly * pAssembly = m_pModule->GetAssembly();
+    if ((pAssembly != NULL) && (pAssembly->IsAvailableToProfilers()))
     {
         if (m_index < m_cAppDomainIds)
         {

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1282,7 +1282,7 @@ extern "C" BOOL QCALLTYPE RuntimeFieldHandle_GetRVAFieldInfo(FieldDesc* pField, 
         Module* pModule = pField->GetModule();
         *address = pModule->GetRvaField(pField->GetOffset());
         *size = pField->LoadSize();
-        
+
         ret = TRUE;
     }
 
@@ -1332,12 +1332,12 @@ extern "C" void QCALLTYPE ReflectionInvocation_RunModuleConstructor(QCall::Modul
 {
     QCALL_CONTRACT;
 
-    DomainAssembly *pDomainAssembly = pModule->GetDomainAssembly();
-    if (pDomainAssembly != NULL && pDomainAssembly->IsActive())
+    Assembly *pAssembly = pModule->GetAssembly();
+    if (pAssembly != NULL && pAssembly->IsActive())
         return;
 
     BEGIN_QCALL;
-    pDomainAssembly->EnsureActive();
+    pAssembly->EnsureActive();
     END_QCALL;
 }
 


### PR DESCRIPTION
- Make `AppDomain::LoadDomainAssembly` return Assembly, rename to `LoadAssembly`
- Remove `Assembly::CheckLoaded/EnsureLoaded` - not used
- Remove `Assembly::IsVisibleToDebugger` - always true
- Remove `Assembly::ExInfo` - always just wraps `Exception`

cc @jkotas @AaronRobinsonMSFT 

Contributes to https://github.com/dotnet/runtime/issues/104590