### PR TITLE
[NativeAOT/ARM64] Generate frames compatible with Apple compact unwinding

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -659,6 +659,7 @@ protected:
     virtual bool IsSaveFpLrWithAllCalleeSavedRegisters() const;
     bool         genSaveFpLrWithAllCalleeSavedRegisters;
     bool         genForceFuncletFrameType5;
+    bool         genReverseAndPairCalleeSavedRegisters;
 #endif // TARGET_ARM64
 
     //-------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -845,12 +845,19 @@ void CodeGen::genSaveCalleeSavedRegisterGroup(regMaskTP regsMask, int spDelta, i
 
     for (int i = 0; i < regStack.Height(); ++i)
     {
-        RegPair regPair = regStack.Bottom(i);
+        RegPair regPair = genReverseAndPairCalleeSavedRegisters ? regStack.Top(i) : regStack.Bottom(i);
         if (regPair.reg2 != REG_NA)
         {
             // We can use a STP instruction.
-            genPrologSaveRegPair(regPair.reg1, regPair.reg2, spOffset, spDelta, regPair.useSaveNextPair, REG_IP0,
-                                 nullptr);
+            if (genReverseAndPairCalleeSavedRegisters)
+            {
+                genPrologSaveRegPair(regPair.reg2, regPair.reg1, spOffset, spDelta, false, REG_IP0, nullptr);
+            }
+            else
+            {
+                genPrologSaveRegPair(regPair.reg1, regPair.reg2, spOffset, spDelta, regPair.useSaveNextPair, REG_IP0,
+                                     nullptr);
+            }
 
             spOffset += 2 * slotSize;
         }
@@ -926,8 +933,9 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP regsToSaveMask, int lowe
 
     // Save integer registers at higher addresses than floating-point registers.
 
+    regMaskTP maskSaveRegsFrame = regsToSaveMask & (RBM_FP | RBM_LR);
     regMaskTP maskSaveRegsFloat = regsToSaveMask & RBM_ALLFLOAT;
-    regMaskTP maskSaveRegsInt   = regsToSaveMask & ~maskSaveRegsFloat;
+    regMaskTP maskSaveRegsInt   = regsToSaveMask & ~maskSaveRegsFloat & ~maskSaveRegsFrame;
 
     if (maskSaveRegsFloat != RBM_NONE)
     {
@@ -939,6 +947,13 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP regsToSaveMask, int lowe
     if (maskSaveRegsInt != RBM_NONE)
     {
         genSaveCalleeSavedRegisterGroup(maskSaveRegsInt, spDelta, lowestCalleeSavedOffset);
+        spDelta = 0;
+        lowestCalleeSavedOffset += genCountBits(maskSaveRegsInt) * FPSAVE_REGSIZE_BYTES;
+    }
+
+    if (maskSaveRegsFrame != RBM_NONE)
+    {
+        genPrologSaveRegPair(REG_FP, REG_LR, lowestCalleeSavedOffset, spDelta, false, REG_IP0, nullptr);
         // No need to update spDelta, lowestCalleeSavedOffset since they're not used after this.
     }
 }
@@ -970,13 +985,20 @@ void CodeGen::genRestoreCalleeSavedRegisterGroup(regMaskTP regsMask, int spDelta
             stackDelta = spDelta;
         }
 
-        RegPair regPair = regStack.Top(i);
+        RegPair regPair = genReverseAndPairCalleeSavedRegisters ? regStack.Bottom(i) : regStack.Top(i);
         if (regPair.reg2 != REG_NA)
         {
             spOffset -= 2 * slotSize;
 
-            genEpilogRestoreRegPair(regPair.reg1, regPair.reg2, spOffset, stackDelta, regPair.useSaveNextPair, REG_IP1,
-                                    nullptr);
+            if (genReverseAndPairCalleeSavedRegisters)
+            {
+                genEpilogRestoreRegPair(regPair.reg2, regPair.reg1, spOffset, stackDelta, false, REG_IP1, nullptr);
+            }
+            else
+            {
+                genEpilogRestoreRegPair(regPair.reg1, regPair.reg2, spOffset, stackDelta, regPair.useSaveNextPair,
+                                        REG_IP1, nullptr);
+            }
         }
         else
         {
@@ -1043,10 +1065,18 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, in
 
     // Save integer registers at higher addresses than floating-point registers.
 
+    regMaskTP maskRestoreRegsFrame = regsToRestoreMask & (RBM_FP | RBM_LR);
     regMaskTP maskRestoreRegsFloat = regsToRestoreMask & RBM_ALLFLOAT;
-    regMaskTP maskRestoreRegsInt   = regsToRestoreMask & ~maskRestoreRegsFloat;
+    regMaskTP maskRestoreRegsInt   = regsToRestoreMask & ~maskRestoreRegsFloat & ~maskRestoreRegsFrame;
 
     // Restore in the opposite order of saving.
+
+    if (maskRestoreRegsFrame != RBM_NONE)
+    {
+        int spFrameDelta = (maskRestoreRegsFloat != RBM_NONE || maskRestoreRegsInt != RBM_NONE) ? 0 : spDelta;
+        spOffset -= 2 * REGSIZE_BYTES;
+        genEpilogRestoreRegPair(REG_FP, REG_LR, spOffset, spFrameDelta, false, REG_IP1, nullptr);
+    }
 
     if (maskRestoreRegsInt != RBM_NONE)
     {

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -255,6 +255,7 @@ CodeGen::CodeGen(Compiler* theCompiler)
 #ifdef TARGET_ARM64
     genSaveFpLrWithAllCalleeSavedRegisters = false;
     genForceFuncletFrameType5              = false;
+    genReverseAndPairCalleeSavedRegisters  = false;
 #endif // TARGET_ARM64
 }
 
@@ -4839,6 +4840,29 @@ void CodeGen::genFinalizeFrame()
         regSet.rsSetRegsModified(regSet.rsMaskResvd);
     }
 #endif // TARGET_ARM
+
+#ifdef TARGET_ARM64
+    if (compiler->IsTargetAbi(CORINFO_NATIVEAOT_ABI) && TargetOS::IsApplePlatform)
+    {
+        JITDUMP("Setting genReverseAndPairCalleeSavedRegisters = true");
+
+        genReverseAndPairCalleeSavedRegisters = true;
+
+        // Make sure we push the registers in pairs if possible. If we only allocate a contiguous
+        // block of registers this should add at most one integer and at most one floating point
+        // register to the list. The stack has to be 16-byte aligned, so in worst case it results
+        // in allocating 16 bytes more space on stack if odd number of integer and odd number of
+        // FP registers were occupied. Same number of instructions will be generated, just the
+        // STR instructions are replaced with STP (store pair).
+        regMaskTP maskModifiedRegs = regSet.rsGetModifiedRegsMask();
+        regMaskTP maskPairRegs     = ((maskModifiedRegs & (RBM_V8 | RBM_V10 | RBM_V12 | RBM_V14)).getLow() << 1) |
+                                 ((maskModifiedRegs & (RBM_R19 | RBM_R21 | RBM_R23 | RBM_R25 | RBM_R27)).getLow() << 1);
+        if (maskPairRegs != RBM_NONE)
+        {
+            regSet.rsSetRegsModified(maskPairRegs);
+        }
+    }
+#endif
 
 #ifdef DEBUG
     if (verbose)

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -2809,7 +2809,7 @@ inline
         *pBaseReg = REG_SPBASE;
     }
 #elif defined(TARGET_ARM64)
