### PR TITLE
Fix `IsOSVersionAtLeast` when build or revision are not provided

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
@@ -12,8 +12,8 @@ namespace System
             // Check if build and revision are -1 and default them to 0
             int major = version.Major;
             int minor = version.Minor;
-            int build = version.Build >= 0 ? version.Build : 0;
-            int revision = version.Revision >= 0 ? version.Revision : 0;
+            int build = version.Build < 0 ? 0 : version.Build;
+            int revision = version.Revision < 0 ? 0 : version.Revision;
 
             version = new Version(major, minor, build, revision);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
@@ -11,8 +11,12 @@ namespace System
 
             int major = version.Major;
             int minor = version.Minor;
+            // Normalize the build component to 0 if undefined
+            // to match iOS behavior
             int build = version.Build < 0 ? 0 : version.Build;
 
+            // The revision component is always set to -1,
+            // as it is not specified on MacCatalyst or iOS
             version = new Version(major, minor, build);
             return new OperatingSystem(PlatformID.Unix, version);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
@@ -7,16 +7,7 @@ namespace System
     {
         private static OperatingSystem GetOSVersion()
         {
-            Version version = Version.Parse(Interop.Sys.iOSSupportVersion());
-
-            // Check if build and revision are -1 and default them to 0
-            int major = version.Major;
-            int minor = version.Minor;
-            int build = version.Build < 0 ? 0 : version.Build;
-            int revision = version.Revision < 0 ? 0 : version.Revision;
-
-            version = new Version(major, minor, build, revision);
-
+            Version version = new Version(Interop.Sys.iOSSupportVersion());
             return new OperatingSystem(PlatformID.Unix, version);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
@@ -8,6 +8,12 @@ namespace System
         private static OperatingSystem GetOSVersion()
         {
             Version version = new Version(Interop.Sys.iOSSupportVersion());
+
+            int major = version.Major;
+            int minor = version.Minor;
+            int build = version.Build < 0 ? 0 : version.Build;
+
+            version = new Version(major, minor, build);
             return new OperatingSystem(PlatformID.Unix, version);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.OSVersion.MacCatalyst.cs
@@ -7,7 +7,16 @@ namespace System
     {
         private static OperatingSystem GetOSVersion()
         {
-            Version version = new Version(Interop.Sys.iOSSupportVersion());
+            Version version = Version.Parse(Interop.Sys.iOSSupportVersion());
+
+            // Check if build and revision are -1 and default them to 0
+            int major = version.Major;
+            int minor = version.Minor;
+            int build = version.Build >= 0 ? version.Build : 0;
+            int revision = version.Revision >= 0 ? version.Revision : 0;
+
+            version = new Version(major, minor, build, revision);
+
             return new OperatingSystem(PlatformID.Unix, version);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -331,17 +331,16 @@ namespace System
             {
                 return current.Major > major;
             }
-            if (current.Minor != minor)
+            if (current.Minor >= 0 && current.Minor != minor)
             {
                 return current.Minor > minor;
             }
-            if (current.Build != build)
+            if (current.Build >= 0 && current.Build != build)
             {
                 return current.Build > build;
             }
 
-            return current.Revision >= revision
-                || (current.Revision == -1 && revision == 0); // it is unavailable on OSX and Environment.OSVersion.Version.Revision returns -1
+            return current.Revision < 0 || current.Revision >= revision;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -331,7 +331,7 @@ namespace System
             {
                 return current.Major > major;
             }
-            if (current.Minor >= 0 && current.Minor != minor)
+            if (current.Minor != minor)
             {
                 return current.Minor > minor;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -335,7 +335,12 @@ namespace System
             {
                 return current.Minor > minor;
             }
-            if (current.Build >= 0 && current.Build != build)
+            if (current.Build < 0)
+            {
+                // Unspecified component satisfies any required version
+                return true;
+            }
+            if (current.Build != build)
             {
                 return current.Build > build;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -350,6 +350,7 @@ namespace System
                 // Unspecified component satisfies any required version
                 return true;
             }
+
             return current.Revision >= revision;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -336,18 +336,18 @@ namespace System
                 return current.Minor > minor;
             }
             // Unspecified build component is to be treated as zero
-            if (current.Build != build && !(current.Build == -1 && build <= 0))
+            int currentBuild = current.Build == -1 ? 0 : current.Build;
+            build = build < 0 ? 0 : build;
+            if (currentBuild != build)
             {
-                return current.Build > build;
+                return currentBuild > build;
             }
 
-            if (current.Revision < 0)
-            {
-                // Unspecified build component is to be treated as zero
-                return revision <= 0;
-            }
+            // Unspecified revision component is to be treated as zero
+            int currentRevision = current.Revision == -1 ? 0 : current.Revision;
+            revision = revision < 0 ? 0 : revision;
 
-            return current.Revision >= revision;
+            return currentRevision >= revision;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -344,7 +344,7 @@ namespace System
             }
 
             // Unspecified revision component is to be treated as zero
-            int currentRevision = current.Revision == -1 ? 0 : current.Revision;
+            int currentRevision = current.Revision < 0 ? 0 : current.Revision;
             revision = revision < 0 ? 0 : revision;
 
             return currentRevision >= revision;

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -335,12 +335,8 @@ namespace System
             {
                 return current.Minor > minor;
             }
-            if (current.Build < 0)
-            {
-                // Unspecified build component is to be treated as zero
-                return build == 0;
-            }
-            if (current.Build != build)
+            // Unspecified build component is to be treated as zero
+            if (current.Build != build && !(current.Build == -1 && build <= 0))
             {
                 return current.Build > build;
             }
@@ -348,7 +344,7 @@ namespace System
             if (current.Revision < 0)
             {
                 // Unspecified build component is to be treated as zero
-                return revision == 0;
+                return revision <= 0;
             }
 
             return current.Revision >= revision;

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -345,7 +345,12 @@ namespace System
                 return current.Build > build;
             }
 
-            return current.Revision < 0 || current.Revision >= revision;
+            if (current.Revision < 0)
+            {
+                // Unspecified component satisfies any required version
+                return true;
+            }
+            return current.Revision >= revision;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -336,7 +336,7 @@ namespace System
                 return current.Minor > minor;
             }
             // Unspecified build component is to be treated as zero
-            int currentBuild = current.Build == -1 ? 0 : current.Build;
+            int currentBuild = current.Build < 0 ? 0 : current.Build;
             build = build < 0 ? 0 : build;
             if (currentBuild != build)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -337,8 +337,8 @@ namespace System
             }
             if (current.Build < 0)
             {
-                // Unspecified component satisfies any required version
-                return true;
+                // Unspecified build component is to be treated as zero
+                return build == 0;
             }
             if (current.Build != build)
             {
@@ -347,8 +347,8 @@ namespace System
 
             if (current.Revision < 0)
             {
-                // Unspecified component satisfies any required version
-                return true;
+                // Unspecified build component is to be treated as zero
+                return revision == 0;
             }
 
             return current.Revision >= revision;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
@@ -263,8 +263,8 @@ namespace System.Tests
 
             Assert.False(isOSVersionAtLeast(current.Major + 1, current.Minor, current.Build, current.Revision));
             Assert.False(isOSVersionAtLeast(current.Major, current.Minor + 1, current.Build, current.Revision));
-            Assert.False(isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1, current.Revision));
-            Assert.False(isOSVersionAtLeast(current.Major, current.Minor, current.Build, Math.Max(current.Revision + 1, 1))); // OSX Revision reports -1
+            Assert.Equal(current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1, current.Revision));
+            Assert.Equal(current.Revision < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build, current.Revision + 1));
 
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor, current.Build, current.Revision));
 
