### PR TITLE
Mitigate JsonObject performance regression.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -248,17 +248,21 @@ namespace System.Text.Json.Nodes
 
             OrderedDictionary<string, JsonNode?> dict = Dictionary;
 
-            if (dict.TryGetValue(propertyName, out JsonNode? replacedValue))
+            if (!dict.TryAdd(propertyName, value))
             {
+                int index = dict.IndexOf(propertyName);
+                Debug.Assert(index >= 0);
+                JsonNode? replacedValue = dict.GetAt(index).Value;
+
                 if (ReferenceEquals(value, replacedValue))
                 {
                     return;
                 }
 
                 DetachParent(replacedValue);
+                dict.SetAt(index, value);
             }
 
-            dict[propertyName] = value;
             value?.AssignParent(this);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Nodes
     internal sealed class JsonValuePrimitive<TValue> : JsonValue<TValue>
     {
         private readonly JsonConverter<TValue> _converter;
-        private JsonValueKind? _valueKind;
+        private readonly JsonValueKind _valueKind;
 
         public JsonValuePrimitive(TValue value, JsonConverter<TValue> converter, JsonNodeOptions? options) : base(value, options)
         {
@@ -21,9 +21,10 @@ namespace System.Text.Json.Nodes
             Debug.Assert(converter is { IsInternalConverter: true, ConverterStrategy: ConverterStrategy.Value });
 
             _converter = converter;
+            _valueKind = DetermineValueKind(value);
         }
 
-        private protected override JsonValueKind GetValueKindCore() => _valueKind ??= DetermineValueKind(Value);
+        private protected override JsonValueKind GetValueKindCore() => _valueKind;
         internal override JsonNode DeepCloneCore() => new JsonValuePrimitive<TValue>(Value, _converter, Options);
 
         internal override bool DeepEqualsCore(JsonNode otherNode)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Nodes
     internal sealed class JsonValuePrimitive<TValue> : JsonValue<TValue>
     {
         private readonly JsonConverter<TValue> _converter;
-        private readonly JsonValueKind _valueKind;
+        private JsonValueKind? _valueKind;
 
         public JsonValuePrimitive(TValue value, JsonConverter<TValue> converter, JsonNodeOptions? options) : base(value, options)
         {
@@ -21,10 +21,9 @@ namespace System.Text.Json.Nodes
             Debug.Assert(converter is { IsInternalConverter: true, ConverterStrategy: ConverterStrategy.Value });
 
             _converter = converter;
-            _valueKind = DetermineValueKind(value);
         }
 
-        private protected override JsonValueKind GetValueKindCore() => _valueKind;
+        private protected override JsonValueKind GetValueKindCore() => _valueKind ??= DetermineValueKind(Value);
         internal override JsonNode DeepCloneCore() => new JsonValuePrimitive<TValue>(Value, _converter, Options);
 
         internal override bool DeepEqualsCore(JsonNode otherNode)


### PR DESCRIPTION
Makes the following changes:

1. ~Makes the `JsonValueKind` computation for `JsonValue` instances backed by primitives a lazy operation.~
2. Updates the `JsonObject` indexer implementation so that duplicate lookups aren't performed in the common case where a property isn't being overwritten.

Should be backported to .NET 9. Fix #107869.

## Benchmarks

Using https://github.com/dotnet/performance/pull/4463 on arm64.

| Method                  | Branch | Mean     | Error    | StdDev   | Median   | Min      | Max      | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------------ |------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| Create_JsonBool         | .NET 8 | 266.5 ns |  3.24 ns |  3.03 ns | 266.1 ns | 262.5 ns | 272.6 ns |  1.00 |    0.02 | 0.4779 |    2000 B |        1.00 |
| Create_JsonBool         |     PR | 277.2 ns |  2.87 ns |  2.54 ns | 277.7 ns | 273.5 ns | 282.0 ns |  1.04 |    0.01 | 0.4781 |    2000 B |        1.00 |
|                         |        |          |          |          |          |          |          |       |         |        |           |             |
| Create_JsonNumber       | .NET 8 | 268.0 ns |  3.33 ns |  3.11 ns | 268.9 ns | 260.5 ns | 271.3 ns |  1.00 |    0.02 | 0.4773 |    2000 B |        1.00 |
| Create_JsonNumber       |     PR | 285.9 ns | 15.21 ns | 17.52 ns | 275.6 ns | 269.9 ns | 328.5 ns |  1.07 |    0.06 | 0.5732 |    2400 B |        1.20 |
|                         |        |          |          |          |          |          |          |       |         |        |           |             |
| Create_JsonString       | .NET 8 | 366.3 ns |  3.87 ns |  3.62 ns | 366.9 ns | 361.1 ns | 372.9 ns |  1.00 |    0.01 | 0.5738 |    2400 B |        1.00 |
| Create_JsonString       |     PR | 281.5 ns |  2.38 ns |  1.98 ns | 280.8 ns | 278.4 ns | 286.1 ns |  0.77 |    0.01 | 0.6689 |    2800 B |        1.17 |
|                         |        |          |          |          |          |          |          |       |         |        |           |             |
| Create_JsonArray        | .NET 8 | 486.5 ns |  6.29 ns |  5.89 ns | 486.5 ns | 477.5 ns | 495.4 ns |  1.00 |    0.02 | 0.7263 |    3040 B |        1.00 |
| Create_JsonArray        |     PR | 463.9 ns |  4.96 ns |  4.64 ns | 463.1 ns | 455.2 ns | 471.9 ns |  0.95 |    0.01 | 0.7258 |    3040 B |        1.00 |
|                         |        |          |          |          |          |          |          |       |         |        |           |             |
| Create_JsonObject_Small | .NET 8 | 236.1 ns |  1.31 ns |  1.16 ns | 236.1 ns | 233.7 ns | 237.8 ns |  1.00 |    0.01 | 0.1618 |     680 B |        1.00 |
| Create_JsonObject_Small |     PR | 198.7 ns |  2.13 ns |  1.99 ns | 198.2 ns | 195.9 ns | 202.0 ns |  0.84 |    0.01 | 0.2503 |    1048 B |        1.54 |
|                         |        |          |          |          |          |          |          |       |         |        |           |             |
| Create_JsonObject_Large | .NET 8 | 639.4 ns |  6.81 ns |  6.37 ns | 638.6 ns | 631.1 ns | 652.8 ns |  1.00 |    0.01 | 0.5612 |    2352 B |        1.00 |
| Create_JsonObject_Large |     PR | 393.0 ns |  2.78 ns |  2.60 ns | 393.0 ns | 389.8 ns | 397.8 ns |  0.61 |    0.01 | 0.5102 |    2136 B |        0.91 |
