### PR TITLE
[release/9.0] More doc updates for source-of-truth assemblies

### DIFF
--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/IMetricsBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/IMetricsBuilder.cs
@@ -6,13 +6,13 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// Represents a type used to configure the metrics system by registering IMetricsListeners and using rules
+    /// Configures the metrics system by registering IMetricsListeners and using rules
     /// to determine which metrics are enabled.
     /// </summary>
     public interface IMetricsBuilder
     {
         /// <summary>
-        /// The application <see cref="IServiceCollection"/>. This is used by extension methods to register services.
+        /// Gets the application service collection that's used by extension methods to register services.
         /// </summary>
         IServiceCollection Services { get; }
     }

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/IMetricsListener.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/IMetricsListener.cs
@@ -6,12 +6,12 @@ using System.Diagnostics.Metrics;
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// Represents a type used to listen to metrics emitted from the system.
+    /// Listens to metrics emitted from the system.
     /// </summary>
     public interface IMetricsListener
     {
         /// <summary>
-        /// The name of the listener. This is used to identify the listener in the rules configuration.
+        /// Gets the name of the listener. This is used to identify the listener in the rules configuration.
         /// </summary>
         public string Name { get; }
 
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
         /// <param name="instrument">The new <see cref="Instrument"/>.</param>
         /// <param name="userState">Listener state associated with this instrument. This will be returned to <see cref="MeasurementCallback{T}"/>
         /// and <see cref="MeasurementsCompleted(Instrument, object?)"/>.</param>
-        /// <returns>Returns true if the listener wants to subscribe to this instrument, otherwise false.</returns>
+        /// <returns><see langword="true" /> if the listener wants to subscribe to this instrument, otherwise <see langword="false" />.</returns>
         public bool InstrumentPublished(Instrument instrument, out object? userState);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/IObservableInstrumentsSource.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/IObservableInstrumentsSource.cs
@@ -6,13 +6,15 @@ using System.Diagnostics.Metrics;
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// An interface registered with each IMetricsListener using <see cref="IMetricsListener.Initialize(IObservableInstrumentsSource)"/>. The listener
-    /// can call <see cref="RecordObservableInstruments"/> to receive the current set of measurements for enabled observable instruments.
+    /// An interface registered with each IMetricsListener using <see cref="IMetricsListener.Initialize(IObservableInstrumentsSource)"/>.
     /// </summary>
+    /// <remarks>
+    /// The listener can call <see cref="RecordObservableInstruments"/> to receive the current set of measurements for enabled observable instruments.
+    /// </remarks>
     public interface IObservableInstrumentsSource
     {
         /// <summary>
-        /// Requests that the current set of metrics for enabled instruments be sent to the listener's <see cref="MeasurementCallback{T}"/>'s.
+        /// Requests that the current set of metrics for enabled instruments be sent to the listener's <see cref="MeasurementCallback{T}"/> objects.
         /// </summary>
         public void RecordObservableInstruments();
     }

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/InstrumentRule.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/InstrumentRule.cs
@@ -20,32 +20,41 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
     /// <param name="meterName">The <see cref="Meter.Name">Meter.Name</see> or prefix.</param>
     /// <param name="instrumentName">The <see cref="Instrument.Name">Instrument.Name</see>.</param>
     /// <param name="listenerName">The <see cref="IMetricsListener.Name">IMetricsListener.Name</see>.</param>
-    /// <param name="scopes">The <see cref="MeterScope"/>'s to consider.</param>
-    /// <param name="enable">Enables or disabled the matched instrument for this listener.</param>
+    /// <param name="scopes">A bitwise combination of the enumeration values that specifies the scopes to consider.</param>
+    /// <param name="enable"><see langword="true" /> to enable the matched instrument for this listener; otherwise, <see langword="false" />.</param>
     public class InstrumentRule(string? meterName, string? instrumentName, string? listenerName, MeterScope scopes, bool enable)
     {
         /// <summary>
         /// Gets the <see cref="Meter.Name">Meter.Name</see>, either an exact match or the longest prefix match. Only full segment matches are considered.
-        /// All meters are matched if this is <see langword="null" />.
         /// </summary>
+        /// <value>
+        /// The meter name. If <see langword="null" />, all meters are matched.
+        /// </value>
         public string? MeterName { get; } = meterName;
 
         /// <summary>
         /// Gets the <see cref="Instrument.Name">Instrument.Name</see>, an exact match.
-        /// All instruments for the given meter are matched if this is <see langword="null" />.
         /// </summary>
+        /// <value>
+        /// The instrument name. If <see langword="null" />, all instruments for the meter are matched.
+        /// </value>
         public string? InstrumentName { get; } = instrumentName;
 
         /// <summary>
         /// Gets the <see cref="IMetricsListener.Name">IMetricsListener.Name</see>, an exact match.
-        /// All listeners are matched if this is <see langword="null" />.
         /// </summary>
+        /// <value>
+        /// The listener name. If <see langword="null" />, all listeners are matched.
+        /// </value>
         public string? ListenerName { get; } = listenerName;
 
         /// <summary>
-        /// Gets the <see cref="MeterScope"/>. This is used to distinguish between meters created via <see cref="Meter"/> constructors (<see cref="MeterScope.Global"/>)
-        /// and those created via Dependency Injection with <see cref="IMeterFactory.Create(MeterOptions)"/> (<see cref="MeterScope.Local"/>)."/>.
+        /// Gets the <see cref="MeterScope"/>.
         /// </summary>
+        /// <remarks>
+        /// This property is used to distinguish between meters created via <see cref="Meter"/> constructors (<see cref="MeterScope.Global"/>)
+        /// and those created via Dependency Injection with <see cref="IMeterFactory.Create(MeterOptions)"/> (<see cref="MeterScope.Local"/>).
+        /// </remarks>
         public MeterScope Scopes { get; } = scopes == MeterScope.None
             ? throw new ArgumentOutOfRangeException(nameof(scopes), scopes, "The MeterScope must be Global, Local, or both.")
             : scopes;

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MeasurementHandlers.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MeasurementHandlers.cs
@@ -6,42 +6,42 @@ using System.Diagnostics.Metrics;
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// A set of supported measurement types. If a listener does not support a given type, the measurement will be skipped.
+    /// Represents a set of supported measurement types. If a listener does not support a given type, the measurement is skipped.
     /// </summary>
     public class MeasurementHandlers
     {
         /// <summary>
-        /// A <see cref="MeasurementCallback{T}"/> for <see cref="byte"/>. If null, byte measurements will be skipped.
+        /// Gets or sets a <see cref="MeasurementCallback{T}"/> for <see cref="byte"/>. If <see langword="null"/>, byte measurements are skipped.
         /// </summary>
         public MeasurementCallback<byte>? ByteHandler { get; set; }
 
         /// <summary>
-        /// A <see cref="MeasurementCallback{T}"/> for <see cref="short"/>. If null, short measurements will be skipped.
+        /// Gets or sets a <see cref="MeasurementCallback{T}"/> for <see cref="short"/>. If <see langword="null"/>, short measurements are skipped.
         /// </summary>
         public MeasurementCallback<short>? ShortHandler { get; set; }
 
         /// <summary>
-        /// A <see cref="MeasurementCallback{T}"/> for <see cref="int"/>. If null, int measurements will be skipped.
+        /// Gets or sets a <see cref="MeasurementCallback{T}"/> for <see cref="int"/>. If <see langword="null"/>, int measurements are skipped.
         /// </summary>
         public MeasurementCallback<int>? IntHandler { get; set; }
 
         /// <summary>
-        /// A <see cref="MeasurementCallback{T}"/> for <see cref="long"/>. If null, long measurements will be skipped.
+        /// Gets or sets a <see cref="MeasurementCallback{T}"/> for <see cref="long"/>. If <see langword="null"/>, long measurements are skipped.
         /// </summary>
         public MeasurementCallback<long>? LongHandler { get; set; }
 
         /// <summary>
-        /// A <see cref="MeasurementCallback{T}"/> for <see cref="float"/>. If null, float measurements will be skipped.
+        /// Gets or sets a <see cref="MeasurementCallback{T}"/> for <see cref="float"/>. If <see langword="null"/>, float measurements are skipped.
         /// </summary>
         public MeasurementCallback<float>? FloatHandler { get; set; }
 
         /// <summary>
-        /// A <see cref="MeasurementCallback{T}"/> for <see cref="double"/>. If null, double measurements will be skipped.
+        /// Gets or sets a <see cref="MeasurementCallback{T}"/> for <see cref="double"/>. If <see langword="null"/>, double measurements are skipped.
         /// </summary>
         public MeasurementCallback<double>? DoubleHandler { get; set; }
 
         /// <summary>
-        /// A <see cref="MeasurementCallback{T}"/> for <see cref="decimal"/>. If null, decimal measurements will be skipped.
+        /// Gets or sets a <see cref="MeasurementCallback{T}"/> for <see cref="decimal"/>. If <see langword="null"/>, decimal measurements are skipped.
         /// </summary>
         public MeasurementCallback<decimal>? DecimalHandler { get; set; }
     }

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MeterScope.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MeterScope.cs
@@ -7,14 +7,14 @@ using System.Diagnostics.Metrics;
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// This is used by <see cref="InstrumentRule"/> to distinguish between meters created via <see cref="Meter"/> constructors (<see cref="Global"/>)
-    /// and those created via Dependency Injection with <see cref="IMeterFactory.Create(MeterOptions)"/> (<see cref="Local"/>)."/>.
+    /// Represents scopes used by <see cref="InstrumentRule"/> to distinguish between meters created via <see cref="Meter"/> constructors (<see cref="Global"/>)
+    /// and those created via Dependency Injection with <see cref="IMeterFactory.Create(MeterOptions)"/> (<see cref="Local"/>).
     /// </summary>
     [Flags]
     public enum MeterScope
     {
         /// <summary>
-        /// No scope is specified. This should not be used.
+        /// No scope is specified. This field should not be used.
         /// </summary>
         None = 0,
 

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MetricsBuilderExtensions.Rules.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MetricsBuilderExtensions.Rules.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
     public static partial class MetricsBuilderExtensions
     {
         /// <summary>
-        /// Enables all <see cref="Instrument"/>'s for the given meter, for all registered <see cref="IMetricsListener"/>'s.
+        /// Enables all instruments for the given meter, for all registered listeners.
         /// </summary>
         /// <param name="builder">The <see cref="IMetricsBuilder"/>.</param>
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
@@ -28,14 +28,14 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
         /// <param name="instrumentName">The <see cref="Instrument.Name"/>. A null value matches all instruments.</param>
         /// <param name="listenerName">The <see cref="IMetricsListener"/>.Name. A null value matches all listeners.</param>
-        /// <param name="scopes">Indicates which <see cref="MeterScope"/>'s to consider. Default to all scopes.</param>
+        /// <param name="scopes">Indicates which meter scopes to consider. Defaults to all scopes.</param>
         /// <returns>The original <see cref="IMetricsBuilder"/> for chaining.</returns>
         public static IMetricsBuilder EnableMetrics(this IMetricsBuilder builder, string? meterName, string? instrumentName = null, string? listenerName = null,
             MeterScope scopes = MeterScope.Global | MeterScope.Local)
             => builder.ConfigureRule(options => options.EnableMetrics(meterName, instrumentName, listenerName, scopes));
 
         /// <summary>
-        /// Enables all <see cref="Instrument"/>'s for the given meter, for all registered <see cref="IMetricsListener"/>'s.
+        /// Enables all instruments for the given meter, for all registered listeners.
         /// </summary>
         /// <param name="options">The <see cref="MetricsOptions"/>.</param>
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
@@ -50,14 +50,14 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
         /// <param name="instrumentName">The <see cref="Instrument.Name"/>. A null value matches all instruments.</param>
         /// <param name="listenerName">The <see cref="IMetricsListener"/>.Name. A null value matches all listeners.</param>
-        /// <param name="scopes">Indicates which <see cref="MeterScope"/>'s to consider. Default to all scopes.</param>
+        /// <param name="scopes">Indicates which meter scopes to consider. Default to all scopes.</param>
         /// <returns>The original <see cref="MetricsOptions"/> for chaining.</returns>
         public static MetricsOptions EnableMetrics(this MetricsOptions options, string? meterName, string? instrumentName = null, string? listenerName = null,
             MeterScope scopes = MeterScope.Global | MeterScope.Local)
             => options.AddRule(meterName, instrumentName, listenerName, scopes, enable: true);
 
         /// <summary>
-        /// Disables all <see cref="Instrument"/>'s for the given meter, for all registered <see cref="IMetricsListener"/>'s.
+        /// Disables all instruments for the given meter, for all registered listeners.
         /// </summary>
         /// <param name="builder">The <see cref="IMetricsBuilder"/>.</param>
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
@@ -72,14 +72,14 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
         /// <param name="instrumentName">The <see cref="Instrument.Name"/>. A null value matches all instruments.</param>
         /// <param name="listenerName">The <see cref="IMetricsListener"/>.Name. A null value matches all listeners.</param>
-        /// <param name="scopes">Indicates which <see cref="MeterScope"/>'s to consider. Default to all scopes.</param>
+        /// <param name="scopes">Indicates which meter scopes to consider. Defaults to all scopes.</param>
         /// <returns>The original <see cref="IMetricsBuilder"/> for chaining.</returns>
         public static IMetricsBuilder DisableMetrics(this IMetricsBuilder builder, string? meterName, string? instrumentName = null, string? listenerName = null,
             MeterScope scopes = MeterScope.Global | MeterScope.Local)
             => builder.ConfigureRule(options => options.DisableMetrics(meterName, instrumentName, listenerName, scopes));
 
         /// <summary>
-        /// Disables all <see cref="Instrument"/>'s for the given meter, for all registered <see cref="IMetricsListener"/>'s.
+        /// Disables all instruments for the given meter, for all registered listeners.
         /// </summary>
         /// <param name="options">The <see cref="MetricsOptions"/>.</param>
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
@@ -94,7 +94,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
         /// <param name="meterName">The <see cref="Meter.Name"/> or prefix. A null value matches all meters.</param>
         /// <param name="instrumentName">The <see cref="Instrument.Name"/>. A null value matches all instruments.</param>
         /// <param name="listenerName">The <see cref="IMetricsListener"/>.Name. A null value matches all listeners.</param>
-        /// <param name="scopes">Indicates which <see cref="MeterScope"/>'s to consider. Default to all scopes.</param>
+        /// <param name="scopes">Indicates which meter scopes to consider. Defaults to all scopes.</param>
         /// <returns>The original <see cref="MetricsOptions"/> for chaining.</returns>
         public static MetricsOptions DisableMetrics(this MetricsOptions options, string? meterName, string? instrumentName = null, string? listenerName = null,
             MeterScope scopes = MeterScope.Global | MeterScope.Local)

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MetricsOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MetricsOptions.cs
@@ -6,12 +6,12 @@ using System.Collections.Generic;
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// Options for configuring the metrics system.
+    /// Represents options for configuring the metrics system.
     /// </summary>
     public class MetricsOptions
     {
         /// <summary>
-        /// A list of <see cref="InstrumentRule"/>'s that identify which metrics, instruments, and listeners are enabled.
+        /// Gets a list of instrument rules that identifies which metrics, instruments, and listeners are enabled.
         /// </summary>
         public IList<InstrumentRule> Rules { get; } = new List<InstrumentRule>();
     }

--- a/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/Configuration/MetricsBuilderConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/Configuration/MetricsBuilderConfigurationExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
     {
         /// <summary>
         /// Reads metrics configuration from the provided <see cref="IConfiguration"/> section and configures
-        /// which <see cref="Meter"/>'s, <see cref="Instrument"/>'s, and <see cref="IMetricsListener"/>'s are enabled.
+        /// which <see cref="Meter">Meters</see>, <see cref="Instrument">Instruments</see>, and <see cref="IMetricsListener">IMetricsListeners</see> are enabled.
         /// </summary>
         /// <param name="builder">The <see cref="IMetricsBuilder"/>.</param>
         /// <param name="configuration">The <see cref="IConfiguration"/> section to load.</param>

--- a/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/ConsoleMetrics.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/ConsoleMetrics.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// Constants for the Console metrics listener.
+    /// Provides constants for the Console metrics listener.
     /// </summary>
     public static class ConsoleMetrics
     {
         /// <summary>
-        /// The name of the listener used in configuration and enabling instruments.
+        /// Gets the name of the listener used in configuration and enabling instruments.
         /// </summary>
         public static string DebugListenerName => "DebugConsole";
     }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/IFileInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/IFileInfo.cs
@@ -12,39 +12,40 @@ namespace Microsoft.Extensions.FileProviders
     public interface IFileInfo
     {
         /// <summary>
-        /// True if resource exists in the underlying storage system.
+        /// Gets a value that indicates if the resource exists in the underlying storage system.
         /// </summary>
         bool Exists { get; }
 
         /// <summary>
-        /// The length of the file in bytes, or -1 for a directory or non-existing files.
+        /// Gets the length of the file in bytes, or -1 for a directory or nonexistent file.
         /// </summary>
         long Length { get; }
 
         /// <summary>
-        /// The path to the file, including the file name. Return null if the file is not directly accessible.
+        /// Gets the path to the file, including the file name. Returns <see langword="null"/> if the file is not directly accessible.
         /// </summary>
         string? PhysicalPath { get; }
 
         /// <summary>
-        /// The name of the file or directory, not including any path.
+        /// Gets the name of the file or directory, not including any path.
         /// </summary>
         string Name { get; }
 
         /// <summary>
-        /// When the file was last modified
+        /// Gets the time when the file was last modified.
         /// </summary>
         DateTimeOffset LastModified { get; }
 
         /// <summary>
-        /// True for the case TryGetDirectoryContents has enumerated a sub-directory
+        /// Gets a value that indicates whether <c>TryGetDirectoryContents</c> has enumerated a subdirectory.
         /// </summary>
         bool IsDirectory { get; }
 
         /// <summary>
-        /// Return file contents as readonly stream. Caller should dispose stream when complete.
+        /// Returns file contents as a read-only stream.
         /// </summary>
-        /// <returns>The file stream</returns>
+        /// <returns>The file stream.</returns>
+        /// <remarks>The caller should dispose the stream when complete.</remarks>
         Stream CreateReadStream();
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/IFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/IFileProvider.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Enumerate a directory at the given path, if any.
         /// </summary>
-        /// <param name="subpath">Relative path that identifies the directory.</param>
-        /// <returns>Returns the contents of the directory.</returns>
+        /// <param name="subpath">The relative path that identifies the directory.</param>
+        /// <returns>The contents of the directory.</returns>
         IDirectoryContents GetDirectoryContents(string subpath);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NotFoundDirectoryContents.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NotFoundDirectoryContents.cs
@@ -8,17 +8,17 @@ using System.Linq;
 namespace Microsoft.Extensions.FileProviders
 {
     /// <summary>
-    /// Represents a non-existing directory
+    /// Represents a nonexistent directory.
     /// </summary>
     public class NotFoundDirectoryContents : IDirectoryContents
     {
         /// <summary>
-        /// A shared instance of <see cref="NotFoundDirectoryContents"/>
+        /// Gets a shared instance of <see cref="NotFoundDirectoryContents"/>.
         /// </summary>
         public static NotFoundDirectoryContents Singleton { get; } = new();
 
         /// <summary>
-        /// Always false.
+        /// Gets a value that's always <see langword="false"/>.
         /// </summary>
         public bool Exists => false;
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NotFoundFileInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NotFoundFileInfo.cs
@@ -8,36 +8,36 @@ using System.IO;
 namespace Microsoft.Extensions.FileProviders
 {
     /// <summary>
-    /// Represents a non-existing file.
+    /// Represents a nonexistent file.
     /// </summary>
     public class NotFoundFileInfo : IFileInfo
     {
         /// <summary>
         /// Initializes an instance of <see cref="NotFoundFileInfo"/>.
         /// </summary>
-        /// <param name="name">The name of the file that could not be found</param>
+        /// <param name="name">The name of the file that could not be found.</param>
         public NotFoundFileInfo(string name)
         {
             Name = name;
         }
 
         /// <summary>
-        /// Always false.
+        /// Gets a value that's always <see langword="false"/>.
         /// </summary>
         public bool Exists => false;
 
         /// <summary>
-        /// Always false.
+        /// Gets a value that's always <see langword="false"/>.
         /// </summary>
         public bool IsDirectory => false;
 
         /// <summary>
-        /// Returns <see cref="DateTimeOffset.MinValue"/>.
+        /// Gets <see cref="DateTimeOffset.MinValue"/>.
         /// </summary>
         public DateTimeOffset LastModified => DateTimeOffset.MinValue;
 
         /// <summary>
-        /// Always equals -1.
+        /// Gets a value that's always -1.
         /// </summary>
         public long Length => -1;
 
@@ -45,15 +45,15 @@ namespace Microsoft.Extensions.FileProviders
         public string Name { get; }
 
         /// <summary>
-        /// Always null.
+        /// Gets a value that's always <see langword="null"/>.
         /// </summary>
         public string? PhysicalPath => null;
 
         /// <summary>
-        /// Always throws. A stream cannot be created for non-existing file.
+        /// Always throws. A stream cannot be created for a nonexistent file.
         /// </summary>
-        /// <exception cref="FileNotFoundException">Always thrown.</exception>
-        /// <returns>Does not return</returns>
+        /// <exception cref="FileNotFoundException">In all cases.</exception>
+        /// <returns>Does not return.</returns>
         [DoesNotReturn]
         public Stream CreateReadStream()
         {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NullChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NullChangeToken.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.FileProviders
     public class NullChangeToken : IChangeToken
     {
         /// <summary>
-        /// A singleton instance of <see cref="NullChangeToken"/>
+        /// Gets a singleton instance of <see cref="NullChangeToken"/>.
         /// </summary>
         public static NullChangeToken Singleton { get; } = new NullChangeToken();
 
@@ -21,21 +21,21 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         /// <summary>
-        /// Always false.
+        /// Gets a value that's always <see langword="false"/>.
         /// </summary>
         public bool HasChanged => false;
 
         /// <summary>
-        /// Always false.
+        /// Gets a value that's always <see langword="false"/>.
         /// </summary>
         public bool ActiveChangeCallbacks => false;
 
         /// <summary>
         /// Always returns an empty disposable object. Callbacks will never be called.
         /// </summary>
-        /// <param name="callback">This parameter is ignored</param>
-        /// <param name="state">This parameter is ignored</param>
-        /// <returns>A disposable object that noops on dispose.</returns>
+        /// <param name="callback">This parameter is ignored.</param>
+        /// <param name="state">This parameter is ignored.</param>
+        /// <returns>A disposable object that no-ops on dispose.</returns>
         public IDisposable RegisterChangeCallback(Action<object?> callback, object? state)
         {
             return EmptyDisposable.Instance;

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NullFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/NullFileProvider.cs
@@ -11,17 +11,17 @@ namespace Microsoft.Extensions.FileProviders
     public class NullFileProvider : IFileProvider
     {
         /// <summary>
-        /// Enumerate a non-existent directory.
+        /// Enumerates a nonexistent directory.
         /// </summary>
         /// <param name="subpath">A path under the root directory. This parameter is ignored.</param>
         /// <returns>A <see cref="IDirectoryContents"/> that does not exist and does not contain any contents.</returns>
         public IDirectoryContents GetDirectoryContents(string subpath) => NotFoundDirectoryContents.Singleton;
 
         /// <summary>
-        /// Locate a non-existent file.
+        /// Locates a nonexistent file.
         /// </summary>
         /// <param name="subpath">A path under the root directory.</param>
-        /// <returns>A <see cref="IFileInfo"/> representing a non-existent file at the given path.</returns>
+        /// <returns>A <see cref="IFileInfo"/> representing a nonexistent file at the given path.</returns>
         public IFileInfo GetFileInfo(string subpath) => new NotFoundFileInfo(subpath);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Composite/src/CompositeDirectoryContents.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Composite/src/CompositeDirectoryContents.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.FileProviders.Composite
         /// Creates an enumerator for all files in all providers given.
         /// Ensures each item in the collection is distinct.
         /// </summary>
-        /// <returns>An enumerator over all files in all given providers</returns>
+        /// <returns>An enumerator over all files in all given providers.</returns>
         public IEnumerator<IFileInfo> GetEnumerator()
         {
             EnsureFilesAreInitialized();
@@ -93,7 +93,7 @@ namespace Microsoft.Extensions.FileProviders.Composite
         }
 
         /// <summary>
-        /// True if any given providers exists
+        /// Gets a value that indicates if any given providers exist.
         /// </summary>
         public bool Exists
         {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Composite/src/CompositeFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Composite/src/CompositeFileProvider.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Locates a file at the given path.
         /// </summary>
-        /// <param name="subpath">The path that identifies the file. </param>
-        /// <returns>The file information. Caller must check Exists property. This will be the first existing <see cref="IFileInfo"/> returned by the provided <see cref="IFileProvider"/> or a not found <see cref="IFileInfo"/> if no existing files is found.</returns>
+        /// <param name="subpath">The path that identifies the file.</param>
+        /// <returns>The file information. The caller must check the <see cref="IFileInfo.Exists" /> property. This is the first existing <see cref="IFileInfo"/> returned by the provided <see cref="IFileProvider"/> or a not found <see cref="IFileInfo"/> if no existing files are found.</returns>
         public IFileInfo GetFileInfo(string subpath)
         {
             foreach (IFileProvider fileProvider in _fileProviders)

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PhysicalDirectoryContents.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PhysicalDirectoryContents.cs
@@ -10,24 +10,24 @@ using Microsoft.Extensions.FileProviders.Physical;
 namespace Microsoft.Extensions.FileProviders.Internal
 {
     /// <summary>
-    /// Represents the contents of a physical file directory
+    /// Represents the contents of a physical file directory.
     /// </summary>
     public class PhysicalDirectoryContents : IDirectoryContents
     {
         private readonly PhysicalDirectoryInfo _info;
 
         /// <summary>
-        /// Initializes an instance of <see cref="PhysicalDirectoryContents"/>
+        /// Initializes an instance of <see cref="PhysicalDirectoryContents"/>.
         /// </summary>
-        /// <param name="directory">The directory</param>
+        /// <param name="directory">The directory to represent.</param>
         public PhysicalDirectoryContents(string directory)
             : this(directory, ExclusionFilters.Sensitive)
         { }
 
         /// <summary>
-        /// Initializes an instance of <see cref="PhysicalDirectoryContents"/>
+        /// Initializes an instance of <see cref="PhysicalDirectoryContents"/>.
         /// </summary>
-        /// <param name="directory">The directory</param>
+        /// <param name="directory">The directory to represent.</param>
         /// <param name="filters">Specifies which files or directories are excluded from enumeration.</param>
         public PhysicalDirectoryContents(string directory, ExclusionFilters filters)
         {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalDirectoryInfo.cs
@@ -11,7 +11,7 @@ using System.Linq;
 namespace Microsoft.Extensions.FileProviders.Physical
 {
     /// <summary>
-    /// Represents a directory on a physical filesystem
+    /// Represents a directory on a physical file system.
     /// </summary>
     public class PhysicalDirectoryInfo : IFileInfo, IDirectoryContents
     {
@@ -20,9 +20,9 @@ namespace Microsoft.Extensions.FileProviders.Physical
         private readonly ExclusionFilters _filters;
 
         /// <summary>
-        /// Initializes an instance of <see cref="PhysicalDirectoryInfo"/> that wraps an instance of <see cref="System.IO.DirectoryInfo"/>
+        /// Initializes an instance of <see cref="PhysicalDirectoryInfo"/> that wraps an instance of <see cref="System.IO.DirectoryInfo"/>.
         /// </summary>
-        /// <param name="info">The directory</param>
+        /// <param name="info">The directory to represent.</param>
         public PhysicalDirectoryInfo(DirectoryInfo info)
         {
             _info = info;
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         public bool Exists => _info.Exists;
 
         /// <summary>
-        /// Always equals -1.
+        /// Gets a value that's always -1.
         /// </summary>
         public long Length => -1;
 
@@ -49,20 +49,20 @@ namespace Microsoft.Extensions.FileProviders.Physical
         public string Name => _info.Name;
 
         /// <summary>
-        /// The time when the directory was last written to.
+        /// Gets the time when the directory was last written to.
         /// </summary>
         public DateTimeOffset LastModified => _info.LastWriteTimeUtc;
 
         /// <summary>
-        /// Always true.
+        /// Gets a value that's always <see langword="true"/>.
         /// </summary>
         public bool IsDirectory => true;
 
         /// <summary>
         /// Always throws an exception because read streams are not support on directories.
         /// </summary>
-        /// <exception cref="InvalidOperationException">Always thrown</exception>
-        /// <returns>Never returns</returns>
+        /// <exception cref="InvalidOperationException">In all cases.</exception>
+        /// <returns>Never returns.</returns>
         public Stream CreateReadStream()
         {
             throw new InvalidOperationException(SR.CannotCreateStream);

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileInfo.cs
@@ -7,16 +7,16 @@ using System.IO;
 namespace Microsoft.Extensions.FileProviders.Physical
 {
     /// <summary>
-    /// Represents a file on a physical filesystem
+    /// Represents a file on a physical file system.
     /// </summary>
     public class PhysicalFileInfo : IFileInfo
     {
         private readonly FileInfo _info;
 
         /// <summary>
-        /// Initializes an instance of <see cref="PhysicalFileInfo"/> that wraps an instance of <see cref="System.IO.FileInfo"/>
+        /// Initializes an instance of <see cref="PhysicalFileInfo"/> that wraps an instance of <see cref="System.IO.FileInfo"/>.
         /// </summary>
-        /// <param name="info">The <see cref="System.IO.FileInfo"/></param>
+        /// <param name="info">The <see cref="System.IO.FileInfo"/>.</param>
         public PhysicalFileInfo(FileInfo info)
         {
             _info = info;
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         public DateTimeOffset LastModified => _info.LastWriteTimeUtc;
 
         /// <summary>
-        /// Always false.
+        /// Gets a value that's always <see langword="false"/>.
         /// </summary>
         public bool IsDirectory => false;
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Extensions.FileProviders
 {
     /// <summary>
-    /// Looks up files using the on-disk file system
+    /// Looks up files using the on-disk file system.
     /// </summary>
     /// <remarks>
     /// When the environment variable "DOTNET_USE_POLLING_FILE_WATCHER" is set to "1" or "true", calls to
@@ -73,17 +73,17 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Gets or sets a value that determines if this instance of <see cref="PhysicalFileProvider"/>
         /// uses polling to determine file changes.
-        /// <para>
-        /// By default, <see cref="PhysicalFileProvider"/>  uses <see cref="FileSystemWatcher"/> to listen to file change events
-        /// for <see cref="Watch(string)"/>. <see cref="FileSystemWatcher"/> is ineffective in some scenarios such as mounted drives.
-        /// Polling is required to effectively watch for file changes.
-        /// </para>
-        /// <seealso cref="UseActivePolling"/>.
         /// </summary>
         /// <value>
         /// The default value of this property is determined by the value of environment variable named <c>DOTNET_USE_POLLING_FILE_WATCHER</c>.
-        /// When <c>true</c> or <c>1</c>, this property defaults to <c>true</c>; otherwise false.
+        /// When <see langword="true"/> or <c>1</c>, this property defaults to <see langword="true"/>; otherwise <see langword="false"/>.
         /// </value>
+        /// <remarks>
+        /// By default, <see cref="PhysicalFileProvider"/>  uses <see cref="FileSystemWatcher"/> to listen to file change events
+        /// for <see cref="Watch(string)"/>. <see cref="FileSystemWatcher"/> is ineffective in some scenarios such as mounted drives.
+        /// Polling is required to effectively watch for file changes.
+        /// </remarks>
+        /// <seealso cref="UseActivePolling"/>
         public bool UsePollingFileWatcher
         {
             get
@@ -111,18 +111,18 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Gets or sets a value that determines if this instance of <see cref="PhysicalFileProvider"/>
         /// actively polls for file changes.
-        /// <para>
-        /// When <see langword="true"/>, <see cref="IChangeToken"/> returned by <see cref="Watch(string)"/> will actively poll for file changes
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the <see cref="IChangeToken"/> returned by <see cref="Watch(string)"/> actively polls for file changes
         /// (<see cref="IChangeToken.ActiveChangeCallbacks"/> will be <see langword="true"/>) instead of being passive.
-        /// </para>
+        /// The default value of this property is determined by the value of environment variable named <c>DOTNET_USE_POLLING_FILE_WATCHER</c>.
+        /// When <see langword="true"/> or <c>1</c>, this property defaults to <see langword="true"/>; otherwise <see langword="false"/>.
+        /// </value>
+        /// <remarks>
         /// <para>
         /// This property is only effective when <see cref="UsePollingFileWatcher"/> is set.
         /// </para>
-        /// </summary>
-        /// <value>
-        /// The default value of this property is determined by the value of environment variable named <c>DOTNET_USE_POLLING_FILE_WATCHER</c>.
-        /// When <c>true</c> or <c>1</c>, this property defaults to <c>true</c>; otherwise false.
-        /// </value>
+        /// </remarks>
         public bool UseActivePolling
         {
             get
@@ -221,7 +221,7 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         /// <summary>
-        /// The root directory for this instance.
+        /// Gets the root directory for this instance.
         /// </summary>
         public string Root { get; }
 
@@ -256,10 +256,10 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         /// <summary>
-        /// Locate a file at the given path by directly mapping path segments to physical directories.
+        /// Locates a file at the given path by directly mapping path segments to physical directories.
         /// </summary>
-        /// <param name="subpath">A path under the root directory</param>
-        /// <returns>The file information. Caller must check <see cref="IFileInfo.Exists"/> property. </returns>
+        /// <param name="subpath">A path under the root directory.</param>
+        /// <returns>The file information. Caller must check the <see cref="IFileInfo.Exists"/> property.</returns>
         public IFileInfo GetFileInfo(string subpath)
         {
             if (string.IsNullOrEmpty(subpath) || PathUtils.HasInvalidPathChars(subpath))
@@ -292,14 +292,17 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         /// <summary>
-        /// Enumerate a directory at the given path, if any.
+        /// Enumerates a directory at the given path, if any.
         /// </summary>
         /// <param name="subpath">A path under the root directory. Leading slashes are ignored.</param>
         /// <returns>
-        /// Contents of the directory. Caller must check <see cref="IDirectoryContents.Exists"/> property. <see cref="NotFoundDirectoryContents" /> if
-        /// <paramref name="subpath" /> is absolute, if the directory does not exist, or <paramref name="subpath" /> has invalid
-        /// characters.
+        /// The contents of the directory.
         /// </returns>
+        /// <remarks>
+        /// <para>The caller must check the <see cref="IDirectoryContents.Exists"/> property.</para>
+        /// <para>Returns <see cref="NotFoundDirectoryContents" /> if <paramref name="subpath" /> is absolute,
+        /// if the directory does not exist, or <paramref name="subpath" /> has invalid characters.</para>
+        /// </remarks>
         public IDirectoryContents GetDirectoryContents(string subpath)
         {
             try
@@ -345,7 +348,7 @@ namespace Microsoft.Extensions.FileProviders
         /// </param>
         /// <returns>
         /// An <see cref="IChangeToken" /> that is notified when a file matching <paramref name="filter" /> is added,
-        /// modified or deleted. Returns a <see cref="NullChangeToken" /> if <paramref name="filter" /> has invalid filter
+        /// modified, or deleted. Returns a <see cref="NullChangeToken" /> if <paramref name="filter" /> has invalid filter
         /// characters or if <paramref name="filter" /> is an absolute path or outside the root directory specified in the
         /// constructor <seealso cref="PhysicalFileProvider(string)" />.
         /// </returns>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -17,12 +17,8 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Extensions.FileProviders.Physical
 {
     /// <summary>
-    ///     <para>
-    ///     A file watcher that watches a physical filesystem for changes.
-    ///     </para>
-    ///     <para>
-    ///     Triggers events on <see cref="IChangeToken" /> when files are created, change, renamed, or deleted.
-    ///     </para>
+    /// Watches a physical file system for changes and triggers events on
+    /// <see cref="IChangeToken" /> when files are created, change, renamed, or deleted.
     /// </summary>
     public class PhysicalFilesWatcher : IDisposable
     {
@@ -46,13 +42,13 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         /// <summary>
         /// Initializes an instance of <see cref="PhysicalFilesWatcher" /> that watches files in <paramref name="root" />.
-        /// Wraps an instance of <see cref="System.IO.FileSystemWatcher" />
+        /// Wraps an instance of <see cref="System.IO.FileSystemWatcher" />.
         /// </summary>
-        /// <param name="root">Root directory for the watcher</param>
-        /// <param name="fileSystemWatcher">The wrapped watcher that is watching <paramref name="root" /></param>
+        /// <param name="root">Root directory for the watcher.</param>
+        /// <param name="fileSystemWatcher">The wrapped watcher that's watching <paramref name="root" />.</param>
         /// <param name="pollForChanges">
-        /// True when the watcher should use polling to trigger instances of
-        /// <see cref="IChangeToken" /> created by <see cref="CreateFileChangeToken(string)" />
+        /// <see langword="true"/> for the poller to use polling to trigger instances of
+        /// <see cref="IChangeToken" /> created by <see cref="CreateFileChangeToken(string)" />.
         /// </param>
         public PhysicalFilesWatcher(
             string root,
@@ -64,13 +60,13 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         /// <summary>
         /// Initializes an instance of <see cref="PhysicalFilesWatcher" /> that watches files in <paramref name="root" />.
-        /// Wraps an instance of <see cref="System.IO.FileSystemWatcher" />
+        /// Wraps an instance of <see cref="System.IO.FileSystemWatcher" />.
         /// </summary>
-        /// <param name="root">Root directory for the watcher</param>
-        /// <param name="fileSystemWatcher">The wrapped watcher that is watching <paramref name="root" /></param>
+        /// <param name="root">Root directory for the watcher.</param>
+        /// <param name="fileSystemWatcher">The wrapped watcher that is watching <paramref name="root" />.</param>
         /// <param name="pollForChanges">
-        /// True when the watcher should use polling to trigger instances of
-        /// <see cref="IChangeToken" /> created by <see cref="CreateFileChangeToken(string)" />
+        /// <see langword="true"/> for the poller to use polling to trigger instances of
+        /// <see cref="IChangeToken" /> created by <see cref="CreateFileChangeToken(string)" />.
         /// </param>
         /// <param name="filters">Specifies which files or directories are excluded. Notifications of changes to are not raised to these.</param>
         public PhysicalFilesWatcher(
@@ -118,19 +114,17 @@ namespace Microsoft.Extensions.FileProviders.Physical
         internal ConcurrentDictionary<IPollingChangeToken, IPollingChangeToken> PollingChangeTokens { get; }
 
         /// <summary>
-        ///     <para>
-        ///     Creates an instance of <see cref="IChangeToken" /> for all files and directories that match the
-        ///     <paramref name="filter" />
-        ///     </para>
-        ///     <para>
-        ///     Globbing patterns are relative to the root directory given in the constructor
-        ///     <seealso cref="PhysicalFilesWatcher(string, FileSystemWatcher, bool)" />. Globbing patterns
-        ///     are interpreted by <seealso cref="Matcher" />.
-        ///     </para>
+        /// Creates an instance of <see cref="IChangeToken" /> for all files and directories that match the
+        /// <paramref name="filter" />.
         /// </summary>
-        /// <param name="filter">A globbing pattern for files and directories to watch</param>
-        /// <returns>A change token for all files that match the filter</returns>
-        /// <exception cref="ArgumentNullException">When <paramref name="filter" /> is null</exception>
+        /// <param name="filter">A globbing pattern for files and directories to watch.</param>
+        /// <returns>A change token for all files that match the filter.</returns>
+        /// <remarks>
+        /// Globbing patterns are relative to the root directory given in the constructor
+        /// <see cref="PhysicalFilesWatcher(string, FileSystemWatcher, bool)" />. Globbing patterns
+        /// are interpreted by <see cref="Matcher" />.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="filter" /> is <see langword="null"/>.</exception>
         public IChangeToken CreateFileChangeToken(string filter)
         {
             ThrowHelper.ThrowIfNull(filter);

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
@@ -11,17 +11,12 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Extensions.FileProviders.Physical
 {
     /// <summary>
-    ///     <para>
-    ///     A change token that polls for file system changes.
-    ///     </para>
-    ///     <para>
-    ///     This change token does not raise any change callbacks. Callers should watch for <see cref="HasChanged" /> to turn
-    ///     from false to true
-    ///     and dispose the token after this happens.
-    ///     </para>
+    /// A change token that polls for file system changes.
     /// </summary>
     /// <remarks>
-    /// Polling occurs every 4 seconds.
+    /// <para>Polling occurs every 4 seconds.</para>
+    /// <para>This change token does not raise any change callbacks. Callers should watch for <see cref="HasChanged" /> to turn
+    /// from <see langword="false"/> to <see langword="true"/> and dispose the token after this happens.</para>
     /// </remarks>
     public class PollingFileChangeToken : IPollingChangeToken
     {
@@ -36,7 +31,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// Initializes a new instance of <see cref="PollingFileChangeToken" /> that polls the specified file for changes as
         /// determined by <see cref="System.IO.FileSystemInfo.LastWriteTimeUtc" />.
         /// </summary>
-        /// <param name="fileInfo">The <see cref="System.IO.FileInfo"/> to poll</param>
+        /// <param name="fileInfo">The <see cref="System.IO.FileInfo"/> to poll.</param>
         public PollingFileChangeToken(FileInfo fileInfo)
         {
             _fileInfo = fileInfo;
@@ -59,7 +54,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         }
 
         /// <summary>
-        /// Always false.
+        /// Gets a value that's always <see langword="false"/>.
         /// </summary>
         public bool ActiveChangeCallbacks { get; internal set; }
 
@@ -79,10 +74,10 @@ namespace Microsoft.Extensions.FileProviders.Physical
         CancellationTokenSource? IPollingChangeToken.CancellationTokenSource => CancellationTokenSource;
 
         /// <summary>
-        /// True when the file has changed since the change token was created. Once the file changes, this value is always true
+        /// Gets a value that indicates whether the file has changed since the change token was created.
         /// </summary>
         /// <remarks>
-        /// Once true, the value will always be true. Change tokens should not re-used once expired. The caller should discard this
+        /// Once the file changes, this value is always <see langword="true"/>. Change tokens should not reused once expired. The caller should discard this
         /// instance once it sees <see cref="HasChanged" /> is true.
         /// </remarks>
         public bool HasChanged
@@ -115,9 +110,9 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// <summary>
         /// Does not actually register callbacks.
         /// </summary>
-        /// <param name="callback">This parameter is ignored</param>
-        /// <param name="state">This parameter is ignored</param>
-        /// <returns>A disposable object that noops when disposed</returns>
+        /// <param name="callback">This parameter is ignored.</param>
+        /// <param name="state">This parameter is ignored.</param>
+        /// <returns>A disposable object that no-ops when disposed.</returns>
         public IDisposable RegisterChangeCallback(Action<object?> callback, object? state)
         {
             if (!ActiveChangeCallbacks)

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostEnvironmentEnvExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostEnvironmentEnvExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Hosting
         /// Checks if the current host environment name is <see cref="Environments.Development"/>.
         /// </summary>
         /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
-        /// <returns>True if the environment name is <see cref="Environments.Development"/>, otherwise false.</returns>
+        /// <returns><see langword="true"/> if the environment name is <see cref="Environments.Development"/>, otherwise <see langword="false"/>.</returns>
         public static bool IsDevelopment(this IHostEnvironment hostEnvironment)
         {
             ThrowHelper.ThrowIfNull(hostEnvironment);
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Hosting
         /// Checks if the current host environment name is <see cref="Environments.Staging"/>.
         /// </summary>
         /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
-        /// <returns>True if the environment name is <see cref="Environments.Staging"/>, otherwise false.</returns>
+        /// <returns><see langword="true"/> if the environment name is <see cref="Environments.Staging"/>, otherwise <see langword="false"/>.</returns>
         public static bool IsStaging(this IHostEnvironment hostEnvironment)
         {
             ThrowHelper.ThrowIfNull(hostEnvironment);
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Hosting
         /// Checks if the current host environment name is <see cref="Environments.Production"/>.
         /// </summary>
         /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
-        /// <returns>True if the environment name is <see cref="Environments.Production"/>, otherwise false.</returns>
+        /// <returns><see langword="true"/> if the environment name is <see cref="Environments.Production"/>, otherwise <see langword="false"/>.</returns>
         public static bool IsProduction(this IHostEnvironment hostEnvironment)
         {
             ThrowHelper.ThrowIfNull(hostEnvironment);
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
         /// <param name="environmentName">Environment name to validate against.</param>
-        /// <returns>True if the specified name is the same as the current environment, otherwise false.</returns>
+        /// <returns><see langword="true"/> if the specified name is the same as the current environment, otherwise <see langword="false"/>.</returns>
         public static bool IsEnvironment(
             this IHostEnvironment hostEnvironment,
             string environmentName)

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Block the calling thread until shutdown is triggered via Ctrl+C or SIGTERM.
+        /// Blocks the calling thread until shutdown is triggered via Ctrl+C or SIGTERM.
         /// </summary>
         /// <param name="host">The running <see cref="IHost"/>.</param>
         public static void WaitForShutdown(this IHost host)
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Runs an application and block the calling thread until host shutdown.
+        /// Runs an application and blocks the calling thread until host shutdown is triggered and all <see cref="T:Microsoft.Extensions.Hosting.IHostedService" /> instances are stopped.
         /// </summary>
         /// <param name="host">The <see cref="IHost"/> to run.</param>
         public static void Run(this IHost host)

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingEnvironmentExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingEnvironmentExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Hosting
         /// Checks if the current hosting environment name is <see cref="EnvironmentName.Development"/>.
         /// </summary>
         /// <param name="hostingEnvironment">An instance of <see cref="IHostingEnvironment"/>.</param>
-        /// <returns>True if the environment name is <see cref="EnvironmentName.Development"/>, otherwise false.</returns>
+        /// <returns><see langword="true" /> if the environment name is <see cref="EnvironmentName.Development"/>, otherwise <see langword="false" />.</returns>
         public static bool IsDevelopment(this IHostingEnvironment hostingEnvironment)
         {
             ThrowHelper.ThrowIfNull(hostingEnvironment);
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Hosting
         /// Checks if the current hosting environment name is <see cref="EnvironmentName.Staging"/>.
         /// </summary>
         /// <param name="hostingEnvironment">An instance of <see cref="IHostingEnvironment"/>.</param>
-        /// <returns>True if the environment name is <see cref="EnvironmentName.Staging"/>, otherwise false.</returns>
+        /// <returns><see langword="true" /> if the environment name is <see cref="EnvironmentName.Staging"/>, otherwise <see langword="false" />.</returns>
         public static bool IsStaging(this IHostingEnvironment hostingEnvironment)
         {
             ThrowHelper.ThrowIfNull(hostingEnvironment);
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Hosting
         /// Checks if the current hosting environment name is <see cref="EnvironmentName.Production"/>.
         /// </summary>
         /// <param name="hostingEnvironment">An instance of <see cref="IHostingEnvironment"/>.</param>
-        /// <returns>True if the environment name is <see cref="EnvironmentName.Production"/>, otherwise false.</returns>
+        /// <returns><see langword="true" /> if the environment name is <see cref="EnvironmentName.Production"/>, otherwise <see langword="false" />.</returns>
         public static bool IsProduction(this IHostingEnvironment hostingEnvironment)
         {
             ThrowHelper.ThrowIfNull(hostingEnvironment);
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="hostingEnvironment">An instance of <see cref="IHostingEnvironment"/>.</param>
         /// <param name="environmentName">Environment name to validate against.</param>
-        /// <returns>True if the specified name is the same as the current environment, otherwise false.</returns>
+        /// <returns><see langword="true" /> if the specified name is the same as the current environment, otherwise <see langword="false" />.</returns>
         public static bool IsEnvironment(
             this IHostingEnvironment hostingEnvironment,
             string environmentName)

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IApplicationLifetime.cs
@@ -17,19 +17,19 @@ namespace Microsoft.Extensions.Hosting
     public interface IApplicationLifetime
     {
         /// <summary>
-        /// Triggered when the application host has fully started and is about to wait
+        /// Gets a cancellation token. Triggered when the application host has fully started and is about to wait
         /// for a graceful shutdown.
         /// </summary>
         CancellationToken ApplicationStarted { get; }
 
         /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
+        /// Gets a cancellation token. Triggered when the application host is performing a graceful shutdown.
         /// Requests may still be in flight. Shutdown will block until this event completes.
         /// </summary>
         CancellationToken ApplicationStopping { get; }
 
         /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
+        /// Gets a cancellation token. Triggered when the application host is performing a graceful shutdown.
         /// All requests should be complete at this point. Shutdown will block
         /// until this event completes.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostApplicationBuilder.cs
@@ -39,7 +39,7 @@ public interface IHostApplicationBuilder
     ILoggingBuilder Logging { get; }
 
     /// <summary>
-    /// Allows enabling metrics and directing their output.
+    /// Gets a builder that allows enabling metrics and directing their output.
     /// </summary>
     IMetricsBuilder Metrics { get; }
 

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostApplicationLifetime.cs
@@ -11,18 +11,18 @@ namespace Microsoft.Extensions.Hosting
     public interface IHostApplicationLifetime
     {
         /// <summary>
-        /// Triggered when the application host has fully started.
+        /// Gets a cancellation token. Triggered when the application host has fully started.
         /// </summary>
         CancellationToken ApplicationStarted { get; }
 
         /// <summary>
-        /// Triggered when the application host is starting a graceful shutdown.
+        /// Gets a cancellation token. Triggered when the application host is starting a graceful shutdown.
         /// Shutdown will block until all callbacks registered on this token have completed.
         /// </summary>
         CancellationToken ApplicationStopping { get; }
 
         /// <summary>
-        /// Triggered when the application host has completed a graceful shutdown.
+        /// Gets a cancellation token. Triggered when the application host has completed a graceful shutdown.
         /// The application will not exit until all callbacks registered on this token have completed.
         /// </summary>
         CancellationToken ApplicationStopped { get; }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostBuilder.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Extensions.Hosting
     public interface IHostBuilder
     {
         /// <summary>
-        /// A central location for sharing state between components during the host building process.
+        /// Gets a central location for sharing state between components during the host building process.
         /// </summary>
         IDictionary<object, object> Properties { get; }
 
         /// <summary>
-        /// Set up the configuration for the builder itself. This will be used to initialize the <see cref="IHostEnvironment"/>
+        /// Sets up the configuration for the builder itself. This will be used to initialize the <see cref="IHostEnvironment"/>
         /// for use later in the build process. This can be called multiple times and the results will be additive.
         /// </summary>
         /// <param name="configureDelegate">The delegate for configuring the <see cref="IConfigurationBuilder"/> that will be used
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Hosting
         IHostBuilder ConfigureContainer<TContainerBuilder>(Action<HostBuilderContext, TContainerBuilder> configureDelegate);
 
         /// <summary>
-        /// Run the given actions to initialize the host. This can only be called once.
+        /// Runs the given actions to initialize the host. This can only be called once.
         /// </summary>
         /// <returns>An initialized <see cref="IHost"/>.</returns>
         IHost Build();

--- a/src/libraries/Microsoft.Extensions.Hosting/src/ConsoleLifetimeOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/ConsoleLifetimeOptions.cs
@@ -9,9 +9,12 @@ namespace Microsoft.Extensions.Hosting
     public class ConsoleLifetimeOptions
     {
         /// <summary>
-        /// Indicates if host lifetime status messages should be suppressed such as on startup.
-        /// The default is false.
+        /// Gets or sets a value that indicates if host lifetime status messages should be suppressed, such as on startup.
         /// </summary>
+        /// <value>
+        /// <see langword="true"/> if host lifetime status messages should be suppressed.
+        /// The default is <see langword="false"/>.
+        /// </value>
         public bool SuppressStatusMessages { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Extensions.Hosting
 {
     /// <summary>
-    /// Represents a hosted applications and services builder which helps manage configuration, logging, lifetime, and more.
+    /// Represents a hosted applications and services builder that helps manage configuration, logging, lifetime, and more.
     /// </summary>
     public sealed class HostApplicationBuilder : IHostApplicationBuilder
     {
@@ -226,7 +226,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Build the host. This can only be called once.
+        /// Builds the host. This method can only be called once.
         /// </summary>
         /// <returns>An initialized <see cref="IHost"/>.</returns>
         public IHost Build()

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
@@ -20,9 +20,12 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// If <see langword="false"/>, configures the <see cref="HostApplicationBuilder"/> instance with pre-configured defaults.
-        /// This has a similar effect to calling <see cref="HostingHostBuilderExtensions.ConfigureDefaults(IHostBuilder, string[])"/>.
+        /// Gets or sets a value that indicates whether the <see cref="HostApplicationBuilder"/> instance is configured with pre-configured defaults.
         /// </summary>
+        /// <value>
+        /// <see langword="false"/> if the <see cref="HostApplicationBuilder"/> instance is configured with pre-configured defaults.
+        /// This has a similar effect to calling <see cref="HostingHostBuilderExtensions.ConfigureDefaults(IHostBuilder, string[])"/>.
+        /// </value>
         /// <remarks>
         ///   The following defaults are applied to the <see cref="IHostBuilder"/>:
         ///     * set the <see cref="IHostEnvironment.ContentRootPath"/> to the result of <see cref="Directory.GetCurrentDirectory()"/>
@@ -37,29 +40,29 @@ namespace Microsoft.Extensions.Hosting
         public bool DisableDefaults { get; set; }
 
         /// <summary>
-        /// The command line arguments to add to the <see cref="HostApplicationBuilder.Configuration"/>.
+        /// Gets or sets the command-line arguments to add to the <see cref="HostApplicationBuilder.Configuration"/>.
         /// </summary>
         public string[]? Args { get; set; }
 
         /// <summary>
-        /// Initial configuration sources to be added to the <see cref="HostApplicationBuilder.Configuration"/>. These sources can influence
+        /// Gets or sets the initial configuration sources to be added to the <see cref="HostApplicationBuilder.Configuration"/>. These sources can influence
         /// the <see cref="HostApplicationBuilder.Environment"/> through the use of <see cref="HostDefaults"/> keys. Disposing the built
         /// <see cref="IHost"/> disposes the <see cref="ConfigurationManager"/>.
         /// </summary>
         public ConfigurationManager? Configuration { get; set; }
 
         /// <summary>
-        /// The environment name.
+        /// Gets or sets the environment name.
         /// </summary>
         public string? EnvironmentName { get; set; }
 
         /// <summary>
-        /// The application name.
+        /// Gets or sets the application name.
         /// </summary>
         public string? ApplicationName { get; set; }
 
         /// <summary>
-        /// The content root path.
+        /// Gets or sets the content root path.
         /// </summary>
         public string? ContentRootPath { get; set; }
     }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// A central location for sharing state between components during the host building process.
+        /// Gets a central location for sharing state between components during the host building process.
         /// </summary>
         public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
@@ -147,7 +147,7 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// Run the given actions to initialize the host. This can only be called once.
         /// </summary>
-        /// <returns>An initialized <see cref="IHost"/></returns>
+        /// <returns>An initialized <see cref="IHost"/>.</returns>
         /// <remarks>Adds basic services to the host such as application lifetime, host environment, and logging.</remarks>
         public IHost Build()
         {

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostOptions.cs
@@ -9,12 +9,12 @@ using Microsoft.Extensions.Configuration;
 namespace Microsoft.Extensions.Hosting
 {
     /// <summary>
-    /// Options for <see cref="IHost"/>
+    /// Options for <see cref="IHost"/>.
     /// </summary>
     public class HostOptions
     {
         /// <summary>
-        /// The default timeout for <see cref="IHost.StopAsync(CancellationToken)"/>.
+        /// Gets or sets the default timeout for <see cref="IHost.StopAsync(CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// This timeout also encompasses all host services implementing
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.Hosting
         public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// The default timeout for <see cref="IHost.StartAsync(CancellationToken)"/>.
+        /// Gets or sets the default timeout for <see cref="IHost.StartAsync(CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// This timeout also encompasses all host services implementing
@@ -34,17 +34,23 @@ namespace Microsoft.Extensions.Hosting
         public TimeSpan StartupTimeout { get; set; } = Timeout.InfiniteTimeSpan;
 
         /// <summary>
-        /// Determines if the <see cref="IHost"/> will start registered instances of <see cref="IHostedService"/> concurrently or sequentially. Defaults to false.
+        /// Gets or sets a value that indicates if the <see cref="IHost"/> will start registered instances of <see cref="IHostedService"/> concurrently or sequentially.
         /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the <see cref="IHost"/> will start registered instances of <see cref="IHostedService"/> concurrently; <see langword="false"/> if the <see cref="IHost"/> will start registered instances sequentially. The default is <see langword="false"/> .
+        /// </value>
         public bool ServicesStartConcurrently { get; set; }
 
         /// <summary>
-        /// Determines if the <see cref="IHost"/> will stop registered instances of <see cref="IHostedService"/> concurrently or sequentially. Defaults to false.
+        /// Gets or sets a value that indicates if the <see cref="IHost"/> will stop registered instances of <see cref="IHostedService"/> concurrently or sequentially.
         /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the <see cref="IHost"/> will stop registered instances of <see cref="IHostedService"/> concurrently; <see langword="false"/> if the <see cref="IHost"/> will stop registered instances sequentially. The default is <see langword="false"/> .
+        /// </value>
         public bool ServicesStopConcurrently { get; set; }
 
         /// <summary>
-        /// The behavior the <see cref="IHost"/> will follow when any of
+        /// Gets or sets the behavior the <see cref="IHost"/> will follow when any of
         /// its <see cref="BackgroundService"/> instances throw an unhandled exception.
         /// </summary>
         /// <remarks>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Hosting
     public static class HostingHostBuilderExtensions
     {
         /// <summary>
-        /// Specify the environment to be used by the host. To avoid the environment being overwritten by a default
+        /// Specifies the environment to be used by the host. To avoid the environment being overwritten by a default
         /// value, ensure this is called after defaults are configured.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder"/> to configure.</param>
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Specify the content root directory to be used by the host. To avoid the content root directory being
+        /// Specifies the content root directory to be used by the host. To avoid the content root directory being
         /// overwritten by a default value, ensure this is called after defaults are configured.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder"/> to configure.</param>
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Specify the <see cref="IServiceProvider"/> to be the default one.
+        /// Specifies the <see cref="IServiceProvider"/> to be the default one.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder"/> to configure.</param>
         /// <param name="configure">The delegate that configures the <see cref="IServiceProvider"/>.</param>
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Hosting
             => hostBuilder.UseDefaultServiceProvider((context, options) => configure(options));
 
         /// <summary>
-        /// Specify the <see cref="IServiceProvider"/> to be the default one.
+        /// Specifies the <see cref="IServiceProvider"/> to be the default one.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder"/> to configure.</param>
         /// <param name="configure">The delegate that configures the <see cref="IServiceProvider"/>.</param>
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Adds a delegate for configuring the provided <see cref="ILoggingBuilder"/>. This may be called multiple times.
+        /// Adds a delegate for configuring the provided <see cref="ILoggingBuilder"/>. This can be called multiple times.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
@@ -101,7 +101,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Adds a delegate for configuring the provided <see cref="ILoggingBuilder"/>. This may be called multiple times.
+        /// Adds a delegate for configuring the provided <see cref="ILoggingBuilder"/>. This can be called multiple times.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Adds a delegate for configuring the provided <see cref="IMetricsBuilder"/>. This may be called multiple times.
+        /// Adds a delegate for configuring the provided <see cref="IMetricsBuilder"/>. This can be called multiple times.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
         /// <param name="configureMetrics">The delegate that configures the <see cref="IMetricsBuilder"/>.</param>
@@ -410,7 +410,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Adds a delegate for configuring the provided <see cref="IMetricsBuilder"/>. This may be called multiple times.
+        /// Adds a delegate for configuring the provided <see cref="IMetricsBuilder"/>. This can be called multiple times.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
         /// <param name="configureMetrics">The delegate that configures the <see cref="IMetricsBuilder"/>.</param>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
@@ -33,19 +33,19 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         /// <summary>
-        /// Triggered when the application host has fully started and is about to wait
+        /// Gets a cancellation token. Triggered when the application host has fully started and is about to wait
         /// for a graceful shutdown.
         /// </summary>
         public CancellationToken ApplicationStarted => _startedSource.Token;
 
         /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
-        /// Request may still be in flight. Shutdown will block until this event completes.
+        /// Gets a cancellation token. Triggered when the application host is performing a graceful shutdown.
+        /// Request might still be in flight. Shutdown will block until this event completes.
         /// </summary>
         public CancellationToken ApplicationStopping => _stoppingSource.Token;
 
         /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
+        /// Gets a cancellation token. Triggered when the application host is performing a graceful shutdown.
         /// All requests should be complete at this point. Shutdown will block
         /// until this event completes.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Http.Logging;
 namespace Microsoft.Extensions.Http
 {
     /// <summary>
-    /// An options class for configuring the default <see cref="IHttpClientFactory"/>.
+    /// Provides options for configuring the default <see cref="IHttpClientFactory"/>.
     /// </summary>
     public class HttpClientFactoryOptions
     {
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Http
         }
 
         /// <summary>
-        /// The <see cref="Func{T, R}"/> which determines whether to redact the HTTP header value before logging.
+        /// Gets or sets the <see cref="Func{T, R}"/> that determines whether to redact the HTTP header value before logging.
         /// </summary>
         public Func<string, bool> ShouldRedactHeaderValue { get; set; } = LogHelper.ShouldRedactHeaderValue;
 

--- a/src/libraries/Microsoft.Extensions.Http/src/IHttpMessageHandlerBuilderFilter.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/IHttpMessageHandlerBuilderFilter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Http
         /// <summary>
         /// Applies additional initialization to the <see cref="HttpMessageHandlerBuilder"/>
         /// </summary>
-        /// <param name="next">A delegate which will run the next <see cref="IHttpMessageHandlerBuilderFilter"/>.</param>
+        /// <param name="next">A delegate that will run the next <see cref="IHttpMessageHandlerBuilderFilter"/>.</param>
         /// <returns>The configured <see cref="HttpMessageHandlerBuilder"/>.</returns>
         Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next);
     }

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/IHttpClientAsyncLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/IHttpClientAsyncLogger.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Http.Logging
         /// <param name="request">The HTTP request message that will be sent.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task object representing the asynchronous operation. The result of the operation is a context object that will
-        /// be passed to a corresponding <see cref="LogRequestStopAsync"/> or <see cref="LogRequestFailedAsync"/>. Can be `null`
+        /// be passed to a corresponding <see cref="LogRequestStopAsync"/> or <see cref="LogRequestFailedAsync"/>. Can be <see langword="null" />
         /// if no context object is needed by the implementation.</returns>
         ValueTask<object?> LogRequestStartAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
 
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Http.Logging
         /// </summary>
         /// <param name="context">The context object that was previously returned by <see cref="LogRequestStartAsync"/>.</param>
         /// <param name="request">The HTTP request message that was sent.</param>
-        /// <param name="response">If available, the HTTP response message that was received, and `null` otherwise.</param>
+        /// <param name="response">If available, the HTTP response message that was received, and <see langword="null" /> otherwise.</param>
         /// <param name="exception">Exception that happened during processing the HTTP request.</param>
         /// <param name="elapsed">Time elapsed since calling <see cref="LogRequestStartAsync"/>.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/IHttpClientLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/IHttpClientLogger.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Http.Logging
         /// Logs before sending an HTTP request.
         /// </summary>
         /// <param name="request">The HTTP request message that will be sent.</param>
-        /// <returns>A context object that will be passed to a corresponding <see cref="LogRequestStop"/> or <see cref="LogRequestFailed"/>. Can be `null`
+        /// <returns>A context object that will be passed to a corresponding <see cref="LogRequestStop"/> or <see cref="LogRequestFailed"/>. Can be <see langword="null" />
         /// if no context object is needed by the implementation.</returns>
         object? LogRequestStart(HttpRequestMessage request);
 
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.Http.Logging
         /// </summary>
         /// <param name="context">The context object that was previously returned by <see cref="LogRequestStart"/>.</param>
         /// <param name="request">The HTTP request message that was sent.</param>
-        /// <param name="response">If available, the HTTP response message that was received, and `null` otherwise.</param>
+        /// <param name="response">If available, the HTTP response message that was received, and <see langword="null" /> otherwise.</param>
         /// <param name="exception">Exception that happened during processing the HTTP request.</param>
         /// <param name="elapsed">Time elapsed since calling <see cref="LogRequestStart"/>.</param>
         void LogRequestFailed(object? context, HttpRequestMessage request, HttpResponseMessage? response, Exception exception, TimeSpan elapsed);

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/BufferedLogRecord.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/BufferedLogRecord.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
     /// Represents a buffered log record to be written in batch to an <see cref="IBufferedLogger" />.
     /// </summary>
     /// <remarks>
-    /// Instances of this type may be pooled and reused. Implementations of <see cref="IBufferedLogger" /> must
+    /// Instances of this type can be pooled and reused. Implementations of <see cref="IBufferedLogger" /> must
     /// not hold onto instance of <see cref="BufferedLogRecord" /> passed to its <see cref="IBufferedLogger.LogRecords" /> method
     /// beyond the invocation of that method.
     /// </remarks>
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
         public abstract LogLevel LogLevel { get; }
 
         /// <summary>
-        /// Gets the record's event id.
+        /// Gets the record's event ID.
         /// </summary>
         public abstract EventId EventId { get; }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/IExternalScopeProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/IExternalScopeProvider.cs
@@ -14,15 +14,15 @@ namespace Microsoft.Extensions.Logging
         /// Executes callback for each currently active scope objects in order of creation.
         /// All callbacks are guaranteed to be called inline from this method.
         /// </summary>
-        /// <param name="callback">The callback to be executed for every scope object</param>
-        /// <param name="state">The state object to be passed into the callback</param>
+        /// <param name="callback">The callback to be executed for every scope object.</param>
+        /// <param name="state">The state object to be passed into the callback.</param>
         /// <typeparam name="TState">The type of state to accept.</typeparam>
         void ForEachScope<TState>(Action<object?, TState> callback, TState state);
 
         /// <summary>
-        /// Adds scope object to the list
+        /// Adds scope object to the list.
         /// </summary>
-        /// <param name="state">The scope object</param>
+        /// <param name="state">The scope object.</param>
         /// <returns>The <see cref="IDisposable"/> token that removes scope on dispose.</returns>
         IDisposable Push(object? state);
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILogger.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Logging
         /// Checks if the given <paramref name="logLevel"/> is enabled.
         /// </summary>
         /// <param name="logLevel">Level to be checked.</param>
-        /// <returns><c>true</c> if enabled.</returns>
+        /// <returns><see langword="true" /> if enabled.</returns>
         bool IsEnabled(LogLevel logLevel);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogDefineOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogDefineOptions.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
-    /// Options for <see cref="LoggerMessage.Define(LogLevel, EventId, string)"/> and its overloads
+    /// Options for <see cref="LoggerMessage.Define(LogLevel, EventId, string)"/> and its overloads.
     /// </summary>
     public class LogDefineOptions
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogEntry.cs
@@ -30,32 +30,32 @@ namespace Microsoft.Extensions.Logging.Abstractions
         }
 
         /// <summary>
-        /// Gets the LogLevel
+        /// Gets the log level.
         /// </summary>
         public LogLevel LogLevel { get; }
 
         /// <summary>
-        /// Gets the log category
+        /// Gets the log category.
         /// </summary>
         public string Category { get; }
 
         /// <summary>
-        /// Gets the log EventId
+        /// Gets the log event ID.
         /// </summary>
         public EventId EventId { get; }
 
         /// <summary>
-        /// Gets the TState
+        /// Gets the state.
         /// </summary>
         public TState State { get; }
 
         /// <summary>
-        /// Gets the log exception
+        /// Gets the log exception.
         /// </summary>
         public Exception? Exception { get; }
 
         /// <summary>
-        /// Gets the formatter
+        /// Gets the formatter.
         /// </summary>
         public Func<TState, Exception?, string> Formatter { get; }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExtensions.cs
@@ -20,9 +20,13 @@ namespace Microsoft.Extensions.Logging
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogDebug(0, exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogDebug(0, exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogDebug(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Debug, eventId, exception, message, args);
@@ -33,9 +37,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogDebug(0, "Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogDebug(0, "Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogDebug(this ILogger logger, EventId eventId, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Debug, eventId, message, args);
@@ -46,9 +54,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogDebug(exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogDebug(exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogDebug(this ILogger logger, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Debug, exception, message, args);
@@ -58,9 +70,13 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes a debug log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogDebug("Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogDebug("Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogDebug(this ILogger logger, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Debug, message, args);
@@ -74,9 +90,13 @@ namespace Microsoft.Extensions.Logging
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogTrace(0, exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogTrace(0, exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogTrace(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Trace, eventId, exception, message, args);
@@ -87,9 +107,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogTrace(0, "Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogTrace(0, "Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogTrace(this ILogger logger, EventId eventId, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Trace, eventId, message, args);
@@ -100,9 +124,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogTrace(exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogTrace(exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogTrace(this ILogger logger, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Trace, exception, message, args);
@@ -112,9 +140,13 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes a trace log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogTrace("Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogTrace("Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogTrace(this ILogger logger, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Trace, message, args);
@@ -128,9 +160,13 @@ namespace Microsoft.Extensions.Logging
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogInformation(0, exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogInformation(0, exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogInformation(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Information, eventId, exception, message, args);
@@ -141,9 +177,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogInformation(0, "Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogInformation(0, "Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogInformation(this ILogger logger, EventId eventId, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Information, eventId, message, args);
@@ -154,9 +194,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogInformation(exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogInformation(exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogInformation(this ILogger logger, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Information, exception, message, args);
@@ -166,9 +210,13 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes an informational log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogInformation("Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogInformation("Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogInformation(this ILogger logger, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Information, message, args);
@@ -182,9 +230,13 @@ namespace Microsoft.Extensions.Logging
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogWarning(0, exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogWarning(0, exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogWarning(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Warning, eventId, exception, message, args);
@@ -195,9 +247,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogWarning(0, "Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogWarning(0, "Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogWarning(this ILogger logger, EventId eventId, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Warning, eventId, message, args);
@@ -208,9 +264,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogWarning(exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogWarning(exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogWarning(this ILogger logger, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Warning, exception, message, args);
@@ -220,9 +280,13 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes a warning log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogWarning("Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogWarning("Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogWarning(this ILogger logger, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Warning, message, args);
@@ -236,9 +300,13 @@ namespace Microsoft.Extensions.Logging
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogError(0, exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogError(0, exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogError(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Error, eventId, exception, message, args);
@@ -249,9 +317,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogError(0, "Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogError(0, "Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogError(this ILogger logger, EventId eventId, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Error, eventId, message, args);
@@ -262,9 +334,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogError(exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogError(exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogError(this ILogger logger, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Error, exception, message, args);
@@ -274,9 +350,13 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes an error log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogError("Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogError("Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogError(this ILogger logger, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Error, message, args);
@@ -290,9 +370,13 @@ namespace Microsoft.Extensions.Logging
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogCritical(0, exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogCritical(0, exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogCritical(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Critical, eventId, exception, message, args);
@@ -303,9 +387,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogCritical(0, "Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogCritical(0, "Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogCritical(this ILogger logger, EventId eventId, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Critical, eventId, message, args);
@@ -316,9 +404,13 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="exception">The exception to log.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogCritical(exception, "Error while processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogCritical(exception, "Error while processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogCritical(this ILogger logger, Exception? exception, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Critical, exception, message, args);
@@ -328,9 +420,13 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes a critical log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
-        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        /// <example>logger.LogCritical("Processing request from {Address}", address)</example>
+        /// <example>
+        /// <code language="csharp">
+        /// logger.LogCritical("Processing request from {Address}", address)
+        /// </code>
+        /// </example>
         public static void LogCritical(this ILogger logger, string? message, params object?[] args)
         {
             logger.Log(LogLevel.Critical, message, args);
@@ -396,13 +492,13 @@ namespace Microsoft.Extensions.Logging
         /// Formats the message and creates a scope.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to create the scope in.</param>
-        /// <param name="messageFormat">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
+        /// <param name="messageFormat">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <returns>A disposable scope object. Can be null.</returns>
         /// <example>
-        /// using(logger.BeginScope("Processing request from {Address}", address))
-        /// {
-        /// }
+        /// <code language="csharp">
+        /// using(logger.BeginScope("Processing request from {Address}", address)) { }
+        /// </code>
         /// </example>
         public static IDisposable? BeginScope(
             this ILogger logger,

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExternalScopeProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExternalScopeProvider.cs
@@ -7,7 +7,7 @@ using System.Threading;
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
-    /// Default implementation of <see cref="IExternalScopeProvider"/>
+    /// Default implementation of <see cref="IExternalScopeProvider"/>.
     /// </summary>
     public class LoggerExternalScopeProvider : IExternalScopeProvider
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
@@ -9,15 +9,15 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
-    /// Creates delegates which can be later cached to log messages in a performant way.
+    /// Creates delegates that can be later cached to log messages in a performant way.
     /// </summary>
     public static class LoggerMessage
     {
         /// <summary>
-        /// Creates a delegate which can be invoked to create a log scope.
+        /// Creates a delegate that can be invoked to create a log scope.
         /// </summary>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log scope.</returns>
         public static Func<ILogger, IDisposable?> DefineScope(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 0);
@@ -28,11 +28,11 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked to create a log scope.
+        /// Creates a delegate that can be invoked to create a log scope.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log scope.</returns>
         public static Func<ILogger, T1, IDisposable?> DefineScope<T1>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 1);
@@ -41,12 +41,12 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked to create a log scope.
+        /// Creates a delegate that can be invoked to create a log scope.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log scope.</returns>
         public static Func<ILogger, T1, T2, IDisposable?> DefineScope<T1, T2>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 2);
@@ -55,13 +55,13 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked to create a log scope.
+        /// Creates a delegate that can be invoked to create a log scope.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log scope.</returns>
         public static Func<ILogger, T1, T2, T3, IDisposable?> DefineScope<T1, T2, T3>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 3);
@@ -70,14 +70,14 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked to create a log scope.
+        /// Creates a delegate that can be invoked to create a log scope.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log scope.</returns>
         public static Func<ILogger, T1, T2, T3, T4, IDisposable?> DefineScope<T1, T2, T3, T4>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
@@ -86,15 +86,15 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked to create a log scope.
+        /// Creates a delegate that can be invoked to create a log scope.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log scope.</returns>
         public static Func<ILogger, T1, T2, T3, T4, T5, IDisposable?> DefineScope<T1, T2, T3, T4, T5>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked to create a log scope.
+        /// Creates a delegate that can be invoked to create a log scope.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
@@ -111,8 +111,8 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log scope.</returns>
         public static Func<ILogger, T1, T2, T3, T4, T5, T6, IDisposable?> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);
@@ -121,23 +121,23 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, Exception?> Define(LogLevel logLevel, EventId eventId, string formatString)
             => Define(logLevel, eventId, formatString, options: null);
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, Exception?> Define(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 0);
@@ -162,25 +162,25 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, Exception?> Define<T1>(LogLevel logLevel, EventId eventId, string formatString)
             => Define<T1>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, Exception?> Define<T1>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 1);
@@ -205,27 +205,27 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, Exception?> Define<T1, T2>(LogLevel logLevel, EventId eventId, string formatString)
             => Define<T1, T2>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, Exception?> Define<T1, T2>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 2);
@@ -250,29 +250,29 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, Exception?> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString)
             => Define<T1, T2, T3>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, Exception?> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 3);
@@ -297,31 +297,31 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, T4, Exception?> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString)
             => Define<T1, T2, T3, T4>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, T4, Exception?> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
@@ -346,33 +346,33 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, T4, T5, Exception?> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString)
             => Define<T1, T2, T3, T4, T5>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, T4, T5, Exception?> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
@@ -397,7 +397,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
@@ -405,15 +405,15 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, T4, T5, T6, Exception?> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString)
             => Define<T1, T2, T3, T4, T5, T6>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
-        /// Creates a delegate which can be invoked for logging a message.
+        /// Creates a delegate that can be invoked for logging a message.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
@@ -421,11 +421,11 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
-        /// <returns>A delegate which when invoked creates a log message.</returns>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate that, when invoked, creates a log message.</returns>
         public static Action<ILogger, T1, T2, T3, T4, T5, T6, Exception?> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
-    /// Provides information to guide the production of a strongly-typed logging method.
+    /// Provides information to guide the production of a strongly typed logging method.
     /// </summary>
     /// <remarks>
     /// <para>The method this attribute is applied to:</para>
@@ -33,15 +33,15 @@ namespace Microsoft.Extensions.Logging
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
-        /// which is used to guide the production of a strongly-typed logging method.
+        /// that's used to guide the production of a strongly typed logging method.
         /// </summary>
         public LoggerMessageAttribute() { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
-        /// which is used to guide the production of a strongly-typed logging method.
+        /// that's used to guide the production of a strongly typed logging method.
         /// </summary>
-        /// <param name="eventId">The log event Id.</param>
+        /// <param name="eventId">The log event ID.</param>
         /// <param name="level">The log level.</param>
         /// <param name="message">Format string of the log message.</param>
         public LoggerMessageAttribute(int eventId, LogLevel level, string message)
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.Logging
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
-        /// which is used to guide the production of a strongly-typed logging method.
+        /// that's used to guide the production of a strongly typed logging method.
         /// </summary>
         /// <param name="level">The log level.</param>
         /// <param name="message">Format string of the log message.</param>
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.Logging
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
-        /// which is used to guide the production of a strongly-typed logging method.
+        /// that's used to guide the production of a strongly typed logging method.
         /// </summary>
         /// <param name="level">The log level.</param>
         public LoggerMessageAttribute(LogLevel level)
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.Logging
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
-        /// which is used to guide the production of a strongly-typed logging method.
+        /// that's used to guide the production of a strongly typed logging method.
         /// </summary>
         /// <param name="message">Format string of the log message.</param>
         public LoggerMessageAttribute(string message)
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Gets the logging event id for the logging method.
+        /// Gets or sets the logging event ID for the logging method.
         /// </summary>
         public int EventId { get; set; } = -1;
 
@@ -97,17 +97,17 @@ namespace Microsoft.Extensions.Logging
         public string? EventName { get; set; }
 
         /// <summary>
-        /// Gets the logging level for the logging method.
+        /// Gets or sets the logging level for the logging method.
         /// </summary>
         public LogLevel Level { get; set; } = LogLevel.None;
 
         /// <summary>
-        /// Gets the message text for the logging method.
+        /// Gets or sets the message text for the logging method.
         /// </summary>
         public string Message { get; set; } = "";
 
         /// <summary>
-        /// Gets the flag to skip IsEnabled check for the logging method.
+        /// Gets or sets the flag to skip IsEnabled check for the logging method.
         /// </summary>
         public bool SkipEnabledCheck { get; set; }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLoggerFactory.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Extensions.Logging.Abstractions
 {
     /// <summary>
-    /// An <see cref="ILoggerFactory"/> used to create instance of
+    /// An <see cref="ILoggerFactory"/> used to create an instance of
     /// <see cref="NullLogger"/> that logs nothing.
     /// </summary>
     public class NullLoggerFactory : ILoggerFactory
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
 
         /// <inheritdoc />
         /// <remarks>
-        /// This returns a <see cref="NullLogger"/> instance which logs nothing.
+        /// This returns a <see cref="NullLogger"/> instance that logs nothing.
         /// </remarks>
         public ILogger CreateLogger(string name)
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Configuration/src/ILoggerProviderConfiguration.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Configuration/src/ILoggerProviderConfiguration.cs
@@ -6,13 +6,13 @@ using Microsoft.Extensions.Configuration;
 namespace Microsoft.Extensions.Logging.Configuration
 {
     /// <summary>
-    /// Allows access to configuration section associated with logger provider
+    /// Allows access to configuration section associated with logger provider.
     /// </summary>
-    /// <typeparam name="T">Type of logger provider to get configuration for</typeparam>
+    /// <typeparam name="T">The type of logger provider to get configuration for.</typeparam>
     public interface ILoggerProviderConfiguration<T>
     {
         /// <summary>
-        /// Configuration section for requested logger provider
+        /// Gets the configuration section for the requested logger provider.
         /// </summary>
         IConfiguration Configuration { get; }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Configuration/src/ILoggerProviderConfigurationFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Configuration/src/ILoggerProviderConfigurationFactory.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Extensions.Logging.Configuration
     public interface ILoggerProviderConfigurationFactory
     {
         /// <summary>
-        /// Return configuration section associated with logger provider
+        /// Returns the configuration section associated with the logger provider.
         /// </summary>
-        /// <param name="providerType">The logger provider type</param>
+        /// <param name="providerType">The logger provider type.</param>
         /// <returns>The <see cref="IConfiguration"/> for the given <paramref name="providerType" />.</returns>
         IConfiguration GetConfiguration(Type providerType);
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Configuration/src/LoggerProviderConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Configuration/src/LoggerProviderConfigurationExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Extensions.Logging.Configuration
         /// Indicates that settings for <typeparamref name="TProvider"/> should be loaded into <typeparamref name="TOptions"/> type.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> to register on.</param>
-        /// <typeparam name="TOptions">The options class </typeparam>
-        /// <typeparam name="TProvider">The provider class</typeparam>
+        /// <typeparam name="TOptions">The options class.</typeparam>
+        /// <typeparam name="TProvider">The provider class.</typeparam>
         [RequiresDynamicCode(RequiresDynamicCodeMessage)]
         [RequiresUnreferencedCode(TrimmingRequiresUnreferencedCodeMessage)]
         public static void RegisterProviderOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TOptions, TProvider>(IServiceCollection services) where TOptions : class

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConfigurationConsoleLoggerSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConfigurationConsoleLoggerSettings.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Creates a new instance of <see cref="ConfigurationConsoleLoggerSettings"/>.
         /// </summary>
-        /// <param name="configuration">provides access to configuration values.</param>
+        /// <param name="configuration">The configuration values.</param>
         public ConfigurationConsoleLoggerSettings(IConfiguration configuration)
         {
             _configuration = configuration;
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         /// <summary>
-        /// Gets the <see cref="IChangeToken"/> propagates notifications that a change has occurred.
+        /// Gets the <see cref="IChangeToken"/> that propagates notifications that a change has occurred.
         /// </summary>
         public IChangeToken? ChangeToken { get; private set; }
 
@@ -70,9 +70,9 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Gets the log level for the specified switch.
         /// </summary>
-        /// <param name="name">The name of the switch to look up</param>
-        /// <param name="level">An out parameter that will be set to the value of the switch if it is found. If the switch is not found, the method returns false and sets the value of level to LogLevel.None</param>
-        /// <returns>True if the switch was found, otherwise false.</returns>
+        /// <param name="name">The name of the switch to look up.</param>
+        /// <param name="level">When this method returns, contains the value of the switch if it is found. If the switch is not found, the method returns false and sets the value of level to LogLevel.None</param>
+        /// <returns><see langword="true" /> if the switch was found, otherwise <see langword="false" />.</returns>
         /// <exception cref="InvalidOperationException"></exception>
         public bool TryGetSwitch(string name, out LogLevel level)
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatter.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Microsoft.Extensions.Logging.Console
 {
     /// <summary>
-    /// Allows custom log messages formatting
+    /// Allows custom log messages formatting.
     /// </summary>
     public abstract class ConsoleFormatter
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterNames.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterNames.cs
@@ -9,17 +9,17 @@ namespace Microsoft.Extensions.Logging.Console
     public static class ConsoleFormatterNames
     {
         /// <summary>
-        /// Reserved name for simple console formatter
+        /// Reserved name for simple console formatter.
         /// </summary>
         public const string Simple = "simple";
 
         /// <summary>
-        /// Reserved name for json console formatter
+        /// Reserved name for json console formatter.
         /// </summary>
         public const string Json = "json";
 
         /// <summary>
-        /// Reserved name for systemd console formatter
+        /// Reserved name for systemd console formatter.
         /// </summary>
         public const string Systemd = "systemd";
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterOptions.cs
@@ -17,19 +17,28 @@ namespace Microsoft.Extensions.Logging.Console
         public ConsoleFormatterOptions() { }
 
         /// <summary>
-        /// Includes scopes when <see langword="true" />.
+        /// Gets or sets a value that indicates whether scopes are included.
         /// </summary>
+        /// <value>
+        /// <see langword="true" /> if scopes are included.
+        /// </value>
         public bool IncludeScopes { get; set; }
 
         /// <summary>
-        /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
+        /// Gets or sets the format string used to format timestamp in logging messages.
         /// </summary>
+        /// <value>
+        /// The default is <see langword="null" />.
+        /// </value>
         [StringSyntax(StringSyntaxAttribute.DateTimeFormat)]
         public string? TimestampFormat { get; set; }
 
         /// <summary>
-        /// Gets or sets indication whether or not UTC timezone should be used to format timestamps in logging messages. Defaults to <c>false</c>.
+        /// Gets or sets a value that indicates whether or not UTC timezone should be used to format timestamps in logging messages.
         /// </summary>
+        /// <value>
+        /// The default is <see langword="false" />.
+        /// </value>
         public bool UseUtcTimestamp { get; set; }
 
         internal virtual void Configure(IConfiguration configuration) => configuration.Bind(this);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
@@ -4,17 +4,17 @@
 namespace Microsoft.Extensions.Logging.Console
 {
     /// <summary>
-    /// Format of <see cref="ConsoleLogger" /> messages.
+    /// Describes the format of <see cref="ConsoleLogger" /> messages.
     /// </summary>
     [System.ObsoleteAttribute("ConsoleLoggerFormat has been deprecated.")]
     public enum ConsoleLoggerFormat
     {
         /// <summary>
-        /// Produces messages in the default console format.
+        /// Produce messages in the default console format.
         /// </summary>
         Default,
         /// <summary>
-        /// Produces messages in a format suitable for console output to the systemd journal.
+        /// Produce messages in a format suitable for console output to the systemd journal.
         /// </summary>
         Systemd,
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -11,16 +11,22 @@ namespace Microsoft.Extensions.Logging.Console
     public class ConsoleLoggerOptions
     {
         /// <summary>
-        /// Disables colors when <see langword="true" />.
+        /// Gets or sets a value that indicates whether colors are disabled.
         /// </summary>
+        /// <value>
+        /// <see langword="true" /> if colors are disabled.
+        /// </value>
         [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Use SimpleConsoleFormatterOptions.ColorBehavior instead.")]
         public bool DisableColors { get; set; }
 
 #pragma warning disable CS0618
         private ConsoleLoggerFormat _format = ConsoleLoggerFormat.Default;
         /// <summary>
-        /// Gets or sets log message format. Defaults to <see cref="ConsoleLoggerFormat.Default" />.
+        /// Gets or sets the log message format.
         /// </summary>
+        /// <value>
+        /// The default value is <see cref="ConsoleLoggerFormat.Default" />.
+        /// </value>
         [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Use ConsoleLoggerOptions.FormatterName instead.")]
         public ConsoleLoggerFormat Format
         {
@@ -37,37 +43,52 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         /// <summary>
-        /// Name of the log message formatter to use. Defaults to <c>simple</c>.
+        /// Gets or sets the name of the log message formatter to use.
         /// </summary>
+        /// <value>
+        /// The default value is <see langword="simple" />.
+        /// </value>
         public string? FormatterName { get; set; }
 
         /// <summary>
-        /// Includes scopes when <see langword="true" />.
+        /// Gets or sets a value that indicates whether scopes are included.
         /// </summary>
+        /// <value>
+        /// <see langword="true" /> if scopes are included.
+        /// </value>
         [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.")]
         public bool IncludeScopes { get; set; }
 
         /// <summary>
-        /// Gets or sets value indicating the minimum level of messages that would get written to <c>Console.Error</c>.
+        /// Gets or sets value indicating the minimum level of messages that get written to <c>Console.Error</c>.
         /// </summary>
         public LogLevel LogToStandardErrorThreshold { get; set; } = LogLevel.None;
 
         /// <summary>
-        /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
+        /// Gets or sets the format string used to format timestamp in logging messages.
         /// </summary>
+        /// <value>
+        /// The default value is <see langword="null" />.
+        /// </value>
         [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.")]
         public string? TimestampFormat { get; set; }
 
         /// <summary>
-        /// Gets or sets indication whether or not UTC timezone should be used to format timestamps in logging messages. Defaults to <c>false</c>.
+        /// Gets or sets a value that indicates whether UTC timezone should be used to format timestamps in logging messages.
         /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the UTC timezone should be used to format timestamps. The default value is <see langword="false" />.
+        /// </value>
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
         public bool UseUtcTimestamp { get; set; }
 
         private ConsoleLoggerQueueFullMode _queueFullMode = ConsoleLoggerQueueFullMode.Wait;
         /// <summary>
-        /// Gets or sets the desired console logger behavior when the queue becomes full. Defaults to <c>Wait</c>.
+        /// Gets or sets the desired console logger behavior when the queue becomes full.
         /// </summary>
+        /// <value>
+        /// The default value is <see langword="wait" />.
+        /// </value>
         public ConsoleLoggerQueueFullMode QueueFullMode
         {
             get => _queueFullMode;
@@ -85,8 +106,11 @@ namespace Microsoft.Extensions.Logging.Console
         private int _maxQueuedMessages = DefaultMaxQueueLengthValue;
 
         /// <summary>
-        /// Gets or sets the maximum number of enqueued messages. Defaults to 2500.
+        /// Gets or sets the maximum number of enqueued messages.
         /// </summary>
+        /// <value>
+        /// The default value is 2500.
+        /// </value>
         public int MaxQueueLength
         {
             get => _maxQueuedMessages;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// Creates an instance of <see cref="ConsoleLoggerProvider"/>.
         /// </summary>
         /// <param name="options">The options to create <see cref="ConsoleLogger"/> instances with.</param>
-        /// <param name="formatters">Log formatters added for <see cref="ConsoleLogger"/> insteaces.</param>
+        /// <param name="formatters">Log formatters added for <see cref="ConsoleLogger"/> instances.</param>
         public ConsoleLoggerProvider(IOptionsMonitor<ConsoleLoggerOptions> options, IEnumerable<ConsoleFormatter>? formatters)
         {
             _options = options;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Extensions.Logging.Console
 {
     /// <summary>
-    /// Determines the console logger behavior when the queue becomes full.
+    /// Describes the console logger behavior when the queue becomes full.
     /// </summary>
     public enum ConsoleLoggerQueueFullMode
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterOptions.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Configuration;
 namespace Microsoft.Extensions.Logging.Console
 {
     /// <summary>
-    /// Options for the built-in json console log formatter.
+    /// Options for the built-in JSON console log formatter.
     /// </summary>
     public class JsonConsoleFormatterOptions : ConsoleFormatterOptions
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/LoggerColorBehavior.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/LoggerColorBehavior.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Extensions.Logging.Console
 {
     /// <summary>
-    /// Determines when to use color when logging messages.
+    /// Describes when to use color when logging messages.
     /// </summary>
     public enum LoggerColorBehavior
     {
@@ -16,11 +16,11 @@ namespace Microsoft.Extensions.Logging.Console
         /// </remarks>
         Default,
         /// <summary>
-        /// Enable color for logging
+        /// Enable color for logging.
         /// </summary>
         Enabled,
         /// <summary>
-        /// Disable color for logging
+        /// Disable color for logging.
         /// </summary>
         Disabled,
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterOptions.cs
@@ -16,13 +16,16 @@ namespace Microsoft.Extensions.Logging.Console
         public SimpleConsoleFormatterOptions() { }
 
         /// <summary>
-        /// Determines when to use color when logging messages.
+        /// Gets or sets the behavior that describes when to use color when logging messages.
         /// </summary>
         public LoggerColorBehavior ColorBehavior { get; set; }
 
         /// <summary>
-        /// When <see langword="true" />, the entire message gets logged in a single line.
+        /// Gets or sets a value that indicates whether the entire message is logged in a single line.
         /// </summary>
+        /// <value>
+        /// <see langword="true" /> if the entire message is logged in a single line.
+        /// </value>
         public bool SingleLine { get; set; }
 
         internal override void Configure(IConfiguration configuration) => configuration.Bind(this);

--- a/src/libraries/Microsoft.Extensions.Logging.Debug/src/DebugLoggerFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Debug/src/DebugLoggerFactoryExtensions.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Extensions.Logging
         /// Adds a debug logger that is enabled as defined by the filter function.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        /// <param name="filter">The function used to filter events based on the log level.  This parameter is no longer honored and will be ignored.</param>
+        /// <param name="filter">The function used to filter events based on the log level. This parameter is no longer honored and is ignored.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddDebug(this ILoggingBuilder builder).", error: true)]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory, Func<string, LogLevel, bool> filter) => AddDebug(factory);
 
         /// <summary>
-        /// Adds a debug logger that is enabled for <see cref="LogLevel"/>s of minLevel or higher.
+        /// Adds a debug logger that is enabled for log levels of minLevel or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
@@ -13,22 +13,22 @@ namespace Microsoft.Extensions.Logging.EventLog
         private IEventLog? _eventLog;
 
         /// <summary>
-        /// Name of the event log. If <c>null</c> or not specified, "Application" is the default.
+        /// Gets or sets the name of the event log. If <see langword="null" /> or not specified, "Application" is the default.
         /// </summary>
         public string? LogName { get; set; }
 
         /// <summary>
-        /// Name of the event log source. If <c>null</c> or not specified, ".NET Runtime" is the default.
+        /// Gets or sets the name of the event log source. If <see langword="null" /> or not specified, ".NET Runtime" is the default.
         /// </summary>
         public string? SourceName { get; set; }
 
         /// <summary>
-        /// Name of the machine having the event log. If <c>null</c> or not specified, local machine is the default.
+        /// Gets or sets the name of the machine with the event log. If <see langword="null" /> or not specified, local machine is the default.
         /// </summary>
         public string? MachineName { get; set; }
 
         /// <summary>
-        /// The function used to filter events based on the log level.
+        /// Gets or sets the function used to filter events based on the log level.
         /// </summary>
         public Func<string, LogLevel, bool>? Filter { get; set; }
 

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLoggerFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLoggerFactoryExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Logging
     public static class EventLoggerFactoryExtensions
     {
         /// <summary>
-        /// Adds an event logger. Use <paramref name="settings"/> to enable logging for specific <see cref="LogLevel"/>s.
+        /// Adds an event logger. Use <paramref name="settings"/> to enable logging for specific log levels.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an event logger that is enabled for <see cref="LogLevel"/>s of minLevel or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
+        /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddEventLog(this ILoggingBuilder builder).", error: true)]
         public static ILoggerFactory AddEventLog(this ILoggerFactory factory, LogLevel minLevel) =>
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Adds an event logger. Use <paramref name="settings"/> to enable logging for specific <see cref="LogLevel"/>s.
+        /// Adds an event logger. Use <paramref name="settings"/> to enable logging for specific log levels.
         /// </summary>
         /// <param name="builder">The extension method argument.</param>
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Adds an event logger. Use <paramref name="configure"/> to enable logging for specific <see cref="LogLevel"/>s.
+        /// Adds an event logger. Use <paramref name="configure"/> to enable logging for specific log levels.
         /// </summary>
         /// <param name="builder">The extension method argument.</param>
         /// <param name="configure">A delegate to configure the <see cref="EventLogSettings"/>.</param>

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/EventSourceLoggerFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/EventSourceLoggerFactoryExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Logging
     public static class EventSourceLoggerFactoryExtensions
     {
         /// <summary>
-        /// Adds an logger that writes messages to the <see cref="LoggingEventSource"/> instance.
+        /// Adds a logger that writes messages to the <see cref="LoggingEventSource"/> instance.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <returns>The <see cref="ILoggerFactory"/> so that additional calls can be chained.</returns>
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Adds an logger that writes messages to the <see cref="LoggingEventSource"/> instance.
+        /// Adds a logger that writes messages to the <see cref="LoggingEventSource"/> instance.
         /// </summary>
         /// <param name="builder">The extension method argument.</param>
         /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
@@ -13,8 +13,9 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Extensions.Logging.EventSource
 {
     /// <summary>
-    /// The LoggingEventSource is the bridge from all ILogger based logging to EventSource/EventListener logging.
-    ///
+    /// Bridges all ILogger-based logging to EventSource/EventListener logging.
+    /// </summary>
+    /// <remarks>
     /// You turn this logging on by enabling the EventSource called
     ///
     ///      Microsoft-Extensions-Logging
@@ -76,7 +77,7 @@ namespace Microsoft.Extensions.Logging.EventSource
     ///             Console.WriteLine("Logger {0}: {1}", eventData.Payload[2], eventData.Payload[4]);
     ///     }
     /// }
-    /// </summary>
+    /// </remarks>
     [EventSource(Name = "Microsoft-Extensions-Logging")]
     public sealed class LoggingEventSource : System.Diagnostics.Tracing.EventSource
     {

--- a/src/libraries/Microsoft.Extensions.Logging/src/ActivityTrackingOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/ActivityTrackingOptions.cs
@@ -16,17 +16,17 @@ namespace Microsoft.Extensions.Logging
         None        = 0x0000,
 
         /// <summary>
-        /// Span Id will be included in the logging.
+        /// Span ID will be included in the logging.
         /// </summary>
         SpanId      = 0x0001,
 
         /// <summary>
-        /// Trace Id will be included in the logging.
+        /// Trace ID will be included in the logging.
         /// </summary>
         TraceId     = 0x0002,
 
         /// <summary>
-        /// Parent Id will be included in the logging.
+        /// Parent ID will be included in the logging.
         /// </summary>
         ParentId    = 0x0004,
 

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         /// Check if the factory has been disposed.
         /// </summary>
-        /// <returns>True when <see cref="Dispose()"/> as been called</returns>
+        /// <returns><see langword="true" /> when <see cref="Dispose()"/> as been called</returns>
         protected virtual bool CheckDisposed() => _disposed;
 
         /// <inheritdoc/>

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
@@ -18,8 +18,11 @@ namespace Microsoft.Extensions.Logging
         public LoggerFilterOptions() { }
 
         /// <summary>
-        /// Gets or sets value indicating whether logging scopes are being captured. Defaults to <c>true</c>
+        /// Gets or sets a value indicating whether logging scopes are being captured.
         /// </summary>
+        /// <value>
+        /// The default value is <see langword="true" />
+        /// </value>
         public bool CaptureScopes { get; set; } = true;
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggingBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggingBuilderExtensions.cs
@@ -52,8 +52,8 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         /// Configure the <paramref name="builder"/> with the <see cref="LoggerFactoryOptions"/>.
         /// </summary>
-        /// <param name="builder">The <see cref="ILoggingBuilder"/> to be configured with <see cref="LoggerFactoryOptions"/></param>
-        /// <param name="action">The action used to configure the logger factory</param>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to be configured with <see cref="LoggerFactoryOptions"/>.</param>
+        /// <param name="action">The action used to configure the logger factory.</param>
         /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>
         public static ILoggingBuilder Configure(this ILoggingBuilder builder, Action<LoggerFactoryOptions> action)
         {

--- a/src/libraries/Microsoft.Extensions.Logging/src/ProviderAliasAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/ProviderAliasAttribute.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// The alias of the provider.
+        /// Gets the alias of the provider.
         /// </summary>
         public string Alias { get; }
 

--- a/src/libraries/Microsoft.Extensions.Primitives/src/CompositeChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/CompositeChangeToken.cs
@@ -10,7 +10,7 @@ using System.Threading;
 namespace Microsoft.Extensions.Primitives
 {
     /// <summary>
-    /// An <see cref="IChangeToken"/> which represents one or more <see cref="IChangeToken"/> instances.
+    /// An <see cref="IChangeToken"/> that represents one or more <see cref="IChangeToken"/> instances.
     /// </summary>
     [DebuggerDisplay("HasChanged = {HasChanged}")]
     public class CompositeChangeToken : IChangeToken
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Returns the list of <see cref="IChangeToken"/> which compose the current <see cref="CompositeChangeToken"/>.
+        /// Returns the list of <see cref="IChangeToken"/> that compose the current <see cref="CompositeChangeToken"/>.
         /// </summary>
         public IReadOnlyList<IChangeToken> ChangeTokens { get; }
 

--- a/src/libraries/Microsoft.Extensions.Primitives/src/Extensions.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/Extensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Primitives
     public static class Extensions
     {
         /// <summary>
-        /// Add the given <see cref="StringSegment"/> to the <see cref="StringBuilder"/>.
+        /// Adds the given <see cref="StringSegment"/> to the <see cref="StringBuilder"/>.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to add to.</param>
         /// <param name="segment">The <see cref="StringSegment"/> to add.</param>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/IChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/IChangeToken.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Primitives
         bool HasChanged { get; }
 
         /// <summary>
-        /// Indicates if this token will pro-actively raise callbacks. If <c>false</c>, the token consumer must
+        /// Indicates if this token will proactively raise callbacks. If <c>false</c>, the token consumer must
         /// poll <see cref="HasChanged" /> to detect changes.
         /// </summary>
         bool ActiveChangeCallbacks { get; }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.Primitives
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="obj">An object to compare with this object.</param>
-        /// <returns><see langword="true" /> if the current object is equal to the other parameter; otherwise, <see langword="false" />.</returns>
+        /// <returns><see langword="true" /> if the current object is equal to <paramref name="obj"/>; otherwise, <see langword="false" />.</returns>
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is StringSegment segment && Equals(segment);
@@ -203,7 +203,7 @@ namespace Microsoft.Extensions.Primitives
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
-        /// <returns><see langword="true" /> if the current object is equal to the other parameter; otherwise, <see langword="false" />.</returns>
+        /// <returns><see langword="true" /> if the current object is equal to <paramref name="other"/>; otherwise, <see langword="false" />.</returns>
         public bool Equals(StringSegment other) => Equals(other, StringComparison.Ordinal);
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
         /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
-        /// <returns><see langword="true" /> if the current object is equal to the other parameter; otherwise, <see langword="false" />.</returns>
+        /// <returns><see langword="true" /> if the current object is equal to <paramref name="other"/>; otherwise, <see langword="false" />.</returns>
         public bool Equals(StringSegment other, StringComparison comparisonType)
         {
             if (HasValue && other.HasValue)
@@ -303,7 +303,7 @@ namespace Microsoft.Extensions.Primitives
         /// <summary>
         /// Creates a new <see cref="StringSegment"/> from the given <see cref="string"/>.
         /// </summary>
-        /// <param name="value">The <see cref="string"/> to convert to a <see cref="StringSegment"/></param>
+        /// <param name="value">The <see cref="string"/> to convert to a <see cref="StringSegment"/>.</param>
         public static implicit operator StringSegment(string? value) => new StringSegment(value);
 
         /// <summary>
@@ -376,7 +376,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
         /// <returns>A <see cref="string"/> that is equivalent to the substring of remaining length that begins at
-        /// <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
+        /// <paramref name="offset"/> in this <see cref="StringSegment"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> is greater than or equal to <see cref="Length"/> or less than zero.
         /// </exception>
@@ -389,7 +389,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
         /// <param name="length">The number of characters in the substring.</param>
         /// <returns>A <see cref="string"/> that is equivalent to the substring of <paramref name="length"/> that begins at
-        /// <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
+        /// <paramref name="offset"/> in this <see cref="StringSegment"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> or <paramref name="length"/> is less than zero, or <paramref name="offset"/> + <paramref name="length"/> is
         /// greater than <see cref="Length"/>.
@@ -423,7 +423,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
         /// <param name="length">The number of characters in the substring.</param>
-        /// <returns>A <see cref="StringSegment"/> that is equivalent to the substring of <paramref name="length"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
+        /// <returns>A <see cref="StringSegment"/> that is equivalent to the substring of <paramref name="length"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> or <paramref name="length"/> is less than zero, or <paramref name="offset"/> + <paramref name="length"/> is
         /// greater than <see cref="Length"/>.

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.Extensions.Primitives
 {
     /// <summary>
-    /// Tokenizes a <see cref="string"/> into <see cref="StringSegment"/>s.
+    /// Tokenizes a <see cref="string"/> into <see cref="StringSegment">StringSegments</see>.
     /// </summary>
     public readonly struct StringTokenizer : IEnumerable<StringSegment>
     {
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Primitives
             /// <summary>
             /// Initializes an <see cref="Enumerator"/> using a <see cref="StringTokenizer"/>.
             /// </summary>
-            /// <param name="tokenizer"><see cref="StringTokenizer"/> containing value and separators for enumeration.</param>
+            /// <param name="tokenizer">A <see cref="StringTokenizer" /> that contains the value to enumerate and token separators.</param>
             public Enumerator(ref StringTokenizer tokenizer)
             {
                 _value = tokenizer._value;

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Primitives
         /// <summary>
         /// Initializes a new instance of the <see cref="StringValues"/> structure using the specified string.
         /// </summary>
-        /// <param name="value">A string value or <c>null</c>.</param>
+        /// <param name="value">A string value or <see langword="null"/>.</param>
         public StringValues(string? value)
         {
             _values = value;
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.Primitives
         /// Defines an implicit conversion of a given <see cref="StringValues"/> to a string, with multiple values joined as a comma separated string.
         /// </summary>
         /// <remarks>
-        /// Returns <c>null</c> where <see cref="StringValues"/> has been initialized from an empty string array or is <see cref="StringValues.Empty"/>.
+        /// Returns <see langword="null"/> where <see cref="StringValues"/> has been initialized from an empty string array or is <see cref="StringValues.Empty"/>.
         /// </remarks>
         /// <param name="values">A <see cref="StringValues"/> to implicitly convert.</param>
         public static implicit operator string?(StringValues values)
@@ -114,7 +114,7 @@ namespace Microsoft.Extensions.Primitives
         bool ICollection<string?>.IsReadOnly => true;
 
         /// <summary>
-        /// Gets the <see cref="string"/> at index.
+        /// Gets the <see cref="string"/> at the specified index.
         /// </summary>
         /// <value>The string at the specified index.</value>
         /// <param name="index">The zero-based index of the element to get.</param>
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Gets the <see cref="string"/> at index.
+        /// Gets the <see cref="string"/> at the specified index.
         /// </summary>
         /// <value>The string at the specified index.</value>
         /// <param name="index">The zero-based index of the element to get.</param>
@@ -348,7 +348,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="arrayIndex">The zero-based index in the destination array at which copying begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array" /> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex" /> is less than 0.</exception>
-        /// <exception cref="ArgumentException">The number of elements in the source <see cref="StringValues"></see> is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />.</exception>
+        /// <exception cref="ArgumentException">The number of elements in the source <see cref="StringValues" /> is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />.</exception>
         void ICollection<string?>.CopyTo(string?[] array, int arrayIndex)
         {
             CopyTo(array, arrayIndex);
@@ -418,7 +418,7 @@ namespace Microsoft.Extensions.Primitives
         /// Indicates whether the specified <see cref="StringValues"/> contains no string values.
         /// </summary>
         /// <param name="value">The <see cref="StringValues"/> to test.</param>
-        /// <returns>true if <paramref name="value" /> contains a single null or empty string or an empty array; otherwise, false.</returns>
+        /// <returns><see langword="true"/> if <paramref name="value"/> contains a single <see langword="null"/> or empty string or an empty array; otherwise, <see langword="false"/>.</returns>
         public static bool IsNullOrEmpty(StringValues value)
         {
             object? data = value._values;
@@ -524,7 +524,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The first <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The second <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool Equals(StringValues left, StringValues right)
         {
             int count = left.Count;
@@ -550,7 +550,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The first <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The second <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(StringValues left, StringValues right)
         {
             return Equals(left, right);
@@ -561,7 +561,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The first <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The second <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(StringValues left, StringValues right)
         {
             return !Equals(left, right);
@@ -571,7 +571,7 @@ namespace Microsoft.Extensions.Primitives
         /// Determines whether this instance and another specified <see cref="StringValues"/> object have the same values.
         /// </summary>
         /// <param name="other">The string to compare to this instance.</param>
-        /// <returns><c>true</c> if the value of <paramref name="other"/> is the same as the value of this instance; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the value of <paramref name="other" /> is the same as the value of this instance; otherwise, <see langword="false" />.</returns>
         public bool Equals(StringValues other) => Equals(this, other);
 
         /// <summary>
@@ -579,7 +579,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="string"/> to compare.</param>
         /// <param name="right">The <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>. If <paramref name="left"/> is <c>null</c>, the method returns <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>. If <paramref name="left"/> is <see langword="null"/>, the method returns <see langword="false"/>.</returns>
         public static bool Equals(string? left, StringValues right) => Equals(new StringValues(left), right);
 
         /// <summary>
@@ -587,14 +587,14 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The <see cref="string"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>. If <paramref name="right"/> is <c>null</c>, the method returns <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>. If <paramref name="right"/> is <see langword="null"/>, the method returns <see langword="false"/>.</returns>
         public static bool Equals(StringValues left, string? right) => Equals(left, new StringValues(right));
 
         /// <summary>
         /// Determines whether this instance and a specified <see cref="string"/>, have the same value.
         /// </summary>
         /// <param name="other">The <see cref="string"/> to compare to this instance.</param>
-        /// <returns><c>true</c> if the value of <paramref name="other"/> is the same as this instance; otherwise, <c>false</c>. If <paramref name="other"/> is <c>null</c>, returns <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="other"/> is the same as this instance; otherwise, <see langword="false"/>. If <paramref name="other"/> is <see langword="null"/>, returns <see langword="false"/>.</returns>
         public bool Equals(string? other) => Equals(this, new StringValues(other));
 
         /// <summary>
@@ -602,7 +602,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The string array to compare.</param>
         /// <param name="right">The <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool Equals(string?[]? left, StringValues right) => Equals(new StringValues(left), right);
 
         /// <summary>
@@ -610,14 +610,14 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The string array to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool Equals(StringValues left, string?[]? right) => Equals(left, new StringValues(right));
 
         /// <summary>
         /// Determines whether this instance and a specified string array have the same values.
         /// </summary>
         /// <param name="other">The string array to compare to this instance.</param>
-        /// <returns><c>true</c> if the value of <paramref name="other"/> is the same as this instance; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="other"/> is the same as this instance; otherwise, <see langword="false"/>.</returns>
         public bool Equals(string?[]? other) => Equals(this, new StringValues(other));
 
         /// <inheritdoc cref="Equals(StringValues, string)" />
@@ -628,7 +628,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The <see cref="string"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(StringValues left, string? right) => !Equals(left, new StringValues(right));
 
         /// <inheritdoc cref="Equals(string, StringValues)" />
@@ -639,7 +639,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="string"/> to compare.</param>
         /// <param name="right">The <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(string? left, StringValues right) => !Equals(new StringValues(left), right);
 
         /// <inheritdoc cref="Equals(StringValues, string[])" />
@@ -650,7 +650,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The string array to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(StringValues left, string?[]? right) => !Equals(left, new StringValues(right));
 
         /// <inheritdoc cref="Equals(string[], StringValues)" />
@@ -661,7 +661,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The string array to compare.</param>
         /// <param name="right">The <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(string?[]? left, StringValues right) => !Equals(new StringValues(left), right);
 
         /// <summary>
@@ -670,7 +670,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The <see cref="object"/> to compare.</param>
-        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(StringValues left, object? right) => left.Equals(right);
 
         /// <summary>
@@ -679,7 +679,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The <see cref="object"/> to compare.</param>
-        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(StringValues left, object? right) => !left.Equals(right);
 
         /// <summary>
@@ -688,7 +688,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The <see cref="object"/> to compare.</param>
-        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(object? left, StringValues right) => right.Equals(left);
 
         /// <summary>
@@ -696,14 +696,14 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="left">The <see cref="object"/> to compare.</param>
         /// <param name="right">The <see cref="StringValues"/> to compare.</param>
-        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(object? left, StringValues right) => !right.Equals(left);
 
         /// <summary>
         /// Determines whether this instance and a specified object have the same value.
         /// </summary>
         /// <param name="obj">An object to compare with this object.</param>
-        /// <returns><c>true</c> if the current object is equal to <paramref name="obj"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the current object is equal to <paramref name="obj"/>; otherwise, <see langword="false"/>.</returns>
         public override bool Equals(object? obj)
         {
             if (obj == null)


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/107810
cc @gewarren

Tell-mode: These are only docs changes in assemblies that use triple slash as their source of truth.