### PR TITLE
[wasm] Dispose Xunit ToolCommand

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -46,11 +46,11 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
     public string CreateBlazorWasmTemplateProject(string id)
     {
         InitBlazorWasmProjectDir(id);
-        new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
-                .WithWorkingDirectory(_projectDir!)
-                .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
-                .ExecuteWithCapturedOutput("new blazorwasm")
-                .EnsureSuccessful();
+        using DotNetCommand dotnetCommand = new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false);
+        CommandResult result = dotnetCommand.WithWorkingDirectory(_projectDir!)
+            .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
+            .ExecuteWithCapturedOutput("new blazorwasm")
+            .EnsureSuccessful();
 
         return Path.Combine(_projectDir!, $"{id}.csproj");
     }
@@ -195,12 +195,12 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
         runOptions.ServerEnvironment?.ToList().ForEach(
             kv => s_buildEnv.EnvVars[kv.Key] = kv.Value);
 
-        using var runCommand = new RunCommand(s_buildEnv, _testOutput)
-                                    .WithWorkingDirectory(workingDirectory);
+        using RunCommand runCommand = new RunCommand(s_buildEnv, _testOutput);
+        ToolCommand cmd = runCommand.WithWorkingDirectory(workingDirectory);
 
         await using var runner = new BrowserRunner(_testOutput);
         var page = await runner.RunAsync(
-            runCommand,
+            cmd,
             runArgs,
             onConsoleMessage: OnConsoleMessage,
             onServerMessage: runOptions.OnServerMessage,

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/CleanTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/CleanTests.cs
@@ -40,11 +40,11 @@ public class CleanTests : BlazorWasmTestBase
         Assert.True(Directory.Exists(relinkDir), $"Could not find expected relink dir: {relinkDir}");
 
         string logPath = Path.Combine(s_buildEnv.LogRootPath, id, $"{id}-clean.binlog");
-        new DotNetCommand(s_buildEnv, _testOutput)
-                .WithWorkingDirectory(_projectDir!)
-                .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
-                .ExecuteWithCapturedOutput("build", "-t:Clean", $"-p:Configuration={config}", $"-bl:{logPath}")
-                .EnsureSuccessful();
+        using ToolCommand cmd = new DotNetCommand(s_buildEnv, _testOutput)
+                                    .WithWorkingDirectory(_projectDir!);
+        cmd.WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
+            .ExecuteWithCapturedOutput("build", "-t:Clean", $"-p:Configuration={config}", $"-bl:{logPath}")
+            .EnsureSuccessful();
 
         AssertEmptyOrNonExistentDirectory(relinkDir);
     }
@@ -88,9 +88,9 @@ public class CleanTests : BlazorWasmTestBase
             Assert.True(Directory.Exists(relinkDir), $"Could not find expected relink dir: {relinkDir}");
 
         string logPath = Path.Combine(s_buildEnv.LogRootPath, id, $"{id}-clean.binlog");
-        new DotNetCommand(s_buildEnv, _testOutput)
-                .WithWorkingDirectory(_projectDir!)
-                .WithEnvironmentVariable("NUGET_PACKAGES", _projectDir!)
+        using ToolCommand cmd = new DotNetCommand(s_buildEnv, _testOutput)
+                                    .WithWorkingDirectory(_projectDir!);
+        cmd.WithEnvironmentVariable("NUGET_PACKAGES", _projectDir!)
                 .ExecuteWithCapturedOutput("build", "-t:Clean", $"-p:Configuration={config}", $"-bl:{logPath}")
                 .EnsureSuccessful();
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests2.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests2.cs
@@ -59,11 +59,11 @@ public class MiscTests2 : BlazorWasmTestBase
                                     extraItems: extraItems);
 
         string publishLogPath = Path.Combine(s_buildEnv.LogRootPath, id, $"{id}.binlog");
