### PR TITLE
linux/arm64: Verify TLS resolver code

### DIFF
--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -799,28 +799,81 @@ static void* GetTlsIndexObjectAddress();
 
 #if !defined(TARGET_OSX) && defined(TARGET_UNIX) && (defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64))
 extern "C" size_t GetTLSResolverAddress();
-#endif // !TARGET_OSX && TARGET_UNIX && (TARGET_ARM64 || TARGET_LOONGARCH64)
 
-bool CanJITOptimizeTLSAccess()
+// Check if the resolver address retrieval code is expected. We verify the exact
+// code sequence for all the instructions. However, for two instructions adrp/ldr,
+// we make sure that the instruction's opcode and registers matches.
+// If the resolver address retrieval code is correct, we invoke it to determine if
+// it is a static or dynamic resolver. TLS optimization is enabled only for for static
+// resolver. That's because for static resolver, the TP offset is same for all threads.
+// For dynamic resolver, TP offset returned is for the current thread and will be
+// different for the other threads.
+static bool IsValidTLSResolver()
 {
-    LIMITED_METHOD_CONTRACT;
+#define READ_CODE(p, code)                                      \
+    code = (p[3] << 24) | (p[2] << 16) | (p[1] << 8) | p[0];    \
+    p += 4;
 
-    bool optimizeThreadStaticAccess = false;
-#if defined(TARGET_ARM)
-    // Optimization is disabled for linux/windows arm
-#elif !defined(TARGET_WINDOWS) && defined(TARGET_X86)
-    // Optimization is disabled for linux/x86
-#elif defined(TARGET_LINUX_MUSL) && defined(TARGET_ARM64)
-    // Optimization is disabled for linux musl arm64
-#elif defined(TARGET_FREEBSD) && defined(TARGET_ARM64)
-    // Optimization is disabled for FreeBSD/arm64
-#elif defined(FEATURE_INTERPRETER)
-    // Optimization is disabled when interpreter may be used
-#elif !defined(TARGET_OSX) && defined(TARGET_UNIX) && defined(TARGET_ARM64)
-    // Optimization is enabled for linux/arm64 only for static resolver.
-    // For static resolver, the TP offset is same for all threads.
-    // For dynamic resolver, TP offset returned is for the current thread and
-    // will be different for the other threads.
+    uint32_t code;
+    uint8_t* p = reinterpret_cast<uint8_t*>(&GetTLSResolverAddress);
+
+    // stp     x29, x30, [sp, #-32]!
+    READ_CODE(p, code)
+    if (code != 0xA9BE7BFD)
+    {
+        return false;
+    }
+
+    // mov     x29, sp
+    READ_CODE(p, code)
+    if (code != 0x910003FD)
+    {
+        return false;
+    }
+
+    // adrp    x0, <address>
+    // 28:24 have 0x10 for adrp
+    // 4:0 should have x0
+    READ_CODE(p, code)
+    if ((code & 0x9F00001F) != 0x90000000)
+    {
+        return false;
+    }
+
+    // ldr     x0, [x0, <offet>]
+    READ_CODE(p, code)
+    // 31:24 have 0xf9 for ldr
+    // 23:22 have 01
+    // 9:5 have 0 for x0
+    // 4:0 have 1 for x1
+    if ((code & 0xFFC003FF) != 0xF9400001)
+    {
+        return false;
+    }
+
+    // mov     x0, x1
+    READ_CODE(p, code)
+    if (code != 0xAA0103E0)
+    {
+        return false;
+    }
+
+    // ldp     x29, x30, [sp], #32
+    READ_CODE(p, code)
+    if (code != 0xA8C27BFD)
+    {
+        return false;
+    }
+
+    // ret
+    READ_CODE(p, code)
+    if (code != 0xD65F03C0)
+    {
+        return false;
+    }
+
+    // Now invoke the code to retrieve the resolver address
+    // and verify if that is as expected.
     uint32_t* resolverAddress = reinterpret_cast<uint32_t*>(GetTLSResolverAddress());
     int ip = 0;
     if ((resolverAddress[ip] == 0xd503201f) || (resolverAddress[ip] == 0xd503241f))
@@ -838,13 +891,38 @@ bool CanJITOptimizeTLSAccess()
         (resolverAddress[ip + 1] == 0xd65f03c0)
     )
     {
+        return true;
+    }
+
+    return false;
+}
+#endif // !TARGET_OSX && TARGET_UNIX && (TARGET_ARM64 || TARGET_LOONGARCH64)
+
+bool CanJITOptimizeTLSAccess()
+{
+    LIMITED_METHOD_CONTRACT;
+    bool optimizeThreadStaticAccess = false;
+#if defined(TARGET_ARM)
+    // Optimization is disabled for linux/windows arm
+#elif !defined(TARGET_WINDOWS) && defined(TARGET_X86)
+    // Optimization is disabled for linux/x86
+#elif defined(TARGET_LINUX_MUSL) && defined(TARGET_ARM64)
+    // Optimization is disabled for linux musl arm64
+#elif defined(TARGET_FREEBSD) && defined(TARGET_ARM64)
+    // Optimization is disabled for FreeBSD/arm64
+#elif defined(FEATURE_INTERPRETER)
+    // Optimization is disabled when interpreter may be used
+#elif !defined(TARGET_OSX) && defined(TARGET_UNIX) && defined(TARGET_ARM64)
+    bool tlsResolverValid = IsValidTLSResolver();
+    if (tlsResolverValid)
+    {
         optimizeThreadStaticAccess = true;
 #ifdef _DEBUG
         if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_AssertNotStaticTlsResolver) != 0)
         {
             _ASSERTE(!"Detected static resolver in use when not expected");
         }
