### PR TITLE
[NRBF] Comments and bug fixes from security review

### DIFF
--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/AllowedRecordType.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/AllowedRecordType.cs
@@ -3,6 +3,9 @@
 
 namespace System.Formats.Nrbf;
 
+// See [MS-NRBF] Sec. 2.7 for more information.
+// https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/ca3ad2bc-777b-413a-a72a-9ba6ced76bc3
+
 [Flags]
 internal enum AllowedRecordTypes : uint
 {

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArrayInfo.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArrayInfo.cs
@@ -16,7 +16,11 @@ namespace System.Formats.Nrbf;
 [DebuggerDisplay("{ArrayType}, rank={Rank}")]
 internal readonly struct ArrayInfo
 {
-    internal const int MaxArrayLength = 2147483591; // Array.MaxLength
+#if NET8_0_OR_GREATER
+    internal static int MaxArrayLength => Array.MaxLength; // dynamic lookup in case the value changes in a future runtime
+#else
+    internal const int MaxArrayLength = 2147483591; // hardcode legacy Array.MaxLength for downlevel runtimes
+#endif
 
     internal ArrayInfo(SerializationRecordId id, long totalElementsCount, BinaryArrayType arrayType = BinaryArrayType.Single, int rank = 1)
     {
@@ -47,7 +51,7 @@ internal readonly struct ArrayInfo
     {
         int length = reader.ReadInt32();
 
-        if (length is < 0 or > MaxArrayLength)
+        if (length < 0 || length > MaxArrayLength)
         {
             ThrowHelper.ThrowInvalidValue(length);
         }

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArrayOfClassesRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArrayOfClassesRecord.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Formats.Nrbf.Utils;
+using System.Diagnostics;
 
 namespace System.Formats.Nrbf;
 
@@ -54,6 +55,7 @@ internal sealed class ArrayOfClassesRecord : SZArrayRecord<ClassRecord>
                 }
 
                 int nullCount = ((NullsRecord)actual).NullCount;
+                Debug.Assert(nullCount > 0, "All implementations of NullsRecord are expected to return a positive value for NullCount.");
                 do
                 {
                     result[resultIndex++] = null;
@@ -62,6 +64,8 @@ internal sealed class ArrayOfClassesRecord : SZArrayRecord<ClassRecord>
                 while (nullCount > 0);
             }
         }
+
+        Debug.Assert(resultIndex == result.Length, "We should have traversed the entirety of the newly created array.");
 
         return result;
     }

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySingleObjectRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySingleObjectRecord.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Formats.Nrbf.Utils;
+using System.Diagnostics;
 
 namespace System.Formats.Nrbf;
 
@@ -33,7 +34,8 @@ internal sealed class ArraySingleObjectRecord : SZArrayRecord<object?>
     {
         object?[] values = new object?[Length];
 
-        for (int recordIndex = 0, valueIndex = 0; recordIndex < Records.Count; recordIndex++)
+        int valueIndex = 0;
+        for (int recordIndex = 0; recordIndex < Records.Count; recordIndex++)
         {
             SerializationRecord record = Records[recordIndex];
 
@@ -58,6 +60,8 @@ internal sealed class ArraySingleObjectRecord : SZArrayRecord<object?>
             }
             while (nullCount > 0);
         }
+
+        Debug.Assert(valueIndex == values.Length, "We should have traversed the entirety of the newly created array.");
 
         return values;
     }

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySingleObjectRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySingleObjectRecord.cs
@@ -42,6 +42,7 @@ internal sealed class ArraySingleObjectRecord : SZArrayRecord<object?>
             int nullCount = record is NullsRecord nullsRecord ? nullsRecord.NullCount : 0;
             if (nullCount == 0)
             {
+                // "new object[] { <SELF> }" is special cased because it allows for storing reference to itself.
                 values[valueIndex++] = record is MemberReferenceRecord referenceRecord && referenceRecord.Reference.Equals(Id)
                     ? values // a reference to self, and a way to get StackOverflow exception ;)
                     : record.GetValue();

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySinglePrimitiveRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySinglePrimitiveRecord.cs
@@ -175,6 +175,17 @@ internal sealed class ArraySinglePrimitiveRecord<T> : SZArrayRecord<T>
                 }
             }
         }
