### PR TITLE
Enable build with Checked option for libraries configuration

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -15,7 +15,7 @@ Param(
   [switch]$cross = $false,
   [string][Alias('s')]$subset,
   [ValidateSet("Debug","Release","Checked")][string][Alias('rc')]$runtimeConfiguration,
-  [ValidateSet("Debug","Release")][string][Alias('lc')]$librariesConfiguration,
+  [ValidateSet("Debug","Release","Checked")][string][Alias('lc')]$librariesConfiguration,
   [ValidateSet("CoreCLR","Mono")][string][Alias('rf')]$runtimeFlavor,
   [ValidateSet("Debug","Release","Checked")][string][Alias('hc')]$hostConfiguration,
   [switch]$usemonoruntime = $false,
@@ -41,7 +41,7 @@ function Get-Help() {
   Write-Host "  -help (-h)                     Print help and exit."
   Write-Host "  -hostConfiguration (-hc)       Host build configuration: Debug, Release or Checked."
   Write-Host "                                 [Default: Debug]"
-  Write-Host "  -librariesConfiguration (-lc)  Libraries build configuration: Debug or Release."
+  Write-Host "  -librariesConfiguration (-lc)  Libraries build configuration: Debug, Release or Checked."
   Write-Host "                                 [Default: Debug]"
   Write-Host "  -os                            Target operating system: windows, linux, osx, android, wasi or browser."
   Write-Host "                                 [Default: Your machine's OS.]"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -384,12 +384,12 @@ while [[ $# > 0 ]]; do
       fi
       passedLibConf="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
       case "$passedLibConf" in
-        debug|release)
+        debug|release|checked)
           val="$(tr '[:lower:]' '[:upper:]' <<< ${passedLibConf:0:1})${passedLibConf:1}"
           ;;
         *)
           echo "Unsupported libraries configuration '$2'."
-          echo "The allowed values are Debug and Release."
+          echo "The allowed values are Debug, Release and Checked."
           exit 1
           ;;
       esac


### PR DESCRIPTION
Enabling build with Checked configuration for `-lc` / `-librariesConfiguration` switch as currently this option is blocked from build command. Such build can be done with `/p:LibrariesConfiguration=Checked` msbuild option and is working fine in case of FX tests for risc-v. 
Part of [#84834](https://github.com/dotnet/runtime/issues/84834)
cc @dotnet/samsung