### PR TITLE
Fix IndexOf Optimization Code

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -130,12 +130,14 @@ namespace System.Globalization
                 }
 
                 int startIndex, endIndex, jump;
+                ReadOnlySpan<char> remainingSource;
                 if (fromBeginning)
                 {
                     // Left to right, from zero to last possible index in the source string.
                     // Incrementing by one after each iteration. Stop condition is last possible index plus 1.
                     startIndex = 0;
                     endIndex = source.Length - target.Length + 1;
+                    remainingSource = source.Slice(endIndex);
                     jump = 1;
                 }
                 else
@@ -144,6 +146,7 @@ namespace System.Globalization
                     // Decrementing by one after each iteration. Stop condition is last possible index minus 1.
                     startIndex = source.Length - target.Length;
                     endIndex = -1;
+                    remainingSource = source.Slice(0, startIndex);
                     jump = -1;
                 }
 
@@ -190,6 +193,12 @@ namespace System.Globalization
                     return i;
 
                 Next: ;
+                }
+
+                // Before we return -1, check if the remaining source contains any special on non-Ascii characters.
+                if (remainingSource.ContainsAnyExcept(s_nonSpecialAsciiChars))
+                {
+                    goto InteropCall;
                 }
 
                 return -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -195,7 +195,7 @@ namespace System.Globalization
                 Next: ;
                 }
 
-                // Before we return -1, check if the remaining source contains any special on non-Ascii characters.
+                // Before we return -1, check if the remaining source contains any special or non-Ascii characters.
                 if (remainingSource.ContainsAnyExcept(s_nonSpecialAsciiChars))
                 {
                     goto InteropCall;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -255,12 +255,14 @@ namespace System.Globalization
                 }
 
                 int startIndex, endIndex, jump;
+                ReadOnlySpan<char> remainingSource;
                 if (fromBeginning)
                 {
                     // Left to right, from zero to last possible index in the source string.
                     // Incrementing by one after each iteration. Stop condition is last possible index plus 1.
                     startIndex = 0;
                     endIndex = source.Length - target.Length + 1;
+                    remainingSource = source.Slice(endIndex);
                     jump = 1;
                 }
                 else
@@ -269,6 +271,7 @@ namespace System.Globalization
                     // Decrementing by one after each iteration. Stop condition is last possible index minus 1.
                     startIndex = source.Length - target.Length;
                     endIndex = -1;
+                    remainingSource = source.Slice(0, startIndex);
                     jump = -1;
                 }
 
@@ -304,6 +307,12 @@ namespace System.Globalization
                     return i;
 
                 Next: ;
+                }
+
+                // Before we return -1, check if the remaining source contains any special or non-Ascii characters.
+                if (remainingSource.ContainsAnyExcept(s_nonSpecialAsciiChars))
+                {
+                    goto InteropCall;
                 }
 
                 return -1;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -127,6 +127,13 @@ namespace System.Globalization.Tests
             yield return new object[] { s_currentCompare, "\u0130", "\u0131", 0, 1, CompareOptions.Ordinal, -1, 0 };
             yield return new object[] { s_currentCompare, "\u0131", "\u0130", 0, 1, CompareOptions.Ordinal, -1, 0 };
 
+            yield return new object[] { s_invariantCompare, "eﬆ", "est", 0, 2, CompareOptions.IgnoreCase, 0, 2 };
+            yield return new object[] { s_invariantCompare, " eﬆ", "est", 0, 3, CompareOptions.IgnoreCase, 1, 2 };
+            yield return new object[] { s_invariantCompare, " ﬆ", "st", 0, 2, CompareOptions.IgnoreCase, 1, 1 };
+            yield return new object[] { s_invariantCompare, "est", "eﬆ", 0, 3, CompareOptions.IgnoreCase, 0, 3 };
+            yield return new object[] { s_invariantCompare, " est", "eﬆ", 0, 4, CompareOptions.IgnoreCase, 1, 3 };
+            yield return new object[] { s_invariantCompare, " st", "ﬆ", 0, 3, CompareOptions.IgnoreCase, 1, 2 };
+
             // Platform differences
             if (PlatformDetection.IsNlsGlobalization)
             {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -127,12 +127,15 @@ namespace System.Globalization.Tests
             yield return new object[] { s_currentCompare, "\u0130", "\u0131", 0, 1, CompareOptions.Ordinal, -1, 0 };
             yield return new object[] { s_currentCompare, "\u0131", "\u0130", 0, 1, CompareOptions.Ordinal, -1, 0 };
 
-            yield return new object[] { s_invariantCompare, "eﬆ", "est", 0, 2, CompareOptions.IgnoreCase, 0, 2 };
-            yield return new object[] { s_invariantCompare, " eﬆ", "est", 0, 3, CompareOptions.IgnoreCase, 1, 2 };
-            yield return new object[] { s_invariantCompare, " ﬆ", "st", 0, 2, CompareOptions.IgnoreCase, 1, 1 };
-            yield return new object[] { s_invariantCompare, "est", "eﬆ", 0, 3, CompareOptions.IgnoreCase, 0, 3 };
-            yield return new object[] { s_invariantCompare, " est", "eﬆ", 0, 4, CompareOptions.IgnoreCase, 1, 3 };
-            yield return new object[] { s_invariantCompare, " st", "ﬆ", 0, 3, CompareOptions.IgnoreCase, 1, 2 };
+            if (!PlatformDetection.IsHybridGlobalizationOnBrowser)
+            {
+                yield return new object[] { s_invariantCompare, "eﬆ", "est", 0, 2, CompareOptions.IgnoreCase, 0, 2 };
+                yield return new object[] { s_invariantCompare, " eﬆ", "est", 0, 3, CompareOptions.IgnoreCase, 1, 2 };
+                yield return new object[] { s_invariantCompare, " ﬆ", "st", 0, 2, CompareOptions.IgnoreCase, 1, 1 };
+                yield return new object[] { s_invariantCompare, "est", "eﬆ", 0, 3, CompareOptions.IgnoreCase, 0, 3 };
+                yield return new object[] { s_invariantCompare, " est", "eﬆ", 0, 4, CompareOptions.IgnoreCase, 1, 3 };
+                yield return new object[] { s_invariantCompare, " st", "ﬆ", 0, 3, CompareOptions.IgnoreCase, 1, 2 };
+            }
 
             // Platform differences
             if (PlatformDetection.IsNlsGlobalization)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/108424

We have optimization code that attempts to perform the `IndexOf` operation using ASCII characters until the operation completes or encounters a character that requires linguistic processing, at which point it falls back to the slower ICU path. However, there was an issue where, if the source was longer than the value, the optimization would reach the boundary in the source and incorrectly conclude that no match was found. The code wasn't checking the remaining characters in the source to determine if it needed to fall back to the ICU path, which caused `IndexOf` to return incorrect results.

Example `" eﬆ".IndexOf("est", System.StringComparison.InvariantCultureIgnoreCase); // -1` returns wrong result `-1` while `"eﬆ".IndexOf("est", System.StringComparison.InvariantCultureIgnoreCase); // 0` returns correct result `0`.