### PR TITLE
JIT: adjust where folded comma throws are morphed

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16521,6 +16521,11 @@ INTEGRAL_OVF:
 
     tree = gtNewOperNode(GT_COMMA, tree->TypeGet(), op1, op2);
 
+    if (fgGlobalMorph)
+    {
+        tree = fgMorphTree(tree);
+    }
+
     return tree;
 }
 #ifdef _PREFAST_

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8349,20 +8349,6 @@ DONE_MORPHING_CHILDREN:
 
     if (oldTree != tree)
     {
-        /* if gtFoldExpr returned op1 or op2 then we are done */
-        if ((tree == op1) || (tree == op2) || (tree == qmarkOp1) || (tree == qmarkOp2))
-        {
-            return tree;
-        }
-
-        /* If we created a comma-throw tree then we need to morph op1 */
-        if (fgIsCommaThrow(tree))
-        {
-            tree->AsOp()->gtOp1 = fgMorphTree(tree->AsOp()->gtOp1);
-            fgMorphTreeDone(tree);
-            return tree;
-        }
-
         return tree;
     }
     else if (tree->OperIsConst())


### PR DESCRIPTION
Probably too simplistic, but it would be nice if `gtFoldExpr` would obey a contract where it is easy to tell if the trees coming back are morphed or not.