### PR TITLE
instrumentation (mostly) for DATAS

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -26684,6 +26684,7 @@ void gc_heap::add_to_hc_history_worker (hc_history* hist, int* current_index, hc
     current_hist->concurrent_p = (bool)settings.concurrent;
     current_hist->bgc_thread_running = (bool)bgc_thread_running;
 
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(_DEBUG)
     int bgc_thread_os_id = 0;
 
     if (bgc_thread)
@@ -26692,6 +26693,7 @@ void gc_heap::add_to_hc_history_worker (hc_history* hist, int* current_index, hc
     }
 
     current_hist->bgc_thread_os_id = bgc_thread_os_id;
+#endif //TARGET_AMD64 && TARGET_WINDOWS && !_DEBUG
 #endif //BACKGROUND_GC
 
     *current_index  = (*current_index + 1) % max_hc_history_count;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -783,9 +783,10 @@ public:
         return join_struct.n_threads;
     }
 
+    // This is for instrumentation only.
     int get_join_lock()
     {
-        return join_struct.join_lock;
+        return VolatileLoadWithoutBarrier (&join_struct.join_lock);
     }
 
     void destroy ()
@@ -2425,7 +2426,7 @@ last_recorded_gc_info gc_heap::last_full_blocking_gc_info;
 
 uint64_t    gc_heap::last_alloc_reset_suspended_end_time = 0;
 size_t      gc_heap::max_peak_heap_size = 0;
-size_t      gc_heap::llc_size = 0;
+VOLATILE(size_t) gc_heap::llc_size = 0;
 
 #ifdef BACKGROUND_GC
 last_recorded_gc_info gc_heap::last_bgc_info[2];

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -783,6 +783,11 @@ public:
         return join_struct.n_threads;
     }
 
+    int get_join_lock()
+    {
+        return join_struct.join_lock;
+    }
+
     void destroy ()
     {
         dprintf (JOIN_LOG, ("Destroying join structure"));
@@ -2420,12 +2425,27 @@ last_recorded_gc_info gc_heap::last_full_blocking_gc_info;
 
 uint64_t    gc_heap::last_alloc_reset_suspended_end_time = 0;
 size_t      gc_heap::max_peak_heap_size = 0;
+size_t      gc_heap::llc_size = 0;
 
 #ifdef BACKGROUND_GC
 last_recorded_gc_info gc_heap::last_bgc_info[2];
 VOLATILE(bool)        gc_heap::is_last_recorded_bgc = false;
 VOLATILE(int)         gc_heap::last_bgc_info_index = 0;
 #endif //BACKGROUND_GC
+
+#ifdef DYNAMIC_HEAP_COUNT
+size_t      gc_heap::hc_change_cancelled_count_prep = 0;
+#ifdef BACKGROUND_GC
+int         gc_heap::bgc_th_creation_hist_index = 0;
+gc_heap::bgc_thread_creation_history gc_heap::bgc_th_creation_hist[max_bgc_thread_creation_count];
+size_t      gc_heap::bgc_th_count_created = 0;
+size_t      gc_heap::bgc_th_count_created_th_existed = 0;
+size_t      gc_heap::bgc_th_count_creation_failed = 0;
+size_t      gc_heap::bgc_init_gc_index = 0;
+VOLATILE(short) gc_heap::bgc_init_n_heaps = 0;
+size_t      gc_heap::hc_change_cancelled_count_bgc = 0;
+#endif //BACKGROUND_GC
+#endif //DYNAMIC_HEAP_COUNT
 
 #if defined(HOST_64BIT)
 #define MAX_ALLOWED_MEM_LOAD 85
@@ -2898,6 +2918,8 @@ gc_heap::dynamic_heap_count_data_t SVR::gc_heap::dynamic_heap_count_data;
 size_t gc_heap::current_total_soh_stable_size = 0;
 uint64_t gc_heap::last_suspended_end_time = 0;
 uint64_t gc_heap::change_heap_count_time = 0;
+uint64_t gc_heap::total_change_heap_count = 0;
+uint64_t gc_heap::total_change_heap_count_time = 0;
 size_t gc_heap::gc_index_full_gc_end = 0;
 uint64_t gc_heap::before_distribute_free_regions_time = 0;
 bool gc_heap::trigger_initial_gen2_p = false;
@@ -7099,6 +7121,7 @@ void gc_heap::gc_thread_function ()
 #endif //BACKGROUND_GC
                     {
                         dprintf (6666, ("changing heap count due to timeout"));
+                        add_to_hc_history (hc_record_before_check_timeout);
                         check_heap_count();
                     }
                 }
