### PR TITLE
Issue a deprecation warning for COMPlus_ prefix

### DIFF
--- a/src/coreclr/inc/clrconfignocache.h
+++ b/src/coreclr/inc/clrconfignocache.h
@@ -91,6 +91,8 @@ public:
             strcpy_s(nameBuffer, ARRAY_SIZE(nameBuffer), fallbackPrefix);
             strcat_s(nameBuffer, ARRAY_SIZE(nameBuffer), cfg);
             val = getEnvFptr != NULL ? getEnvFptr(nameBuffer) : getenv(nameBuffer);
+            if (val)
+                printf("Warning: COMPlus_ prefixes are deprecated and will be removed in future releases. Use DOTNET_ prefix in %s instead.\n", nameBuffer);
         }
 
         return { val };


### PR DESCRIPTION
Before removing it completely, we can deprecate it for .NET 10:

```sh
$ COMPlus_DefaultStackSize=5 artifacts/bin/coreclr/osx.arm64.Debug/corerun foo.dll
Warning: COMPlus_ prefixes are deprecated and will be removed in future releases. Use DOTNET_ prefix in COMPlus_DefaultStackSize instead.
```