### PR TITLE
Added DateOnly overload methods to IsoWeek

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
@@ -31,7 +31,7 @@ namespace System
 
         private static int DayNumberFromDateTime(DateTime dt) => (int)((ulong)dt.Ticks / TimeSpan.TicksPerDay);
 
-        private DateTime GetEquivalentDateTime() => DateTime.UnsafeCreate(_dayNumber * TimeSpan.TicksPerDay);
+        internal DateTime GetEquivalentDateTime() => DateTime.UnsafeCreate(_dayNumber * TimeSpan.TicksPerDay);
 
         private DateOnly(int dayNumber)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
@@ -34,6 +34,11 @@ namespace System.Globalization
             return week;
         }
 
+        /// <summary>
+        /// Calculates the ISO week number of a given Gregorian date.
+        /// </summary>
+        /// <param name="date">A date in the Gregorian calendar.</param>
+        /// <returns>A number between 1 and 53 representing the ISO week number of the given Gregorian date.</returns>
         public static int GetWeekOfYear(DateOnly date) => GetWeekOfYear(date.GetEquivalentDateTime());
 
         public static int GetYear(DateTime date)
@@ -57,6 +62,11 @@ namespace System.Globalization
             return date.Year;
         }
 
+        /// <summary>
+        /// Calculates the ISO week-numbering year (also called ISO year informally) mapped to the input Gregorian date.
+        /// </summary>
+        /// <param name="date">A date in the Gregorian calendar.</param>
+        /// <returns>The ISO week-numbering year, between 1 and 9999</returns>
         public static int GetYear(DateOnly date) => GetYear(date.GetEquivalentDateTime());
 
         // The year parameter represents an ISO week-numbering year (also called ISO year informally).
@@ -142,6 +152,14 @@ namespace System.Globalization
             return new DateTime(year, month: 1, day: 1).AddDays(ordinal - 1);
         }
 
+
+        /// <summary>
+        /// Maps the ISO week date represented by a specified ISO year, week number, and day of week to the equivalent Gregorian date.
+        /// </summary>
+        /// <param name="year">An ISO week-numbering year (also called an ISO year informally).</param>
+        /// <param name="week">The ISO week number in the given ISO week-numbering year.</param>
+        /// <param name="dayOfWeek">The day of week inside the given ISO week.</param>
+        /// <returns>The Gregorian date equivalent to the input ISO week date.</returns>
         public static DateOnly ToDateOnly(int year, int week, DayOfWeek dayOfWeek) => DateOnly.FromDateTime(ToDateTime(year, week, dayOfWeek));
 
         // From https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_of_a_given_date:

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
@@ -34,6 +34,8 @@ namespace System.Globalization
             return week;
         }
 
+        public static int GetWeekOfYear(DateOnly date) => GetWeekOfYear(date.GetEquivalentDateTime());
+
         public static int GetYear(DateTime date)
         {
             int week = GetWeekNumber(date);
@@ -54,6 +56,8 @@ namespace System.Globalization
 
             return date.Year;
         }
+
+        public static int GetYear(DateOnly date) => GetYear(date.GetEquivalentDateTime());
 
         // The year parameter represents an ISO week-numbering year (also called ISO year informally).
         // Each week's year is the Gregorian year in which the Thursday falls.
@@ -137,6 +141,8 @@ namespace System.Globalization
 
             return new DateTime(year, month: 1, day: 1).AddDays(ordinal - 1);
         }
+
+        public static DateOnly ToDateOnly(int year, int week, DayOfWeek dayOfWeek) => DateOnly.FromDateTime(ToDateTime(year, week, dayOfWeek));
 
         // From https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_of_a_given_date:
         //

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9471,11 +9471,14 @@ namespace System.Globalization
     }
     public static partial class ISOWeek
     {
+        public static int GetWeekOfYear(System.DateOnly date) { throw null; }
         public static int GetWeekOfYear(System.DateTime date) { throw null; }
         public static int GetWeeksInYear(int year) { throw null; }
+        public static int GetYear(System.DateOnly date) { throw null; }
         public static int GetYear(System.DateTime date) { throw null; }
         public static System.DateTime GetYearEnd(int year) { throw null; }
         public static System.DateTime GetYearStart(int year) { throw null; }
+        public static System.DateOnly ToDateOnly(int year, int week, System.DayOfWeek dayOfWeek) { throw null; }
         public static System.DateTime ToDateTime(int year, int week, System.DayOfWeek dayOfWeek) { throw null; }
     }
     public partial class JapaneseCalendar : System.Globalization.Calendar

--- a/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/ISOWeek/ISOWeekTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/ISOWeek/ISOWeekTests.cs
@@ -147,6 +147,7 @@ namespace System.Globalization
         public static void ToDateTime_WithInvalidYear_Throws(int year)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(year), () => ISOWeek.ToDateTime(year, 1, DayOfWeek.Friday));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(year), () => ISOWeek.ToDateOnly(year, 1, DayOfWeek.Friday));
         }
 
         [Theory]
@@ -155,6 +156,7 @@ namespace System.Globalization
         public static void ToDateTime_WithInvalidWeek_Throws(int week)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(week), () => ISOWeek.ToDateTime(2018, week, DayOfWeek.Friday));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(week), () => ISOWeek.ToDateOnly(2018, week, DayOfWeek.Friday));
         }
 
         [Theory]
