### PR TITLE
Run our CI source-build legs on CentOS Stream 9

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -79,9 +79,9 @@ extends:
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
-      # We use a CentOS Stream 8 image here to test building from source on CentOS Stream 8.
+      # We use a CentOS Stream 8 image here to test building from source on CentOS Stream 9.
       SourceBuild_centos_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
 
       # AlmaLinux 8 is a RHEL 8 rebuild, so we use it to test building from source on RHEL 8.
       SourceBuild_linux_x64:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1848,17 +1848,17 @@ extends:
         #
         # Sourcebuild legs
         # We have 3 important legs for source-build:
-        # - Centos.8 (ensures that known non-portable RID is working)
+        # - Centos.9 (ensures that known non-portable RID is working)
         # - Linux-x64 portable (used for dependency flow and downstream PR verification)
         # - Banana.24 - Non-existent RID to ensure we don't break RIDs we don't know about.
         #
-        # Running all of these everywhere is wasteful. Run Banana.24 and CentOS.8 in rolling CI,
+        # Running all of these everywhere is wasteful. Run Banana.24 and CentOS.9 in rolling CI,
         # Run Linux-x64 in PR.
         - template: /eng/common/templates/jobs/source-build.yml
           parameters:
             platforms:
-              - name: CentOS8
-                targetRID: centos.8-x64
+              - name: CentOS9
+                targetRID: centos.9-x64
                 nonPortable: true
                 container: SourceBuild_centos_x64
               - name: NonexistentRID


### PR DESCRIPTION
CentOS Stream 8 is out of support