### PR TITLE
JIT: run a late pass of empty try/finally/fault removal

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5134,6 +5134,9 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     DoPhase(this, PHASE_STRESS_SPLIT_TREE, &Compiler::StressSplitTree);
 #endif
 
+    // Try again to remove empty try finally/fault clauses
+    DoPhase(this, PHASE_EMPTY_FINALLY_2, &Compiler::fgRemoveEmptyFinally);
+
     if (UsesFunclets())
     {
         // Create funclets from the EH handlers.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6808,6 +6808,9 @@ public:
         // Which EH region forms the key?
         AcdKeyDesignator  acdKeyDsg;
 
+        // Update the key designator, after modifying the region indices
+        bool UpdateKeyDesignator(Compiler* compiler);
+
         SpecialCodeKind acdKind; // what kind of a special block is this?
         bool            acdUsed; // do we need to keep this helper block?
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6801,9 +6801,6 @@ public:
         // we jump to raise the exception.
         BasicBlock*     acdDstBlk;
 
-        // EH region key used to look up this dsc in the map
-        unsigned        acdData;
-
         // EH regions for this dsc
         unsigned short acdTryIndex;
         unsigned short acdHndIndex;
@@ -6819,7 +6816,10 @@ public:
         unsigned acdStkLvl;     // stack level in stack slots.
 #endif                          // !FEATURE_FIXED_OUT_ARGS
 
-        INDEBUG(unsigned acdNum);
+#ifdef DEBUG
+        unsigned acdNum;
+        void Dump();
+#endif;
     };
 
     unsigned acdCount = 0;

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -94,6 +94,7 @@ CompPhaseNameMacro(PHASE_OPTIMIZE_BRANCHES,          "Redundant branch opts",   
 CompPhaseNameMacro(PHASE_ASSERTION_PROP_MAIN,        "Assertion prop",                 false, -1, false)
 CompPhaseNameMacro(PHASE_IF_CONVERSION,              "If conversion",                  false, -1, false)
 CompPhaseNameMacro(PHASE_VN_BASED_DEAD_STORE_REMOVAL,"VN-based dead store removal",    false, -1, false)
+CompPhaseNameMacro(PHASE_EMPTY_FINALLY_2,            "Remove empty finally 2",         false, -1, false)
 CompPhaseNameMacro(PHASE_OPT_UPDATE_FLOW_GRAPH,      "Update flow graph opt pass",     false, -1, false)
 CompPhaseNameMacro(PHASE_STRESS_SPLIT_TREE,          "Stress gtSplitTree",             false, -1, false)
 CompPhaseNameMacro(PHASE_EXPAND_RTLOOKUPS,           "Expand runtime lookups",         false, -1, true)

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -74,11 +74,11 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
     {
         EHblkDsc* const HBtab = &compHndBBtab[XTnum];
 
-        // Check if this is a try/finally.  We could also look for empty
-        // try/fault but presumably those are rare.
-        if (!HBtab->HasFinallyHandler())
+        // Check if this is a try/finally or try/fault.
+        //
+        if (!HBtab->HasFinallyOrFaultHandler())
         {
-            JITDUMP("EH#%u is not a try-finally; skipping.\n", XTnum);
+            JITDUMP("EH#%u is not a try-finally or try-fault; skipping.\n", XTnum);
             XTnum++;
             continue;
         }
@@ -89,18 +89,18 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
         BasicBlock* const firstBlock = HBtab->ebdHndBeg;
         BasicBlock* const lastBlock  = HBtab->ebdHndLast;
 
-        // Limit for now to finallys that are single blocks.
+        // Limit for now to handlers that are single blocks.
         if (firstBlock != lastBlock)
         {
-            JITDUMP("EH#%u finally has multiple basic blocks; skipping.\n", XTnum);
+            JITDUMP("EH#%u handler has multiple basic blocks; skipping.\n", XTnum);
             XTnum++;
             continue;
         }
 
-        // If the finally's block jumps back to itself, then it is not empty.
+        // If the handler's block jumps back to itself, then it is not empty.
         if (firstBlock->KindIs(BBJ_ALWAYS) && firstBlock->TargetIs(firstBlock))
         {
-            JITDUMP("EH#%u finally has basic block that jumps to itself; skipping.\n", XTnum);
+            JITDUMP("EH#%u handler has basic block that jumps to itself; skipping.\n", XTnum);
             XTnum++;
             continue;
         }
@@ -121,63 +121,69 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
 
         if (!isEmpty)
         {
-            JITDUMP("EH#%u finally is not empty; skipping.\n", XTnum);
+            JITDUMP("EH#%u handler is not empty; skipping.\n", XTnum);
             XTnum++;
             continue;
         }
 
-        assert(lastBlock->KindIs(BBJ_EHFINALLYRET));
+        // Note we may see single empty BBJ_THROW handler blocks for EH regions
+        // deemed unreachable.
+        //
+        assert(lastBlock->KindIs(BBJ_EHFINALLYRET, BBJ_EHFAULTRET, BBJ_THROW));
 
-        JITDUMP("EH#%u has empty finally, removing the region.\n", XTnum);
+        JITDUMP("EH#%u has empty handler, removing the region.\n", XTnum);
 
-        // Find all the call finallys that invoke this finally,
-        // and modify them to jump to the return point.
-        BasicBlock* firstCallFinallyRangeBlock = nullptr;
-        BasicBlock* lastCallFinallyRangeBlock  = nullptr;
-        ehGetCallFinallyBlockRange(XTnum, &firstCallFinallyRangeBlock, &lastCallFinallyRangeBlock);
-
-        BasicBlock*       currentBlock             = firstCallFinallyRangeBlock;
-        BasicBlock* const endCallFinallyRangeBlock = lastCallFinallyRangeBlock->Next();
-
-        while (currentBlock != endCallFinallyRangeBlock)
+        if (HBtab->HasFinallyHandler())
         {
-            BasicBlock* nextBlock = currentBlock->Next();
+            // Find all the call finallys that invoke this finally,
+            // and modify them to jump to the return point.
+            BasicBlock* firstCallFinallyRangeBlock = nullptr;
+            BasicBlock* lastCallFinallyRangeBlock  = nullptr;
+            ehGetCallFinallyBlockRange(XTnum, &firstCallFinallyRangeBlock, &lastCallFinallyRangeBlock);
 
-            if (currentBlock->KindIs(BBJ_CALLFINALLY) && currentBlock->TargetIs(firstBlock))
+            BasicBlock*       currentBlock             = firstCallFinallyRangeBlock;
+            BasicBlock* const endCallFinallyRangeBlock = lastCallFinallyRangeBlock->Next();
+
+            while (currentBlock != endCallFinallyRangeBlock)
             {
-                // Retarget the call finally to jump to the return point.
-                //
-                // We don't expect to see retless finallys here, since
-                // the finally is empty.
-                noway_assert(currentBlock->isBBCallFinallyPair());
+                BasicBlock* nextBlock = currentBlock->Next();
 
-                BasicBlock* const leaveBlock          = currentBlock->Next();
-                BasicBlock* const postTryFinallyBlock = leaveBlock->GetFinallyContinuation();
+                if (currentBlock->KindIs(BBJ_CALLFINALLY) && currentBlock->TargetIs(firstBlock))
+                {
+                    // Retarget the call finally to jump to the return point.
+                    //
+                    // We don't expect to see retless finallys here, since
+                    // the finally is empty.
+                    noway_assert(currentBlock->isBBCallFinallyPair());
 
-                JITDUMP("Modifying callfinally " FMT_BB " leave " FMT_BB " finally " FMT_BB " continuation " FMT_BB
-                        "\n",
-                        currentBlock->bbNum, leaveBlock->bbNum, firstBlock->bbNum, postTryFinallyBlock->bbNum);
-                JITDUMP("so that " FMT_BB " jumps to " FMT_BB "; then remove " FMT_BB "\n", currentBlock->bbNum,
-                        postTryFinallyBlock->bbNum, leaveBlock->bbNum);
+                    BasicBlock* const leaveBlock          = currentBlock->Next();
+                    BasicBlock* const postTryFinallyBlock = leaveBlock->GetFinallyContinuation();
 
-                // Remove the `leaveBlock` first.
-                nextBlock = leaveBlock->Next();
-                fgPrepareCallFinallyRetForRemoval(leaveBlock);
-                fgRemoveBlock(leaveBlock, /* unreachable */ true);
+                    JITDUMP("Modifying callfinally " FMT_BB " leave " FMT_BB " finally " FMT_BB " continuation " FMT_BB
+                            "\n",
+                            currentBlock->bbNum, leaveBlock->bbNum, firstBlock->bbNum, postTryFinallyBlock->bbNum);
+                    JITDUMP("so that " FMT_BB " jumps to " FMT_BB "; then remove " FMT_BB "\n", currentBlock->bbNum,
+                            postTryFinallyBlock->bbNum, leaveBlock->bbNum);
 
-                // Ref count updates.
-                fgRedirectTargetEdge(currentBlock, postTryFinallyBlock);
-                currentBlock->SetKind(BBJ_ALWAYS);
-                currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
+                    // Remove the `leaveBlock` first.
+                    nextBlock = leaveBlock->Next();
+                    fgPrepareCallFinallyRetForRemoval(leaveBlock);
+                    fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
-                // Cleanup the postTryFinallyBlock
-                fgCleanupContinuation(postTryFinallyBlock);
+                    // Ref count updates.
+                    fgRedirectTargetEdge(currentBlock, postTryFinallyBlock);
+                    currentBlock->SetKind(BBJ_ALWAYS);
+                    currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
 
-                // Make sure iteration isn't going off the deep end.
-                assert(leaveBlock != endCallFinallyRangeBlock);
+                    // Cleanup the postTryFinallyBlock
+                    fgCleanupContinuation(postTryFinallyBlock);
+
+                    // Make sure iteration isn't going off the deep end.
+                    assert(leaveBlock != endCallFinallyRangeBlock);
+                }
+
+                currentBlock = nextBlock;
             }
-
-            currentBlock = nextBlock;
         }
 
         JITDUMP("Remove now-unreachable handler " FMT_BB "\n", firstBlock->bbNum);
@@ -219,6 +225,111 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
             }
         }
 