-#endif
+#endif // _DEBUG
     }
 #elif defined(TARGET_LOONGARCH64)
     // Optimization is enabled for linux/loongarch64 only for static resolver.

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -901,6 +901,11 @@ static bool IsValidTLSResolver()
 bool CanJITOptimizeTLSAccess()
 {
     LIMITED_METHOD_CONTRACT;
+    if (g_pConfig->DisableOptimizedThreadStaticAccess())
+    {
+        return false;
+    }
+
     bool optimizeThreadStaticAccess = false;
 #if defined(TARGET_ARM)
     // Optimization is disabled for linux/windows arm
@@ -955,11 +960,6 @@ bool CanJITOptimizeTLSAccess()
     optimizeThreadStaticAccess = GetTlsIndexObjectAddress() != nullptr;
 #endif // !TARGET_OSX && TARGET_UNIX && TARGET_AMD64
 #endif
-
-    if (g_pConfig->DisableOptimizedThreadStaticAccess())
-    {
-        optimizeThreadStaticAccess = false;
-    }
 
     return optimizeThreadStaticAccess;
 }


### PR DESCRIPTION
For linux/arm64, in #106052 , we added a piece of code to retrieve the TLS resolver to check if it is static or dynamic resolver and disable the TLS optimization if it was dynamic. In that, we disassemble the resolver address to check the instruction stream in order to determine if it is static or dynamic resolver. However, when SingleApps are compiled, we noticed that the TLS resolver address retrieval code was linked with different code sequence because of which it did not return the correct address of resolver that the caller was expecting. The caller simply tries to de-reference the value (it assumes it is a function pointer), but with invalid value, we would segfault. I added a check for the TLS resolver retrieval code itself to make sure that it is in correct format.

On my local machine, I was able to repro the original issue, but when I tried reproing it by pointing it to locally build `singleAppHost`, the resolver code did return an incorrect address, but it was not a totally invalid one and the code sequence was getting dereferenced and disassembled.  So, I was not able to see the segfault, but the existing checks were able to find out that the resolver is incorrect and was not doing the optimization. With the fix, I did verify that we would bail out even before invoking the resolver code.

I did locally verify that JIT linux/arm64 scenario still triggers the TLS optimization.

I do not have much knowledge about the SingleAppHost test, and there is a test hole because of which we were not able to catch this issue earlier. @agocke / @elinor-fung - I will need your help in writing and enabling a test for it. We can use the existing environment variable `DOTNET_DisableOptimizedThreadStaticAccess ` to make sure we hit the code path and validate the code.

The issue was reported by the customer in https://github.com/dotnet/runtime/issues/108327. 