### PR TITLE
feat: makes GeneratedCodeAttribute constructor parameters optional

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/GeneratedCodeAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/GeneratedCodeAttribute.cs
@@ -9,7 +9,7 @@ namespace System.CodeDom.Compiler
         private readonly string? _tool;
         private readonly string? _version;
 
-        public GeneratedCodeAttribute(string? tool, string? version)
+        public GeneratedCodeAttribute(string? tool = null, string? version = null)
         {
             _tool = tool;
             _version = version;


### PR DESCRIPTION
fixes #108443

There's no reason those parameters should be required as far as I know, and forcing generators to specify a tool name or a version without validating anything doesn't bring much value.