### PR TITLE
Disable Comparer_get_Default test on linux-arm64-crossgen

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -647,8 +647,8 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- Crossgen2 win-arm64 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'windows'">
+    <!-- Crossgen2 win-arm64 and linux-arm64 specific excludes -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetArchitecture)' == 'arm64' and ('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux')">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Devirtualization/Comparer_get_Default/*">
             <Issue>https://github.com/dotnet/runtime/issues/104927</Issue>
         </ExcludeList>


### PR DESCRIPTION
This test was disabled on windows-arm64, but the outerloop also fails on linux-arm64.

See https://github.com/dotnet/runtime/issues/104927