### PR TITLE
Add project to create helix work items for host tests

### DIFF
--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -6,6 +6,8 @@
     <ProjectReferenceExclusion Include="@(NetCoreAppLibrary)" />
   </ItemGroup>
 
+  <Target Name="GetTargetDir" Returns="$([System.IO.Path]::GetFullPath('$(TargetDir)'))" />
+
   <Target Name="SetupTestContextVariables"
           Condition="'$(IsTestProject)' == 'true'"
           DependsOnTargets="

--- a/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
@@ -7,20 +7,30 @@ namespace Microsoft.DotNet.CoreSetup.Test
     {
         public static readonly RepoDirectoriesProvider Default = new RepoDirectoriesProvider();
 
-        // Paths computed by looking for the repo root
+        // Paths computed by looking for the repo root or helix correlation payload
         public string BaseArtifactsFolder { get; }
         public string HostArtifacts { get; }
         public string HostTestArtifacts { get; }
 
         private RepoDirectoriesProvider()
         {
-            string repoRoot = GetRepoRootDirectory();
-            BaseArtifactsFolder = Path.Combine(repoRoot, "artifacts");
+            string helixPayload = Environment.GetEnvironmentVariable("HELIX_CORRELATION_PAYLOAD");
+            if (helixPayload != null)
+            {
+                // See src/installer/tests/helixpublish.proj
+                HostArtifacts = Path.Combine(helixPayload, "host_bin");
+                HostTestArtifacts = Path.Combine(helixPayload, "host_test_bin");
+            }
+            else
+            {
+                string repoRoot = GetRepoRootDirectory();
+                BaseArtifactsFolder = Path.Combine(repoRoot, "artifacts");
 
-            string osPlatformConfig = $"{TestContext.BuildRID}.{TestContext.Configuration}";
-            string artifacts = Path.Combine(BaseArtifactsFolder, "bin", osPlatformConfig);
-            HostArtifacts = Path.Combine(artifacts, "corehost");
-            HostTestArtifacts = Path.Combine(artifacts, "corehost_test");
+                string osPlatformConfig = $"{TestContext.BuildRID}.{TestContext.Configuration}";
+                string artifacts = Path.Combine(BaseArtifactsFolder, "bin", osPlatformConfig);
+                HostArtifacts = Path.Combine(artifacts, "corehost");
+                HostTestArtifacts = Path.Combine(artifacts, "corehost_test");
+            }
         }
 
         private static string GetRepoRootDirectory()

--- a/src/installer/tests/helixpublish.proj
+++ b/src/installer/tests/helixpublish.proj
@@ -1,0 +1,65 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk">
+
+  <PropertyGroup>
+    <HelixArchitecture>$(TargetArchitecture)</HelixArchitecture>
+    <HelixBuild Condition="'$(HelixBuild)' == ''">$(BUILD_BUILDNUMBER)</HelixBuild>
+    <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
+    <HelixConfiguration>$(Configuration)</HelixConfiguration>
+    <HelixType>test/host</HelixType>
+
+    <IncludeDotNetCli>true</IncludeDotNetCli>
+    <DotNetCliPackageType>sdk</DotNetCliPackageType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <HostTestProject Include="$(InstallerProjectRoot)tests\AppHost.Bundle.Tests\AppHost.Bundle.Tests.csproj" />
+    <HostTestProject Include="$(InstallerProjectRoot)tests\HostActivation.Tests\HostActivation.Tests.csproj" />
+    <HostTestProject Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Pre-built test projects and constructed .NET install layout -->
+    <HelixCorrelationPayload Include="$(TestArtifactsOutputRoot)" Destination="test_assets" />
+    <!-- Native host binaries -->
+    <HelixCorrelationPayload Include="$(DotNetHostBinDir)" Destination="host_bin" />
+    <!-- Native host test/mock binaries -->
+    <HelixCorrelationPayload Include="$([MSBuild]::NormalizePath('$(DotNetHostBinDir)', '..', 'corehost_test'))" Destination="host_test_bin" />
+  </ItemGroup>
+
+  <!-- Environment variables used by host tests to find test assets. See src/installer/tests/TestUtils/TestContext.cs -->
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
+    <_HelixPreCommands Include="set TEST_ASSETS_OUTPUT=%HELIX_CORRELATION_PAYLOAD%\test_assets" />
+    <_HelixPreCommands Include="set TEST_ARTIFACTS=%HELIX_WORKITEM_ROOT%\test_artifacts" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' != 'windows'">
+    <_HelixPreCommands Include="export TEST_ASSETS_OUTPUT=$HELIX_CORRELATION_PAYLOAD/test_assets" />
+    <_HelixPreCommands Include="export TEST_ARTIFACTS=$HELIX_WORKITEM_ROOT/test_artifacts" />
+  </ItemGroup>
+
+  <!-- Get the command and payload directory corresponding to each test -->
+  <Target Name="ComputePayloadPaths" Outputs="%(HostTestProject.Identity)">
+    <MSBuild Projects="%(HostTestProject.Identity)" Targets="GetTargetDir">
+      <Output TaskParameter="TargetOutputs" PropertyName="_PayloadDirectory" />
+    </MSBuild>
+    <MSBuild Projects="%(HostTestProject.Identity)" Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs" PropertyName="_TargetPath" />
+    </MSBuild>
+    <ItemGroup>
+      <HostTestProject>
+        <Command>dotnet test $([System.IO.Path]::GetFileName($(_TargetPath))) $(TestRunnerAdditionalArguments)</Command>
+        <PayloadDirectory>$(_PayloadDirectory)</PayloadDirectory>
+      </HostTestProject>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CreateHelixWorkItems" DependsOnTargets="ComputePayloadPaths" BeforeTargets="CoreTest">
+    <ItemGroup>
+      <HelixWorkItem Include="$([System.IO.Path]::GetFileNameWithoutExtension(%(HostTestProject.Identity)))">
+        <PayloadDirectory>%(HostTestProject.PayloadDirectory)</PayloadDirectory>
+        <Command>%(HostTestProject.Command)</Command>
+        <PreCommands>@(_HelixPreCommands)</PreCommands>
+      </HelixWorkItem>
+    </ItemGroup>
+  </Target>
+
+</Project>


### PR DESCRIPTION
- Add `src/installer/tests/helixpublish.proj`
  - Defines correlation payloads (pre-built test targets, .NET install layout, product host binaries, test/mock host binaries)
  - Sets pre-commands to set environment variables used by tests for test assets and artifacts locations
  - Generate helix work items for each host test project - runs `dotnet test <host_test_dll>` for each test with the built output as the payload directory
- Update `RepoDirectoryProvider` to use `HELIX_CORRELATION_PAYLOAD` (when available) for path to product/test host binaries.

This is not hooked up to actually run in a pipeline. I tested by manually kicking off runs by [setting environment variables](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/Readme.md#developing-helix-sdk) and directly building the new project. For example:
- `dotnet build src\installer\tests\helixpublish.proj -c Release /t:Test /p:Creator=dev /p:HelixTargetQueues=Windows.Amd64.Server2022.Open`
- `dotnet build ./src/installer/tests/helixpublish.proj -c Release /t:Test /p:Creator=dev /p:HelixTargetQueues=Ubuntu.2204.Amd64.Open`

Contributes to https://github.com/dotnet/runtime/issues/77800

cc @dotnet/appmodel