### PR TITLE
Expand an optimization for short values to IgnoreCase in single-value SearchValues<string>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/SingleStringSearchValuesThreeChars.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/SingleStringSearchValuesThreeChars.cs
@@ -31,6 +31,14 @@ namespace System.Buffers
 
         private static bool IgnoreCase => typeof(TCaseSensitivity) != typeof(CaseSensitive);
 
+        // If the value is short (!TValueLength.AtLeast4Chars => 2 or 3 characters), the anchors already represent the whole value.
+        // With case-sensitive comparisons, we've therefore already confirmed the match.
+        // With case-insensitive comparisons, we've applied the CaseConversionMask to the input, so while the anchors likely matched, we can't be sure.
+        // An exception to that is if we know the value is composed of only ASCII letters, in which case masking the input can't produce false positives.
+        private static bool CanSkipAnchorMatchVerification =>
+            !TValueLength.AtLeast4Chars &&
+            (typeof(TCaseSensitivity) == typeof(CaseSensitive) || typeof(TCaseSensitivity) == typeof(CaseInsensitiveAsciiLetters));
+
         public SingleStringSearchValuesThreeChars(HashSet<string>? uniqueValues, string value) : base(uniqueValues)
         {
             // We could have more than one entry in 'uniqueValues' if this value is an exact prefix of all the others.
@@ -327,11 +335,7 @@ namespace System.Buffers
 
                 ValidateReadPosition(ref searchSpaceStart, searchSpaceLength, ref matchRef, _value.Length);
 
-                // If the value is short (!TValueLength.AtLeast4Chars => 2 or 3 characters), the anchors already represent the whole value.
-                // With case-sensitive comparisons, we've therefore already confirmed the match, so we can skip doing so here.
-                // With case-insensitive comparisons, we applied a mask to the input, so while the anchors likely matched, we can't be sure.
-                if ((typeof(TCaseSensitivity) == typeof(CaseSensitive) && !TValueLength.AtLeast4Chars) ||
-                    TCaseSensitivity.Equals<TValueLength>(ref matchRef, _value))
+                if (CanSkipAnchorMatchVerification || TCaseSensitivity.Equals<TValueLength>(ref matchRef, _value))
                 {
                     offsetFromStart = (int)((nuint)Unsafe.ByteOffset(ref searchSpaceStart, ref matchRef) / 2);
                     return true;
@@ -359,11 +363,7 @@ namespace System.Buffers
 
                 ValidateReadPosition(ref searchSpaceStart, searchSpaceLength, ref matchRef, _value.Length);
 
-                // If the value is short (!TValueLength.AtLeast4Chars => 2 or 3 characters), the anchors already represent the whole value.
-                // With case-sensitive comparisons, we've therefore already confirmed the match, so we can skip doing so here.
-                // With case-insensitive comparisons, we applied a mask to the input, so while the anchors likely matched, we can't be sure.
-                if ((typeof(TCaseSensitivity) == typeof(CaseSensitive) && !TValueLength.AtLeast4Chars) ||
-                    TCaseSensitivity.Equals<TValueLength>(ref matchRef, _value))
+                if (CanSkipAnchorMatchVerification || TCaseSensitivity.Equals<TValueLength>(ref matchRef, _value))
                 {
                     offsetFromStart = (int)((nuint)Unsafe.ByteOffset(ref searchSpaceStart, ref matchRef) / 2);
                     return true;


### PR DESCRIPTION
For values length 2 or 3, we have a special case where we don't verify matches at all if we know that false positives are impossible when all the anchors match.
https://github.com/dotnet/runtime/blob/ba9b3ba83603d1f54c00c45a87344568d4277966/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/SingleStringSearchValuesThreeChars.cs#L362-L366
We were using this trick with case-sensitive comparisons, but it's actually also valid if we know that all the characters are ASCII letters, so this PR extends the optimization to apply to those values as well.

---

```c#
public class EarlyMatches
{
    private const string Needle = "the";
    private static readonly string s_haystack = string.Concat(Enumerable.Repeat(Needle, 10_000));
    private static readonly SearchValues<string> s_values = SearchValues.Create([Needle], StringComparison.OrdinalIgnoreCase);

    [Benchmark]
    public int Count()
    {
        int count = 0;
        ReadOnlySpan<char> haystack = s_haystack;
        while (true)
        {
            int pos = haystack.IndexOfAny(s_values);
            if (pos < 0) break;
            count++;
            haystack = haystack.Slice(Needle.Length);
        }
        return count;
    }
}
```

| Method | Toolchain | Mean     | Error    | Ratio | Code Size |
|------- |---------- |---------:|---------:|------:|----------:|
| Count  | main      | 29.41 us | 0.517 us |  1.00 |     946 B |
| Count  | pr        | 23.30 us | 0.269 us |  0.79 |     726 B |