### PR TITLE
[release/8.0] Fix compilation on ARM64 hosts

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -11,7 +11,7 @@ Param(
   [switch]$coverage,
   [string]$testscope,
   [switch]$testnobuild,
-  [ValidateSet("x86","x64","arm","arm64","wasm")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
+  [ValidateSet("x86","x64","arm","arm64","wasm")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()),
   [Parameter(Position=0)][string][Alias('s')]$subset,
   [ValidateSet("Debug","Release","Checked")][string][Alias('rc')]$runtimeConfiguration,
   [ValidateSet("Debug","Release")][string][Alias('lc')]$librariesConfiguration,

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -945,7 +945,11 @@ if (CLR_CMAKE_HOST_WIN32)
     elseif(CLR_CMAKE_HOST_ARCH_ARM64)
 
       # Explicitly specify the assembler to be used for Arm64 compile
-      file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\HostX86\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+      if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+        file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\Hostarm64\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+      else()
+        file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\HostX64\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+      endif()
 
       set(CMAKE_ASM_MASM_COMPILER ${CMAKE_ASM_COMPILER})
       message("CMAKE_ASM_MASM_COMPILER explicitly set to: ${CMAKE_ASM_MASM_COMPILER}")

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -4,11 +4,19 @@
 :: as an argument, it also initializes VC++ build environment and CMakePath.
 
 set "__VCBuildArch="
-if /i "%~1" == "x86"   (set __VCBuildArch=x86)
-if /i "%~1" == "x64"   (set __VCBuildArch=x86_amd64)
-if /i "%~1" == "arm"   (set __VCBuildArch=x86_arm)
-if /i "%~1" == "arm64" (set __VCBuildArch=x86_arm64)
-if /i "%~1" == "wasm" (if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (set __VCBuildArch=x86_arm64) else (set __VCBuildArch=x86_amd64))
+if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
+    if /i "%~1" == "x64"   ( set __VCBuildArch=arm64_amd64 )
+    if /i "%~1" == "x86"   ( set __VCBuildArch=arm64_x86 )
+    if /i "%~1" == "arm"   ( set __VCBuildArch=arm64_arm )
+    if /i "%~1" == "arm64" ( set __VCBuildArch=arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=arm64 )
+) else (
+    if /i "%~1" == "x64"   ( set __VCBuildArch=amd64 )
+    if /i "%~1" == "x86"   ( set __VCBuildArch=amd64_x86 )
+    if /i "%~1" == "arm"   ( set __VCBuildArch=amd64_arm )
+    if /i "%~1" == "arm64" ( set __VCBuildArch=amd64_arm64 )
+    if /i "%~1" == "wasm"  ( set __VCBuildArch=amd64 )
+)
 
 :: Default to highest Visual Studio version available that has Visual C++ tools.
 ::

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -174,9 +174,6 @@ if %__TotalSpecifiedTargetArch% GTR 1 (
     goto Usage
 )
 
-set __ProcessorArch=%PROCESSOR_ARCHITEW6432%
-if "%__ProcessorArch%"=="" set __ProcessorArch=%PROCESSOR_ARCHITECTURE%
-
 if %__TargetArchX64%==1   set __TargetArch=x64
 if %__TargetArchX86%==1   set __TargetArch=x86
 if %__TargetArchArm%==1   set __TargetArch=arm
@@ -361,18 +358,21 @@ if %__BuildNative% EQU 1 (
     echo %__MsgPrefix%Commencing build of native components for %__TargetOS%.%__TargetArch%.%__BuildType%
 
     REM Set the environment for the native build
-    set __VCTargetArch=amd64
-    if /i "%__HostArch%" == "x86" ( set __VCTargetArch=x86 )
-    if /i "%__HostArch%" == "arm" (
-        set __VCTargetArch=x86_arm
-    )
-    if /i "%__HostArch%" == "arm64" (
-        set __VCTargetArch=x86_arm64
+    if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
+        set __VCBuildArch=arm64
+        if /i "%__HostArch%" == "x64" ( set __VCBuildArch=arm64_amd64 )
+        if /i "%__HostArch%" == "x86" ( set __VCBuildArch=arm64_x86 )
+        if /i "%__HostArch%" == "arm" ( set __VCBuildArch=arm64_arm )
+    ) else (
+        set __VCBuildArch=amd64
+        if /i "%__HostArch%" == "x86"   ( set __VCBuildArch=amd64_x86 )
+        if /i "%__HostArch%" == "arm64" ( set __VCBuildArch=amd64_arm64 )
+        if /i "%__HostArch%" == "arm"   ( set __VCBuildArch=amd64_arm )
     )
 
     if NOT DEFINED SkipVCEnvInit (
-        echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCTargetArch!
-        call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCTargetArch!
+        echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
+        call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
     )
     @if defined _echo @echo on
 


### PR DESCRIPTION
Backports https://github.com/dotnet/runtime/pull/104792/, https://github.com/dotnet/runtime/pull/104763, and  https://github.com/dotnet/runtime/pull/104695 to `release/8.0` so that the product can be compiled on ARM64 hosts.