### PR TITLE
Fix the operands of NI_AVX512F_TernaryLogic during lowering

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3901,7 +3901,7 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
                         std::swap(node->Op(1), node->Op(2));
 
                         // Make sure we also fixup the control byte
-                        control = TernaryLogicInfo::GetTernaryControlByte(info, C, A, B);
+                        control = TernaryLogicInfo::GetTernaryControlByte(info, B, C, A);
                         op4->AsIntCon()->SetIconValue(control);
 
                         useFlags = TernaryLogicUseFlags::BC;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3897,10 +3897,11 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
                     case TernaryLogicUseFlags::AB:
                     {
                         // Swap the operands here to make the containment checks in codegen significantly simpler
-                        std::swap(node->Op(1), node->Op(3));
+                        std::swap(node->Op(2), node->Op(3));
+                        std::swap(node->Op(1), node->Op(2));
 
                         // Make sure we also fixup the control byte
-                        control = TernaryLogicInfo::GetTernaryControlByte(info, C, B, A);
+                        control = TernaryLogicInfo::GetTernaryControlByte(info, C, A, B);
                         op4->AsIntCon()->SetIconValue(control);
 
                         useFlags = TernaryLogicUseFlags::BC;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3897,11 +3897,10 @@ GenTree* Lowering::LowerHWIntrinsicTernaryLogic(GenTreeHWIntrinsic* node)
                     case TernaryLogicUseFlags::AB:
                     {
                         // Swap the operands here to make the containment checks in codegen significantly simpler
-                        std::swap(node->Op(2), node->Op(3));
-                        std::swap(node->Op(1), node->Op(2));
+                        std::swap(node->Op(1), node->Op(3));
 
                         // Make sure we also fixup the control byte
-                        control = TernaryLogicInfo::GetTernaryControlByte(info, C, A, B);
+                        control = TernaryLogicInfo::GetTernaryControlByte(info, C, B, A);
                         op4->AsIntCon()->SetIconValue(control);
 
                         useFlags = TernaryLogicUseFlags::BC;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
@@ -29,6 +29,9 @@ public class Runtime_107587
     [Fact]   
     public static void TestEntryPoint()
     {
-        new Runtime_107587().Method0();
+        try
+        {
+            new Runtime_107587().Method0();
+        } catch {}
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
@@ -29,6 +29,9 @@ public class Runtime_107587
     [Fact]   
     public static void TestEntryPoint()
     {
-        new Runtime_107587().Method0();
+        if (Avx512F.IsSupported)
+        {
+            new Runtime_107587().Method0();
+        }
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+// Reduced from 20.86 KB to 1.7 KB.
+// JIT assert failed:
+// Assertion failed 'unreached' in 'Runtime_107587:Method0():this' during 'Lowering nodeinfo' (IL size 133; hash 0x46e9aa75; FullOpts)
+
+    // File: D:\a\_work\1\s\src\coreclr\jit\lowerxarch.cpp Line: 11752
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using System.Numerics;
+using Xunit;
+
+public class Runtime_107587
+{
+    public struct S2
+    {
+    }
+    static Vector256<ushort> s_v256_ushort_34 = Vector256.Create((ushort)2);
+    static Vector512<sbyte> s_v512_sbyte_42 = Vector512.Create((sbyte)92);
+    static Vector512<short> s_v512_short_43 = Vector512.Create(1, -2, -2, 0, 92, 2, 0, 1, 0, 0, 5, 1, 1, 5, 0, 1, -2, -1, 1, 5, 92, 92, -1, 5, -1, 3, 5, 0, -1, 92, 2, 5);
+    static S2 s_s2_65 = new S2();
+    Vector512<sbyte> v512_sbyte_102 = Vector512.CreateScalar((sbyte)-2);
+    Vector3 v3_122 = Vector3.UnitX;
+    private static List<string> toPrint = new List<string>();
+    public Vector512<short> Method1(Vector3 p_v3_126, S2 p_s2_127, int p_int_128, S2 p_s2_129, Vector512<sbyte> p_v512_sbyte_130, ref Vector256<ushort> p_v256_ushort_131, byte p_byte_132)
+    {
+        unchecked
+        {
+            return s_v512_short_43 -= s_v512_short_43;
+        }
+    }
+    public void Method0()
+    {
+        unchecked
+        {
+            byte byte_152 = 3;
+            int int_157 = 0;
+            S2 s2_167 = new S2();
+            s_v512_short_43 = Method1(15*4* (v3_122 += Vector3.Round(v3_122)), s_s2_65, int_157, s2_167, s_v512_sbyte_42 *= s_v512_sbyte_42 *= Avx512F.TernaryLogic(v512_sbyte_102, s_v512_sbyte_42, s_v512_sbyte_42, byte_152), ref s_v256_ushort_34, 15+4);
+            return;
+        }
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        new Runtime_107587().Method0();
+        return string.Join(Environment.NewLine, toPrint).GetHashCode();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
@@ -29,9 +29,6 @@ public class Runtime_107587
     [Fact]   
     public static void TestEntryPoint()
     {
-        try
-        {
-            new Runtime_107587().Method0();
-        } catch {}
+        new Runtime_107587().Method0();
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.cs
@@ -19,39 +19,16 @@ using Xunit;
 
 public class Runtime_107587
 {
-    public struct S2
-    {
-    }
-    static Vector256<ushort> s_v256_ushort_34 = Vector256.Create((ushort)2);
     static Vector512<sbyte> s_v512_sbyte_42 = Vector512.Create((sbyte)92);
-    static Vector512<short> s_v512_short_43 = Vector512.Create(1, -2, -2, 0, 92, 2, 0, 1, 0, 0, 5, 1, 1, 5, 0, 1, -2, -1, 1, 5, 92, 92, -1, 5, -1, 3, 5, 0, -1, 92, 2, 5);
-    static S2 s_s2_65 = new S2();
-    Vector512<sbyte> v512_sbyte_102 = Vector512.CreateScalar((sbyte)-2);
-    Vector3 v3_122 = Vector3.UnitX;
-    private static List<string> toPrint = new List<string>();
-    public Vector512<short> Method1(Vector3 p_v3_126, S2 p_s2_127, int p_int_128, S2 p_s2_129, Vector512<sbyte> p_v512_sbyte_130, ref Vector256<ushort> p_v256_ushort_131, byte p_byte_132)
+    public Vector512<sbyte> Method0()
     {
-        unchecked
-        {
-            return s_v512_short_43 -= s_v512_short_43;
-        }
+        byte byte_152 = 3;
+        return Avx512F.TernaryLogic(s_v512_sbyte_42, s_v512_sbyte_42, s_v512_sbyte_42, byte_152);
     }
-    public void Method0()
-    {
-        unchecked
-        {
-            byte byte_152 = 3;
-            int int_157 = 0;
-            S2 s2_167 = new S2();
-            s_v512_short_43 = Method1(15*4* (v3_122 += Vector3.Round(v3_122)), s_s2_65, int_157, s2_167, s_v512_sbyte_42 *= s_v512_sbyte_42 *= Avx512F.TernaryLogic(v512_sbyte_102, s_v512_sbyte_42, s_v512_sbyte_42, byte_152), ref s_v256_ushort_34, 15+4);
-            return;
-        }
-    }
-
-    [Fact]
-    public static int TestEntryPoint()
+    
+    [Fact]   
+    public static void TestEntryPoint()
     {
         new Runtime_107587().Method0();
-        return string.Join(Environment.NewLine, toPrint).GetHashCode();
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_107587/Runtime_107587.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We were not correctly translating the logical operation into control word leading to assert getting hit during containment.

Fixes: https://github.com/dotnet/runtime/issues/107587
Fixes: https://github.com/dotnet/runtime/issues/107324