### PR TITLE
[cdac][tests] Make it easier to set up a unit test

### DIFF
--- a/src/native/managed/cdacreader/tests/DacStreamsTests.cs
+++ b/src/native/managed/cdacreader/tests/DacStreamsTests.cs
@@ -71,9 +71,9 @@ public class DacStreamsTests
                 builder = configure(builder);
             }
 
-            using MockMemorySpace.ReadContext context = builder.Create();
+            MockMemorySpace.ReadContext context = builder.Create();
 
-            bool success = MockMemorySpace.TryCreateTarget(&context, out Target? target);
+            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
             Assert.True(success);
 
             testCase(target);

--- a/src/native/managed/cdacreader/tests/DacStreamsTests.cs
+++ b/src/native/managed/cdacreader/tests/DacStreamsTests.cs
@@ -56,12 +56,11 @@ public class DacStreamsTests
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
-        MockMemorySpace.Builder builder = new();
+        MockMemorySpace.Builder builder = new(targetTestHelpers);
 
         builder = builder
                 .SetJson(json)
-                .SetPointerData(pointerData)
-                .FillDescriptor(targetTestHelpers);
+                .SetPointerData(pointerData);
 
         if (configure != null)
         {

--- a/src/native/managed/cdacreader/tests/DacStreamsTests.cs
+++ b/src/native/managed/cdacreader/tests/DacStreamsTests.cs
@@ -69,9 +69,7 @@ public class DacStreamsTests
             builder = configure(builder);
         }
 
-        MockMemorySpace.ReadContext context = builder.Create();
-
-        bool success = MockMemorySpace.TryCreateTarget(context, out ContractDescriptorTarget? target);
+        bool success = builder.TryCreateTarget(out Target? target);
         Assert.True(success);
 
         testCase(target);

