### PR TITLE
[browser] disable GetAsync_ServerNeedsAuthAndNoCredential_StatusCodeUnauthorized

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -165,6 +165,7 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/101115", typeof(PlatformDetection), nameof(PlatformDetection.IsFirefox))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/108019", TestPlatforms.Browser)]
         public async Task GetAsync_ServerNeedsAuthAndNoCredential_StatusCodeUnauthorized(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))


### PR DESCRIPTION
disable `GetAsync_ServerNeedsAuthAndNoCredential_StatusCodeUnauthorized` for browser
See https://github.com/dotnet/runtime/issues/108019