### PR TITLE
Remove all kernel32.dll references and debug breakpoints

### DIFF
--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -79,7 +79,6 @@ internal class RFLogging
                 }
                 catch (IOException e)
                 {
-                    ReliabilityFramework.MyDebugBreak(String.Format("LogWorker IOException:{0}", e.ToString()));
                     //Disk may be full so simply stop logging
                 }
             }
@@ -120,7 +119,6 @@ internal class RFLogging
                 }
                 catch (IOException e)
                 {
-                    ReliabilityFramework.MyDebugBreak(String.Format("LogWorker IOException:{0}", e.ToString()));
                 }
             }
         }

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -80,7 +80,18 @@ internal class RFLogging
                 catch (IOException e)
                 {
                     //Disk may be full so simply stop logging
-                    throw new Exception("Fail to write message to log file: " + e.Message);
+                    if (ReliabilityFramework._debugBreakOnTestHang)
+                    {
+                        string msg = String.Format("Interrupt because fail to write message to log file: {0}", e.Message);
+                        Console.WriteLine(msg);
+                        Debugger.Break();
+                    }
+                    else
+                    {
+                        string msg = String.Format("Throw exception because fail to write message to log file: {0}", e.Message);
+                        Console.WriteLine(msg);
+                        throw new Exception("Fail to write message to log file");
+                    }
                 }
             }
 
@@ -120,7 +131,18 @@ internal class RFLogging
                 }
                 catch (IOException e)
                 {
-                    throw new Exception("Fail to write message to log file: " + e.Message);
+                    if (ReliabilityFramework._debugBreakOnTestHang)
+                    {
+                        string msg = String.Format("Interrupt because fail to write message to log file: {0}", e.Message);
+                        Console.WriteLine(msg);
+                        Debugger.Break();
+                    }
+                    else
+                    {
+                        string msg = String.Format("Throw exception because fail to write message to log file: {0}", e.Message);
+                        Console.WriteLine(msg);
+                        throw new Exception("Fail to write message to log file");
+                    }
                 }
             }
         }

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -120,6 +120,7 @@ internal class RFLogging
                 }
                 catch (IOException e)
                 {
+                    throw new Exception("Fail to write message to log file: " + e.Message);
                 }
             }
         }

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -80,7 +80,12 @@ internal class RFLogging
                 catch (IOException e)
                 {
                     //Disk may be full so simply stop logging
-                    ReliabilityFramework.DebugBreakOrThrowException(ReliabilityFramework._debugBreakOnTestHang, e);
+                    ExceptionHandler exceptionHandler = ReliabilityFramework.GenerateExceptionMessageAndHandler(ReliabilityFramework._debugBreakOnTestHang, e);
+                    string msg = exceptionHandler.HandleMessage;
+                    Action handler = exceptionHandler.Handler;
+
+                    Console.WriteLine(msg);
+                    handler();
                 }
             }
 
@@ -120,7 +125,12 @@ internal class RFLogging
                 }
                 catch (IOException e)
                 {
-                    ReliabilityFramework.DebugBreakOrThrowException(ReliabilityFramework._debugBreakOnTestHang, e);
+                    ExceptionHandler exceptionHandler = ReliabilityFramework.GenerateExceptionMessageAndHandler(ReliabilityFramework._debugBreakOnTestHang, e);
+                    string msg = exceptionHandler.HandleMessage;
+                    Action handler = exceptionHandler.Handler;
+
+                    Console.WriteLine(msg);
+                    handler();
                 }
             }
         }

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -80,6 +80,7 @@ internal class RFLogging
                 catch (IOException e)
                 {
                     //Disk may be full so simply stop logging
+                    throw new Exception("Fail to write message to log file: " + e.Message);
                 }
             }
 

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -80,18 +80,7 @@ internal class RFLogging
                 catch (IOException e)
                 {
                     //Disk may be full so simply stop logging
-                    if (ReliabilityFramework._debugBreakOnTestHang)
-                    {
-                        string msg = String.Format("Interrupt because fail to write message to log file: {0}", e.Message);
-                        Console.WriteLine(msg);
-                        Debugger.Break();
-                    }
-                    else
-                    {
-                        string msg = String.Format("Throw exception because fail to write message to log file: {0}", e.Message);
-                        Console.WriteLine(msg);
-                        throw new Exception("Fail to write message to log file");
-                    }
+                    ReliabilityFramework.DebugBreakOrThrowException(ReliabilityFramework._debugBreakOnTestHang, e);
                 }
             }
 
