### PR TITLE
bgc deadlock fix

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -25767,7 +25767,7 @@ void gc_heap::calculate_new_heap_count ()
 
                     dprintf (6666, ("we want to grow but DATAS is limiting, trigger a gen2 right away"));
 #ifdef BACKGROUND_GC
-                    if (background_running_p())
+                    if (is_bgc_in_progress())
                     {
                         trigger_initial_gen2_p = false;
                     }


### PR DESCRIPTION
this was a regression introduced in https://github.com/dotnet/runtime/pull/105545. this would only manifest during the beginning of a process when we needed to grow the # of heaps (and can grow) and we haven't done a gen2 GC yet so we set it to doing one. 

the problem is the check I made did not include the ephemeral GC that may happen at the beginning of a BGC before we set `gc_background_running` to true. so at the end of that eph GC, we are in `calculate_new_heap_count` and set `trigger_initial_gen2_p` to true, not realizing we are already in a BGC.

then during the `joined_generation_to_condemn` at the beginning of the next GC, if our conclusion was still doing an eph GC we'd make it a BGC due to `trigger_initial_gen2_p` which obviously would cause problem if a BGC is already in progress (I do have an assert for this but we haven't seen this in a dbg build...).

the fix is to simply use the right check - `is_bgc_in_progress()` instead of `background_running_p()` which includes that eph GC case.