+        // Likewise, look for ACDs within this try, and update their try regions.
+        // And look for ACDs within the now-removed handler, and remove them.
+        //
+        if (fgHasAddCodeDscMap())
+        {
+            AddCodeDscMap* const map = fgGetAddCodeDscMap();
+            for (AddCodeDsc* const add : AddCodeDscMap::ValueIteration(map))
+            {
+                // Remember the old lookup key
+                //
+                AddCodeDscKey oldKey(add);
+
+                // If this ACD is in the handler we just removed,
+                // it must no longer be needed.
+                //
+                const bool inHnd = add->acdHndIndex > 0;
+                if (inHnd && ((unsigned)(add->acdHndIndex - 1) == XTnum))
+                {
+                    bool const removed = map->Remove(oldKey);
+                    assert(removed);
+                    JITDUMP("ACD%u was in EH#%u handler region: removing\n", XTnum);
+                    JITDUMPEXEC(add->Dump());
+                    continue;
+                }
+
+                // If this ACD is NOT in the try we just removed,
+                // it is unaffected (though it may get updated
+                // when the EH region is removed)..
+                //
+                bool inTry = add->acdTryIndex > 0;
+
+                if (!inTry || ((unsigned)(add->acdTryIndex - 1) != XTnum))
+                {
+                    continue;
+                }
+
+                // This ACD is in the try we just removed,
+                // update it to belong to the enclosing try region,
+                // which is the enclosing try of the associated handler.
+                //
+                // Then see if there is already an equivalent ACD in
+                // that region, and if so, "merge" this ACD into
+                // that one (by removing this ACD from the map).
+                //
+                // If there is no equivalent ACD, re-add this current ACD
+                // with an updated key.
+                //
+                add->acdTryIndex = firstBlock->bbTryIndex;
+                inTry            = add->acdTryIndex > 0;
+
+                // Because we "relocated" this ACD, it now be enclosed
+                // in a different region type. Figure this out.
+                //
+                AcdKeyDesignator newDsg = add->acdKeyDsg;
+
+                if (!inTry && !inHnd)
+                {
+                    // Moved outside of all EH regions.
+                    //
+                    newDsg = AcdKeyDesignator::KD_NONE;
+                }
+                else if (inTry && (!inHnd || (add->acdTryIndex < add->acdHndIndex)))
+                {
+                    // Moved into a parent try region.
+                    //
+                    newDsg = AcdKeyDesignator::KD_TRY;
+                }
+                else
+                {
+                    // Moved into a parent handler region.
+                    // Note this cannot be a filter region.
+                    //
+                    newDsg = AcdKeyDesignator::KD_HND;
+                }
+
+                add->acdKeyDsg = newDsg;
+
+                // Remove the ACD from the map via its old key
+                //
+                bool const removed = map->Remove(oldKey);
+                assert(removed);
+
+                // Compute the new key an see if there's an existing
+                // ACD with that key.
+                //
+                AddCodeDscKey newKey(add);
+                AddCodeDsc*   existing = nullptr;
+                if (map->Lookup(newKey, &existing))
+                {
+                    // If so, this ACD is now redundant
+                    //
+                    JITDUMP("ACD%u merged into ACD%u\n", add->acdNum, existing->acdNum);
+                    JITDUMPEXEC(existing->Dump());
+                }
+                else
+                {
+                    // If not, re-enter this ACD in the map with the updated key
+                    //
+                    JITDUMP("ACD%u updated\n", add->acdNum);
+                    map->Set(newKey, add);
+                    JITDUMPEXEC(add->Dump());
+                }
+            }
+        }
+
         // Remove the try-finally EH region. This will compact the EH table
         // so XTnum now points at the next entry.
         fgRemoveEHTableEntry(XTnum);
