### PR TITLE
[browser][MT] fix rooting JSWebWorkerInstance

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSWebWorker.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSWebWorker.cs
@@ -64,7 +64,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 // We don't want the continuations of that task to run on JSWebWorker
                 // only the tasks created inside of the callback should run in JSWebWorker
                 // TODO TaskCreationOptions.HideScheduler ?
-                _taskCompletionSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _taskCompletionSource = new TaskCompletionSource<T>(this, TaskCreationOptions.RunContinuationsAsynchronously);
                 _thread = new Thread(ThreadMain);
                 _thread.Name = "JSWebWorker";
                 _resultTask = null;


### PR DESCRIPTION
Pass instance of `JSWebWorkerInstance`  to `Task.AsyncState` to keep it alive as long as the `Task` is not collected.

Fixes https://github.com/dotnet/runtime/issues/102010