### PR TITLE
Avoid lock contention during thread creation of thread pool

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -75,14 +75,12 @@ namespace System.Threading
                 Thread workerThread = new Thread(s_workerThreadStart);
                 workerThread.IsThreadPoolThread = true;
                 workerThread.IsBackground = true;
-                // thread name will be set in thread proc
+                workerThread.SetThreadPoolWorkerThreadName();
                 workerThread.UnsafeStart();
             }
 
             private static void WorkerThreadStart()
             {
-                Thread.CurrentThread.SetThreadPoolWorkerThreadName();
-
                 PortableThreadPool threadPoolInstance = ThreadPoolInstance;
 
                 if (NativeRuntimeEventSource.Log.IsEnabled())

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -403,7 +403,7 @@ namespace System.Threading
 
         internal void SetThreadPoolWorkerThreadName()
         {
-            Debug.Assert(this == CurrentThread);
+            Debug.Assert(ThreadState.HasFlag(ThreadState.Unstarted) || this == CurrentThread);
             Debug.Assert(IsThreadPoolThread);
 
             lock (this)

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1467,6 +1467,68 @@ namespace System.Threading.ThreadPools.Tests
             }).Dispose();
         }
 
+        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
+        public static void ThreadPoolThreadCreationDoesNotCauseLockContention()
+        {
+            // Run in a separate process to test in a clean thread pool environment such that work items queued by the test
+            // would cause the thread pool to create threads
+            RemoteExecutor.Invoke(() =>
+            {
+                int processorCount = Environment.ProcessorCount;
+                var values = new double[processorCount];
+                StartBusyThreads();
+
+                long lockContentionCount = Monitor.LockContentionCount;
+                var done = new ManualResetEvent(false);
+                int count = 0;
+
+                for (int i = 0; i < processorCount; i++)
+                {
+                    ThreadPool.QueueUserWorkItem(m =>
+                    {
+                        if (Interlocked.Increment(ref count) == processorCount)
+                        {
+                            done.Set();
+                        }
+                    });
+                }
+
+                done.WaitOne();
+
+                Assert.Equal(0, Monitor.LockContentionCount - lockContentionCount);
+
+                void StartBusyThreads()
+                {
+                    using var sem = new Semaphore(0, values.Length);
+
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        int index = i;
+
+                        var t = new Thread(_ =>
+                        {
+                            sem.Release();
+
+                            while (true)
+                            {
+                                for (int j = 0; j < int.MaxValue; j++)
+                                {
+                                    values[index] += Math.Sqrt(j);
+                                }
+                            }
+                        });
+
+                        t.Start();
+                    }
+
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        sem.WaitOne();
+                    }
+                }
+            }).Dispose();
+        }
+
         public static bool IsThreadingAndRemoteExecutorSupported =>
             PlatformDetection.IsThreadingSupported && RemoteExecutor.IsSupported;
 


### PR DESCRIPTION
For a worker thread, `Thread.StartCore` and `Thread.SetThreadPoolWorkerThreadName` have lock contention.

Fix #108057