### PR TITLE
Fix AbandonedMutexException errors in System.Memory tests

### DIFF
--- a/src/libraries/System.Memory/tests/Span/Overflow.cs
+++ b/src/libraries/System.Memory/tests/Span/Overflow.cs
@@ -100,7 +100,7 @@ namespace System.SpanTests
                     }
                     finally
                     {
-                        Marshal.FreeHGlobal(memory);
+                        AllocationHelper.ReleaseNative(ref memory);
                     }
                 }
             }
@@ -147,7 +147,7 @@ namespace System.SpanTests
                     }
                     finally
                     {
-                        Marshal.FreeHGlobal(memory);
+                        AllocationHelper.ReleaseNative(ref memory);
                     }
                 }
             }


### PR DESCRIPTION
I was seeing these errors pretty consistently in local runs because these two test cases weren't going through `AllocationHelper.ReleaseNative`, which also releases a Mutex.

```
Discovering: System.Memory.Tests (method display = ClassAndMethod, method display options = None)
Discovered:  System.Memory.Tests (found 2824 of 2827 test cases)
Starting:    System.Memory.Tests (parallel test collections = on [32 threads], stop on fail = off)
  System.SpanTests.ReadOnlySpanTests.IndexOverflow [FAIL]
    System.Threading.AbandonedMutexException : The wait completed due to an abandoned mutex.
    Stack Trace:
      at System.Threading.WaitHandle.WaitOneNoCheck(Int32 millisecondsTimeout, Boolean useTrivialWaits, Object associatedObject, WaitHandleWaitSourceMap waitSource)
      at System.Threading.WaitHandle.WaitOne(TimeSpan timeout)
      at System.SpanTests.AllocationHelper.TryAllocNative(IntPtr size, IntPtr& memory)
      at System.SpanTests.ReadOnlySpanTests.IndexOverflow()
      at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
      at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
Finished:    System.Memory.Tests
=== TEST EXECUTION SUMMARY ===
 System.Memory.Tests  Total: 52115, Errors: 0, Failed: 1, Skipped: 0, Time: 61.163s
```