### PR TITLE
[release/8.0] Fix a possible infinite wait for GC completion at process shutdown.

### DIFF
--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -491,7 +491,7 @@ inline bool IsAtProcessExit()
 #if defined(DACCESS_COMPILE) || !defined(HOST_WINDOWS)
     return g_fProcessDetach;
 #else
-    // RtlDllShutdownInProgress provides more accurace information about whether the process is shutting down.
+    // RtlDllShutdownInProgress provides more accurate information about whether the process is shutting down.
     // Use it if it is available to avoid shutdown deadlocks.
     // https://learn.microsoft.com/windows/win32/devnotes/rtldllshutdowninprogress
     return g_pfnRtlDllShutdownInProgress();

--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -478,12 +478,24 @@ GVAL_DECL(bool, g_metadataUpdatesApplied);
 #endif
 EXTERN bool g_fManagedAttach;
 
+#ifdef HOST_WINDOWS
+typedef BOOLEAN (WINAPI* PRTLDLLSHUTDOWNINPROGRESS)();
+EXTERN PRTLDLLSHUTDOWNINPROGRESS g_pfnRtlDllShutdownInProgress;
+#endif
+
 // Indicates whether we're executing shut down as a result of DllMain
 // (DLL_PROCESS_DETACH). See comments at code:EEShutDown for details.
-inline BOOL    IsAtProcessExit()
+inline bool IsAtProcessExit()
 {
     SUPPORTS_DAC;
+#if defined(DACCESS_COMPILE) || !defined(HOST_WINDOWS)
     return g_fProcessDetach;
+#else
+    // RtlDllShutdownInProgress provides more accurace information about whether the process is shutting down.
+    // Use it if it is available to avoid shutdown deadlocks.
+    // https://learn.microsoft.com/windows/win32/devnotes/rtldllshutdowninprogress
+    return g_pfnRtlDllShutdownInProgress();
+#endif
 }
 
 enum FWStatus

--- a/src/tests/Regressions/coreclr/GitHub_107800/test107800.cs
+++ b/src/tests/Regressions/coreclr/GitHub_107800/test107800.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static int Main()
+    {
+        Task.Run(() =>
+        {
+            for (; ; )
+            {
+                GC.Collect();
+            }
+        });
+
+        Thread.Sleep(10);
+        Environment.Exit(100);
+
+        throw new Exception("UNREACHABLE");
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_107800/test107800.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_107800/test107800.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Calls ExitProcess -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestPriority>0</CLRTestPriority>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test107800.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/107800

This is a partial/minimal port of https://github.com/dotnet/runtime/pull/103877.

Cooperative process cleanup is fragile and #103877 addresses many potential issues, however the change is not small and in parts works on top of 9.0 changes. 
This is a port of a small part of the change to address a specific scenario that is known to affect end users. 

----

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Bug was reported by internal partners. In some relatively infrequent cases a worker process may get stuck at exiting.
Such "stuck" processes could become a nuisance, especially when the memory footprint of workers is very large.

## Regression

- [x] Yes
- [ ] No

Appears to be introduced in .NET 6 as the repro scenario passes with 5.0, but deadlocks in 6.0, 8.0 and early 9.0 previews

## Testing

Added a targeted unit test. 

## Risk

Small. 
The code already tries to detect if the process is shutting down. We just use a more reliable mechanism - a new Windows API introduced in Win10 (`RtlDllShutdownInProgress`)

The main concern is that there could be other similar issues.
The 9.0 fix addresses several more patterns similar to the one involved here. They may or may not result in actual failures and there is some added risk that proactive fixing of other areas may actually break something, which we decided not to do in a servicing fix.
