### PR TITLE
Fix perf problems found in investigation of issue #107728

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -901,6 +901,12 @@ HCIMPL1(void*, JIT_GetNonGCThreadStaticBaseOptimized, UINT32 staticBlockIndex)
 
     FCALL_CONTRACT;
 
+    staticBlock = GetThreadLocalStaticBaseIfExistsAndInitialized(staticBlockIndex);
+    if (staticBlock != NULL)
+    {
+        return staticBlock;
+    }
+
     HELPER_METHOD_FRAME_BEGIN_RET_0();    // Set up a frame
     TLSIndex tlsIndex(staticBlockIndex);
     // Check if the class constructor needs to be run
@@ -974,6 +980,12 @@ HCIMPL1(void*, JIT_GetGCThreadStaticBaseOptimized, UINT32 staticBlockIndex)
     void* staticBlock = nullptr;
 
     FCALL_CONTRACT;
+
+    staticBlock = GetThreadLocalStaticBaseIfExistsAndInitialized(staticBlockIndex);
+    if (staticBlock != NULL)
+    {
+        return staticBlock;
+    }
 
     HELPER_METHOD_FRAME_BEGIN_RET_0();    // Set up a frame
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3797,8 +3797,8 @@ void MethodTable::CheckRunClassInitThrowing()
     // To find GC hole easier...
     TRIGGERSGC();
 
-    // Don't initialize shared generic instantiations (e.g. MyClass<__Canon>)
-    if (IsSharedByGenericInstantiations())
+    // Don't initialize shared generic instantiations (e.g. MyClass<__Canon>), or an already initialized MethodTable
+    if (IsClassInited() || IsSharedByGenericInstantiations())
         return;
 
     _ASSERTE(!ContainsGenericVariables());
@@ -3903,7 +3903,11 @@ void MethodTable::EnsureTlsIndexAllocated()
     CONTRACTL_END;
 
     PTR_MethodTableAuxiliaryData pAuxiliaryData = GetAuxiliaryDataForWrite();
-    if (!pAuxiliaryData->IsTlsIndexAllocated() && GetNumThreadStaticFields() > 0)
+
+    if (pAuxiliaryData->IsTlsIndexAllocated())
+        return;
+
+    if (GetNumThreadStaticFields() > 0)
     {
         ThreadStaticsInfo *pThreadStaticsInfo = MethodTableAuxiliaryData::GetThreadStaticsInfo(GetAuxiliaryDataForWrite());
         // Allocate space for normal statics if we might have them


### PR DESCRIPTION
- `CheckRunClassInitThrowing` didn't check to see if the class had been initialized before taking a lock
- `EnsureTlsIndexAllocated` didn't check if the Tls index had been allocated before setting the flag via an expensive Interlocked call to indicate that it had been allocated
- And finally `JIT_GetNonGCThreadStaticBaseOptimized` and `JIT_GetGCThreadStaticBaseOptimized` were missing the fast paths which avoided even calling those apis at all.

Perf with a small benchmark which does multithreaded work and is forced into the paths which hit this issue...

| Runtime | Time |
| ---- | ---- |
| .NET 8 | 00.9414682 s |
| .NET 9 before this fix |  22.8079382 s |
| .NET 9 with this fix | 00.2004539 s |

Fixes #107728