### PR TITLE
Fix memory corruption bug in virtual static method dispatch

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -7825,8 +7825,9 @@ MethodTable::ResolveVirtualStaticMethod(
     ClassLoadLevel level)
 {
     CONTRACTL{
-       THROWS;
-       GC_TRIGGERS;
+        MODE_ANY;
+        THROWS;
+        GC_TRIGGERS;
     } CONTRACTL_END;
 
     bool verifyImplemented = (resolveVirtualStaticMethodFlags & ResolveVirtualStaticMethodFlags::VerifyImplemented) != ResolveVirtualStaticMethodFlags::None;
@@ -7986,6 +7987,12 @@ MethodTable::ResolveVirtualStaticMethod(
 MethodDesc*
 MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType, MethodDesc* pInterfaceMD, ResolveVirtualStaticMethodFlags resolveVirtualStaticMethodFlags, ClassLoadLevel level)
 {
+    CONTRACTL{
+        MODE_ANY;
+        THROWS;
+        GC_TRIGGERS;
+    } CONTRACTL_END;
+
     bool instantiateMethodParameters = (resolveVirtualStaticMethodFlags & ResolveVirtualStaticMethodFlags::InstantiateResultOverFinalMethodDesc) != ResolveVirtualStaticMethodFlags::None;
     bool allowVariance = (resolveVirtualStaticMethodFlags & ResolveVirtualStaticMethodFlags::AllowVariantMatches) != ResolveVirtualStaticMethodFlags::None;
     bool verifyImplemented = (resolveVirtualStaticMethodFlags & ResolveVirtualStaticMethodFlags::VerifyImplemented) != ResolveVirtualStaticMethodFlags::None;
@@ -8041,7 +8048,7 @@ MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType
         {
             // Allow variant, but not equivalent interface match
             if (!pInterfaceType->HasSameTypeDefAs(pInterfaceMT) ||
-                !pInterfaceMT->CanCastTo(pInterfaceType, NULL))
+                !TypeHandle(pInterfaceMT).CanCastTo(pInterfaceType, NULL))
             {
                 continue;
             }

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/VariantVirtualStaticDefaultDispatch.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/VariantVirtualStaticDefaultDispatch.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+// This test comes from https://github.com/dotnet/runtime/issues/107754
+
+namespace VariantVirtualStaticDefaultDispatch
+{
+    interface IStaticConstraint<in T>
+    {
+        public abstract static void M();
+    }
+
+    interface IStaticConstraintDefaultImpl<in T> : IStaticConstraint<T>
+    {
+        static void IStaticConstraint<T>.M() { }
+    }
+
+    interface IConstraintCheck<U, W> where U : IStaticConstraint<W>
+    {
+    }
+
+    struct StructThatImplementsConstraint : IStaticConstraintDefaultImpl<object>
+    {
+    }
+
+    public class Tests
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void M<U>() where U: IStaticConstraint<string>
+        {
+            U.M();
+        }
+
+        [Fact]
+        public static void RunTest()
+        {
+            System.Console.WriteLine(typeof(IConstraintCheck<StructThatImplementsConstraint, string>));
+            M<StructThatImplementsConstraint>();
+        }
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/VariantVirtualStaticDefaultDispatch.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/VariantVirtualStaticDefaultDispatch.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Use `TypeHandle::CanCastTo` instead of `MethodTable::CanCastTo`
  - The issue is that the `MethodTable` api requires cooperative mode, and the `TypeHandle` supports either mode

Fixes #107754