--- a/src/native/managed/cdacreader/tests/DacStreamsTests.cs
+++ b/src/native/managed/cdacreader/tests/DacStreamsTests.cs
@@ -34,33 +34,13 @@ public class DacStreamsTests
     private static unsafe void DacStreamsContractHelper(MockTarget.Architecture arch, ConfigureContextBuilder configure, Action<Target> testCase)
     {
         TargetTestHelpers targetTestHelpers = new(arch);
-        string metadataTypesJson = TargetTestHelpers.MakeTypesJson(DacStreamsTypes);
-        string metadataGlobalsJson = TargetTestHelpers.MakeGlobalsJson(DacStreamsGlobals);
-        byte[] json = Encoding.UTF8.GetBytes($$"""
-        {
-            "version": 0,
-            "baseline": "empty",
-            "contracts": {
-                "{{nameof(Contracts.DacStreams)}}": 1
-            },
-            "types": { {{metadataTypesJson}} },
-            "globals": { {{metadataGlobalsJson}} }
-        }
-        """);
-
-        int pointerSize = targetTestHelpers.PointerSize;
-        Span<byte> pointerData = stackalloc byte[DacStreamsGlobals.Length * pointerSize];
-        for (int i = 0; i < DacStreamsGlobals.Length; i++)
-        {
-            var (_, value, _) = DacStreamsGlobals[i];
-            targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
-        }
 
         MockMemorySpace.Builder builder = new(targetTestHelpers);
 
         builder = builder
-                .SetJson(json)
-                .SetPointerData(pointerData);
+                .SetContracts([nameof(Contracts.DacStreams)])
+                .SetTypes(DacStreamsTypes)
+                .SetGlobals(DacStreamsGlobals);
 
         if (configure != null)
         {

--- a/src/native/managed/cdacreader/tests/DacStreamsTests.cs
+++ b/src/native/managed/cdacreader/tests/DacStreamsTests.cs
@@ -47,8 +47,6 @@ public class DacStreamsTests
             "globals": { {{metadataGlobalsJson}} }
         }
         """);
-        Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, DacStreamsGlobals.Length);
 
         int pointerSize = targetTestHelpers.PointerSize;
         Span<byte> pointerData = stackalloc byte[DacStreamsGlobals.Length * pointerSize];
@@ -60,9 +58,10 @@ public class DacStreamsTests
 
         MockMemorySpace.Builder builder = new();
 
-        builder = builder.SetDescriptor(descriptor)
+        builder = builder
                 .SetJson(json)
-                .SetPointerData(pointerData);
+                .SetPointerData(pointerData)
+                .FillDescriptor(targetTestHelpers);
 
         if (configure != null)
         {

--- a/src/native/managed/cdacreader/tests/DacStreamsTests.cs
+++ b/src/native/managed/cdacreader/tests/DacStreamsTests.cs
@@ -58,27 +58,23 @@ public class DacStreamsTests
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
-        fixed (byte* jsonPtr = json)
+        MockMemorySpace.Builder builder = new();
+
+        builder = builder.SetDescriptor(descriptor)
+                .SetJson(json)
+                .SetPointerData(pointerData);
+
+        if (configure != null)
         {
-            MockMemorySpace.Builder builder = new();
-
-            builder = builder.SetDescriptor(descriptor)
-                    .SetJson(json)
-                    .SetPointerData(pointerData);
-
-            if (configure != null)
-            {
-                builder = configure(builder);
-            }
-
-            MockMemorySpace.ReadContext context = builder.Create();
-
-            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
-            Assert.True(success);
-
-            testCase(target);
+            builder = configure(builder);
         }
-        GC.KeepAlive(json);
+
+        MockMemorySpace.ReadContext context = builder.Create();
+
+        bool success = MockMemorySpace.TryCreateTarget(context, out ContractDescriptorTarget? target);
+        Assert.True(success);
+
+        testCase(target);
     }
 
     MockMemorySpace.Builder AddMiniMetaDataBuffMaxSize(TargetTestHelpers targetTestHelpers, MockMemorySpace.Builder builder, uint maxSize)

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -42,29 +42,25 @@ public unsafe class MethodTableTests
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
-        fixed (byte* jsonPtr = json)
+        MockMemorySpace.Builder builder = new();
+
+        builder = builder.SetDescriptor(descriptor)
+                .SetJson(json)
+                .SetPointerData(pointerData);
+
+        builder = MockRTS.AddGlobalPointers(targetTestHelpers, builder);
+
+        if (configure != null)
         {
-            MockMemorySpace.Builder builder = new();
-
-            builder = builder.SetDescriptor(descriptor)
-                    .SetJson(json)
-                    .SetPointerData(pointerData);
-
-            builder = MockRTS.AddGlobalPointers(targetTestHelpers, builder);
-
-            if (configure != null)
-            {
-                builder = configure(builder);
-            }
-
-            MockMemorySpace.ReadContext context = builder.Create();
-
-            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
-            Assert.True(success);
-
-            testCase(target);
+            builder = configure(builder);
         }
-        GC.KeepAlive(json);
+
+        MockMemorySpace.ReadContext context = builder.Create();
+
+        bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
+        Assert.True(success);
+
+        testCase(target);
     }
 
     [Theory]

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -55,9 +55,7 @@ public unsafe class MethodTableTests
             builder = configure(builder);
         }
 
-        MockMemorySpace.ReadContext context = builder.Create();
-
-        bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
+        bool success = builder.TryCreateTarget(out Target? target);
         Assert.True(success);
 
         testCase(target);

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -40,12 +40,11 @@ public unsafe class MethodTableTests
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
-        MockMemorySpace.Builder builder = new();
+        MockMemorySpace.Builder builder = new(targetTestHelpers);
 
         builder = builder
                 .SetJson(json)
-                .SetPointerData(pointerData)
-                .FillDescriptor(targetTestHelpers);
+                .SetPointerData(pointerData);
 
         builder = MockRTS.AddGlobalPointers(targetTestHelpers, builder);
 

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -57,9 +57,9 @@ public unsafe class MethodTableTests
                 builder = configure(builder);
             }
 
-            using MockMemorySpace.ReadContext context = builder.Create();
+            MockMemorySpace.ReadContext context = builder.Create();
 
-            bool success = MockMemorySpace.TryCreateTarget(&context, out Target? target);
+            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
             Assert.True(success);
 
             testCase(target);

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -31,8 +31,6 @@ public unsafe class MethodTableTests
             "globals": { {{metadataGlobalsJson}} }
         }
         """);