@@ -7127,6 +7150,7 @@ void gc_heap::gc_thread_function ()
                 {
                     // this was a request to do a GC so make sure we follow through with one.
                     dprintf (6666, ("changing heap count at a GC start"));
+                    add_to_hc_history (hc_record_before_check_gc_start);
                     check_heap_count ();
                 }
             }
@@ -7145,6 +7169,8 @@ void gc_heap::gc_thread_function ()
                     dprintf (9999, ("heap count changed %d->%d, now idle is %d", dynamic_heap_count_data.last_n_heaps, n_heaps,
                         VolatileLoadWithoutBarrier (&dynamic_heap_count_data.idle_thread_count)));
                 }
+
+                add_to_hc_history (hc_record_set_last_heaps);
 
                 dynamic_heap_count_data.last_n_heaps = n_heaps;
             }
@@ -7209,11 +7235,14 @@ void gc_heap::gc_thread_function ()
                         // only that many threads will participate in the following GCs.
                         if (heap_number < new_n_heaps)
                         {
+                            add_to_hc_history (hc_record_still_active);
                             dprintf (9999, ("h%d < %d participating (dec)", heap_number, new_n_heaps));
                         }
                         else
                         {
                             Interlocked::Increment (&dynamic_heap_count_data.idle_thread_count);
+                            add_to_hc_history (hc_record_became_inactive);
+
                             dprintf (9999, ("GC thread %d wait_on_idle(%d < %d)(gc%Id), total idle %d", heap_number, old_n_heaps, new_n_heaps,
                                 VolatileLoadWithoutBarrier (&settings.gc_index), VolatileLoadWithoutBarrier (&dynamic_heap_count_data.idle_thread_count)));
                             gc_idle_thread_event.Wait (INFINITE, FALSE);
@@ -7222,12 +7251,14 @@ void gc_heap::gc_thread_function ()
                     }
                     else
                     {
+                        add_to_hc_history ((heap_number < old_n_heaps) ? hc_record_still_active : hc_record_became_active);
                         dprintf (9999, ("h%d < %d participating (inc)", heap_number, new_n_heaps));
                     }
                 }
                 else
                 {
                     Interlocked::Increment (&dynamic_heap_count_data.idle_thread_count);
+                    add_to_hc_history (hc_record_inactive_waiting);
                     dprintf (9999, ("GC thread %d wait_on_idle(< max %d)(gc%Id), total  idle %d", heap_number, num_threads_to_wake,
                         VolatileLoadWithoutBarrier (&settings.gc_index), VolatileLoadWithoutBarrier (&dynamic_heap_count_data.idle_thread_count)));
                     gc_idle_thread_event.Wait (INFINITE, FALSE);
@@ -15046,6 +15077,14 @@ gc_heap::init_gc_heap (int h_number)
     gc_done_event_set = false;
 
 #ifdef DYNAMIC_HEAP_COUNT
+    hchist_index_per_heap = 0;
+    memset (hchist_per_heap, 0, sizeof (hchist_per_heap));
+
+#ifdef BACKGROUND_GC
+    bgc_hchist_index_per_heap = 0;
+    memset (bgc_hchist_per_heap, 0, sizeof (bgc_hchist_per_heap));
+#endif //BACKGROUND_GC
+
     if (h_number != 0)
     {
         if (!gc_idle_thread_event.CreateAutoEventNoThrow (FALSE))
@@ -24371,10 +24410,31 @@ void gc_heap::garbage_collect (int n)
 #ifdef MULTIPLE_HEAPS
         if (heap_number == 0)
         {
+#ifdef DYNAMIC_HEAP_COUNT
+            size_t current_gc_index = VolatileLoadWithoutBarrier (&settings.gc_index);
+            if (!bgc_init_gc_index)
+            {
+                assert (!bgc_init_n_heaps);
+                bgc_init_gc_index = current_gc_index;
+                bgc_init_n_heaps = (short)n_heaps;
+            }
+            size_t saved_bgc_th_count_created = bgc_th_count_created;
+            size_t saved_bgc_th_count_created_th_existed = bgc_th_count_created_th_existed;
+            size_t saved_bgc_th_count_creation_failed = bgc_th_count_creation_failed;
+#endif //DYNAMIC_HEAP_COUNT
+
             for (int i = 0; i < n_heaps; i++)
             {
                 prepare_bgc_thread (g_heaps[i]);
             }
+
+#ifdef DYNAMIC_HEAP_COUNT
+            add_to_bgc_th_creation_history (current_gc_index,
+                (bgc_th_count_created - saved_bgc_th_count_created),
+                (bgc_th_count_created_th_existed - saved_bgc_th_count_created_th_existed),
+                (bgc_th_count_creation_failed - saved_bgc_th_count_creation_failed));
+#endif //DYNAMIC_HEAP_COUNT
+
             dprintf (2, ("setting bgc_threads_sync_event"));
             bgc_threads_sync_event.Set();
         }
@@ -25891,6 +25951,8 @@ void gc_heap::check_heap_count ()
         if (gc_heap::background_running_p())
         {
             // background GC is running - reset the new heap count
+            add_to_hc_history (hc_record_check_cancelled_bgc);
+            hc_change_cancelled_count_bgc++;
             dynamic_heap_count_data.new_n_heaps = n_heaps;
             dprintf (6666, ("can't change heap count! BGC in progress"));
         }
@@ -25903,6 +25965,8 @@ void gc_heap::check_heap_count ()
         if (!prepare_to_change_heap_count (dynamic_heap_count_data.new_n_heaps))
         {
             // we don't have sufficient resources - reset the new heap count
+            add_to_hc_history (hc_record_check_cancelled_prep);
+            hc_change_cancelled_count_prep++;
             dynamic_heap_count_data.new_n_heaps = n_heaps;
         }
     }
@@ -26478,7 +26542,10 @@ bool gc_heap::change_heap_count (int new_n_heaps)
 
     if (heap_number == 0)
     {
+        add_to_hc_history (hc_record_change_done);
         change_heap_count_time = GetHighPrecisionTimeStamp() - start_time;
+        total_change_heap_count_time += change_heap_count_time;
+        total_change_heap_count++;
         dprintf (6666, ("changing HC took %I64dus", change_heap_count_time));
     }
 
@@ -26595,6 +26662,50 @@ void gc_heap::process_datas_sample()
     last_suspended_end_time = before_distribute_free_regions_time;
 }
 
