### PR TITLE
Automatically synthesize ilproj assembly names for tests

### DIFF
--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
@@ -118,6 +118,10 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="$(CoreCompileDependsOn)">
 
     <PropertyGroup>
+      <_IlasmAssemblyName Condition="'$(IlasmAssemblyName)' != ''">$(IlasmAssemblyName)</_IlasmAssemblyName>
+      <_IlasmAssemblyName Condition="'$(IlasmAssemblyName)' == ''">$(MSBuildProjectName)</_IlasmAssemblyName>
+      <_IlasmAssemblyNameSynthesizedFile>$(IntermediateOutputPath)\synthesized_assembly_name.il</_IlasmAssemblyNameSynthesizedFile>
+
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">-DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">-EXE</_OutputTypeArgument>
 
@@ -133,7 +137,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_IlasmSwitches Condition="'$(IlasmResourceFile)' != ''">$(_IlasmSwitches) -RESOURCES="$(IlasmResourceFile)"</_IlasmSwitches>
     </PropertyGroup>
 
-    <Exec Command="&quot;$(_IlasmDir)ilasm&quot; $(_IlasmSwitches) $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=&quot;@(IntermediateAssembly)&quot; $(_KeyFileArgument) @(Compile, ' ')">
+    <WriteLinesToFile File="$(_IlasmAssemblyNameSynthesizedFile)"
+        Lines="#define ASSEMBLY_NAME $(_IlasmAssemblyName)"
+        WriteOnlyWhenDifferent="true"
+        Overwrite="true"
+        />
+
+    <Exec Command="&quot;$(_IlasmDir)ilasm&quot; $(_IlasmSwitches) $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=&quot;@(IntermediateAssembly)&quot; $(_KeyFileArgument) $(_IlasmAssemblyNameSynthesizedFile) @(Compile, ' ')">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
 
@@ -141,7 +151,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''"/>
   </Target>
-  
+
   <!-- Target is called by the language server. No-op for ILProj as there is no language service support. -->
   <Target Name="CompileDesignTime" />
 

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
@@ -118,9 +118,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="$(CoreCompileDependsOn)">
 
     <PropertyGroup>
-      <_IlasmAssemblyName Condition="'$(IlasmAssemblyName)' != ''">$(IlasmAssemblyName)</_IlasmAssemblyName>
-      <_IlasmAssemblyName Condition="'$(IlasmAssemblyName)' == ''">$(MSBuildProjectName)</_IlasmAssemblyName>
-      <_IlasmAssemblyNameSynthesizedFile>$(IntermediateOutputPath)\synthesized_assembly_name.il</_IlasmAssemblyNameSynthesizedFile>
+      <IlasmAssemblyName Condition="('$(IlasmAssemblyName)' == '') and ('$(SynthesizeIlasmAssemblyName)' == 'true')">$(MSBuildProjectName)</_IlasmAssemblyName>
 
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">-DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">-EXE</_OutputTypeArgument>
@@ -128,6 +126,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">-KEY="$(KeyOriginatorFile)"</_KeyFileArgument>
 
       <_IlasmSwitches>-QUIET -NOLOGO</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(IlasmAssemblyName)' != ''">$(_IlasmSwitches) -ANAME=$(IlasmAssemblyName)</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(FoldIdenticalMethods)' == 'True'">$(_IlasmSwitches) -FOLD</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(SizeOfStackReserve)' != ''">$(_IlasmSwitches) -STACK=$(SizeOfStackReserve)</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(DebugType)' == 'Full'">$(_IlasmSwitches) -DEBUG</_IlasmSwitches>
@@ -137,13 +136,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_IlasmSwitches Condition="'$(IlasmResourceFile)' != ''">$(_IlasmSwitches) -RESOURCES="$(IlasmResourceFile)"</_IlasmSwitches>
     </PropertyGroup>
 
-    <WriteLinesToFile File="$(_IlasmAssemblyNameSynthesizedFile)"
-        Lines="#define ASSEMBLY_NAME $(_IlasmAssemblyName)"
-        WriteOnlyWhenDifferent="true"
-        Overwrite="true"
-        />
-
-    <Exec Command="&quot;$(_IlasmDir)ilasm&quot; $(_IlasmSwitches) $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=&quot;@(IntermediateAssembly)&quot; $(_KeyFileArgument) $(_IlasmAssemblyNameSynthesizedFile) @(Compile, ' ')">
+    <Exec Command="&quot;$(_IlasmDir)ilasm&quot; $(_IlasmSwitches) $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=&quot;@(IntermediateAssembly)&quot; $(_KeyFileArgument) @(Compile, ' ')">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
 

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
@@ -118,7 +118,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="$(CoreCompileDependsOn)">
 
     <PropertyGroup>