@@ -231,7 +342,8 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
 
     if (emptyCount > 0)
     {
-        JITDUMP("fgRemoveEmptyFinally() removed %u try-finally clauses from %u finallys\n", emptyCount, finallyCount);
+        JITDUMP("fgRemoveEmptyFinally() removed %u try-finally/fault clauses from %u finally/fault(s)\n", emptyCount,
+                finallyCount);
         fgOptimizedFinally = true;
 
 #ifdef DEBUG
@@ -1069,6 +1181,8 @@ PhaseStatus Compiler::fgCloneFinally()
                 // Mark the block as the end of the cloned finally.
                 newBlock->SetFlags(BBF_CLONED_FINALLY_END);
             }
+
+            newBlock->RemoveFlags(BBF_DONT_REMOVE);
 
             // Make sure clone block state hasn't munged the try region.
             assert(newBlock->bbTryIndex == finallyTryIndex);

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -252,7 +252,7 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
 
                 // If this ACD is NOT in the try we just removed,
                 // it is unaffected (though it may get updated
-                // when the EH region is removed)..
+                // when the EH region is removed).
                 //
                 bool inTry = add->acdTryIndex > 0;
 
@@ -273,34 +273,7 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
                 // with an updated key.
                 //
                 add->acdTryIndex = firstBlock->bbTryIndex;