-        return new DotNetCommand(s_buildEnv, _testOutput)
-                        .WithWorkingDirectory(_projectDir!)
-                        .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
-                        .ExecuteWithCapturedOutput("publish",
-                                                    $"-bl:{publishLogPath}",
-                                                    $"-p:Configuration={config}");
+        using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput);
+        return cmd.WithWorkingDirectory(_projectDir!)
+                    .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
+                    .ExecuteWithCapturedOutput("publish",
+                                                $"-bl:{publishLogPath}",
+                                                $"-p:Configuration={config}");
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests3.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests3.cs
@@ -99,17 +99,15 @@ public class MiscTests3 : BlazorWasmTestBase
         string wasmProjectDir = Path.Combine(_projectDir!, "wasm");
         string wasmProjectFile = Path.Combine(wasmProjectDir, "wasm.csproj");
         Directory.CreateDirectory(wasmProjectDir);
-        new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
-                .WithWorkingDirectory(wasmProjectDir)
-                .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
-                .ExecuteWithCapturedOutput("new blazorwasm")
-                .EnsureSuccessful();
-
+        using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false);
+        cmd.WithWorkingDirectory(wasmProjectDir)
+            .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
+            .ExecuteWithCapturedOutput("new blazorwasm")
+            .EnsureSuccessful();
 
         string razorProjectDir = Path.Combine(_projectDir!, "RazorClassLibrary");
         Directory.CreateDirectory(razorProjectDir);
-        new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
-                .WithWorkingDirectory(razorProjectDir)
+        cmd.WithWorkingDirectory(razorProjectDir)
                 .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
                 .ExecuteWithCapturedOutput("new razorclasslib")
                 .EnsureSuccessful();

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -163,10 +163,10 @@ namespace Wasm.Build.Tests
             if (buildProjectOptions.Publish && buildProjectOptions.BuildOnlyAfterPublish)
                 commandLineArgs.Append("-p:WasmBuildOnlyAfterPublish=true");
 
-            var cmd = new DotNetCommand(s_buildEnv, _testOutput)
-                                    .WithWorkingDirectory(_projectDir!)
-                                    .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
-                                    .WithEnvironmentVariables(buildProjectOptions.ExtraBuildEnvironmentVariables);
+            using ToolCommand cmd = new DotNetCommand(s_buildEnv, _testOutput)
+                                        .WithWorkingDirectory(_projectDir!);
+            cmd.WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
+                .WithEnvironmentVariables(buildProjectOptions.ExtraBuildEnvironmentVariables);
             if (UseWBTOverridePackTargets && s_buildEnv.IsWorkload)
                 cmd.WithEnvironmentVariable("WBTOverrideRuntimePack", "true");
 

--- a/src/mono/wasm/Wasm.Build.Tests/Common/TestOutputWrapper.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/TestOutputWrapper.cs
@@ -15,32 +15,18 @@ public class TestOutputWrapper(ITestOutputHelper baseOutput) : ITestOutputHelper
 
     public void WriteLine(string message)
     {
-        try
-        {
-            baseOutput.WriteLine(message);
-            _outputBuffer.AppendLine(message);
-            if (EnvironmentVariables.ShowBuildOutput)
-                Console.WriteLine(message);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error in TestOutputWrapper.WriteLine: {ex}");
-        }        
+        baseOutput.WriteLine(message);
+        _outputBuffer.AppendLine(message);
+        if (EnvironmentVariables.ShowBuildOutput)
+            Console.WriteLine(message);      
     }
 
     public void WriteLine(string format, params object[] args)
     {
-        try
-        {
-            baseOutput.WriteLine(format, args);
-            _outputBuffer.AppendFormat(format, args).AppendLine();
-            if (EnvironmentVariables.ShowBuildOutput)
-                Console.WriteLine(format, args);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error in TestOutputWrapper.WriteLine: {ex}");
-        }
+        baseOutput.WriteLine(format, args);
+        _outputBuffer.AppendFormat(format, args).AppendLine();
+        if (EnvironmentVariables.ShowBuildOutput)
+            Console.WriteLine(format, args);
     }
 
     public override string ToString() => _outputBuffer.ToString();

