### PR TITLE
Switch `SwiftSelf<T>` position requirement to last

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2226,9 +2226,9 @@ void Compiler::impPopArgsForSwiftCall(GenTreeCall* call, CORINFO_SIG_INFO* sig, 
                     BADCODE("Duplicate SwiftSelf parameter");
                 }
 
-                if (argIndex != 0)
+                if (argIndex != (sig->numArgs - 1))
                 {
-                    BADCODE("SwiftSelf<T> must be the first argument in the signature");
+                    BADCODE("SwiftSelf<T> must be the last argument in the signature");
                 }
 
                 selfType                = info.compCompHnd->getTypeInstantiationArgument(argClass, 0);

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3714,9 +3714,9 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 						break;
 					} else if (param_klass == swift_error || param_klass == swift_error_ptr) {
 						swift_error_args++;
-					} else if (param_gklass && (param_gklass->container_class == swift_self_t) && i > 0) {
+					} else if (param_gklass && (param_gklass->container_class == swift_self_t) && (i != method->signature->param_count - 1)) {
 						swift_error_args = swift_self_args = 0;
-						mono_error_set_generic_error (emitted_error, "System", "InvalidProgramException", "SwiftSelf<T> must be the first argument in the signature.");
+						mono_error_set_generic_error (emitted_error, "System", "InvalidProgramException", "SwiftSelf<T> must be the last argument in the signature.");
 						break;
 					} else if (param_gklass && (param_gklass->container_class == swift_self_t) && m_type_is_byref (method->signature->params [i])) {
 						swift_error_args = swift_self_args = 0;

--- a/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.cs
+++ b/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.cs
@@ -61,11 +61,11 @@ public class SelfContextTests
     }
 
     [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
-    [DllImport(SwiftLib, EntryPoint = "$s16SwiftSelfContext24FrozenEnregisteredStructV3Sums5Int64VyF")]
+    [DllImport(SwiftLib, EntryPoint = "$s16SwiftSelfContext24FrozenEnregisteredStructV3sums5Int64VyF")]
     public static extern long SumFrozenEnregisteredStruct(SwiftSelf<FrozenEnregisteredStruct> self);
 
     [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
-    [DllImport(SwiftLib, EntryPoint = "$s16SwiftSelfContext27FrozenNonEnregisteredStructV3Sums5Int64VyF")]
+    [DllImport(SwiftLib, EntryPoint = "$s16SwiftSelfContext27FrozenNonEnregisteredStructV3sums5Int64VyF")]
     public static extern long SumFrozenNonEnregisteredStruct(SwiftSelf<FrozenNonEnregisteredStruct> self);
 
     [Fact]
@@ -80,5 +80,27 @@ public class SelfContextTests
     {
         long sum = SumFrozenNonEnregisteredStruct(new SwiftSelf<FrozenNonEnregisteredStruct>(new FrozenNonEnregisteredStruct { A = 10, B = 20, C = 30, D = 40, E = 50 }));
         Assert.Equal(150, sum);
+    }
+
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+    [DllImport(SwiftLib, EntryPoint = "$s16SwiftSelfContext24FrozenEnregisteredStructV16sumWithExtraArgs1c1dS2f_SftF")]
+    public static extern float SumFrozenEnregisteredStructWithExtraArgs(float c, float d, SwiftSelf<FrozenEnregisteredStruct> self);
+
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+    [DllImport(SwiftLib, EntryPoint = "$s16SwiftSelfContext27FrozenNonEnregisteredStructV16sumWithExtraArgs1f1gS2f_SftF")]
+    public static extern float SumFrozenNonEnregisteredStructWithExtraArgs(float f, float g, SwiftSelf<FrozenNonEnregisteredStruct> self);
+
+    [Fact]
+    public unsafe static void TestSelfIsFrozenEnregisteredStructWithExtraArgs()
+    {
+        float sum = SumFrozenEnregisteredStructWithExtraArgs(3f, 4f, new SwiftSelf<FrozenEnregisteredStruct>(new FrozenEnregisteredStruct { A = 10, B = 20 }));
+        Assert.Equal(37f, sum);
+    }
+
+    [Fact]
+    public unsafe static void TestSelfIsFrozenNonEnregisteredStructWithExtraArgs()
+    {
+        float sum = SumFrozenNonEnregisteredStructWithExtraArgs(3f, 4f, new SwiftSelf<FrozenNonEnregisteredStruct>(new FrozenNonEnregisteredStruct { A = 10, B = 20, C = 30, D = 40, E = 50 }));
+        Assert.Equal(157f, sum);
     }
 }

--- a/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.cs
+++ b/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.cs
@@ -98,6 +98,7 @@ public class SelfContextTests
     }
 
     [Fact]
+    [SkipOnMono("https://github.com/dotnet/runtime/issues/108855")]
     public unsafe static void TestSelfIsFrozenNonEnregisteredStructWithExtraArgs()
     {
         float sum = SumFrozenNonEnregisteredStructWithExtraArgs(3f, 4f, new SwiftSelf<FrozenNonEnregisteredStruct>(new FrozenNonEnregisteredStruct { A = 10, B = 20, C = 30, D = 40, E = 50 }));

--- a/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.swift
+++ b/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.swift
@@ -26,8 +26,12 @@ public struct FrozenEnregisteredStruct
     let a : Int64;
     let b : Int64;
 
-    public func Sum() -> Int64 {
+    public func sum() -> Int64 {
         return a + b
+    }
+
+    public func sumWithExtraArgs(c: Float, d: Float) -> Float {
+        return Float(a + b) + c + d
     }
 }
 
@@ -39,7 +43,11 @@ public struct FrozenNonEnregisteredStruct {
     let d : Int64;
     let e : Int64;
 
-    public func Sum() -> Int64 {
+    public func sum() -> Int64 {
         return a + b + c + d + e
+    }
+
+    public func sumWithExtraArgs(f: Float, g: Float) -> Float {
+        return Float(a + b + c + d + e) + f + g
     }
 }


### PR DESCRIPTION
This is added as the last parameter by the Swift compiler, so to support instance calls taking parameters this needs to come last.

Fix #107946