### PR TITLE
Fix LINQ Last() in ConcatNIterator to also check base case (Concat2Iterator)

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
@@ -340,14 +340,7 @@ namespace System.Linq
                 while ((previousN = node.PreviousN) is not null);
 
                 Debug.Assert(node._tail is Concat2Iterator<TSource>);
-                result = node._tail.TryGetLast(out found);
-                if (found)
-                {
-                    return result;
-                }
-
-                found = false;
-                return default;
+                return node._tail.TryGetLast(out found);
             }
         }
 

--- a/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
@@ -326,16 +326,25 @@ namespace System.Linq
 
             public override TSource? TryGetLast(out bool found)
             {
-                ConcatNIterator<TSource>? node = this;
+                ConcatNIterator<TSource>? node, previousN = this;
+                TSource? result;
                 do
                 {
-                    TSource? result = node._head.TryGetLast(out found);
+                    node = previousN;
+                    result = node._head.TryGetLast(out found);
                     if (found)
                     {
                         return result;
                     }
                 }
-                while ((node = node!.PreviousN) is not null);
+                while ((previousN = node.PreviousN) is not null);
+
+                Debug.Assert(node._tail is Concat2Iterator<TSource>);
+                result = node._tail.TryGetLast(out found);
+                if (found)
+                {
+                    return result;
+                }
 
                 found = false;
                 return default;

--- a/src/libraries/System.Linq/tests/ConcatTests.cs
+++ b/src/libraries/System.Linq/tests/ConcatTests.cs
@@ -93,6 +93,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(ConcatWithSelfData))]
         [MemberData(nameof(ChainedCollectionConcatData))]
         [MemberData(nameof(AppendedPrependedConcatAlternationsData))]
+        [MemberData(nameof(ConcatWithEmptyEnumerableData))]
         public void First_Last_ElementAt(IEnumerable<int> _, IEnumerable<int> actual)
         {
             int count = actual.Count();
@@ -230,6 +231,15 @@ namespace System.Linq.Tests
                     expected.Clear();
                 }
             }
+        }
+
+        public static IEnumerable<object[]> ConcatWithEmptyEnumerableData()
+        {
+            yield return new object[]
+            {
+                Enumerable.Range(0, 10),
+                Enumerable.Concat(Enumerable.Concat(Enumerable.Range(0, 10), new List<int>()), new List<int>())
+            };
         }
 
         private static IEnumerable<object[]> GenerateSourcesData(

--- a/src/libraries/System.Linq/tests/ConcatTests.cs
+++ b/src/libraries/System.Linq/tests/ConcatTests.cs
@@ -235,10 +235,27 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> ConcatWithEmptyEnumerableData()
         {
+            List<int> baseList = [0, 1, 2, 3, 4];
+
             yield return new object[]
             {
-                Enumerable.Range(0, 10),
-                Enumerable.Concat(Enumerable.Concat(Enumerable.Range(0, 10), new List<int>()), new List<int>())
+                Enumerable.Range(0, 5),
+                Enumerable.Concat(Enumerable.Concat(new List<int>(), new List<int>()), baseList)
+            };
+            yield return new object[]
+            {
+                Enumerable.Range(0, 5),
+                Enumerable.Concat(new List<int>(), baseList)
+            };
+            yield return new object[]
+            {
+                Enumerable.Range(0, 5),
+                Enumerable.Concat(Enumerable.Concat(baseList, new List<int>()), new List<int>())
+            };
+            yield return new object[]
+            {
+                Enumerable.Range(0, 5),
+                Enumerable.Concat(baseList, new List<int>())
             };
         }
 


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/108477

`ConcatNIterator.PreviousN` returns `null` in the base case as `_tail` is `Concat2Iterator`. I've copied the `ConcatNIterator<TSource>? node, previousN = this;` pattern used in other methods over to here and added test cases