### PR TITLE
Enable GC double reporting detection

### DIFF
--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -30,21 +30,6 @@ typedef void enum_alloc_context_func(gc_alloc_context*, void*);
 // Callback passed to CreateBackgroundThread.
 typedef uint32_t (__stdcall *GCBackgroundThreadFunction)(void* param);
 
-template<typename ELEMENT,typename TRAITS>
-class SetSHash;
-
-template<typename ELEMENT>
-class PtrSetSHashTraits;
-
-// Struct often used as a parameter to callbacks.
-typedef struct
-{
-    promote_func*  f;
-    ScanContext*   sc;
-    CrawlFrame *   cf;
-    SetSHash<Object**, PtrSetSHashTraits<Object**> > *pScannedSlots;
-} GCCONTEXT;
-
 // SUSPEND_REASON is the reason why the GC wishes to suspend the EE,
 // used as an argument to IGCToCLR::SuspendEE.
 typedef enum

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -30,12 +30,19 @@ typedef void enum_alloc_context_func(gc_alloc_context*, void*);
 // Callback passed to CreateBackgroundThread.
 typedef uint32_t (__stdcall *GCBackgroundThreadFunction)(void* param);
 
+template<typename ELEMENT,typename TRAITS>
+class SetSHash;
+
+template<typename ELEMENT>
+class PtrSetSHashTraits;
+
 // Struct often used as a parameter to callbacks.
 typedef struct
 {
     promote_func*  f;
     ScanContext*   sc;
     CrawlFrame *   cf;
+    SetSHash<Object**, PtrSetSHashTraits<Object**> > *pScannedSlots;
 } GCCONTEXT;
 
 // SUSPEND_REASON is the reason why the GC wishes to suspend the EE,

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -278,7 +278,7 @@ CONFIG_STRING_INFO(INTERNAL_SkipGCCoverage, W("SkipGcCoverage"), "Specify a list
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_StatsUpdatePeriod, W("StatsUpdatePeriod"), 60, "Specifies the interval, in seconds, at which to update the statistics")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCRetainVM, W("GCRetainVM"), 0, "When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way)")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_gcAllowVeryLargeObjects, W("gcAllowVeryLargeObjects"), 1, "Allow allocation of 2GB+ objects on GC heap")
-RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_EnableGCHoleMonitoring, W("EnableGCHoleMonitoring"), 0, "Enable checks to proactively watch for possible GC holes")
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_CheckDoubleReporting, W("CheckDoubleReporting"), 0, "Enable checks to proactively watch for possible GC holes")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCStress, W("GCStress"), 0, "Trigger GCs at regular intervals")
 CONFIG_DWORD_INFO(INTERNAL_GcStressOnDirectCalls, W("GcStressOnDirectCalls"), 0, "Whether to trigger a GC on direct calls")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_HeapVerify, W("HeapVerify"), 0, "When set verifies the integrity of the managed heap on entry and exit of each GC")

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -278,6 +278,7 @@ CONFIG_STRING_INFO(INTERNAL_SkipGCCoverage, W("SkipGcCoverage"), "Specify a list
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_StatsUpdatePeriod, W("StatsUpdatePeriod"), 60, "Specifies the interval, in seconds, at which to update the statistics")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCRetainVM, W("GCRetainVM"), 0, "When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way)")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_gcAllowVeryLargeObjects, W("gcAllowVeryLargeObjects"), 1, "Allow allocation of 2GB+ objects on GC heap")
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_EnableGCHoleMonitoring, W("EnableGCHoleMonitoring"), 0, "Enable checks to proactively watch for possible GC holes")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCStress, W("GCStress"), 0, "Trigger GCs at regular intervals")
 CONFIG_DWORD_INFO(INTERNAL_GcStressOnDirectCalls, W("GcStressOnDirectCalls"), 0, "Whether to trigger a GC on direct calls")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_HeapVerify, W("HeapVerify"), 0, "When set verifies the integrity of the managed heap on entry and exit of each GC")

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -349,6 +349,14 @@ void* GetClrModuleBase();
 // use this when you want to memcpy something that contains GC refs
 void memmoveGCRefs(void *dest, const void *src, size_t len);
 
+// Struct often used as a parameter to callbacks.
+typedef struct
+{
+    promote_func*  f;
+    ScanContext*   sc;
+    CrawlFrame *   cf;
+    SetSHash<Object**, PtrSetSHashTraits<Object**> > *pScannedSlots;
+} GCCONTEXT;
 
 #if defined(_DEBUG)
 

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -425,7 +425,7 @@ HRESULT EEConfig::sync()
     iGCConservative =  (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_gcConservative) != 0);
 #endif // FEATURE_CONSERVATIVE_GC
 
