### PR TITLE
[release/9.0] Fix devirtualization across genericness in the hierarchy

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -559,7 +559,7 @@ namespace ILCompiler
                                 if (currentType == null)
                                     return vtable;
 
-                                BuildVTable(factory, currentType.BaseType?.ConvertToCanonForm(CanonicalFormKind.Specific), implType, vtable);
+                                BuildVTable(factory, currentType.BaseType, implType, vtable);
 
                                 IReadOnlyList<MethodDesc> slice = factory.VTable(currentType).Slots;
                                 foreach (MethodDesc decl in slice)
@@ -571,19 +571,19 @@ namespace ILCompiler
                                 return vtable;
                             }
 
-                            baseType = canonType.BaseType?.ConvertToCanonForm(CanonicalFormKind.Specific);
-                            if (!canonType.IsArray && baseType != null)
+                            baseType = type.BaseType;
+                            if (!type.IsArray && baseType != null)
                             {
                                 if (!vtables.TryGetValue(baseType, out List<MethodDesc> baseVtable))
                                     vtables.Add(baseType, baseVtable = BuildVTable(factory, baseType, baseType, new List<MethodDesc>()));
 
-                                if (!vtables.TryGetValue(canonType, out List<MethodDesc> vtable))
-                                    vtables.Add(canonType, vtable = BuildVTable(factory, canonType, canonType, new List<MethodDesc>()));
+                                if (!vtables.TryGetValue(type, out List<MethodDesc> vtable))
+                                    vtables.Add(type, vtable = BuildVTable(factory, type, type, new List<MethodDesc>()));
 
                                 for (int i = 0; i < baseVtable.Count; i++)
                                 {
                                     if (baseVtable[i] != vtable[i])
-                                        _overridenMethods.Add(baseVtable[i]);
+                                        _overridenMethods.Add(baseVtable[i].GetCanonMethodTarget(CanonicalFormKind.Specific));
                                 }
                             }
                         }

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Devirtualization.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Devirtualization.cs
@@ -12,6 +12,7 @@ class Devirtualization
     internal static int Run()
     {
         RegressionBug73076.Run();
+        RegressionGenericHierarchy.Run();
         DevirtualizationCornerCaseTests.Run();
         DevirtualizeIntoUnallocatedGenericType.Run();
 
@@ -50,6 +51,36 @@ class Devirtualization
             var made = factory.Make<object>();
             if (made.GetId() != "Derived")
                 throw new Exception();
+        }
+    }
+
+    class RegressionGenericHierarchy
+    {
+        class Base<T>
+        {
+            public virtual string Print() => "Base<T>";
+        }
+
+        class Mid : Base<Atom>
+        {
+            public override string Print() => "Mid";
+            public override string ToString() => Print();
+        }
+
+        class Derived : Mid
+        {
+            public override string Print() => "Derived";
+        }
+
+        class Atom { }
+
+        public static void Run()
+        {
+            if (Get().ToString() != "Derived")
+                throw new Exception();
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static object Get() => new Derived();
         }
     }
 


### PR DESCRIPTION
Backport of #108442 to release/9.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

A new optimization added in 9.0 was causing incorrect devirtualization to a method on a base class instead of the correct more derived class.

## Regression

- [x] Yes
- [ ] No

Introduced in #97812 when the optimization was added.

## Testing

This was found when I was making devirtualization kick in even more often in a .NET 10 PR. It is however hittable in .NET 9 too.

## Risk

Should be low. The change was straightforward and none of our test passes found problems with it.
