### PR TITLE
Improve software exception handling performance

### DIFF
--- a/src/coreclr/inc/vptr_list.h
+++ b/src/coreclr/inc/vptr_list.h
@@ -55,6 +55,9 @@ VPTR_CLASS(DebuggerSecurityCodeMarkFrame)
 VPTR_CLASS(DebuggerExitFrame)
 VPTR_CLASS(DebuggerU2MCatchHandlerFrame)
 VPTR_CLASS(FaultingExceptionFrame)
+#ifdef FEATURE_EH_FUNCLETS
+VPTR_CLASS(SoftwareExceptionFrame)
+#endif // FEATURE_EH_FUNCLETS
 VPTR_CLASS(FuncEvalFrame)
 VPTR_CLASS(HelperMethodFrame)
 VPTR_CLASS(HelperMethodFrame_1OBJ)

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -11591,7 +11591,7 @@ void SoftwareExceptionFrame::Init()
 {
     WRAPPER_NO_CONTRACT;
 
-#define CALLEE_SAVED_REGISTER(regname) m_ContextPointers.regname = &m_Context.regname;
+#define CALLEE_SAVED_REGISTER(regname) m_ContextPointers.regname = NULL;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
@@ -11605,6 +11605,10 @@ void SoftwareExceptionFrame::Init()
         EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
     }
 #endif // !TARGET_UNIX
+
+#define CALLEE_SAVED_REGISTER(regname) if (m_ContextPointers.regname == NULL) m_ContextPointers.regname = &m_Context.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
 
     _ASSERTE(ExecutionManager::IsManagedCode(::GetIP(&m_Context)));
 

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -806,10 +806,10 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
             *(&__exceptionFrame)->GetGSCookiePtr() = GetProcessGSCookie(); \
             RtlCaptureContext(__exceptionFrame.GetContext()); \
             __exceptionFrame.InitAndLink(GET_THREAD(), funCallDepth); \
-            FC_CAN_TRIGGER_GC_HAVE_THREAD(GET_THREAD())
+            FC_CAN_TRIGGER_GC()
 
 #define EXCEPTION_METHOD_FRAME_END() \
-            FC_CAN_TRIGGER_GC_HAVE_THREADEND(GET_THREAD()) \
+            FC_CAN_TRIGGER_GC_END(); \
         } \
         while (0)
 
@@ -905,8 +905,6 @@ void HCallAssert(void*& cache, void* target);
 #define FC_COMMON_PROLOG(target, assertFn) FCALL_TRANSITION_BEGIN()
 #define FC_CAN_TRIGGER_GC()
 #define FC_CAN_TRIGGER_GC_END()
-#define FC_CAN_TRIGGER_GC_HAVE_THREAD(thread)
-#define FC_CAN_TRIGGER_GC_HAVE_THREADEND(thread)
 #endif // ENABLE_CONTRACTS
 
 // #FC_INNER

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -799,13 +799,13 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
 #define HELPER_METHOD_FRAME_GET_RETURN_ADDRESS()                                        \
     ( static_cast<UINT_PTR>( (__helperframe.InsureInit(NULL)), (__helperframe.MachineState()->GetRetAddr()) ) )
 
