### PR TITLE
Fixing SetSlice, Reshape, TryCopyTo.

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -228,4 +228,7 @@
   <data name="ThrowArgument_StackShapesNotSame" xml:space="preserve">
     <value>All tensors must have the same shape.</value>
   </data>
+  <data name="Argument_CannotReshapeNonContiguousOrDense" xml:space="preserve">
+    <value>The Tensor provided is either non-contiguous or non-dense. Reshape only works with contigous and dense memory. You may need to Broadcast or Copy the data to be contigous.</value>
+  </data>
 </root>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -520,10 +520,11 @@ namespace System.Numerics.Tensors
             // Using "if (!TryCopyTo(...))" results in two branches: one for the length
             // check, and one for the result of TryCopyTo. Since these checks are equivalent,
             // we can optimize by performing the check once ourselves then calling Memmove directly.
-            if (_shape.FlattenedLength <= destination.FlattenedLength)
+            if (TensorHelpers.IsBroadcastableTo(Lengths, destination.Lengths))
             {
                 scoped Span<nint> curIndexes;
                 nint[]? curIndexesArray;
+
                 if (Rank > TensorShape.MaxInlineRank)
                 {
                     curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
@@ -532,19 +533,25 @@ namespace System.Numerics.Tensors
                 else
                 {
                     curIndexesArray = null;
-                    curIndexes = stackalloc nint[Rank];
+                    curIndexes = stackalloc nint[destination.Rank];
                 }
                 curIndexes.Clear();
 
                 nint copiedValues = 0;
-                TensorSpan<T> slice = destination.Slice(_shape.Lengths);
-                while (copiedValues < _shape.FlattenedLength)
+                nint[] tempLengths = Tensor.GetSmallestBroadcastableLengths(Lengths, destination.Lengths);
+
+                TensorSpan<T> destinationSlice = destination.Slice(tempLengths);
+                ReadOnlyTensorSpan<T> srcSlice = Tensor.LazyBroadcast(this, tempLengths);
+                nint copyLength = srcSlice.Strides[srcSlice.Rank - 1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Lengths[srcSlice.Rank - 1] : 1;
+                int indexToAdjust = srcSlice.Strides[srcSlice.Rank - 1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Rank - 2 : srcSlice.Rank - 1;
+
+                while (copiedValues < destination.FlattenedLength)
                 {
-                    TensorSpanHelpers.Memmove(ref Unsafe.Add(ref slice._reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, Strides, Lengths)), ref Unsafe.Add(ref _reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, Strides, Lengths)), Lengths[Rank - 1]);
-                    TensorSpanHelpers.AdjustIndexes(Rank - 2, 1, curIndexes, _shape.Lengths);
-                    copiedValues += Lengths[Rank - 1];
+                    TensorSpanHelpers.Memmove(ref Unsafe.Add(ref destinationSlice._reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, destinationSlice.Strides, destinationSlice.Lengths)), ref Unsafe.Add(ref srcSlice._reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, srcSlice.Strides, srcSlice.Lengths)), copyLength);
+                    TensorSpanHelpers.AdjustIndexes(indexToAdjust, 1, curIndexes, tempLengths);
+                    copiedValues += copyLength;
                 }
-                Debug.Assert(copiedValues == _shape.FlattenedLength, "Didn't copy the right amount to the array.");
+                Debug.Assert(copiedValues == destination.FlattenedLength, "Didn't copy the right amount to the array.");
 
                 if (curIndexesArray != null)
                     ArrayPool<nint>.Shared.Return(curIndexesArray);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/ReadOnlyTensorSpan.cs
