### PR TITLE
Interpreter Fixes

### DIFF
--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -12022,7 +12022,7 @@ const char* Interpreter::getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd,
         return pMD->GetName();
     }
 
-    return info->getMethodNameFromMetadata(hnd, className, namespaceName, enclosingClassName);
+    return info->getMethodNameFromMetadata(hnd, className, namespaceName, enclosingClassName, 0);
 }
 
 const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** clsName)

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -12022,7 +12022,7 @@ const char* Interpreter::getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd,
         return pMD->GetName();
     }
 
-    return info->getMethodNameFromMetadata(hnd, className, namespaceName, enclosingClassName, 0);
+    return info->getMethodNameFromMetadata(hnd, className, namespaceName, enclosingClassName, 1);
 }
 
 const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** clsName)

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -9302,7 +9302,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
             // Hardware intrinsics are recognized by name.
             const char* namespaceName = NULL;
             const char* className = NULL;
-            const char* methodName = getMethodName(&m_interpCeeInfo, (CORINFO_METHOD_HANDLE)methToCall, &className, &namespaceName, NULL);
+            const char* methodName = getMethodName(&m_interpCeeInfo, (CORINFO_METHOD_HANDLE)methToCall, &className, &namespaceName);
             if (
                 (strcmp(namespaceName, "System.Runtime.Intrinsics") == 0 ||
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
@@ -11943,7 +11943,7 @@ Interpreter::InterpreterNamedIntrinsics Interpreter::getNamedIntrinsicID(CEEInfo
 
     const char* namespaceName = NULL;
     const char* className = NULL;
-    const char* methodName = getMethodName(info, (CORINFO_METHOD_HANDLE)methodHnd, &className, &namespaceName, NULL);
+    const char* methodName = getMethodName(info, (CORINFO_METHOD_HANDLE)methodHnd, &className, &namespaceName);
 
     if (strncmp(namespaceName, "System", 6) == 0)
     {
@@ -12010,7 +12010,7 @@ Interpreter::InterpreterNamedIntrinsics Interpreter::getNamedIntrinsicID(CEEInfo
 
 // Simple version of getMethodName which supports IL Stubs such as IL_STUB_PInvoke additionally.
 // Also see getMethodNameFromMetadata and printMethodName in corinfo.h
-const char* Interpreter::getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName, const char **enclosingClassName)
+const char* Interpreter::getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName)
 {
     MethodDesc *pMD = GetMethod(hnd);
     if (pMD->IsILStub())
@@ -12022,7 +12022,7 @@ const char* Interpreter::getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd,
         return pMD->GetName();
     }
 
-    return info->getMethodNameFromMetadata(hnd, className, namespaceName, enclosingClassName, 0);
+    return info->getMethodNameFromMetadata(hnd, className, namespaceName, nullptr, 0);
 }
 
 const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** clsName)

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -12022,7 +12022,7 @@ const char* Interpreter::getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd,
         return pMD->GetName();
     }
 
-    return info->getMethodNameFromMetadata(hnd, className, namespaceName, enclosingClassName, 1);
+    return info->getMethodNameFromMetadata(hnd, className, namespaceName, enclosingClassName, 0);
 }
 
 const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** clsName)

--- a/src/coreclr/vm/interpreter.h
+++ b/src/coreclr/vm/interpreter.h
@@ -926,7 +926,7 @@ public:
         NI_System_Threading_Interlocked_ExchangeAdd,
     };
     static InterpreterNamedIntrinsics getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HANDLE methodHnd);
-    static const char* getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName = NULL, const char **enclosingClassName = NULL);
+    static const char* getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName = NULL);
 
 private:
     // Architecture-dependent helpers.

--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -1811,7 +1811,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
     //
 
     pHeaderRW->pNext = pStubHeapSegment->pUnwindHeaderList;
-                     pStubHeapSegment->pUnwindHeaderList = pHeaderRW;
+    pStubHeapSegment->pUnwindHeaderList = pHeaderRW;
 
 #ifdef TARGET_AMD64
     // Publish Unwind info to ETW stack crawler

--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -1309,13 +1309,16 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
     //
 
     StubUnwindInfoHeader *pHeader = pStubRW->GetUnwindInfoHeader();
+    StubUnwindInfoHeader *pHeaderX = pStubRX->GetUnwindInfoHeader();
     _ASSERTE(IS_ALIGNED(pHeader, sizeof(void*)));
 
     BYTE *pbBaseAddress = pbRegionBaseAddress;
+    BYTE *pbBaseAddressW = (BYTE*)((uint64_t)pbRegionBaseAddress + (uint64_t)pHeader - (uint64_t)pHeaderX);
 
-    while ((size_t)((BYTE*)pHeader - pbBaseAddress) > MaxSegmentSize)
+    while ((size_t)((BYTE*)pHeaderX - pbBaseAddress) > MaxSegmentSize)
     {
         pbBaseAddress += MaxSegmentSize;
+        pbBaseAddressW += MaxSegmentSize;
     }
 
     //
