### PR TITLE
[mono] Remove looking at .exe in assembly loader

### DIFF
--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -635,7 +635,6 @@ real_load (gchar **search_path, const gchar *culture, const gchar *name, const M
 	gchar **path;
 	gchar *filename;
 	const gchar *local_culture;
-	size_t len;
 
 	if (!culture || *culture == '\0') {
 		local_culture = "";
@@ -644,7 +643,6 @@ real_load (gchar **search_path, const gchar *culture, const gchar *name, const M
 	}
 
 	filename =  g_strconcat (name, ".dll", (const char*)NULL);
-	len = strlen (filename);
 
 	for (path = search_path; *path; path++) {
 		if (**path == '\0') {
@@ -653,22 +651,10 @@ real_load (gchar **search_path, const gchar *culture, const gchar *name, const M
 
 		/* See test cases in bug #58992 and bug #57710 */
 		/* 1st try: [culture]/[name].dll (culture may be empty) */
-		strcpy (filename + len - 4, ".dll");
 		if (try_load_from (&result, *path, local_culture, "", filename, req))
 			break;
 
-		/* 2nd try: [culture]/[name].exe (culture may be empty) */
-		strcpy (filename + len - 4, ".exe");
-		if (try_load_from (&result, *path, local_culture, "", filename, req))
-			break;
-
-		/* 3rd try: [culture]/[name]/[name].dll (culture may be empty) */
-		strcpy (filename + len - 4, ".dll");
-		if (try_load_from (&result, *path, local_culture, name, filename, req))
-			break;
-
-		/* 4th try: [culture]/[name]/[name].exe (culture may be empty) */
-		strcpy (filename + len - 4, ".exe");
+		/* 2nd try: [culture]/[name]/[name].dll (culture may be empty) */
 		if (try_load_from (&result, *path, local_culture, name, filename, req))
 			break;
 	}

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -209,9 +209,9 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 		if (size > 4 && strncmp ((char*)raw_contents, "BSJB", 4) == 0)
 			ppdb_image = mono_image_open_from_data_internal (alc, (char*)raw_contents, size, TRUE, &status, TRUE, NULL, NULL);
 	} else {
-		/* ppdb files drop the .exe/.dll extension */
+		/* ppdb files drop the .dll extension */
 		filename = mono_image_get_filename (image);
-		if (strlen (filename) > 4 && (!strcmp (filename + strlen (filename) - 4, ".exe") || !strcmp (filename + strlen (filename) - 4, ".dll"))) {
+		if (strlen (filename) > 4 && !strcmp (filename + strlen (filename) - 4, ".dll")) {
 			s = g_strdup (filename);
 			s [strlen (filename) - 4] = '\0';
 			ppdb_filename = g_strdup_printf ("%s.pdb", s);


### PR DESCRIPTION
Modern .NET doesn't use .exe for managed assemblies.
Contributes to https://github.com/dotnet/runtime/issues/107883