+        else if (typeof(T) == typeof(DateTime))
+        {
+            DateTime[] dateTimes = (DateTime[])(object)result;
+            Span<ulong> span = MemoryMarshal.Cast<T, ulong>(result);
+            for (int i = 0; i < dateTimes.Length; i++)
+            {
+                // The value needs to get validated.
+                dateTimes[i] = BinaryReaderExtensions.CreateDateTimeFromData(span[i]);
+            }
+        }
+
         return result;
     }
 

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySinglePrimitiveRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySinglePrimitiveRecord.cs
@@ -163,6 +163,18 @@ internal sealed class ArraySinglePrimitiveRecord<T> : SZArrayRecord<T>
             }
         }
 
+        if (typeof(T) == typeof(bool))
+        {
+            // See DontCastBytesToBooleans test to see what could go wrong.
+            bool[] booleans = (bool[])(object)result;
+            for (int i = 0; i < booleans.Length; i++)
+            {
+                if (booleans[i]) // it can be any byte different than 0
+                {
+                    booleans[i] = true; // set it to 1 in explicit way
+                }
+            }
+        }
         return result;
     }
 

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySingleStringRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ArraySingleStringRecord.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Formats.Nrbf.Utils;
+using System.Diagnostics;
 
 namespace System.Formats.Nrbf;
 
@@ -47,7 +48,8 @@ internal sealed class ArraySingleStringRecord : SZArrayRecord<string?>
     {
         string?[] values = new string?[Length];
 
-        for (int recordIndex = 0, valueIndex = 0; recordIndex < Records.Count; recordIndex++)
+        int valueIndex = 0;
+        for (int recordIndex = 0; recordIndex < Records.Count; recordIndex++)
         {
             SerializationRecord record = Records[recordIndex];
 
@@ -73,6 +75,7 @@ internal sealed class ArraySingleStringRecord : SZArrayRecord<string?>
             }
 
             int nullCount = ((NullsRecord)record).NullCount;
+            Debug.Assert(nullCount > 0, "All implementations of NullsRecord are expected to return a positive value for NullCount.");
             do
             {
                 values[valueIndex++] = null;
@@ -80,6 +83,8 @@ internal sealed class ArraySingleStringRecord : SZArrayRecord<string?>
             }
             while (nullCount > 0);
         }
+
+        Debug.Assert(valueIndex == values.Length, "We should have traversed the entirety of the newly created array.");
 
         return values;
     }

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ClassInfo.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ClassInfo.cs
@@ -50,7 +50,8 @@ internal sealed class ClassInfo
 
         // Use Dictionary instead of List so that searching for member IDs by name
         // is O(n) instead of O(m * n), where m = memberCount and n = memberNameLength,
