### PR TITLE
JIT: remove fgAddCodeList

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -527,12 +527,15 @@ void CodeGen::genMarkLabelsForCodegen()
     }
 
     // Walk all the exceptional code blocks and mark them, since they don't appear in the normal flow graph.
-    for (Compiler::AddCodeDsc* add = compiler->fgAddCodeList; add != nullptr; add = add->acdNext)
+    if (compiler->fgHasAddCodeDscMap())
     {
-        if (add->acdUsed)
+        for (Compiler::AddCodeDsc* const add : Compiler::AddCodeDscMap::ValueIteration(compiler->fgGetAddCodeDscMap()))
         {
-            JITDUMP("  " FMT_BB " : throw helper block\n", add->acdDstBlk->bbNum);
-            add->acdDstBlk->SetFlags(BBF_HAS_LABEL);
+            if (add->acdUsed)
+            {
+                JITDUMP("  " FMT_BB " : throw helper block\n", add->acdDstBlk->bbNum);
+                add->acdDstBlk->SetFlags(BBF_HAS_LABEL);
+            }
         }
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6797,8 +6797,6 @@ public:
 
     struct AddCodeDsc
     {
-        AddCodeDsc*     acdNext;
-
         // After fgCreateThrowHelperBlocks, the block to which
         // we jump to raise the exception.
         BasicBlock*     acdDstBlk;
@@ -6855,30 +6853,22 @@ public:
     };
 
     typedef JitHashTable<AddCodeDscKey, AddCodeDscKey, AddCodeDsc*> AddCodeDscMap;
-
     AddCodeDscMap* fgGetAddCodeDscMap();
 
 private:
     static unsigned acdHelper(SpecialCodeKind codeKind);
 
-    AddCodeDsc* fgAddCodeList = nullptr;
     bool        fgRngChkThrowAdded = false;
     AddCodeDscMap* fgAddCodeDscMap = nullptr;
 
     void fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind);
     PhaseStatus fgCreateThrowHelperBlocks();
 
-
 public:
+
+    bool fgHasAddCodeDscMap() const { return fgAddCodeDscMap != nullptr; }
     AddCodeDsc* fgFindExcptnTarget(SpecialCodeKind kind, BasicBlock* fromBlock);
-
     bool fgUseThrowHelperBlocks();
-
-    AddCodeDsc* fgGetAdditionalCodeDescriptors()
-    {
-        return fgAddCodeList;
-    }
-
     void fgCreateThrowHelperBlockCode(AddCodeDsc* add);
 
 private:

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3182,11 +3182,14 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
     }
 
     // Ensure that all throw helper blocks are currently in the block list.