-        Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, MockRTS.Globals.Length);
 
         int pointerSize = targetTestHelpers.PointerSize;
         Span<byte> pointerData = stackalloc byte[MockRTS.Globals.Length * pointerSize];
@@ -44,9 +42,10 @@ public unsafe class MethodTableTests
 
         MockMemorySpace.Builder builder = new();
 
-        builder = builder.SetDescriptor(descriptor)
+        builder = builder
                 .SetJson(json)
-                .SetPointerData(pointerData);
+                .SetPointerData(pointerData)
+                .FillDescriptor(targetTestHelpers);
 
         builder = MockRTS.AddGlobalPointers(targetTestHelpers, builder);
 

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -18,33 +18,12 @@ public unsafe class MethodTableTests
     private static void RTSContractHelper(MockTarget.Architecture arch, ConfigureContextBuilder configure, Action<Target> testCase)
     {
         TargetTestHelpers targetTestHelpers = new(arch);
-        string metadataTypesJson = TargetTestHelpers.MakeTypesJson(MockRTS.Types);
-        string metadataGlobalsJson = TargetTestHelpers.MakeGlobalsJson(MockRTS.Globals);
-        byte[] json = Encoding.UTF8.GetBytes($$"""
-        {
-            "version": 0,
-            "baseline": "empty",
-            "contracts": {
-                "{{nameof(Contracts.RuntimeTypeSystem)}}": 1
-            },
-            "types": { {{metadataTypesJson}} },
-            "globals": { {{metadataGlobalsJson}} }
-        }
-        """);
-
-        int pointerSize = targetTestHelpers.PointerSize;
-        Span<byte> pointerData = stackalloc byte[MockRTS.Globals.Length * pointerSize];
-        for (int i = 0; i < MockRTS.Globals.Length; i++)
-        {
-            var (_, value, _) = MockRTS.Globals[i];
-            targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
-        }
-
         MockMemorySpace.Builder builder = new(targetTestHelpers);
 
         builder = builder
-                .SetJson(json)
-                .SetPointerData(pointerData);
+                .SetContracts ([ nameof(Contracts.RuntimeTypeSystem) ])
+                .SetTypes (MockRTS.Types)
+                .SetGlobals (MockRTS.Globals);
 
         builder = MockRTS.AddGlobalPointers(targetTestHelpers, builder);
 

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -20,6 +20,10 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 /// </remarks>
 internal unsafe static class MockMemorySpace
 {
+    // These addresses are arbitrary and are used to store the contract descriptor components.
+    // They should not overlap with any other heap fragment addresses.
+    private const ulong ContractDescriptorAddr = 0xaaaaaaaa;
+    // TODO: remove the references to these from TargetTestHelpers.ContractDescriptorFill
     internal const uint JsonDescriptorAddr = 0xdddddddd;
     internal const uint ContractPointerDataAddr = 0xeeeeeeee;
 
@@ -115,7 +119,6 @@ internal unsafe static class MockMemorySpace
         {
             byte[] descriptor = new byte[_targetTestHelpers.ContractDescriptorSize];
             _targetTestHelpers.ContractDescriptorFill(descriptor, jsonLength, pointerDataCount);
-            const ulong ContractDescriptorAddr = 0xaaaaaaaa;
             return new HeapFragment
             {
                 Address = ContractDescriptorAddr,

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -158,22 +158,24 @@ internal unsafe static class MockMemorySpace
         public bool TryCreateTarget([NotNullWhen(true)] out Target? target)
         {
             ReadContext context = CreateContext();
-            return Target.TryCreate(context.ContractDescriptor.Address, context.ReadFromTarget, out target);
+            return ContractDescriptorTarget.TryCreate(context.ContractDescriptor.Address, context.ReadFromTarget, out target);
         }
     }
 
-    public static Target CreateTarget(ReadOnlySpan<byte> descriptor, ReadOnlySpan<byte> json, ReadOnlySpan<byte> pointerData = default)
+    public static ContractDescriptorTarget CreateTarget(ReadOnlySpan<byte> descriptor, ReadOnlySpan<byte> json, ReadOnlySpan<byte> pointerData = default)
     {
         Builder builder = new Builder()
         .SetJson(json)
         .SetDescriptor(descriptor)
         .SetPointerData(pointerData);
-        return builder.Create();
+        bool success = builder.TryCreateTarget(out var target);
+        Assert.True(success);
+        return target;
     }
 
     public static bool TryCreateTarget(ReadContext context, out Target? target)
     {
-        return Target.TryCreate(context.ContractDescriptor.Address, context.ReadFromTarget, out target);
+        return ContractDescriptorTarget.TryCreate(context.ContractDescriptor.Address, context.ReadFromTarget, out target);
     }
 
     // Used by ReadFromTarget to return the appropriate bytes

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -51,7 +51,7 @@ internal unsafe static class MockMemorySpace
 
         }
 
-        public Builder SetDescriptor(scoped ReadOnlySpan<byte> descriptor)
+        internal Builder SetDescriptor(scoped ReadOnlySpan<byte> descriptor)
         {
             const ulong ContractDescriptorAddr = 0xaaaaaaaa;
 
@@ -112,6 +112,14 @@ internal unsafe static class MockMemorySpace
                 // add fragments one at a time to check for overlaps
                 AddHeapFragment(f);
             }
+            return this;
+        }
+
+        public Builder FillDescriptor(TargetTestHelpers targetTestHelpers)
+        {
+            Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
+            targetTestHelpers.ContractDescriptorFill(descriptor, _jsonLength, _pointerDataLength / targetTestHelpers.PointerSize);
+            SetDescriptor(descriptor);
             return this;
         }
 

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 /// Use MockMemorySpace.CreateContext to create a mostly empty context for reading from the target.
 /// Use MockMemorySpace.ContextBuilder to create a context with additional MockMemorySpace.HeapFragment data.
 /// </remarks>
-/// <remarks>
-/// All the spans should be stackalloc or pinned while the context is being used.
-/// </remarks>
 internal unsafe static class MockMemorySpace
 {
     internal const uint JsonDescriptorAddr = 0xdddddddd;
@@ -116,13 +113,13 @@ internal unsafe static class MockMemorySpace
 
         private HeapFragment CreateContractDescriptor(int jsonLength, int pointerDataCount)
         {
-            Span<byte> descriptor = stackalloc byte[_targetTestHelpers.ContractDescriptorSize];
+            byte[] descriptor = new byte[_targetTestHelpers.ContractDescriptorSize];
             _targetTestHelpers.ContractDescriptorFill(descriptor, jsonLength, pointerDataCount);
             const ulong ContractDescriptorAddr = 0xaaaaaaaa;
             return new HeapFragment
             {
                 Address = ContractDescriptorAddr,
-                Data = descriptor.ToArray(),
+                Data = descriptor,
                 Name = "ContractDescriptor"
             };
         }
@@ -165,16 +162,16 @@ internal unsafe static class MockMemorySpace
             if (_indirectValues != null)
             {
                 int pointerSize = _targetTestHelpers.PointerSize;
-                Span<byte> pointerDataBytes = stackalloc byte[_indirectValues.Count * pointerSize];
+                byte[] pointerDataBytes = new byte[_indirectValues.Count * pointerSize];
                 int offset = 0;
                 foreach (var value in _indirectValues)
                 {
-                    _targetTestHelpers.WritePointer(pointerDataBytes.Slice(offset), value);
+                    _targetTestHelpers.WritePointer(pointerDataBytes.AsSpan(offset, pointerSize), value);
                     offset += pointerSize;
                 }
                 pointerData =new HeapFragment {
                     Address = ContractPointerDataAddr,
-                    Data = pointerDataBytes.ToArray(),
+                    Data = pointerDataBytes,
                     Name = "PointerData"
                 };
             } else {

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -229,7 +229,7 @@ internal unsafe static class MockMemorySpace
         public bool TryCreateTarget([NotNullWhen(true)] out Target? target)
         {
             ReadContext context = CreateContext();
-            return ContractDescriptorTarget.TryCreate(context.ContractDescriptor.Address, context.ReadFromTarget, out target);
+            return Target.TryCreate(context.ContractDescriptor.Address, context.ReadFromTarget, out target);
         }
     }
 

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -44,28 +44,23 @@ public unsafe class ObjectTests
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
-        fixed (byte* jsonPtr = json)
+        MockMemorySpace.Builder builder = new();
+        builder = builder.SetDescriptor(descriptor)
+                .SetJson(json)
+                .SetPointerData(pointerData);
+
+        builder = MockObject.AddGlobalPointers(targetTestHelpers, builder);
+
+        if (configure != null)
         {
-            MockMemorySpace.Builder builder = new();
-            builder = builder.SetDescriptor(descriptor)
-                    .SetJson(json)
-                    .SetPointerData(pointerData);
-
-            builder = MockObject.AddGlobalPointers(targetTestHelpers, builder);
-
-            if (configure != null)
-            {
-                builder = configure(builder);
-            }
-
-            MockMemorySpace.ReadContext context = builder.Create();
-
-            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
-            Assert.True(success);
-            testCase(target);
+            builder = configure(builder);
         }
 
-        GC.KeepAlive(json);
+        MockMemorySpace.ReadContext context = builder.Create();
+
+        bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
+        Assert.True(success);
+        testCase(target);
     }
 
     [Theory]

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -58,9 +58,9 @@ public unsafe class ObjectTests
                 builder = configure(builder);
             }
 
