### PR TITLE
Fix getting default install location for x64 when running x86 host on x64 Windows

### DIFF
--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -404,20 +404,28 @@ bool pal::get_default_installation_dir_for_arch(pal::architecture arch, pal::str
         return false;
 
     const pal::char_t* program_files_dir;
-    if (is_current_arch && pal::is_running_in_wow64())
+    if (is_current_arch)
     {
-        // Running x86 on x64, looking for x86 install
-        program_files_dir = _X("ProgramFiles(x86)");
+        program_files_dir = _X("ProgramFiles");
     }
 #if defined(TARGET_AMD64)
-    else if (!is_current_arch && arch == pal::architecture::x86)
+    else if (arch == pal::architecture::x86)
     {
         // Running x64, looking for x86 install
         program_files_dir = _X("ProgramFiles(x86)");
     }
 #endif
+#if defined(TARGET_X86)
+    else if (pal::is_running_in_wow64() && arch == pal::architecture::x64)
+    {
+        // Running x86 on x64, looking for x64 install
+        program_files_dir = _X("ProgramW6432");
+    }
+#endif
     else
     {
+        // Running arm64/x64, looking for x64/arm64.
+        // Other cases should have bailed out based on is_supported_multi_arch_install
         program_files_dir = _X("ProgramFiles");
     }
 


### PR DESCRIPTION
- Handle x86 on x64 looking for x64 install so that it looks at `ProgramW6432` instead of `ProgramFiles`
- Just check `ProgramFiles` for when determining location for current arch
  - We were unnecessarily checking `ProgramFiles(x86)` for x86 running in wow64

Because this is looking at machine-wide locations, our tests don't actually go down this path (tests for default install location go through a test-only environment variable which bypasses the ProgramFiles environment variables lookup).

Fixes #108502

cc @dotnet/appmodel @AaronRobinsonMSFT @nagilson 