### PR TITLE
[browser] Fix custom icu fingerprinting.

### DIFF
--- a/src/mono/browser/runtime/loader/icu.ts
+++ b/src/mono/browser/runtime/loader/icu.ts
@@ -68,7 +68,7 @@ export function getIcuResourceName (config: MonoConfig): string | null {
         if (config.globalizationMode === GlobalizationMode.Custom) {
             // custom ICU file is saved in the resources with fingerprinting and does not require mapping
             if (icuFiles.length === 1) {
-                return icuFile;
+                return icuFiles[0];
             }
         } else if (config.globalizationMode === GlobalizationMode.Hybrid) {
             icuFile = "icudt_hybrid.dat";

--- a/src/mono/browser/runtime/loader/icu.ts
+++ b/src/mono/browser/runtime/loader/icu.ts
@@ -67,7 +67,7 @@ export function getIcuResourceName (config: MonoConfig): string | null {
         let icuFile = null;
         if (config.globalizationMode === GlobalizationMode.Custom) {
             // custom ICU file is saved in the resources with fingerprinting and does not require mapping
-            if (icuFiles.length === 1) {
+            if (icuFiles.length >= 1) {
                 return icuFiles[0];
             }
         } else if (config.globalizationMode === GlobalizationMode.Hybrid) {

--- a/src/mono/browser/runtime/loader/icu.ts
+++ b/src/mono/browser/runtime/loader/icu.ts
@@ -66,8 +66,9 @@ export function getIcuResourceName (config: MonoConfig): string | null {
 
         let icuFile = null;
         if (config.globalizationMode === GlobalizationMode.Custom) {
+            // custom ICU file is saved in the resources with fingerprinting and does not require mapping
             if (icuFiles.length === 1) {
-                icuFile = icuFiles[0];
+                return icuFile;
             }
         } else if (config.globalizationMode === GlobalizationMode.Hybrid) {
             icuFile = "icudt_hybrid.dat";


### PR DESCRIPTION
Using custom ICU files got broken with fingerprinting.
Repro:
```
<BlazorIcuDataFileName>/workspaces/runtime/artifacts-samples/browser/icudt_custom.dat</BlazorIcuDataFileName>
```
produces boot.config.json:
```
  "mainAssemblyName": "browser",
  "resources": {
    "hash": "sha256-mDtUMfPuXPyYADO8g8Kk3TOZPMhbHv/IMatrIfcVy8M=",
    "fingerprinting": {
         ...........
        "icudt_custom.oh1zvcfom8.dat": "icudt_custom.dat",
     },
    "icu": {
      "icudt_custom.oh1zvcfom8.dat": "sha256-tO5O5YzMTVSaKBboxAqezOQL9ewmupzV2JrB5Rkc8a4="
    },
   }
  "globalizationMode": "custom"
```
`fileMapping` has contents: `mapping={  "icudt_custom.dat": "icudt_custom.oh1zvcfom8.dat" }`
`icuFile` has a value `icudt_custom.oh1zvcfom8.dat`.
So we won't enter the condition:
```
        if (icuFile && fileMapping[icuFile]) {
            return fileMapping[icuFile];
        }
```
and would finish with invariant mode that prevents globalization methods from working.

ToDo:
should be backported to net9.