-    if (FPbased && !codeGen->isFramePointerRequired() && varOffset < 0 &&
+    if (FPbased && !codeGen->isFramePointerRequired() && varOffset < 0 && !opts.IsOSR() &&
         lvaDoneFrameLayout == Compiler::FINAL_FRAME_LAYOUT && codeGen->IsSaveFpLrWithAllCalleeSavedRegisters())
     {
         int spVarOffset = varOffset + codeGen->genSPtoFPdelta();

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -2808,6 +2808,16 @@ inline
     {
         *pBaseReg = REG_SPBASE;
     }
+#elif defined(TARGET_ARM64)
+    if (FPbased && !codeGen->isFramePointerRequired() && varOffset < 0 &&
+        lvaDoneFrameLayout == Compiler::FINAL_FRAME_LAYOUT && codeGen->IsSaveFpLrWithAllCalleeSavedRegisters())
+    {
+        int spVarOffset = varOffset + codeGen->genSPtoFPdelta();
+        JITDUMP("lvaFrameAddress optimization for V%02u: [FP-%d] -> [SP+%d]\n", varNum, -varOffset, spVarOffset);
+        FPbased   = false;
+        varOffset = spVarOffset;
+    }
+    *pFPbased = FPbased;
 #else
     *pFPbased = FPbased;
 #endif

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/MachNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/MachNative.cs
@@ -120,5 +120,18 @@ namespace ILCompiler.ObjectWriter
         public const uint PLATFORM_TVOSSIMULATOR = 8;
         public const uint PLATFORM_WATCHOSSIMULATOR = 9;
         public const uint PLATFORM_DRIVERKIT = 10;
+
+        public const uint UNWIND_ARM64_MODE_FRAMELESS = 0x02000000;
+        public const uint UNWIND_ARM64_MODE_DWARF = 0x03000000;
+        public const uint UNWIND_ARM64_MODE_FRAME = 0x04000000;
+        public const uint UNWIND_ARM64_FRAME_X19_X20_PAIR = 0x00000001;
+        public const uint UNWIND_ARM64_FRAME_X21_X22_PAIR = 0x00000002;
+        public const uint UNWIND_ARM64_FRAME_X23_X24_PAIR = 0x00000004;
+        public const uint UNWIND_ARM64_FRAME_X25_X26_PAIR = 0x00000008;
+        public const uint UNWIND_ARM64_FRAME_X27_X28_PAIR = 0x00000010;
+        public const uint UNWIND_ARM64_FRAME_D8_D9_PAIR = 0x00000100;
+        public const uint UNWIND_ARM64_FRAME_D10_D11_PAIR = 0x00000200;
+        public const uint UNWIND_ARM64_FRAME_D12_D13_PAIR = 0x00000400;
+        public const uint UNWIND_ARM64_FRAME_D14_D15_PAIR = 0x00000800;
     }
 }


