### PR TITLE
[Android] Put Java JNI function in a separate static library

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -144,9 +144,12 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Apple" Condition="'$(_IsApplePlatform)' == 'true'" />
       <!-- No OpenSSL on Apple platforms or Android -->
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(StaticOpenSslLinking)' != 'true' and '$(_IsApplePlatform)' != 'true' and '$(_targetOS)' != 'android'" />
-      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android" Condition="'$(_targetOS)' == 'android'" />
-      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android.JNIExport" Condition="'$(_targetOS)' == 'android'" />
-      <IlcArg Include="--export-dynamic-symbol:Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate" Condition="'$(_targetOS)' == 'android'" />
+    </ItemGroup>
+    
+    </ItemGroup Condition="'$(_targetOS)' == 'android'">
+      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android" />
+      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android.JNIExport" />
+      <IlcArg Include="--export-dynamic-symbol:Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -146,7 +146,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(StaticOpenSslLinking)' != 'true' and '$(_IsApplePlatform)' != 'true' and '$(_targetOS)' != 'android'" />
     </ItemGroup>
     
-    </ItemGroup Condition="'$(_targetOS)' == 'android'">
+    <ItemGroup Condition="'$(_targetOS)' == 'android'">
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android" />
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android.JNIExport" />
       <IlcArg Include="--export-dynamic-symbol:Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -146,6 +146,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(StaticOpenSslLinking)' != 'true' and '$(_IsApplePlatform)' != 'true' and '$(_targetOS)' != 'android'" />
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android" Condition="'$(_targetOS)' == 'android'" />
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android.JNIExport" Condition="'$(_targetOS)' == 'android'" />
+      <IlcArg Include="--export-dynamic-symbol:Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate" Condition="'$(_targetOS)' == 'android'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -145,6 +145,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- No OpenSSL on Apple platforms or Android -->
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(StaticOpenSslLinking)' != 'true' and '$(_IsApplePlatform)' != 'true' and '$(_targetOS)' != 'android'" />
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android" Condition="'$(_targetOS)' == 'android'" />
+      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android.JNIExport" Condition="'$(_targetOS)' == 'android'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -91,6 +91,7 @@
     <PlatformManifestFileEntry Include="libSystem.Security.Cryptography.Native.Apple.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libSystem.Security.Cryptography.Native.Apple.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="libSystem.Security.Cryptography.Native.Android.a" IsNative="true" />