@@ -280,7 +280,7 @@ namespace System.Tests
 
             Assert.False(isOSVersionAtLeast(current.Major + 1, current.Minor, current.Build));
             Assert.False(isOSVersionAtLeast(current.Major, current.Minor + 1, current.Build));
-            Assert.False(isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1));
+            Assert.Equal(current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1));
 
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor, current.Build));
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
@@ -236,11 +236,18 @@ namespace System.Tests
                     isCurrentOS = true;
                 }
 
+                // Four-parameter overload
                 AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName, major, minor, build, revision));
                 AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName.ToLower(), major, minor, build, revision));
                 AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName.ToUpper(), major, minor, build, revision));
+
+                // Three-parameter overload
+                AssertVersionChecks(isCurrentOS, (major, minor, build) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName, major, minor, build));
+
+                // Two-parameter overload
+                AssertVersionChecks(isCurrentOS, (major, minor) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName, major, minor));
             }
-            
+
             AssertVersionChecks(currentOSName.Equals("Android", StringComparison.OrdinalIgnoreCase), OperatingSystem.IsAndroidVersionAtLeast);
             AssertVersionChecks(currentOSName == "MacCatalyst" || currentOSName.Equals("iOS", StringComparison.OrdinalIgnoreCase), OperatingSystem.IsIOSVersionAtLeast);
             AssertVersionChecks(currentOSName.Equals("macOS", StringComparison.OrdinalIgnoreCase), OperatingSystem.IsMacOSVersionAtLeast);