+void gc_heap::add_to_hc_history_worker (hc_history* hist, int* current_index, hc_record_stage stage, const char* msg)
+{
+    dprintf (6666, ("h%d ADDING %s HC hist to entry #%d, stage %d, gc index %Id, last %d, n %d, new %d",
+        heap_number, msg, *current_index, (int)stage, VolatileLoadWithoutBarrier (&settings.gc_index),
+        dynamic_heap_count_data.last_n_heaps, n_heaps, dynamic_heap_count_data.new_n_heaps));
+    hc_history* current_hist = &hist[*current_index];
+    current_hist->gc_index = VolatileLoadWithoutBarrier (&settings.gc_index);
+    current_hist->stage = (short)stage;
+    current_hist->last_n_heaps = (short)dynamic_heap_count_data.last_n_heaps;
+    current_hist->n_heaps = (short)n_heaps;
+    current_hist->new_n_heaps = (short)dynamic_heap_count_data.new_n_heaps;
+    current_hist->idle_thread_count = (short)dynamic_heap_count_data.idle_thread_count;
+    current_hist->gc_t_join_n_threads = (short)gc_t_join.get_num_threads();
+    current_hist->gc_t_join_join_lock = (short)gc_t_join.get_join_lock();
+    current_hist->gc_t_join_joined_p = (bool)gc_t_join.joined();
+#ifdef BACKGROUND_GC
+    current_hist->bgc_t_join_n_threads = (short)bgc_t_join.get_num_threads();
+    current_hist->bgc_t_join_join_lock = (short)bgc_t_join.get_join_lock();
+    current_hist->bgc_t_join_joined_p = (bool)bgc_t_join.joined();
+    current_hist->concurrent_p = (bool)settings.concurrent;
+    current_hist->bgc_thread_running = (bool)bgc_thread_running;
+
+    int bgc_thread_os_id = 0;
+
+    if (bgc_thread)
+    {
+        bgc_thread_os_id = (int)(*(size_t*)((uint8_t*)bgc_thread + 0x130));
+    }
+
+    current_hist->bgc_thread_os_id = bgc_thread_os_id;
+#endif //BACKGROUND_GC
+
+    *current_index  = (*current_index + 1) % max_hc_history_count;
+}
+
+void gc_heap::add_to_hc_history (hc_record_stage stage)
+{
+    add_to_hc_history_worker (hchist_per_heap, &hchist_index_per_heap, stage, "GC");
+}
+
+void gc_heap::add_to_bgc_hc_history (hc_record_stage stage)
+{
+    add_to_hc_history_worker (bgc_hchist_per_heap, &bgc_hchist_index_per_heap, stage, "BGC");
+}
 #endif //DYNAMIC_HEAP_COUNT
 #endif //USE_REGIONS
 
