### PR TITLE
fix OS detection for test scripts

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -70,8 +70,8 @@
   <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
                         '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                          $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
-    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __IsXUnitLogCheckerSupported=1" />
-    <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __IsXUnitLogCheckerSupported=1" />
+    <SetScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export __IsXUnitLogCheckerSupported=1" />
+    <SetScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set __IsXUnitLogCheckerSupported=1" />
   </ItemGroup>
 
   <!-- Archive test binaries. -->

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <!-- Configures xunit to not print out passing tests with output when diagnostic messages are enabled. -->
-    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set XUNIT_HIDE_PASSING_OUTPUT_DIAGNOSTICS=1" />
-    <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export XUNIT_HIDE_PASSING_OUTPUT_DIAGNOSTICS=1" />
+    <SetScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export XUNIT_HIDE_PASSING_OUTPUT_DIAGNOSTICS=1" />
+    <SetScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set XUNIT_HIDE_PASSING_OUTPUT_DIAGNOSTICS=1" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BundleXunitRunner)' == 'true'">


### PR DESCRIPTION
`c:\Dev\runtime\artifacts\bin\System.Net.Http.Functional.Tests\Debug\net9.0-wasi\wasi-wasm\AppBundle\RunTests.cmd` was generated with `export XUNIT_HIDE_PASSING_OUTPUT_DIAGNOSTICS=1` and that fails with `'export' is not recognized as an internal or external command`