### PR DESCRIPTION
Contributes to #76371

The are two changes in the PR that work in tandem. The first is a JIT change for generating slightly different frame layout on NativeAOT/ARM64/Apple platforms (iOS, macOS and tvOS). The second change is ObjWriter code that recognizes the structurally compatible unwinding information and generates compact unwinding codes in the object files instead of verbose DWARF unwinding information.

For NativeAOT/ARM64/Apple ABI do the following:
1) Save callee registers in opposite order and in pairs.
2) Prefer saving FP/LR on the top of the frame. Heuristics are used to avoid worse code quality outside of prolog/epilog due to addressing range limits of the ARM64 instruction set.
3) Added optimization to `lvaFrameAddress` to rewrite FP-x references to SP+y when possible. This allows efficient addressing using positive indexes when FP points to the top of the frame. It mimics similar optimization on ARM32.

Each of these changes comes with some caveats:
1) Saving registers in pairs may lead to 16 bytes more used in the stack space. The ARM64 stack has to be 16 byte aligned. If the prolog previously saved odd number of integer callee saved registers and odd number of floating point callee saved registers, we'd now generate one more 16 byte stack slot. This seems to be rather rare occurrence. It does not affect the number of instructions used. Likewise, the changed order doesn't have any impact on code size.
2) Saving FP/LR at the top of the frame may cause one additional instruction in the prolog if any local or temporary variables are used. Additionally, addressing using negative offsets from FP is less efficient than addressing with positive offsets since the ARM64 instruction encoding can only address negative offsets with non-scaled encoding which significantly reduces the addressable range. This is mostly mitigated by the optimization in `lvaFrameAddress`. The additional increase in prolog size also causes a cascading effect where loop alignment and related code alignment (32-byte alignment for method start) significantly contribute to the code section size. In some cases the same alignment logic may also reduce the size.

As you can see, this is a bit of a trade-off and it's valid to ask if it's worth it.

Firstly, let me address the size question. The loop alignment seems to be the biggest contributor to the code size variation, and I filed issue https://github.com/dotnet/runtime/issues/107284 to investigate whether we can come up with a better defaults for Apple platforms. The code size changes are predominantly contained to the small fixed change in the prolog size and the additional alignment. When testing the prototype on MAUI apps the biggest culprit to increased code size was the code generated from XAML that generates methods with ton of local variables. The change in `lvaFrameAddress` practically eliminated any negative effect of the frame layout on this type of code. Without the change the regression was nearly 50% due to stack references needing an indirect load with a register and extra instruction. Outside of MAUI the biggest visible effect is on code from Regex source generator but in that case it's quite evenly split between size improvements and regressions. That suggests the regex code may be a good candidate for measuring the performance characteristics of the loop alignment. The code size regressions on few examples I tried amount to around 2% (incl. the alignment). The saved space in the DWARF unwinding section is hovering around 90% +- 3%. To put that into absolute numbers we are looking at savings around 0.7 Mb for `dotnet new maui` app and around 3 Mb for `System.Runtime.Tests` in the linked executables. The savings in the size of the unwinding information far outweigh any increase in the code size.

