### PR TITLE
[wasm] Include browser targets if RID is not wasi-wasm

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Pack.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Pack.targets
@@ -10,7 +10,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0">
- <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != 'wasi-wasm'">
     <_WebAssemblyTargetsFile>$(MSBuildThisFileDirectory)\Microsoft.NET.Sdk.WebAssembly.Browser.targets</_WebAssemblyTargetsFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Because VS publish to container by default set RuntimeIndentifier to linux-x64, we need to treat any non-wasi RID as browser.
This is a runtime part of change, SDK part is in https://github.com/dotnet/sdk/pull/43721.