### PR TITLE
Remove invalid assert in RSAOpenSsl

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -654,7 +654,6 @@ namespace System.Security.Cryptography
         [MemberNotNull(nameof(_key))]
         private void SetKey(SafeEvpPKeyHandle newKey)
         {
-            Debug.Assert(!newKey.IsInvalid);
             FreeKey();
             _key = new Lazy<SafeEvpPKeyHandle>(newKey);
 


### PR DESCRIPTION
This assert is asserting that the key is not `IsInvalid`, but this is not a valid assumption when using the key and disposing of it is raced.

We have a test for that race here https://github.com/dotnet/runtime/issues/107929 which got hit at https://github.com/dotnet/runtime/issues/107929. This was also reported in https://github.com/dotnet/runtime/issues/105715.

We should remove the assert and just get SafeHandle's do their thing since they correctly handle validity of the handle (when used correctly).