### PR TITLE
Replace VectorXx.Exp's edge case fallback with scalar processing

### DIFF
--- a/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
@@ -39,6 +39,11 @@ namespace System.Numerics.Tensors.Tests
                 return false;
             }
 
+            if (T.IsNegativeInfinity(expected) != T.IsNegativeInfinity(actual))
+            {
+                return false;
+            }
+
             tolerance = tolerance ?? DefaultTolerance<T>.Value;
             T diff = T.Abs(expected - actual);
             return !(diff > tolerance && diff > T.Max(T.Abs(expected), T.Abs(actual)) * tolerance);

--- a/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
@@ -39,11 +39,6 @@ namespace System.Numerics.Tensors.Tests
                 return false;
             }
 
-            if (T.IsNegativeInfinity(expected) != T.IsNegativeInfinity(actual))
-            {
-                return false;
-            }
-
             tolerance = tolerance ?? DefaultTolerance<T>.Value;
             T diff = T.Abs(expected - actual);
             return !(diff > tolerance && diff > T.Max(T.Abs(expected), T.Abs(actual)) * tolerance);

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -163,9 +163,17 @@ namespace System.Numerics.Tensors.Tests
         /// the value is stored into a random position in <paramref name="x"/>, and the original
         /// value is subsequently restored.
         /// </summary>
-        protected void RunForEachSpecialValue(Action action, BoundedMemory<T> x)
+        protected void RunForEachSpecialValue(Action action, BoundedMemory<T> x) =>
+            RunForEachSpecialValue(action, x, GetSpecialValues());
+
+        /// <summary>
+        /// Runs the specified action for each special value. Before the action is invoked,
+        /// the value is stored into a random position in <paramref name="x"/>, and the original
+        /// value is subsequently restored.
+        /// </summary>
+        protected void RunForEachSpecialValue(Action action, BoundedMemory<T> x, IEnumerable<T> specialValues)
         {
-            Assert.All(GetSpecialValues(), value =>
+            Assert.All(specialValues, value =>
             {
                 int pos = Random.Next(x.Length);
                 T orig = x[pos];
@@ -1021,6 +1029,17 @@ namespace System.Numerics.Tensors.Tests
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
                 using BoundedMemory<T> destination = CreateTensor(tensorLength);
 
+                T[] additionalSpecialValues =
+                [
+                    typeof(T) == typeof(float) ? (T)(object)-709.7f :
+                        typeof(T) == typeof(double) ? (T)(object)-709.7 :
+                        default,
+
+                    typeof(T) == typeof(float) ? (T)(object)709.7f :
+                        typeof(T) == typeof(double) ? (T)(object)709.7 :
+                        default,
+                ];
+
                 RunForEachSpecialValue(() =>
                 {
                     Exp(x, destination);
@@ -1028,7 +1047,7 @@ namespace System.Numerics.Tensors.Tests
                     {
                         AssertEqualTolerance(Exp(x[i]), destination[i]);
                     }
-                }, x);
+                }, x, GetSpecialValues().Concat(additionalSpecialValues));
             });
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
@@ -391,9 +391,6 @@ namespace System.Runtime.Intrinsics
             const ulong V_ARG_MAX = 0x40862000_00000000;
             const ulong V_DP64_BIAS = 1023;
 
-            const double V_EXPF_MIN = -709.782712893384;
-            const double V_EXPF_MAX = +709.782712893384;
-
             const double V_EXPF_HUGE = 6755399441055744;
             const double V_TBL_LN2 = 1.4426950408889634;
 
@@ -411,66 +408,69 @@ namespace System.Runtime.Intrinsics
             const double C11 = 2.7632293298250954E-07;
             const double C12 = 2.499430431958571E-08;
 
-            // x * (64.0 / ln(2))
-            TVectorDouble dn = TVectorDouble.MultiplyAddEstimate(x, TVectorDouble.Create(V_TBL_LN2), TVectorDouble.Create(V_EXPF_HUGE));
-
-            // n = (int)z
-            TVectorUInt64 n = Unsafe.BitCast<TVectorDouble, TVectorUInt64>(dn);
-
-            // dn = (double)n
-            dn -= TVectorDouble.Create(V_EXPF_HUGE);
-
-            // r = x - (dn * (ln(2) / 64))
-            // where ln(2) / 64 is split into Head and Tail values
-            TVectorDouble r = TVectorDouble.MultiplyAddEstimate(dn, TVectorDouble.Create(-V_LN2_HEAD), x);
-            r = TVectorDouble.MultiplyAddEstimate(dn, TVectorDouble.Create(-V_LN2_TAIL), r);
-
-            TVectorDouble r2 = r * r;
-            TVectorDouble r4 = r2 * r2;
-            TVectorDouble r8 = r4 * r4;
-
-            // Compute polynomial
-            TVectorDouble poly = TVectorDouble.MultiplyAddEstimate(
-                TVectorDouble.MultiplyAddEstimate(
-                    TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C12), r, TVectorDouble.Create(C11)),
-                    r2,
-                    TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C10), r, TVectorDouble.Create(C09))),
-                r8,
-                TVectorDouble.MultiplyAddEstimate(
-                    TVectorDouble.MultiplyAddEstimate(
-                        TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C08), r, TVectorDouble.Create(C07)),
-                        r2,
-                        TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C06), r, TVectorDouble.Create(C05))),
-                    r4,
-                    TVectorDouble.MultiplyAddEstimate(
-                        TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C04), r, TVectorDouble.Create(C03)),
-                        r2,
-                        r + TVectorDouble.One
-                    )
-                )
-            );
-
-            // m = (n - j) / 64
-            // result = polynomial * 2^m
-            TVectorDouble result = poly * Unsafe.BitCast<TVectorUInt64, TVectorDouble>((n + TVectorUInt64.Create(V_DP64_BIAS)) << 52);
-
             // Check if -709 < vx < 709