+    <PlatformManifestFileEntry Include="libSystem.Security.Cryptography.Native.Android.JNIExport.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libSystem.Security.Cryptography.Native.Android.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libSystem.Security.Cryptography.Native.Android.dex" IsNative="true" />
     <PlatformManifestFileEntry Include="libSystem.Security.Cryptography.Native.Android.jar" IsNative="true" />

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -176,6 +176,7 @@ else()
     else()
         list(APPEND NATIVE_LIBS
             System.Security.Cryptography.Native.Android-Static
+            System.Security.Cryptography.Native.Android-StaticJNIExport
         )
     endif()
 

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -176,7 +176,7 @@ else()
     else()
         list(APPEND NATIVE_LIBS
             System.Security.Cryptography.Native.Android-Static
-            System.Security.Cryptography.Native.Android-StaticJNIExport
+            System.Security.Cryptography.Native.Android.JNIExport-Static
         )
     endif()
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -33,7 +33,7 @@ set(NATIVECRYPTO_SOURCES
 
 add_library(System.Security.Cryptography.Native.Android
     SHARED
-    ${NATIVECRYPTO_SOURCES} pal_jni_onload.c
+    ${NATIVECRYPTO_SOURCES} pal_jni_onload.c pal_trust_manager_jni_export.c
     ${VERSION_FILE_PATH}
 )
 
@@ -42,7 +42,10 @@ add_library(System.Security.Cryptography.Native.Android-Static
     ${NATIVECRYPTO_SOURCES}
 )
 
-set_target_properties(System.Security.Cryptography.Native.Android-Static PROPERTIES OUTPUT_NAME System.Security.Cryptography.Native.Android CLEAN_DIRECT_OUTPUT 1)
+add_library(System.Security.Cryptography.Native.Android-StaticJNIExport
+    STATIC
+    pal_trust_manager_jni_export.c
+)
 
 target_link_libraries(System.Security.Cryptography.Native.Android
     PRIVATE
@@ -50,7 +53,8 @@ target_link_libraries(System.Security.Cryptography.Native.Android
 )
 
 set_target_properties(System.Security.Cryptography.Native.Android PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android")
-set_target_properties(System.Security.Cryptography.Native.Android-Static PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android")
+set_target_properties(System.Security.Cryptography.Native.Android-Static PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android" CLEAN_DIRECT_OUTPUT 1)
+set_target_properties(System.Security.Cryptography.Native.Android-StaticJNIExport PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android.JNIExport"  CLEAN_DIRECT_OUTPUT 1)
 
 if (GEN_SHARED_LIB)
     install_with_stripped_symbols (System.Security.Cryptography.Native.Android PROGRAMS .)
@@ -60,4 +64,5 @@ install (TARGETS System.Security.Cryptography.Native.Android-Static DESTINATION 
 
 if(CLR_CMAKE_HOST_ANDROID)
     install (TARGETS System.Security.Cryptography.Native.Android-Static DESTINATION sharedFramework COMPONENT runtime)
+    install (TARGETS System.Security.Cryptography.Native.Android-StaticJNIExport DESTINATION sharedFramework COMPONENT runtime)
 endif()

--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -42,6 +42,20 @@ add_library(System.Security.Cryptography.Native.Android-Static
     ${NATIVECRYPTO_SOURCES}
 )
 
+#
+# This is necessary so that dynamic linking of the .NET for Android runtime
+# can hide all the other symbols in System.Security.Cryptography.Native.Android.
+#
+# .NET for Android dynamic runtime linking links all the relevant native BCL
+# libraries into a single .so, using the .a archives built here.  clang allows
+# hiding all the symbols in the .a archive, but there's no (working) way to
+# exclude just select symbols from hiding.
+#
+# Java VM requires that all the functions implementing the `native` methods are
+# exported from the shared libraries they are implemented in.  Therefore it is
+# necessary to put this symbol in a separate .a archive so that we can exclude it
+# from hiding described above.
+#
 add_library(System.Security.Cryptography.Native.Android-StaticJNIExport
     STATIC
     pal_trust_manager_jni_export.c

--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -56,7 +56,7 @@ add_library(System.Security.Cryptography.Native.Android-Static
 # necessary to put this symbol in a separate .a archive so that we can exclude it
 # from hiding described above.
 #
-add_library(System.Security.Cryptography.Native.Android-StaticJNIExport
+add_library(System.Security.Cryptography.Native.Android.JNIExport-Static
     STATIC
     pal_trust_manager_jni_export.c
 )
@@ -68,16 +68,16 @@ target_link_libraries(System.Security.Cryptography.Native.Android
 
 set_target_properties(System.Security.Cryptography.Native.Android PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android")
 set_target_properties(System.Security.Cryptography.Native.Android-Static PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android" CLEAN_DIRECT_OUTPUT 1)
-set_target_properties(System.Security.Cryptography.Native.Android-StaticJNIExport PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android.JNIExport"  CLEAN_DIRECT_OUTPUT 1)
+set_target_properties(System.Security.Cryptography.Native.Android.JNIExport-Static PROPERTIES OUTPUT_NAME "System.Security.Cryptography.Native.Android.JNIExport"  CLEAN_DIRECT_OUTPUT 1)
 
 if (GEN_SHARED_LIB)
     install_with_stripped_symbols (System.Security.Cryptography.Native.Android PROGRAMS .)
 endif()
 
 install (TARGETS System.Security.Cryptography.Native.Android-Static DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
-install (TARGETS System.Security.Cryptography.Native.Android-StaticJNIExport DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
+install (TARGETS System.Security.Cryptography.Native.Android.JNIExport-Static DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
 
 if(CLR_CMAKE_HOST_ANDROID)
     install (TARGETS System.Security.Cryptography.Native.Android-Static DESTINATION sharedFramework COMPONENT runtime)
-    install (TARGETS System.Security.Cryptography.Native.Android-StaticJNIExport DESTINATION sharedFramework COMPONENT runtime)
+    install (TARGETS System.Security.Cryptography.Native.Android.JNIExport-Static DESTINATION sharedFramework COMPONENT runtime)
 endif()

--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -75,6 +75,7 @@ if (GEN_SHARED_LIB)
 endif()
 
 install (TARGETS System.Security.Cryptography.Native.Android-Static DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
+install (TARGETS System.Security.Cryptography.Native.Android-StaticJNIExport DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
 
 if(CLR_CMAKE_HOST_ANDROID)
     install (TARGETS System.Security.Cryptography.Native.Android-Static DESTINATION sharedFramework COMPONENT runtime)

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.c
@@ -1,11 +1,8 @@
 #include "pal_trust_manager.h"
-#include <stdatomic.h>
-
-static _Atomic RemoteCertificateValidationCallback verifyRemoteCertificate;
 
 ARGS_NON_NULL_ALL void AndroidCryptoNative_RegisterRemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback)
 {
-    atomic_store(&verifyRemoteCertificate, callback);
+    StoreRemoteVerificationCallback(callback);
 }
 
 ARGS_NON_NULL_ALL jobjectArray GetTrustManagers(JNIEnv* env, intptr_t sslStreamProxyHandle)
@@ -28,10 +25,3 @@ cleanup:
     return trustManagers;
 }
 
-ARGS_NON_NULL_ALL jboolean Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate(
-    JNIEnv* env, jobject thisHandle, jlong sslStreamProxyHandle)
-{
-    RemoteCertificateValidationCallback verify = atomic_load(&verifyRemoteCertificate);
-    abort_unless(verify, "verifyRemoteCertificate callback has not been registered");
-    return verify((intptr_t)sslStreamProxyHandle);
-}

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.c
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #include "pal_trust_manager.h"
 
 ARGS_NON_NULL_ALL void AndroidCryptoNative_RegisterRemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback)

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.h
@@ -6,5 +6,6 @@ PALEXPORT void AndroidCryptoNative_RegisterRemoteCertificateValidationCallback(R
 
 jobjectArray GetTrustManagers(JNIEnv* env, intptr_t sslStreamProxyHandle);
 
+void StoreRemoteVerificationCallback (RemoteCertificateValidationCallback callback);
 JNIEXPORT jboolean JNICALL Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate(
     JNIEnv *env, jobject thisHandle, jlong sslStreamProxyHandle);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.h
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #include "pal_jni.h"
 
 typedef bool (*RemoteCertificateValidationCallback)(intptr_t);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager_jni_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager_jni_export.c
@@ -1,0 +1,17 @@
+#include "pal_trust_manager.h"
+#include <stdatomic.h>
+
+static _Atomic RemoteCertificateValidationCallback verifyRemoteCertificate;
+
+void StoreRemoteVerificationCallback (RemoteCertificateValidationCallback callback)
+{
+    atomic_store(&verifyRemoteCertificate, callback);
+}
+
+ARGS_NON_NULL_ALL jboolean Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate(
+    JNIEnv* env, jobject thisHandle, jlong sslStreamProxyHandle)
+{
+    RemoteCertificateValidationCallback verify = atomic_load(&verifyRemoteCertificate);
+    abort_unless(verify, "verifyRemoteCertificate callback has not been registered");
+    return verify((intptr_t)sslStreamProxyHandle);
+}

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager_jni_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager_jni_export.c
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #include "pal_trust_manager.h"
 #include <stdatomic.h>
 


### PR DESCRIPTION
In https://github.com/dotnet/android/pull/9006 we are working on linking the `.NET for Android`
runtime dynamically at the application build time.

Linking includes all the relevant BCL native libraries, and one of the goals is to
hide all the exported symbols used as `p/invokes` by the managed BCL
libraries.  This is because `p/invoke` calls are handled internally and,
with dynamic linking of the runtime, there is no longer any reason to
use `dlopen` and `dlsym` to look them up, they are all resolved
internally, at the link time.

Symbol hiding works fine thanks to the `--exclude-libs` `clang` flag,
which makes all the exported symbols in the indicated `.a` archives to
not be exported by the linker.  However, `System.Security.Cryptography.Native.Android` 
is special in the sense that it contains one symbol which must not be hidden,
`Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate`.

The above function is a Java `native` method implementation, and it
requires that not only its name follows the Java JNI naming rules, but
that it is also available for the JVM to look up using `dlsym`.

I tried using the `--export-dynamic-symbol` clang flag to
export **just** this function, but it doesn't appear to work no matter
where I put the flag in relation to reference to the `.a` archives.

Instead, the problem can be dealt with by putting the JNI function in a
separate static library, so that I can link it without changing symbol
visibility, while making all the `System.Security.Cryptography.Native.Android` 
symbols invisible.