-#define EXCEPTION_METHOD_FRAME_BEGIN(funCallDepth) \
+#define EXCEPTION_METHOD_FRAME_BEGIN() \
         do \
         { \
             FrameWithCookie<SoftwareExceptionFrame> __exceptionFrame; \
             *(&__exceptionFrame)->GetGSCookiePtr() = GetProcessGSCookie(); \
             RtlCaptureContext(__exceptionFrame.GetContext()); \
-            __exceptionFrame.InitAndLink(GET_THREAD(), funCallDepth); \
+            __exceptionFrame.InitAndLink(GET_THREAD()); \
             FC_CAN_TRIGGER_GC()
 
 #define EXCEPTION_METHOD_FRAME_END() \

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -799,22 +799,6 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
 #define HELPER_METHOD_FRAME_GET_RETURN_ADDRESS()                                        \
     ( static_cast<UINT_PTR>( (__helperframe.InsureInit(NULL)), (__helperframe.MachineState()->GetRetAddr()) ) )
 
-#define EXCEPTION_METHOD_FRAME_BEGIN() \
-        do \
-        { \
-            FrameWithCookie<SoftwareExceptionFrame> __exceptionFrame; \
-            *(&__exceptionFrame)->GetGSCookiePtr() = GetProcessGSCookie(); \
-            RtlCaptureContext(__exceptionFrame.GetContext()); \
-            __exceptionFrame.InitAndLink(GET_THREAD()); \
-            FC_CAN_TRIGGER_GC()
-
-#define EXCEPTION_METHOD_FRAME_END() \
-            FC_CAN_TRIGGER_GC_END(); \
-        } \
-        while (0)
-
-#define EXCEPTION_METHOD_FRAME_GET_CONTEXT() (__exceptionFrame.GetContext())
-
     // Very short routines, or routines that are guaranteed to force GC or EH
     // don't need to poll the GC.  USE VERY SPARINGLY!!!
 #define FC_GC_POLL_NOT_NEEDED()    INCONTRACT(__fCallCheck.SetNotNeeded())

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -190,6 +190,9 @@ FRAME_TYPE_NAME(ResumableFrame)
 FRAME_TYPE_NAME(RedirectedThreadFrame)
 #endif // FEATURE_HIJACK
 FRAME_TYPE_NAME(FaultingExceptionFrame)
+#ifdef FEATURE_EH_FUNCLETS
+FRAME_TYPE_NAME(SoftwareExceptionFrame)
+#endif // FEATURE_EH_FUNCLETS
 #ifdef DEBUGGING_SUPPORTED
 FRAME_TYPE_NAME(FuncEvalFrame)
 #endif // DEBUGGING_SUPPORTED
@@ -1145,6 +1148,69 @@ public:
     // Keep as last entry in class
     DEFINE_VTABLE_GETTER_AND_DTOR(FaultingExceptionFrame)
 };
+
+#ifdef FEATURE_EH_FUNCLETS
+
+class SoftwareExceptionFrame : public Frame
+{
+    TADDR                           m_ReturnAddress;
+    T_CONTEXT                       m_Context;
+    T_KNONVOLATILE_CONTEXT_POINTERS m_ContextPointers;
+
+    VPTR_VTABLE_CLASS(SoftwareExceptionFrame, Frame)
+
+public:
+#ifndef DACCESS_COMPILE
+    SoftwareExceptionFrame() {
+        LIMITED_METHOD_CONTRACT;
+    }
+#endif
+
+    virtual TADDR GetReturnAddressPtr()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return PTR_HOST_MEMBER_TADDR(SoftwareExceptionFrame, this, m_ReturnAddress);
+    }
+
+    void Init(int funCallDepth);
+    void InitAndLink(Thread *pThread, int funCallDepth);
+
+    Interception GetInterception()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return INTERCEPTION_EXCEPTION;
+    }
+
+    virtual ETransitionType GetTransitionType()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return TT_InternalCall;
+    }
+
+    unsigned GetFrameAttribs()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return FRAME_ATTR_EXCEPTION;
+    }
+
+    T_CONTEXT* GetContext()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return &m_Context;
+    }
+
+    virtual BOOL NeedsUpdateRegDisplay()
+    {
+        return TRUE;
+    }
+
+    virtual void UpdateRegDisplay(const PREGDISPLAY, bool updateFloats = false);
+
+    // Keep as last entry in class
+    DEFINE_VTABLE_GETTER_AND_DTOR(SoftwareExceptionFrame)
+};
+
+#endif // FEATURE_EH_FUNCLETS
 
 //-----------------------------------------------------------------------
 // Frame for debugger function evaluation
