### PR TITLE
Move computation of `DebuggerAssemblyControlFlags` from `DomainAssembly` to `Assembly`

### DIFF
--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -48,7 +48,7 @@ class Assembly
     friend class ClrDataAccess;
 
 private:
-    Assembly(PEAssembly *pPEAssembly, DebuggerAssemblyControlFlags debuggerFlags, LoaderAllocator* pLoaderAllocator);
+    Assembly(PEAssembly *pPEAssembly, LoaderAllocator* pLoaderAllocator);
     void Init(AllocMemTracker *pamTracker);
 
 // Load state tracking
@@ -163,7 +163,7 @@ public:
     void StartUnload();
     void Terminate( BOOL signalProfiler = TRUE );
 
-    static Assembly *Create(PEAssembly *pPEAssembly, DebuggerAssemblyControlFlags debuggerFlags, AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocator);
+    static Assembly *Create(PEAssembly *pPEAssembly, AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocator);
     static void Initialize();
 
     BOOL IsSystem() { WRAPPER_NO_CONTRACT; return m_pPEAssembly->IsSystem(); }
@@ -324,6 +324,11 @@ public:
         m_debuggerFlags = flags;
     }
 
+private:
+    DebuggerAssemblyControlFlags ComputeDebuggingConfig(void);
+    HRESULT GetDebuggingCustomAttributes(DWORD* pdwFlags);
+
+public:
     // On failure:
     //      if loadFlag == Loader::Load => throw
     //      if loadFlag != Loader::Load => return NULL

--- a/src/coreclr/vm/comdynamic.cpp
+++ b/src/coreclr/vm/comdynamic.cpp
@@ -894,9 +894,6 @@ void UpdateRuntimeStateForAssemblyCustomAttribute(Module* pModule, mdToken tkCus
         DomainAssembly* pDomainAssembly = pAssembly->GetDomainAssembly();
 
         DWORD actualFlags;
-        actualFlags =  ((DWORD)pDomainAssembly->GetDebuggerInfoBits() & mask) | flags;
-        pDomainAssembly->SetDebuggerInfoBits((DebuggerAssemblyControlFlags)actualFlags);
-
         actualFlags = ((DWORD)pAssembly->GetDebuggerInfoBits() & mask) | flags;
         pAssembly->SetDebuggerInfoBits((DebuggerAssemblyControlFlags)actualFlags);
 

--- a/src/coreclr/vm/domainassembly.h
+++ b/src/coreclr/vm/domainassembly.h
@@ -149,28 +149,6 @@ public:
 
     DomainAssembly(PEAssembly* pPEAssembly, LoaderAllocator* pLoaderAllocator, AllocMemTracker* memTracker);
 
-public:
-// ------------------------------------------------------------
-// Debugger control API
-// ------------------------------------------------------------
-
-    DebuggerAssemblyControlFlags GetDebuggerInfoBits(void)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_debuggerFlags;
-    }
-
-    void SetDebuggerInfoBits(DebuggerAssemblyControlFlags newBits)
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_debuggerFlags = newBits;
-    }
-
-    void SetupDebuggingConfig(void);
-    DWORD ComputeDebuggingConfig(void);
-
-    HRESULT GetDebuggingCustomAttributes(DWORD* pdwFlags);
-
 private:
     // ------------------------------------------------------------
     // Instance data
@@ -183,8 +161,6 @@ private:
     BOOL                        m_fCollectible;
     DomainAssembly*             m_NextDomainAssemblyInSameALC;
     PTR_LoaderAllocator         m_pLoaderAllocator;
-
-    DebuggerAssemblyControlFlags    m_debuggerFlags;
 };
 
 #endif  // _DOMAINASSEMBLY_H_


### PR DESCRIPTION
This moves the initial computation into `Assembly` and removes the flags from `DomainAssembly`. Actual consumers were already getting the flags off of `Assembly` or `Module`

cc @jkotas @AaronRobinsonMSFT 