### PR TITLE
Don't error for NuGet audit on non-official builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -387,6 +387,8 @@
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
+    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
+    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true' OR '$(NuGetAuditWarnNotError)' == 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
     <!-- Warnings to always disable -->
     <NoWarn>$(NoWarn);CS8500;CS8969</NoWarn>
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors for private assemblies. -->


### PR DESCRIPTION
I added an escape hatch as well in case we do want to make an official build without committing a change (EG: a rebuild of a specific hash).

I had [mentioned the same thing](https://github.com/dotnet/arcade/pull/15018#issuecomment-2303285554) when enabling `arcade` but missed when enabling here in runtime.  