### PR TITLE
Remove duplicate code block in `DiagnosticsHandler`.

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -214,25 +214,6 @@ namespace System.Net.Http
                         }
                     }
 
-                    if (activity.IsAllDataRequested)
-                    {
-                        // Add standard tags known at request completion.
-                        if (response is not null)
-                        {
-                            activity.SetTag("http.response.status_code", DiagnosticsHelper.GetBoxedInt32((int)response.StatusCode));
-                            activity.SetTag("network.protocol.version", DiagnosticsHelper.GetProtocolVersionString(response.Version));
-                        }
-
-                        if (DiagnosticsHelper.TryGetErrorType(response, exception, out string? errorType))
-                        {
-                            activity.SetTag("error.type", errorType);
-
-                            // The presence of error.type indicates that the conditions for setting Error status are also met.
-                            // https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/http/http-spans.md#status
-                            activity.SetStatus(ActivityStatusCode.Error);
-                        }
-                    }
-
                     // Only send stop event to users who subscribed for it.
                     if (diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.RequestActivityStopName))
                     {


### PR DESCRIPTION
The duplication seems to have been caused by a concurrent merging of #103922 and #104251.