@@ -131,18 +120,7 @@ internal class RFLogging
                 }
                 catch (IOException e)
                 {
-                    if (ReliabilityFramework._debugBreakOnTestHang)
-                    {
-                        string msg = String.Format("Interrupt because fail to write message to log file: {0}", e.Message);
-                        Console.WriteLine(msg);
-                        Debugger.Break();
-                    }
-                    else
-                    {
-                        string msg = String.Format("Throw exception because fail to write message to log file: {0}", e.Message);
-                        Console.WriteLine(msg);
-                        throw new Exception("Fail to write message to log file");
-                    }
+                    ReliabilityFramework.DebugBreakOrThrowException(ReliabilityFramework._debugBreakOnTestHang, e);
                 }
             }
         }

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -839,13 +839,14 @@ public class ReliabilityFramework
 
             if (_curTestSet.DebugBreakOnTestHang)
             {
-                string msg = "Test hang because of timeout"
+                string msg = "Test hang because of timeout";
+                Console.WriteLine(msg);
                 _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.StartupShutdown, msg);
                 Debugger.Break();
             }
             else
             {
-                string msg = "Throw exception because of timeout"
+                string msg = "Throw exception because of timeout";
                 _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.StartupShutdown, msg);
                 throw new TimeoutException("Time limit reached.");
             }

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -277,7 +277,6 @@ public class ReliabilityFramework
         }
         catch (OutOfMemoryException)
         {
-            // hang and let someone debug if we can't even break in...
             _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.Tests, "Out of memory");
         }
     }

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -227,6 +227,10 @@ public class ReliabilityFramework
             {
                 rf.HandleOom(e, "Running tests");
             }
+            catch (TimeoutException e)
+            {
+                throw e;
+            }
             catch (Exception e)
             {
                 Exception eTemp = e.InnerException;
@@ -831,6 +835,17 @@ public class ReliabilityFramework
                     Console.WriteLine(msg);
                     AddFailure("Test Hang", _curTestSet.Tests[i], -1);
                 }
+            }
+
+            if (_curTestSet.DebugBreakOnTestHang)
+            {
+                Console.WriteLine("Test hang.");
+                Debugger.Break();
+            }
+            else
+            {
+                Console.WriteLine("Time limit reached.");
+                throw new TimeoutException("Time limit reached.");
             }
         }
     }

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -278,7 +278,7 @@ public class ReliabilityFramework
         catch (OutOfMemoryException)
         {
             // hang and let someone debug if we can't even break in...
-            _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.Tests, String.Format("Exception while running tests: {0}", OutOfMemoryException));
+            _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.Tests, "Out of memory");
         }
     }
 
@@ -740,7 +740,7 @@ public class ReliabilityFramework
                     Thread.Sleep(250);	// give the CPU a bit of a rest if we don't need to start a new test.
                     if (_curTestSet.DebugBreakOnMissingTest && DateTime.Now.Subtract(_startTime) > minTimeToStartTest)
                     {
-                        _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.TestStarter, String.Format("New tests not starting."));
+                        _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.TestStarter, String.Format("New tests not starting"));
                     }
                 }
             }

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -839,12 +839,14 @@ public class ReliabilityFramework
 
             if (_curTestSet.DebugBreakOnTestHang)
             {
-                Console.WriteLine("Test hang.");
+                string msg = "Test hang because of timeout"
+                _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.StartupShutdown, msg);
                 Debugger.Break();
             }
             else
             {
-                Console.WriteLine("Time limit reached.");
+                string msg = "Throw exception because of timeout"
+                _logger.WriteToInstrumentationLog(_curTestSet, LoggingLevels.StartupShutdown, msg);
                 throw new TimeoutException("Time limit reached.");
             }
         }

--- a/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
@@ -24,7 +24,7 @@ public class ReliabilityTestSet
     private string _friendlyName;
     private bool _enablePerfCounters = true, _disableLogging = false, _installDetours = false;
     private bool _suppressConsoleOutputFromTests = false;
-    private bool _debugBreakOnTestHang = true;
+    private bool _debugBreakOnTestHang = false;
     private bool _debugBreakOnBadTest = false;
     private bool _debugBreakOnOutOfMemory = false;
     private bool _debugBreakOnPathTooLong = false;

--- a/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
@@ -24,7 +24,7 @@ public class ReliabilityTestSet
     private string _friendlyName;
     private bool _enablePerfCounters = true, _disableLogging = false, _installDetours = false;
     private bool _suppressConsoleOutputFromTests = false;