-            using MockMemorySpace.ReadContext context = builder.Create();
+            MockMemorySpace.ReadContext context = builder.Create();
 
-            bool success = MockMemorySpace.TryCreateTarget(&context, out Target? target);
+            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
             Assert.True(success);
             testCase(target);
         }

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -17,35 +17,11 @@ public unsafe class ObjectTests
     {
         TargetTestHelpers targetTestHelpers = new(arch);
 
-        (string Name, ulong Value, string? Type)[] globals = MockObject.Globals(targetTestHelpers);
-
-        string typesJson = TargetTestHelpers.MakeTypesJson(MockObject.Types(targetTestHelpers));
-        string globalsJson = TargetTestHelpers.MakeGlobalsJson(globals);
-        byte[] json = Encoding.UTF8.GetBytes($$"""
-        {
-            "version": 0,
-            "baseline": "empty",
-            "contracts": {
-                "{{nameof(Contracts.Object)}}": 1,
-                "{{nameof(Contracts.RuntimeTypeSystem)}}": 1
-            },
-            "types": { {{typesJson}} },
-            "globals": { {{globalsJson}} }
-        }
-        """);
-
-        int pointerSize = targetTestHelpers.PointerSize;
-        Span<byte> pointerData = stackalloc byte[globals.Length * pointerSize];
-        for (int i = 0; i < globals.Length; i++)
-        {
-            var (_, value, _) = globals[i];
-            targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
-        }
-
         MockMemorySpace.Builder builder = new(targetTestHelpers);
         builder = builder
-                .SetJson(json)
-                .SetPointerData(pointerData);
+            .SetContracts([ nameof (Contracts.Object), nameof (Contracts.RuntimeTypeSystem) ])
+            .SetGlobals(MockObject.Globals(targetTestHelpers))
+            .SetTypes(MockObject.Types(targetTestHelpers));
 
         builder = MockObject.AddGlobalPointers(targetTestHelpers, builder);
 

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -56,9 +56,7 @@ public unsafe class ObjectTests
             builder = configure(builder);
         }
 
