### PR TITLE
[PERF] Fix the perf r2rRunType and pgoRunType argument formats for new flow

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -213,7 +213,7 @@ jobs:
         runKind: micro
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perftiger'
-        pgoRunType: -NoDynamicPGO
+        pgoRunType: nodynamicpgo
         perfBranch: ${{ parameters.perfBranch }}
 
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -230,7 +230,7 @@ jobs:
         runKind: micro
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perftiger'
-        pgoRunType: --nodynamicpgo
+        pgoRunType: nodynamicpgo
         perfBranch: ${{ parameters.perfBranch }}
 
   # run coreclr perftiger microbenchmarks no R2R perf jobs
@@ -248,7 +248,7 @@ jobs:
         runKind: micro
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perftiger'
-        r2rRunType: -NoR2R
+        r2rRunType: nor2r
         perfBranch: ${{ parameters.perfBranch }}
 
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -265,7 +265,7 @@ jobs:
         runKind: micro
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perftiger'
-        r2rRunType: --nor2r
+        r2rRunType: nor2r
         perfBranch: ${{ parameters.perfBranch }}
 
   # run coreclr perfowl microbenchmarks perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -214,7 +214,7 @@ extends:
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
               timeoutInMinutes: 780
-              pgoRunType: --nodynamicpgo
+              pgoRunType: nodynamicpgo
               perfBranch: ${{ parameters.perfBranch }}
 
       #run coreclr Linux arm64 ampere no R2R microbenchmarks perf job
@@ -233,7 +233,7 @@ extends:
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
               timeoutInMinutes: 780
-              r2rRunType: --nor2r
+              r2rRunType: nor2r
               perfBranch: ${{ parameters.perfBranch }}
 
       # run coreclr Windows arm64 microbenchmarks perf job
@@ -286,7 +286,7 @@ extends:
               runKind: micro
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
-              pgoRunType: -NoDynamicPGO
+              pgoRunType: nodynamicpgo
               timeoutInMinutes: 780
               perfBranch: ${{ parameters.perfBranch }}
 
@@ -305,7 +305,7 @@ extends:
               runKind: micro
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
-              r2rRunType: -NoR2R
+              r2rRunType: nor2r
               timeoutInMinutes: 780
               perfBranch: ${{ parameters.perfBranch }}
 


### PR DESCRIPTION
Update the perf r2rRunType and pgoRunType argument formats to not include dashes, fixing their passing into the new perf flow added in commit b14e2f5ef3008ab62bdbe8044f00fe948e20595e. The issue we were hitting was arguments such as --r2r-run-type being passed the r2rRunType with the dashes, causing it to not correctly get parsed as an argument. (--r2r-run-type --nodynamicpgo was passed instead of --r2r-run-type nodynamicpgo). Also matched the letter casing for both.