--- a/src/mono/wasm/Wasm.Build.Tests/Common/TestOutputWrapper.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/TestOutputWrapper.cs
@@ -15,18 +15,32 @@ public class TestOutputWrapper(ITestOutputHelper baseOutput) : ITestOutputHelper
 
     public void WriteLine(string message)
     {
-        baseOutput.WriteLine(message);
-        _outputBuffer.AppendLine(message);
-        if (EnvironmentVariables.ShowBuildOutput)
-            Console.WriteLine(message);
+        try
+        {
+            baseOutput.WriteLine(message);
+            _outputBuffer.AppendLine(message);
+            if (EnvironmentVariables.ShowBuildOutput)
+                Console.WriteLine(message);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error in TestOutputWrapper.WriteLine: {ex}");
+        }        
     }
 
     public void WriteLine(string format, params object[] args)
     {
-        baseOutput.WriteLine(format, args);
-        _outputBuffer.AppendFormat(format, args).AppendLine();
-        if (EnvironmentVariables.ShowBuildOutput)
-            Console.WriteLine(format, args);
+        try
+        {
+            baseOutput.WriteLine(format, args);
+            _outputBuffer.AppendFormat(format, args).AppendLine();
+            if (EnvironmentVariables.ShowBuildOutput)
+                Console.WriteLine(format, args);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error in TestOutputWrapper.WriteLine: {ex}");
+        }
     }
 
     public override string ToString() => _outputBuffer.ToString();

--- a/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
@@ -108,22 +108,20 @@ public class NonWasmTemplateBuildTests : TestMainJsTestBase
         File.WriteAllText(Path.Combine(_projectDir, "Directory.Build.props"), "<Project />");
         File.WriteAllText(Path.Combine(_projectDir, "Directory.Build.targets"), directoryBuildTargets);
 
-        new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
-                .WithWorkingDirectory(_projectDir!)
-                .ExecuteWithCapturedOutput("new console --no-restore")
-                .EnsureSuccessful();
+        using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false);
+        cmd.WithWorkingDirectory(_projectDir!)
+            .ExecuteWithCapturedOutput("new console --no-restore")
+            .EnsureSuccessful();
 
-        new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
-                .WithWorkingDirectory(_projectDir!)
-                .ExecuteWithCapturedOutput($"build -restore -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")} {extraBuildArgs} -f {targetFramework}")
-                .EnsureSuccessful();
+        cmd.WithWorkingDirectory(_projectDir!)
+            .ExecuteWithCapturedOutput($"build -restore -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")} {extraBuildArgs} -f {targetFramework}")
+            .EnsureSuccessful();
 
         if (shouldRun)
         {
-            var result = new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
-                                .WithWorkingDirectory(_projectDir!)
-                                .ExecuteWithCapturedOutput($"run -c {config} -f {targetFramework} --no-build")
-                                .EnsureSuccessful();
+            CommandResult result = cmd.WithWorkingDirectory(_projectDir!)
+            .ExecuteWithCapturedOutput($"run -c {config} -f {targetFramework} --no-build")
+            .EnsureSuccessful();
 
             Assert.Contains("Hello, World!", result.Output);
         }

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/NativeBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/NativeBuildTests.cs
@@ -45,10 +45,10 @@ namespace Wasm.Build.Templates.Tests
             File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), code);
             File.Copy(Path.Combine(BuildEnvironment.TestAssetsPath, "native-libs", "undefined-symbol.c"), Path.Combine(_projectDir!, "undefined_xyz.c"));
 
-            CommandResult result = new DotNetCommand(s_buildEnv, _testOutput)
-                .WithWorkingDirectory(_projectDir!)
-                .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
-                .ExecuteWithCapturedOutput("build", "-c Release");
+            using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput);
+            CommandResult result = cmd.WithWorkingDirectory(_projectDir!)
+                    .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
+                    .ExecuteWithCapturedOutput("build", "-c Release");
 
             if (allowUndefined)
             {
@@ -83,17 +83,17 @@ namespace Wasm.Build.Templates.Tests
                                     Path.Combine(_projectDir!, "Program.cs"),
                                     overwrite: true);
 
