### PR TITLE
[wasm] improve local diagnostic of AOT enabled build

### DIFF
--- a/src/mono/llvm/llvm-init.proj
+++ b/src/mono/llvm/llvm-init.proj
@@ -88,7 +88,7 @@
     <ItemGroup>
       <LLVMFiles Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\$(MonoLLVMHostOS)-%(PackageReference.PackageArch)\**"
                  FileArch="%(PackageReference.PackageArch)"  Condition="'$(_LocalLLVMArtifacts)' == ''" />
-      <LLVMFiles Include="$(LocalLLVMArtifacts)\obj\InstallRoot-$(BuildArchitecture)\**"
+      <LLVMFiles Include="$(_LocalLLVMArtifacts)\obj\InstallRoot-$(BuildArchitecture)\**"
                  FileArch="%(PackageReference.PackageArch)"  Condition="'$(_LocalLLVMArtifacts)' != ''" />
     </ItemGroup>
     <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(LLVMFiles.FileArch)\%(RecursiveDir)">

--- a/src/mono/llvm/llvm-init.proj
+++ b/src/mono/llvm/llvm-init.proj
@@ -87,7 +87,9 @@
   <Target Name="CopyLLVMToTree" AfterTargets="Build">
     <ItemGroup>
       <LLVMFiles Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\$(MonoLLVMHostOS)-%(PackageReference.PackageArch)\**"
-                 FileArch="%(PackageReference.PackageArch)" />
+                 FileArch="%(PackageReference.PackageArch)"  Condition="'$(_LocalLLVMArtifacts)' == ''" />
+      <LLVMFiles Include="$(LocalLLVMArtifacts)\obj\InstallRoot-$(BuildArchitecture)\**"
+                 FileArch="%(PackageReference.PackageArch)"  Condition="'$(_LocalLLVMArtifacts)' != ''" />
     </ItemGroup>
     <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(LLVMFiles.FileArch)\%(RecursiveDir)">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -621,7 +621,7 @@
 
     <Error Condition="'$(RunAOTCompilation)' == 'true' and '$(PublishTrimmed)' != 'true'"
            Text="AOT is not supported without IL trimming (PublishTrimmed=true required)." />
-    <Error Condition="'$(RunAOTCompilation)' == 'true' and '$(Configuration)' == 'Debug'"
+    <Error Condition="'$(RunAOTCompilation)' == 'true' and '$(Configuration)' == 'Debug' and '$(_WasmAllowAOTDebug)' != 'true'"
            Text="AOT is not supported in debug configuration (Configuration=Release required)." />
     <Error Condition="'@(_WasmAssembliesInternal)' == ''" Text="Item _WasmAssembliesInternal is empty" />
     <Error Condition="'$(_IsToolchainMissing)' == 'true'"


### PR DESCRIPTION
Add 2 private msbuild properties to allow debug AOT build and using local llvm build artifacts