### PR TITLE
Use architecture independent code paths in Array

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -928,11 +928,13 @@ namespace System
                                 result = GenericBinarySearch<ulong>(array, adjustedIndex, length, value);
                                 break;
                             case CorElementType.ELEMENT_TYPE_I:
-                                result = (IntPtr.Size == 4) ? GenericBinarySearch<int>(array, adjustedIndex, length, value) : GenericBinarySearch<long>(array, adjustedIndex, length, value);
-                                break;
+                                if (IntPtr.Size == 4)
+                                    goto case CorElementType.ELEMENT_TYPE_I4;
+                                goto case CorElementType.ELEMENT_TYPE_I8;
                             case CorElementType.ELEMENT_TYPE_U:
-                                result = (IntPtr.Size == 4) ? GenericBinarySearch<uint>(array, adjustedIndex, length, value) : GenericBinarySearch<ulong>(array, adjustedIndex, length, value);
-                                break;
+                                if (IntPtr.Size == 4)
+                                    goto case CorElementType.ELEMENT_TYPE_U4;
+                                goto case CorElementType.ELEMENT_TYPE_U8;
                             case CorElementType.ELEMENT_TYPE_R4:
                                 result = GenericBinarySearch<float>(array, adjustedIndex, length, value);
                                 break;
@@ -1426,8 +1428,9 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
-                            result = (IntPtr.Size == 4) ? GenericIndexOf<int>(array, value, adjustedIndex, count) : GenericIndexOf<long>(array, value, adjustedIndex, count);
-                            break;
+                            if (IntPtr.Size == 4)
+                                goto case CorElementType.ELEMENT_TYPE_I4;
+                            goto case CorElementType.ELEMENT_TYPE_I8;
                         case CorElementType.ELEMENT_TYPE_R4:
                             result = GenericIndexOf<float>(array, value, adjustedIndex, count);
                             break;
@@ -1652,8 +1655,9 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
-                            result = (IntPtr.Size == 4) ? GenericLastIndexOf<int>(array, value, adjustedIndex, count) : GenericLastIndexOf<long>(array, value, adjustedIndex, count);
-                            break;
+                            if (IntPtr.Size == 4)
+                                goto case CorElementType.ELEMENT_TYPE_I4;
+                            goto case CorElementType.ELEMENT_TYPE_I8;
                         case CorElementType.ELEMENT_TYPE_R4:
                             result = GenericLastIndexOf<float>(array, value, adjustedIndex, count);
                             break;
@@ -1860,10 +1864,8 @@ namespace System
                 case CorElementType.ELEMENT_TYPE_I:
                 case CorElementType.ELEMENT_TYPE_U:
                     if (IntPtr.Size == 4)
-                        UnsafeArrayAsSpan<int>(array, adjustedIndex, length).Reverse();
-                    else
-                        UnsafeArrayAsSpan<long>(array, adjustedIndex, length).Reverse();
-                    return;
+                        goto case CorElementType.ELEMENT_TYPE_I4;
+                    goto case CorElementType.ELEMENT_TYPE_I8;
                 case CorElementType.ELEMENT_TYPE_OBJECT:
                 case CorElementType.ELEMENT_TYPE_ARRAY:
                 case CorElementType.ELEMENT_TYPE_SZARRAY:
@@ -2067,16 +2069,12 @@ namespace System
                             return;
                         case CorElementType.ELEMENT_TYPE_I:
                             if (IntPtr.Size == 4)
-                                GenericSort<int>(keys, items, adjustedIndex, length);
-                            else
-                                GenericSort<long>(keys, items, adjustedIndex, length);
-                            return;
+                                goto case CorElementType.ELEMENT_TYPE_I4;
+                            goto case CorElementType.ELEMENT_TYPE_I8;
                         case CorElementType.ELEMENT_TYPE_U:
                             if (IntPtr.Size == 4)
-                                GenericSort<uint>(keys, items, adjustedIndex, length);
-                            else
-                                GenericSort<ulong>(keys, items, adjustedIndex, length);
-                            return;
+                                goto case CorElementType.ELEMENT_TYPE_U4;
+                            goto case CorElementType.ELEMENT_TYPE_U8;
                         case CorElementType.ELEMENT_TYPE_R4:
                             GenericSort<float>(keys, items, adjustedIndex, length);
                             return;

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -916,28 +916,22 @@ namespace System
                                 result = GenericBinarySearch<ushort>(array, adjustedIndex, length, value);
                                 break;
                             case CorElementType.ELEMENT_TYPE_I4:
-#if TARGET_32BIT
-                            case CorElementType.ELEMENT_TYPE_I:
-#endif
                                 result = GenericBinarySearch<int>(array, adjustedIndex, length, value);
                                 break;
                             case CorElementType.ELEMENT_TYPE_U4:
-#if TARGET_32BIT
-                            case CorElementType.ELEMENT_TYPE_U:
-#endif
                                 result = GenericBinarySearch<uint>(array, adjustedIndex, length, value);
                                 break;
                             case CorElementType.ELEMENT_TYPE_I8:
-#if TARGET_64BIT
-                            case CorElementType.ELEMENT_TYPE_I:
-#endif
                                 result = GenericBinarySearch<long>(array, adjustedIndex, length, value);
                                 break;
                             case CorElementType.ELEMENT_TYPE_U8:
-#if TARGET_64BIT
-                            case CorElementType.ELEMENT_TYPE_U:
-#endif
                                 result = GenericBinarySearch<ulong>(array, adjustedIndex, length, value);
+                                break;
+                            case CorElementType.ELEMENT_TYPE_I:
+                                result = (IntPtr.Size == 4) ? GenericBinarySearch<int>(array, adjustedIndex, length, value) : GenericBinarySearch<long>(array, adjustedIndex, length, value);
+                                break;
+                            case CorElementType.ELEMENT_TYPE_U:
+                                result = (IntPtr.Size == 4) ? GenericBinarySearch<uint>(array, adjustedIndex, length, value) : GenericBinarySearch<ulong>(array, adjustedIndex, length, value);
                                 break;
                             case CorElementType.ELEMENT_TYPE_R4:
                                 result = GenericBinarySearch<float>(array, adjustedIndex, length, value);
@@ -1424,19 +1418,15 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-#if TARGET_32BIT
-                        case CorElementType.ELEMENT_TYPE_I:
-                        case CorElementType.ELEMENT_TYPE_U:
-#endif
                             result = GenericIndexOf<int>(array, value, adjustedIndex, count);
                             break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-#if TARGET_64BIT
+                            result = GenericIndexOf<long>(array, value, adjustedIndex, count);
+                            break;
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
-#endif
-                            result = GenericIndexOf<long>(array, value, adjustedIndex, count);
+                            result = (IntPtr.Size == 4) ? GenericIndexOf<int>(array, value, adjustedIndex, count) : GenericIndexOf<long>(array, value, adjustedIndex, count);
                             break;
                         case CorElementType.ELEMENT_TYPE_R4:
                             result = GenericIndexOf<float>(array, value, adjustedIndex, count);
@@ -1654,19 +1644,15 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-#if TARGET_32BIT
-                        case CorElementType.ELEMENT_TYPE_I:
-                        case CorElementType.ELEMENT_TYPE_U:
-#endif
                             result = GenericLastIndexOf<int>(array, value, adjustedIndex, count);
                             break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-#if TARGET_64BIT
+                            result = GenericLastIndexOf<long>(array, value, adjustedIndex, count);
+                            break;
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
-#endif
-                            result = GenericLastIndexOf<long>(array, value, adjustedIndex, count);
+                            result = (IntPtr.Size == 4) ? GenericLastIndexOf<int>(array, value, adjustedIndex, count) : GenericLastIndexOf<long>(array, value, adjustedIndex, count);
                             break;
                         case CorElementType.ELEMENT_TYPE_R4:
                             result = GenericLastIndexOf<float>(array, value, adjustedIndex, count);
@@ -1863,21 +1849,20 @@ namespace System
                     return;
                 case CorElementType.ELEMENT_TYPE_I4:
                 case CorElementType.ELEMENT_TYPE_U4:
-#if TARGET_32BIT
-                case CorElementType.ELEMENT_TYPE_I:
-                case CorElementType.ELEMENT_TYPE_U:
-#endif
                 case CorElementType.ELEMENT_TYPE_R4:
                     UnsafeArrayAsSpan<int>(array, adjustedIndex, length).Reverse();
                     return;
                 case CorElementType.ELEMENT_TYPE_I8:
                 case CorElementType.ELEMENT_TYPE_U8:
-#if TARGET_64BIT
-                case CorElementType.ELEMENT_TYPE_I:
-                case CorElementType.ELEMENT_TYPE_U:
-#endif
                 case CorElementType.ELEMENT_TYPE_R8:
                     UnsafeArrayAsSpan<long>(array, adjustedIndex, length).Reverse();
+                    return;
+                case CorElementType.ELEMENT_TYPE_I:
+                case CorElementType.ELEMENT_TYPE_U:
+                    if (IntPtr.Size == 4)
+                        UnsafeArrayAsSpan<int>(array, adjustedIndex, length).Reverse();
+                    else
+                        UnsafeArrayAsSpan<long>(array, adjustedIndex, length).Reverse();
                     return;
                 case CorElementType.ELEMENT_TYPE_OBJECT:
                 case CorElementType.ELEMENT_TYPE_ARRAY:
@@ -2069,28 +2054,28 @@ namespace System
                             GenericSort<ushort>(keys, items, adjustedIndex, length);
                             return;
                         case CorElementType.ELEMENT_TYPE_I4:
-#if TARGET_32BIT
-                        case CorElementType.ELEMENT_TYPE_I:
-#endif
                             GenericSort<int>(keys, items, adjustedIndex, length);
                             return;
                         case CorElementType.ELEMENT_TYPE_U4:
-#if TARGET_32BIT
-                        case CorElementType.ELEMENT_TYPE_U:
-#endif
                             GenericSort<uint>(keys, items, adjustedIndex, length);
                             return;
                         case CorElementType.ELEMENT_TYPE_I8:
-#if TARGET_64BIT
-                        case CorElementType.ELEMENT_TYPE_I:
-#endif
                             GenericSort<long>(keys, items, adjustedIndex, length);
                             return;
                         case CorElementType.ELEMENT_TYPE_U8:
-#if TARGET_64BIT
-                        case CorElementType.ELEMENT_TYPE_U:
-#endif
                             GenericSort<ulong>(keys, items, adjustedIndex, length);
+                            return;
+                        case CorElementType.ELEMENT_TYPE_I:
+                            if (IntPtr.Size == 4)
+                                GenericSort<int>(keys, items, adjustedIndex, length);
+                            else
+                                GenericSort<long>(keys, items, adjustedIndex, length);
+                            return;
+                        case CorElementType.ELEMENT_TYPE_U:
+                            if (IntPtr.Size == 4)
+                                GenericSort<uint>(keys, items, adjustedIndex, length);
+                            else
+                                GenericSort<ulong>(keys, items, adjustedIndex, length);
                             return;
                         case CorElementType.ELEMENT_TYPE_R4:
                             GenericSort<float>(keys, items, adjustedIndex, length);


### PR DESCRIPTION
We at Unity have [in-progress work towards a modern .NET ecosystem](https://discussions.unity.com/t/coreclr-and-net-modernization-unite-2024/1519272) enabled by adopting CoreCLR in lieu of Mono and updating IL2CPP to support the .NET BCL. I am investigating how architecture specific code paths can be reduced if not completely removed in the .NET BCL. I understand this architecture agnostic approach is not the direction of .NET in general, but I am hoping to validate how to best approach this without maintaining a completely separate fork.

The current BCL, more specifically `System.Private.Corlib`, has a non-trivial number of preprocessor checks for architecture/bit specific code. At Unity, our IL2CPP AOT compiler has historically consumed the Mono BCL which was architecture agnostic. This enabled a number of benefits for us when targeting multiple architectures such as reduced iteration time via a single managed linker step and transpile step to C++, and reduced deployment size via sharing our binary metadata file between architectures (produced during transpile).

In this preliminary PR, I include two commits with possible approaches that I wanted to validate before submitting larger PRs. In the first commit, native sized integers (`nint` & `nuint`) are used rather than a preprocessor check and `int` & `long` types. In the second commit, the `int` & `long` types remain in use but are switched via a `IntPtr.Size` check.

A few questions:
1. Any preference on either commit as a general approach when possible?
2. What metrics should be evaluated when making such changes? Are there sufficient performance and size tests run as part of the automated PR process?
3. In [more complex scenarios where the preprocessor checks are used](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs#L1920), does a new architecture independent target, e.g. `TARGET_ARCH_NEUTRAL`, make sense to introduce and use alongside the existing code paths? I would expect this path to contain both implementations with a runtime check similar to commit 2 in this PR.

Thanks for any feedback!