-            CommandResult result = new DotNetCommand(s_buildEnv, _testOutput)
-                .WithWorkingDirectory(_projectDir!)
-                .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
-                .ExecuteWithCapturedOutput("build", $"-c {config} -bl");
+            using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput);
+            CommandResult result = cmd.WithWorkingDirectory(_projectDir!)
+                    .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
+                    .ExecuteWithCapturedOutput("build", $"-c {config} -bl");
 
             Assert.True(result.ExitCode == 0, "Expected build to succeed");
 
-            CommandResult res = new RunCommand(s_buildEnv, _testOutput)
-                                        .WithWorkingDirectory(_projectDir!)
-                                        .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {config}")
-                                        .EnsureSuccessful();
+            using RunCommand runCmd = new RunCommand(s_buildEnv, _testOutput);
+            CommandResult res = runCmd.WithWorkingDirectory(_projectDir!)
+                    .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {config}")
+                    .EnsureSuccessful();
             Assert.Contains("Hello, Console!", res.Output);
             Assert.Contains("Hello, World! Greetings from node version", res.Output);
         }

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
@@ -193,10 +193,10 @@ namespace Wasm.Build.Tests
                         IsBrowserProject: false
                         ));
 
-            CommandResult res = new RunCommand(s_buildEnv, _testOutput)
-                                        .WithWorkingDirectory(_projectDir!)
-                                        .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {config}")
-                                        .EnsureSuccessful();
+            using RunCommand cmd = new RunCommand(s_buildEnv, _testOutput);
+            CommandResult res = cmd.WithWorkingDirectory(_projectDir!)
+                                    .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {config}")
+                                    .EnsureSuccessful();
             Assert.Contains("Hello, Console!", res.Output);
 
             if (!_buildContext.TryGetBuildFor(buildArgs, out BuildProduct? product))
@@ -262,10 +262,10 @@ namespace Wasm.Build.Tests
                             IsBrowserProject: false
                             ));
 
-            CommandResult res = new RunCommand(s_buildEnv, _testOutput)
-                                        .WithWorkingDirectory(_projectDir!)
-                                        .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {config} x y z")
-                                        .EnsureExitCode(42);
+            using RunCommand cmd = new RunCommand(s_buildEnv, _testOutput);
+            CommandResult res = cmd.WithWorkingDirectory(_projectDir!)
+                                    .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {config} x y z")
+                                    .EnsureExitCode(42);
 
             Assert.Contains("args[0] = x", res.Output);
             Assert.Contains("args[1] = y", res.Output);
@@ -355,7 +355,7 @@ namespace Wasm.Build.Tests
                 using var cmd = new RunCommand(s_buildEnv, _testOutput, label: id)
                                     .WithWorkingDirectory(workingDir)
                                     .WithEnvironmentVariables(s_buildEnv.EnvVars);
-                var res = cmd.ExecuteWithCapturedOutput(runArgs).EnsureExitCode(42);
+                CommandResult res = cmd.ExecuteWithCapturedOutput(runArgs).EnsureExitCode(42);
 
                 Assert.Contains("args[0] = x", res.Output);
                 Assert.Contains("args[1] = y", res.Output);
@@ -370,7 +370,7 @@ namespace Wasm.Build.Tests
                 runArgs += " x y z";
                 using var cmd = new RunCommand(s_buildEnv, _testOutput, label: id)
                                 .WithWorkingDirectory(workingDir);
-                var res = cmd.ExecuteWithCapturedOutput(runArgs).EnsureExitCode(42);
+                CommandResult res = cmd.ExecuteWithCapturedOutput(runArgs).EnsureExitCode(42);
 
                 Assert.Contains("args[0] = x", res.Output);
                 Assert.Contains("args[1] = y", res.Output);
@@ -429,23 +429,26 @@ namespace Wasm.Build.Tests
                             UseCache: false,
                             IsBrowserProject: false));
 
