### PR TITLE
Fix constraint on FrozenSet.{Try}GetAlternateLookup

### DIFF
--- a/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.net9.cs
+++ b/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.net9.cs
@@ -22,9 +22,9 @@ namespace System.Collections.Frozen
     }
     public abstract partial class FrozenSet<T>
     {
-        public System.Collections.Frozen.FrozenSet<T>.AlternateLookup<TAlternate> GetAlternateLookup<TAlternate>() { throw null; }
-        public bool TryGetAlternateLookup<TAlternate>(out System.Collections.Frozen.FrozenSet<T>.AlternateLookup<TAlternate> lookup) { throw null; }
-        public readonly partial struct AlternateLookup<TAlternate>
+        public System.Collections.Frozen.FrozenSet<T>.AlternateLookup<TAlternate> GetAlternateLookup<TAlternate>() where TAlternate : allows ref struct { throw null; }
+        public bool TryGetAlternateLookup<TAlternate>(out System.Collections.Frozen.FrozenSet<T>.AlternateLookup<TAlternate> lookup) where TAlternate : allows ref struct { throw null; }
+        public readonly partial struct AlternateLookup<TAlternate> where TAlternate : allows ref struct
         {
             private readonly object _dummy;
             private readonly int _dummyPrimitive;


### PR DESCRIPTION
Normally we would have caught this oversight immediately, as tests would have failed to compile, but unlike the vast majority of our test suites, System.Collections.Immutable's test suite references the implementation assembly rather than the ref assembly, in order to access internals via InternalsVisibleTo. Grrr. (And it seems our API compat tools aren't yet aware of `allows ref struct`? cc: @ViktorHofer )

https://github.com/dotnet/runtime/issues/107840