### PR TITLE
[RISC-V] Fixed DBG_DebugBreak stub

### DIFF
--- a/src/coreclr/pal/src/arch/riscv64/debugbreak.S
+++ b/src/coreclr/pal/src/arch/riscv64/debugbreak.S
@@ -4,4 +4,5 @@
 #include "unixasmmacros.inc"
 LEAF_ENTRY DBG_DebugBreak, _TEXT
     EMIT_BREAKPOINT
+    ret
 LEAF_END_MARKED DBG_DebugBreak, _TEXT


### PR DESCRIPTION
Added missing `ret` instruction after breakpoint instruction call in the `debugbreak.S` stub 

@shushanhf, I noticed that LA also lacks this instruction, Could you check it?

Part of #84834, cc @dotnet/samsung