### PR TITLE
Fix buffer dropped reason in ConfigurableArrayPool

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ConfigurableArrayPool.cs
@@ -149,7 +149,7 @@ namespace System.Buffers
                 log.BufferReturned(bufferId, array.Length, Id);
                 if (!haveBucket)
                 {
-                    log.BufferDropped(bufferId, array.Length, Id, ArrayPoolEventSource.NoBucketId, ArrayPoolEventSource.BufferDroppedReason.Full);
+                    log.BufferDropped(bufferId, array.Length, Id, ArrayPoolEventSource.NoBucketId, ArrayPoolEventSource.BufferDroppedReason.OverMaximumSize);
                 }
             }
         }


### PR DESCRIPTION
This log is emitted when a buffer is returned to a ConfigurableArrayPool but its size was higher than the highest bucket, so if I'm not mistaken, the reason should be BufferDroppedReason.OverMaximumSize.