### PR TITLE
Fix handling of appending keywords to boolean schemas.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -34,6 +34,14 @@ namespace System.Text.Json.Schema
 
         public bool IsTrue => _trueOrFalse is true;
         public bool IsFalse => _trueOrFalse is false;
+
+        /// <summary>
+        /// Per the JSON schema core specification section 4.3
+        /// (https://json-schema.org/draft/2020-12/json-schema-core#name-json-schema-documents)
+        /// A JSON schema must either be an object or a boolean.
+        /// We represent false and true schemas using this flag.
+        /// It is not possible to specify keywords in boolean schemas.
+        /// </summary>
         private readonly bool? _trueOrFalse;
 
         public string? Ref { get => _ref; set { VerifyMutable(); _ref = value; } }
@@ -95,6 +103,7 @@ namespace System.Text.Json.Schema
             {
                 if (_trueOrFalse != null)
                 {
+                    // Boolean schemas admit no keywords
                     return 0;
                 }
 
@@ -129,6 +138,7 @@ namespace System.Text.Json.Schema
         {
             if (_trueOrFalse != null)
             {
+                // boolean schemas do not admit type keywords.
                 return;
             }
 
@@ -260,6 +270,10 @@ namespace System.Text.Json.Schema
             }
         }
 
+        /// <summary>
+        /// If the schema is boolean, replaces it with a semantically
+        /// equivalent object schema that allows appending keywords.
+        /// </summary>
         public static void EnsureMutable(ref JsonSchema schema)
         {
             switch (schema._trueOrFalse)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -260,6 +260,19 @@ namespace System.Text.Json.Schema
             }
         }
 
+        public static void EnsureMutable(ref JsonSchema schema)
+        {
+            switch (schema._trueOrFalse)
+            {
+                case false:
+                    schema = new JsonSchema { Not = True };
+                    break;
+                case true:
+                    schema = new JsonSchema();
+                    break;
+            }
+        }
+
         private static ReadOnlySpan<JsonSchemaType> s_schemaValues =>
         [
             // NB the order of these values influences order of types in the rendered schema

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -240,6 +240,7 @@ namespace System.Text.Json.Schema
 
                         if (property.AssociatedParameter is { HasDefaultValue: true } parameterInfo)
                         {
+                            JsonSchema.EnsureMutable(ref propertySchema);
                             propertySchema.DefaultValue = JsonSerializer.SerializeToNode(parameterInfo.DefaultValue, property.JsonTypeInfo);
                             propertySchema.HasDefaultValue = true;
                         }

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -1034,6 +1034,18 @@ namespace System.Text.Json.Schema.Tests
                 }
                 """);
 
+            yield return new TestData<ClassWithOptionalObjectParameter>(
+                Value: new(value: null),
+                AdditionalValues: [new(true), new(42), new(""), new(new object()), new(Array.Empty<int>())],
+                ExpectedJsonSchema: """
+                        {
+                            "type": ["object","null"],
+                            "properties": {
+                              "Value": { "default": null }
+                            }
+                        }
+                        """);
+
             // Collection types
             yield return new TestData<int[]>([1, 2, 3], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"integer"}}""");
             yield return new TestData<List<bool>>([false, true, false], ExpectedJsonSchema: """{"type":["array","null"],"items":{"type":"boolean"}}""");
@@ -1439,6 +1451,11 @@ namespace System.Text.Json.Schema.Tests
         {
             [JsonPropertyName("~/path/to/value")]
             public PocoWithRecursiveMembers Value { get; set; }
+        }
+
+        public class ClassWithOptionalObjectParameter(object? value = null)
+        {
+            public object? Value { get; } = value;
         }
 
         public readonly struct StructDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> values)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
@@ -107,6 +107,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(PocoCombiningPolymorphicTypeAndDerivedTypes))]
         [JsonSerializable(typeof(ClassWithComponentModelAttributes))]
         [JsonSerializable(typeof(ClassWithJsonPointerEscapablePropertyNames))]
+        [JsonSerializable(typeof(ClassWithOptionalObjectParameter))]
         // Collection types
         [JsonSerializable(typeof(int[]))]
         [JsonSerializable(typeof(List<bool>))]


### PR DESCRIPTION
Fix https://github.com/microsoft/semantic-kernel/issues/8983. Replicated in https://github.com/eiriktsarpalis/stj-schema-mapper/pull/6. Should be backported to .NET 9.