### PR TITLE
JIT: Null out SSA def nodes upon removal in RBO

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -2177,8 +2177,8 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
         // Make sure the removed store node isn't referenced by an SSA definition
         assert(candidateStmt->GetRootNode()->OperIs(GT_STORE_LCL_VAR));
         GenTreeLclVarCommon* const rootNode = candidateStmt->GetRootNode()->AsLclVarCommon();
-        LclVarDsc* const varDsc = lvaGetDesc(rootNode);
-        LclSsaVarDsc* const defDsc = varDsc->GetPerSsaData(rootNode->GetSsaNum());
+        LclVarDsc* const           varDsc   = lvaGetDesc(rootNode);
+        LclSsaVarDsc* const        defDsc   = varDsc->GetPerSsaData(rootNode->GetSsaNum());
         assert(defDsc->GetDefNode() == rootNode);
         defDsc->SetDefNode(nullptr);
 

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -2174,7 +2174,7 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
     {
         fgRemoveStmt(block, candidateStmt);
 
-        // Make sure the removed store node isn't referenced in any SSA definitions
+        // Make sure the removed store node isn't referenced by an SSA definition
         assert(candidateStmt->GetRootNode()->OperIs(GT_STORE_LCL_VAR));
         GenTreeLclVarCommon* const rootNode = candidateStmt->GetRootNode()->AsLclVarCommon();
         LclVarDsc* const varDsc = lvaGetDesc(rootNode);

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -2177,16 +2177,10 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
         // Make sure the removed store node isn't referenced in any SSA definitions
         assert(candidateStmt->GetRootNode()->OperIs(GT_STORE_LCL_VAR));
         GenTreeLclVarCommon* const rootNode = candidateStmt->GetRootNode()->AsLclVarCommon();
-
         LclVarDsc* const varDsc = lvaGetDesc(rootNode);
-        for (unsigned defIndex = 0; defIndex < varDsc->lvPerSsaData.GetCount(); defIndex++)
-        {
-            LclSsaVarDsc* const defDsc = varDsc->lvPerSsaData.GetSsaDefByIndex(defIndex);
-            if (defDsc->GetDefNode() == rootNode)
-            {
-                defDsc->SetDefNode(nullptr);
-            }
-        }
+        LclSsaVarDsc* const defDsc = varDsc->GetPerSsaData(rootNode->GetSsaNum());
+        assert(defDsc->GetDefNode() == rootNode);
+        defDsc->SetDefNode(nullptr);
 
         DEBUG_DESTROY_NODE(rootNode);
     }


### PR DESCRIPTION
Fixes #108406. When removing redundant store nodes in RBO, we need to also update SSA definitions to no longer track the removed stores. Because call sites that use SSA definitions are responsible for null-checking the store node, the simplest method of removal is to null out the node pointer in the SSA def.

cc @dotnet/jit-contrib, @AndyAyersMS PTAL. I can include a regression test if you think it would be useful, but I think the new `DEBUG_DESTROY_NODE` gives us better coverage anyway.