### PR TITLE
Fold some casts early in importer

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5496,6 +5496,9 @@ var_types Compiler::impGetByRefResultType(genTreeOps oper, bool fUnsigned, GenTr
     GenTree*  op1  = *pOp1;
     GenTree*  op2  = *pOp2;
 
+    assert(op1 != nullptr);
+    assert(op2 != nullptr);
+
     // Arithmetic operations are generally only allowed with primitive types, but certain operations are allowed
     // with byrefs.
     //
@@ -5607,6 +5610,10 @@ var_types Compiler::impGetByRefResultType(genTreeOps oper, bool fUnsigned, GenTr
             type = TYP_DOUBLE;
         }
     }
+
+    // Try to fold the introduced casts
+    *pOp1 = gtFoldExpr(*pOp1);
+    *pOp2 = gtFoldExpr(*pOp2);
 
     assert(TypeIs(type, TYP_BYREF, TYP_DOUBLE, TYP_FLOAT, TYP_LONG, TYP_INT));
     return type;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5572,13 +5572,21 @@ var_types Compiler::impGetByRefResultType(genTreeOps oper, bool fUnsigned, GenTr
         if (genActualType(op1) != TYP_I_IMPL)
         {
             // insert an explicit upcast
-            op1 = *pOp1 = gtNewCastNode(TYP_I_IMPL, op1, fUnsigned, TYP_I_IMPL);
+            op1 = gtNewCastNode(TYP_I_IMPL, op1, fUnsigned, TYP_I_IMPL);
         }
         else if (genActualType(op2) != TYP_I_IMPL)
         {
             // insert an explicit upcast
-            op2 = *pOp2 = gtNewCastNode(TYP_I_IMPL, op2, fUnsigned, TYP_I_IMPL);
+            op2 = gtNewCastNode(TYP_I_IMPL, op2, fUnsigned, TYP_I_IMPL);
         }
+
+        if (opts.OptimizationEnabled())
+        {
+            op1 = gtFoldExpr(op1);
+            op2 = gtFoldExpr(op2);
+        }
+        *pOp1 = op1;
+        *pOp2 = op2;
 
         type = TYP_I_IMPL;
     }
@@ -5609,16 +5617,6 @@ var_types Compiler::impGetByRefResultType(genTreeOps oper, bool fUnsigned, GenTr
 
             type = TYP_DOUBLE;
         }
-    }
-
-    // Try to fold the introduced casts
-    if ((*pOp1)->OperIs(GT_CAST) && (*pOp1)->gtGetOp1()->OperIsConst())
-    {
-        *pOp1 = gtFoldExprConst(*pOp1);
-    }
-    if ((*pOp2)->OperIs(GT_CAST) && (*pOp2)->gtGetOp1()->OperIsConst())
-    {
-        *pOp2 = gtFoldExprConst(*pOp2);
     }
 
     assert(TypeIs(type, TYP_BYREF, TYP_DOUBLE, TYP_FLOAT, TYP_LONG, TYP_INT));

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5612,8 +5612,14 @@ var_types Compiler::impGetByRefResultType(genTreeOps oper, bool fUnsigned, GenTr
     }
 
     // Try to fold the introduced casts
-    *pOp1 = gtFoldExpr(*pOp1);
-    *pOp2 = gtFoldExpr(*pOp2);
+    if ((*pOp1)->OperIs(GT_CAST) && (*pOp1)->gtGetOp1()->OperIsConst())
+    {
+        *pOp1 = gtFoldExprConst(*pOp1);
+    }
+    if ((*pOp2)->OperIs(GT_CAST) && (*pOp2)->gtGetOp1()->OperIsConst())
+    {
+        *pOp2 = gtFoldExprConst(*pOp2);
+    }
 
     assert(TypeIs(type, TYP_BYREF, TYP_DOUBLE, TYP_FLOAT, TYP_LONG, TYP_INT));
     return type;


### PR DESCRIPTION
A small CQ issue reported by the community. Example:
```cs
public static void Test() => Callee();

[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static void Callee()
{
    nint* ptr = stackalloc nint[2];
    Consume(ptr);
}

[MethodImpl(MethodImplOptions.NoInlining)]
private static void Consume(IntPtr* ptr) {}
```
Current codegen:
```asm
; Assembly listing for method Cd:Test() (FullOpts)
       sub      rsp, 40
       call     [Cd:Callee()]
       nop      
       add      rsp, 40
       ret      
; Total bytes of code 16
```
^ JIT refuses to inline `Consume` due to "unknown size stackalloc". But it's "unknown" only because importer didn't fold it
New codegen:
```asm
; Assembly listing for method Cd:Test() (FullOpts)
       sub      rsp, 72
       mov      rax, 0x9ABCDEF012345678
       mov      qword ptr [rsp+0x40], rax
       lea      rcx, [rsp+0x28]
       call     [Cd:Consume(ulong)]
       mov      rcx, 0x9ABCDEF012345678
       cmp      qword ptr [rsp+0x40], rcx
       je       SHORT G_M42256_IG04
       call     CORINFO_HELP_FAIL_FAST
G_M42256_IG04:
       nop      
       add      rsp, 72
       ret      
; Total bytes of code 58
```