@@ -280,6 +287,19 @@ namespace System.Tests
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major - 1, current.Minor, current.Build));
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor - 1, current.Build));
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor, current.Build - 1));
+        }
+
+        private static void AssertVersionChecks(bool isCurrentOS, Func<int, int, bool> isOSVersionAtLeast)
+        {
+            Version current = Environment.OSVersion.Version;
+
+            Assert.False(isOSVersionAtLeast(current.Major + 1, current.Minor));
+            Assert.False(isOSVersionAtLeast(current.Major, current.Minor + 1));
+
+            Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor));
+
+            Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major - 1, current.Minor));
+            Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor - 1));
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
@@ -263,8 +263,8 @@ namespace System.Tests
 
             Assert.False(isOSVersionAtLeast(current.Major + 1, current.Minor, current.Build, current.Revision));
             Assert.False(isOSVersionAtLeast(current.Major, current.Minor + 1, current.Build, current.Revision));
-            Assert.Equal(current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1, current.Revision));
-            Assert.Equal(current.Revision < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build, current.Revision + 1));
+            Assert.Equal(isCurrentOS && current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1, current.Revision));
+            Assert.Equal(isCurrentOS && current.Revision < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build, current.Revision + 1));
 
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor, current.Build, current.Revision));
 
@@ -280,7 +280,7 @@ namespace System.Tests
 
             Assert.False(isOSVersionAtLeast(current.Major + 1, current.Minor, current.Build));
             Assert.False(isOSVersionAtLeast(current.Major, current.Minor + 1, current.Build));
-            Assert.Equal(current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1));
+            Assert.Equal(isCurrentOS && current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1));
 
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor, current.Build));
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
@@ -263,8 +263,8 @@ namespace System.Tests
 
             Assert.False(isOSVersionAtLeast(current.Major + 1, current.Minor, current.Build, current.Revision));
             Assert.False(isOSVersionAtLeast(current.Major, current.Minor + 1, current.Build, current.Revision));
-            Assert.Equal(isCurrentOS && current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1, current.Revision));
-            Assert.Equal(isCurrentOS && current.Revision < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build, current.Revision + 1));
+            Assert.False(isOSVersionAtLeast(current.Major, current.Minor, Math.Max(current.Build + 1, 1), current.Revision));
+            Assert.False(isOSVersionAtLeast(current.Major, current.Minor, current.Build, Math.Max(current.Revision + 1, 1)));
 
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor, current.Build, current.Revision));
 
@@ -280,7 +280,7 @@ namespace System.Tests
 
             Assert.False(isOSVersionAtLeast(current.Major + 1, current.Minor, current.Build));
             Assert.False(isOSVersionAtLeast(current.Major, current.Minor + 1, current.Build));
-            Assert.Equal(isCurrentOS && current.Build < 0, isOSVersionAtLeast(current.Major, current.Minor, current.Build + 1));
+            Assert.False(isOSVersionAtLeast(current.Major, current.Minor, Math.Max(current.Build + 1, 1)));
 
             Assert.Equal(isCurrentOS, isOSVersionAtLeast(current.Major, current.Minor, current.Build));
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/dotnet/runtime/issues/108694 by updating `IsOSVersionAtLeast` to treat unspecified build or revision components as zero.

Breaking change notice: https://github.com/dotnet/docs/issues/43156