@@ -3190,6 +3256,7 @@ public:
     void Poll() { WRAPPER_NO_CONTRACT; m_frame.Poll(); }
     void SetStackPointerPtr(TADDR sp) { WRAPPER_NO_CONTRACT; m_frame.SetStackPointerPtr(sp); }
     void InitAndLink(T_CONTEXT *pContext) { WRAPPER_NO_CONTRACT; m_frame.InitAndLink(pContext); }
+    void InitAndLink(Thread *pThread, int funCallDepth) { WRAPPER_NO_CONTRACT; m_frame.InitAndLink(pThread, funCallDepth); }
     void Init(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior)
         { WRAPPER_NO_CONTRACT; m_frame.Init(pThread, pObjRefs, numObjRefs, maybeInterior); }
     ValueClassInfo ** GetValueClassInfoList() { WRAPPER_NO_CONTRACT; return m_frame.GetValueClassInfoList(); }

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -1172,8 +1172,8 @@ public:
         return PTR_HOST_MEMBER_TADDR(SoftwareExceptionFrame, this, m_ReturnAddress);
     }
 
-    void Init(int funCallDepth);
-    void InitAndLink(Thread *pThread, int funCallDepth);
+    void Init();
+    void InitAndLink(Thread *pThread);
 
     Interception GetInterception()
     {
@@ -3256,7 +3256,7 @@ public:
     void Poll() { WRAPPER_NO_CONTRACT; m_frame.Poll(); }
     void SetStackPointerPtr(TADDR sp) { WRAPPER_NO_CONTRACT; m_frame.SetStackPointerPtr(sp); }
     void InitAndLink(T_CONTEXT *pContext) { WRAPPER_NO_CONTRACT; m_frame.InitAndLink(pContext); }
-    void InitAndLink(Thread *pThread, int funCallDepth) { WRAPPER_NO_CONTRACT; m_frame.InitAndLink(pThread, funCallDepth); }
+    void InitAndLink(Thread *pThread) { WRAPPER_NO_CONTRACT; m_frame.InitAndLink(pThread); }
     void Init(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior)
         { WRAPPER_NO_CONTRACT; m_frame.Init(pThread, pObjRefs, numObjRefs, maybeInterior); }
     ValueClassInfo ** GetValueClassInfoList() { WRAPPER_NO_CONTRACT; return m_frame.GetValueClassInfoList(); }

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -2691,7 +2691,7 @@ HCIMPL1(void, IL_Throw,  Object* obj)
     {
         MAKE_CURRENT_THREAD_AVAILABLE();
 
-        EXCEPTION_METHOD_FRAME_BEGIN(1);
+        EXCEPTION_METHOD_FRAME_BEGIN();
 
         if (oref == 0)
             DispatchManagedException(kNullReferenceException);
@@ -2777,7 +2777,7 @@ HCIMPL0(void, IL_Rethrow)
     {
         MAKE_CURRENT_THREAD_AVAILABLE();
 
-        EXCEPTION_METHOD_FRAME_BEGIN(1);
+        EXCEPTION_METHOD_FRAME_BEGIN();
 
         Thread *pThread = GET_THREAD();
 


### PR DESCRIPTION
I have recently discovered that large part of the time spent in the EH while handling software exception is in the `RtlLookupFunctionEntry` Windows API. That API is called when unwinding native (non-managed) frames on stack. The current implementation of the `IL_Throw` JIT helper that is used to throw managed exceptions needs three unwinds to get to the managed caller. Due to the two passes of EH, it means there are six calls made to that API per throw.
This change reduces that to just a single unwind, which leads to about 12% improvement in single threaded scenarios and about 30% improvement in multi-threaded one for a case when an exception is thrown over 10 managed frames and then caught on Windows. It also leads to similar improvements in async exception handling performance. I have also run the dotnet/performance EH tests and they have shown the same improvements.

An additional benefit of this change is removal of the helper method frame from `IL_Throw` and `IL_Rethrow`, which contributes to the current effort of getting rid of the helper method frames.

In a follow up change, I am planning to make similar change to the `FCThrow` helper and its variants, further reducing the usage of the helper method frames.

I have made this change for the new EH only.