### PR TITLE
Fixed build error

### DIFF
--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -3917,6 +3917,10 @@ inline WCHAR *PAL_wcsstr(WCHAR* S, const WCHAR* P)
 }
 #endif
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 #if !__has_builtin(_rotl) && !defined(_rotl)
 /*++
 Function:


### PR DESCRIPTION
A build error occurred in Tizen OS as below.
```
[   85s] /usr/share/dotnet.tizen/netcoreapp/src/pal/inc/pal.h:4180:19: error: missing binary operator before token "("
[   85s]  4180 | #if !__has_builtin(_rotl)
[   85s]       |                   ^
[   85s] /usr/share/dotnet.tizen/netcoreapp/src/pal/inc/pal.h:4205:19: error: missing binary operator before token "("
[   85s]  4205 | #if !__has_builtin(_rotr)
[   85s]       |                   ^
[   86s] make[2]: *** [CMakeFiles/dotnet_launcher_util.dir/build.make:76: CMakeFiles/dotnet_launcher_util.dir/tool/r2r_checker.cc.o] Error 1
[   86s] make[2]: *** Waiting for unfinished jobs....
```


1. https://github.com/dotnet/runtime/pull/85006
 -> The location of the code has been changed.

2. https://github.com/dotnet/runtime/pull/89342
-> The code has been deleted.

So I restore the code again.
```
#ifndef __has_builtin
#define __has_builtin(x) 0
#endif
```
I think it should be applied to ```release/8.0-staging``` branch as well.