@@ -39403,6 +39514,27 @@ void gc_heap::mark_absorb_new_alloc()
     clear_gen0_bricks();
 }
 
+#ifdef DYNAMIC_HEAP_COUNT
+void gc_heap::add_to_bgc_th_creation_history (size_t gc_index, size_t count_created,
+                                              size_t count_created_th_existed, size_t count_creation_failed)
+{
+    if ((count_created != 0) || (count_created_th_existed != 0) || (count_creation_failed != 0))
+    {
+        dprintf (6666, ("ADDING to BGC th hist entry%d gc index %Id, created %d, %d th existed, %d failed",
+            bgc_th_creation_hist_index, gc_index, count_created, count_created_th_existed, count_creation_failed));
+
+        bgc_thread_creation_history* current_hist = &bgc_th_creation_hist[bgc_th_creation_hist_index];
+        current_hist->gc_index = gc_index;
+        current_hist->n_heaps = (short)n_heaps;
+        current_hist->count_created = (short)count_created;
+        current_hist->count_created_th_existed = (short)count_created_th_existed;
+        current_hist->count_creation_failed = (short)count_creation_failed;
+
+        bgc_th_creation_hist_index = (bgc_th_creation_hist_index + 1) % max_bgc_thread_creation_count;
+    }
+}
+#endif //DYNAMIC_HEAP_COUNT
+
 BOOL gc_heap::prepare_bgc_thread(gc_heap* gh)
 {
     BOOL success = FALSE;
@@ -39412,10 +39544,28 @@ BOOL gc_heap::prepare_bgc_thread(gc_heap* gh)
     if (!(gh->bgc_thread_running))
     {
         dprintf (2, ("GC thread not running"));
-        if ((gh->bgc_thread == 0) && create_bgc_thread(gh))
+        if (gh->bgc_thread == 0)
         {
-            success = TRUE;
-            thread_created = TRUE;
+            if (create_bgc_thread(gh))
+            {
+                success = TRUE;
+                thread_created = TRUE;
+#ifdef DYNAMIC_HEAP_COUNT
+                bgc_th_count_created++;
+#endif //DYNAMIC_HEAP_COUNT
+            }
+            else
+            {
+#ifdef DYNAMIC_HEAP_COUNT
+                bgc_th_count_creation_failed++;
+#endif //DYNAMIC_HEAP_COUNT
+            }
+        }
+        else
+        {
+#ifdef DYNAMIC_HEAP_COUNT
+            bgc_th_count_created_th_existed++;
+#endif //DYNAMIC_HEAP_COUNT
         }
     }
     else
@@ -39677,12 +39827,18 @@ void gc_heap::bgc_thread_function()
 #ifdef DYNAMIC_HEAP_COUNT
         if (n_heaps <= heap_number)
         {
+            add_to_bgc_hc_history (hc_record_bgc_inactive);
+
             // this is the case where we have more background GC threads than heaps
             // - wait until we're told to continue...
             dprintf (9999, ("BGC thread %d idle (%d heaps) (gc%Id)", heap_number, n_heaps, VolatileLoadWithoutBarrier (&settings.gc_index)));
             bgc_idle_thread_event.Wait(INFINITE, FALSE);
             dprintf (9999, ("BGC thread %d waking from idle (%d heaps) (gc%Id)", heap_number, n_heaps, VolatileLoadWithoutBarrier (&settings.gc_index)));
             continue;
+        }
+        else
+        {
+            add_to_bgc_hc_history (hc_record_bgc_active);
         }
 #endif //DYNAMIC_HEAP_COUNT
 
@@ -51558,6 +51714,8 @@ size_t gc_heap::get_gen0_min_size()
         trueSize = max(trueSize, (size_t)(256*1024));
         int n_heaps = 1;
 #endif //SERVER_GC
+
+        llc_size = trueSize;
 
 #ifdef DYNAMIC_HEAP_COUNT
         if (dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes)

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5193,8 +5193,6 @@ private:
     PER_HEAP_ISOLATED_FIELD_MAINTAINED size_t current_total_soh_stable_size;
     PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t last_suspended_end_time;
     PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t change_heap_count_time;
-    PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t total_change_heap_count;
-    PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t total_change_heap_count_time;
 
     // If the last full GC is blocking, this is that GC's index; for BGC, this is the settings.gc_index
     // when the BGC ended.
@@ -5408,8 +5406,8 @@ private:
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t max_peak_heap_size;
 
     // Sometimes it's difficult to figure out why we get the gen0 min/max budget.
-    // These fields help figure those out.
-    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t llc_size;
+    // These fields help figure those out. Making it volatile so it doesn't get optimized out.
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY VOLATILE(size_t) llc_size;
 
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY gc_history_global bgc_data_global;
@@ -5442,6 +5440,8 @@ private:
 #ifdef DYNAMIC_HEAP_COUNT
     // Number of times we bailed from check_heap_count because we didn't have enough memory for the preparation
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t hc_change_cancelled_count_prep;
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY uint64_t total_change_heap_count;
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY uint64_t total_change_heap_count_time;
 
 #ifdef BACKGROUND_GC
     // We log an entry whenever we needed to create new BGC threads.

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -583,6 +583,47 @@ enum gc_dynamic_adaptation_mode
     dynamic_adaptation_default = 0,
     dynamic_adaptation_to_application_sizes = 1,
 };