-        MockMemorySpace.ReadContext context = builder.Create();
-
-        bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
+        bool success = builder.TryCreateTarget(out Target? target);
         Assert.True(success);
         testCase(target);
     }

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -42,11 +42,10 @@ public unsafe class ObjectTests
             targetTestHelpers.WritePointer(pointerData.Slice(i * pointerSize), value);
         }
 
-        MockMemorySpace.Builder builder = new();
+        MockMemorySpace.Builder builder = new(targetTestHelpers);
         builder = builder
                 .SetJson(json)
-                .SetPointerData(pointerData)
-                .FillDescriptor(targetTestHelpers);
+                .SetPointerData(pointerData);
 
         builder = MockObject.AddGlobalPointers(targetTestHelpers, builder);
 

--- a/src/native/managed/cdacreader/tests/ObjectTests.cs
+++ b/src/native/managed/cdacreader/tests/ObjectTests.cs
@@ -33,8 +33,6 @@ public unsafe class ObjectTests
             "globals": { {{globalsJson}} }
         }
         """);
-        Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, globals.Length);
 
         int pointerSize = targetTestHelpers.PointerSize;
         Span<byte> pointerData = stackalloc byte[globals.Length * pointerSize];
@@ -45,9 +43,10 @@ public unsafe class ObjectTests
         }
 
         MockMemorySpace.Builder builder = new();
-        builder = builder.SetDescriptor(descriptor)
+        builder = builder
                 .SetJson(json)
-                .SetPointerData(pointerData);
+                .SetPointerData(pointerData)
+                .FillDescriptor(targetTestHelpers);
 
         builder = MockObject.AddGlobalPointers(targetTestHelpers, builder);
 

--- a/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
+++ b/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
@@ -137,7 +137,36 @@ internal unsafe class TargetTestHelpers
 
     public static string MakeGlobalsJson(IEnumerable<(string Name, ulong Value, string? Type)> globals)
     {
-        return string.Join(',', globals.Select(i => $"\"{i.Name}\": {(i.Type is null ? i.Value.ToString() : $"[{i.Value}, \"{i.Type}\"]")}"));
+        return MakeGlobalsJson (globals.Select(g => (g.Name, (ulong?)g.Value, (uint?)null, g.Type)));
+    }
+    public static string MakeGlobalsJson(IEnumerable<(string Name, ulong? Value, uint? IndirectIndex, string? Type)> globals)
+    {
+        return string.Join(',', globals.Select(FormatGlobal));
+
+        static string FormatGlobal((string Name, ulong? Value, uint? IndirectIndex, string? Type) global)
+        {
+            if (global.Value is ulong value)
+            {
+                return $"\"{global.Name}\": {FormatValue(value, global.Type)}";
+            }
+            else if (global.IndirectIndex is uint index)
+            {
+                return $"\"{global.Name}\": {FormatIndirect(index, global.Type)}";
+            }
+            else
+            {
+                throw new InvalidOperationException("Global must have a value or indirect index");
+            }
+
+        }
+        static string FormatValue(ulong value, string? type)
+        {
+            return type is null ? $"{value}" : $"[{value},\"{type}\"]";
+        }
+        static string FormatIndirect(uint value, string? type)
+        {
+            return type is null ? $"[{value}]" : $"[[{value}],\"{type}\"]";
+        }
     }
 
     #endregion Data descriptor json formatting

--- a/src/native/managed/cdacreader/tests/TargetTests.cs
+++ b/src/native/managed/cdacreader/tests/TargetTests.cs
@@ -54,17 +54,17 @@ public unsafe class TargetTests
 
         Target target = MockMemorySpace.CreateTarget(descriptor, json);
 
-        foreach ((DataType type, ITarget.TypeInfo info) in TestTypes)
+        foreach ((DataType type, Target.TypeInfo info) in TestTypes)
         {
             {
                 // By known type
-                ITarget.TypeInfo actual = target.GetTypeInfo(type);
+                Target.TypeInfo actual = target.GetTypeInfo(type);
                 Assert.Equal(info.Size, actual.Size);
                 Assert.Equal(info.Fields, actual.Fields);
             }
             {
                 // By name
-                ITarget.TypeInfo actual = target.GetTypeInfo(type.ToString());
+                Target.TypeInfo actual = target.GetTypeInfo(type.ToString());
                 Assert.Equal(info.Size, actual.Size);
                 Assert.Equal(info.Fields, actual.Fields);
             }

--- a/src/native/managed/cdacreader/tests/TargetTests.cs
+++ b/src/native/managed/cdacreader/tests/TargetTests.cs
@@ -51,10 +51,8 @@ public unsafe class TargetTests
     """);
         Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
         targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, 0);