-                inTry            = add->acdTryIndex > 0;
-
-                // Because we "relocated" this ACD, it now be enclosed
-                // in a different region type. Figure this out.
-                //
-                AcdKeyDesignator newDsg = add->acdKeyDsg;
-
-                if (!inTry && !inHnd)
-                {
-                    // Moved outside of all EH regions.
-                    //
-                    newDsg = AcdKeyDesignator::KD_NONE;
-                }
-                else if (inTry && (!inHnd || (add->acdTryIndex < add->acdHndIndex)))
-                {
-                    // Moved into a parent try region.
-                    //
-                    newDsg = AcdKeyDesignator::KD_TRY;
-                }
-                else
-                {
-                    // Moved into a parent handler region.
-                    // Note this cannot be a filter region.
-                    //
-                    newDsg = AcdKeyDesignator::KD_HND;
-                }
-
-                add->acdKeyDsg = newDsg;
+                add->UpdateKeyDesignator(this);
 
                 // Remove the ACD from the map via its old key
                 //

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3773,6 +3773,37 @@ Compiler::AddCodeDscKey::AddCodeDscKey(AddCodeDsc* add)
     }
 }
 
+#ifdef DEBUG
+//------------------------------------------------------------------------
+// Dump: dump info about an AddCodeDesc
+//
+void Compiler::AddCodeDsc::Dump()
+{
+    printf("ACD%u %s ", acdNum, sckName(acdKind));
+    switch (acdKeyDsg)
+    {
+        case AcdKeyDesignator::KD_NONE:
+            printf("in method region");
+            break;
+        case AcdKeyDesignator::KD_TRY:
+            printf("in try region of EH#%u", acdTryIndex - 1);
+            break;
+        case AcdKeyDesignator::KD_HND:
+            printf("in handler region of EH#%u", acdHndIndex - 1);
+            break;
+        case AcdKeyDesignator::KD_FLT:
+            printf("in filter region of EH#%u", acdHndIndex - 1);
+            break;
+        default:
+            printf("(unexpected region)");
+            break;
+    }
+
+    AddCodeDscKey key(this);
+    printf(" map key 0x%x\n", key.Data());
+}
+#endif
+
 //------------------------------------------------------------------------
 // fgSetTreeSeq: Sequence the tree, setting the "gtPrev" and "gtNext" links.
 //

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -1520,47 +1520,9 @@ void Compiler::fgRemoveEHTableEntry(unsigned XTnum)
                 isModified = true;
             }
 
