### PR TITLE
Add missing return value doc comments for Create(ROS<float> values)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -299,6 +299,7 @@ namespace System.Numerics
 
         /// <summary>Constructs a vector from the given <see cref="ReadOnlySpan{Single}" />. The span must contain at least 2 elements.</summary>
         /// <param name="values">The span of elements to assign to the vector.</param>
+        /// <returns>A new <see cref="Vector2" /> whose elements have the specified values.</returns>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 Create(ReadOnlySpan<float> values)

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -334,6 +334,7 @@ namespace System.Numerics
 
         /// <summary>Constructs a vector from the given <see cref="ReadOnlySpan{Single}" />. The span must contain at least 3 elements.</summary>
         /// <param name="values">The span of elements to assign to the vector.</param>
+        /// <returns>A new <see cref="Vector3" /> whose elements have the specified values.</returns>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 Create(ReadOnlySpan<float> values)

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -369,6 +369,7 @@ namespace System.Numerics
 
         /// <summary>Constructs a vector from the given <see cref="ReadOnlySpan{Single}" />. The span must contain at least 4 elements.</summary>
         /// <param name="values">The span of elements to assign to the vector.</param>
+        /// <returns>A new <see cref="Vector4" /> whose elements have the specified values.</returns>
         [Intrinsic]
         public static Vector4 Create(ReadOnlySpan<float> values) => Vector128.Create(values).AsVector4();
 


### PR DESCRIPTION
Fixes #105981 by adding the missing return value doc comments. I'll also submit a PR into dotnet-api-docs to get these added for .NET 9.