### PR TITLE
[GC] Revert distribute_free_regions changes in preparation for different strategy

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -13188,21 +13188,6 @@ void region_free_list::age_free_regions (region_free_list free_lists[count_free_
     }
 }
 
-size_t region_free_list::get_size_free_regions(int max_age)
-{
-    size_t result = 0;
-
-    for (heap_segment* region = head_free_region; region != nullptr; region = heap_segment_next (region))
-    {
-        if (heap_segment_age_in_free (region) <= max_age)
-        {
-            result += get_region_size(region);
-        }
-    }
-
-    return result;
-}
-
 void region_free_list::print (int hn, const char* msg, int* ages)
 {
     dprintf (3, ("h%2d PRINTING-------------------------------", hn));
@@ -13531,7 +13516,6 @@ void gc_heap::distribute_free_regions()
     global_free_huge_regions.transfer_regions (&global_regions_to_decommit[huge_free_region]);
 
     size_t free_space_in_huge_regions = global_free_huge_regions.get_size_free_regions();
-    size_t free_space_in_young_huge_regions = global_free_huge_regions.get_size_free_regions(MIN_AGE_TO_DECOMMIT_HUGE - 1);
 
     ptrdiff_t num_regions_to_decommit[kind_count];
     int region_factor[kind_count] = { 1, LARGE_REGION_FACTOR };
@@ -13545,7 +13529,6 @@ void gc_heap::distribute_free_regions()
 #endif //!MULTIPLE_HEAPS
 
     size_t num_huge_region_units_to_consider[kind_count] = { 0, free_space_in_huge_regions / region_size[large_free_region] };
-    size_t num_young_huge_region_units_to_consider[kind_count] = { 0, free_space_in_young_huge_regions / region_size[large_free_region] };
 
     for (int kind = basic_free_region; kind < kind_count; kind++)
     {
@@ -13564,22 +13547,9 @@ void gc_heap::distribute_free_regions()
 
         ptrdiff_t balance = total_num_free_regions[kind] + num_huge_region_units_to_consider[kind] - total_budget_in_region_units[kind];
 
-        // Ignore young huge regions if they are contributing to a surplus.
-        if (balance > 0)
-        {
-            if (balance > static_cast<ptrdiff_t>(num_young_huge_region_units_to_consider[kind]))
-            {
-                balance -= num_young_huge_region_units_to_consider[kind];
-            }
-            else
-            {
-                balance = 0;
-            }
-        }
-
         if (
 #ifdef BACKGROUND_GC
-            (background_running_p() && (settings.condemned_generation != max_generation)) ||
+            background_running_p() ||
 #endif
             (balance < 0))
         {
@@ -38482,7 +38452,8 @@ void gc_heap::background_mark_phase ()
         // age the free regions twice.
         if (!do_ephemeral_gc_p)
         {
-            distribute_free_regions ();
+            // Will be enabled with future distribute_free_regions changes
+            //distribute_free_regions ();
             age_free_regions ("BGC");
         }
 #endif //USE_REGIONS

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -13559,25 +13559,86 @@ void gc_heap::distribute_free_regions()
             num_huge_region_units_to_consider[kind]));
 
         // check if the free regions exceed the budget
-        // if so, consider putting the highest free regions on the decommit list
+        // if so, put the highest free regions on the decommit list
         total_num_free_regions[kind] += num_regions_to_decommit[kind];
 
         ptrdiff_t balance = total_num_free_regions[kind] + num_huge_region_units_to_consider[kind] - total_budget_in_region_units[kind];
 
-        // first check if we should decommit any regions
-        if ((balance > 0)
-#ifdef BACKGROUND_GC
-            && (!background_running_p() || (settings.condemned_generation == max_generation))
-#endif
-            )
+        // Ignore young huge regions if they are contributing to a surplus.
+        if (balance > 0)
         {
-            // ignore young huge regions when determining how much to decommit
-            num_regions_to_decommit[kind] =
-                max(static_cast<ptrdiff_t>(0),
-                    (balance - static_cast<ptrdiff_t>(num_young_huge_region_units_to_consider[kind])));
+            if (balance > static_cast<ptrdiff_t>(num_young_huge_region_units_to_consider[kind]))
+            {
+                balance -= num_young_huge_region_units_to_consider[kind];
+            }
+            else
+            {
+                balance = 0;
+            }
+        }
 
-            balance -= num_regions_to_decommit[kind];
+        if (
+#ifdef BACKGROUND_GC
+            (background_running_p() && (settings.condemned_generation != max_generation)) ||
+#endif
+            (balance < 0))
+        {
+            dprintf (REGIONS_LOG, ("distributing the %zd %s regions deficit", -balance, kind_name[kind]));
 
+#ifdef MULTIPLE_HEAPS
+            // we may have a deficit or  - if background GC is going on - a surplus.
+            // adjust the budget per heap accordingly
+            if (balance != 0)
+            {
+                ptrdiff_t curr_balance = 0;
+                ptrdiff_t rem_balance = 0;
+                for (int i = 0; i < n_heaps; i++)
+                {
+                    curr_balance += balance;
+                    ptrdiff_t adjustment_per_heap = curr_balance / n_heaps;
+                    curr_balance -= adjustment_per_heap * n_heaps;
+                    ptrdiff_t new_budget = (ptrdiff_t)heap_budget_in_region_units[i][kind] + adjustment_per_heap;
+                    ptrdiff_t min_budget = (kind == basic_free_region) ? (ptrdiff_t)min_heap_budget_in_region_units[i] : 0;
+                    dprintf (REGIONS_LOG, ("adjusting the budget for heap %d from %zd %s regions by %zd to %zd",
+                        i,
+                        heap_budget_in_region_units[i][kind],
+                        kind_name[kind],
+                        adjustment_per_heap,
+                        max (min_budget, new_budget)));
+                    heap_budget_in_region_units[i][kind] = max (min_budget, new_budget);
+                    rem_balance += new_budget - heap_budget_in_region_units[i][kind];
+                }
+                assert (rem_balance <= 0);
+                dprintf (REGIONS_LOG, ("remaining balance: %zd %s regions", rem_balance, kind_name[kind]));
+
+                // if we have a left over deficit, distribute that to the heaps that still have more than the minimum
+                while (rem_balance < 0)
+                {
+                    for (int i = 0; i < n_heaps; i++)
+                    {
+                        size_t min_budget = (kind == basic_free_region) ? min_heap_budget_in_region_units[i] : 0;
+                        if (heap_budget_in_region_units[i][kind] > min_budget)
+                        {
+                            dprintf (REGIONS_LOG, ("adjusting the budget for heap %d from %zd %s regions by %d to %zd",
+                                i,
+                                heap_budget_in_region_units[i][kind],
+                                kind_name[kind],
+                                -1,
+                                heap_budget_in_region_units[i][kind] - 1));
+
+                            heap_budget_in_region_units[i][kind] -= 1;
+                            rem_balance += 1;
+                            if (rem_balance == 0)
+                                break;
+                        }
+                    }
+                }
+            }
+#endif //MULTIPLE_HEAPS
+        }
+        else
+        {
+            num_regions_to_decommit[kind] = balance;
             dprintf(REGIONS_LOG, ("distributing the %zd %s regions, removing %zd regions",
                 total_budget_in_region_units[kind],
                 kind_name[kind],
@@ -13611,60 +13672,6 @@ void gc_heap::distribute_free_regions()
                 }
             }
         }
-
-#ifdef MULTIPLE_HEAPS
-        if (balance != 0)
-        {
-            dprintf (REGIONS_LOG, ("distributing the %zd %s regions deficit", -balance, kind_name[kind]));
-
-            // we may have a deficit or  - if background GC is going on - a surplus.
-            // adjust the budget per heap accordingly
-
-            ptrdiff_t curr_balance = 0;
-            ptrdiff_t rem_balance = 0;
-            for (int i = 0; i < n_heaps; i++)
-            {
-                curr_balance += balance;
-                ptrdiff_t adjustment_per_heap = curr_balance / n_heaps;
-                curr_balance -= adjustment_per_heap * n_heaps;
-                ptrdiff_t new_budget = (ptrdiff_t)heap_budget_in_region_units[i][kind] + adjustment_per_heap;
-                ptrdiff_t min_budget = (kind == basic_free_region) ? (ptrdiff_t)min_heap_budget_in_region_units[i] : 0;
-                dprintf (REGIONS_LOG, ("adjusting the budget for heap %d from %zd %s regions by %zd to %zd",
-                    i,
-                    heap_budget_in_region_units[i][kind],
-                    kind_name[kind],
-                    adjustment_per_heap,
-                    max (min_budget, new_budget)));
-                heap_budget_in_region_units[i][kind] = max (min_budget, new_budget);
-                rem_balance += new_budget - heap_budget_in_region_units[i][kind];
-            }
-            assert (rem_balance <= 0);
-            dprintf (REGIONS_LOG, ("remaining balance: %zd %s regions", rem_balance, kind_name[kind]));
-
-            // if we have a left over deficit, distribute that to the heaps that still have more than the minimum
-            while (rem_balance < 0)
-            {
-                for (int i = 0; i < n_heaps; i++)
-                {
-                    size_t min_budget = (kind == basic_free_region) ? min_heap_budget_in_region_units[i] : 0;
-                    if (heap_budget_in_region_units[i][kind] > min_budget)
-                    {
-                        dprintf (REGIONS_LOG, ("adjusting the budget for heap %d from %zd %s regions by %d to %zd",
-                            i,
-                            heap_budget_in_region_units[i][kind],
-                            kind_name[kind],
-                            -1,
-                            heap_budget_in_region_units[i][kind] - 1));
-
-                        heap_budget_in_region_units[i][kind] -= 1;
-                        rem_balance += 1;
-                        if (rem_balance == 0)
-                            break;
-                    }
-                }
-            }
-        }
-#endif
     }
 
     for (int kind = basic_free_region; kind < kind_count; kind++)

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1445,7 +1445,6 @@ public:
     size_t get_num_free_regions();
     size_t get_size_committed_in_free() { return size_committed_in_free_regions; }
     size_t get_size_free_regions() { return size_free_regions; }
-    size_t get_size_free_regions(int max_age);
     heap_segment* get_first_free_region() { return head_free_region; }
     static void unlink_region (heap_segment* region);
     static void add_region (heap_segment* region, region_free_list to_free_list[count_free_region_kinds]);
@@ -6187,7 +6186,6 @@ public:
     // the region's free list.
     #define MAX_AGE_IN_FREE 99
     #define AGE_IN_FREE_TO_DECOMMIT 20
-    #define MIN_AGE_TO_DECOMMIT_HUGE 2
     int             age_in_free;
     // This is currently only used by regions that are swept in plan -
     // we then thread this list onto the generation's free list.


### PR DESCRIPTION
- Revert "[GC] Allow distribute_free_regions to decommit and redistribute (#106414)"

    This reverts commit 566a3bd57607bd92d163ebac5125d2f5ed0cab6a.
- Cherry-pick part of '[release/9.0] Revert "[GC] Avoid OOM in large-allocation-only workloads (#105521)" (#107712)', which is b27a8086

    The 9.0 revert already handled merge conflicts with bfb674ec, which is in main
    and 9.0.  However, this keeps the changes to age huge free regions.  Nothing is
    done with those ages, but this avoids churn to put it back in later.