### PR TITLE
Improve debugger StackOverflow handling

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12597,7 +12597,7 @@ bool Debugger::IsThreadAtSafePlace(Thread *thread)
 
     // On the Stack Overflow code path calling IsThreadAtSafePlaceWorker as it is
     // currently implemented is way too stack intensive. Conservatively we assume that
-    // any thread handling an SO is not at a safe place.
+    // any thread handling a SO is not at a safe place.
     // NOTE: don't check for thread->IsExceptionInProgress(), SO has special handling
     // that directly sets the last thrown object without ever creating a tracker.
     // (Tracker is what thread->IsExceptionInProgress() checks for)   

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12595,21 +12595,16 @@ bool Debugger::IsThreadAtSafePlace(Thread *thread)
         return true;
     }
 
-    // <TODO>
-    //
-    // Make sure this fix is evaluated when doing real work for debugging SO handling.
-    //
     // On the Stack Overflow code path calling IsThreadAtSafePlaceWorker as it is
-    // currently implemented is way too stack intensive. For now we cheat and just
-    // say that if a thread is in the middle of handling a SO it is NOT at a safe
-    // place. This is a reasonably safe assumption to make and hopefully shouldn't
-    // result in deadlocking the debugger.
-    if ( (thread->IsExceptionInProgress()) &&
-         (g_pEEInterface->GetThreadException(thread) == CLRException::GetPreallocatedStackOverflowExceptionHandle()) )
+    // currently implemented is way too stack intensive. Conservatively we assume that
+    // any thread handling an SO is not at a safe place.
+    // NOTE: don't check for thread->IsExceptionInProgress(), SO has special handling
+    // that directly sets the last thrown object without ever creating a tracker.
+    // (Tracker is what thread->IsExceptionInProgress() checks for)   
+    if (g_pEEInterface->GetThreadException(thread) == CLRException::GetPreallocatedStackOverflowExceptionHandle())
     {
         return false;
     }
-    // </TODO>
     else
     {
         return IsThreadAtSafePlaceWorker(thread);


### PR DESCRIPTION
In the function Debugger::IsThreadAtSafePlace we have some code that attempts to avoid calling a stack intensive helper method if the runtime is currently handling a StackOverflowException. The logic to do that check was incorrect because the runtime's EH has some special case handling for StackOverflow. Most exceptions cause the EH code to create an ExceptionTracker object which in turn causes thread->IsExceptionInProgress() to return TRUE. StackOverflow doesn't set that and goes straight to fatal error handling so thread->IsExceptionInProgress() is false.

The fix avoids checking IsExceptionInProgress(). g_pEEInterface->GetThreadException() works because it checks both the tracker and also falls back to thread->m_lastThrownObject where the StackOverflow exception will be stored.

Fixes https://github.com/dotnet/runtime/issues/70755