### PR TITLE
[LoongArch64] Fix the instruction check in 'CodeGen::genInstrWithConstant()' when called by 'CodeGen::genHomeStackSegment()'.

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -85,7 +85,9 @@ bool CodeGen::genInstrWithConstant(instruction ins,
         case INS_fst_d:
 
         case INS_ld_b:
+        case INS_ld_bu:
         case INS_ld_h:
+        case INS_ld_hu:
         case INS_ld_w:
         case INS_fld_s:
         case INS_ld_d:


### PR DESCRIPTION
[LoongArch64] Fix the instruction check in 'CodeGen::genInstrWithConstant()' when called by 'CodeGen::genHomeStackSegment()'.