### PR TITLE
[wasm] Dispose Xunit ToolCommand - follow up

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Common/TestOutputWrapper.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/TestOutputWrapper.cs
@@ -18,7 +18,7 @@ public class TestOutputWrapper(ITestOutputHelper baseOutput) : ITestOutputHelper
         baseOutput.WriteLine(message);
         _outputBuffer.AppendLine(message);
         if (EnvironmentVariables.ShowBuildOutput)
-            Console.WriteLine(message);      
+            Console.WriteLine(message);
     }
 
     public void WriteLine(string format, params object[] args)

--- a/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
@@ -108,20 +108,18 @@ public class NonWasmTemplateBuildTests : TestMainJsTestBase
         File.WriteAllText(Path.Combine(_projectDir, "Directory.Build.props"), "<Project />");
         File.WriteAllText(Path.Combine(_projectDir, "Directory.Build.targets"), directoryBuildTargets);
 
-        using DotNetCommand cmd = new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false);
-        cmd.WithWorkingDirectory(_projectDir!)
-            .ExecuteWithCapturedOutput("new console --no-restore")
+        using ToolCommand cmd = new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
+            .WithWorkingDirectory(_projectDir!);
+        cmd.ExecuteWithCapturedOutput("new console --no-restore")
             .EnsureSuccessful();
 
-        cmd.WithWorkingDirectory(_projectDir!)
-            .ExecuteWithCapturedOutput($"build -restore -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")} {extraBuildArgs} -f {targetFramework}")
+        cmd.ExecuteWithCapturedOutput($"build -restore -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")} {extraBuildArgs} -f {targetFramework}")
             .EnsureSuccessful();
 
         if (shouldRun)
         {
-            CommandResult result = cmd.WithWorkingDirectory(_projectDir!)
-            .ExecuteWithCapturedOutput($"run -c {config} -f {targetFramework} --no-build")
-            .EnsureSuccessful();
+            CommandResult result = cmd.ExecuteWithCapturedOutput($"run -c {config} -f {targetFramework} --no-build")
+                .EnsureSuccessful();
 
             Assert.Contains("Hello, World!", result.Output);
         }


### PR DESCRIPTION
Addressing @maraf's feedback from https://github.com/dotnet/runtime/pull/108319.
- whitespace
- removal of redundant project dir setup
- discussion: will sharing the `ToolCommand` have any negative impact on the tests?