### PR TITLE
[8.0] Guard against empty Accept address

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3601,7 +3601,7 @@ namespace System.Net.Sockets
         }
 
         // CreateAcceptSocket - pulls unmanaged results and assembles them into a new Socket object.
-        internal Socket CreateAcceptSocket(SafeSocketHandle fd, EndPoint remoteEP)
+        internal Socket CreateAcceptSocket(SafeSocketHandle fd, EndPoint? remoteEP)
         {
             // Internal state of the socket is inherited from listener.
             Debug.Assert(fd != null && !fd.IsInvalid);
@@ -3609,7 +3609,7 @@ namespace System.Net.Sockets
             return UpdateAcceptSocket(socket, remoteEP);
         }
 
-        internal Socket UpdateAcceptSocket(Socket socket, EndPoint remoteEP)
+        internal Socket UpdateAcceptSocket(Socket socket, EndPoint? remoteEP)
         {
             // Internal state of the socket is inherited from listener.
             socket._addressFamily = _addressFamily;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -343,7 +343,7 @@ namespace System.Net.Sockets
 
             Socket acceptedSocket = _currentSocket!.CreateAcceptSocket(
                 SocketPal.CreateSocket(_acceptedFileDescriptor),
-                _currentSocket._rightEndPoint!.Create(remoteSocketAddress));
+                remoteSocketAddress.Size > 0 ? _currentSocket._rightEndPoint!.Create(remoteSocketAddress) : null);
             if (_acceptSocket is null)
             {
                 // Store the accepted socket

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -35,7 +35,6 @@ namespace System.Net.Sockets
             _acceptedFileDescriptor = acceptedFileDescriptor;
             if (socketError == SocketError.Success)
             {
-                Debug.Assert(socketAddress.Length > 0);
                 _acceptAddressBufferCount = socketAddress.Length;
             }
             else


### PR DESCRIPTION
Backports #108616

Fixes #108026 and #102663

## Customer Impact

- [x] Customer reported
- [ ] Found internally

There is problem in 8.0+ when `Socket.Accept` can fail and throw exception on background thread on macOS, which leads to application termination. This was already reported by 2 customers who upgraded to 8.0 from previous LTS 6.0 - see #108026 and #102663.

## Regression

- [X] Yes - from 7.0 to 8.0
- [ ] No

Prior 8.0 we used internal duplicate of class `SocketAddress` that was apparently more forgiving in certain corner cases. We switch in 8.0 to usage of public API that is more strict.

## Testing

The fix was merged to main and verified by customer. Also 8.0 binaries were tested in their lab. See https://github.com/dotnet/runtime/pull/108334#issuecomment-2478665135 for details.

## Risk

Low. The fix basically checks for error condition to avoid throwing. It seems like the condition is coming from Darwin kernel where sometime `accept` operation fails to provide remote address.