Secondly, part of the motivation is that the Apple linker is notoriously buggy with processing the DWARF unwinding data. The compact unwinding tables are used as an index to the DWARF data for anything that cannot be expressed using compact unwinding code directly. Due to the structure of the tables this limits the effective offset of DWARF info to 24 bits and places a hard limit on the DWARF unwinding info size. At least with some versions of the Apple linker, breaking this limit results in silent corruption and runtime failures.

<details>
<summary>Comparison between `main` and PR for System.Runtime.Tests in Release build</summary>

Compare raw size of linked binaries:
```
ls -l ./artifacts/bin/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/publish/System.Runtime.Tests ../runtime-main/artifacts/bin/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/publish/System.Runtime.Tests
-rwxr-xr-x  1 filipnavara  staff  48913112 Sep 12 22:26 ../runtime-main/artifacts/bin/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/publish/System.Runtime.Tests
-rwxr-xr-x  1 filipnavara  staff  45827128 Sep 12 22:34 ./artifacts/bin/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/publish/System.Runtime.Tests
```

Bloaty check of linked binaries:
```
bloaty -d symbols ./artifacts/bin/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/publish/System.Runtime.Tests -- ../runtime-main/artifacts/bin/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/publish/System.Runtime.Tests
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +1.9%  +406Ki  +1.9%  +406Ki    [__TEXT,__managedcode]
   +55% +8.80Ki   +54% +8.80Ki    [__TEXT]
  +0.1% +2.51Ki  +0.1% +2.51Ki    [__DATA,.dotnet_eh_table]
  +0.1%    +272  +0.1%    +272    [__DATA,__data]
  -0.0%      -5  -0.0%      -5    [__TEXT,__cstring]
  -0.0%     -16  -0.0%     -16    [__TEXT,__const]
 -33.0% -2.78Ki -25.0% -2.78Ki    [__DATA]
  -3.6% -21.7Ki  -2.6% -16.0Ki    [__LINKEDIT]
 -20.5%  -437Ki -20.5%  -437Ki    [__TEXT,__unwind_info]
 -88.7% -2.90Mi -88.7% -2.90Mi    [__TEXT,__eh_frame]
  -6.3% -2.94Mi  -5.4% -2.94Mi    TOTAL
```

Bloaty check of object files:
```
bloaty ./artifacts/obj/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/native/System.Runtime.Tests.o -- ../runtime-main/artifacts/obj/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/native/System.Runtime.Tests.o 
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +1.9%  +406Ki  +1.9%  +406Ki    ,__managedcode
  +0.1% +9.64Ki  +0.1% +9.64Ki    ,__debug_loc
  +0.1% +2.51Ki  +0.1% +2.51Ki    ,.dotnet_eh_table
  +0.0%    +348  +0.0%    +348    ,__debug_line
  +0.1%    +272  +0.1%    +272    ,__data
  +0.0%     +20  +0.0%     +20    ,__debug_info
  -0.1%      -1  -2.3%      -1    []
  -0.0%      -9  -0.0%      -9    ,__const
  -6.8% -1.76Mi  [ = ]       0    [Unmapped]
 -88.7% -2.90Mi -88.7% -2.90Mi    ,__eh_frame
  -2.4% -4.25Mi  -2.4% -2.49Mi    TOTAL
```