-      <IlasmAssemblyName Condition="('$(IlasmAssemblyName)' == '') and ('$(SynthesizeIlasmAssemblyName)' == 'true')">$(MSBuildProjectName)</_IlasmAssemblyName>
+      <IlasmAssemblyName Condition="('$(IlasmAssemblyName)' == '') and ('$(SynthesizeIlasmAssemblyName)' == 'true')">$(MSBuildProjectName)</IlasmAssemblyName>
 
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">-DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">-EXE</_OutputTypeArgument>

--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -245,7 +245,8 @@ void    AsmMan::EmitFiles()
 
 void    AsmMan::StartAssembly(_In_ __nullterminated char* szName, _In_opt_z_ char* szAlias, DWORD dwAttr, BOOL isRef)
 {
-    if(!isRef && (0==strcmp(szName, "mscorlib"))) ((Assembler*)m_pAssembler)->m_fIsMscorlib = TRUE;
+    Assembler *mPA = ((Assembler*)m_pAssembler);
+    if(!isRef && (0==strcmp(szName, "mscorlib"))) mPA->m_fIsMscorlib = TRUE;
     if(!isRef && (m_pAssembly != NULL))
     {
         if(strcmp(szName, m_pAssembly->szName))
@@ -257,11 +258,12 @@ void    AsmMan::StartAssembly(_In_ __nullterminated char* szName, _In_opt_z_ cha
     {
         if((m_pCurAsmRef = new (nothrow) AsmManAssembly()))
         {
+            bool hasOverride = (!isRef && mPA->m_pOverrideAssemblyName);
             m_pCurAsmRef->usVerMajor = (USHORT)0xFFFF;
             m_pCurAsmRef->usVerMinor = (USHORT)0xFFFF;
             m_pCurAsmRef->usBuild = (USHORT)0xFFFF;
             m_pCurAsmRef->usRevision = (USHORT)0xFFFF;
-            m_pCurAsmRef->szName = szName;
+            m_pCurAsmRef->szName = hasOverride ? mPA->m_pOverrideAssemblyName : szName;
             m_pCurAsmRef->szAlias = szAlias ? szAlias : szName;
             m_pCurAsmRef->dwAlias = (DWORD)strlen(m_pCurAsmRef->szAlias);
             m_pCurAsmRef->dwAttr = dwAttr;

--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -275,9 +275,9 @@ void    AsmMan::StartAssembly(_In_ __nullterminated char* szName, _In_opt_z_ cha
         else
             report->error("Failed to allocate AsmManAssembly structure\n");
     }
-    ((Assembler*)m_pAssembler)->m_tkCurrentCVOwner = 0;
-    ((Assembler*)m_pAssembler)->m_CustomDescrListStack.PUSH(((Assembler*)m_pAssembler)->m_pCustomDescrList);
-    ((Assembler*)m_pAssembler)->m_pCustomDescrList = m_pCurAsmRef ? &(m_pCurAsmRef->m_CustomDescrList) : NULL;
+    mPA->m_tkCurrentCVOwner = 0;
+    mPA->m_CustomDescrListStack.PUSH(mPA->m_pCustomDescrList);
+    mPA->m_pCustomDescrList = m_pCurAsmRef ? &(m_pCurAsmRef->m_CustomDescrList) : NULL;
 
 }
 // copied from asmparse.y

--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -154,6 +154,7 @@ Assembler::Assembler()
     indexKeywords(&indxKeywords);
 
     m_pPortablePdbWriter = NULL;
+    m_pOverrideAssemblyName = NULL;
 }
 
 

--- a/src/coreclr/ilasm/assembler.h
+++ b/src/coreclr/ilasm/assembler.h
@@ -1254,6 +1254,7 @@ public:
 
     void EmitGenericParamConstraints(int numTyPars, TyParDescr* pTyPars, mdToken tkOwner, GenericParamConstraintList* pGPCL);
 
+    char *m_pOverrideAssemblyName;
 };
 
 #endif  // Assember_h

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -529,7 +529,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pEqualOrColon = EqualOrColon(argv[i]);
                         if (pEqualOrColon == NULL) goto InvalidOption;
                         MAKE_UTF8PTR_FROMWIDE_NOTHROW(anameOverride, pEqualOrColon + 1);
-                        pAsm->m_pOverrideAssemblyName = anameOverride;
+                        pAsm->m_pOverrideAssemblyName = strdup(anameOverride);
                     }
                     else
                     {

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -529,7 +529,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pEqualOrColon = EqualOrColon(argv[i]);
                         if (pEqualOrColon == NULL) goto InvalidOption;
                         MAKE_UTF8PTR_FROMWIDE_NOTHROW(anameOverride, pEqualOrColon + 1);
-                        pAsm->m_pOverrideAssemblyName = strdup(anameOverride);
+                        pAsm->m_pOverrideAssemblyName = _strdup(anameOverride);
                     }
                     else
                     {

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -529,7 +529,6 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pEqualOrColon = EqualOrColon(argv[i]);
                         if (pEqualOrColon == NULL) goto InvalidOption;
                         MAKE_UTF8PTR_FROMWIDE_NOTHROW(anameOverride, pEqualOrColon + 1);
-                        fprintf(stderr, "ANAME %s\n", anameOverride);
                         pAsm->m_pOverrideAssemblyName = anameOverride;
                     }
                     else

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -188,6 +188,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
       printf("\n/OUTPUT=<targetfile>    Compile to file with specified name \n\t\t\t(user must provide extension, if any)");
       printf("\n/KEY=<keyfile>      Compile with strong signature \n\t\t\t(<keyfile> contains private key)");
       printf("\n/KEY=@<keysource>   Compile with strong signature \n\t\t\t(<keysource> is the private key source name)");
+      printf("\n/ANAME=<asmname>    Override the name of the compiled assembly");
       printf("\n/INCLUDE=<path>     Set path to search for #include'd files");
       printf("\n/SUBSYSTEM=<int>    Set Subsystem value in the NT Optional header");
       printf("\n/SSVER=<int>.<int>  Set Subsystem version number in the NT Optional header");
@@ -523,6 +524,14 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         if(sscanf_s(str,pFmt,&g_dwTestRepeat)!=1) goto InvalidOption;
                     }
 #endif