-        // in degenerate cases.
+        // in degenerate cases. Since memberCount may be hostile, don't allow it to be
+        // used as the initial capacity in the collection instance.
         Dictionary<string, int> memberNames = new(StringComparer.Ordinal);
         for (int i = 0; i < memberCount; i++)
         {

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ClassTypeInfo.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/ClassTypeInfo.cs
@@ -9,7 +9,7 @@ using System.Formats.Nrbf.Utils;
 namespace System.Formats.Nrbf;
 
 /// <summary>
-/// Identifies a class by it's name and library id.
+/// Identifies a class by its name and library id.
 /// </summary>
 /// <remarks>
 /// ClassTypeInfo structures are described in <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/844b24dd-9f82-426e-9b98-05334307a239">[MS-NRBF] 2.1.1.8</see>.

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/MemberTypeInfo.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/MemberTypeInfo.cs
@@ -110,7 +110,7 @@ internal readonly struct MemberTypeInfo
     {
         // This library tries to minimize the number of concepts the users need to learn to use it.
         // Since SZArrays are most common, it provides an SZArrayRecord<T> abstraction.
-        // Every other array (jagged, multi-dimensional etc) is represented using SZArrayRecord.
+        // Every other array (jagged, multi-dimensional etc) is represented using ArrayRecord.
         // The goal of this method is to determine whether given array can be represented as SZArrayRecord<ClassRecord>.
 
         (BinaryType binaryType, object? additionalInfo) = Infos[0];

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NextInfo.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NextInfo.cs
@@ -27,7 +27,5 @@ internal readonly struct NextInfo
     internal PrimitiveType PrimitiveType { get; }
 
     internal NextInfo With(AllowedRecordTypes allowed, PrimitiveType primitiveType)
-        => allowed == Allowed && primitiveType == PrimitiveType
-            ? this // previous record was of the same type
-            : new(allowed, Parent, Stack, primitiveType);
+        => new(allowed, Parent, Stack, primitiveType);
 }

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NrbfDecoder.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/NrbfDecoder.cs
@@ -22,7 +22,7 @@ public static class NrbfDecoder
     // The header consists of:
     // - a byte that describes the record type (SerializationRecordType.SerializedStreamHeader)
     // - four 32 bit integers:
-    //   - root Id (every value is valid)
+    //   - root Id (every value except of 0 is valid)
     //   - header Id (value is ignored)
     //   - major version, it has to be equal 1.
     //   - minor version, it has to be equal 0.

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/PayloadOptions.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/PayloadOptions.cs
@@ -25,10 +25,17 @@ public sealed class PayloadOptions
     /// </summary>
     /// <value><see langword="true" /> if truncated type names should be reassembled; otherwise, <see langword="false" />.</value>
     /// <remarks>
+    /// <para>
     /// Example:
     /// TypeName: "Namespace.TypeName`1[[Namespace.GenericArgName"
     /// LibraryName: "AssemblyName]]"
     /// Is combined into "Namespace.TypeName`1[[Namespace.GenericArgName, AssemblyName]]"
+    /// </para>
+    /// <para>
+    /// Setting this to <see langword="true" /> can render <see cref="NrbfDecoder"/> susceptible to Denial of Service
+    /// attacks when parsing or handling malicious input.
+    /// </para>
+    /// <para>The default value is <see langword="false" />.</para>
     /// </remarks>
     public bool UndoTruncatedTypeNames { get; set; }
 }

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/RectangularArrayRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/RectangularArrayRecord.cs
@@ -8,6 +8,7 @@ using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Formats.Nrbf.Utils;
+using System.Diagnostics;
 
 namespace System.Formats.Nrbf;
 
@@ -55,10 +56,12 @@ internal sealed class RectangularArrayRecord : ArrayRecord
 
 #if !NET8_0_OR_GREATER
         int[] indices = new int[_lengths.Length];
+        nuint numElementsWritten = 0; // only for debugging; not used in release builds
 
         foreach (object value in _values)
         {
             result.SetValue(GetActualValue(value), indices);
+            numElementsWritten++;
 
             int dimension = indices.Length - 1;
             while (dimension >= 0)
@@ -77,6 +80,9 @@ internal sealed class RectangularArrayRecord : ArrayRecord
                 break;
             }
         }
+
+        Debug.Assert(numElementsWritten == (uint)_values.Count, "We should have traversed the entirety of the source values collection.");
+        Debug.Assert(numElementsWritten == (ulong)result.LongLength, "We should have traversed the entirety of the destination array.");
 
         return result;
 #else
@@ -118,6 +124,8 @@ internal sealed class RectangularArrayRecord : ArrayRecord
                 targetElement = (T)GetActualValue(value)!;
                 flattenedIndex++;
             }
+
+            Debug.Assert(flattenedIndex == (ulong)array.LongLength, "We should have traversed the entirety of the array.");
         }
 #endif
     }
@@ -158,7 +166,7 @@ internal sealed class RectangularArrayRecord : ArrayRecord
                 PrimitiveType.Boolean => sizeof(bool),
                 PrimitiveType.Byte => sizeof(byte),
                 PrimitiveType.SByte => sizeof(sbyte),
-                PrimitiveType.Char => sizeof(byte), // it's UTF8
+                PrimitiveType.Char => sizeof(byte), // it's UTF8 (see comment below)
                 PrimitiveType.Int16 => sizeof(short),
                 PrimitiveType.UInt16 => sizeof(ushort),
                 PrimitiveType.Int32 => sizeof(int),
