### PR TITLE
[release/9.0] Backport "JIT: Run single EH region repair pass after layout"

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2938,6 +2938,8 @@ public:
 
     void fgSetHndEnd(EHblkDsc* handlerTab, BasicBlock* newHndLast);
 
+    void fgFindEHRegionEnds();
+
     void fgSkipRmvdBlocks(EHblkDsc* handlerTab);
 
     void fgAllocEHTable();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2829,9 +2829,6 @@ public:
     EHblkDsc* ehIsBlockHndLast(BasicBlock* block);
     bool ehIsBlockEHLast(BasicBlock* block);
 
-    template <typename GetTryLast, typename SetTryLast>
-    void ehUpdateTryLasts(GetTryLast getTryLast, SetTryLast setTryLast);
-
     bool ehBlockHasExnFlowDsc(BasicBlock* block);
 
     // Return the region index of the most nested EH region this block is in.

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3357,6 +3357,11 @@ bool Compiler::fgReorderBlocks(bool useProfile)
             fgDoReversePostOrderLayout();
             fgMoveColdBlocks();
 
+            if (compHndBBtabCount != 0)
+            {
+                fgFindEHRegionEnds();
+            }
+
             // Renumber blocks to facilitate LSRA's order of block visitation
             // TODO: Consider removing this, and using traversal order in lSRA
             //

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4707,22 +4707,6 @@ void Compiler::fgDoReversePostOrderLayout()
         return;
     }
 
-    // The RPO will scramble the EH regions, requiring us to correct their state.
-    // To do so, we will need to determine the new end blocks of each region.
-    //
-    struct EHLayoutInfo
-    {
-        BasicBlock* tryRegionEnd;
-        BasicBlock* hndRegionEnd;
-        bool        tryRegionInMainBody;
-
-        // Default constructor provided so we can call ArrayStack::Emplace
-        //
-        EHLayoutInfo() = default;
-    };
-
-    ArrayStack<EHLayoutInfo> regions(getAllocator(CMK_ArrayStack), compHndBBtabCount);
-
     // The RPO will break up call-finally pairs, so save them before re-ordering
     //
     struct CallFinallyPair
@@ -4743,9 +4727,6 @@ void Compiler::fgDoReversePostOrderLayout()
 
     for (EHblkDsc* const HBtab : EHClauses(this))
     {
-        // Default-initialize a EHLayoutInfo for each EH clause
-        regions.Emplace();
-
         if (HBtab->HasFinallyHandler())
         {
             for (BasicBlock* const pred : HBtab->ebdHndBeg->PredBlocks())
@@ -4792,89 +4773,6 @@ void Compiler::fgDoReversePostOrderLayout()
     }
 
     fgMoveHotJumps</* hasEH */ true>();
-
-    // The RPO won't change the entry blocks of any EH regions, but reordering can change the last block in a region
-    // (for example, by pushing throw blocks unreachable via normal flow to the end of the region).
-    // First, determine the new EH region ends.
-    //
-
-    for (BasicBlock* const block : Blocks(fgFirstBB, fgLastBBInMainFunction()))
-    {
-        if (block->hasTryIndex())
-        {
-            EHLayoutInfo& layoutInfo       = regions.BottomRef(block->getTryIndex());
-            layoutInfo.tryRegionEnd        = block;
-            layoutInfo.tryRegionInMainBody = true;
-        }
-
-        if (block->hasHndIndex())
-        {
-            regions.BottomRef(block->getHndIndex()).hndRegionEnd = block;
-        }
-    }
-
-    for (BasicBlock* const block : Blocks(fgFirstFuncletBB))
-    {
-        if (block->hasHndIndex())
-        {
-            regions.BottomRef(block->getHndIndex()).hndRegionEnd = block;
-        }
-
-        if (block->hasTryIndex())
-        {
-            EHLayoutInfo& layoutInfo = regions.BottomRef(block->getTryIndex());
-
-            if (!layoutInfo.tryRegionInMainBody)
-            {
-                layoutInfo.tryRegionEnd = block;
-            }
-        }
-    }
-
-    // Now, update the EH descriptors, starting with the try regions
-    //
-    auto getTryLast = [&regions](const unsigned index) -> BasicBlock* {
-        return regions.BottomRef(index).tryRegionEnd;
-    };
-
-    auto setTryLast = [&regions](const unsigned index, BasicBlock* const block) {
-        regions.BottomRef(index).tryRegionEnd = block;
-    };
-
-    ehUpdateTryLasts<decltype(getTryLast), decltype(setTryLast)>(getTryLast, setTryLast);
-
-    // Now, do the handler regions
-    //
-    unsigned XTnum = 0;
-    for (EHblkDsc* const HBtab : EHClauses(this))
-    {
-        // The end of each handler region should have been visited by iterating the blocklist above
-        //
-        BasicBlock* const hndEnd = regions.BottomRef(XTnum++).hndRegionEnd;
-        assert(hndEnd != nullptr);
-
-        // Update the end pointer of this handler region to the new last block
-        //
-        HBtab->ebdHndLast                = hndEnd;
-        const unsigned enclosingHndIndex = HBtab->ebdEnclosingHndIndex;
-
-        // If this handler region is nested in another one, we might need to update its enclosing region's end block
-        //
-        if (enclosingHndIndex != EHblkDsc::NO_ENCLOSING_INDEX)
-        {
-            BasicBlock* const enclosingHndEnd = regions.BottomRef(enclosingHndIndex).hndRegionEnd;
-            assert(enclosingHndEnd != nullptr);
-
-            // If the enclosing region ends right before the nested region begins,
-            // extend the enclosing region's last block to the end of the nested region.
-            //
-            BasicBlock* const hndBeg = HBtab->HasFilter() ? HBtab->ebdFilter : HBtab->ebdHndBeg;
-            if (enclosingHndEnd->NextIs(hndBeg))
-            {
-                regions.BottomRef(enclosingHndIndex).hndRegionEnd = hndEnd;
-            }
-        }
-    }
 }
 
 //-----------------------------------------------------------------------------