+                    else if (!_stricmp(szOpt, "ANA"))
+                    {
+                        WCHAR *pEqualOrColon = EqualOrColon(argv[i]);
+                        if (pEqualOrColon == NULL) goto InvalidOption;
+                        MAKE_UTF8PTR_FROMWIDE_NOTHROW(anameOverride, pEqualOrColon + 1);
+                        fprintf(stderr, "ANAME %s\n", anameOverride);
+                        pAsm->m_pOverrideAssemblyName = anameOverride;
+                    }
                     else
                     {
                     InvalidOption:

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -225,8 +225,10 @@ typedef LPSTR   LPUTF8;
     } \
     LPSTR ptrname = (LPSTR)__CQuickBytes##ptrname.Ptr()
 
+// ptrname will be deleted when it goes out of scope.
 #define MAKE_UTF8PTR_FROMWIDE(ptrname, widestr) CQuickBytes _##ptrname; _##ptrname.ConvertUnicode_Utf8(widestr); LPSTR ptrname = (LPSTR) _##ptrname.Ptr();
 
+// ptrname will be deleted when it goes out of scope.
 #define MAKE_UTF8PTR_FROMWIDE_NOTHROW(ptrname, widestr) \
     CQuickBytes __qb##ptrname; \
     int __l##ptrname = (int)u16_strlen(widestr); \

--- a/src/tests/baseservices/Directory.Build.props
+++ b/src/tests/baseservices/Directory.Build.props
@@ -7,5 +7,6 @@
     <RunAnalyzers>true</RunAnalyzers>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <SynthesizeIlasmAssemblyName>true</SynthesizeIlasmAssemblyName>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* Add `-ANAME:AssemblyName` switch to ilasm
* Add `SynthesizeIlasmAssemblyName` msbuild property to the IL SDK that overrides the assembly name of the assembled IL to match the name of the current project

Motivation:
We have a bunch of ilproj tests that have random `.assembly` directives in them with names that don't match the name of the actual .dll file. This creates a problem for the crossgen2 composite tests, because the actual name of the dll isn't encoded anywhere in the binary.
We also have a bunch of tests where we build the same .il file multiple times with different names, i.e. `varargsupport_r` and `varargsupport` both being built from `varargsupport.il`. In this scenario it's impossible for the `.assembly` directive to encode the correct name unless you jump through some elaborate hoops, which not all of our tests are doing. The result is that during the crossgen2 tests, `varargsupport.dll` will be loaded (because the assembly name encoded in the reference and binaries is `varargsupport`) but the actual file is `varargsupport_r.dll` so we'll fail.
To solve that, this PR adds an `-ANAME` switch which allows overriding the assembly name of the .il file(s) being compiled, ignoring any directives being used in them. And then it updates the SDK to allow setting this switch's value manually, or set it automatically (synthesize it) from the name of the current msbuild project.

Once the synthesize property is applied to all the relevant test projects it should fix a bunch of failures on the crossgen2 outerloop tests. I verified it locally for the one folder I've applied it to in this PR.

These changes (to ILAsm and the IL sdk) will need to flow before the tests actually start passing on outerloop, when I tested locally I changed global.json and eng/versions.props to `10.0.0-dev` for the relevant packages in order to test it manually. I don't think it's possible for the flow to happen until this PR lands.