### PR TITLE
Fix SG nullability annotations for required and init properties.

### DIFF
--- a/src/libraries/System.Text.Json/gen/Helpers/RoslynExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Helpers/RoslynExtensions.cs
@@ -323,7 +323,7 @@ namespace System.Text.Json.SourceGeneration
             {
                 // Because System.Text.Json cannot distinguish between nullable and non-nullable type parameters,
                 // (e.g. the same metadata is being used for both KeyValuePair<string, string?> and KeyValuePair<string, string>),
-                // we derive nullability annotations from the original definition of the field and not instation.
+                // we derive nullability annotations from the original definition of the field and not its instantiation.
                 // This preserves compatibility with the capabilities of the reflection-based NullabilityInfo reader.
                 parameter = parameter.OriginalDefinition;
                 return !IsInputTypeNonNullable(parameter, parameter.Type);

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -754,6 +754,7 @@ namespace System.Text.Json.SourceGeneration
                             Name = {{FormatStringLiteral(spec.Name)}},
                             ParameterType = typeof({{spec.ParameterType.FullyQualifiedName}}),
                             Position = {{spec.ParameterIndex}},
+                            IsNullable = {{FormatBoolLiteral(spec.IsNullable)}},
                             IsMemberInitializer = true,
                         },
                         """);

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -1534,6 +1534,7 @@ namespace System.Text.Json.SourceGeneration
                                 ParameterType = property.PropertyType,
                                 MatchesConstructorParameter = matchingConstructorParameter is not null,
                                 ParameterIndex = matchingConstructorParameter?.ParameterIndex ?? paramCount++,
+                                IsNullable = property.PropertyType.CanBeNull && !property.IsSetterNonNullableAnnotation,
                             };
 
                             (propertyInitializers ??= new()).Add(propertyInitializer);

--- a/src/libraries/System.Text.Json/gen/Model/PropertyInitializerGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/Model/PropertyInitializerGenerationSpec.cs
@@ -31,5 +31,7 @@ namespace System.Text.Json.SourceGeneration
         public required int ParameterIndex { get; init; }
 
         public required bool MatchesConstructorParameter { get; init; }
+
+        public required bool IsNullable { get; init; }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/NullableAnnotationsTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/NullableAnnotationsTests.cs
@@ -72,6 +72,8 @@ namespace System.Text.Json.Serialization.Tests
             yield return Wrap(typeof(NotNullableSpecialTypePropertiesClass), nameof(NotNullableSpecialTypePropertiesClass.JsonDocument));
             yield return Wrap(typeof(NullableObliviousConstructorParameter), nameof(NullableObliviousConstructorParameter.Property));
             yield return Wrap(typeof(NotNullGenericPropertyClass<string>), nameof(NotNullGenericPropertyClass<string>.Property));
+            yield return Wrap(typeof(ClassWithNonNullableInitProperty), nameof(ClassWithNonNullableInitProperty.Property));
+            yield return Wrap(typeof(ClassWithNonNullableInitProperty), nameof(ClassWithNonNullableRequiredProperty.Property));
 
             static object[] Wrap(Type type, string propertyName) => [type, propertyName];
         }
@@ -125,6 +127,8 @@ namespace System.Text.Json.Serialization.Tests
             yield return Wrap(typeof(NullableObliviousPropertyClass), nameof(NullableObliviousPropertyClass.Property));
             yield return Wrap(typeof(GenericPropertyClass<string>), nameof(GenericPropertyClass<string>.Property));
             yield return Wrap(typeof(NullableGenericPropertyClass<string>), nameof(NullableGenericPropertyClass<string>.Property));
+            yield return Wrap(typeof(ClassWithNullableInitProperty), nameof(ClassWithNullableInitProperty.Property));
+            yield return Wrap(typeof(ClassWithNullableInitProperty), nameof(ClassWithNullableRequiredProperty.Property));
 
             static object[] Wrap(Type type, string propertyName) => [type, propertyName];
         }
@@ -191,6 +195,8 @@ namespace System.Text.Json.Serialization.Tests
             yield return Wrap(typeof(DisallowNullConstructorParameter), nameof(DisallowNullConstructorParameter.Property));
             yield return Wrap(typeof(DisallowNullConstructorParameter<string>), nameof(DisallowNullConstructorParameter<string>.Property));
             yield return Wrap(typeof(NotNullGenericConstructorParameter<string>), nameof(NotNullGenericConstructorParameter<string>.Property));
+            yield return Wrap(typeof(ClassWithNonNullableInitProperty), nameof(ClassWithNonNullableInitProperty.Property));
+            yield return Wrap(typeof(ClassWithNonNullableInitProperty), nameof(ClassWithNonNullableRequiredProperty.Property));
 
             static object[] Wrap(Type type, string propertyName) => [type, propertyName];
         }
@@ -249,6 +255,8 @@ namespace System.Text.Json.Serialization.Tests
             yield return Wrap(typeof(AllowNullConstructorParameter<string>), nameof(AllowNullConstructorParameter<string>.Property));
             yield return Wrap(typeof(GenericConstructorParameter<string>), nameof(GenericConstructorParameter<string>.Property));
             yield return Wrap(typeof(NullableGenericConstructorParameter<string>), nameof(NullableGenericConstructorParameter<string>.Property));
+            yield return Wrap(typeof(ClassWithNullableInitProperty), nameof(ClassWithNullableInitProperty.Property));
+            yield return Wrap(typeof(ClassWithNullableInitProperty), nameof(ClassWithNullableRequiredProperty.Property));
 
             static object[] Wrap(Type type, string propertyName) => [type, propertyName];
         }
@@ -764,6 +772,26 @@ namespace System.Text.Json.Serialization.Tests
         {
             [JsonInclude]
             public string? Field;
+        }
+
+        public class ClassWithNullableInitProperty
+        {
+            public string? Property { get; init; }
+        }
+
+        public class ClassWithNonNullableInitProperty
+        {
+            public string Property { get; init; }
+        }
+
+        public class ClassWithNullableRequiredProperty
+        {
+            public required string? Property { get; set; }
+        }
+
+        public class ClassWithNonNullableRequiredProperty
+        {
+            public required string Property { get; set; }
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/NullableAnnotationsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/NullableAnnotationsTests.cs
@@ -65,6 +65,10 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(NullableGenericConstructorParameter<string>))]
         [JsonSerializable(typeof(NotNullGenericConstructorParameter<string>))]
         [JsonSerializable(typeof(NotNullablePropertyWithIgnoreConditions))]
+        [JsonSerializable(typeof(ClassWithNullableInitProperty))]
+        [JsonSerializable(typeof(ClassWithNonNullableInitProperty))]
+        [JsonSerializable(typeof(ClassWithNullableRequiredProperty))]
+        [JsonSerializable(typeof(ClassWithNonNullableRequiredProperty))]
         internal sealed partial class NullableAnnotationsTestsContext_Metadata
             : JsonSerializerContext { }
     }
@@ -128,6 +132,10 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(NullableGenericConstructorParameter<string>))]
         [JsonSerializable(typeof(NotNullGenericConstructorParameter<string>))]
         [JsonSerializable(typeof(NotNullablePropertyWithIgnoreConditions))]
+        [JsonSerializable(typeof(ClassWithNullableInitProperty))]
+        [JsonSerializable(typeof(ClassWithNonNullableInitProperty))]
+        [JsonSerializable(typeof(ClassWithNullableRequiredProperty))]
+        [JsonSerializable(typeof(ClassWithNonNullableRequiredProperty))]
         internal sealed partial class NullableAnnotationsTestsContext_Default
             : JsonSerializerContext
         { }


### PR DESCRIPTION
Fix #107968. Should be backported to .NET 9.