### PR TITLE
ILLink: Don't mark attributes from MarkEntireType

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -326,8 +326,6 @@ namespace Mono.Linker.Steps
 			}
 
 			MarkTypeVisibleToReflection (type, reason, origin);
-			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type), origin);
-			MarkTypeSpecialCustomAttributes (type, origin);
 
 			if (type.HasInterfaces) {
 				foreach (InterfaceImplementation iface in type.Interfaces)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInRootAllAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInRootAllAssembly.cs
@@ -8,6 +8,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
+	[IgnoreTestCase ("NativeAOT test infrastructure doesn't implement rooting behavior the same way", IgnoredBy = Tool.NativeAot)]
 	[SetupLinkerArgument ("-a", "test.exe", "all")]
 
 	[SkipKeptItemsValidation]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInRootAllAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInRootAllAssembly.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -54,6 +54,17 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			public static int Property { get; set; }
 
 			public static event EventHandler PropertyChanged;
+		}
+
+		[AttributeWithRequires]
+		[ExpectedWarning ("IL2026")]
+		public sealed class ClassWithAttributeWithRequires
+		{
+		}
+
+		[RequiresUnreferencedCode ("--AttributeWithRequiresAttribute--")]
+		public sealed class AttributeWithRequiresAttribute : Attribute
+		{
 		}
 	}
 }


### PR DESCRIPTION
They are already marked from MarkType, called by MarkEntireType. The removed marking logic was using the assembly as the warning message origin, making these warnings hard to suppress (in addition to being redundant with the warnings at the type level).

Fixes some warnings encountered in https://github.com/dotnet/runtime/pull/108464 in the OOB library trimming step.