### PR TITLE
JIT: refactor AddCodeDsc

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1593,8 +1593,7 @@ void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKi
             excpRaisingBlock = failBlk;
 
 #ifdef DEBUG
-            Compiler::AddCodeDsc* add =
-                compiler->fgFindExcptnTarget(codeKind, compiler->bbThrowIndex(compiler->compCurBB));
+            Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
             assert(add->acdUsed);
             assert(excpRaisingBlock == add->acdDstBlk);
 #if !FEATURE_FIXED_OUT_ARGS
@@ -1605,8 +1604,7 @@ void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKi
         else
         {
             // Find the helper-block which raises the exception.
-            Compiler::AddCodeDsc* add =
-                compiler->fgFindExcptnTarget(codeKind, compiler->bbThrowIndex(compiler->compCurBB));
+            Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
             PREFIX_ASSUME_MSG((add != nullptr), ("ERROR: failed to find exception throw block"));
             assert(add->acdUsed);
             excpRaisingBlock = add->acdDstBlk;

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -6841,8 +6841,7 @@ inline void CodeGen::genJumpToThrowHlpBlk_la(
             excpRaisingBlock = failBlk;
 
 #ifdef DEBUG
-            Compiler::AddCodeDsc* add =
-                compiler->fgFindExcptnTarget(codeKind, compiler->bbThrowIndex(compiler->compCurBB));
+            Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
             assert(add->acdUsed);
             assert(excpRaisingBlock == add->acdDstBlk);
 #if !FEATURE_FIXED_OUT_ARGS
@@ -6853,8 +6852,7 @@ inline void CodeGen::genJumpToThrowHlpBlk_la(
         else
         {
             // Find the helper-block which raises the exception.
-            Compiler::AddCodeDsc* add =
-                compiler->fgFindExcptnTarget(codeKind, compiler->bbThrowIndex(compiler->compCurBB));
+            Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
             PREFIX_ASSUME_MSG((add != nullptr), ("ERROR: failed to find exception throw block"));
             assert(add->acdUsed);
             excpRaisingBlock = add->acdDstBlk;

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -6871,8 +6871,7 @@ void CodeGen::genJumpToThrowHlpBlk_la(
             excpRaisingBlock = failBlk;
 
 #ifdef DEBUG
-            Compiler::AddCodeDsc* add =
-                compiler->fgFindExcptnTarget(codeKind, compiler->bbThrowIndex(compiler->compCurBB));
+            Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
             assert(add->acdUsed);
             assert(excpRaisingBlock == add->acdDstBlk);
 #if !FEATURE_FIXED_OUT_ARGS
@@ -6883,8 +6882,7 @@ void CodeGen::genJumpToThrowHlpBlk_la(
         else
         {
             // Find the helper-block which raises the exception.
-            Compiler::AddCodeDsc* add =
-                compiler->fgFindExcptnTarget(codeKind, compiler->bbThrowIndex(compiler->compCurBB));
+            Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
             PREFIX_ASSUME_MSG((add != nullptr), ("ERROR: failed to find exception throw block"));
             assert(add->acdUsed);
             excpRaisingBlock = add->acdDstBlk;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2897,8 +2897,6 @@ public:
     bool     ehAnyFunclets();  // Are there any funclets in this function?
     unsigned ehFuncletCount(); // Return the count of funclets in the function
 
-    unsigned bbThrowIndex(BasicBlock* blk); // Get the index to use as the cache key for sharing throw blocks
-
     FlowEdge* BlockPredsWithEH(BasicBlock* blk);
     FlowEdge* BlockDominancePreds(BasicBlock* blk);
 
@@ -6794,29 +6792,50 @@ private:
     //  range checking or explicit calls to enable GC, and so on.
     //
 public:
+
+    enum class AcdKeyDesignator { KD_NONE, KD_TRY, KD_HND, KD_FLT };
+
     struct AddCodeDsc
     {
         AddCodeDsc*     acdNext;
 
-        // Initially the source block of the exception. After fgCreateThrowHelperBlocks, the block to which
+        // After fgCreateThrowHelperBlocks, the block to which
         // we jump to raise the exception.
         BasicBlock*     acdDstBlk;
 
+        // EH region key used to look up this dsc in the map
         unsigned        acdData;
+
+        // EH regions for this dsc
+        unsigned short acdTryIndex;
+        unsigned short acdHndIndex;
+
+        // Which EH region forms the key?
+        AcdKeyDesignator  acdKeyDsg;
+
         SpecialCodeKind acdKind; // what kind of a special block is this?
         bool            acdUsed; // do we need to keep this helper block?
+
 #if !FEATURE_FIXED_OUT_ARGS
         bool     acdStkLvlInit; // has acdStkLvl value been already set?
         unsigned acdStkLvl;     // stack level in stack slots.
 #endif                          // !FEATURE_FIXED_OUT_ARGS
+
+        INDEBUG(unsigned acdNum);
     };
+
+    unsigned acdCount = 0;
+
+    // Get the index to use as part of the AddCodeDsc key for sharing throw blocks
+    unsigned bbThrowIndex(BasicBlock* blk, AcdKeyDesignator* dsg); 
 
     struct AddCodeDscKey
     {
     public:
         AddCodeDscKey(): acdKind(SCK_NONE), acdData(0) {}
-        AddCodeDscKey(SpecialCodeKind kind, unsigned data): acdKind(kind), acdData(data) {}
-
+        AddCodeDscKey(SpecialCodeKind kind, BasicBlock* block, Compiler* comp);
+        AddCodeDscKey(AddCodeDsc* add);
+        
         static bool Equals(const AddCodeDscKey& x, const AddCodeDscKey& y)
         {
             return (x.acdData == y.acdData) && (x.acdKind == y.acdKind);
@@ -6827,7 +6846,10 @@ public:
             return (x.acdData << 3) | (unsigned) x.acdKind;
         }
 
+        unsigned Data() const { return acdData; }
+
     private:
+
         SpecialCodeKind acdKind;
         unsigned acdData;
     };
@@ -6848,7 +6870,7 @@ private:
 
 
 public:
-    AddCodeDsc* fgFindExcptnTarget(SpecialCodeKind kind, unsigned refData);
+    AddCodeDsc* fgFindExcptnTarget(SpecialCodeKind kind, BasicBlock* fromBlock);
 
     bool fgUseThrowHelperBlocks();
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3384,47 +3384,63 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
         return;
     }
 
-    JITDUMP(FMT_BB " requires throw helper block for %s\n", srcBlk->bbNum, sckName(kind));
-
-    unsigned const refData = (kind == SCK_FAIL_FAST) ? 0 : bbThrowIndex(srcBlk);
-
     // Look for an existing entry that matches what we're looking for
     //
-    AddCodeDsc* add = fgFindExcptnTarget(kind, refData);
+    AddCodeDsc* add = fgFindExcptnTarget(kind, srcBlk);
 
     if (add != nullptr)
     {
+        JITDUMP(FMT_BB " requires throw helper block for %s, sharing ACD%u (data 0x%08x)\n", srcBlk->bbNum,
+                sckName(kind), add->acdNum, add->refData);
         return;
     }
 
     assert(!fgRngChkThrowAdded);
 
+    // Fetch block data and designator
+    //
+    AcdKeyDesignator dsg     = AcdKeyDesignator::KD_NONE;
+    unsigned const   refData = (kind == SCK_FAIL_FAST) ? 0 : bbThrowIndex(srcBlk, &dsg);
+
     // Allocate a new entry and prepend it to the list
     //
-    add          = new (this, CMK_Unknown) AddCodeDsc;
-    add->acdData = refData;
-    add->acdKind = kind;
-    add->acdNext = fgAddCodeList;
-#if !FEATURE_FIXED_OUT_ARGS
-    add->acdStkLvl     = 0;
-    add->acdStkLvlInit = false;
-#endif // !FEATURE_FIXED_OUT_ARGS
+    add              = new (this, CMK_Unknown) AddCodeDsc;
+    add->acdNext     = fgAddCodeList;
+    add->acdDstBlk   = nullptr;
+    add->acdTryIndex = srcBlk->bbTryIndex;
+    add->acdHndIndex = srcBlk->bbHndIndex;
+    add->acdKeyDsg   = dsg;
+    add->acdKind     = kind;
 
     // This gets set true in the stack level setter
     // if there's still a need for this helper
     add->acdUsed = false;
 
-    fgAddCodeList = add;
+#if !FEATURE_FIXED_OUT_ARGS
+    add->acdStkLvl     = 0;
+    add->acdStkLvlInit = false;
+#endif // !FEATURE_FIXED_OUT_ARGS
+    INDEBUG(add->acdNum = acdCount++);
 
-    // Defer creating of the blocks until later.
-    //
-    add->acdDstBlk = srcBlk;
+    fgAddCodeList = add;
 
     // Add to map
     //
     AddCodeDscMap* const map = fgGetAddCodeDscMap();
-    AddCodeDscKey        key(kind, refData);
+    AddCodeDscKey        key(add);
+    assert(key.Data() == refData);
     map->Set(key, add);
+
+    JITDUMP(FMT_BB " requires throw helper block for %s, created ACD%u with data 0x%08x\n", srcBlk->bbNum,
+            sckName(kind), add->acdNum, key.Data());
+
+#ifdef DEBUG
+    // Verify we can re-lookup...
+    AddCodeDscKey key2(kind, srcBlk, this);
+    AddCodeDsc*   add2 = nullptr;
+    assert(map->Lookup(key2, &add2));
+    assert(add == add2);
+#endif
 }
 
 //------------------------------------------------------------------------
@@ -3458,20 +3474,15 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
 
     for (AddCodeDsc* add = fgAddCodeList; add != nullptr; add = add->acdNext)
     {
-        // Create the target basic block in the region indicated by srcBlk.
+        // Create the target basic block in the region indicated by the acd info
         //
-        BasicBlock* const srcBlk = add->acdDstBlk;
-
-        // Double-check that this is a fail fast, or that srcBlk hasn't changed EH
-        // regions since the time the descriptor was created.
-        //
-        assert((add->acdKind == SCK_FAIL_FAST) || (bbThrowIndex(srcBlk) == add->acdData));
         assert(add->acdKind != SCK_NONE);
+        bool const        putInFilter = (add->acdKeyDsg == AcdKeyDesignator::KD_FLT);
+        BasicBlock* const newBlk      = fgNewBBinRegion(jumpKinds[add->acdKind], add->acdTryIndex, add->acdHndIndex,
+                                                        /* nearBlk */ nullptr, putInFilter,
+                                                        /* runRarely */ true, /* insertAtEnd */ true);
 
-        BasicBlock* const newBlk = fgNewBBinRegion(jumpKinds[add->acdKind], srcBlk,
-                                                   /* runRarely */ true, /* insertAtEnd */ true);
-
-        // Update the descriptor
+        // Update the descriptor so future lookups can find the block
         //
         add->acdDstBlk = newBlk;
 
@@ -3479,25 +3490,26 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
         if (verbose)
         {
             const char* msgWhere = "";
-            if (!srcBlk->hasTryIndex() && !srcBlk->hasHndIndex())
+            switch (add->acdKeyDsg)
             {
-                msgWhere = "non-EH region";
-            }
-            else if (!srcBlk->hasTryIndex())
-            {
-                msgWhere = "handler";
-            }
-            else if (!srcBlk->hasHndIndex())
-            {
-                msgWhere = "try";
-            }
-            else if (srcBlk->getTryIndex() < srcBlk->getHndIndex())
-            {
-                msgWhere = "try";
-            }
-            else
-            {
-                msgWhere = "handler";
+                case AcdKeyDesignator::KD_NONE:
+                    msgWhere = "non-EH region";
+                    break;
+
+                case AcdKeyDesignator::KD_HND:
+                    msgWhere = "handler";
+                    break;
+
+                case AcdKeyDesignator::KD_TRY:
+                    msgWhere = "try";
+                    break;
+
+                case AcdKeyDesignator::KD_FLT:
+                    msgWhere = "filter";
+                    break;
+
+                default:
+                    msgWhere = "? unexpected";
             }
 
             const char* msg;
@@ -3526,12 +3538,12 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
                     break;
             }
 
-            printf("\nAdding throw helper " FMT_BB " for %s in %s%s (inspired by " FMT_BB ")\n", newBlk->bbNum,
-                   sckName(add->acdKind), msgWhere, msg, srcBlk->bbNum);
+            printf("\nAdding throw helper " FMT_BB " for ACD%u %s in %s%s\n", newBlk->bbNum, add->acdNum,
+                   sckName(add->acdKind), msgWhere, msg);
         }
 #endif // DEBUG
 
-        //  Mark the block as added by the compiler and not removable by future flow
+        // Mark the block as added by the compiler and not removable by future flow
         // graph optimizations. Note that no target block points to these blocks.
         //
         newBlk->SetFlags(BBF_IMPORTED | BBF_DONT_REMOVE);
@@ -3620,28 +3632,148 @@ void Compiler::fgCreateThrowHelperBlockCode(AddCodeDsc* add)
 //
 // Arguments:
 //    kind -- kind of exception to throw
-//    refData -- bbThrowIndex of the block that will jump to the throw helper
+//    fromBlock -- block that will jump to the throw helper
 //
 // Return Value:
 //    Code descriptor for the appropriate throw helper block, or nullptr if no such
 //    descriptor exists.
 //
-Compiler::AddCodeDsc* Compiler::fgFindExcptnTarget(SpecialCodeKind kind, unsigned refData)
+Compiler::AddCodeDsc* Compiler::fgFindExcptnTarget(SpecialCodeKind kind, BasicBlock* fromBlock)
 {
     assert(fgUseThrowHelperBlocks() || (kind == SCK_FAIL_FAST));
     AddCodeDsc*          add = nullptr;
     AddCodeDscMap* const map = fgGetAddCodeDscMap();
-    AddCodeDscKey        key(kind, refData);
+    AddCodeDscKey        key(kind, fromBlock, this);
     map->Lookup(key, &add);
 
     if (add == nullptr)
     {
         // We shouldn't be asking for these blocks late in compilation
         // unless we know there are entries to be found.
+        if (fgRngChkThrowAdded)
+        {
+            JITDUMP(FMT_BB ": unexpected request for new throw helper: kind %d (%s), data 0x%08x\n", fromBlock->bbNum,
+                    kind, sckName(kind), key.Data());
+        }
         assert(!fgRngChkThrowAdded);
     }
 
     return add;
+}
+
+//------------------------------------------------------------------------
+// bbThrowIndex: find acd map key for a given block
+//
+// Arguments:
+//    blk -- block that may eventually throw an exception
+//    dsg [out] -- designator for which region controls throw block placement
+//
+// Return Value:
+//    encoded region value to use in acd key formation
+//
+unsigned Compiler::bbThrowIndex(BasicBlock* blk, AcdKeyDesignator* dsg)
+{
+    if (!UsesFunclets())
+    {
+        *dsg = AcdKeyDesignator::KD_TRY;
+        return blk->bbTryIndex;
+    }
+
+    const unsigned tryIndex = blk->bbTryIndex;
+    const unsigned hndIndex = blk->bbHndIndex;
+    const bool     inTry    = tryIndex > 0;
+    const bool     inHnd    = hndIndex > 0;
+
+    if (!inTry && !inHnd)
+    {
+        *dsg = AcdKeyDesignator::KD_NONE;
+        return 0;
+    }
+
+    assert(inTry || inHnd);
+
+    if (inTry && (!inHnd || (tryIndex < hndIndex)))
+    {
+        // The most enclosing region is a try body, use it
+        assert(tryIndex <= 0x3FFFFFFF);
+        *dsg = AcdKeyDesignator::KD_TRY;
+        return tryIndex;
+    }
+
+    // The most enclosing region is a handler which will be a funclet
+    // Now we have to figure out if blk is in the filter or handler
+    assert(hndIndex <= 0x3FFFFFFF);
+    assert(hndIndex >= 1);
+    if (ehGetDsc(hndIndex - 1)->InFilterRegionBBRange(blk))
+    {
+        *dsg = AcdKeyDesignator::KD_FLT;
+        return hndIndex | 0x80000000;
+    }
+
+    *dsg = AcdKeyDesignator::KD_HND;
+    return hndIndex | 0x40000000;
+}
+
+//------------------------------------------------------------------------
+// AddCodedDscKey: construct from kind and block
+//
+// Arguments:
+//    kind - exception kind
+//    block - block throwing (or potentially throwing) an exception
+//
+// Returns:
+//    appropriate lookup key
+//
+Compiler::AddCodeDscKey::AddCodeDscKey(SpecialCodeKind kind, BasicBlock* block, Compiler* comp)
+    : acdKind(kind)
+{
+    if (acdKind == SCK_FAIL_FAST)
+    {
+        acdData = 0;
+    }
+    else
+    {
+        AcdKeyDesignator dsg;
+        acdData = comp->bbThrowIndex(block, &dsg);
+    }
+}
+
+//------------------------------------------------------------------------
+// AddCodedDscKey: construct from AddCodeDsc
+//
+// Arguments:
+//    add - add code dsc in querstion
+//
+// Returns:
+//    appropriate lookup key
+//
+Compiler::AddCodeDscKey::AddCodeDscKey(AddCodeDsc* add)
+    : acdKind(add->acdKind)
+{
+    if (acdKind == SCK_FAIL_FAST)
+    {
+        acdData = 0;
+    }
+    else
+    {
+        switch (add->acdKeyDsg)
+        {
+            case AcdKeyDesignator::KD_NONE:
+                acdData = 0;
+                break;
+            case AcdKeyDesignator::KD_TRY:
+                acdData = add->acdTryIndex;
+                break;
+            case AcdKeyDesignator::KD_HND:
+                acdData = add->acdHndIndex | 0x40000000;
+                break;
+            case AcdKeyDesignator::KD_FLT:
+                acdData = add->acdHndIndex | 0x80000000;
+                break;
+            default:
+                unreached();
+        }
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3384,6 +3384,11 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
         return;
     }
 
+    // Fetch block data and designator
+    //
+    AcdKeyDesignator dsg     = AcdKeyDesignator::KD_NONE;
+    unsigned const   refData = (kind == SCK_FAIL_FAST) ? 0 : bbThrowIndex(srcBlk, &dsg);
+
     // Look for an existing entry that matches what we're looking for
     //
     AddCodeDsc* add = fgFindExcptnTarget(kind, srcBlk);
@@ -3391,16 +3396,11 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
     if (add != nullptr)
     {
         JITDUMP(FMT_BB " requires throw helper block for %s, sharing ACD%u (data 0x%08x)\n", srcBlk->bbNum,
-                sckName(kind), add->acdNum, add->refData);
+                sckName(kind), add->acdNum, refData);
         return;
     }
 
     assert(!fgRngChkThrowAdded);
-
-    // Fetch block data and designator
-    //
-    AcdKeyDesignator dsg     = AcdKeyDesignator::KD_NONE;
-    unsigned const   refData = (kind == SCK_FAIL_FAST) ? 0 : bbThrowIndex(srcBlk, &dsg);
 
     // Allocate a new entry and prepend it to the list
     //

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -268,7 +268,7 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
 //
 void StackLevelSetter::SetThrowHelperBlock(SpecialCodeKind kind, BasicBlock* block)
 {
-    Compiler::AddCodeDsc* add = comp->fgFindExcptnTarget(kind, comp->bbThrowIndex(block));
+    Compiler::AddCodeDsc* add = comp->fgFindExcptnTarget(kind, block);
     assert(add != nullptr);
 
     // We expect we'll actually need this helper.


### PR DESCRIPTION
The main aim of this change is to remove the block reference from AddCodeDsc, as it can become stale over time, making it impossible to determine where a throw helper block should be placed, if we have subsequently eliminated EH regions.

Instead we use the try/handler indices plus a bit of extra info to track where the throw helper block should be placed.

I also moved the key formation logic nearby and reworked it a bit, and gave the AddCodeDscs debug indices for dumps.

This should unblock doing late EH region removal.