### PR TITLE
RandomAccess.Write throws System.IO.IOException when buffers total size greater than 2GB

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -435,7 +435,7 @@ namespace System.IO
         internal static void WriteGatherAtOffset(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset)
         {
             // WriteFileGather does not support sync handles, so we just call WriteFile in a loop
-            int bytesWritten = 0;
+            long bytesWritten = 0;
             int buffersCount = buffers.Count;
             for (int i = 0; i < buffersCount; i++)
             {


### PR DESCRIPTION
Fixes #108322

# Description

Fixes RandomAccess.Write that throws System.IO.IOException on windows machine where the buffer is larger than 2GB

# Customer Impact

Possible file corruption when writing

# Regression

https://github.com/dotnet/runtime/issues/108322#issuecomment-2379442217

# Testing

Without the fix:
![image](https://github.com/user-attachments/assets/272f7429-d425-4193-946d-3c6c93e16558)

With the fix:
![image](https://github.com/user-attachments/assets/57f65ba3-8719-4e42-aa0f-6d732991ca66)

Test method

```csharp
[Fact]
void RandomAccessWrite_ShouldNot_Throw_IOException_When_Buffer_Larger_Than_MaxInt32()
{
    // Arrange
    const long gigabyte = 1L * 1024 * 1024 * 1024;

    var rolist = new List<ReadOnlyMemory<byte>>();

    for (int i = 0; i < 3; i++)
    {
        rolist.Add(new ReadOnlyMemory<byte>(new byte[gigabyte]));
    }

    // Act
    try
    {
        UnmanagedFileLoader loader = new UnmanagedFileLoader("C:\\tmp\\testfile.txt");
        RandomAccess.Write(loader.Handle, rolist, 0);
    }
    catch (IOException ex)
    {
        Assert.Fail("Unable to write file" + ex.Message);
    }            
}
```

The actual UnmanagedFileLoader implementation can be found [here](https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.safehandles.safefilehandle?view=net-8.0#examples) from official microsoft documentation
# Risk

None

# Package authoring signed off?

IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](../../docs/project/library-servicing.md) and gotten it explicitly reviewed.
