### PR TITLE
[workloads] Consider workload band versions stable when we are at rtm

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,8 @@
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
+    <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PreReleaseVersionIteration)' == '' and '$(PreReleaseVersionLabel)' != 'rtm'">-$(PreReleaseVersionLabel)</WorkloadVersionSuffix>
+    <WorkloadVersionSuffix Condition="'$(WorkloadVersionSuffix)' == '' and '$(DotNetFinalVersionKind)' != 'release' and '$(PreReleaseVersionLabel)' != 'rtm'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
     <SdkBandVersionForWorkload_FromRuntimeVersions>$(SdkBandVersion)$(WorkloadVersionSuffix)</SdkBandVersionForWorkload_FromRuntimeVersions>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->

--- a/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
@@ -110,7 +110,7 @@
     <Exec Condition="$(_DotNetVersionExitCode) != '0'" Command="$(_DotNetVersionCommand)" CustomErrorRegularExpression=".*" />
 
     <PropertyGroup>
-      <SdkBandVersionForWorkload_ComputedFromInstaller>$(SdkBandVersion)$([System.Text.RegularExpressions.Regex]::Match($(_DotNetVersionOutput), `-[A-z]*[\.]*\d*`))</SdkBandVersionForWorkload_ComputedFromInstaller>
+      <SdkBandVersionForWorkload_ComputedFromInstaller>$(SdkBandVersion)$([System.Text.RegularExpressions.Regex]::Match($(_DotNetVersionOutput), `-(?!rtm)[A-z]*[\.]*\d*`))</SdkBandVersionForWorkload_ComputedFromInstaller>
       <VersionBandForSdkManifestsDir Condition="'$(VersionBandForSdkManifestsDir)' == ''">$(SdkBandVersionForWorkload_ComputedFromInstaller)</VersionBandForSdkManifestsDir>
       <VersionBandForManifestPackages Condition="'$(VersionBandForManifestPackages)' == ''">$(VersionBandForSdkManifestsDir)</VersionBandForManifestPackages>
     </PropertyGroup>

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Workload.Build.Tasks
             ReadCommentHandling = JsonCommentHandling.Skip
         };
 
-        [GeneratedRegex(@"^\d+\.\d+\.\d+(-[A-z]*\.*\d*)?")]
+        [GeneratedRegex(@"^\d+\.\d+\.\d+(-(?!rtm)[A-z]*\.*\d*)?")]
         private static partial Regex bandVersionRegex();
 
         public override bool Execute()
@@ -301,7 +301,8 @@ namespace Microsoft.Workload.Build.Tasks
             if (!string.IsNullOrEmpty(bandPreleaseVersion) &&
                 packagePreleaseVersion != bandPreleaseVersion &&
                 packagePreleaseVersion != "-dev" &&
-                packagePreleaseVersion != "-ci")
+                packagePreleaseVersion != "-ci" &&
+                packagePreleaseVersion != "-rtm")
             {
                 bandVersion = bandVersion.Replace (bandPreleaseVersion, packagePreleaseVersion);
             }


### PR DESCRIPTION
Backport of the hotfix in release/9.0 that did the same thing.