+
+enum hc_record_stage
+{
+    hc_record_set_last_heaps = 0,
+    hc_record_before_check_timeout = 1,
+    hc_record_before_check_gc_start = 2,
+    hc_record_change_done = 3,
+    hc_record_still_active = 4,
+    hc_record_became_active = 5,
+    hc_record_became_inactive = 6,
+    hc_record_inactive_waiting = 7, 
+    hc_record_check_cancelled_prep = 8,
+#ifdef BACKGROUND_GC
+    hc_record_check_cancelled_bgc = 9,
+    hc_record_bgc_active = 10,
+    hc_record_bgc_inactive = 11,
+#endif //BACKGROUND_GC
+};
+
+struct hc_history
+{
+    size_t gc_index;
+    short stage;
+    short last_n_heaps;
+    short n_heaps;
+    short new_n_heaps;
+    short idle_thread_count;
+    short gc_t_join_n_threads;
+    short gc_t_join_join_lock;
+#ifdef BACKGROUND_GC
+    short bgc_t_join_n_threads;
+    int bgc_thread_os_id;
+    short bgc_t_join_join_lock;
+#endif //BACKGROUND_GC
+    bool gc_t_join_joined_p;
+#ifdef BACKGROUND_GC
+    bool bgc_t_join_joined_p;
+    bool concurrent_p;
+    bool bgc_thread_running;
+#endif //BACKGROUND_GC
+};
 #endif //DYNAMIC_HEAP_COUNT
 
 //encapsulates the mechanism for the current gc
@@ -2611,6 +2652,19 @@ private:
     PER_HEAP_ISOLATED_METHOD void get_msl_wait_time (size_t* soh_msl_wait_time, size_t* uoh_msl_wait_time);
 
     PER_HEAP_ISOLATED_METHOD void process_datas_sample();
+
+    PER_HEAP_METHOD void add_to_hc_history_worker (hc_history* hist, int* current_index, hc_record_stage stage, const char* msg);
+
+    PER_HEAP_METHOD void add_to_hc_history (hc_record_stage stage);
+
+#ifdef BACKGROUND_GC
+    PER_HEAP_METHOD void add_to_bgc_hc_history (hc_record_stage stage);
+
+    PER_HEAP_ISOLATED_METHOD void add_to_bgc_th_creation_history (size_t gc_index,
+                                                                  size_t count_created,
+                                                                  size_t  count_created_th_existed,
+                                                                  size_t count_creation_failed);
+#endif //BACKGROUND_GC
 #endif //DYNAMIC_HEAP_COUNT
 #endif //USE_REGIONS
 
@@ -3972,6 +4026,17 @@ private:
 #endif //STRESS_REGIONS
 #endif //USE_REGIONS
 