-        MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json);
 
-        bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
-        Assert.True(success);
+        Target target = MockMemorySpace.CreateTarget(descriptor, json);
 
         foreach ((DataType type, ITarget.TypeInfo info) in TestTypes)
         {
@@ -106,10 +104,8 @@ public unsafe class TargetTests
         """);
         Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
         targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, 0);
-        MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json);
 
-        bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
-        Assert.True(success);
+        Target target = MockMemorySpace.CreateTarget(descriptor, json);
 
         ValidateGlobals(target, TestGlobals);
     }
@@ -139,10 +135,8 @@ public unsafe class TargetTests
         """);
         Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
         targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, pointerData.Length / pointerSize);
-        MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json, pointerData);
 
-        bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
-        Assert.True(success);
+        Target target = MockMemorySpace.CreateTarget(descriptor, json, pointerData);
 
         // Indirect values are pointer-sized, so max 32-bits for a 32-bit target
         var expected = arch.Is64Bit

--- a/src/native/managed/cdacreader/tests/TargetTests.cs
+++ b/src/native/managed/cdacreader/tests/TargetTests.cs
@@ -53,9 +53,9 @@ public unsafe class TargetTests
         targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, 0);
         fixed (byte* jsonPtr = json)
         {
-            using MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json);
+            MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json);
 
