### PR TITLE
Packaging: Port fix for GetParts from .NETFramework

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
+++ b/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
@@ -5,6 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides classes that support storage of multiple data objects in a single container.</PackageDescription>
     <!-- TODO: Add package README file: https://github.com/dotnet/runtime/issues/99358 -->
     <EnableDefaultPackageReadmeFile>false</EnableDefaultPackageReadmeFile>

--- a/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
+++ b/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
@@ -5,8 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides classes that support storage of multiple data objects in a single container.</PackageDescription>
     <!-- TODO: Add package README file: https://github.com/dotnet/runtime/issues/99358 -->
     <EnableDefaultPackageReadmeFile>false</EnableDefaultPackageReadmeFile>

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -380,6 +380,8 @@ namespace System.IO.Packaging
         /// <returns></returns>
         /// <exception cref="ObjectDisposedException">If this Package object has been disposed</exception>
         /// <exception cref="IOException">If the package is writeonly, no information can be retrieved from it</exception>
+        /// <exception cref="FileFormatException">The package has a bad format.</exception>
+        /// <exception cref="InvalidOperationException">The part name prefix exists.</exception>
         public PackagePartCollection GetParts()
         {
             ThrowIfObjectDisposed();
@@ -412,8 +414,8 @@ namespace System.IO.Packaging
                 //Note: We cannot use the _partList member variable, as that gets updated incrementally and so its
                 //not possible to find the collisions using that list.
                 //PackUriHelper.ValidatedPartUri implements the IComparable interface.
-                Dictionary<string, KeyValuePair<PackUriHelper.ValidatedPartUri, PackagePart>> partDictionary = new Dictionary<string, KeyValuePair<PackUriHelper.ValidatedPartUri, PackagePart>>(parts.Length);
-                List<string> partIndex = new List<string>(parts.Length);
+                Dictionary<string, KeyValuePair<PackUriHelper.ValidatedPartUri, PackagePart>> partDictionary = new(parts.Length);
+                List<string> partIndex = new(parts.Length);
 
                 for (int i = 0; i < parts.Length; i++)
                 {
@@ -427,7 +429,7 @@ namespace System.IO.Packaging
                     }
                     else
                     {
-                        //since we will arive to this line of code after the parts are already sorted
+                        //since we will arrive to this line of code after the parts are already sorted
                         string? precedingPartName = null;
 
                         if (partIndex.Count > 0)
@@ -456,7 +458,7 @@ namespace System.IO.Packaging
                 }
 
                 //copying parts from partdictionary to partlist
-                CopyPartDicitonaryToPartList(partDictionary, partIndex);
+                CopyPartDictionaryToPartList(partDictionary, partIndex);
 
                 _partCollection = new PackagePartCollection(_partList);
             }
@@ -1204,7 +1206,7 @@ namespace System.IO.Packaging
             return new PackageRelationshipCollection(_relationships, filterString);
         }
 
-        private void CopyPartDicitonaryToPartList(Dictionary<string, KeyValuePair<PackUriHelper.ValidatedPartUri, PackagePart>> partDictionary, List<string> partIndex)
+        private void CopyPartDictionaryToPartList(Dictionary<string, KeyValuePair<PackUriHelper.ValidatedPartUri, PackagePart>> partDictionary, List<string> partIndex)
         {
             //Clearing _partList before copying in new data. Reassigning the variable, assuming the previous object to be garbage collected.
             //ideally addition to sortedlist takes O(n) but since we have sorted data and also we defined the size, it will take O(log n) per addition

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -739,7 +739,7 @@ namespace System.IO.Packaging
                 //with the rules for comparing/normalizing partnames.
                 //Refer to PackUriHelper.ValidatedPartUri.GetNormalizedPartUri method.
                 //Currently normalization just involves upper-casing ASCII and hence the simplification.
-                return extensionA.Equals(extensionB, StringComparison.InvariantCultureIgnoreCase);
+                return extensionA.Equals(extensionB, StringComparison.OrdinalIgnoreCase);
             }
 
             int IEqualityComparer<string>.GetHashCode(string extension)


### PR DESCRIPTION
This ports a fix for the `GetParts` method to improve part URI handling and collision detection.  Fix in .NETFramework originally made by @Kuldeep-MS 

`src/libraries/System.IO.Packaging/src/System/IO/Packaging/Package.cs`: Added sorting of parts array to ensure proper order, introduced a dictionary and list to track parts and detect collisions, and implemented a new method `CopyPartDictionaryToPartList` to copy parts to `_partList`.