-            new RunCommand(s_buildEnv, _testOutput, label: id)
-                                .WithWorkingDirectory(_projectDir!)
-                                .ExecuteWithCapturedOutput("--info")
-                                .EnsureExitCode(0);
+            using (RunCommand cmd = new RunCommand(s_buildEnv, _testOutput, label: id))
+            {
+                cmd.WithWorkingDirectory(_projectDir!)
+                    .ExecuteWithCapturedOutput("--info")
+                    .EnsureExitCode(0);
+            }            
 
             string runArgs = $"run --no-silent --no-build -c {config} -v diag";
             runArgs += " x y z";
-            var res = new RunCommand(s_buildEnv, _testOutput, label: id)
-                                .WithWorkingDirectory(_projectDir!)
-                                .ExecuteWithCapturedOutput(runArgs)
-                                .EnsureExitCode(42);
-
-            if (aot)
-                Assert.Contains($"AOT: image '{Path.GetFileNameWithoutExtension(projectFile)}' found", res.Output);
-            Assert.Contains("args[0] = x", res.Output);
-            Assert.Contains("args[1] = y", res.Output);
-            Assert.Contains("args[2] = z", res.Output);
+            using (RunCommand cmd = new RunCommand(s_buildEnv, _testOutput, label: id))
+            {
+                CommandResult res = cmd.WithWorkingDirectory(_projectDir!)
+                                        .ExecuteWithCapturedOutput(runArgs)
+                                        .EnsureExitCode(42);
+                if (aot)
+                    Assert.Contains($"AOT: image '{Path.GetFileNameWithoutExtension(projectFile)}' found", res.Output);
+                Assert.Contains("args[0] = x", res.Output);
+                Assert.Contains("args[1] = y", res.Output);
+                Assert.Contains("args[2] = z", res.Output);
+            }
         }
 
         public static IEnumerable<object?[]> BrowserBuildAndRunTestData()
@@ -474,10 +477,10 @@ namespace Wasm.Build.Tests
 
             UpdateBrowserMainJs(targetFramework, runtimeAssetsRelativePath);
 
-            new DotNetCommand(s_buildEnv, _testOutput)
-                    .WithWorkingDirectory(_projectDir!)
-                    .Execute($"build -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")} {(runtimeAssetsRelativePath != DefaultRuntimeAssetsRelativePath ? "-p:WasmRuntimeAssetsLocation=" + runtimeAssetsRelativePath : "")}")
-                    .EnsureSuccessful();
+            using ToolCommand cmd = new DotNetCommand(s_buildEnv, _testOutput)
+                                        .WithWorkingDirectory(_projectDir!);
+            cmd.Execute($"build -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")} {(runtimeAssetsRelativePath != DefaultRuntimeAssetsRelativePath ? "-p:WasmRuntimeAssetsLocation=" + runtimeAssetsRelativePath : "")}")
+                .EnsureSuccessful();
 
             using var runCommand = new RunCommand(s_buildEnv, _testOutput)
                                         .WithWorkingDirectory(_projectDir!);
@@ -578,10 +581,10 @@ namespace Wasm.Build.Tests
                             AssertAppBundle: false));
 
             string runArgs = $"run --no-silent --no-build -c {config}";
-            var res = new RunCommand(s_buildEnv, _testOutput, label: id)
-                                .WithWorkingDirectory(_projectDir!)
-                                .ExecuteWithCapturedOutput(runArgs)
-                                .EnsureExitCode(42);
+            using ToolCommand cmd = new RunCommand(s_buildEnv, _testOutput, label: id)
+                                        .WithWorkingDirectory(_projectDir!);
+            CommandResult res = cmd.ExecuteWithCapturedOutput(runArgs)
+                                    .EnsureExitCode(42);
 
             string frameworkDir = Path.Combine(projectDirectory, "bin", config, BuildTestBase.DefaultTargetFramework, "browser-wasm", "AppBundle", "_framework");
             string objBuildDir = Path.Combine(projectDirectory, "obj", config, BuildTestBase.DefaultTargetFramework, "browser-wasm", "wasm", "for-publish");

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/InterpPgoTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/InterpPgoTests.cs
@@ -44,7 +44,7 @@ public class InterpPgoTests : AppTestBase
         // Create a single browser instance and single context to host all our pages.
         // If we don't do this, each page will have its own unique cache and the table won't be loaded.
         using var runCommand = new RunCommand(s_buildEnv, _testOutput)
