### PR TITLE
Remove managed EH code frames from stack trace

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -558,6 +558,7 @@ namespace System.Runtime
 #if NATIVEAOT
         [RuntimeExport("RhThrowHwEx")]
 #endif
+        [StackTraceHidden]
         public static void RhThrowHwEx(uint exceptionCode, ref ExInfo exInfo)
         {
 #if NATIVEAOT
@@ -644,6 +645,7 @@ namespace System.Runtime
 #if NATIVEAOT
         [RuntimeExport("RhThrowEx")]
 #endif
+        [StackTraceHidden]
         public static void RhThrowEx(object exceptionObj, ref ExInfo exInfo)
         {
 #if NATIVEAOT
@@ -725,6 +727,7 @@ namespace System.Runtime
 #if NATIVEAOT
         [RuntimeExport("RhRethrow")]
 #endif
+        [StackTraceHidden]
         public static void RhRethrow(ref ExInfo activeExInfo, ref ExInfo exInfo)
         {
 #if NATIVEAOT
@@ -742,6 +745,7 @@ namespace System.Runtime
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
 
+        [StackTraceHidden]
         private static void DispatchEx(scoped ref StackFrameIterator frameIter, ref ExInfo exInfo)
         {
             Debug.Assert(exInfo._passNumber == 1, "expected asm throw routine to set the pass");
@@ -997,6 +1001,7 @@ namespace System.Runtime
             prevFramePtr = curFramePtr;
         }
 
+        [StackTraceHidden]
         private static bool FindFirstPassHandler(object exception, uint idxStart,
             ref StackFrameIterator frameIter, out uint tryRegionIdx, out byte* pHandler)
         {
@@ -1154,6 +1159,7 @@ namespace System.Runtime
         {
             InvokeSecondPass(ref exInfo, idxStart, MaxTryRegionIdx);
         }
+
         private static void InvokeSecondPass(ref ExInfo exInfo, uint idxStart, uint idxLimit)
         {
             EHEnum ehEnum;


### PR DESCRIPTION
When `StackTrace` is created inside of an exception filter, it contains stack frames of the managed exception handling code, like `System.Runtime.EH.RhThrowEx`
`System.Runtime.EH.DispatchEx`
`System.Runtime.EH.FindFirstPassHandler`

These should not occur on the stack trace as they are internal implementation detail of the new EH.

This change fixes it by adding the `[StackTraceHidden]` attribute to these methods.

Close #107995