### PR TITLE
Update System.Formats.Nrbf ref sources and restore package description

### DIFF
--- a/src/libraries/System.Formats.Nrbf/ref/System.Formats.Nrbf.cs
+++ b/src/libraries/System.Formats.Nrbf/ref/System.Formats.Nrbf.cs
@@ -77,8 +77,9 @@ namespace System.Formats.Nrbf
         public abstract System.Reflection.Metadata.TypeName TypeName { get; }
         public bool TypeNameMatches(System.Type type) { throw null; }
     }
-    public partial struct SerializationRecordId : System.IEquatable<System.Formats.Nrbf.SerializationRecordId>
+    public readonly partial struct SerializationRecordId : System.IEquatable<System.Formats.Nrbf.SerializationRecordId>
     {
+        private readonly int _dummyPrimitive;
         public bool Equals(System.Formats.Nrbf.SerializationRecordId other) { throw null; }
         public override bool Equals(object? obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/src/libraries/System.Formats.Nrbf/ref/System.Formats.Nrbf.cs
+++ b/src/libraries/System.Formats.Nrbf/ref/System.Formats.Nrbf.cs
@@ -9,11 +9,11 @@ namespace System.Formats.Nrbf
     public abstract partial class ArrayRecord : System.Formats.Nrbf.SerializationRecord
     {
         internal ArrayRecord() { }
+        public virtual long FlattenedLength { get { throw null; } }
         public override System.Formats.Nrbf.SerializationRecordId Id { get { throw null; } }
         public abstract System.ReadOnlySpan<int> Lengths { get; }
-        public virtual long FlattenedLength { get; }
         public int Rank { get { throw null; } }
-        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("The code for an array of the specified type might not be available.")]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("The code for an array of the specified type might not be available.")]
         public System.Array GetArray(System.Type expectedArrayType, bool allowNulls = true) { throw null; }
     }
     public abstract partial class ClassRecord : System.Formats.Nrbf.SerializationRecord
@@ -46,11 +46,11 @@ namespace System.Formats.Nrbf
     }
     public static partial class NrbfDecoder
     {
-        public static System.Formats.Nrbf.SerializationRecord Decode(System.IO.Stream payload, out System.Collections.Generic.IReadOnlyDictionary<System.Formats.Nrbf.SerializationRecordId, System.Formats.Nrbf.SerializationRecord> recordMap, System.Formats.Nrbf.PayloadOptions options=null, bool leaveOpen=false) { throw null; }
-        public static System.Formats.Nrbf.SerializationRecord Decode(System.IO.Stream payload, System.Formats.Nrbf.PayloadOptions? options=null, bool leaveOpen=false) { throw null; }
-        public static System.Formats.Nrbf.ClassRecord DecodeClassRecord(System.IO.Stream payload, System.Formats.Nrbf.PayloadOptions? options=null, bool leaveOpen=false) { throw null; }
-        public static bool StartsWithPayloadHeader(System.ReadOnlySpan<byte> bytes) { throw null; }
+        public static System.Formats.Nrbf.SerializationRecord Decode(System.IO.Stream payload, out System.Collections.Generic.IReadOnlyDictionary<System.Formats.Nrbf.SerializationRecordId, System.Formats.Nrbf.SerializationRecord> recordMap, System.Formats.Nrbf.PayloadOptions? options = null, bool leaveOpen = false) { throw null; }
+        public static System.Formats.Nrbf.SerializationRecord Decode(System.IO.Stream payload, System.Formats.Nrbf.PayloadOptions? options = null, bool leaveOpen = false) { throw null; }
+        public static System.Formats.Nrbf.ClassRecord DecodeClassRecord(System.IO.Stream payload, System.Formats.Nrbf.PayloadOptions? options = null, bool leaveOpen = false) { throw null; }
         public static bool StartsWithPayloadHeader(System.IO.Stream stream) { throw null; }
+        public static bool StartsWithPayloadHeader(System.ReadOnlySpan<byte> bytes) { throw null; }
     }
     public sealed partial class PayloadOptions
     {

--- a/src/libraries/System.Formats.Nrbf/src/System.Formats.Nrbf.csproj
+++ b/src/libraries/System.Formats.Nrbf/src/System.Formats.Nrbf.csproj
@@ -6,7 +6,6 @@
     <CLSCompliant>false</CLSCompliant>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides a safe reader for .NET Remoting Binary Format (NRBF) payloads.</PackageDescription>
-    <EnableDefaultPackageReadmeFile>true</EnableDefaultPackageReadmeFile>
 
     <!-- Disabling baseline validation since this is a brand new package.
          Once this package has shipped a stable version, the following line

--- a/src/libraries/System.Formats.Nrbf/src/System.Formats.Nrbf.csproj
+++ b/src/libraries/System.Formats.Nrbf/src/System.Formats.Nrbf.csproj
@@ -5,12 +5,13 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <CLSCompliant>false</CLSCompliant>
     <IsPackable>true</IsPackable>
+    <PackageDescription>Provides a safe reader for .NET Remoting Binary Format (NRBF) payloads.</PackageDescription>
+    <EnableDefaultPackageReadmeFile>true</EnableDefaultPackageReadmeFile>
 
     <!-- Disabling baseline validation since this is a brand new package.
          Once this package has shipped a stable version, the following line
          should be removed in order to re-enable validation. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
-    <EnableDefaultPackageReadmeFile>true</EnableDefaultPackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Experimentals.cs"

--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -157,6 +157,19 @@ namespace System.Reflection.Metadata
             void System.IDisposable.Dispose() { }
         }
     }
