### PR TITLE
[cdac][cdac-build-tool] Don't let msbuild rewrite the resource name

### DIFF
--- a/src/coreclr/tools/cdac-build-tool/cdac-build-tool.csproj
+++ b/src/coreclr/tools/cdac-build-tool/cdac-build-tool.csproj
@@ -24,9 +24,9 @@
     <BaselineManifestResourcePrefix>Microsoft.DotNet.Diagnostics.DataContract.Baseline:</BaselineManifestResourcePrefix>
   </PropertyGroup>
   <ItemGroup>
-      <EmbeddedResource Include="Resources/contract-descriptor.c.in" />
+      <EmbeddedResource Include="Resources/contract-descriptor.c.in" WithCulture="false" />
       <!-- embed baseline specs with manifest resource names like Microsoft.DotNet.Diagnostics.DataContract.Baseline:net9.0/osx-arm64.jsonc -->
       <!-- TODO: [cdac] - make sure we use / not \ on windows, too. -->
-      <EmbeddedResource Include="$(RepoRoot)docs\design\datacontracts\data\**\*.jsonc" LogicalName="$(BaselineManifestResourcePrefix)%(RecursiveDir)%(Filename)%(Extension)" />
+      <EmbeddedResource Include="$(RepoRoot)docs\design\datacontracts\data\**\*.jsonc" LogicalName="$(BaselineManifestResourcePrefix)%(RecursiveDir)%(Filename)%(Extension)" WithCulture="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Work around https://github.com/dotnet/msbuild/issues/9152

Possibly fixes https://github.com/dotnet/runtime/issues/107936