### PR TITLE
[browser] Fix fingerprinting and loadAllSatelliteResources=true

### DIFF
--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -375,12 +375,12 @@ export function prepareAssets () {
         if (config.loadAllSatelliteResources && resources.satelliteResources) {
             for (const culture in resources.satelliteResources) {
                 for (const name in resources.satelliteResources[culture]) {
-                    assetsToLoad.push({
+                    addAsset({
                         name,
                         hash: resources.satelliteResources[culture][name],
                         behavior: "resource",
                         culture
-                    });
+                    }, !resources.coreAssembly);
                 }
             }
         }

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SatelliteLoadingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SatelliteLoadingTests.cs
@@ -24,13 +24,19 @@ public class SatelliteLoadingTests : AppTestBase
     {
     }
 
-    [Fact, TestCategory("no-fingerprinting")]
-    public async Task LoadSatelliteAssembly()
+    [Theory, TestCategory("no-fingerprinting")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task LoadSatelliteAssembly(bool loadAllSatelliteResources)
     {
         CopyTestAsset("WasmBasicTestApp", "SatelliteLoadingTests", "App");
         BuildProject("Debug");
 
-        var result = await RunSdkStyleAppForBuild(new(Configuration: "Debug", TestScenario: "SatelliteAssembliesTest"));
+        var result = await RunSdkStyleAppForBuild(new(
+            Configuration: "Debug", 
+            TestScenario: "SatelliteAssembliesTest",
+            BrowserQueryString: new Dictionary<string, string> { ["loadAllSatelliteResources"] = loadAllSatelliteResources.ToString() }
+        ));
         Assert.Collection(
             result.TestOutput,
             m => Assert.Equal("default: hello", m),

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/SatelliteAssembliesTest.cs
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/SatelliteAssembliesTest.cs
@@ -8,11 +8,12 @@ using System.Threading.Tasks;
 public partial class SatelliteAssembliesTest
 {
     [JSExport]
-    public static async Task Run()
+    public static async Task Run(bool loadSatelliteAssemblies)
     {
         ResourceLibrary.ResourceAccessor.Read(TestOutput.WriteLine, false);
 
-        await LoadSatelliteAssemblies(new[] { "es-ES" });
+        if (loadSatelliteAssemblies)
+            await LoadSatelliteAssemblies(new[] { "es-ES" });
 
         ResourceLibrary.ResourceAccessor.Read(TestOutput.WriteLine, true);
     }

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -28,6 +28,11 @@ dotnet
 
 // Modify runtime start based on test case
 switch (testCase) {
+    case "SatelliteAssembliesTest":
+        if (params.get("loadAllSatelliteResources") === "true") {
+            dotnet.withConfig({ loadAllSatelliteResources: true });
+        }
+        break;
     case "AppSettingsTest":
         dotnet.withApplicationEnvironment(params.get("applicationEnvironment"));
         break;
@@ -141,7 +146,7 @@ const assemblyExtension = Object.keys(config.resources.coreAssembly)[0].endsWith
 try {
     switch (testCase) {
         case "SatelliteAssembliesTest":
-            await exports.SatelliteAssembliesTest.Run();
+            await exports.SatelliteAssembliesTest.Run(params.get("loadAllSatelliteResources") !== "true");
             exit(0);
             break;
         case "LazyLoadingTest":


### PR DESCRIPTION
- Fix loading fingerprinted satellite assets with `loadAllSatelliteResources=true`
- Add WBT test 

Fixes https://github.com/dotnet/runtime/issues/107742