Bloaty check of object files (detailed):
```
bloaty -d symbols ./artifacts/obj/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/native/System.Runtime.Tests.o -- ../runtime-main/artifacts/obj/System.Runtime.Tests/Release/net9.0-unix/osx-arm64/native/System.Runtime.Tests.o
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +1.9%  +410Ki  +1.6%  +410Ki    [36252 Others]
  +0.1% +9.64Ki  +0.1% +9.64Ki    [,__debug_loc]
  [NEW] +7.19Ki  [NEW] +6.97Ki    _TestUtilities_Unicode_System_Text_RegularExpressions_Generated__RegexGenerator_g_F026929D4AD63EB6EDB749A9B02B133C084237B3AFB8777B3DE0107C755B91565__GetRegex_0_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [NEW] +2.42Ki  [NEW] +2.20Ki    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F417AD2970E27AC5D022778EC7081B94838CBCB072379596BB27CB8792C23ED76__EnsureArrayIndexRegex_5_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [NEW] +2.02Ki  [NEW] +1.81Ki    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F417AD2970E27AC5D022778EC7081B94838CBCB072379596BB27CB8792C23ED76__Regex1_3_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [NEW] +1.54Ki  [NEW] +1.51Ki    _lsda0_TestUtilities_Unicode_System_Text_RegularExpressions_Generated__RegexGenerator_g_F026929D4AD63EB6EDB749A9B02B133C084237B3AFB8777B3DE0107C755B91565__GetRegex_0_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [NEW] +1.44Ki  [NEW] +1.23Ki    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F417AD2970E27AC5D022778EC7081B94838CBCB072379596BB27CB8792C23ED76__P0Regex_6_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [NEW] +1.18Ki  [NEW]    +976    _System_Runtime_Tests_System_Text_RegularExpressions_Generated__RegexGenerator_g_FB4BB6619E624A9FE5F4E687DA0CF38E2970A0CF70BB059A398625E558ACC7DAC__IanaAbbreviationRegex_0_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [NEW] +1.14Ki  [NEW]    +960    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F417AD2970E27AC5D022778EC7081B94838CBCB072379596BB27CB8792C23ED76__Regex2_4_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [NEW] +1.11Ki  [NEW]    +912    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F417AD2970E27AC5D022778EC7081B94838CBCB072379596BB27CB8792C23ED76__UnknownNodeObjectEmptyRegex_8_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL]   -1017  [DEL]    -800    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F24C2B164CF72F5E63C813A2B442D56F3F17BFFC74EAF7C2818EB7F6278C5183A__EncodeCharRegex_1_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -1.11Ki  [DEL]    -912    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F24C2B164CF72F5E63C813A2B442D56F3F17BFFC74EAF7C2818EB7F6278C5183A__UnknownNodeObjectEmptyRegex_8_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -1.14Ki  [DEL]    -960    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F24C2B164CF72F5E63C813A2B442D56F3F17BFFC74EAF7C2818EB7F6278C5183A__Regex2_4_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -1.17Ki  [DEL]    -960    _System_Runtime_Tests_System_Text_RegularExpressions_Generated__RegexGenerator_g_F23FFE14CED6C53CC123B603EF102D84787AD8CF9A59E83434F2BDF516814C2CC__IanaAbbreviationRegex_0_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -1.44Ki  [DEL] -1.23Ki    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F24C2B164CF72F5E63C813A2B442D56F3F17BFFC74EAF7C2818EB7F6278C5183A__P0Regex_6_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -1.57Ki  [DEL] -1.54Ki    _lsda0_TestUtilities_Unicode_System_Text_RegularExpressions_Generated__RegexGenerator_g_F25E40F247ED975110B5E93851ECC9A2CB78C4DC17A73BF5F5EE6D76B142C41B6__GetRegex_0_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -2.00Ki  [DEL] -1.80Ki    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F24C2B164CF72F5E63C813A2B442D56F3F17BFFC74EAF7C2818EB7F6278C5183A__Regex1_3_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -2.42Ki  [DEL] -2.20Ki    _S_P_Xml_System_Text_RegularExpressions_Generated__RegexGenerator_g_F24C2B164CF72F5E63C813A2B442D56F3F17BFFC74EAF7C2818EB7F6278C5183A__EnsureArrayIndexRegex_5_RunnerFactory_Runner__TryMatchAtCurrentPosition
  [DEL] -7.19Ki  [DEL] -6.97Ki    _TestUtilities_Unicode_System_Text_RegularExpressions_Generated__RegexGenerator_g_F25E40F247ED975110B5E93851ECC9A2CB78C4DC17A73BF5F5EE6D76B142C41B6__GetRegex_0_RunnerFactory_Runner__TryMatchAtCurrentPosition
  -6.8% -1.76Mi  [ = ]       0    [Unmapped]
 -88.7% -2.90Mi -88.7% -2.90Mi    lsection3
  -2.4% -4.25Mi  -2.4% -2.49Mi    TOTAL
```
</details>