@@ -1452,7 +1455,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
         COMPlusThrowArithmetic();
     pCurFunction->EndAddress = sEndAddress.Value();
 
-    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddress);
+    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressW);
     if (sTemp.IsOverflow())
         COMPlusThrowArithmetic();
     RUNTIME_FUNCTION__SetUnwindInfoAddress(pCurFunction, sTemp.Value());
@@ -1470,7 +1473,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
         COMPlusThrowArithmetic();
     RUNTIME_FUNCTION__SetBeginAddress(pCurFunction, sBeginAddress.Value());
 
-    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddress);
+    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressW);
     if (sTemp.IsOverflow())
         COMPlusThrowArithmetic();
     RUNTIME_FUNCTION__SetUnwindInfoAddress(pCurFunction, sTemp.Value());

--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -1627,7 +1627,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
         if (sBeginAddress.IsOverflow())
             COMPlusThrowArithmetic();
 
-        S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressRX);
+        S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressRW);
         if (sTemp.IsOverflow())
             COMPlusThrowArithmetic();
 

--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -1308,17 +1308,17 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
     // make that INT32_MAX.
     //
 
-    StubUnwindInfoHeader *pHeader = pStubRW->GetUnwindInfoHeader();
-    StubUnwindInfoHeader *pHeaderX = pStubRX->GetUnwindInfoHeader();
-    _ASSERTE(IS_ALIGNED(pHeader, sizeof(void*)));
+    StubUnwindInfoHeader *pHeaderRW = pStubRW->GetUnwindInfoHeader();
+    StubUnwindInfoHeader *pHeaderRX = pStubRX->GetUnwindInfoHeader();
+    _ASSERTE(IS_ALIGNED(pHeaderRW, sizeof(void*)));
 
-    BYTE *pbBaseAddress = pbRegionBaseAddress;
-    BYTE *pbBaseAddressW = (BYTE*)((uint64_t)pbRegionBaseAddress + (uint64_t)pHeader - (uint64_t)pHeaderX);
+    BYTE *pbBaseAddressRX = pbRegionBaseAddress;
+    BYTE *pbBaseAddressRW = (BYTE*)((uint64_t)pbRegionBaseAddress + (uint64_t)pHeaderRW - (uint64_t)pHeaderRX);
 
-    while ((size_t)((BYTE*)pHeaderX - pbBaseAddress) > MaxSegmentSize)
+    while ((size_t)((BYTE*)pHeaderRX - pbBaseAddressRX) > MaxSegmentSize)
     {
-        pbBaseAddress += MaxSegmentSize;
-        pbBaseAddressW += MaxSegmentSize;
+        pbBaseAddressRX += MaxSegmentSize;
+        pbBaseAddressRW += MaxSegmentSize;
     }
 
     //
@@ -1330,7 +1330,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
     // allocations are freed.
     //
 
-    if ((size_t)(pCode + globalsize - pbBaseAddress) > MaxSegmentSize)
+    if ((size_t)(pCode + globalsize - pbBaseAddressRX) > MaxSegmentSize)
     {
         return false;
     }
@@ -1445,17 +1445,17 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
     PT_RUNTIME_FUNCTION pCurFunction = &pUnwindInfoHeader->FunctionEntry;
     _ASSERTE(IS_ALIGNED(pCurFunction, sizeof(ULONG)));
 
-    S_UINT32 sBeginAddress = S_BYTEPTR(pCode) - S_BYTEPTR(pbBaseAddress);
+    S_UINT32 sBeginAddress = S_BYTEPTR(pCode) - S_BYTEPTR(pbBaseAddressRX);
     if (sBeginAddress.IsOverflow())
         COMPlusThrowArithmetic();
     pCurFunction->BeginAddress = sBeginAddress.Value();
 
-    S_UINT32 sEndAddress = S_BYTEPTR(pCode) + S_BYTEPTR(globalsize) - S_BYTEPTR(pbBaseAddress);
+    S_UINT32 sEndAddress = S_BYTEPTR(pCode) + S_BYTEPTR(globalsize) - S_BYTEPTR(pbBaseAddressRX);
     if (sEndAddress.IsOverflow())
         COMPlusThrowArithmetic();
     pCurFunction->EndAddress = sEndAddress.Value();
 
-    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressW);
+    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressRW);
     if (sTemp.IsOverflow())
         COMPlusThrowArithmetic();
     RUNTIME_FUNCTION__SetUnwindInfoAddress(pCurFunction, sTemp.Value());
@@ -1468,12 +1468,12 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
     PT_RUNTIME_FUNCTION pCurFunction = &pUnwindInfoHeader->FunctionEntry;
     _ASSERTE(IS_ALIGNED(pCurFunction, sizeof(ULONG)));
 