-    private bool _debugBreakOnTestHang = false;
+    private bool _debugBreakOnTestHang = true;
     private bool _debugBreakOnBadTest = false;
     private bool _debugBreakOnOutOfMemory = false;
     private bool _debugBreakOnPathTooLong = false;

--- a/src/tests/GC/Stress/finalization.config
+++ b/src/tests/GC/Stress/finalization.config
@@ -11,8 +11,7 @@
             installDetours="false" 
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
-            suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="true">
+            suppressConsoleOutputFromTests="true">
 
     <Assembly id="GCPerfSim - SOH Allocations Finalizable Objects."
             successCode="100"

--- a/src/tests/GC/Stress/finalization.config
+++ b/src/tests/GC/Stress/finalization.config
@@ -12,7 +12,7 @@
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
             suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="false">
+            debugBreakOnTestHang="true">
 
     <Assembly id="GCPerfSim - SOH Allocations Finalizable Objects."
             successCode="100"

--- a/src/tests/GC/Stress/finalization.config
+++ b/src/tests/GC/Stress/finalization.config
@@ -12,7 +12,7 @@
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
             suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="true">
+            debugBreakOnTestHang="false">
 
     <Assembly id="GCPerfSim - SOH Allocations Finalizable Objects."
             successCode="100"

--- a/src/tests/GC/Stress/loh.config
+++ b/src/tests/GC/Stress/loh.config
@@ -11,8 +11,7 @@
             installDetours="false" 
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
-            suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="true">
+            suppressConsoleOutputFromTests="true">
 
     <!-- Add GCPerfSim with No live data on the LOH -->
     <Assembly id="GCPerfSim - LOH No Live Data."

--- a/src/tests/GC/Stress/loh.config
+++ b/src/tests/GC/Stress/loh.config
@@ -12,7 +12,7 @@
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
             suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="false">
+            debugBreakOnTestHang="true">
 
     <!-- Add GCPerfSim with No live data on the LOH -->
     <Assembly id="GCPerfSim - LOH No Live Data."

--- a/src/tests/GC/Stress/loh.config
+++ b/src/tests/GC/Stress/loh.config
@@ -12,7 +12,7 @@
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
             suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="true">
+            debugBreakOnTestHang="false">
 
     <!-- Add GCPerfSim with No live data on the LOH -->
     <Assembly id="GCPerfSim - LOH No Live Data."

--- a/src/tests/GC/Stress/non_induced.config
+++ b/src/tests/GC/Stress/non_induced.config
@@ -11,7 +11,8 @@
             installDetours="false" 
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
-            suppressConsoleOutputFromTests="true">
+            suppressConsoleOutputFromTests="true"
+            debugBreakOnTestHang="false">
 
    <Assembly id="SingLinkStay.dll" 
             successCode="100" 

--- a/src/tests/GC/Stress/non_induced.config
+++ b/src/tests/GC/Stress/non_induced.config
@@ -11,8 +11,7 @@
             installDetours="false" 
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
-            suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="false">
+            suppressConsoleOutputFromTests="true">
 
    <Assembly id="SingLinkStay.dll" 
             successCode="100" 

--- a/src/tests/GC/Stress/poh.config
+++ b/src/tests/GC/Stress/poh.config
@@ -11,8 +11,7 @@
             installDetours="false" 
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
-            suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="true">
+            suppressConsoleOutputFromTests="true">
 
     <!-- Add GCPerfSim with No live data on the POH -->
     <Assembly id="GCPerfSim - POH No Live Data."

--- a/src/tests/GC/Stress/poh.config
+++ b/src/tests/GC/Stress/poh.config
@@ -12,7 +12,7 @@
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
             suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="false">
+            debugBreakOnTestHang="true">
 
     <!-- Add GCPerfSim with No live data on the POH -->
     <Assembly id="GCPerfSim - POH No Live Data."

--- a/src/tests/GC/Stress/poh.config
+++ b/src/tests/GC/Stress/poh.config
@@ -12,7 +12,7 @@
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
             suppressConsoleOutputFromTests="true"
-            debugBreakOnTestHang="true">
+            debugBreakOnTestHang="false">
 
     <!-- Add GCPerfSim with No live data on the POH -->
     <Assembly id="GCPerfSim - POH No Live Data."


### PR DESCRIPTION
This pull request aims at:
1. Removing all kernel32.dll references
2. Replacing all debug breakpoints with logging
3. Setting `debugBreakOnTestHang` to false for all configurations