### PR TITLE
Update `field` references in property accessors

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.TypeEquivalence.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.TypeEquivalence.cs
@@ -136,20 +136,20 @@ namespace Internal.TypeSystem
                             return false;
                     }
 
-                    foreach (var field in GetFields())
+                    foreach (var fieldInfo in GetFields())
                     {
-                        if (field.IsLiteral)
+                        if (fieldInfo.IsLiteral)
                         {
                             // Literal fields are ok
                             continue;
                         }
 
-                        if (field.IsStatic)
+                        if (fieldInfo.IsStatic)
                         {
                             return false;
                         }
 
-                        if (field.GetEffectiveVisibility() != EffectiveVisibility.Public)
+                        if (fieldInfo.GetEffectiveVisibility() != EffectiveVisibility.Public)
                         {
                             return false;
                         }

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -472,10 +472,10 @@ namespace Internal.TypeSystem
                 if (!this.IsEnum)
                     return this;
 
-                foreach (var field in this.GetFields())
+                foreach (var fieldInfo in this.GetFields())
                 {
-                    if (!field.IsStatic)
-                        return field.FieldType;
+                    if (!fieldInfo.IsStatic)
+                        return fieldInfo.FieldType;
                 }
 
                 ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, this);

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -464,9 +464,9 @@ namespace Internal.TypeSystem.Ecma
 
                 foreach (var handle in _typeDefinition.GetFields())
                 {
-                    var field = _module.GetField(handle, this);
-                    if (!field.IsStatic)
-                        return field.FieldType;
+                    var fieldInfo = _module.GetField(handle, this);
+                    if (!fieldInfo.IsStatic)
+                        return fieldInfo.FieldType;
                 }
 
                 return base.UnderlyingType; // Use the base implementation to get consistent error behavior

--- a/src/libraries/Common/src/System/Net/CookieParser.cs
+++ b/src/libraries/Common/src/System/Net/CookieParser.cs
@@ -553,9 +553,9 @@ namespace System.Net
                 if (s_isQuotedDomainField == null)
                 {
                     // TODO https://github.com/dotnet/runtime/issues/19348:
-                    FieldInfo? field = typeof(Cookie).GetField("IsQuotedDomain", BindingFlags.Instance | BindingFlags.NonPublic);
-                    Debug.Assert(field != null, "We need to use an internal field named IsQuotedDomain that is declared on Cookie.");
-                    s_isQuotedDomainField = field;
+                    FieldInfo? fieldInfo = typeof(Cookie).GetField("IsQuotedDomain", BindingFlags.Instance | BindingFlags.NonPublic);
+                    Debug.Assert(fieldInfo != null, "We need to use an internal field named IsQuotedDomain that is declared on Cookie.");
+                    s_isQuotedDomainField = fieldInfo;
                 }
 
                 return s_isQuotedDomainField;