-            if (TVectorUInt64.GreaterThanAny(Unsafe.BitCast<TVectorDouble, TVectorUInt64>(TVectorDouble.Abs(x)), TVectorUInt64.Create(V_ARG_MAX)))
+            if (TVectorUInt64.LessThanOrEqualAll(Unsafe.BitCast<TVectorDouble, TVectorUInt64>(TVectorDouble.Abs(x)), TVectorUInt64.Create(V_ARG_MAX)))
             {
-                // (x > V_EXPF_MAX) ? double.PositiveInfinity : x
-                TVectorDouble infinityMask = TVectorDouble.GreaterThan(x, TVectorDouble.Create(V_EXPF_MAX));
+                // x * (64.0 / ln(2))
+                TVectorDouble dn = TVectorDouble.MultiplyAddEstimate(x, TVectorDouble.Create(V_TBL_LN2), TVectorDouble.Create(V_EXPF_HUGE));
 
-                result = TVectorDouble.ConditionalSelect(
-                    infinityMask,
-                    TVectorDouble.Create(double.PositiveInfinity),
-                    result
+                // n = (int)z
+                TVectorUInt64 n = Unsafe.BitCast<TVectorDouble, TVectorUInt64>(dn);
+
+                // dn = (double)n
+                dn -= TVectorDouble.Create(V_EXPF_HUGE);
+
+                // r = x - (dn * (ln(2) / 64))
+                // where ln(2) / 64 is split into Head and Tail values
+                TVectorDouble r = TVectorDouble.MultiplyAddEstimate(dn, TVectorDouble.Create(-V_LN2_HEAD), x);
+                r = TVectorDouble.MultiplyAddEstimate(dn, TVectorDouble.Create(-V_LN2_TAIL), r);
+
+                TVectorDouble r2 = r * r;
+                TVectorDouble r4 = r2 * r2;
+                TVectorDouble r8 = r4 * r4;
+
+                // Compute polynomial
+                TVectorDouble poly = TVectorDouble.MultiplyAddEstimate(
+                    TVectorDouble.MultiplyAddEstimate(
+                        TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C12), r, TVectorDouble.Create(C11)),
+                        r2,
+                        TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C10), r, TVectorDouble.Create(C09))),
+                    r8,
+                    TVectorDouble.MultiplyAddEstimate(
+                        TVectorDouble.MultiplyAddEstimate(
+                            TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C08), r, TVectorDouble.Create(C07)),
+                            r2,
+                            TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C06), r, TVectorDouble.Create(C05))),
+                        r4,
+                        TVectorDouble.MultiplyAddEstimate(
+                            TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(C04), r, TVectorDouble.Create(C03)),
+                            r2,
+                            r + TVectorDouble.One
+                        )
+                    )
                 );
 
-                // (x < V_EXPF_MIN) ? 0 : x
-                result = TVectorDouble.AndNot(result, TVectorDouble.LessThan(x, TVectorDouble.Create(V_EXPF_MIN)));
+                // m = (n - j) / 64
+                // result = polynomial * 2^m
+                return poly * Unsafe.BitCast<TVectorUInt64, TVectorDouble>((n + TVectorUInt64.Create(V_DP64_BIAS)) << 52);
             }
+            else
+            {
+                return ScalarFallback(x);
 
-            return result;
+                static TVectorDouble ScalarFallback(TVectorDouble x)
+                {
+                    TVectorDouble expResult = TVectorDouble.Zero;
+
+                    for (int i = 0; i < TVectorDouble.Count; i++)
+                    {
+                        double expScalar = double.Exp(x[i]);
+                        expResult = expResult.WithElement(i, expScalar);
+                    }
+
+                    return expResult;
+                }
+            }
         }
 
         public static TVectorSingle ExpSingle<TVectorSingle, TVectorUInt32, TVectorDouble, TVectorUInt64>(TVectorSingle x)


### PR DESCRIPTION
The better, vectorized fix is more complex and can be done for .NET 10.

Fixes https://github.com/dotnet/runtime/issues/107838

Easiest to review with whitespace hidden: https://github.com/dotnet/runtime/pull/107886/files?diff=split&w=1