+#ifdef DYNAMIC_HEAP_COUNT
+#define max_hc_history_count 16
+    PER_HEAP_FIELD_DIAG_ONLY int hchist_index_per_heap;
+    PER_HEAP_FIELD_DIAG_ONLY hc_history hchist_per_heap[max_hc_history_count];
+
+#ifdef BACKGROUND_GC
+    PER_HEAP_FIELD_DIAG_ONLY int bgc_hchist_index_per_heap;
+    PER_HEAP_FIELD_DIAG_ONLY hc_history bgc_hchist_per_heap[max_hc_history_count];
+#endif //BACKGROUND_GC
+#endif //DYNAMIC_HEAP_COUNT
+
 #ifdef FEATURE_EVENT_TRACE
 #define max_etw_item_count 2000
 
@@ -5122,6 +5187,8 @@ private:
     PER_HEAP_ISOLATED_FIELD_MAINTAINED size_t current_total_soh_stable_size;
     PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t last_suspended_end_time;
     PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t change_heap_count_time;
+    PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t total_change_heap_count;
+    PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t total_change_heap_count_time;
 
     // If the last full GC is blocking, this is that GC's index; for BGC, this is the settings.gc_index
     // when the BGC ended.
@@ -5334,6 +5401,10 @@ private:
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY uint64_t last_alloc_reset_suspended_end_time;
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t max_peak_heap_size;
 
+    // Sometimes it's difficult to figure out why we get the gen0 min/max budget.
+    // These fields help figure those out.
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t llc_size;
+
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY gc_history_global bgc_data_global;
 
@@ -5361,6 +5432,41 @@ private:
     // it means the bgc info is ready.
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY VOLATILE(bool) is_last_recorded_bgc;
 #endif //BACKGROUND_GC
+
+#ifdef DYNAMIC_HEAP_COUNT
+    // Number of times we bailed from check_heap_count because we didn't have enough memory for the preparation
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t hc_change_cancelled_count_prep;
+
+#ifdef BACKGROUND_GC
+    // We log an entry whenever we needed to create new BGC threads.
+    struct bgc_thread_creation_history
+    {
+        size_t gc_index;
+        short n_heaps;
+        short count_created;
+        // bgc_thread_running was false but bgc_thread was true. 
+        short count_created_th_existed;
+        short count_creation_failed;
+    };
+
+#define max_bgc_thread_creation_count 16
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY int bgc_th_creation_hist_index;
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY bgc_thread_creation_history bgc_th_creation_hist[max_bgc_thread_creation_count];
+
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t bgc_th_count_created;
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t bgc_th_count_created_th_existed;
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t bgc_th_count_creation_failed;
+
+    // The gc index of the very first BGC that happened.
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t bgc_init_gc_index;
+    // The number of heaps during that first BGC. Making it volatile so it doesn't get optimized out.
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY VOLATILE(short) bgc_init_n_heaps;
+
+    // Number of times we bailed from check_heap_count because we noticed BGC is in progress even
+    // though it was not in progress when we check before calling it. 
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t hc_change_cancelled_count_bgc;
+#endif //BACKGROUND_GC
+#endif //DYNAMIC_HEAP_COUNT
 
 #ifdef FEATURE_EVENT_TRACE
     // Initialized each time in mark_phase and background_mark_phase (during the 2nd non concurrent stage)

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -614,7 +614,13 @@ struct hc_history
     short gc_t_join_join_lock;
 #ifdef BACKGROUND_GC
     short bgc_t_join_n_threads;
+    // We have observed a problem on Windows in production where GC indicates a BGC thread was created successfully yet we have
+    // invalid fields on the Thread object such as m_OSThreadId. This is to help with debugging that problem so I
+    // only enable it for retail builds on Windows. We can extend this with a GCToEEInterface interface method to get the offset
+    // of that particular field on the Thread object.
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(_DEBUG)
     int bgc_thread_os_id;
+#endif
     short bgc_t_join_join_lock;
 #endif //BACKGROUND_GC
     bool gc_t_join_joined_p;


### PR DESCRIPTION
add instru to help with DATAS debugging
+ record heap count change history on blocking GC threads and BGC threads (I'm including a change to get the `m_OSThreadId` field of the `Thread` object since we recently discovered an issue where GC indicates a BGC thread was successfully created yet that field is 0. I'm only recording this on the OS we discovered this on. for future releases we should get it properly via a `GCToEEInterface` method)
+ record BGC thread creation history

record LLC size to help with gen0 min size debugging