### PR TITLE
JIT: Move hot/cold splitting phase to backend

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5177,10 +5177,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // Conditional to Switch conversion
         //
         DoPhase(this, PHASE_SWITCH_RECOGNITION, &Compiler::optSwitchRecognition);
-
-        // Determine start of cold region if we are hot/cold splitting
-        //
-        DoPhase(this, PHASE_DETERMINE_FIRST_COLD_BLOCK, &Compiler::fgDetermineFirstColdBlock);
     }
 
 #ifdef DEBUG
@@ -5261,13 +5257,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             };
 
             DoPhase(this, PHASE_OPTIMIZE_LAYOUT, lateLayoutPhase);
-
-            if (fgFirstColdBlock != nullptr)
-            {
-                fgFirstColdBlock = nullptr;
-                DoPhase(this, PHASE_DETERMINE_FIRST_COLD_BLOCK, &Compiler::fgDetermineFirstColdBlock);
-            }
         }
+
+        // Determine start of cold region if we are hot/cold splitting
+        DoPhase(this, PHASE_DETERMINE_FIRST_COLD_BLOCK, &Compiler::fgDetermineFirstColdBlock);
 
         // Now that the flowgraph is finalized, run post-layout optimizations.
         DoPhase(this, PHASE_OPTIMIZE_POST_LAYOUT, &Compiler::optOptimizePostLayout);


### PR DESCRIPTION
Fixes #108611. Running hot/cold splitting at most once ensures the coldness of blocks (as tracked by `BBF_COLD`) is correct by the time we get to the emitter.

@dotnet/jit-contrib PTAL, thanks!