### PR TITLE
Clean up the notes on experimental APIs to simplify for maintenance

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -306,8 +306,8 @@ Diagnostic id values for experimental APIs must not be recycled, as that could s
 
 | Diagnostic ID     | Introduced | Removed | Description |
 | :---------------- | ---------: | ------: | :---------- |
-|  __`SYSLIB5001`__ |     .NET 9 |     TBD | `Tensor<T>` and related APIs in System.Numerics.Tensors are experimental in .NET 9 |
-|  __`SYSLIB5002`__ |     .NET 9 |     TBD | `SystemColors` alternate colors are experimental in .NET 9 |
-|  __`SYSLIB5003`__ |     .NET 9 |     TBD | `System.Runtime.Intrinsics.Arm.Sve` is experimental in .NET 9 |
-|  __`SYSLIB5004`__ |     .NET 9 |     TBD | `X86Base.DivRem` is experimental in .NET 9 since performance is not as optimized as `T.DivRem` |
-|  __`SYSLIB5005`__ |     .NET 9 |     TBD | `System.Formats.Nrbf` is experimental in .NET 9 |
+|  __`SYSLIB5001`__ |     .NET 9 |     TBD | `Tensor<T>` and related APIs in System.Numerics.Tensors are experimental |
+|  __`SYSLIB5002`__ |     .NET 9 |     TBD | `SystemColors` alternate colors are experimental |
+|  __`SYSLIB5003`__ |     .NET 9 |     TBD | `System.Runtime.Intrinsics.Arm.Sve` is experimental |
+|  __`SYSLIB5004`__ |     .NET 9 |     TBD | `X86Base.DivRem` is experimental since performance is not as optimized as `T.DivRem` |
+|  __`SYSLIB5005`__ |     .NET 9 |     TBD | `System.Formats.Nrbf` is experimental |

--- a/src/libraries/Common/src/System/Experimentals.cs
+++ b/src/libraries/Common/src/System/Experimentals.cs
@@ -16,19 +16,19 @@ namespace System
         // but retained in the table in docs\project\list-of-diagnostics.md to prevent reuse. Be sure to remove
         // suppressions from the codebase as well.
 
-        // Tensor<T> and related APIs in System.Numerics.Tensors are experimental in .NET 9
+        // Tensor<T> and related APIs in System.Numerics.Tensors are experimental
         internal const string TensorTDiagId = "SYSLIB5001";
 
-        // SystemColors alternate colors are marked as [Experimental] in .NET 9
+        // SystemColors alternate colors are marked as [Experimental]
         internal const string SystemColorsDiagId = "SYSLIB5002";
 
-        // System.Runtime.Intrinsics.Arm.Sve is experimental in .NET 9
+        // System.Runtime.Intrinsics.Arm.Sve is experimental
         internal const string ArmSveDiagId = "SYSLIB5003";
 
-        // X86Base.DivRem is experimental in .NET 9 since performance is not as optimized as T.DivRem
+        // X86Base.DivRem is experimental since performance is not as optimized as T.DivRem
         internal const string X86BaseDivRemDiagId = "SYSLIB5004";
 
-        // System.Formats.Nrbf is experimental in .NET 9
+        // System.Formats.Nrbf is experimental
         internal const string NrbfDecoderDiagId = "SYSLIB5005";
 
         // When adding a new diagnostic ID, add it to the table in docs\project\list-of-diagnostics.md as well.


### PR DESCRIPTION
As noted in https://github.com/dotnet/runtime/pull/107905#discussion_r1763861853, we don't need to indicate the version in the note for experimental APIs. The table already lists the versions the diagnostic was added and removed.