-    for (Compiler::AddCodeDsc* add = fgAddCodeList; add != nullptr; add = add->acdNext)
+    if (fgHasAddCodeDscMap())
     {
-        if (add->acdUsed)
+        for (Compiler::AddCodeDsc* const add : Compiler::AddCodeDscMap::ValueIteration(fgAddCodeDscMap))
         {
-            assert(add->acdDstBlk->bbTraversalStamp == curTraversalStamp);
+            if (add->acdUsed)
+            {
+                assert(add->acdDstBlk->bbTraversalStamp == curTraversalStamp);
+            }
         }
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3405,7 +3405,6 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
     // Allocate a new entry and prepend it to the list
     //
     add              = new (this, CMK_Unknown) AddCodeDsc;
-    add->acdNext     = fgAddCodeList;
     add->acdDstBlk   = nullptr;
     add->acdTryIndex = srcBlk->bbTryIndex;
     add->acdHndIndex = srcBlk->bbHndIndex;
@@ -3421,8 +3420,6 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
     add->acdStkLvlInit = false;
 #endif // !FEATURE_FIXED_OUT_ARGS
     INDEBUG(add->acdNum = acdCount++);
-
-    fgAddCodeList = add;
 
     // Add to map
     //
@@ -3451,7 +3448,7 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
 //
 PhaseStatus Compiler::fgCreateThrowHelperBlocks()
 {
-    if (fgAddCodeList == nullptr)
+    if (fgAddCodeDscMap == nullptr)
     {
         return PhaseStatus::MODIFIED_NOTHING;
     }
@@ -3472,7 +3469,7 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
 
     noway_assert(sizeof(jumpKinds) == SCK_COUNT); // sanity check
 
-    for (AddCodeDsc* add = fgAddCodeList; add != nullptr; add = add->acdNext)
+    for (AddCodeDsc* const add : AddCodeDscMap::ValueIteration(fgAddCodeDscMap))
     {
         // Create the target basic block in the region indicated by the acd info
         //

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -1371,7 +1371,7 @@ void Compiler::fgRemoveEHTableEntry(unsigned XTnum)
 {
     assert(compHndBBtabCount > 0);
     assert(XTnum < compHndBBtabCount);
-    assert(fgAddCodeList == nullptr);
+    assert((fgAddCodeDscMap == nullptr) || (fgAddCodeDscMap->GetCount() == 0));
 
     EHblkDsc* HBtab;
 

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -64,41 +64,44 @@ PhaseStatus StackLevelSetter::DoPhase()
     //
     bool madeChanges = false;
 
-    if (comp->opts.OptimizationEnabled())
+    if (comp->fgHasAddCodeDscMap())
     {
-        comp->compUsesThrowHelper = false;
-        for (Compiler::AddCodeDsc* add = comp->fgGetAdditionalCodeDescriptors(); add != nullptr; add = add->acdNext)
+        if (comp->opts.OptimizationEnabled())
         {
-            if (add->acdUsed)
+            comp->compUsesThrowHelper = false;
+            for (Compiler::AddCodeDsc* const add : Compiler::AddCodeDscMap::ValueIteration(comp->fgGetAddCodeDscMap()))
             {
-                // Create the helper call
-                //
-                comp->fgCreateThrowHelperBlockCode(add);
-                comp->compUsesThrowHelper = true;
-            }
-            else
-            {
-                // Remove the helper call block
-                //
-                BasicBlock* const block = add->acdDstBlk;
-                assert(block->isEmpty());
-                JITDUMP("Throw help block " FMT_BB " is unused\n", block->bbNum);
-                block->RemoveFlags(BBF_DONT_REMOVE);
-                comp->fgRemoveBlock(block, /* unreachable */ true);
-            }
+                if (add->acdUsed)
+                {
+                    // Create the helper call
+                    //
+                    comp->fgCreateThrowHelperBlockCode(add);
+                    comp->compUsesThrowHelper = true;
+                }
+                else
+                {
+                    // Remove the helper call block
+                    //
+                    BasicBlock* const block = add->acdDstBlk;
+                    assert(block->isEmpty());
+                    JITDUMP("Throw help block " FMT_BB " is unused\n", block->bbNum);
+                    block->RemoveFlags(BBF_DONT_REMOVE);
+                    comp->fgRemoveBlock(block, /* unreachable */ true);
+                }
 
-            madeChanges = true;
+                madeChanges = true;
+            }
         }
-    }
-    else
-    {
-        // Assume all helpers used. Fill in all helper block code.
-        //
-        for (Compiler::AddCodeDsc* add = comp->fgGetAdditionalCodeDescriptors(); add != nullptr; add = add->acdNext)
+        else
         {
-            add->acdUsed = true;
-            comp->fgCreateThrowHelperBlockCode(add);
-            madeChanges = true;
+            // Assume all helpers used. Fill in all helper block code.
+            //
+            for (Compiler::AddCodeDsc* const add : Compiler::AddCodeDscMap::ValueIteration(comp->fgGetAddCodeDscMap()))
+            {
+                add->acdUsed = true;
+                comp->fgCreateThrowHelperBlockCode(add);
+                madeChanges = true;
+            }
         }
     }
 


### PR DESCRIPTION
AddCodeDscs are currently kept in both a linked list and in a hash map. Since the order of these descriptors is not important, remove the list and use map iterators to enumerate them.

This makes it easier to remove ACDs.