-    fEnableGCHoleMonitoring = (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_EnableGCHoleMonitoring) != 0);
+    fCheckDoubleReporting = (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_CheckDoubleReporting, iGCStress ? 1 : 0) != 0);
 
 #ifdef HOST_64BIT
     iGCAllowVeryLargeObjects = (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_gcAllowVeryLargeObjects) != 0);

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -425,6 +425,8 @@ HRESULT EEConfig::sync()
     iGCConservative =  (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_gcConservative) != 0);
 #endif // FEATURE_CONSERVATIVE_GC
 
+    fEnableGCHoleMonitoring = (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_EnableGCHoleMonitoring) != 0);
+
 #ifdef HOST_64BIT
     iGCAllowVeryLargeObjects = (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_gcAllowVeryLargeObjects) != 0);
 #endif

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -389,7 +389,7 @@ public:
 #ifdef FEATURE_CONSERVATIVE_GC
     bool    GetGCConservative()             const {LIMITED_METHOD_CONTRACT; return iGCConservative;}
 #endif
-    bool    GetEnableGCHoleMonitoring()     const {LIMITED_METHOD_CONTRACT; return fEnableGCHoleMonitoring; }
+    bool    GetCheckDoubleReporting()       const {LIMITED_METHOD_CONTRACT; return fCheckDoubleReporting; }
 #ifdef HOST_64BIT
     bool    GetGCAllowVeryLargeObjects()    const {LIMITED_METHOD_CONTRACT; return iGCAllowVeryLargeObjects;}
 #endif
@@ -573,7 +573,7 @@ private: //----------------------------------------------------------------
     bool iGCAllowVeryLargeObjects;
 #endif // HOST_64BIT
 
-    bool fEnableGCHoleMonitoring;
+    bool fCheckDoubleReporting;
 
     bool fGCBreakOnOOM;
 

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -389,6 +389,7 @@ public:
 #ifdef FEATURE_CONSERVATIVE_GC
     bool    GetGCConservative()             const {LIMITED_METHOD_CONTRACT; return iGCConservative;}
 #endif
+    bool    GetEnableGCHoleMonitoring()     const {LIMITED_METHOD_CONTRACT; return fEnableGCHoleMonitoring; }
 #ifdef HOST_64BIT
     bool    GetGCAllowVeryLargeObjects()    const {LIMITED_METHOD_CONTRACT; return iGCAllowVeryLargeObjects;}
 #endif
@@ -571,6 +572,8 @@ private: //----------------------------------------------------------------
 #ifdef HOST_64BIT
     bool iGCAllowVeryLargeObjects;
 #endif // HOST_64BIT
+
+    bool fEnableGCHoleMonitoring;
 
     bool fGCBreakOnOOM;
 

--- a/src/coreclr/vm/gcenv.ee.common.cpp
+++ b/src/coreclr/vm/gcenv.ee.common.cpp
@@ -149,6 +149,14 @@ void CheckDoubleReporting(GCCONTEXT *pCtx, Object **ppObj, uint32_t flags)
 {
     if ((GCStress<cfg_any>::IsEnabled() || g_pConfig->GetEnableGCHoleMonitoring()) && ((flags & GC_CALL_PINNED) == 0) && pCtx->sc->promotion)
     {
+        if (pCtx->pScannedSlots == NULL)
+        {
+            pCtx->pScannedSlots = new (nothrow) SetSHash<Object**, PtrSetSHashTraits<Object**> >();
+            if (pCtx->pScannedSlots == NULL)
+            {
+                return;
+            }
+        }
         _ASSERTE_ALL_BUILDS(pCtx->pScannedSlots->Lookup(ppObj) == NULL);
         pCtx->pScannedSlots->AddNoThrow(ppObj);
     }

--- a/src/coreclr/vm/gcenv.ee.common.cpp
+++ b/src/coreclr/vm/gcenv.ee.common.cpp
@@ -137,10 +137,22 @@ inline bool SafeToReportGenericParamContext(CrawlFrame* pCF)
     return true;
 }
 
