### PR TITLE
Fixes typo of word dictionary throughout repo

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.CompilerServices
         where TValue : class?
     {
         // Lifetimes of keys and values:
-        // Inserting a key and value into the dictonary will not
+        // Inserting a key and value into the dictionary will not
         // prevent the key from dying, even if the key is strongly reachable
         // from the value. Once the key dies, the dictionary automatically removes
         // the key/value entry.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -183,7 +183,7 @@ namespace System.Threading.Tasks
         // When true the Async Causality logging trace is enabled as well as a dictionary to relate operation ids with Tasks
         internal static bool s_asyncDebuggingEnabled; // false by default
 
-        // This dictonary relates the task id, from an operation id located in the Async Causality log to the actual
+        // This dictionary relates the task id, from an operation id located in the Async Causality log to the actual
         // task. This is to be used by the debugger ONLY. Task in this dictionary represent current active tasks.
         private static Dictionary<int, Task>? s_currentActiveTasks;
 

--- a/src/libraries/System.Text.Json/tests/Common/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ExtensionDataTests.cs
@@ -1251,7 +1251,7 @@ namespace System.Text.Json.Serialization.Tests
         public class ClassWithExtensionPropertyThreeGenericParameters
         {
             [JsonExtensionData]
-            public GenericIDictonaryWrapperThreeGenericParameters<string, object, string> MyOverflow { get; set; }
+            public GenericIDictionaryWrapperThreeGenericParameters<string, object, string> MyOverflow { get; set; }
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.GenericCollections.cs
@@ -817,7 +817,7 @@ namespace System.Text.Json.Serialization.Tests
         internal GenericIDictionaryWrapperInternalConstructor() { }
     }
 
-    public class GenericIDictonaryWrapperThreeGenericParameters<TKey, TValue, TUnused> : GenericIDictionaryWrapper<TKey, TValue> { }
+    public class GenericIDictionaryWrapperThreeGenericParameters<TKey, TValue, TUnused> : GenericIDictionaryWrapper<TKey, TValue> { }
 
     public class ReadOnlyStringToStringIDictionaryWrapper : GenericIDictionaryWrapper<string, string>
     {


### PR DESCRIPTION
Fixes a typo in a comment in ConditionalWeakTable.cs
- `dictonary` should be `dictionary`