### PR TITLE
JIT: Use binary search in `FlowGraphNaturalLoops::GetLoopByHeader`

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4487,12 +4487,29 @@ FlowGraphNaturalLoop* FlowGraphNaturalLoops::GetLoopByIndex(unsigned index)
 //
 FlowGraphNaturalLoop* FlowGraphNaturalLoops::GetLoopByHeader(BasicBlock* block)
 {
-    // TODO-TP: This can use binary search based on post order number.
-    for (FlowGraphNaturalLoop* loop : m_loops)
+    // Loops are stored in reverse post-order,
+    // so we can binary-search for the desired loop's header by its post-order number.
+    size_t min = 0;
+    size_t max = NumLoops();
+
+    while (min < max)
     {
-        if (loop->m_header == block)
+        const size_t                mid    = min + ((max - min) / 2);
+        FlowGraphNaturalLoop* const loop   = m_loops[mid];
+        BasicBlock* const           header = loop->m_header;
+
+        if (header == block)
         {
             return loop;
+        }
+        else if (header->bbPostorderNum < block->bbPostorderNum)
+        {
+            max = mid;
+        }
+        else
+        {
+            assert(header->bbPostorderNum > block->bbPostorderNum);
+            min = mid + 1;
         }
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4487,6 +4487,11 @@ FlowGraphNaturalLoop* FlowGraphNaturalLoops::GetLoopByIndex(unsigned index)
 //
 FlowGraphNaturalLoop* FlowGraphNaturalLoops::GetLoopByHeader(BasicBlock* block)
 {
+    if (!m_dfsTree->Contains(block))
+    {
+        return nullptr;
+    }
+    
     // Loops are stored in reverse post-order,
     // so we can binary-search for the desired loop's header by its post-order number.
     size_t min = 0;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4491,7 +4491,7 @@ FlowGraphNaturalLoop* FlowGraphNaturalLoops::GetLoopByHeader(BasicBlock* block)
     {
         return nullptr;
     }
-    
+
     // Loops are stored in reverse post-order,
     // so we can binary-search for the desired loop's header by its post-order number.
     size_t min = 0;


### PR DESCRIPTION
Follow-up to #108086. Since loops are stored in reverse post-order in `FlowGraphNaturalLoops::m_loops`, loop headers' post-order numbers are stored in descending order. Thus, we can use binary search, and since we plan to use loop-aware RPOs in more places, we should probably take advantage of this.