### PR TITLE
Add feature switch to disable DataSet XML serialization

### DIFF
--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -14,7 +14,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | VerifyDependencyInjectionOpenGenericServiceTrimmability | Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability | When set to true, DependencyInjection will verify trimming annotations applied to open generic services are correct. |
 | _AggressiveAttributeTrimming | System.AggressiveAttributeTrimming | When set to true, aggressively trims attributes to allow for the most size savings possible, even if it could result in runtime behavior changes |
 | _ComObjectDescriptorSupport | System.ComponentModel.TypeDescriptor.IsComObjectDescriptorSupported | When set to true, supports creating a TypeDescriptor based view of COM objects. |
-| _DataSetXmlSerializationSupport | System.Data.DataSet.XmlSerializationSupport | When set to false, DataSet implementation of IXmlSerializable will throw instead of using trim-incompatible XML serialization. |
+| _DataSetXmlSerializationSupport | System.Data.DataSet.XmlSerializationIsSupported | When set to false, DataSet implementation of IXmlSerializable will throw instead of using trim-incompatible XML serialization. |
 | _DefaultValueAttributeSupport | System.ComponentModel.DefaultValueAttribute.IsSupported | When set to true, supports creating a DefaultValueAttribute at runtime. |
 | _DesignerHostSupport | System.ComponentModel.Design.IDesignerHost.IsSupported | When set to true, supports creating design components at runtime. |
 | _EnableConsumingManagedCodeFromNativeHosting | System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting | Getting a managed function from native hosting is disabled when set to false and related functionality can be trimmed. |

--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -14,6 +14,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | VerifyDependencyInjectionOpenGenericServiceTrimmability | Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability | When set to true, DependencyInjection will verify trimming annotations applied to open generic services are correct. |
 | _AggressiveAttributeTrimming | System.AggressiveAttributeTrimming | When set to true, aggressively trims attributes to allow for the most size savings possible, even if it could result in runtime behavior changes |
 | _ComObjectDescriptorSupport | System.ComponentModel.TypeDescriptor.IsComObjectDescriptorSupported | When set to true, supports creating a TypeDescriptor based view of COM objects. |
+| _DataSetXmlSerializationSupport | System.Data.DataSet.XmlSerializationSupport | When set to false, DataSet implementation of IXmlSerializable will throw instead of using trim-incompatible XML serialization. |
 | _DefaultValueAttributeSupport | System.ComponentModel.DefaultValueAttribute.IsSupported | When set to true, supports creating a DefaultValueAttribute at runtime. |
 | _DesignerHostSupport | System.ComponentModel.Design.IDesignerHost.IsSupported | When set to true, supports creating design components at runtime. |
 | _EnableConsumingManagedCodeFromNativeHosting | System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting | Getting a managed function from native hosting is disabled when set to false and related functionality can be trimmed. |

--- a/src/libraries/System.Data.Common/src/Resources/Strings.resx
+++ b/src/libraries/System.Data.Common/src/Resources/Strings.resx
@@ -527,4 +527,5 @@
   <data name="DataSetLinq_CannotCompareDeletedRow" xml:space="preserve"><value>The DataRowComparer does not work with DataRows that have been deleted since it only compares current values.</value></data>
   <data name="DataSetLinq_CannotLoadDeletedRow" xml:space="preserve"><value>The source contains a deleted DataRow that cannot be copied to the DataTable.</value></data>
   <data name="DataSetLinq_NonNullableCast" xml:space="preserve"><value>Cannot cast DBNull. Value to type '{0}'. Please use a nullable type.</value></data>
+  <data name="DataSet_XmlSerializationUnsupported" xml:space="preserve"><value>DataSet implementation of IXmlSerializable is not trim compatible and has been disabled in the app configuration.</value></data>
 </root>

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -77,10 +77,10 @@ namespace System.Data
         internal bool _useDataSetSchemaOnly; // UseDataSetSchemaOnly  , for YUKON
         internal bool _udtIsWrapped; // if UDT is wrapped , for YUKON
 
