### PR TITLE
JIT: Update lexical pointers after compacting blocks in `fgUpdateFlowGraph`

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5299,16 +5299,15 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication /* = false */,
                             {
                                 fgCompactBlock(otherPred);
                                 fgFoldSimpleCondByForwardSub(otherPred);
+
+                                // Since compaction removes blocks, update lexical pointers
+                                bPrev = block->Prev();
+                                bNext = block->Next();
                             }
                         }
 
                         assert(block->KindIs(BBJ_ALWAYS));
                         bDest = block->GetTarget();
-                    }
-                    else
-                    {
-                        bDest      = block->GetTrueTarget();
-                        bFalseDest = block->GetFalseTarget();
                     }
                 }
             }


### PR DESCRIPTION
Fixes #107920. The normal block compaction call site already updates bPrev correctly. When we fold a BBJ_COND into a BBJ_ALWAYS, we might compact the sole predecessor of the ex-target of the block whose control flow we just straightened. If this happens, the best thing to do is to probably repeat the pass for that block, which will automatically update bPrev/bNext -- but a more surgical fix is to just update the pointers in-place, and not change any logic in fgUpdateFlowGraph.

@dotnet/jit-contrib PTAL, thanks!