### PR TITLE
Fix createdump 'stack smashing detected' error on arm64

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -199,8 +199,8 @@ CrashInfo::GatherCrashInfo(DumpType dumpType)
     {
         return false;
     }
-    // Add the special (fake) memory region for the special diagnostics info
-    MemoryRegion special(PF_R, SpecialDiagInfoAddress, SpecialDiagInfoAddress + PAGE_SIZE);
+    // Add the special (fake) memory region for the special diagnostics info. Use constructor that doesn't assert PAGE_SIZE alignment.
+    MemoryRegion special(PF_R, SpecialDiagInfoAddress, SpecialDiagInfoAddress + SpecialDiagInfoSize, /* offset */ 0);
     m_memoryRegions.insert(special);
 #ifdef __APPLE__
     InitializeOtherMappings();


### PR DESCRIPTION
The changes from PR #91865 were reverted by PR #95433.

This change restores the fix from PR #91865 by changing the size back to SpecialDiagInfoSize but uses the 4 parameter MemoryRegion constructor that doesn't assert the address/size is on a PAGE_SIZE alignment (PR #95433).

Issue: https://github.com/dotnet/runtime/issues/108023