### PR TITLE
Remove `DebuggerModule::Get/SetPrimaryModule` - always itself

### DIFF
--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -469,42 +469,16 @@ class DebuggerModule
 
     Module * GetRuntimeModule();
 
-
-    // <TODO> (8/12/2002)
-    // Currently we create a new DebuggerModules for each appdomain a shared
-    // module lives in. We then pretend there aren't any shared modules.
-    // This is bad. We need to move away from this.
-    // Once we stop lying, then every module will be it's own PrimaryModule. :)
-    //
-    // Currently, Module* is 1:n w/ DebuggerModule.
-    // We add a notion of PrimaryModule so that:
-    // Module* is 1:1 w/ DebuggerModule::GetPrimaryModule();
-    // This should help transition towards exposing shared modules.
-    // If the Runtime module is shared, then this gives a common DM.
-    // If the runtime module is not shared, then this is an identity function.
-    //
-    // The runtime has the notion of "DomainAssembly", which is 1:1 with DebuggerModule
-    // and thus 1:1 with CordbModule.  The CordbModule hash table on the RS now uses
-    // the DomainAssembly as the key instead of DebuggerModule.  This is a temporary
-    // workaround to facilitate the removal of DebuggerModule.
-    // </TODO>
-    DebuggerModule * GetPrimaryModule();
     DomainAssembly * GetDomainAssembly()
     {
         LIMITED_METHOD_DAC_CONTRACT;
         return m_pRuntimeDomainAssembly;
     }
 
-    // Called by DebuggerModuleTable to set our primary module
-    void SetPrimaryModule(DebuggerModule * pPrimary);
-
     void SetCanChangeJitFlags(bool fCanChangeJitFlags);
 
   private:
     BOOL            m_enableClassLoadCallbacks;
-
-    // First step in moving away from hiding shared modules.
-    DebuggerModule* m_pPrimaryModule;
 
     PTR_Module     m_pRuntimeModule;
     PTR_DomainAssembly m_pRuntimeDomainAssembly;
@@ -513,13 +487,9 @@ class DebuggerModule
 
     bool m_fHasOptimizedCode;
 
-    void PickPrimaryModule();
-
     // Can we change jit flags on the module?
     // This is true during the Module creation
     bool           m_fCanChangeJitFlags;
