### PR TITLE
[LoongArch64] Fixed DBG_DebugBreak stub for missing return instruction.

### DIFF
--- a/src/coreclr/pal/src/arch/loongarch64/debugbreak.S
+++ b/src/coreclr/pal/src/arch/loongarch64/debugbreak.S
@@ -4,4 +4,5 @@
 #include "unixasmmacros.inc"
 LEAF_ENTRY DBG_DebugBreak, _TEXT
     EMIT_BREAKPOINT
+    jirl  $r0, $ra, 0
 LEAF_END_MARKED DBG_DebugBreak, _TEXT


### PR DESCRIPTION
Fixed DBG_DebugBreak stub for missing return instruction after #107972 
Thanks @Bajtazar 