### PR TITLE
[NRBF] Remove array allocation when decoding `decimal`s.

### DIFF
--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SystemClassWithMembersAndTypesRecord.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SystemClassWithMembersAndTypesRecord.cs
@@ -93,15 +93,7 @@ internal sealed class SystemClassWithMembersAndTypesRecord : ClassRecord
             && GetRawValue("hi") is int hi && GetRawValue("flags") is int flags
             && TypeNameMatches(typeof(decimal)))
         {
-            int[] bits =
-            [
-                lo,
-                mid,
-                hi,
-                flags
-            ];
-
-            return Create(new decimal(bits));
+            return Create(new decimal([lo, mid, hi, flags]));
         }
 
         return this;


### PR DESCRIPTION
By directly passing a collection expression to `decimal`'s constructor, we avoid allocating an array on frameworks that have an overload that accepts a `ReadOnlySpan<int>`, in which case the span's memory is allocated on the stack.