-            // The ACD may now have a new enclosing region.
-            // Figure out the new parent key designator.
-            //
-            // For example, suppose there is a try that has an array
-            // bounds check and an empty finally, all within a
-            // finally. When we remove the try, the ACD for the bounds
-            // check changes from being enclosed in a try to being
-            // enclosed in a finally.
-            //
-            // (given the above I think we can say the designator
-            // does not change...)
-            AcdKeyDesignator newDsg = add->acdKeyDsg;
-
-            if (!inTry && !inHnd)
-            {
-                // Moved outside of all EH regions.
-                //
-                newDsg = AcdKeyDesignator::KD_NONE;
-            }
-            else if (inTry && (!inHnd || (add->acdTryIndex < add->acdHndIndex)))
-            {
-                // Moved into a parent try region.
-                //
-                newDsg = AcdKeyDesignator::KD_TRY;
-            }
-            else
-            {
-                // Moved into a parent handler region.
-                // Note this cannot be a filter region.
-                //
-                newDsg = AcdKeyDesignator::KD_HND;
-            }
-
-            if (newDsg != add->acdKeyDsg)
-            {
-                assert(isModified);
-                add->acdKeyDsg = newDsg;
-            }
-
             if (isModified)
             {
+                add->UpdateKeyDesignator(this);
                 bool const removed = map->Remove(oldKey);
                 assert(removed);
                 modified.Push(add);

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -1371,7 +1371,6 @@ void Compiler::fgRemoveEHTableEntry(unsigned XTnum)
 {
     assert(compHndBBtabCount > 0);
     assert(XTnum < compHndBBtabCount);
-    assert((fgAddCodeDscMap == nullptr) || (fgAddCodeDscMap->GetCount() == 0));
 
     EHblkDsc* HBtab;
 
@@ -1471,6 +1470,126 @@ void Compiler::fgRemoveEHTableEntry(unsigned XTnum)
         {
             /* Last entry. Don't need to do anything */
             noway_assert(XTnum == compHndBBtabCount);
+        }
+    }
+
+    // We also need to update any AddCodeDesc records and map entries
+    //
+    if (!fgHasAddCodeDscMap())
+    {
+        JITDUMP("No ACD entries to update");
+    }
+    else
+    {
+        // There are three possibilities for each ACD entry
+        //
+        // 1. remains as is (stays in same region with same indices)
+        // 2. gets merged with ACD from parent region
+        // 3. gets updated (moves to parent region with new indices)
+        //
+        // First, update each ACD, and remove any modified ones from the
+        // map (via their old key)
+        //
+        AddCodeDscMap* const    map = fgGetAddCodeDscMap();
+        ArrayStack<AddCodeDsc*> modified(getAllocator(CMK_Unknown));
+
+        for (AddCodeDsc* const add : AddCodeDscMap::ValueIteration(map))
+        {
+            bool          isModified = false;
+            AddCodeDscKey oldKey(add);
+
+            // We expect callers have already updated any ACDs that
+            // reference the EH region being removed.
+            //
+            bool inTry = add->acdTryIndex > 0;
+            bool inHnd = add->acdHndIndex > 0;
+            assert(!inTry || ((unsigned)(add->acdTryIndex - 1) != XTnum));
+            assert(!inHnd || ((unsigned)(add->acdHndIndex - 1) != XTnum));
+
+            if (add->acdTryIndex > XTnum)
+            {
+                add->acdTryIndex--;
+                inTry      = add->acdTryIndex > 0;
+                isModified = true;
+            }
+
+            if (add->acdHndIndex > XTnum)
+            {
+                add->acdHndIndex--;
+                inHnd      = add->acdHndIndex > 0;
+                isModified = true;
+            }
+
+            // The ACD may now have a new enclosing region.
+            // Figure out the new parent key designator.
+            //
+            // For example, suppose there is a try that has an array
+            // bounds check and an empty finally, all within a
+            // finally. When we remove the try, the ACD for the bounds
+            // check changes from being enclosed in a try to being
+            // enclosed in a finally.
+            //
+            // (given the above I think we can say the designator
+            // does not change...)
+            AcdKeyDesignator newDsg = add->acdKeyDsg;
+
+            if (!inTry && !inHnd)
+            {
+                // Moved outside of all EH regions.
+                //
+                newDsg = AcdKeyDesignator::KD_NONE;
+            }
+            else if (inTry && (!inHnd || (add->acdTryIndex < add->acdHndIndex)))
+            {
+                // Moved into a parent try region.
+                //
+                newDsg = AcdKeyDesignator::KD_TRY;
+            }
+            else
+            {
+                // Moved into a parent handler region.
+                // Note this cannot be a filter region.
+                //
+                newDsg = AcdKeyDesignator::KD_HND;
+            }
+
+            if (newDsg != add->acdKeyDsg)
+            {
+                assert(isModified);
+                add->acdKeyDsg = newDsg;
+            }
+
+            if (isModified)
+            {
+                bool const removed = map->Remove(oldKey);
+                assert(removed);
+                modified.Push(add);
+            }
+        }
+
+        // Second, walk the modified ACDs and either "merge" them into some
+        // other ACD, or re-insert into the map.
+        //
+        // (Note this can't easily be done in the first pass, since we need to know
+        // the potential merge target won't itself get subsequently modified, and the
+        // order of ACD enumeration is unrelated to the order of EH regions).
+        //
+        while (modified.Height() > 0)
+        {
+            AddCodeDsc* const add = modified.Pop();
+            AddCodeDscKey     newKey(add);
+            AddCodeDsc*       existing = nullptr;
+            if (map->Lookup(newKey, &existing))
+            {
+                JITDUMP("ACD%u merged into ACD%u\n", add->acdNum, existing->acdNum);
+                JITDUMPEXEC(existing->Dump());
+            }
+            else
+            {
+                JITDUMP("ACD%u updated\n", add->acdNum);
+                map->Set(newKey, add);
+                JITDUMPEXEC(add->Dump());
+            }
         }
     }
 }


### PR DESCRIPTION
The JIT can sometimes optimize away all the code in a finally or fault, so rerun and generalize the empty try-finally removal to cover faults and run it again after the main optimization passes.