@@ -175,6 +183,20 @@ internal sealed class RectangularArrayRecord : ArrayRecord
 
             if (sizeOfSingleValue > 0)
             {
+                // NRBF encodes rectangular char[,,,...] by converting each standalone UTF-16 code point into
+                // its UTF-8 encoding. This means that surrogate code points (including adjacent surrogate
+                // pairs) occurring within a char[,,,...] cannot be encoded by NRBF. BinaryReader will detect
+                // that they're ill-formed and reject them on read.
+                //
+                // Per the comment in ArraySinglePrimitiveRecord.DecodePrimitiveTypes, we'll assume best-case
+                // encoding where 1 UTF-16 char encodes as a single UTF-8 byte, even though this might lead
+                // to encountering an EOF if we realize later that we actually need to read more bytes in
+                // order to fully populate the char[,,,...] array. Any such allocation is still linearly
+                // proportional to the length of the incoming payload, so it's not a DoS vector.
+                // The multiplication below is guaranteed not to overflow because TotalElementsCount is bounded
+                // to <= uint.MaxValue (see BinaryArrayRecord.Decode) and sizeOfSingleValue is at most 8.
+                Debug.Assert(arrayInfo.TotalElementsCount >= 0 && arrayInfo.TotalElementsCount <= long.MaxValue / sizeOfSingleValue);
+
                 long size = arrayInfo.TotalElementsCount * sizeOfSingleValue;
                 bool? isDataAvailable = reader.IsDataAvailable(size);
                 if (isDataAvailable.HasValue)

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
@@ -50,7 +50,20 @@ public abstract class SerializationRecord
     /// </remarks>
     /// <param name="type">The type to compare against.</param>
     /// <returns><see langword="true" /> if the serialized type name matches the provided type; otherwise, <see langword="false" />.</returns>
-    public bool TypeNameMatches(Type type) => Matches(type, TypeName);
+    /// <exception cref="ArgumentNullException"><paramref name="type" /> is <see langword="null" />.</exception>
+    public bool TypeNameMatches(Type type)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(type);
+#else
+        if (type is null)
+        {
+            throw new ArgumentNullException(nameof(type));
+        }
+#endif
+
+        return Matches(type, TypeName);
+    }
 
     private static bool Matches(Type type, TypeName typeName)
     {

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
@@ -99,7 +99,13 @@ public abstract class SerializationRecord
         // At first, check the non-allocating properties for mismatch.
         if (type.IsArray != typeName.IsArray || type.IsConstructedGenericType != typeName.IsConstructedGenericType
             || type.IsNested != typeName.IsNested
-            || (type.IsArray && type.GetArrayRank() != typeName.GetArrayRank()))
+            || (type.IsArray && type.GetArrayRank() != typeName.GetArrayRank())
+#if NET
+            || type.IsSZArray != typeName.IsSZArray // int[] vs int[*]
+#else
+            || (type.IsArray && type.Name != typeName.Name)
+#endif
+            )
         {
             return false;
         }

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs
@@ -61,6 +61,28 @@ public abstract class SerializationRecord
             return false;
         }
 