-
-
 };
 
 /* ------------------------------------------------------------------------ *
@@ -1109,12 +1079,13 @@ public:
     // correct IL offset if this code happens to be instrumented
     ULONG32 TranslateToInstIL(const InstrumentedILOffsetMapping * pMapping, ULONG32 offOrig, bool fOrigToInst);
 
-
+private:
     // We don't always have a debugger module. (Ex: we're tracking debug info,
     // but no debugger's attached). So this may return NULL alot.
     // If we can, we should use the RuntimeModule when ever possible.
-    DebuggerModule* GetPrimaryModule();
+    DebuggerModule* GetModule();
 
+public:
     // We always have a runtime module.
     Module * GetRuntimeModule();
 

--- a/src/coreclr/debug/ee/debugger.inl
+++ b/src/coreclr/debug/ee/debugger.inl
@@ -55,18 +55,12 @@ inline DebuggerModule::DebuggerModule(Module *      pRuntimeModule,
                                       DomainAssembly *  pDomainAssembly,
                                       AppDomain *   pAppDomain) :
         m_enableClassLoadCallbacks(FALSE),
-        m_pPrimaryModule(NULL),
         m_pRuntimeModule(pRuntimeModule),
         m_pRuntimeDomainAssembly(pDomainAssembly),
         m_pAppDomain(pAppDomain)
 {
     LOG((LF_CORDB,LL_INFO10000, "DM::DM this:0x%x Module:0x%x DF:0x%x AD:0x%x\n",
         this, pRuntimeModule, pDomainAssembly, pAppDomain));
-
-    // Pick a primary module.
-    // Arguably, this could be in DebuggerModuleTable::AddModule
-    PickPrimaryModule();
-
 
     // Do we have any optimized code?
     DWORD dwDebugBits = pRuntimeModule->GetDebuggerInfoBits();
@@ -90,7 +84,7 @@ inline DebuggerModule::DebuggerModule(Module *      pRuntimeModule,
 inline bool DebuggerModule::HasAnyOptimizedCode()
 {
     LIMITED_METHOD_CONTRACT;
-    Module * pModule = this->GetPrimaryModule()->GetRuntimeModule();
+    Module * pModule = GetRuntimeModule();
     DWORD dwDebugBits = pModule->GetDebuggerInfoBits();
     return CORDebuggerAllowJITOpts(dwDebugBits);
 }
@@ -140,40 +134,6 @@ inline Module * DebuggerModule::GetRuntimeModule()
 {
     LIMITED_METHOD_DAC_CONTRACT;
     return m_pRuntimeModule;
-}
-
-//-----------------------------------------------------------------------------
-// <TODO> (8/12/2002)
-// Currently we create a new DebuggerModules for each appdomain a shared
-// module lives in. We then pretend there aren't any shared modules.
-// This is bad. We need to move away from this.
-// Once we stop lying, then every module will be it's own PrimaryModule. :)
-//
-// Currently, Module* is 1:n w/ DebuggerModule.
-// We add a notion of PrimaryModule so that:
-// Module* is 1:1 w/ DebuggerModule::GetPrimaryModule();
-// This should help transition towards exposing shared modules.
-// If the Runtime module is shared, then this gives a common DM.
-// If the runtime module is not shared, then this is an identity function.
-// </TODO>
-//-----------------------------------------------------------------------------
-inline DebuggerModule * DebuggerModule::GetPrimaryModule()
-{
-    _ASSERTE(m_pPrimaryModule != NULL);
-    return m_pPrimaryModule;
-}
-
-//-----------------------------------------------------------------------------
-// This is called by DebuggerModuleTable to set our primary module.
-//-----------------------------------------------------------------------------
-inline void DebuggerModule::SetPrimaryModule(DebuggerModule * pPrimary)
-{
-    _ASSERTE(pPrimary != NULL);
-    // Our primary module must by definition refer to the same runtime module as us
-    _ASSERTE(pPrimary->GetRuntimeModule() == this->GetRuntimeModule());
-
-    LOG((LF_CORDB, LL_EVERYTHING, "DM::SetPrimaryModule - this=%p, pPrimary=%p\n", this, pPrimary));
-    m_pPrimaryModule = pPrimary;
 }
 
 inline DebuggerEval * FuncEvalFrame::GetDebuggerEval()

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1432,7 +1432,7 @@ DebuggerMethodInfo::DebuggerMethodInfo(Module *module, mdMethodDef token) :
 
     _ASSERTE(g_pDebugger->HasDebuggerDataLock());
 
-    DebuggerModule * pModule = GetPrimaryModule();
+    DebuggerModule * pModule = GetModule();
 
     m_fJMCStatus = false;
 
@@ -1448,9 +1448,9 @@ DebuggerMethodInfo::DebuggerMethodInfo(Module *module, mdMethodDef token) :
 
 
 /******************************************************************************
- * Get the primary debugger module for this DMI. This is 1:1 w/ an EE Module.
+ * Get the debugger module for this DMI. This is 1:1 w/ an EE Module.
  ******************************************************************************/
-DebuggerModule* DebuggerMethodInfo::GetPrimaryModule()
+DebuggerModule* DebuggerMethodInfo::GetModule()
 {
     CONTRACTL
     {
@@ -1478,11 +1478,7 @@ DebuggerModule* DebuggerMethodInfo::GetPrimaryModule()
         return NULL;
     }
 
-    // Only give back primary modules...
-    DebuggerModule * p2 = pModule->GetPrimaryModule();
-    _ASSERTE(p2 != NULL);
-
-    return p2;
+    return pModule;
 }
 
 /******************************************************************************


### PR DESCRIPTION
This looks to be from multi-app domain / shared domain support. `DebuggerModule::SetPrimaryModule` is never called anymore - the 'primary' module is always itself.

cc @jkotas @AaronRobinsonMSFT 