### PR TITLE
Add static factory for InvalidEnumArgumentException

### DIFF
--- a/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/InvalidEnumArgumentException.cs
+++ b/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/InvalidEnumArgumentException.cs
@@ -62,5 +62,18 @@ namespace System.ComponentModel
         protected InvalidEnumArgumentException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+
+        /// <summary>
+        /// Creates an exception for an invalid enum argument.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">the invalid value</param>
+        /// <param name="argumentName">the name of the argument</param>
+        /// <returns></returns>
+        public static Exception Create<T>(T value, [CallerArgumentExpression(nameof(value))] string argumentName = null!)
+            where T : Enum
+        {
+            return new System.ComponentModel.InvalidEnumArgumentException(argumentName, (int)Convert.ChangeType(value, typeof(int))!, typeof(T));
+        }
     }
 }


### PR DESCRIPTION
add a convenience method to create a InvalidEnumArgumentException from just the invalid value

```csharp

MyEnum x = (MyEnum)(-9999);

switch(x)
{
  /* ... */
  default:
    throw InvalidEnumArgumentException.Create(x);
}

```