### PR TITLE
[Perf] Improve List<T>.Find and List<T>.FindAll performance by iterating with ReadOnlySpan struct

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -512,11 +512,12 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.match);
             }
 
-            for (int i = 0; i < _size; i++)
+            ReadOnlySpan<T> span = new ReadOnlySpan<T>(_items);
+            foreach (T element in span)
             {
-                if (match(_items[i]))
+                if (match(element))
                 {
-                    return _items[i];
+                    return element;
                 }
             }
             return default;
@@ -530,11 +531,12 @@ namespace System.Collections.Generic
             }
 
             List<T> list = new List<T>();
-            for (int i = 0; i < _size; i++)
+            ReadOnlySpan<T> span = new ReadOnlySpan<T>(_items);
+            foreach (T element in span)
             {
-                if (match(_items[i]))
+                if (match(element))
                 {
-                    list.Add(_items[i]);
+                    list.Add(element);
                 }
             }
             return list;


### PR DESCRIPTION
Implement in the same way as Linq.FirstOrDefault() the loop iteration with ReadOnlySpan for List\<T\>.Find() and List\<T\>.FindAll() methods resulting in performance improvement aligned with the Linq library.

Look at this issue for more information: https://github.com/dotnet/runtime/issues/108064