### PR TITLE
Do not ignore `MemoryMarshal.TryWrite` result

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -914,13 +914,13 @@ namespace System
             var g = new byte[16];
             if (BitConverter.IsLittleEndian)
             {
-                MemoryMarshal.TryWrite(g, in this);
+                MemoryMarshal.Write(g, in this);
             }
             else
             {
                 // slower path for BigEndian
                 Guid guid = new Guid(MemoryMarshal.AsBytes(new ReadOnlySpan<Guid>(in this)), false);
-                MemoryMarshal.TryWrite(g, in guid);
+                MemoryMarshal.Write(g, in guid);
             }
             return g;
         }
@@ -932,13 +932,13 @@ namespace System
             var g = new byte[16];
             if (BitConverter.IsLittleEndian != bigEndian)
             {
-                MemoryMarshal.TryWrite(g, in this);
+                MemoryMarshal.Write(g, in this);
             }
             else
             {
                 // slower path for Reverse
                 Guid guid = new Guid(MemoryMarshal.AsBytes(new ReadOnlySpan<Guid>(in this)), bigEndian);
-                MemoryMarshal.TryWrite(g, in guid);
+                MemoryMarshal.Write(g, in guid);
             }
             return g;
         }
@@ -951,13 +951,13 @@ namespace System
 
             if (BitConverter.IsLittleEndian)
             {
-                MemoryMarshal.TryWrite(destination, in this);
+                MemoryMarshal.Write(destination, in this);
             }
             else
             {
                 // slower path for BigEndian
                 Guid guid = new Guid(MemoryMarshal.AsBytes(new ReadOnlySpan<Guid>(in this)), false);
-                MemoryMarshal.TryWrite(destination, in guid);
+                MemoryMarshal.Write(destination, in guid);
             }
             return true;
         }
@@ -973,13 +973,13 @@ namespace System
 
             if (BitConverter.IsLittleEndian != bigEndian)
             {
-                MemoryMarshal.TryWrite(destination, in this);
+                MemoryMarshal.Write(destination, in this);
             }
             else
             {
                 // slower path for Reverse
                 Guid guid = new Guid(MemoryMarshal.AsBytes(new ReadOnlySpan<Guid>(in this)), bigEndian);
-                MemoryMarshal.TryWrite(destination, in guid);
+                MemoryMarshal.Write(destination, in guid);
             }
             bytesWritten = 16;
             return true;


### PR DESCRIPTION
It is unidiomatic to ignore the return value of a Try method.

Supersedes https://github.com/dotnet/runtime/pull/104728