-        [FeatureSwitchDefinition("System.Data.DataSet.XmlSerializationSupport")]
+        [FeatureSwitchDefinition("System.Data.DataSet.XmlSerializationIsSupported")]
         [FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 #pragma warning disable IL4000
-        internal static bool XmlSerializationSupport => AppContext.TryGetSwitch("System.Data.DataSet.XmlSerializationSupport", out bool isSupported) ? isSupported : true;
+        internal static bool XmlSerializationIsSupported => AppContext.TryGetSwitch("System.Data.DataSet.XmlSerializationIsSupported", out bool isSupported) ? isSupported : true;
 #pragma warning restore IL4000
 
         /// <summary>
@@ -3465,7 +3465,7 @@ namespace System.Data
 
         XmlSchema? IXmlSerializable.GetSchema()
         {
-            if (!XmlSerializationSupport)
+            if (!XmlSerializationIsSupported)
             {
                 throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
             }
@@ -3494,7 +3494,7 @@ namespace System.Data
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            if (!XmlSerializationSupport)
+            if (!XmlSerializationIsSupported)
             {
                 throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
             }
@@ -3537,7 +3537,7 @@ namespace System.Data
 
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            if (!XmlSerializationSupport)
+            if (!XmlSerializationIsSupported)
             {
                 throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
             }

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -77,6 +77,12 @@ namespace System.Data
         internal bool _useDataSetSchemaOnly; // UseDataSetSchemaOnly  , for YUKON
         internal bool _udtIsWrapped; // if UDT is wrapped , for YUKON
 
+        [FeatureSwitchDefinition("System.Data.DataSet.XmlSerializationSupport")]
+        [FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
+#pragma warning disable IL4000
+        internal static bool XmlSerializationSupport => AppContext.TryGetSwitch("System.Data.DataSet.XmlSerializationSupport", out bool isSupported) ? isSupported : true;
+#pragma warning restore IL4000
+
         /// <summary>
         /// Initializes a new instance of the <see cref='System.Data.DataSet'/> class.
         /// </summary>
@@ -3459,6 +3465,11 @@ namespace System.Data
 
         XmlSchema? IXmlSerializable.GetSchema()
         {
+            if (!XmlSerializationSupport)
+            {
+                throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
+            }
+
             if (GetType() == typeof(DataSet))
             {
                 return null;
@@ -3469,9 +3480,7 @@ namespace System.Data
             XmlWriter writer = new XmlTextWriter(stream, null);
             if (writer != null)
             {
-#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
                 WriteXmlSchema(this, writer);
-#pragma warning restore IL2026
             }
             stream.Position = 0;
             return XmlSchema.Read(new XmlTextReader(stream), null);
@@ -3485,6 +3494,11 @@ namespace System.Data
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
+            if (!XmlSerializationSupport)
+            {
+                throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
+            }
+
             bool fNormalization = true;
             XmlTextReader? xmlTextReader = null;
             IXmlTextParser? xmlTextParser = reader as IXmlTextParser;
@@ -3503,9 +3517,7 @@ namespace System.Data
                 }
             }
 
-#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
             ReadXmlSerializableInternal(reader);
-#pragma warning restore IL2026
 
             if (xmlTextParser != null)
             {
@@ -3525,9 +3537,12 @@ namespace System.Data
 
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
+            if (!XmlSerializationSupport)
+            {
+                throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
+            }
+
             WriteXmlInternal(writer);
-#pragma warning restore IL2026
         }
 
         [RequiresUnreferencedCode("DataSet.WriteXml uses XmlSerialization underneath which is not trimming safe. Members from serialized types may be trimmed if not referenced directly.")]

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -6664,9 +6664,15 @@ namespace System.Data
             return type;
         }
 
-#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
-        XmlSchema? IXmlSerializable.GetSchema() => GetXmlSchema();
-#pragma warning restore IL2026
+        XmlSchema? IXmlSerializable.GetSchema()
+        {
+            if (!DataSet.XmlSerializationSupport)
+            {
+                throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
+            }
+
+            return GetXmlSchema();
+        }
 
         [RequiresUnreferencedCode(DataSet.RequiresUnreferencedCodeMessage)]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2046:UnrecognizedReflectionPattern",
@@ -6693,6 +6699,11 @@ namespace System.Data
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
+            if (!DataSet.XmlSerializationSupport)
+            {
+                throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
+            }
+
             IXmlTextParser? textReader = reader as IXmlTextParser;
             bool fNormalization = true;
             if (textReader != null)
@@ -6700,9 +6711,7 @@ namespace System.Data
                 fNormalization = textReader.Normalized;
                 textReader.Normalized = false;
             }
-#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
             ReadXmlSerializableInternal(reader);
-#pragma warning restore IL2026
 
             if (textReader != null)
             {
@@ -6718,9 +6727,12 @@ namespace System.Data
 
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
+            if (!DataSet.XmlSerializationSupport)
+            {
+                throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
+            }
+
             WriteXmlInternal(writer);
-#pragma warning restore IL2026
         }
 
         [RequiresUnreferencedCode("DataTable.WriteXml uses XmlSerialization underneath which is not trimming safe. Members from serialized types may be trimmed if not referenced directly.")]

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -6666,7 +6666,7 @@ namespace System.Data
 
         XmlSchema? IXmlSerializable.GetSchema()
         {
-            if (!DataSet.XmlSerializationSupport)
+            if (!DataSet.XmlSerializationIsSupported)
             {
                 throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
             }
@@ -6699,7 +6699,7 @@ namespace System.Data
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            if (!DataSet.XmlSerializationSupport)
+            if (!DataSet.XmlSerializationIsSupported)
             {
                 throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
             }
@@ -6727,7 +6727,7 @@ namespace System.Data
 
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            if (!DataSet.XmlSerializationSupport)
+            if (!DataSet.XmlSerializationIsSupported)
             {
                 throw new NotSupportedException(SR.DataSet_XmlSerializationUnsupported);
             }

--- a/src/libraries/System.Data.Common/tests/TrimmingTests/DataSetXmlSerialization.cs
+++ b/src/libraries/System.Data.Common/tests/TrimmingTests/DataSetXmlSerialization.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Data;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace DataSetXmlSerializationTrimmingTests
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            IXmlSerializable xmlSerializable = new DataSet();
+
+            // Calling GetSchema should throw NotSupportedException
+            try
+            {
+                xmlSerializable.GetSchema();
+                return -1;
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            // Calling ReadXml should throw NotSupportedException
+            try
+            {
+                xmlSerializable.ReadXml(null);
+                return -2;
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            // Calling WriteXml should throw NotSupportedException
+            try
+            {
+                xmlSerializable.WriteXml(null);
+                return -3;
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            xmlSerializable = new DataTable();
+
+            // Calling GetSchema should throw NotSupportedException
+            try
+            {
+                xmlSerializable.GetSchema();
+                return -4;
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            // Calling ReadXml should throw NotSupportedException
+            try
+            {
+                xmlSerializable.ReadXml(null);
+                return -5;
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            // Calling WriteXml should throw NotSupportedException
+            try
+            {
+                xmlSerializable.WriteXml(null);
+                return -6;
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            return 100;
+        }
+    }
+}

--- a/src/libraries/System.Data.Common/tests/TrimmingTests/System.Data.Common.TrimmingTests.proj
+++ b/src/libraries/System.Data.Common/tests/TrimmingTests/System.Data.Common.TrimmingTests.proj
@@ -5,7 +5,7 @@
     <TestConsoleAppSourceFiles Include="CreateSqlXmlReader.cs" />
     <TestConsoleAppSourceFiles Include="DbConnectionStringBuilder.cs" />
     <TestConsoleAppSourceFiles Include="DataSetXmlSerialization.cs" >
-      <DisabledFeatureSwitches>System.Data.DataSet.XmlSerializationSupport</DisabledFeatureSwitches>
+      <DisabledFeatureSwitches>System.Data.DataSet.XmlSerializationIsSupported</DisabledFeatureSwitches>
     </TestConsoleAppSourceFiles>
   </ItemGroup>
 

--- a/src/libraries/System.Data.Common/tests/TrimmingTests/System.Data.Common.TrimmingTests.proj
+++ b/src/libraries/System.Data.Common/tests/TrimmingTests/System.Data.Common.TrimmingTests.proj
@@ -4,6 +4,9 @@
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="CreateSqlXmlReader.cs" />
     <TestConsoleAppSourceFiles Include="DbConnectionStringBuilder.cs" />
+    <TestConsoleAppSourceFiles Include="DataSetXmlSerialization.cs" >
+      <DisabledFeatureSwitches>System.Data.DataSet.XmlSerializationSupport</DisabledFeatureSwitches>
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -57,6 +57,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_DefaultValueAttributeSupport Condition="'$(_DefaultValueAttributeSupport)' == ''">false</_DefaultValueAttributeSupport>
     <DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == ''">true</DynamicCodeSupport>
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">false</UseSystemResourceKeys>
+    <_DataSetXmlSerializationSupport Condition="'$(_DataSetXmlSerializationSupport)' == ''">false</_DataSetXmlSerializationSupport>
   </PropertyGroup>
 
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/107704 by introducing a feature switch that makes the DataSet and DataTable implementation of IXmlSerializable throw. This prevents unactionable warnings from the DataSet/DataTable implementation details when both DataSet and IXmlSerializable happen to be used in an app.

The downside of this approach is that the trim warnings are replaced by a runtime failure. But I believe this is better than the currently available alternatives (annotating IXmlSerializable or the current unactionable warnings).

If folks are on board with this approach, I'll make a corresponding SDK change to add the RuntimeHostConfigurationOption.