### PR TITLE
Fix TRACE_GC build

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -203,6 +203,12 @@ jobs:
       - src/coreclr/pal/*
       - src/coreclr/vm/*
 
+    # We have some GC code variants that only effect GC code.
+    # Only run legs that validate those variants on GC changes.
+    - subset: coreclr_GC
+      include:
+      - src/coreclr/gc/*
+
     #
     # ** WASM **
     # Changes in *only* Wasm.Build.Tests, debugger, or runtime-tests are very

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -81,6 +81,25 @@ extends:
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
+      # Re-enable when fixing https://github.com/dotnet/runtime/issues/108628
+      # #
+      # # Build CoreCLR GC with TRACE_GC
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Checked
+      #     runtimeFlavor: coreclr
+      #     platforms:
+      #       - linux_x64
+      #     jobParameters:
+      #       nameSuffix: CoreCLR_GC_TRACE_GC
+      #       buildArgs: -s clr.runtime -c $(_BuildConfig) -cmakeargs -DTRACE_GC=1
+      #       condition: >-
+      #         or(
+      #           eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr_GC.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
       #
       # Build Libraries AllConfigurations. This exercises the code path where we build libraries and tests for all
       # configurations on a non Windows operating system.

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1840,6 +1840,24 @@ extends:
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
+      #
+      # Build CoreCLR GC with TRACE_GC
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Checked
+          runtimeFlavor: coreclr
+          platforms:
+            - linux_x64
+          jobParameters:
+            nameSuffix: CoreCLR_GC_TRACE_GC
+            buildArgs: -s clr.runtime -c $(_BuildConfig) -cmakeargs -DTRACE_GC=1
+            condition: >-
+              or(
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr_GC.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
     - stage: SourceBuild
       displayName: Source Build Validation
       dependsOn: []

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1840,24 +1840,6 @@ extends:
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
-      #
-      # Build CoreCLR GC with TRACE_GC
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Checked
-          runtimeFlavor: coreclr
-          platforms:
-            - linux_x64
-          jobParameters:
-            nameSuffix: CoreCLR_GC_TRACE_GC
-            buildArgs: -s clr.runtime -c $(_BuildConfig) -cmakeargs -DTRACE_GC=1
-            condition: >-
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr_GC.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
     - stage: SourceBuild
       displayName: Source Build Validation
       dependsOn: []

--- a/src/coreclr/gc/CMakeLists.txt
+++ b/src/coreclr/gc/CMakeLists.txt
@@ -100,6 +100,10 @@ list(APPEND GC_SOURCES ${GC_HEADERS})
 
 convert_to_absolute_path(GC_SOURCES ${GC_SOURCES})
 
+if (TRACE_GC)
+  add_compile_definitions(TRACE_GC)
+endif (TRACE_GC)
+
 # clrgcexp is build with standalone+regions
 if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
   add_library_clr(clrgcexp SHARED ${GC_SOURCES})

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -192,18 +192,24 @@ struct StressLogMsg
     }
 };
 
-template<>
-void* StressLogMsg::ConvertArgument(float arg) = delete;
-
 #if TARGET_64BIT
 template<>
 inline void* StressLogMsg::ConvertArgument(double arg)
 {
     return (void*)(size_t)(*((uint64_t*)&arg));
 }
+// COMPAT: Convert 32-bit floats to 64-bit doubles.
+template<>
+inline void* StressLogMsg::ConvertArgument(float arg)
+{
+    return StressLogMsg::ConvertArgument((double)arg);
+}
 #else
 template<>
 void* StressLogMsg::ConvertArgument(double arg) = delete;
+
+template<>
+void* StressLogMsg::ConvertArgument(float arg) = delete;
 
 // COMPAT: Truncate 64-bit integer arguments to 32-bit
 template<>

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -371,19 +371,24 @@ typedef USHORT
     static StressLog theLog;    // We only have one log, and this is it
 };
 
-
-template<>
-void* StressLog::ConvertArgument(float arg) = delete;
-
 #if TARGET_64BIT
 template<>
 inline void* StressLog::ConvertArgument(double arg)
 {
     return (void*)(size_t)(*((uint64_t*)&arg));
 }
+
+// COMPAT: Convert 32-bit floats to 64-bit doubles.
+template<>
+inline void* StressLog::ConvertArgument(float arg)
+{
+    return StressLog::ConvertArgument((double)arg);
+}
 #else
 template<>
 void* StressLog::ConvertArgument(double arg) = delete;
+template<>
+void* StressLog::ConvertArgument(float arg) = delete;
 
 // COMPAT: Truncate 64-bit integer arguments to 32-bit
 template<>

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -344,18 +344,25 @@ public:
 };
 
 
-template<>
-void* StressLog::ConvertArgument(float arg) = delete;
-
 #if TARGET_64BIT
 template<>
 inline void* StressLog::ConvertArgument(double arg)
 {
     return (void*)(size_t)(*((uint64_t*)&arg));
 }
+
+// COMPAT: Convert 32-bit floats to 64-bit doubles.
+template<>
+inline void* StressLog::ConvertArgument(float arg)
+{
+    return StressLog::ConvertArgument((double)arg);
+}
 #else
 template<>
 void* StressLog::ConvertArgument(double arg) = delete;
+
+template<>
+void* StressLog::ConvertArgument(float arg) = delete;
 
 // COMPAT: Truncate 64-bit integer arguments to 32-bit
 template<>

--- a/src/coreclr/vm/wks/CMakeLists.txt
+++ b/src/coreclr/vm/wks/CMakeLists.txt
@@ -7,6 +7,10 @@ if (CLR_CMAKE_TARGET_WIN32)
   endif()
 endif (CLR_CMAKE_TARGET_WIN32)
 
+if (TRACE_GC)
+  add_compile_definitions(TRACE_GC)
+endif (TRACE_GC)
+
 add_library_clr(cee_wks_core OBJECT ${VM_SOURCES_WKS} ${VM_SOURCES_WKS_ARCH_ASM})
 add_library_clr(cee_wks OBJECT ${VM_SOURCES_WKS_SPECIAL})
 add_library_clr(cee_wks_mergeable OBJECT ${VM_SOURCES_WKS_SPECIAL})


### PR DESCRIPTION
Allow floats to be passed on 64-bit builds.

@Maoni0 in https://github.com/dotnet/runtime/pull/105545, you added too many arguments to the `gcDetailedStartMsg` and passed the 16-arg maximum (which is causing the build to fail). Also, by changing that message, using the StressLogAnalyzer on logs with the old "gcDetailedStartMsg" value (or in the non-BACKGROUND_GC builds) will not recognize GC start/end with the current native StressLogAnalyzer. Can we split the message into two separate messages to fix these issues?