### PR TITLE
Use ExtractAsciiVector helpers in Base64Url

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
@@ -675,7 +675,11 @@ namespace System.Buffers.Text
                     return false;
                 }
 
+#if NET9_0_OR_GREATER
+                str = Ascii.ExtractAsciiVector(utf16VectorLower, utf16VectorUpper).AsSByte();
+#else
                 str = Vector512.Narrow(utf16VectorLower, utf16VectorUpper).AsSByte();
+#endif
                 return true;
             }
 
@@ -699,7 +703,11 @@ namespace System.Buffers.Text
                     return false;
                 }
 
+#if NET9_0_OR_GREATER
+                str = Ascii.ExtractAsciiVector(utf16VectorLower, utf16VectorUpper).AsSByte();
+#else
                 str = Vector256.Narrow(utf16VectorLower, utf16VectorUpper).AsSByte();
+#endif
                 return true;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1677,7 +1677,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector256<byte> ExtractAsciiVector(Vector256<ushort> vectorFirst, Vector256<ushort> vectorSecond)
+        internal static Vector256<byte> ExtractAsciiVector(Vector256<ushort> vectorFirst, Vector256<ushort> vectorSecond)
         {
             return Avx2.IsSupported
                 ? PackedSpanHelpers.FixUpPackedVector256Result(Avx2.PackUnsignedSaturate(vectorFirst.AsInt16(), vectorSecond.AsInt16()))
@@ -1685,7 +1685,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector512<byte> ExtractAsciiVector(Vector512<ushort> vectorFirst, Vector512<ushort> vectorSecond)
+        internal static Vector512<byte> ExtractAsciiVector(Vector512<ushort> vectorFirst, Vector512<ushort> vectorSecond)
         {
             return Avx512BW.IsSupported
                 ? PackedSpanHelpers.FixUpPackedVector512Result(Avx512BW.PackUnsignedSaturate(vectorFirst.AsInt16(), vectorSecond.AsInt16()))


### PR DESCRIPTION
Same idea as #102735, now just using the existing helpers from `Base64Url` logic.

```c#
public class Base64UrlBenchmark
{
    private static readonly byte[] s_bytes = new byte[10_000];
    private static readonly string s_chars = new('a', 10_000);

    [Benchmark]
    public int DecodeFromChars() => Base64Url.DecodeFromChars(s_chars, s_bytes);
}
```

On Avx2, this is a clear improvement
| Method          | Toolchain | Mean     | Error   | Ratio |
|---------------- |-----------|---------:|--------:|------:|
| DecodeFromChars | main      | 491.4 ns | 2.57 ns |  1.00 |
| DecodeFromChars | pr        | 429.2 ns | 1.13 ns |  0.87 |

On Avx512, there's practically no difference on the 9950x, and a small improvement on other CPUs like in https://github.com/dotnet/runtime/pull/102735#issuecomment-2134179353.