-            bool success = MockMemorySpace.TryCreateTarget(&context, out Target? target);
+            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
             Assert.True(success);
 
             foreach ((DataType type, Target.TypeInfo info) in TestTypes)
@@ -111,9 +111,9 @@ public unsafe class TargetTests
         targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, 0);
         fixed (byte* jsonPtr = json)
         {
-            using MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json);
+            MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json);
 
-            bool success = MockMemorySpace.TryCreateTarget(&context, out Target? target);
+            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
             Assert.True(success);
 
             ValidateGlobals(target, TestGlobals);
@@ -147,9 +147,9 @@ public unsafe class TargetTests
         targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, pointerData.Length / pointerSize);
         fixed (byte* jsonPtr = json)
         {
-            using MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json, pointerData);
+            MockMemorySpace.ReadContext context = MockMemorySpace.CreateContext(descriptor, json, pointerData);
 
-            bool success = MockMemorySpace.TryCreateTarget(&context, out Target? target);
+            bool success = MockMemorySpace.TryCreateTarget(context, out Target? target);
             Assert.True(success);
 
             // Indirect values are pointer-sized, so max 32-bits for a 32-bit target

--- a/src/native/managed/cdacreader/tests/TargetTests.cs
+++ b/src/native/managed/cdacreader/tests/TargetTests.cs
@@ -49,10 +49,8 @@ public unsafe class TargetTests
         "globals": {}
     }
     """);
-        Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, 0);
 
-        Target target = MockMemorySpace.CreateTarget(descriptor, json);
+        Target target = MockMemorySpace.CreateTarget(targetTestHelpers, json);
 
         foreach ((DataType type, Target.TypeInfo info) in TestTypes)
         {
@@ -102,10 +100,8 @@ public unsafe class TargetTests
             "globals": { {{globalsJson}} }
         }
         """);
-        Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, 0);
 
-        Target target = MockMemorySpace.CreateTarget(descriptor, json);
+        Target target = MockMemorySpace.CreateTarget(targetTestHelpers, json);
 
         ValidateGlobals(target, TestGlobals);
     }
@@ -133,10 +129,8 @@ public unsafe class TargetTests
             "globals": { {{globalsJson}} }
         }
         """);
-        Span<byte> descriptor = stackalloc byte[targetTestHelpers.ContractDescriptorSize];
-        targetTestHelpers.ContractDescriptorFill(descriptor, json.Length, pointerData.Length / pointerSize);
 
-        Target target = MockMemorySpace.CreateTarget(descriptor, json, pointerData);
+        Target target = MockMemorySpace.CreateTarget(targetTestHelpers, json, pointerData);
 
         // Indirect values are pointer-sized, so max 32-bits for a 32-bit target
         var expected = arch.Is64Bit


### PR DESCRIPTION
1. We used to stackalloc a lot of data because the `Target` callback had to be an UnmanagedCallersOnly function pointer.  But now it's just a delegate.  So we can heap allocate the mock memory space and get rid of a bunch of incidental `fixed` statements
2. We used to spell out the JSON contract descriptor in every test case.  We dont' need to do that - most tests are not testing parsing.  Hide all that stuff in `MockMemorySpace.Builder`