@@ -5057,7 +4955,7 @@ void Compiler::fgMoveColdBlocks()
         }
     }
 
-    // Before updating EH descriptors, find the new try region ends
+    // Find the new try region ends
     //
     for (unsigned XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
     {
@@ -5101,75 +4999,6 @@ void Compiler::fgMoveColdBlocks()
                 assert(!prev->HasFlag(BBF_RETLESS_CALL));
                 fgUnlinkBlock(prev);
                 fgInsertBBafter(newTryEnd, prev);
-            }
-        }
-        else
-        {
-            // Otherwise, just update the try region end
-            //
-            tryRegionEnds[XTnum] = newTryEnd;
-        }
-    }
-
-    // Now, update EH descriptors
-    //
-    auto getTryLast = [tryRegionEnds](const unsigned index) -> BasicBlock* {
-        return tryRegionEnds[index];
-    };
-
-    auto setTryLast = [tryRegionEnds](const unsigned index, BasicBlock* const block) {
-        tryRegionEnds[index] = block;
-    };
-
-    ehUpdateTryLasts<decltype(getTryLast), decltype(setTryLast)>(getTryLast, setTryLast);
-}
-
-//-------------------------------------------------------------
-// ehUpdateTryLasts: Iterates EH descriptors, updating each try region's
-// end block as determined by getTryLast.
-//
-// Type parameters:
-//    GetTryLast - Functor type that takes an EH index,
-//    and returns the corresponding region's new try end block
-//    SetTryLast - Functor type that takes an EH index and a BasicBlock*,
-//    and updates some internal state tracking the new try end block of each EH region
-//
-// Parameters:
-//    getTryLast - Functor to get new try end block for an EH region
-//    setTryLast - Functor to update the new try end block for an EH region
-//
-template <typename GetTryLast, typename SetTryLast>
-void Compiler::ehUpdateTryLasts(GetTryLast getTryLast, SetTryLast setTryLast)
-{
-    unsigned XTnum = 0;
-    for (EHblkDsc* const HBtab : EHClauses(this))
-    {
-        BasicBlock* const tryEnd = getTryLast(XTnum++);
-
-        if (tryEnd == nullptr)
-        {
-            continue;
-        }
-
-        // Update the end pointer of this try region to the new last block
-        //
-        HBtab->ebdTryLast                = tryEnd;
-        const unsigned enclosingTryIndex = HBtab->ebdEnclosingTryIndex;
-
-        // If this try region is nested in another one, we might need to update its enclosing region's end block
-        //
-        if (enclosingTryIndex != EHblkDsc::NO_ENCLOSING_INDEX)
-        {
-            BasicBlock* const enclosingTryEnd = getTryLast(enclosingTryIndex);
-
-            // If multiple EH descriptors map to the same try region,
-            // then the enclosing region's last block might be null in the table, so set it here.
-            // Similarly, if the enclosing region ends right before the nested region begins,
-            // extend the enclosing region's last block to the end of the nested region.
-            //
-            if ((enclosingTryEnd == nullptr) || enclosingTryEnd->NextIs(HBtab->ebdTryBeg))
-            {
-                setTryLast(enclosingTryIndex, tryEnd);
             }
         }
     }

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -1308,24 +1308,23 @@ void Compiler::fgSetHndEnd(EHblkDsc* handlerTab, BasicBlock* newHndLast)
 void Compiler::fgFindEHRegionEnds()
 {
     assert(compHndBBtabCount != 0);
-    bool* const tryEndsSet = new (this, CMK_Generic) bool[compHndBBtabCount * 2]{};
-    bool* const hndEndsSet = tryEndsSet + compHndBBtabCount;
-    unsigned unsetTryEnds  = compHndBBtabCount;
-    unsigned unsetHndEnds  = compHndBBtabCount;
+    bool* const tryEndsSet   = new (this, CMK_Generic) bool[compHndBBtabCount * 2]{};
+    bool* const hndEndsSet   = tryEndsSet + compHndBBtabCount;
+    unsigned    unsetTryEnds = compHndBBtabCount;
+    unsigned    unsetHndEnds = compHndBBtabCount;
 
     // Updates the try region's (and all of its parent regions') end block to 'block,'
     // if the try region's end block hasn't been updated yet.
     auto setTryEnd = [this, tryEndsSet, &unsetTryEnds](BasicBlock* block) {
         for (unsigned tryIndex = block->getTryIndex(); tryIndex != EHblkDsc::NO_ENCLOSING_INDEX;
-             tryIndex = ehGetEnclosingTryIndex(tryIndex))
+             tryIndex          = ehGetEnclosingTryIndex(tryIndex))
         {
             if (!tryEndsSet[tryIndex])
             {
                 assert(unsetTryEnds != 0);
                 ehGetDsc(tryIndex)->ebdTryLast = block;
-                tryEndsSet[tryIndex] = true;
+                tryEndsSet[tryIndex]           = true;
                 unsetTryEnds--;
-
             }
             else
             {
@@ -1338,13 +1337,13 @@ void Compiler::fgFindEHRegionEnds()
     // if the handler region's end block hasn't been updated yet.
     auto setHndEnd = [this, hndEndsSet, &unsetHndEnds](BasicBlock* block) {
         for (unsigned hndIndex = block->getHndIndex(); hndIndex != EHblkDsc::NO_ENCLOSING_INDEX;
-             hndIndex = ehGetEnclosingHndIndex(hndIndex))
+             hndIndex          = ehGetEnclosingHndIndex(hndIndex))
         {
             if (!hndEndsSet[hndIndex])
             {
                 assert(unsetHndEnds != 0);
                 ehGetDsc(hndIndex)->ebdHndLast = block;
-                hndEndsSet[hndIndex] = true;
+                hndEndsSet[hndIndex]           = true;
                 unsetHndEnds--;
             }
             else
@@ -1355,8 +1354,7 @@ void Compiler::fgFindEHRegionEnds()
     };
 
     // Iterate backwards through the main method body, and update each try region's end block
-    for (BasicBlock* block = fgLastBBInMainFunction(); (unsetTryEnds != 0) && (block != nullptr);
-         block = block->Prev())
+    for (BasicBlock* block = fgLastBBInMainFunction(); (unsetTryEnds != 0) && (block != nullptr); block = block->Prev())
     {
         if (block->hasTryIndex())
         {
@@ -1369,7 +1367,7 @@ void Compiler::fgFindEHRegionEnds()
 
     // If we do have a funclet section, update the ends of any try regions nested in funclets
     for (BasicBlock* block = fgLastBB; (unsetTryEnds != 0) && (block != fgLastBBInMainFunction());
-         block = block->Prev())
+         block             = block->Prev())
     {
         if (block->hasTryIndex())
         {

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -1302,6 +1302,91 @@ void Compiler::fgSetHndEnd(EHblkDsc* handlerTab, BasicBlock* newHndLast)
     }
 }
 
+//-------------------------------------------------------------
+// fgFindEHRegionEnds: Walk the block list, and set each try/handler region's end block.
+//
+void Compiler::fgFindEHRegionEnds()
+{
+    assert(compHndBBtabCount != 0);
+    bool* const tryEndsSet = new (this, CMK_Generic) bool[compHndBBtabCount * 2]{};
+    bool* const hndEndsSet = tryEndsSet + compHndBBtabCount;
+    unsigned unsetTryEnds  = compHndBBtabCount;
+    unsigned unsetHndEnds  = compHndBBtabCount;
+
+    // Updates the try region's (and all of its parent regions') end block to 'block,'
+    // if the try region's end block hasn't been updated yet.
+    auto setTryEnd = [this, tryEndsSet, &unsetTryEnds](BasicBlock* block) {
+        for (unsigned tryIndex = block->getTryIndex(); tryIndex != EHblkDsc::NO_ENCLOSING_INDEX;
+             tryIndex = ehGetEnclosingTryIndex(tryIndex))
+        {
+            if (!tryEndsSet[tryIndex])
+            {
+                assert(unsetTryEnds != 0);
+                ehGetDsc(tryIndex)->ebdTryLast = block;
+                tryEndsSet[tryIndex] = true;
+                unsetTryEnds--;
+
+            }
+            else
+            {
+                break;
+            }
+        }
+    };
+
+    // Updates the handler region's (and all of its parent regions') end block to 'block,'
+    // if the handler region's end block hasn't been updated yet.
+    auto setHndEnd = [this, hndEndsSet, &unsetHndEnds](BasicBlock* block) {
+        for (unsigned hndIndex = block->getHndIndex(); hndIndex != EHblkDsc::NO_ENCLOSING_INDEX;
+             hndIndex = ehGetEnclosingHndIndex(hndIndex))
+        {
+            if (!hndEndsSet[hndIndex])
+            {
+                assert(unsetHndEnds != 0);
+                ehGetDsc(hndIndex)->ebdHndLast = block;
+                hndEndsSet[hndIndex] = true;
+                unsetHndEnds--;
+            }
+            else
+            {
+                break;
+            }
+        }
+    };
+
+    // Iterate backwards through the main method body, and update each try region's end block
+    for (BasicBlock* block = fgLastBBInMainFunction(); (unsetTryEnds != 0) && (block != nullptr);
+         block = block->Prev())
+    {
+        if (block->hasTryIndex())
+        {
+            setTryEnd(block);
+        }
+    }
+
+    // If we don't have a funclet section, then all of the try regions should have been updated above
+    assert((unsetTryEnds == 0) || (fgFirstFuncletBB != nullptr));
+
+    // If we do have a funclet section, update the ends of any try regions nested in funclets
+    for (BasicBlock* block = fgLastBB; (unsetTryEnds != 0) && (block != fgLastBBInMainFunction());
+         block = block->Prev())
+    {
+        if (block->hasTryIndex())
+        {
+            setTryEnd(block);
+        }
+    }
+
+    // Finally, update the handler regions' ends
+    for (BasicBlock* block = fgLastBB; (unsetHndEnds != 0) && (block != nullptr); block = block->Prev())
+    {
+        if (block->hasHndIndex())
+        {
+            setHndEnd(block);
+        }
+    }
+}
+
 /*****************************************************************************
  *
  *  Given a EH handler table entry update the ebdTryLast and ebdHndLast pointers


### PR DESCRIPTION
Backport of #108634 to release/9.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

CoreCLR's exception model requires that EH regions (try blocks, catch blocks, etc.) are contiguous in memory. Thus, the JIT keeps track of each EH region at the basic block level by maintaining a table of pointers to each region's first and last block -- this information is eventually reported to the VM. When reordering blocks to optimize code layout, EH regions will remain contiguous, but the JIT needs to ensure each region's last block pointer is updated. This is usually trivial, though nested EH regions can complicate this bookkeeping. Previously, we would walk the block list looking for new EH region ends, and then propagate the updated information to the EH table starting with most-nested regions, and "bubbling up" the end of the nested region if it's at the end of its parent region. This works well, unless a nested region at the end of a parent region is immediately preceded by another sibling region; we recently discovered that the JIT fails to determine the current nested region is at the end of its parent in such cases. This means the JIT incorrectly reports the nested relationship between these EH regions, which could break stack walking if the method throws.

The new implementation walks the block list in reverse, which vastly simplifies identifying and propagating EH region ends: By iterating backwards, there's no need to determine/guess if the nested EH region is at the end of its parent region, because reaching it before its parent guarantees it concludes the parent region.

## Regression

- [ ] Yes
- [x] No

The flawed EH fixup logic was introduced in .NET 9.

## Testing
This flaw was revealed by a test generated by one of our fuzzing tools. The fixed JIT logic now reports EH regions correctly for this case, and it has zero diffs with the previous implementation in EH information reported across our SuperPMI collections, which suggests we were getting most cases correct already. Outerloop tests and fuzzing pipelines did not reveal any flaws with the new implementation.

## Risk
The total LOC changed suggests some risk, though most of this churn is from deleting the previous implementation, which was quite a bit more verbose. Attempts to surgically fix this issue with the old implementation incurred codegen diffs, since some block reordering logic uses temporary EH region ends as insertion points for other blocks. Churning codegen at this point isn't ideal, and attempts to tweak the old EH fixup logic revealed it to be quite fragile. The new implementation has no codegen diffs, only seems to have diffs in EH region info reported to the VM when the old strategy was getting it wrong, and is overall much easier (in my opinion) to understand. Thus, I consider this fix low-risk relative to any solution that keeps the old implementation around.