@@ -570,9 +570,9 @@ namespace System.Net
                 if (s_isQuotedVersionField == null)
                 {
                     // TODO https://github.com/dotnet/runtime/issues/19348:
-                    FieldInfo? field = typeof(Cookie).GetField("IsQuotedVersion", BindingFlags.Instance | BindingFlags.NonPublic);
-                    Debug.Assert(field != null, "We need to use an internal field named IsQuotedVersion that is declared on Cookie.");
-                    s_isQuotedVersionField = field;
+                    FieldInfo? fieldInfo = typeof(Cookie).GetField("IsQuotedVersion", BindingFlags.Instance | BindingFlags.NonPublic);
+                    Debug.Assert(fieldInfo != null, "We need to use an internal field named IsQuotedVersion that is declared on Cookie.");
+                    s_isQuotedVersionField = fieldInfo;
                 }
 
                 return s_isQuotedVersionField;

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -131,9 +131,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             get
             {
-                if (this is FieldSymbol field)
+                if (this is FieldSymbol fieldInfo)
                 {
-                    return field.isStatic;
+                    return fieldInfo.isStatic;
                 }
 
                 if (this is EventSymbol ev)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
@@ -170,8 +170,8 @@ namespace System.Runtime.Serialization.DataContracts
                 {
                     if (_memberType == null)
                     {
-                        if (MemberInfo is FieldInfo field)
-                            _memberType = field.FieldType;
+                        if (MemberInfo is FieldInfo fieldInfo)
+                            _memberType = fieldInfo.FieldType;
                         else if (MemberInfo is PropertyInfo prop)
                             _memberType = prop.PropertyType;
                         else

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Models.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Models.cs
@@ -431,8 +431,8 @@ namespace System.Xml.Serialization
                     FieldInfo[] fields = Type.GetFields();
                     for (int i = 0; i < fields.Length; i++)
                     {
-                        FieldInfo field = fields[i];
-                        ConstantModel? constant = GetConstantModel(field);
+                        FieldInfo fieldInfo = fields[i];
+                        ConstantModel? constant = GetConstantModel(fieldInfo);
                         if (constant != null) list.Add(constant);
                     }
                     _constants = list.ToArray();

--- a/src/libraries/System.Reflection.TypeExtensions/tests/TypeTests.cs
+++ b/src/libraries/System.Reflection.TypeExtensions/tests/TypeTests.cs
@@ -792,8 +792,8 @@ namespace System.Reflection.Tests
 
         public T publicField
         {
-            get { return field; }
-            set { field = value; }
+            get { return this.field; }
+            set { this.field = value; }
         }
 
         public T ReturnAndSetField(T newFieldValue, params T[] moreFieldValues)
@@ -815,8 +815,8 @@ namespace System.Reflection.Tests
 
         public int publicField
         {
-            get { return field; }
-            set { field = value; }
+            get { return this.field; }
+            set { this.field = value; }
         }
 
         public int ReturnAndSetField(int newFieldValue, params int[] moreFieldValues)

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContract.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContract.cs
@@ -1057,9 +1057,9 @@ namespace SerializationTestTypes
         {
             get
             {
-                FieldInfo field = MemberInfo as FieldInfo;
-                if (field != null)
-                    return field.FieldType;
+                FieldInfo fieldInfo = MemberInfo as FieldInfo;
+                if (fieldInfo != null)
+                    return fieldInfo.FieldType;
                 return ((PropertyInfo)MemberInfo).PropertyType;
             }
         }

--- a/src/libraries/System.Runtime/tests/System.Dynamic.Runtime.Tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.event.+=.cs
+++ b/src/libraries/System.Runtime/tests/System.Dynamic.Runtime.Tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.event.+=.cs
@@ -302,12 +302,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
         {
             get
             {
-                return field;
+                return this.field;
             }
 
             set
             {
-                field = value;
+                this.field = value;
             }
         }
 
@@ -372,12 +372,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
         {
             get
             {
-                return field;
+                return this.field;
             }
 
             set
             {
-                field = value;
+                this.field = value;
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Dynamic.Runtime.Tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.event.-=.cs
+++ b/src/libraries/System.Runtime/tests/System.Dynamic.Runtime.Tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.event.-=.cs
@@ -776,12 +776,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
         {
             get
             {
-                return field;
+                return this.field;
             }
 
             set
             {
-                field = value;
+                this.field = value;
             }
         }
 
@@ -864,12 +864,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
         {
             get
             {
-                return field;
+                return this.field;
             }
 
             set
             {
-                field = value;
+                this.field = value;
             }
         }
 
@@ -952,12 +952,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
         {
             get
             {
-                return field;
+                return this.field;
             }
 
             set
             {
-                field = value;
+                this.field = value;
             }
         }
 
@@ -1041,12 +1041,12 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
         {
             get
             {
-                return field;
+                return this.field;
             }
 
             set
             {
-                field = value;
+                this.field = value;
             }
         }
 


### PR DESCRIPTION
Rename or qualify `field` references in property accessors to avoid conflict with [`field` keyword](https://github.com/dotnet/csharplang/blob/main/proposals/field-keyword.md) in C# compiler preview.