### PR TITLE
Update field references in property accessors

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             field = "abcd";
         }
 
-        public string GetField => field;
+        public string GetField => this.field;
 
         private string field;
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis_v1.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             field = "abcd";
         }
 
-        public string GetField => field;
+        public string GetField => this.field;
 
         private string field;
 


### PR DESCRIPTION
Continuation of https://github.com/dotnet/runtime/pull/108219.

For reference, errors were found building with preview C# compiler using:
```
build -build
build clr+libs+libs.tests
```

cc @stephentoub, @jaredpar