### PR TITLE
[Profiler] Update GetFunctionInfo2 to have a decent default ClassID

### DIFF
--- a/src/coreclr/inc/corprof.idl
+++ b/src/coreclr/inc/corprof.idl
@@ -3168,7 +3168,7 @@ interface ICorProfilerInfo2 : ICorProfilerInfo
      * When a COR_PRF_FRAME_INFO from any other source is passed, or
      * when 0 is passed as the frameInfo argument, exact ClassID and type
      * arguments cannot always be determined.  The value returned in pClassId
-     * may be NULL and some type args will come back as System.Object.
+     * may not be exact and some type args will come back as System.Object.
      *
      */
     HRESULT GetFunctionInfo2(

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -5989,7 +5989,8 @@ HRESULT ProfToEEInterfaceImpl::GetFunctionInfo2(FunctionID funcId,
     TypeHandle specificClass;
     MethodDesc* pActualMethod;
 
-    ClassID classId = 0;
+    TypeHandle typeHandle(pMethDesc->GetMethodTable());
+    ClassID classId = TypeHandleToClassID(typeHandle);
 
     if (pMethDesc->IsSharedByGenericInstantiations())
     {
@@ -6041,14 +6042,10 @@ HRESULT ProfToEEInterfaceImpl::GetFunctionInfo2(FunctionID funcId,
             // Though missing frameInfo may not lead to an exact typeHandle match for the method's class,
             // the default value of the method's method table may still be helpful to callers.
             //
-            TypeHandle typeHandle(pMethDesc->GetMethodTable());
-            classId = TypeHandleToClassID(typeHandle);
         }
     }
     else
     {
-        TypeHandle typeHandle(pMethDesc->GetMethodTable());
-        classId = TypeHandleToClassID(typeHandle);
         pActualMethod = pMethDesc;
     }
 

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -5994,7 +5994,6 @@ HRESULT ProfToEEInterfaceImpl::GetFunctionInfo2(FunctionID funcId,
 
     if (pMethDesc->IsSharedByGenericInstantiations())
     {
-        BOOL exactMatch;
         OBJECTREF pThis = NULL;
 
         if (pFrameInfo != NULL)
@@ -6017,31 +6016,20 @@ HRESULT ProfToEEInterfaceImpl::GetFunctionInfo2(FunctionID funcId,
             }
         }
 
-        exactMatch = Generics::GetExactInstantiationsOfMethodAndItsClassFromCallInformation(
+        Generics::GetExactInstantiationsOfMethodAndItsClassFromCallInformation(
             pMethDesc,
             pThis,
             PTR_VOID((pFrameInfo != NULL) ? pFrameInfo->extraArg : NULL),
             &specificClass,
             &pActualMethod);
 
-        if (exactMatch)
+        // When GetExactInstantiationsOfMethodAndItsClassFromCallInformation cannot determine
+        // the exact class match, the value is correct if the class is not a generic class
+        // or is instantiated with value types. Even if those conditions aren't met, the
+        // default returned value of the method's method table may still be helpful to callers.
+        if (specificClass != NULL)
         {
             classId = TypeHandleToClassID(specificClass);
-        }
-        else if (!specificClass.HasInstantiation() || !specificClass.IsSharedByGenericInstantiations())
-        {
-            //
-            // In this case we could not get the type args for the method, but if the class
-            // is not a generic class or is instantiated with value types, this value is correct.
-            //
-            classId = TypeHandleToClassID(specificClass);
-        }
-        else
-        {
-            //
-            // Though missing frameInfo may not lead to an exact typeHandle match for the method's class,
-            // the default value of the method's method table may still be helpful to callers.
-            //
         }
     }
     else

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -6038,9 +6038,11 @@ HRESULT ProfToEEInterfaceImpl::GetFunctionInfo2(FunctionID funcId,
         else
         {
             //
-            // We could not get any class information.
+            // Though missing frameInfo may not lead to an exact typeHandle match for the method's class,
+            // the default value of the method's method table may still be helpful to callers.
             //
-            classId = 0;
+            TypeHandle typeHandle(pMethDesc->GetMethodTable());
+            classId = TypeHandleToClassID(typeHandle);
         }
     }
     else


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/107139

Historically, `GetFunctionInfo2` would only return a valid `ClassID` if an exact match was found, and `0` otherwise.
It is documented that missing frame information would make it difficult for `GetFunctionInfo2` to find an exact class match. https://github.com/dotnet/runtime/blob/d7948dc7b9b061c7e3ee9ef6e3c9dd6854d195c0/src/coreclr/inc/corprof.idl#L3168-L3171  Even in these scenarios, having some information may prove useful to callers.

This PR modifies `GetFunctionInfo2` to return the function's MethodTable as a "decent" default value for its class in case an exact match cannot be determined, leveraging the documented behavior that missing frame information would not guarantee an exact match.