@@ -163,29 +165,6 @@ namespace System.Globalization
         public static void ToDateTime_WithInvalidDayOfWeek_Throws(int dayOfWeek)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(dayOfWeek), () => ISOWeek.ToDateTime(2018, 1, (DayOfWeek)dayOfWeek));
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(10000)]
-        public static void ToDateOnly_WithInvalidYear_Throws(int year)
-        {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(year), () => ISOWeek.ToDateOnly(year, 1, DayOfWeek.Friday));
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(54)]
-        public static void ToDateOnly_WithInvalidWeek_Throws(int week)
-        {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(week), () => ISOWeek.ToDateOnly(2018, week, DayOfWeek.Friday));
-        }
-
-        [Theory]
-        [InlineData(-1)]
-        [InlineData(8)]
-        public static void ToDateOnly_WithInvalidDayOfWeek_Throws(int dayOfWeek)
-        {
             AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(dayOfWeek), () => ISOWeek.ToDateOnly(2018, 1, (DayOfWeek)dayOfWeek));
         }
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/ISOWeek/ISOWeekTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/ISOWeek/ISOWeekTests.cs
@@ -70,14 +70,29 @@ namespace System.Globalization
             return s_dateData.Select(x => new object[] {x.Date, x.Week});
         }
 
+        public static IEnumerable<object[]> GetWeekOfYear_DateOnly_TestData()
+        {
+            return s_dateData.Select(x => new object[] { DateOnly.FromDateTime(x.Date), x.Week});
+        }
+
         public static IEnumerable<object[]> GetYear_TestData()
         {
             return s_dateData.Select(x => new object[] {x.Date, x.Year});
         }
 
+        public static IEnumerable<object[]> GetYear_DateOnly_TestData()
+        {
+            return s_dateData.Select(x => new object[] { DateOnly.FromDateTime(x.Date), x.Year});
+        }
+
         public static IEnumerable<object[]> ToDateTime_TestData()
         {
             return s_dateData.Select(x => new object[] {x.Year, x.Week, x.DayOfWeek, x.Date});
+        }
+
+        public static IEnumerable<object[]> ToDateOnly_TestData()
+        {
+            return s_dateData.Select(x => new object[] {x.Year, x.Week, x.DayOfWeek, DateOnly.FromDateTime(x.Date)});
         }
 
         public static IEnumerable<object[]> GetYearStart_TestData()
@@ -96,8 +111,20 @@ namespace System.Globalization
             Assert.Equal(expected, ISOWeek.GetWeekOfYear(date));
         }
 
+        [Theory, MemberData(nameof(GetWeekOfYear_DateOnly_TestData))]
+        public static void GetWeekOfYear(DateOnly date, int expected)
+        {
+            Assert.Equal(expected, ISOWeek.GetWeekOfYear(date));
+        }
+
         [Theory, MemberData(nameof(GetYear_TestData))]
         public static void GetYear(DateTime date, int expected)
+        {
+            Assert.Equal(expected, ISOWeek.GetYear(date));
+        }
+
+        [Theory, MemberData(nameof(GetYear_DateOnly_TestData))]
+        public static void GetYear(DateOnly date, int expected)
         {
             Assert.Equal(expected, ISOWeek.GetYear(date));
         }
@@ -106,6 +133,12 @@ namespace System.Globalization
         public static void ToDateTime(int year, int week, DayOfWeek dayOfWeek, DateTime expected)
         {
             Assert.Equal(expected, ISOWeek.ToDateTime(year, week, dayOfWeek));
+        }
+
+        [Theory, MemberData(nameof(ToDateOnly_TestData))]
+        public static void ToDateOnly(int year, int week, DayOfWeek dayOfWeek, DateOnly expected)
+        {
+            Assert.Equal(expected, ISOWeek.ToDateOnly(year, week, dayOfWeek));
         }
 
         [Theory]
@@ -130,6 +163,30 @@ namespace System.Globalization
         public static void ToDateTime_WithInvalidDayOfWeek_Throws(int dayOfWeek)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(dayOfWeek), () => ISOWeek.ToDateTime(2018, 1, (DayOfWeek)dayOfWeek));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10000)]
+        public static void ToDateOnly_WithInvalidYear_Throws(int year)
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(year), () => ISOWeek.ToDateOnly(year, 1, DayOfWeek.Friday));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(54)]
+        public static void ToDateOnly_WithInvalidWeek_Throws(int week)
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(week), () => ISOWeek.ToDateOnly(2018, week, DayOfWeek.Friday));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(8)]
+        public static void ToDateOnly_WithInvalidDayOfWeek_Throws(int dayOfWeek)
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(nameof(dayOfWeek), () => ISOWeek.ToDateOnly(2018, 1, (DayOfWeek)dayOfWeek));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/ISOWeek/ISOWeekTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/ISOWeek/ISOWeekTests.cs
@@ -112,7 +112,7 @@ namespace System.Globalization
         }
 
         [Theory, MemberData(nameof(GetWeekOfYear_DateOnly_TestData))]
-        public static void GetWeekOfYear(DateOnly date, int expected)
+        public static void GetWeekOfYearUsingDateOnly(DateOnly date, int expected)
         {
             Assert.Equal(expected, ISOWeek.GetWeekOfYear(date));
         }
@@ -124,7 +124,7 @@ namespace System.Globalization
         }
 
         [Theory, MemberData(nameof(GetYear_DateOnly_TestData))]
-        public static void GetYear(DateOnly date, int expected)
+        public static void GetYearUsingDateOnly(DateOnly date, int expected)
         {
             Assert.Equal(expected, ISOWeek.GetYear(date));
         }


### PR DESCRIPTION
Fixes #101597

As discussed in proposal #101597