+        // The TypeName.FullName property getter is recursive and backed by potentially hostile
+        // input. See comments in that property getter for more information, including what defenses
+        // are in place to prevent attacks.
+        //
+        // Note that the equality comparison below is worst-case O(n) since the adversary could ensure
+        // that only the last char differs. Even if the strings have equal contents, we should still
+        // expect the comparison to take O(n) time since RuntimeType.FullName and TypeName.FullName
+        // will never reference the same string instance with current runtime implementations.
+        //
+        // Since a call to Matches could take place within a loop, and since TypeName.FullName could
+        // be arbitrarily long (it's attacker-controlled and the NRBF protocol allows backtracking via
+        // the ClassWithId record, providing a form of compression), this presents opportunity
+        // for an algorithmic complexity attack, where a (2 * l)-length payload has an l-length type
+        // name and an array with l elements, resulting in O(l^2) total work factor. Protection against
+        // such attack is provided by the fact that the System.Type object is fully under the app's
+        // control and is assumed to be trusted and a reasonable length. This brings the cumulative loop
+        // work factor back down to O(l * RuntimeType.FullName), which is acceptable.
+        //
+        // The above statement assumes that "(string)m == (string)n" has worst-case complexity
+        // O(min(m.Length, n.Length)). This is not stated in string's public docs, but it is
+        // a guaranteed behavior for all built-in Ordinal string comparisons.
+
         // At first, check the non-allocating properties for mismatch.
         if (type.IsArray != typeName.IsArray || type.IsConstructedGenericType != typeName.IsConstructedGenericType
             || type.IsNested != typeName.IsNested
@@ -111,6 +133,11 @@ public abstract class SerializationRecord
     /// For reference records, it returns the referenced record.
     /// For other records, it returns the records themselves.
     /// </summary>
+    /// <remarks>
+    /// Overrides of this method should take care not to allow
+    /// the introduction of cycles, even in the face of adversarial
+    /// edges in the object graph.
+    /// </remarks>
     internal virtual object? GetValue() => this;
 
     internal virtual void HandleNextRecord(SerializationRecord nextRecord, NextInfo info)

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecordId.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecordId.cs
@@ -31,6 +31,15 @@ public readonly struct SerializationRecordId : IEquatable<SerializationRecordId>
     {
         int id = reader.ReadInt32();
 
+        // Many object ids are required to be positive. See:
+        // - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/8fac763f-e46d-43a1-b360-80eb83d2c5fb
+        // - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/eb503ca5-e1f6-4271-a7ee-c4ca38d07996
+        // - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/7fcf30e1-4ad4-4410-8f1a-901a4a1ea832 (for library id)
+        //
+        // Exception: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/0a192be0-58a1-41d0-8a54-9c91db0ab7bf may be negative
+        // The problem is that input generated with FormatterTypeStyle.XsdString ends up generating negative Ids anyway.
+        // That information is not reflected in payload in anyway, so we just always allow for negative Ids.
+
         if (id == 0)
         {
             ThrowHelper.ThrowInvalidValue(id);

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecordId.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecordId.cs
@@ -32,11 +32,11 @@ public readonly struct SerializationRecordId : IEquatable<SerializationRecordId>
         int id = reader.ReadInt32();
 
         // Many object ids are required to be positive. See:
-        // - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/8fac763f-e46d-43a1-b360-80eb83d2c5fb
-        // - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/eb503ca5-e1f6-4271-a7ee-c4ca38d07996
-        // - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/7fcf30e1-4ad4-4410-8f1a-901a4a1ea832 (for library id)
+        // - https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/8fac763f-e46d-43a1-b360-80eb83d2c5fb
+        // - https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/eb503ca5-e1f6-4271-a7ee-c4ca38d07996
+        // - https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/7fcf30e1-4ad4-4410-8f1a-901a4a1ea832 (for library id)
         //
-        // Exception: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/0a192be0-58a1-41d0-8a54-9c91db0ab7bf may be negative
+        // Exception: https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/0a192be0-58a1-41d0-8a54-9c91db0ab7bf may be negative
         // The problem is that input generated with FormatterTypeStyle.XsdString ends up generating negative Ids anyway.
         // That information is not reflected in payload in anyway, so we just always allow for negative Ids.
 

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecordType.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecordType.cs
@@ -6,6 +6,9 @@ namespace System.Formats.Nrbf;
 /// <summary>
 /// Specifies record types.
 /// </summary>
+/// <remarks>
+/// SerializationRecordType enumeration is described in <see href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/954a0657-b901-4813-9398-4ec732fe8b32">[MS-NRBF] 2.1.2.1</see>.
+/// </remarks>
 public enum SerializationRecordType
 {
     /// <summary>

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/Utils/BinaryReaderExtensions.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/Utils/BinaryReaderExtensions.cs
@@ -101,6 +101,11 @@ internal static class BinaryReaderExtensions
     // BinaryFormatter serializes decimals as strings and we can't BinaryReader.ReadDecimal.
     internal static decimal ParseDecimal(this BinaryReader reader)
     {
+        // The spec (MS NRBF 2.1.1.6, https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/10b218f5-9b2b-4947-b4b7-07725a2c8127)
+        // says that the length of LengthPrefixedString must be of optimal size (using as few bytes as possible).
+        // BinaryReader.ReadString does not enforce that and we are OK with that,
+        // as it takes care of handling multiple edge cases and we don't want to re-implement it.
+
         string text = reader.ReadString();
         if (!decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out decimal result))
         {

--- a/src/libraries/System.Formats.Nrbf/tests/ArraySinglePrimitiveRecordTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/ArraySinglePrimitiveRecordTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Text;
 using Xunit;
 
@@ -50,6 +51,24 @@ public class ArraySinglePrimitiveRecordTests : ReadTests
         Assert.True(b);
         bool c = a && b;
         Assert.True(c);
+    }
+
+    [Fact]
+    public void DontCastBytesToDateTimes()
+    {
+        using MemoryStream stream = new();
+        BinaryWriter writer = new(stream, Encoding.UTF8);
+
+        WriteSerializedStreamHeader(writer);
+        writer.Write((byte)SerializationRecordType.ArraySinglePrimitive);
+        writer.Write(1); // object ID
+        writer.Write(1); // length
+        writer.Write((byte)PrimitiveType.DateTime); // element type
+        writer.Write(ulong.MaxValue); // un-representable DateTime
+        writer.Write((byte)SerializationRecordType.MessageEnd);
+        stream.Position = 0;
+
+        Assert.Throws<SerializationException>(() => NrbfDecoder.Decode(stream));
     }
 
     [Theory]

--- a/src/libraries/System.Formats.Nrbf/tests/ArraySinglePrimitiveRecordTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/ArraySinglePrimitiveRecordTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Xunit;
 
 namespace System.Formats.Nrbf.Tests;
@@ -22,6 +23,33 @@ public class ArraySinglePrimitiveRecordTests : ReadTests
             yield return new object[] { size, true };
             yield return new object[] { size, false };
         }
+    }
+
+    [Fact]
+    public void DontCastBytesToBooleans()
+    {
+        using MemoryStream stream = new();
+        BinaryWriter writer = new(stream, Encoding.UTF8);
+
+        WriteSerializedStreamHeader(writer);
+        writer.Write((byte)SerializationRecordType.ArraySinglePrimitive);
+        writer.Write(1); // object ID
+        writer.Write(2); // length
+        writer.Write((byte)PrimitiveType.Boolean); // element type
+        writer.Write((byte)0x01);
+        writer.Write((byte)0x02);
+        writer.Write((byte)SerializationRecordType.MessageEnd);
+        stream.Position = 0;
+
+        SZArrayRecord<bool> serializationRecord = (SZArrayRecord<bool>)NrbfDecoder.Decode(stream);
+
+        bool[] bools = serializationRecord.GetArray();
+        bool a = bools[0];
+        Assert.True(a);
+        bool b = bools[1];
+        Assert.True(b);
+        bool c = a && b;
+        Assert.True(c);
     }
 
     [Theory]

--- a/src/libraries/System.Formats.Nrbf/tests/AttackTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/AttackTests.cs
@@ -154,7 +154,7 @@ public class AttackTests : ReadTests
         writer.Write((byte)SerializationRecordType.ArraySinglePrimitive);
         writer.Write(1); // object ID
         writer.Write(Array.MaxLength); // length
-        writer.Write((byte)2); // PrimitiveType.Byte
+        writer.Write((byte)PrimitiveType.Byte);
         writer.Write((byte)SerializationRecordType.MessageEnd);
 
         stream.Position = 0;

--- a/src/libraries/System.Formats.Nrbf/tests/InvalidInputTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/InvalidInputTests.cs
@@ -429,6 +429,7 @@ public class InvalidInputTests : ReadTests
                 yield return new object[] { recordType, binaryType, (byte)0 }; // value not used by the spec
                 yield return new object[] { recordType, binaryType, (byte)4 }; // value not used by the spec
                 yield return new object[] { recordType, binaryType, (byte)17 }; // used by the spec, but illegal in given context
+                yield return new object[] { recordType, binaryType, (byte)18 }; // used by the spec, but illegal in given context
                 yield return new object[] { recordType, binaryType, (byte)19 };
             }
         }

