### PR TITLE
dont try to capture threadId for NativeAOT

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -26686,14 +26686,17 @@ void gc_heap::add_to_hc_history_worker (hc_history* hist, int* current_index, hc
     current_hist->bgc_thread_running = (bool)bgc_thread_running;
 
 #if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(_DEBUG) && !defined(FEATURE_NATIVEAOT)
-    int bgc_thread_os_id = 0;
-
-    if (bgc_thread)
+    if (GCConfig::GetGCLogBGCThreadId())
     {
-        bgc_thread_os_id = (int)(*(size_t*)((uint8_t*)bgc_thread + 0x130));
-    }
+        int bgc_thread_os_id = 0;
 
-    current_hist->bgc_thread_os_id = bgc_thread_os_id;
+        if (bgc_thread)
+        {
+            bgc_thread_os_id = (int)(*(size_t*)((uint8_t*)bgc_thread + 0x130));
+        }
+
+        current_hist->bgc_thread_os_id = bgc_thread_os_id;
+    }
 #endif //TARGET_AMD64 && TARGET_WINDOWS && !_DEBUG && !FEATURE_NATIVEAOT
 #endif //BACKGROUND_GC
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -26685,7 +26685,7 @@ void gc_heap::add_to_hc_history_worker (hc_history* hist, int* current_index, hc
     current_hist->concurrent_p = (bool)settings.concurrent;
     current_hist->bgc_thread_running = (bool)bgc_thread_running;
 
-#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(_DEBUG)
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(_DEBUG) && !defined(FEATURE_NATIVEAOT)
     int bgc_thread_os_id = 0;
 
     if (bgc_thread)
@@ -26694,7 +26694,7 @@ void gc_heap::add_to_hc_history_worker (hc_history* hist, int* current_index, hc
     }
 
     current_hist->bgc_thread_os_id = bgc_thread_os_id;
-#endif //TARGET_AMD64 && TARGET_WINDOWS && !_DEBUG
+#endif //TARGET_AMD64 && TARGET_WINDOWS && !_DEBUG && !FEATURE_NATIVEAOT
 #endif //BACKGROUND_GC
 
     *current_index  = (*current_index + 1) % max_hc_history_count;

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -141,7 +141,10 @@ public:
     STRING_CONFIG(GCPath,                    "GCPath",                    "System.GC.Path",                                        "Specifies the path of the standalone GC implementation.")                                \
     INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           NULL,                                0,                  "Specifies the spin count unit used by the GC.")                                          \
     INT_CONFIG   (GCDynamicAdaptationMode,   "GCDynamicAdaptationMode",   "System.GC.DynamicAdaptationMode",   1,                  "Enable the GC to dynamically adapt to application sizes.")                               \
-    INT_CONFIG   (GCDTargetTCP,              "GCDTargetTCP",              "System.GC.DTargetTCP",              0,                  "Specifies the target tcp for DATAS")
+    INT_CONFIG   (GCDTargetTCP,              "GCDTargetTCP",              "System.GC.DTargetTCP",              0,                  "Specifies the target tcp for DATAS")                                                     \
+    BOOL_CONFIG  (GCLogBGCThreadId,          "GCLogBGCThreadId",          NULL,                                false,              "Specifies if BGC ThreadId should be logged")                                         
+
+
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.
 class GCConfig

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -618,7 +618,7 @@ struct hc_history
     // invalid fields on the Thread object such as m_OSThreadId. This is to help with debugging that problem so I
     // only enable it for retail builds on Windows. We can extend this with a GCToEEInterface interface method to get the offset
     // of that particular field on the Thread object.
-#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(_DEBUG)
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(_DEBUG) && !defined(FEATURE_NATIVEAOT)
     int bgc_thread_os_id;
 #endif
     short bgc_t_join_join_lock;


### PR DESCRIPTION
Fix an issue while collecting threadId which might not work for NativeAOT. This was included as part of the recent instrumentation changes. 