### PR TITLE
`WasmBuildTest` can exit with negative code

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -18,7 +18,7 @@ internal class BrowserRunner : IAsyncDisposable
 {
     private static Regex s_blazorUrlRegex = new Regex("Now listening on: (?<url>https?://.*$)");
     private static Regex s_appHostUrlRegex = new Regex("^App url: (?<url>https?://.*$)");
-    private static Regex s_exitRegex = new Regex("WASM EXIT (?<exitCode>[0-9]+)$");
+    private static Regex s_exitRegex = new Regex("WASM EXIT (?<exitCode>-?[0-9]+)$");
     private static readonly Lazy<string> s_chromePath = new(() =>
     {
         string artifactsBinDir = Path.Combine(Path.GetDirectoryName(typeof(BuildTestBase).Assembly.Location)!, "..", "..", "..", "..");


### PR DESCRIPTION
Before the change:

```
Error: incorrect localized value for Sunday in locale zh-CN. Expected 'nedeľa' but got 'Sunday'.
WASM EXIT -1
Exception: System.Exception: Timed out after 120s waiting for 'WASM EXIT' message
     at Wasm.Build.Tests.BrowserRunner.WaitForExitMessageAsync(TimeSpan timeout) in /workspaces/runtime/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs:line 211
     at Wasm.Build.Tests.WasmTemplateTestsBase.RunBrowser(String config, String projectFile, String language) in /workspaces/runtime/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs:line 119
     at Wasm.Build.Tests.WasmTemplateTestsBase.RunBrowser(String config, String projectFile, String language) in /workspaces/runtime/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs:line 120
     at Wasm.Build.Tests.IcuTestsBase.BuildAndRunIcuTest(String config, String templateType, Boolean aot, String testedLocales, GlobalizationMode globalizationMode, String extraProperties, Boolean onlyPredefinedCultures, String language, String icuFileName) in /workspaces/runtime/src/mono/wasm/Wasm.Build.Tests/IcuTestsBase.cs:line 180; _testOutput=[] Executing (Captured Output) - /workspaces/runtime/artifacts/bin/dotnet-latest/dotnet new wasmbrowser  -  in pwd /workspaces/runtime/artifacts/bin/Wasm.Build.Tests/Release/net9.0/linux-x64/wbt artifacts/icu_Release_False_0zfc3ohv_13h
```

After:
Just failure with -1, no timeout exception.