### PR TITLE
Document Important Note About the Host and the CLR for Testing

### DIFF
--- a/docs/workflow/building/coreclr/README.md
+++ b/docs/workflow/building/coreclr/README.md
@@ -55,6 +55,8 @@ Once you have both subsets built, you can generate the *Core_Root*, which as men
 
 Since this is more related to testing, you can find the full details and instructions in the CoreCLR testing doc [over here](/docs/workflow/testing/coreclr/testing.md).
 
+**WARNING:** When building CoreCLR, the `apphost` will also get constructed as part of the build. However, `apphost` belongs to the `host` subset. This means that if you only pass the `runtimeConfiguration` and/or the `librariesConfiguration` flag to your builds, then the `apphost` will get built in `Debug`. This will result in issues when trying to build the tests. Because of this, it is highly recommended to always also include the `-c` or `-hc` flags when building `clr` to ensure all of its related components are constructed in the same configuration.
+
 #### The Dev Shipping Packs
 
 It is also possible to generate the full runtime NuGet packages and installer that you can use to test in a more production-esque scenario. To generate these shipping artifacts, you have to build the `clr`, `libs`, `host`, and `packs` subsets:

--- a/docs/workflow/testing/coreclr/testing.md
+++ b/docs/workflow/testing/coreclr/testing.md
@@ -44,6 +44,8 @@ Building the tests can be as simple as calling the build script without any argu
 
 Note that for the libraries configuration, we are passing the argument directly to MSBuild instead of the build script, hence the `/p:LibrariesConfiguration` flag. Also, make sure you use the correct syntax depending on our platform. The _cmd_ script takes the arguments by placing, while the _sh_ script requires them to be with a hyphen.
 
+In the case you are working with a different build configuration for the host, you can specify it here via the `/p:HostConfiguration` flag.
+
 **NOTE**: Building the whole test suite is a very lengthy process, so it is highly recommended you build individual tests, and/or test subtrees as you need them, to make your workflow more efficient. This is explained in detail later on in this doc.
 
 ## Building the Core_Root


### PR DESCRIPTION
The documentation is not clear enough that using `-runtimeConfiguration` and `-librariesConfiguration` to build `clr+libs` might not be enough. This is because when building the CLR, the apphost gets also built, and that one has its own configuration. Unknowingly, one might attempt the usual workflow of using a `Checked` runtime with `Release` libraries, and then fail when building the tests. This happens because the apphost got built in `Debug`, and therefore it can't be found. This PR adds the necessary notes to make this gotcha visible and clear for the users, and how they should build instead.