### PR TITLE
Avoid backing field for marshallers.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -110,7 +110,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// This property represents a potential optimization for the marshaller.
             /// </remarks>
             // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
-            public static int BufferSize { get; } = 0x200 / sizeof(TUnmanagedElement);
+            public static int BufferSize => 0x200 / sizeof(TUnmanagedElement);
 
             private T[]? _managedArray;
             private TUnmanagedElement* _allocatedMemory;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
@@ -81,7 +81,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// Gets the size of the caller-allocated buffer to allocate.
             /// </summary>
             // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
-            public static int BufferSize { get; } = 0x200 / sizeof(TUnmanagedElement);
+            public static int BufferSize => 0x200 / sizeof(TUnmanagedElement);
 
             private ReadOnlySpan<T> _managedArray;
             private TUnmanagedElement* _allocatedMemory;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
@@ -109,7 +109,7 @@ namespace System.Runtime.InteropServices.Marshalling
         public ref struct ManagedToUnmanagedIn
         {
             // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
-            public static int BufferSize { get; } = 0x200 / sizeof(TUnmanagedElement);
+            public static int BufferSize => 0x200 / sizeof(TUnmanagedElement);
 
             private Span<T> _managedArray;
             private TUnmanagedElement* _allocatedMemory;


### PR DESCRIPTION
This also makes the `BufferSize` pattern consistent across all new source generated custom marshallers.