--- a/src/libraries/System.Formats.Nrbf/tests/TypeMatchTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/TypeMatchTests.cs
@@ -74,6 +74,16 @@ public class TypeMatchTests : ReadTests
     }
 
     [Fact]
+    public void ThrowsForNullType()
+    {
+        List<int> input = new List<int>();
+
+        SerializationRecord record = NrbfDecoder.Decode(Serialize(input));
+
+        Assert.Throws<ArgumentNullException>(() => record.TypeNameMatches(type: null));
+    }
+
+    [Fact]
     public void TakesGenericTypeDefinitionIntoAccount()
     {
         List<int> input = new List<int>();

--- a/src/libraries/System.Formats.Nrbf/tests/TypeMatchTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/TypeMatchTests.cs
@@ -84,6 +84,24 @@ public class TypeMatchTests : ReadTests
     }
 
     [Fact]
+    public void TakesCustomOffsetsIntoAccount()
+    {
+        int[] input = [1, 2, 3];
+
+        SerializationRecord record = NrbfDecoder.Decode(Serialize(input));
+
+        Assert.True(record.TypeNameMatches(typeof(int[])));
+
+        Type nonSzArray = typeof(int).Assembly.GetType("System.Int32[*]");
+#if NET
+        Assert.False(nonSzArray.IsSZArray);
+        Assert.True(nonSzArray.IsVariableBoundArray);
+#endif
+        Assert.Equal(1, nonSzArray.GetArrayRank());
+        Assert.False(record.TypeNameMatches(nonSzArray));
+    }
+
+    [Fact]
     public void TakesGenericTypeDefinitionIntoAccount()
     {
         List<int> input = new List<int>();

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/AssemblyNameInfo.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/AssemblyNameInfo.cs
@@ -81,6 +81,10 @@ namespace System.Reflection.Metadata
         /// <summary>
         /// Gets the name of the culture associated with the assembly.
         /// </summary>
+        /// <remarks>
+        /// Do not create a <see cref="System.Globalization.CultureInfo"/> instance from this string unless
+        /// you know the string has originated from a trustworthy source.
+        /// </remarks>
         public string? CultureName { get; }
 
         /// <summary>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/AssemblyNameInfo.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/AssemblyNameInfo.cs
@@ -135,6 +135,10 @@ namespace System.Reflection.Metadata
         /// <summary>
         /// Initializes a new instance of the <seealso cref="AssemblyName"/> class based on the stored information.
         /// </summary>
+        /// <remarks>
+        /// Do not create an <see cref="AssemblyName"/> instance with <see cref="CultureName"/> string unless
+        /// you know the string has originated from a trustworthy source.
+        /// </remarks>
         public AssemblyName ToAssemblyName()
         {
             AssemblyName assemblyName = new();

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeName.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeName.cs
@@ -95,7 +95,7 @@ namespace System.Reflection.Metadata
         /// If <see cref="AssemblyName"/> returns null, simply returns <see cref="FullName"/>.
         /// </remarks>
         public string AssemblyQualifiedName
-            => _assemblyQualifiedName ??= AssemblyName is null ? FullName : $"{FullName}, {AssemblyName.FullName}";
+            => _assemblyQualifiedName ??= AssemblyName is null ? FullName : $"{FullName}, {AssemblyName.FullName}"; // see recursion comments in FullName
 
         /// <summary>
         /// Returns assembly name which contains this type, or null if this <see cref="TypeName"/> was not
@@ -142,6 +142,17 @@ namespace System.Reflection.Metadata
         {
             get
             {
+                // This is a recursive method over potentially hostile input. Protection against DoS is offered
+                // via the [Try]Parse method and TypeNameParserOptions.MaxNodes property at construction time.
+                // This FullName property getter and related methods assume that this TypeName instance has an
+                // acceptable node count.
+                //
+                // The node count controls the total amount of work performed by this method, including:
+                // - The max possible stack depth due to the recursive methods calls; and
+                // - The total number of bytes allocated by this function. For a deeply-nested TypeName
+                //   object, the total allocation across the full object graph will be
+                //   O(FullName.Length * GetNodeCount()).
+
                 if (_fullName is null)
                 {
                     if (IsConstructedGenericType)
@@ -245,6 +256,8 @@ namespace System.Reflection.Metadata
         {
             get
             {
+                // Lookups to Name and FullName might be recursive. See comments in FullName property getter.
+
                 if (_name is null)
                 {
                     if (IsConstructedGenericType)
@@ -425,6 +438,17 @@ namespace System.Reflection.Metadata
         /// <exception cref="InvalidOperationException">The current type name is not simple.</exception>
         public TypeName WithAssemblyName(AssemblyNameInfo? assemblyName)
         {
+            // Recursive method. See comments in FullName property getter for more information
+            // on how this is protected against attack.
+            //
+            // n.b. AssemblyNameInfo could also be hostile. The typical exploit is that a single
+            // long AssemblyNameInfo is associated with one or more simple TypeName objects,
+            // leading to an alg. complexity attack (DoS). It's important that TypeName doesn't
+            // actually *do* anything with the provided AssemblyNameInfo rather than store it.
+            // For example, don't use it inside a string concat operation unless the caller
+            // explicitly requested that to happen. If the input is hostile, the caller should
+            // never perform such concats in a loop.
+
             if (!IsSimple)
             {
                 TypeNameParserHelpers.ThrowInvalidOperation_NotSimpleName(FullName);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParserOptions.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParserOptions.cs
@@ -10,6 +10,13 @@ namespace System.Reflection.Metadata
         /// <summary>
         /// Limits the maximum value of <seealso cref="TypeName.GetNodeCount">node count</seealso> that parser can handle.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Setting this to a large value can render <see cref="TypeName"/> susceptible to Denial of Service
+        /// attacks when parsing or handling malicious input.
+        /// </para>
+        /// <para>The default value is 20.</para>
+        /// </remarks>
         public int MaxNodes
         {
             get => _maxNodes;


### PR DESCRIPTION
This PR does the following:
- copies all comments authored by @GrabYourPitchforks in our internal repo (https://github.com/dotnet/runtime/pull/107735/commits/f3f87a3b109328d5f8ac765d22ae188b425b3f3a)
- changes a const that represented max array length to a field (because it may change in the future and should not be hardocded), it was also @GrabYourPitchforks suggestion (https://github.com/dotnet/runtime/pull/107735/commits/8a42d8bb0b99c5346fe6e3fa5d9a2c8db11d801e)
- adds missing comments based (https://github.com/dotnet/runtime/pull/107735/commits/8a42d8bb0b99c5346fe6e3fa5d9a2c8db11d801e)
- changes `SerializationRecord.TypeNameMatches` to throw `ArgumentNullException` for `null` argument (https://github.com/dotnet/runtime/pull/107735/commits/969a2effa580a1d301730f0c25b0cbd90f868272)
- makes `SerializationRecord.TypeNameMatches` aware of `int[]` vs `int[*]` difference (both are single dimension, but the latter is not zero-indexed, https://github.com/dotnet/runtime/pull/107735/commits/61a9b14a090d146de820d1399a874ba058e725fa)
- stops casting raw bytes to booleans, please see [this example](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEUCuA7AHwAEAmARgFgAoIgBgAIiyA6AJXwwEsBbGZgYQjcADpwA2MKAGVJAN05gYAZwDc1Ooxbs8XXswCSOyRGEyo8xaurVgECGIDaAXXoBDKFHoBeegHEYGABCdmIAgh6uAJ4AFACUalQ2IW7ebh4OtE4JTACc0a7x1lS29vTAqe5QDmRZ6mR5wIWJxclgFfQAZB1l2fXRYE3UDgCyAQAWEAAm+iJi0aMYE9OzAPLCXBB4SswAchCGYpx4RwDmsU51SGUhzn4BwfbhUFFx1ADe1PRf1/a3lal4GAAdx+jhItSo33oUmErjwAB5gJEMDAAHz0JSwvCpUbcaCRYbuJRjVxiZihJSBZHKfIeclKGFwuJNKGYuEZFw+WgIWhkBKsrHVTn0bm0Ej875EADsaSgCQAvtQgA==) from @GrabYourPitchforks 
 to understand why (https://github.com/dotnet/runtime/pull/107735/commits/fcb3c8a3f5699eb875073c38c02d31d32234bd7d)
- stops casting raw bytes to `DateTime` in order to get them properly validated (https://github.com/dotnet/runtime/pull/107735/commits/88504ef179be93153bf1cc261787e5f24410b064)