-thread_local void **doubleReportTracking = NULL;
-thread_local int doubleReportTrackingSize = 0;
-thread_local int doubleReportTrackingIndex = 0;
-static const int DoubleReportTrackingInitialSize = 256;
+/*
+ * CheckDoubleReporting()
+ *
+ * This function is used to check for double reporting of the same stack slot or register.
+ * Double reporting is not allowed unless the reference is pinned, since it would
+ * result in incorrect updating of a reference in the slot in case the GC moves the
+ * object.
+ */
+void CheckDoubleReporting(GCCONTEXT *pCtx, Object **ppObj, uint32_t flags)
+{
+    if ((GCStress<cfg_any>::IsEnabled() || g_pConfig->GetEnableGCHoleMonitoring()) && ((flags & GC_CALL_PINNED) == 0) && pCtx->sc->promotion)
+    {
+        _ASSERTE_ALL_BUILDS(pCtx->pScannedSlots->Lookup(ppObj) == NULL);
+        pCtx->pScannedSlots->AddNoThrow(ppObj);
+    }
+}
 
 /*
  * GcEnumObject()
@@ -154,21 +166,7 @@ void GcEnumObject(LPVOID pData, OBJECTREF *pObj, uint32_t flags)
     Object ** ppObj = (Object **)pObj;
     GCCONTEXT   * pCtx  = (GCCONTEXT *) pData;
 
-    if (g_pConfig->GetEnableGCHoleMonitoring() && ((flags & GC_CALL_PINNED) == 0) && pCtx->sc->promotion)
-    {
-        if (doubleReportTrackingIndex == doubleReportTrackingSize)
-        {
-            doubleReportTrackingSize = (doubleReportTrackingSize == 0) ? DoubleReportTrackingInitialSize : doubleReportTrackingSize * 2;
-            doubleReportTracking = (void**)realloc(doubleReportTracking, doubleReportTrackingSize * sizeof(void*));
-        }
-        for (int i = 0; i < doubleReportTrackingIndex; i++)
-        {
-            // Double reporting of the same slot detected
-            _ASSERTE_ALL_BUILDS(doubleReportTracking[i] != pObj);
-        }
-
-        doubleReportTracking[doubleReportTrackingIndex++] = pObj;
-    }
+    CheckDoubleReporting(pCtx, ppObj, flags);
 
     // Since we may be asynchronously walking another thread's stack,
     // check (frequently) for stack-buffer-overrun corruptions after

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -32,8 +32,6 @@ extern void FinalizeWeakReference(Object* obj);
 extern GCHeapHardLimitInfo g_gcHeapHardLimitInfo;
 extern bool g_gcHeapHardLimitInfoSpecified;
 
-extern thread_local int doubleReportTrackingIndex;
-
 #include <generatedumpflags.h>
 #include "gcrefmap.h"
 

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -203,7 +203,7 @@ static void ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc)
 #if defined(FEATURE_EH_FUNCLETS)
         flagsStackWalk |= GC_FUNCLET_REFERENCE_REPORTING;
 #endif // defined(FEATURE_EH_FUNCLETS)
-        gcctx.pScannedSlots = new SetSHash<Object**, PtrSetSHashTraits<Object**> >();
+        gcctx.pScannedSlots = NULL;
         pThread->StackWalkFrames( GcStackCrawlCallBack, &gcctx, flagsStackWalk);
         delete gcctx.pScannedSlots;
     }

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -32,6 +32,8 @@ extern void FinalizeWeakReference(Object* obj);
 extern GCHeapHardLimitInfo g_gcHeapHardLimitInfo;
 extern bool g_gcHeapHardLimitInfoSpecified;
 
+extern thread_local int doubleReportTrackingIndex;
+
 #include <generatedumpflags.h>
 #include "gcrefmap.h"
 
@@ -201,6 +203,7 @@ static void ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc)
 #if defined(FEATURE_EH_FUNCLETS)
         flagsStackWalk |= GC_FUNCLET_REFERENCE_REPORTING;
 #endif // defined(FEATURE_EH_FUNCLETS)
+        doubleReportTrackingIndex = 0;
         pThread->StackWalkFrames( GcStackCrawlCallBack, &gcctx, flagsStackWalk);
     }
 

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -203,8 +203,9 @@ static void ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc)
 #if defined(FEATURE_EH_FUNCLETS)
         flagsStackWalk |= GC_FUNCLET_REFERENCE_REPORTING;
 #endif // defined(FEATURE_EH_FUNCLETS)
-        doubleReportTrackingIndex = 0;
+        gcctx.pScannedSlots = new SetSHash<Object**, PtrSetSHashTraits<Object**> >();
         pThread->StackWalkFrames( GcStackCrawlCallBack, &gcctx, flagsStackWalk);
+        delete gcctx.pScannedSlots;
     }
 
     GCFrame* pGCFrame = pThread->GetGCFrame();


### PR DESCRIPTION
This change adds detection of double reporting of stack slots and registers during GC stack walk. The detection is disabled by default and can be enabled using the DOTNET_EnableGCHoleMonitoring env variable.

If a double reporting is found, it triggers an assert in both release and debug builds of the runtime.