+    public sealed partial class AssemblyNameInfo
+    {
+        public AssemblyNameInfo(string name, System.Version? version = null, string? cultureName = null, System.Reflection.AssemblyNameFlags flags = System.Reflection.AssemblyNameFlags.None, System.Collections.Immutable.ImmutableArray<byte> publicKeyOrToken = default(System.Collections.Immutable.ImmutableArray<byte>)) { }
+        public string? CultureName { get { throw null; } }
+        public System.Reflection.AssemblyNameFlags Flags { get { throw null; } }
+        public string FullName { get { throw null; } }
+        public string Name { get { throw null; } }
+        public System.Collections.Immutable.ImmutableArray<byte> PublicKeyOrToken { get { throw null; } }
+        public System.Version? Version { get { throw null; } }
+        public static System.Reflection.Metadata.AssemblyNameInfo Parse(System.ReadOnlySpan<char> assemblyName) { throw null; }
+        public System.Reflection.AssemblyName ToAssemblyName() { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> assemblyName, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Reflection.Metadata.AssemblyNameInfo? result) { throw null; }
+    }
     public readonly partial struct AssemblyReference
     {
         private readonly object _dummy;
@@ -2408,25 +2421,11 @@ namespace System.Reflection.Metadata
         public int PackingSize { get { throw null; } }
         public int Size { get { throw null; } }
     }
-    public sealed partial class AssemblyNameInfo
-    {
-        public AssemblyNameInfo(string name, System.Version? version = null, string? cultureName = null, System.Reflection.AssemblyNameFlags flags = AssemblyNameFlags.None,
-           Collections.Immutable.ImmutableArray<byte> publicKeyOrToken = default) { }
-        public string Name { get { throw null; } }
-        public string? CultureName { get { throw null; } }
-        public string FullName { get { throw null; } }
-        public System.Version? Version { get { throw null; } }
-        public System.Reflection.AssemblyNameFlags Flags { get { throw null; } }
-        public System.Collections.Immutable.ImmutableArray<byte> PublicKeyOrToken { get { throw null; } }
-        public static System.Reflection.Metadata.AssemblyNameInfo Parse(System.ReadOnlySpan<char> assemblyName) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> assemblyName, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Reflection.Metadata.AssemblyNameInfo? result) { throw null; }
-        public System.Reflection.AssemblyName ToAssemblyName() { throw null; }
-    }
     public sealed partial class TypeName
     {
         internal TypeName() { }
+        public System.Reflection.Metadata.AssemblyNameInfo? AssemblyName { get { throw null; } }
         public string AssemblyQualifiedName { get { throw null; } }
-        public AssemblyNameInfo? AssemblyName { get { throw null; } }
         public System.Reflection.Metadata.TypeName DeclaringType { get { throw null; } }
         public string FullName { get { throw null; } }
         public bool IsArray { get { throw null; } }
@@ -2438,19 +2437,19 @@ namespace System.Reflection.Metadata
         public bool IsSZArray { get { throw null; } }
         public bool IsVariableBoundArrayType { get { throw null; } }
         public string Name { get { throw null; } }
-        public static System.Reflection.Metadata.TypeName Parse(System.ReadOnlySpan<char> typeName, System.Reflection.Metadata.TypeNameParseOptions? options = null) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> typeName, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Reflection.Metadata.TypeName? result, System.Reflection.Metadata.TypeNameParseOptions? options = null) { throw null; }
         public int GetArrayRank() { throw null; }
