### PR TITLE
[release/9.0] instrumentation (mostly) for DATAS

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -746,9 +746,10 @@ public:
         return join_struct.n_threads;
     }
 
+    // This is for instrumentation only.
     int get_join_lock()
     {
-        return join_struct.join_lock;
+        return VolatileLoadWithoutBarrier (&join_struct.join_lock);
     }
 
     void destroy ()
@@ -2388,7 +2389,7 @@ last_recorded_gc_info gc_heap::last_full_blocking_gc_info;
 
 uint64_t    gc_heap::last_alloc_reset_suspended_end_time = 0;
 size_t      gc_heap::max_peak_heap_size = 0;
-size_t      gc_heap::llc_size = 0;
+VOLATILE(size_t) gc_heap::llc_size = 0;
 
 #ifdef BACKGROUND_GC
 last_recorded_gc_info gc_heap::last_bgc_info[2];

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5192,8 +5192,6 @@ private:
     PER_HEAP_ISOLATED_FIELD_MAINTAINED size_t current_total_soh_stable_size;
     PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t last_suspended_end_time;
     PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t change_heap_count_time;
-    PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t total_change_heap_count;
-    PER_HEAP_ISOLATED_FIELD_MAINTAINED uint64_t total_change_heap_count_time;
 
     // If the last full GC is blocking, this is that GC's index; for BGC, this is the settings.gc_index
     // when the BGC ended.
@@ -5407,8 +5405,8 @@ private:
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t max_peak_heap_size;
 
     // Sometimes it's difficult to figure out why we get the gen0 min/max budget.
-    // These fields help figure those out.
-    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t llc_size;
+    // These fields help figure those out. Making it volatile so it doesn't get optimized out.
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY VOLATILE(size_t) llc_size;
 
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY gc_history_global bgc_data_global;
@@ -5441,6 +5439,8 @@ private:
 #ifdef DYNAMIC_HEAP_COUNT
     // Number of times we bailed from check_heap_count because we didn't have enough memory for the preparation
     PER_HEAP_ISOLATED_FIELD_DIAG_ONLY size_t hc_change_cancelled_count_prep;
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY uint64_t total_change_heap_count;
+    PER_HEAP_ISOLATED_FIELD_DIAG_ONLY uint64_t total_change_heap_count_time;
 
 #ifdef BACKGROUND_GC
     // We log an entry whenever we needed to create new BGC threads.


### PR DESCRIPTION
my bad for not asking to hold off merging for the [previous PR](https://github.com/dotnet/runtime/pull/107858)! I did need to address an important CR feedback which was I forgot to make another instru only global variable (`llc_size`) volatile. also changed loading of `join_lock` to `VolatileWithoutBarrier` to avoid unnecessary perf penalty when we log to these entries (we don't log often but still). this is the template from the original PR but since it was already merged I'm submitting this one manually. sorry for the trouble!

## Customer Impact

- [X] Customer reported
- [ ] Found internally

adding this to help with DATAS debugging, especially to help with a recent issue discovered by a customer where GC indicates a BGC thread was successfully created yet the `m_OSThreadId` field of the `Thread` object was 0.

## Regression

- [ ] Yes
- [X] No

## Testing

Tested via debugging.

## Risk

Low. Instrumentation only.