### PR TITLE
[infra][android Disable Android ARM64 runtime tests job

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -13,44 +13,44 @@ jobs:
 #
 # Build the whole product using Mono for Android and run runtime tests with Android devices
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-    isAndroidOnlyBuild: ${{ parameters.isAndroidOnlyBuild }}
-    platforms:
-      - android_arm64
-    variables:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: pr/dotnet/runtime/$(Build.SourceBranch)
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: ci/dotnet/runtime/$(Build.SourceBranch)
-      - name: timeoutPerTestInMinutes
-        value: 60
-      - name: timeoutPerTestCollectionInMinutes
-        value: 180
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_RuntimeTests
-      runtimeVariant: minijit
-      buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 480
-      # don't run tests on PRs until we can get significantly more devices
-      # Turn off the testing for now, until https://github.com/dotnet/runtime/issues/60128 gets resolved
-      # ${{ if eq(variables['isRollingBuild'], true) }}:
-      #   # extra steps, run tests
-      #   postBuildSteps:
-      #     - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-      #       parameters:
-      #         creator: dotnet-bot
-      #         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-      #   extraVariablesTemplates:
-      #     - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+# Turn off the runtime testing for now, until https://github.com/dotnet/runtime/issues/60128 gets resolved
+# don't run tests on PRs until we can get significantly more devices
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     buildConfig: Release
+#     runtimeFlavor: mono
+#     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+#     isAndroidOnlyBuild: ${{ parameters.isAndroidOnlyBuild }}
+#     platforms:
+#       - android_arm64
+#     variables:
+#       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+#         - name: _HelixSource
+#           value: pr/dotnet/runtime/$(Build.SourceBranch)
+#       - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+#         - name: _HelixSource
+#           value: ci/dotnet/runtime/$(Build.SourceBranch)
+#       - name: timeoutPerTestInMinutes
+#         value: 60
+#       - name: timeoutPerTestCollectionInMinutes
+#         value: 180
+#     jobParameters:
+#       testGroup: innerloop
+#       nameSuffix: AllSubsets_Mono_RuntimeTests
+#       runtimeVariant: minijit
+#       buildArgs: -s mono+libs -c $(_BuildConfig)
+#       timeoutInMinutes: 480
+#       ${{ if eq(variables['isRollingBuild'], true) }}:
+#         # extra steps, run tests
+#         postBuildSteps:
+#           - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+#             parameters:
+#               creator: dotnet-bot
+#               testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+#         extraVariablesTemplates:
+#           - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
 #
 # Android devices


### PR DESCRIPTION
Currently, we don't run runtime tests on arm64 Android devices due to lack of capacity. This means that the `android-arm64 Release AllSubsets_Mono_RuntimeTests minijit` job is only building runtime for Android which we already do for libraries tests, hence not adding any value to the testing coverage.

This change is temporary until issue [#60128](https://github.com/dotnet/runtime/issues/60128) is resolved.