-    S_UINT32 sBeginAddress = S_BYTEPTR(pCode) - S_BYTEPTR(pbBaseAddress);
+    S_UINT32 sBeginAddress = S_BYTEPTR(pCode) - S_BYTEPTR(pbBaseAddressRX);
     if (sBeginAddress.IsOverflow())
         COMPlusThrowArithmetic();
     RUNTIME_FUNCTION__SetBeginAddress(pCurFunction, sBeginAddress.Value());
 
-    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressW);
+    S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressRW);
     if (sTemp.IsOverflow())
         COMPlusThrowArithmetic();
     RUNTIME_FUNCTION__SetUnwindInfoAddress(pCurFunction, sTemp.Value());
@@ -1623,11 +1623,11 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
 
         _ASSERTE(IS_ALIGNED(pCurFunction, sizeof(void*)));
 
-        S_UINT32 sBeginAddress = S_BYTEPTR(pCode) - S_BYTEPTR(pbBaseAddress);
+        S_UINT32 sBeginAddress = S_BYTEPTR(pCode) - S_BYTEPTR(pbBaseAddressRX);
         if (sBeginAddress.IsOverflow())
             COMPlusThrowArithmetic();
 
-        S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddress);
+        S_UINT32 sTemp = S_BYTEPTR(pUnwindInfo) - S_BYTEPTR(pbBaseAddressRX);
         if (sTemp.IsOverflow())
             COMPlusThrowArithmetic();
 
@@ -1752,14 +1752,14 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
          (pStubHeapSegment = *ppPrevStubHeapSegment);
          (ppPrevStubHeapSegment = &pStubHeapSegment->pNext))
     {
-        if (pbBaseAddress < pStubHeapSegment->pbBaseAddress)
+        if (pbBaseAddressRX < pStubHeapSegment->pbBaseAddress)
         {
             // The list is ordered, so address is between segments
             pStubHeapSegment = NULL;
             break;
         }
 
-        if (pbBaseAddress == pStubHeapSegment->pbBaseAddress)
+        if (pbBaseAddressRX == pStubHeapSegment->pbBaseAddress)
         {
             // Found an existing segment
             break;
@@ -1771,7 +1771,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
         //
         // RtlInstallFunctionTableCallback will only accept a ULONG for the
         // region size.  We've already checked above that the RUNTIME_FUNCTION
-        // offsets will work relative to pbBaseAddress.
+        // offsets will work relative to pbBaseAddressRX.
         //
 
         SIZE_T cbSegment = findBlockArgs.cbBlockSize;
@@ -1782,7 +1782,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
         NewHolder<StubUnwindInfoHeapSegment> pNewStubHeapSegment = new StubUnwindInfoHeapSegment();
 
 
-        pNewStubHeapSegment->pbBaseAddress = pbBaseAddress;
+        pNewStubHeapSegment->pbBaseAddress = pbBaseAddressRX;
         pNewStubHeapSegment->cbSegment = cbSegment;
         pNewStubHeapSegment->pUnwindHeaderList = NULL;
 #ifdef TARGET_AMD64
@@ -1799,7 +1799,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
 
         InstallEEFunctionTable(
                 pNewStubHeapSegment,
-                pbBaseAddress,
+                pbBaseAddressRX,
                 (ULONG)cbSegment,
                 &FindStubFunctionEntry,
                 pNewStubHeapSegment,
@@ -1810,8 +1810,8 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
     // Link the new stub into the segment.
     //
 
-    pHeader->pNext = pStubHeapSegment->pUnwindHeaderList;
-                     pStubHeapSegment->pUnwindHeaderList = pHeader;
+    pHeaderRW->pNext = pStubHeapSegment->pUnwindHeaderList;
+                     pStubHeapSegment->pUnwindHeaderList = pHeaderRW;
 
 #ifdef TARGET_AMD64
     // Publish Unwind info to ETW stack crawler
@@ -1822,8 +1822,8 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
 #endif
 
 #ifdef _DEBUG
-    _ASSERTE(pHeader->IsRegistered());
-    _ASSERTE(   &pHeader->FunctionEntry
+    _ASSERTE(pHeaderRW->IsRegistered());
+    _ASSERTE(   &pHeaderRW->FunctionEntry
              == FindStubFunctionEntry((ULONG64)pCode,                  EncodeDynamicFunctionTableContext(pStubHeapSegment, DYNFNTABLE_STUB)));
 #endif
 


### PR DESCRIPTION
This change fixed some bugs in the interpreter.

The change in `interpreter.cpp` allows the code to build successfully, it is unclear what that value should be, but 0 seems to work just fine, @jakobbotsch?

The change in `stublink.cpp` fixes an infinite loop and arithmetic overflow in the unwind info emitter. With R^X, we should only perform arithmetic on pointers coming from the same mapping, @janvorli?

With this change. we can at least get started to interpret some bytecode, it still hit assertion after generating the interpreter stub for a few methods and start interpreting, but this should be enough to get us started.