### PR TITLE
Support class target in RUC/RDC code fixers

### DIFF
--- a/src/tools/illink/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
@@ -87,7 +87,7 @@ namespace ILLink.CodeFix
 			Field = 0x0004,
 			Event = 0x0008,
 			Class = 0x0010,
-			All = MethodOrConstructor | Property | Field | Event
+			All = MethodOrConstructor | Property | Field | Event | Class
 		}
 
 		private static CSharpSyntaxNode? FindAttributableParent (SyntaxNode node, AttributeableParentTargets targets)

--- a/src/tools/illink/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
@@ -104,7 +104,7 @@ namespace ILLink.CodeFix
 				case PropertyDeclarationSyntax:
 				case EventDeclarationSyntax:
 					// If the attribute can be placed on a method but not directly on a property/event, we don't want to keep walking up
-					// the syntax tree to annotate the class. Instead the correct thing to do is to add accessor methods and annotatet those.
+					// the syntax tree to annotate the class. Instead the correct thing to do is to add accessor methods and annotate those.
 					// The code fixer doesn't support doing this automatically, so return null to indicate that the attribute can't be added.
 					if (targets.HasFlag (AttributeableParentTargets.MethodOrConstructor))
 						return null;

--- a/src/tools/illink/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
@@ -86,6 +86,7 @@ namespace ILLink.CodeFix
 			Property = 0x0002,
 			Field = 0x0004,
 			Event = 0x0008,
+			Class = 0x0010,
 			All = MethodOrConstructor | Property | Field | Event
 		}
 
@@ -97,10 +98,22 @@ namespace ILLink.CodeFix
 				case LambdaExpressionSyntax:
 					return null;
 
-				case LocalFunctionStatementSyntax or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax when targets.HasFlag (AttributeableParentTargets.MethodOrConstructor):
 				case PropertyDeclarationSyntax when targets.HasFlag (AttributeableParentTargets.Property):
-				case FieldDeclarationSyntax when targets.HasFlag (AttributeableParentTargets.Field):
 				case EventDeclarationSyntax when targets.HasFlag (AttributeableParentTargets.Event):
+					return (CSharpSyntaxNode) parentNode;
+				case PropertyDeclarationSyntax:
+				case EventDeclarationSyntax:
+					// If the attribute can be placed on a method but not directly on a property/event, we don't want to keep walking up
+					// the syntax tree to annotate the class. Instead the correct thing to do is to add accessor methods and annotatet those.
+					// The code fixer doesn't support doing this automatically, so return null to indicate that the attribute can't be added.
+					if (targets.HasFlag (AttributeableParentTargets.MethodOrConstructor))
+						return null;
+
+					parentNode = parentNode.Parent;
+					break;
+				case LocalFunctionStatementSyntax or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax when targets.HasFlag (AttributeableParentTargets.MethodOrConstructor):
+				case FieldDeclarationSyntax when targets.HasFlag (AttributeableParentTargets.Field):
+				case ClassDeclarationSyntax when targets.HasFlag (AttributeableParentTargets.Class):
 					return (CSharpSyntaxNode) parentNode;
 
 				default:

--- a/src/tools/illink/src/ILLink.CodeFix/RequiresDynamicCodeCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/RequiresDynamicCodeCodeFixProvider.cs
@@ -25,7 +25,7 @@ namespace ILLink.CodeFix
 
 		private protected override string FullyQualifiedAttributeName => RequiresDynamicCodeAnalyzer.FullyQualifiedRequiresDynamicCodeAttribute;
 
-		private protected override AttributeableParentTargets AttributableParentTargets => AttributeableParentTargets.MethodOrConstructor;
+		private protected override AttributeableParentTargets AttributableParentTargets => AttributeableParentTargets.MethodOrConstructor | AttributeableParentTargets.Class;
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 

--- a/src/tools/illink/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
@@ -25,7 +25,7 @@ namespace ILLink.CodeFix
 
 		private protected override string FullyQualifiedAttributeName => RequiresUnreferencedCodeAnalyzer.FullyQualifiedRequiresUnreferencedCodeAttribute;
 
-		private protected override AttributeableParentTargets AttributableParentTargets => AttributeableParentTargets.MethodOrConstructor;
+		private protected override AttributeableParentTargets AttributableParentTargets => AttributeableParentTargets.MethodOrConstructor | AttributeableParentTargets.Class;
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 


### PR DESCRIPTION
While annotating some libraries I encountered cases where static field initializers had trim/aot warnings. This adds support for bubbling those warnings up to the class level.