### PR TITLE
Disable codeql on official builds part 2

### DIFF
--- a/eng/pipelines/common/templates/template1es.yml
+++ b/eng/pipelines/common/templates/template1es.yml
@@ -22,8 +22,9 @@ extends:
   parameters:
     sdl:
       codeql:
-        compiled: false
-        justificationForDisabling: 'CodeQL is run on the runtime-codeql pipeline'
+        compiled: 
+          enabled: false
+          justificationForDisabling: 'CodeQL is run on the runtime-codeql pipeline'
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
       policheck:


### PR DESCRIPTION
According to the most updated docs, enabled and justification need to be underneath compiled.