@@ -527,8 +527,9 @@ namespace System.Numerics.Tensors
 
                 if (Rank > TensorShape.MaxInlineRank)
                 {
-                    curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                    curIndexes = curIndexesArray.AsSpan(0, Rank);
+                    curIndexesArray = ArrayPool<nint>.Shared.Rent(destination.Rank);
+                    curIndexes = curIndexesArray.AsSpan(0, destination.Rank);
+
                 }
                 else
                 {
@@ -542,8 +543,8 @@ namespace System.Numerics.Tensors
 
                 TensorSpan<T> destinationSlice = destination.Slice(tempLengths);
                 ReadOnlyTensorSpan<T> srcSlice = Tensor.LazyBroadcast(this, tempLengths);
-                nint copyLength = srcSlice.Strides[srcSlice.Rank - 1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Lengths[srcSlice.Rank - 1] : 1;
-                int indexToAdjust = srcSlice.Strides[srcSlice.Rank - 1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Rank - 2 : srcSlice.Rank - 1;
+                nint copyLength = srcSlice.Strides[^1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Lengths[^1] : 1;
+                int indexToAdjust = srcSlice.Strides[^1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Rank - 2 : srcSlice.Rank - 1;
 
                 while (copiedValues < destination.FlattenedLength)
                 {
@@ -575,32 +576,40 @@ namespace System.Numerics.Tensors
         {
             bool retVal = false;
 
-            if (_shape.FlattenedLength <= destination.FlattenedLength)
+            if (TensorHelpers.IsBroadcastableTo(Lengths, destination.Lengths))
             {
                 scoped Span<nint> curIndexes;
                 nint[]? curIndexesArray;
+
                 if (Rank > TensorShape.MaxInlineRank)
                 {
-                    curIndexesArray = ArrayPool<nint>.Shared.Rent(Rank);
-                    curIndexes = curIndexesArray.AsSpan(0, Rank);
+                    curIndexesArray = ArrayPool<nint>.Shared.Rent(destination.Rank);
+                    curIndexes = curIndexesArray.AsSpan(0, destination.Rank);
+
                 }
                 else
                 {
                     curIndexesArray = null;
-                    curIndexes = stackalloc nint[Rank];
+                    curIndexes = stackalloc nint[destination.Rank];
                 }
                 curIndexes.Clear();
 
                 nint copiedValues = 0;
-                TensorSpan<T> slice = destination.Slice(_shape.Lengths);
-                while (copiedValues < _shape.FlattenedLength)
+                nint[] tempLengths = Tensor.GetSmallestBroadcastableLengths(Lengths, destination.Lengths);
+
+                TensorSpan<T> destinationSlice = destination.Slice(tempLengths);
+                ReadOnlyTensorSpan<T> srcSlice = Tensor.LazyBroadcast(this, tempLengths);
+                nint copyLength = srcSlice.Strides[^1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Lengths[^1] : 1;
+                int indexToAdjust = srcSlice.Strides[^1] == 1 && TensorHelpers.IsContiguousAndDense(srcSlice) ? srcSlice.Rank - 2 : srcSlice.Rank - 1;
+
+                while (copiedValues < destination.FlattenedLength)
                 {
-                    TensorSpanHelpers.Memmove(ref Unsafe.Add(ref slice._reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, Strides, Lengths)), ref Unsafe.Add(ref _reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, Strides, Lengths)), Lengths[Rank - 1]);
-                    TensorSpanHelpers.AdjustIndexes(Rank - 2, 1, curIndexes, _shape.Lengths);
-                    copiedValues += Lengths[Rank - 1];
+                    TensorSpanHelpers.Memmove(ref Unsafe.Add(ref destinationSlice._reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, destinationSlice.Strides, destinationSlice.Lengths)), ref Unsafe.Add(ref srcSlice._reference, TensorSpanHelpers.ComputeLinearIndex(curIndexes, srcSlice.Strides, srcSlice.Lengths)), copyLength);
+                    TensorSpanHelpers.AdjustIndexes(indexToAdjust, 1, curIndexes, tempLengths);
+                    copiedValues += copyLength;
                 }
+                Debug.Assert(copiedValues == destination.FlattenedLength, "Didn't copy the right amount to the array.");
                 retVal = true;
-                Debug.Assert(copiedValues == _shape.FlattenedLength, "Didn't copy the right amount to the array.");
 
                 if (curIndexesArray != null)
                     ArrayPool<nint>.Shared.Return(curIndexesArray);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -2724,6 +2724,11 @@ namespace System.Numerics.Tensors
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
         public static Tensor<T> Reshape<T>(this Tensor<T> tensor, params ReadOnlySpan<nint> lengths)
         {
+            if (!TensorHelpers.IsContiguousAndDense<T>(tensor) && !tensor.Strides.Contains(0))
+            {
+                ThrowHelper.ThrowArgument_CannotReshapeNonContiguousOrDense();
+            }
+
             nint[] arrLengths = lengths.ToArray();
             // Calculate wildcard info.
             if (lengths.Contains(-1))
@@ -2745,7 +2750,33 @@ namespace System.Numerics.Tensors
             nint tempLinear = TensorSpanHelpers.CalculateTotalLength(arrLengths);
             if (tempLinear != tensor.FlattenedLength)
                 ThrowHelper.ThrowArgument_InvalidReshapeDimensions();
-            nint[] strides = TensorSpanHelpers.CalculateStrides(arrLengths);
+
+            nint[] strides;
+
+            // If we contain a 0 stride we can only add dimensions of length 1.
+            if (tensor.Strides.Contains(0))
+            {
+                List<nint> origStrides = new List<nint>(tensor.Strides.ToArray());
+                int lengthOffset = 0;
+                for (int i = 0; i < arrLengths.Length; i++)
+                {
+                    if (lengthOffset < tensor.Rank && arrLengths[i] == tensor.Lengths[lengthOffset])
+                        lengthOffset++;
+                    else if (arrLengths[i] == 1)
+                    {
+                        if (lengthOffset == tensor.Rank)
+                            origStrides.Add(tensor.Strides[lengthOffset - 1]);
+                        else
+                            origStrides.Insert(i, tensor.Strides[i] * tensor.Lengths[i]);
+                    }
+                    else
+                        ThrowHelper.ThrowArgument_InvalidReshapeDimensions();
+                }
+                strides = origStrides.ToArray();
+            }
+            else
+                strides = TensorSpanHelpers.CalculateStrides(arrLengths);
+
             return new Tensor<T>(tensor._values, arrLengths, strides);
         }
 
@@ -2758,6 +2789,11 @@ namespace System.Numerics.Tensors
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
         public static TensorSpan<T> Reshape<T>(in this TensorSpan<T> tensor, params scoped ReadOnlySpan<nint> lengths)
         {
+            if (!TensorHelpers.IsContiguousAndDense<T>(tensor) && !tensor.Strides.Contains(0))
+            {
+                ThrowHelper.ThrowArgument_CannotReshapeNonContiguousOrDense();
+            }
+
             nint[] arrLengths = lengths.ToArray();
             // Calculate wildcard info.
             if (lengths.Contains(-1))
@@ -2779,7 +2815,33 @@ namespace System.Numerics.Tensors
             nint tempLinear = TensorSpanHelpers.CalculateTotalLength(arrLengths);
             if (tempLinear != tensor.FlattenedLength)
                 ThrowHelper.ThrowArgument_InvalidReshapeDimensions();
-            nint[] strides = TensorSpanHelpers.CalculateStrides(arrLengths);
+
+            nint[] strides;
+
+            // If we contain a 0 stride we can only add dimensions of length 1.
+            if (tensor.Strides.Contains(0))
+            {
+                List<nint> origStrides = new List<nint>(tensor.Strides.ToArray());
+                int lengthOffset = 0;
+                for (int i = 0; i < arrLengths.Length; i++)
+                {
+                    if (lengthOffset < tensor.Rank && arrLengths[i] == tensor.Lengths[lengthOffset])
+                        lengthOffset++;
+                    else if (arrLengths[i] == 1)
+                    {
+                        if (lengthOffset == tensor.Rank)
+                            origStrides.Add(tensor.Strides[lengthOffset - 1]);
+                        else
+                            origStrides.Insert(i, tensor.Strides[i] * tensor.Lengths[i]);
+                    }
+                    else
+                        ThrowHelper.ThrowArgument_InvalidReshapeDimensions();
+                }
+                strides = origStrides.ToArray();
+            }
+            else
+                strides = TensorSpanHelpers.CalculateStrides(arrLengths);
+
             TensorSpan<T> output = new TensorSpan<T>(ref tensor._reference, arrLengths, strides, tensor._shape._memoryLength);
             return output;
         }
@@ -2793,6 +2855,11 @@ namespace System.Numerics.Tensors
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
         public static ReadOnlyTensorSpan<T> Reshape<T>(in this ReadOnlyTensorSpan<T> tensor, params scoped ReadOnlySpan<nint> lengths)
         {
+            if (!TensorHelpers.IsContiguousAndDense<T>(tensor) && !tensor.Strides.Contains(0))
+            {
+                ThrowHelper.ThrowArgument_CannotReshapeNonContiguousOrDense();
+            }
+
             nint[] arrLengths = lengths.ToArray();
             // Calculate wildcard info.
             if (lengths.Contains(-1))
@@ -2814,7 +2881,33 @@ namespace System.Numerics.Tensors
             nint tempLinear = TensorSpanHelpers.CalculateTotalLength(arrLengths);
             if (tempLinear != tensor.FlattenedLength)
                 ThrowHelper.ThrowArgument_InvalidReshapeDimensions();
-            nint[] strides = TensorSpanHelpers.CalculateStrides(arrLengths);
+
+            nint[] strides;
+
+            // If we contain a 0 stride we can only add dimensions of length 1.
+            if (tensor.Strides.Contains(0))
+            {
+                List<nint> origStrides = new List<nint>(tensor.Strides.ToArray());
+                int lengthOffset = 0;
+                for (int i = 0; i < arrLengths.Length; i++)
+                {
+                    if (lengthOffset < tensor.Rank && arrLengths[i] == tensor.Lengths[lengthOffset])
+                        lengthOffset++;
+                    else if (arrLengths[i] == 1)
+                    {
+                        if (lengthOffset == tensor.Rank)
+                            origStrides.Add(tensor.Strides[lengthOffset - 1]);
+                        else
+                            origStrides.Insert(i, tensor.Strides[i] * tensor.Lengths[i]);
+                    }
+                    else
+                        ThrowHelper.ThrowArgument_InvalidReshapeDimensions();
+                }
+                strides = origStrides.ToArray();
+            }
+            else
+                strides = TensorSpanHelpers.CalculateStrides(arrLengths);
+
             ReadOnlyTensorSpan<T> output = new ReadOnlyTensorSpan<T>(ref tensor._reference, arrLengths, strides, tensor._shape._memoryLength);
             return output;
         }
@@ -3053,14 +3146,17 @@ namespace System.Numerics.Tensors
             TensorSpan<T> srcSpan;
             if (ranges == ReadOnlySpan<NRange>.Empty)
             {
-                if (!tensor.Lengths.SequenceEqual(values.Lengths))
+                if (!TensorHelpers.IsBroadcastableTo(values.Lengths, tensor.Lengths))
                     ThrowHelper.ThrowArgument_SetSliceNoRange(nameof(values));
-                srcSpan = tensor.Slice(tensor.Lengths);
+                srcSpan = tensor;
             }
             else
                 srcSpan = tensor.Slice(ranges);
 
-            if (!srcSpan.Lengths.SequenceEqual(values.Lengths))
+            if (!TensorHelpers.IsContiguousAndDense<T>(srcSpan))
+                ThrowHelper.ThrowArgument_SetSliceInvalidShapes(nameof(values));
+
+            if (!TensorHelpers.IsBroadcastableTo(values.Lengths, srcSpan.Lengths))
                 ThrowHelper.ThrowArgument_SetSliceInvalidShapes(nameof(values));
 
             values.CopyTo(srcSpan);
@@ -3555,8 +3651,13 @@ namespace System.Numerics.Tensors
 
             List<nint> tempLengths = tensor._lengths.ToList();
             tempLengths.Insert(dimension, 1);
-            nint[] lengths = tempLengths.ToArray();
-            nint[] strides = TensorSpanHelpers.CalculateStrides(lengths);
+            nint[] lengths = [.. tempLengths];
+            List<nint> tempStrides = tensor.Strides.ToArray().ToList();
+            if (dimension == tensor.Rank)
+                tempStrides.Add(tensor.Strides[dimension - 1]);
+            else
+                tempStrides.Insert(dimension, tensor.Strides[dimension] * tensor.Lengths[dimension]);
+            nint[] strides = [.. tempStrides];
             return new Tensor<T>(tensor._values, lengths, strides);
         }
 
@@ -3574,8 +3675,13 @@ namespace System.Numerics.Tensors
 
             List<nint> tempLengths = tensor.Lengths.ToArray().ToList();
             tempLengths.Insert(dimension, 1);
-            nint[] lengths = tempLengths.ToArray();
-            nint[] strides = TensorSpanHelpers.CalculateStrides(lengths);
+            nint[] lengths = [.. tempLengths];
+            List<nint> tempStrides = tensor.Strides.ToArray().ToList();
+            if (dimension == tensor.Rank)
+                tempStrides.Add(tensor.Strides[dimension - 1]);
+            else
+                tempStrides.Insert(dimension, tensor.Strides[dimension] * tensor.Lengths[dimension]);
+            nint[] strides = [.. tempStrides];
             return new TensorSpan<T>(ref tensor._reference, lengths, strides, tensor._shape._memoryLength);
         }
 
@@ -3593,8 +3699,13 @@ namespace System.Numerics.Tensors
 
             List<nint> tempLengths = tensor.Lengths.ToArray().ToList();
             tempLengths.Insert(dimension, 1);
-            nint[] lengths = tempLengths.ToArray();
-            nint[] strides = TensorSpanHelpers.CalculateStrides(lengths);
+            nint[] lengths = [.. tempLengths];
+            List<nint> tempStrides = tensor.Strides.ToArray().ToList();
+            if (dimension == tensor.Rank)
+                tempStrides.Add(tensor.Strides[dimension - 1]);
+            else
+                tempStrides.Insert(dimension, tensor.Strides[dimension] * tensor.Lengths[dimension]);
+            nint[] strides = [.. tempStrides];
             return new ReadOnlyTensorSpan<T>(ref tensor._reference, lengths, strides, tensor._shape._memoryLength);
         }
         #endregion

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -2724,6 +2724,9 @@ namespace System.Numerics.Tensors
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
         public static Tensor<T> Reshape<T>(this Tensor<T> tensor, params ReadOnlySpan<nint> lengths)
         {
+            if (tensor.Lengths.SequenceEqual(lengths))
+                return tensor;
+
             if (!TensorHelpers.IsContiguousAndDense<T>(tensor) && !tensor.Strides.Contains(0))
             {
                 ThrowHelper.ThrowArgument_CannotReshapeNonContiguousOrDense();
@@ -2789,6 +2792,9 @@ namespace System.Numerics.Tensors
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
         public static TensorSpan<T> Reshape<T>(in this TensorSpan<T> tensor, params scoped ReadOnlySpan<nint> lengths)
         {
+            if (tensor.Lengths.SequenceEqual(lengths))
+                return tensor;
+
             if (!TensorHelpers.IsContiguousAndDense<T>(tensor) && !tensor.Strides.Contains(0))
             {
                 ThrowHelper.ThrowArgument_CannotReshapeNonContiguousOrDense();
@@ -2855,6 +2861,9 @@ namespace System.Numerics.Tensors
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
         public static ReadOnlyTensorSpan<T> Reshape<T>(in this ReadOnlyTensorSpan<T> tensor, params scoped ReadOnlySpan<nint> lengths)
         {
+            if (tensor.Lengths.SequenceEqual(lengths))
+                return tensor;
+
             if (!TensorHelpers.IsContiguousAndDense<T>(tensor) && !tensor.Strides.Contains(0))
             {
                 ThrowHelper.ThrowArgument_CannotReshapeNonContiguousOrDense();

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -2832,7 +2832,9 @@ namespace System.Numerics.Tensors
                 for (int i = 0; i < arrLengths.Length; i++)
                 {
                     if (lengthOffset < tensor.Rank && arrLengths[i] == tensor.Lengths[lengthOffset])
+                    {
                         lengthOffset++;
+                    }
                     else if (arrLengths[i] == 1)
                     {
                         if (lengthOffset == tensor.Rank)

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorHelpers.cs
@@ -59,7 +59,7 @@ namespace System.Numerics.Tensors
                 else
                     s2 = lengths2[lengths2Index--];
 
-                if (s1 == s2 || (s1 == 1 && s2 != 1) || (s2 == 1 && s1 != 1)) { }
+                if (s1 == s2 || (s1 == 1 && s2 > 1) || (s2 == 1 && s1 > 1)) { }
                 else
                 {
                     areCompatible = false;

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorHelpers.cs
@@ -43,6 +43,9 @@ namespace System.Numerics.Tensors
             nint s1;
             nint s2;
 
+            if (lengths1.Length == 0 || lengths2.Length == 0)
+                return false;
+
             while (lengths1Index >= 0 || lengths2Index >= 0)
             {
                 // if a dimension is missing in one of the shapes, it is considered to be 1

--- a/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
@@ -222,5 +222,11 @@ namespace System
         {
             throw new ArgumentException(SR.ThrowArgument_StackShapesNotSame);
         }
+
+        [DoesNotReturn]
+        internal static void ThrowArgument_CannotReshapeNonContiguousOrDense()
+        {
+            throw new ArgumentException(SR.Argument_CannotReshapeNonContiguousOrDense);
+        }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
@@ -940,23 +940,7 @@ namespace System.Numerics.Tensors.Tests
             leftSpan = leftData.AsTensorSpan(9);
             rightSpan = rightData.AsTensorSpan(15);
             success = leftSpan.TryCopyTo(rightSpan);
-            leftEnum = leftSpan.GetEnumerator();
-            rightEnum = rightSpan.GetEnumerator();
-            Assert.True(success);
-            // Make sure the first 9 spots are equal after copy
-            while (leftEnum.MoveNext() && rightEnum.MoveNext())
-            {
-                Assert.Equal(leftEnum.Current, rightEnum.Current);
-            }
-            // The rest of the slots shouldn't have been touched.
-            while (rightEnum.MoveNext())
-            {
-                Assert.Equal(0, rightEnum.Current);
-            }
-
-            //Make sure its a copy
-            rightSpan[0] = 100;
-            Assert.NotEqual(leftSpan[0], rightSpan[0]);
+            Assert.False(success);
 
             leftData = [.. Enumerable.Range(0, 27)];
             rightData = [.. Enumerable.Range(0, 27)];

--- a/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/ReadOnlyTensorSpanTests.cs
@@ -885,27 +885,16 @@ namespace System.Numerics.Tensors.Tests
             rightSpan[0, 0] = 100;
             Assert.NotEqual(leftSpan[0, 0], rightSpan[0, 0]);
 
-            leftData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-            rightData = new int[15];
-            leftSpan = leftData.AsTensorSpan(9);
-            rightSpan = rightData.AsTensorSpan(15);
-            leftSpan.CopyTo(rightSpan);
-            leftEnum = leftSpan.GetEnumerator();
-            rightEnum = rightSpan.GetEnumerator();
-            // Make sure the first 9 spots are equal after copy
-            while (leftEnum.MoveNext() && rightEnum.MoveNext())
+            // Can't copy if data is not same shape or broadcastable to.
+            Assert.Throws<ArgumentException>(() =>
             {
-                Assert.Equal(leftEnum.Current, rightEnum.Current);
+                leftData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+                rightData = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+                TensorSpan<int> leftSpan = leftData.AsTensorSpan(9);
+                TensorSpan<int> tensor = rightData.AsTensorSpan(rightData.Length);
+                leftSpan.CopyTo(tensor);
             }
-            // The rest of the slots shouldn't have been touched.
-            while (rightEnum.MoveNext())
-            {
-                Assert.Equal(0, rightEnum.Current);
-            }
-
-            //Make sure its a copy
-            rightSpan[0] = 100;
-            Assert.NotEqual(leftSpan[0], rightSpan[0]);
+            );
 
             leftData = [.. Enumerable.Range(0, 27)];
             rightData = [.. Enumerable.Range(0, 27)];
@@ -984,6 +973,9 @@ namespace System.Numerics.Tensors.Tests
             var l = leftData.AsTensorSpan(3, 3, 3);
             var r = new TensorSpan<int>();
             success = l.TryCopyTo(r);
+            Assert.False(success);
+
+            success = new ReadOnlyTensorSpan<double>(new double[1]).TryCopyTo(Array.Empty<double>());
             Assert.False(success);
         }
 

--- a/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
@@ -556,6 +556,60 @@ namespace System.Numerics.Tensors.Tests
         #endregion
 
         [Fact]
+        public static unsafe void TensorSpanSetSliceTests()
+        {
+            // Cannot reshape if memory is non-contiguous or non-dense
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var ab = new TensorSpan<double>(array: [0d, 1, 2, 3]);  // [0, 1, 2, 3]
+                var b = ab.Reshape(lengths: new IntPtr[] { 2, 2 });  // [[0, 1], [2, 3]]
+                var c = b.Slice(ranges: new NRange[] { ..2, ..1 });  // [[0], [2]]
+                c.Reshape(lengths: new IntPtr[] { 2, 1 });
+            });
+
+            // Make sure even if the Lengths are the same that the underlying memory has to be the same.
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var ar = new double[1];
+                var a = new TensorSpan<double>(ar.AsSpan()[..1], new IntPtr[] { 2 }, new IntPtr[] { 0 });
+                a.SetSlice(new TensorSpan<double>(new double[] { 1, 3 }), new NRange[] { ..2 });
+            });
+
+            // Make sure that slice range and the values are the same length
+            var ar = new double[4];
+            var a = new TensorSpan<double>(ar, new IntPtr[] { 2, 2 }, default);
+
+            a.SetSlice(new TensorSpan<double>(new double[] { 1, 3 }), new NRange[] { ..1, .. });
+            Assert.Equal(1, a[0, 0]);
+            Assert.Equal(3, a[0, 1]);
+            Assert.Equal(0, a[1, 0]);
+            Assert.Equal(0, a[1, 1]);
+
+            // Make sure we can use a stride of 0.
+            a.SetSlice(new TensorSpan<double>(new double[] { -1 }, [2], [0]), new NRange[] { 1.., .. });
+            Assert.Equal(1, a[0, 0]);
+            Assert.Equal(3, a[0, 1]);
+            Assert.Equal(-1, a[1, 0]);
+            Assert.Equal(-1, a[1, 1]);
+
+            // Make sure we can use a multi dimensional span with multiple 0 strides
+            a.SetSlice(new TensorSpan<double>(new double[] { -10 }, [2, 2], [0, 0]));
+            Assert.Equal(-10, a[0, 0]);
+            Assert.Equal(-10, a[0, 1]);
+            Assert.Equal(-10, a[1, 0]);
+            Assert.Equal(-10, a[1, 1]);
+
+            // Make sure if the slice is broadcastable to the correct size you don't need to set a size for SetSlice
+            a.SetSlice(new TensorSpan<double>(new double[] { -20 }, [1], [0]));
+            Assert.Equal(-20, a[0, 0]);
+            Assert.Equal(-20, a[0, 1]);
+            Assert.Equal(-20, a[1, 0]);
+            Assert.Equal(-20, a[1, 1]);
+
+            //Assert.Throws
+        }
+
+        [Fact]
         public static void TensorSpanSystemArrayConstructorTests()
         {
             // When using System.Array constructor make sure the type of the array matches T[]
@@ -1611,27 +1665,16 @@ namespace System.Numerics.Tensors.Tests
             leftSpan[0, 0] = 100;
             Assert.NotEqual(leftSpan[0, 0], rightSpan[0, 0]);
 
-            leftData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-            rightData = new int[15];
-            leftSpan = leftData.AsTensorSpan(9);
-            rightSpan = rightData.AsTensorSpan(15);
-            leftSpan.CopyTo(rightSpan);
-            leftEnum = leftSpan.GetEnumerator();
-            rightEnum = rightSpan.GetEnumerator();
-            // Make sure the first 9 spots are equal after copy
-            while (leftEnum.MoveNext() && rightEnum.MoveNext())
-            {
-                Assert.Equal(leftEnum.Current, rightEnum.Current);
-            }
-            // The rest of the slots shouldn't have been touched.
-            while(rightEnum.MoveNext())
-            {
-                Assert.Equal(0, rightEnum.Current);
-            }
-
-            //Make sure its a copy
-            leftSpan[0] = 100;
-            Assert.NotEqual(leftSpan[0], rightSpan[0]);
+            // Can't copy if data is not same shape or broadcastable to.
+            Assert.Throws<ArgumentException>(() =>
+                {
+                    leftData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+                    rightData = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+                    TensorSpan<int> leftSpan = leftData.AsTensorSpan(9);
+                    TensorSpan<int> tensor = rightData.AsTensorSpan(rightData.Length);
+                    leftSpan.CopyTo(tensor);
+                }
+            );
 
             leftData = [.. Enumerable.Range(0, 27)];
             rightData = [.. Enumerable.Range(0, 27)];
@@ -1710,6 +1753,9 @@ namespace System.Numerics.Tensors.Tests
             var l = leftData.AsTensorSpan(3, 3, 3);
             var r = new TensorSpan<int>();
             success = l.TryCopyTo(r);
+            Assert.False(success);
+
+            success = new TensorSpan<double>(new double[1]).TryCopyTo(Array.Empty<double>());
             Assert.False(success);
         }
 

--- a/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
@@ -1720,23 +1720,8 @@ namespace System.Numerics.Tensors.Tests
             leftSpan = leftData.AsTensorSpan(9);
             rightSpan = rightData.AsTensorSpan(15);
             success = leftSpan.TryCopyTo(rightSpan);
-            leftEnum = leftSpan.GetEnumerator();
-            rightEnum = rightSpan.GetEnumerator();
-            Assert.True(success);
-            // Make sure the first 9 spots are equal after copy
-            while (leftEnum.MoveNext() && rightEnum.MoveNext())
-            {
-                Assert.Equal(leftEnum.Current, rightEnum.Current);
-            }
-            // The rest of the slots shouldn't have been touched.
-            while (rightEnum.MoveNext())
-            {
-                Assert.Equal(0, rightEnum.Current);
-            }
 
-            //Make sure its a copy
-            leftSpan[0] = 100;
-            Assert.NotEqual(leftSpan[0], rightSpan[0]);
+            Assert.False(success);
 
             leftData = [.. Enumerable.Range(0, 27)];
             rightData = [.. Enumerable.Range(0, 27)];

--- a/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
@@ -561,10 +561,10 @@ namespace System.Numerics.Tensors.Tests
             // Cannot reshape if memory is non-contiguous or non-dense
             Assert.Throws<ArgumentException>(() =>
             {
-                var ab = new TensorSpan<double>(array: [0d, 1, 2, 3]);  // [0, 1, 2, 3]
-                var b = ab.Reshape(lengths: new IntPtr[] { 2, 2 });  // [[0, 1], [2, 3]]
-                var c = b.Slice(ranges: new NRange[] { ..2, ..1 });  // [[0], [2]]
-                c.Reshape(lengths: new IntPtr[] { 2, 1 });
+                var ab = new TensorSpan<double>(array: [0d, 1, 2, 3, 0d, 1, 2, 3]);  // [0, 1, 2, 3]
+                var b = ab.Reshape(lengths: new IntPtr[] { 2, 2, 2 });  // [[0, 1], [2, 3]]
+                var c = b.Slice(ranges: new NRange[] { 1.., 1..2, ..1 });  // [[0], [2]]
+                c.Reshape(lengths: new IntPtr[] { 1, 2, 1 });
             });
 
             // Make sure even if the Lengths are the same that the underlying memory has to be the same.

--- a/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
@@ -1788,23 +1788,16 @@ namespace System.Numerics.Tensors.Tests
             Assert.NotEqual(leftSpan[0, 0], rightSpan[0, 0]);
             Assert.NotEqual(leftSpan[0, 0], tensor[0, 0]);
 
-            leftData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-            dims = [15];
-            leftSpan = leftData.AsTensorSpan(9);
-            tensor = Tensor.Create<int>(dims.AsSpan(), false);
-            leftSpan.CopyTo(tensor);
-            leftEnum = leftSpan.GetEnumerator();
-            tensorEnum = tensor.GetEnumerator();
-            // Make sure the first 9 spots are equal after copy
-            while (leftEnum.MoveNext() && tensorEnum.MoveNext())
-            {
-                Assert.Equal(leftEnum.Current, tensorEnum.Current);
-            }
-            // The rest of the slots shouldn't have been touched.
-            while (tensorEnum.MoveNext())
-            {
-                Assert.Equal(0, tensorEnum.Current);
-            }
+            // Can't copy if data is not same shape or broadcastable to.
+            Assert.Throws<ArgumentException>(() =>
+                {
+                    leftData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+                    dims = [15];
+                    TensorSpan<int> leftSpan = leftData.AsTensorSpan(9);
+                    tensor = Tensor.Create<int>(dims.AsSpan(), false);
+                    leftSpan.CopyTo(tensor);
+                }
+            );
 
             Assert.Throws<ArgumentException>(() =>
             {
@@ -1867,6 +1860,9 @@ namespace System.Numerics.Tensors.Tests
             success = l.TryCopyTo(tensor);
             Assert.False(success);
             success = tensor.TryCopyTo(r);
+            Assert.False(success);
+
+            success = new TensorSpan<double>(new double[1]).TryCopyTo(Array.Empty<double>());
             Assert.False(success);
         }
 
@@ -2034,6 +2030,32 @@ namespace System.Numerics.Tensors.Tests
             Assert.Equal(9, tensor[2, 2]);
 
             Assert.Throws<ArgumentException>(() => Tensor.Reshape(tensor, [1, 2, 3, 4, 5]));
+
+            // Make sure reshape works correctly with 0 strides.
+            tensor = Tensor.Create<int>((ReadOnlySpan<nint>)[2], [0], false);
+            tensor = Tensor.Reshape(tensor, [1, 2]);
+            Assert.Equal(2, tensor.Rank);
+            Assert.Equal(1, tensor.Lengths[0]);
+            Assert.Equal(2, tensor.Lengths[1]);
+            Assert.Equal(0, tensor.Strides[0]);
+            Assert.Equal(0, tensor.Strides[1]);
+
+            tensor = Tensor.Create<int>((ReadOnlySpan<nint>)[2], [0], false);
+            tensor = Tensor.Reshape(tensor, [2, 1]);
+            Assert.Equal(2, tensor.Rank);
+            Assert.Equal(2, tensor.Lengths[0]);
+            Assert.Equal(1, tensor.Lengths[1]);
+            Assert.Equal(0, tensor.Strides[0]);
+            Assert.Equal(0, tensor.Strides[1]);
+
+            tensor = Tensor.Reshape(tensor, [1, 2, 1]);
+            Assert.Equal(3, tensor.Rank);
+            Assert.Equal(1, tensor.Lengths[0]);
+            Assert.Equal(2, tensor.Lengths[1]);
+            Assert.Equal(1, tensor.Lengths[2]);
+            Assert.Equal(0, tensor.Strides[0]);
+            Assert.Equal(0, tensor.Strides[1]);
+            Assert.Equal(0, tensor.Strides[2]);
         }
 
         [Fact]
@@ -2098,14 +2120,45 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public static void TensorUnsqueezeTest()
         {
-            var tensor = Tensor.Create<int>([2], false);
+            var tensor = Tensor.Create<int>((ReadOnlySpan<nint>)[2], [0], false);
+            tensor = Tensor.Unsqueeze(tensor, 0);
+            Assert.Equal(2, tensor.Rank);
+            Assert.Equal(1, tensor.Lengths[0]);
+            Assert.Equal(2, tensor.Lengths[1]);
+            Assert.Equal(0, tensor.Strides[0]);
+            Assert.Equal(0, tensor.Strides[1]);
+
+            tensor = Tensor.Create<int>([2], false);
             Assert.Equal(1, tensor.Rank);
             Assert.Equal(2, tensor.Lengths[0]);
+            Assert.Equal(1, tensor.Strides[0]);
 
             tensor = Tensor.Unsqueeze(tensor, 0);
             Assert.Equal(2, tensor.Rank);
             Assert.Equal(1, tensor.Lengths[0]);
             Assert.Equal(2, tensor.Lengths[1]);
+            Assert.Equal(2, tensor.Strides[0]);
+            Assert.Equal(1, tensor.Strides[1]);
+
+            tensor = Tensor.Unsqueeze(tensor, 0);
+            Assert.Equal(3, tensor.Rank);
+            Assert.Equal(1, tensor.Lengths[0]);
+            Assert.Equal(1, tensor.Lengths[1]);
+            Assert.Equal(2, tensor.Lengths[2]);
+            Assert.Equal(2, tensor.Strides[0]);
+            Assert.Equal(2, tensor.Strides[1]);
+            Assert.Equal(1, tensor.Strides[2]);
+
+            tensor = Tensor.Unsqueeze(tensor, 0);
+            Assert.Equal(4, tensor.Rank);
+            Assert.Equal(1, tensor.Lengths[0]);
+            Assert.Equal(1, tensor.Lengths[1]);
+            Assert.Equal(1, tensor.Lengths[2]);
+            Assert.Equal(2, tensor.Lengths[3]);
+            Assert.Equal(2, tensor.Strides[0]);
+            Assert.Equal(2, tensor.Strides[1]);
+            Assert.Equal(2, tensor.Strides[2]);
+            Assert.Equal(1, tensor.Strides[3]);
 
             tensor = Tensor.Create<int>([2], false);
             Assert.Equal(1, tensor.Rank);

--- a/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
@@ -1838,19 +1838,7 @@ namespace System.Numerics.Tensors.Tests
             leftSpan = leftData.AsTensorSpan(9);
             tensor = Tensor.Create<int>(dims.AsSpan(), false);
             success = leftSpan.TryCopyTo(tensor);
-            leftEnum = leftSpan.GetEnumerator();
-            tensorEnum = tensor.GetEnumerator();
-            Assert.True(success);
-            // Make sure the first 9 spots are equal after copy
-            while (leftEnum.MoveNext() && tensorEnum.MoveNext())
-            {
-                Assert.Equal(leftEnum.Current, tensorEnum.Current);
-            }
-            // The rest of the slots shouldn't have been touched.
-            while (tensorEnum.MoveNext())
-            {
-                Assert.Equal(0, tensorEnum.Current);
-            }
+            Assert.False(success);
 
             leftData = [.. Enumerable.Range(0, 27)];
             var l = leftData.AsTensorSpan(3, 3, 3);


### PR DESCRIPTION
Fixes #106539, #106537, and #106535.

They all had to go in one PR as they were all connected, but basically fixes Reshape/SetSlice to work with 0 strides. Also adds a few more checks to make sure its ok to Reshape the values.