### PR TITLE
JIT: Disallow SCEV analysis of non-values

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -779,7 +779,7 @@ bool Compiler::optWidenIVs(ScalarEvolutionContext& scevContext,
         JITDUMP("\n");
         DISPSTMT(stmt);
 
-        Scev* scev = scevContext.Analyze(loop->GetHeader(), stmt->GetRootNode());
+        Scev* scev = scevContext.Analyze(loop->GetHeader(), stmt->GetRootNode()->AsLclVarCommon()->Data());
         if (scev == nullptr)
         {
             JITDUMP("  Could not analyze header PHI\n");
@@ -1417,7 +1417,7 @@ bool StrengthReductionContext::TryStrengthReduce()
         DISPSTMT(stmt);
 
         GenTreeLclVarCommon* primaryIVLcl = stmt->GetRootNode()->AsLclVarCommon();
-        Scev*                candidate    = m_scevContext.Analyze(m_loop->GetHeader(), primaryIVLcl);
+        Scev*                candidate    = m_scevContext.Analyze(m_loop->GetHeader(), primaryIVLcl->Data());
         if (candidate == nullptr)
         {
             JITDUMP("  Could not analyze header PHI\n");

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -230,10 +230,7 @@ class ScalarEvolutionContext
 
     Scev* Analyze(BasicBlock* block, GenTree* tree, int depth);
     Scev* AnalyzeNew(BasicBlock* block, GenTree* tree, int depth);
-    Scev* CreateSimpleAddRec(GenTreeLclVarCommon* headerStore,
-                             ScevLocal*           start,
-                             BasicBlock*          stepDefBlock,
-                             GenTree*             stepDefData);
+    Scev* CreateSimpleAddRec(GenTreePhi* headerPhi, ScevLocal* start, BasicBlock* stepDefBlock, GenTree* stepDefData);
     Scev* MakeAddRecFromRecursiveScev(Scev* start, Scev* scev, Scev* recursiveScev);
     Scev* CreateSimpleInvariantScev(GenTree* tree);
     Scev* CreateScevForConstant(GenTreeIntConCommon* tree);


### PR DESCRIPTION
SCEV analysis would allow stores either via simple add-rec handling or by forwarding to the data of the store. Given that stores are not values this is odd behavior that has bitten me while consuming the analysis package.

Switch the analysis to return nullptr for stores; instead add handling for `GT_PHI` in the places where it was needed.