### PR TITLE
Export `monovm_create_delegate`

### DIFF
--- a/src/mono/mono/mini/monovm.h
+++ b/src/mono/mono/mini/monovm.h
@@ -17,7 +17,7 @@ monovm_execute_assembly (int argc, const char **argv, const char *managedAssembl
 MONO_API int
 monovm_shutdown (int *latchedExitCode);
 
-int
+MONO_API int
 monovm_create_delegate (const char *assemblyName, const char *typeName, const char *methodName, void **delegate);
 
 


### PR DESCRIPTION
`monovm_create_delegate` was missing `MONO_API`, without it the symbol can't be found with `dlsym`.

For context, `MONO_API` was deemed not needed at the time of adding the API[^1]. However, I'm interested in using this API directly instead of going through `coreclr_create_delegate` for a Mono host implementation I'm working on.

[^1]: https://github.com/dotnet/runtime/pull/59962#discussion_r721646839