-                                    .WithWorkingDirectory(_projectDir!);
+                                            .WithWorkingDirectory(_projectDir!);
         await using var runner = new BrowserRunner(_testOutput);
         var url = await runner.StartServerAndGetUrlAsync(runCommand, $"run --no-silent -c {config} --no-build --project \"{_projectDir!}\" --forward-console");
         url = $"{url}?test=InterpPgoTest&iterationCount={iterationCount}";

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SatelliteLoadingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SatelliteLoadingTests.cs
@@ -77,8 +77,8 @@ public class SatelliteLoadingTests : AppTestBase
 
         // Build the library
         var libraryCsprojPath = Path.GetFullPath(Path.Combine(_projectDir!, "..", "ResourceLibrary"));
-        new DotNetCommand(s_buildEnv, _testOutput)
-            .WithWorkingDirectory(libraryCsprojPath)
+        using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput);
+        CommandResult res = cmd.WithWorkingDirectory(libraryCsprojPath)
             .WithEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesDir)
             .ExecuteWithCapturedOutput("build -c Release")
             .EnsureSuccessful();

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/WasmAppBuilderDebugLevelTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/WasmAppBuilderDebugLevelTests.cs
@@ -35,8 +35,8 @@ public class WasmAppBuilderDebugLevelTests : DebugLevelTestsBase
 
     protected override Task<RunResult> RunForBuild(string configuration)
     {
-        CommandResult res = new RunCommand(s_buildEnv, _testOutput)
-            .WithWorkingDirectory(_projectDir!)
+        using RunCommand cmd = new RunCommand(s_buildEnv, _testOutput);
+        CommandResult res = cmd.WithWorkingDirectory(_projectDir!)
             .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {configuration}");
 
         return Task.FromResult(ProcessRunOutput(res));
@@ -61,8 +61,8 @@ public class WasmAppBuilderDebugLevelTests : DebugLevelTestsBase
     {
         // WasmAppBuilder does publish to the same folder as build (it overrides the output), 
         // and thus using dotnet run work correctly for publish as well.
-        CommandResult res = new RunCommand(s_buildEnv, _testOutput)
-            .WithWorkingDirectory(_projectDir!)
+        using RunCommand cmd = new RunCommand(s_buildEnv, _testOutput);
+        CommandResult res = cmd.WithWorkingDirectory(_projectDir!)
             .ExecuteWithCapturedOutput($"run --no-silent --no-build -c {configuration}");
 
         return Task.FromResult(ProcessRunOutput(res));

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTestBase.cs
@@ -43,10 +43,10 @@ public abstract class WasmTemplateTestBase : BuildTestBase
 
         if (addFrameworkArg)
             extraArgs += $" -f {DefaultTargetFramework}";
-        new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
-                .WithWorkingDirectory(_projectDir!)
-                .ExecuteWithCapturedOutput($"new {template} {extraArgs}")
-                .EnsureSuccessful();
+        using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false);
+        CommandResult result = cmd.WithWorkingDirectory(_projectDir!)
+            .ExecuteWithCapturedOutput($"new {template} {extraArgs}")
+            .EnsureSuccessful();
 
         string projectfile = Path.Combine(_projectDir!, $"{id}.csproj");
 


### PR DESCRIPTION
Trying to fix:
https://github.com/dotnet/runtime/issues/105315

Following the stack from the linked issue, we have:
https://github.com/dotnet/runtime/blob/84b7c2f15ceec32e66b46231614dfcb3e334c6fd/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs#L548

https://github.com/xunit/xunit/blob/6bfa188331f6d4ed6e877ab6da5e7b2725ccd721/src/xunit.v3.core/Framework/TestOutputHelper.cs#L45

We might be trying to `WriteLine`, after xunit threw an exception and the test state is already `null`. Do not try to log the messages (both error and info) if the command is already disposed.