+        public System.Reflection.Metadata.TypeName GetElementType() { throw null; }
         public System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeName> GetGenericArguments() { throw null; }
         public System.Reflection.Metadata.TypeName GetGenericTypeDefinition() { throw null; }
-        public System.Reflection.Metadata.TypeName GetElementType() { throw null; }
         public int GetNodeCount() { throw null; }
-        public System.Reflection.Metadata.TypeName MakeSZArrayTypeName() { throw null; }
         public System.Reflection.Metadata.TypeName MakeArrayTypeName(int rank) { throw null; }
         public System.Reflection.Metadata.TypeName MakeByRefTypeName() { throw null; }
         public System.Reflection.Metadata.TypeName MakeGenericTypeName(System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeName> typeArguments) { throw null; }
         public System.Reflection.Metadata.TypeName MakePointerTypeName() { throw null; }
-        public System.Reflection.Metadata.TypeName WithAssemblyName(AssemblyNameInfo? assemblyName) { throw null; }
+        public System.Reflection.Metadata.TypeName MakeSZArrayTypeName() { throw null; }
+        public static System.Reflection.Metadata.TypeName Parse(System.ReadOnlySpan<char> typeName, System.Reflection.Metadata.TypeNameParseOptions? options = null) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> typeName, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Reflection.Metadata.TypeName? result, System.Reflection.Metadata.TypeNameParseOptions? options = null) { throw null; }
+        public System.Reflection.Metadata.TypeName WithAssemblyName(System.Reflection.Metadata.AssemblyNameInfo? assemblyName) { throw null; }
     }
     public sealed partial class TypeNameParseOptions
     {
@@ -2675,11 +2674,11 @@ namespace System.Reflection.Metadata.Ecma335
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public FieldTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;  }
+        public FieldTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null; }
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef = false) { throw null; }
-        public void TypedReference() { throw null; }
+        public void TypedReference() { }
     }
     public readonly partial struct FixedArgumentsEncoder
     {
@@ -3339,14 +3338,14 @@ namespace System.Reflection.PortableExecutable
         MipsFpu16 = (ushort)1126,
         Tricore = (ushort)1312,
         Ebc = (ushort)3772,
-        Amd64 = (ushort)34404,
-        M32R = (ushort)36929,
-        Arm64 = (ushort)43620,
-        LoongArch32 = (ushort)25138,
-        LoongArch64 = (ushort)25188,
         RiscV32 = (ushort)20530,
         RiscV64 = (ushort)20580,
         RiscV128 = (ushort)20776,
+        LoongArch32 = (ushort)25138,
+        LoongArch64 = (ushort)25188,
+        Amd64 = (ushort)34404,
+        M32R = (ushort)36929,
+        Arm64 = (ushort)43620,
     }
     public partial class ManagedPEBuilder : System.Reflection.PortableExecutable.PEBuilder
     {

--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -3120,8 +3120,10 @@ namespace System.Reflection.Metadata.Ecma335
         public void UIntPtr() { }
         public void VoidPointer() { }
     }
-    public readonly struct SwitchInstructionEncoder
+    public readonly partial struct SwitchInstructionEncoder
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public void Branch(System.Reflection.Metadata.Ecma335.LabelHandle label) { }
     }
     public enum TableIndex : byte


### PR DESCRIPTION
In [Mark the System.Formats.Nrbf assembly as [Experimental] with SYSLIB5005 (#107905)](https://github.com/dotnet/runtime/pull/107905), the System.Formats.Nrbf package description was removed entirely rather than being shortened. This restores the short package description that is used in tooling when the full package README isn't displayed.

I also found the ref source for System.Formats.Nrbf and System.Reflection.Metadata was out of sync. It looks like the files were hand-edited and there were a few details missing along with inconsistencies compared to what `dotnet msbuild /t:GenerateReferenceAssemblySource` generates.

The intention is to make these corrections for .NET 9, backporting to `release/9.0` after merged to main.