### PR TITLE
[release/9.0] Remove string.Trim{,Start,End}(ReadOnlySpan<char>) ref-API

### DIFF
--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -6164,7 +6164,6 @@ namespace System.Tests
             }
 
             Assert.Equal(expected, s.Trim(trimChars));
-            Assert.Equal(expected, s.Trim((ReadOnlySpan<char>)trimChars));
             Assert.Equal(expected, s.AsSpan().Trim(trimChars).ToString());
         }
 
@@ -6195,7 +6194,6 @@ namespace System.Tests
             }
 
             Assert.Equal(expected, s.TrimEnd(trimChars));
-            Assert.Equal(expected, s.TrimEnd((ReadOnlySpan<char>)trimChars));
             Assert.Equal(expected, s.AsSpan().TrimEnd(trimChars).ToString());
         }
 
@@ -6226,7 +6224,6 @@ namespace System.Tests
             }
 
             Assert.Equal(expected, s.TrimStart(trimChars));
-            Assert.Equal(expected, s.TrimStart((ReadOnlySpan<char>)trimChars));
             Assert.Equal(expected, s.AsSpan().TrimStart(trimChars).ToString());
         }
 
@@ -6457,27 +6454,18 @@ namespace System.Tests
             Assert.True(s1.SequenceEqual(s1.Trim(trimCharsString)));
             Assert.True(s1.SequenceEqual(s1.TrimStart(trimCharsString)));
             Assert.True(s1.SequenceEqual(s1.TrimEnd(trimCharsString)));
-            Assert.True(s1.SequenceEqual(s1.Trim((ReadOnlySpan<char>)trimCharsString)));
-            Assert.True(s1.SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)trimCharsString)));
-            Assert.True(s1.SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)trimCharsString)));
 
             char[] chars = { 'a', 'b', 'c', 'd', 'e' };
             trimCharsString = chars;
             Assert.True(s1.SequenceEqual(s1.Trim(trimCharsString)));
             Assert.True(s1.SequenceEqual(s1.TrimStart(trimCharsString)));
             Assert.True(s1.SequenceEqual(s1.TrimEnd(trimCharsString)));
-            Assert.True(s1.SequenceEqual(s1.Trim((ReadOnlySpan<char>)trimCharsString)));
-            Assert.True(s1.SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)trimCharsString)));
-            Assert.True(s1.SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)trimCharsString)));
 
             string emptyString = string.Empty;
             char[] trimCharsArrayFromString = "abcde".ToCharArray();
             Assert.True(emptyString.SequenceEqual(emptyString.Trim(trimCharsArrayFromString)));
             Assert.True(emptyString.SequenceEqual(emptyString.TrimStart(trimCharsArrayFromString)));
             Assert.True(emptyString.SequenceEqual(emptyString.TrimEnd(trimCharsArrayFromString)));
-            Assert.True(emptyString.SequenceEqual(emptyString.Trim((ReadOnlySpan<char>)trimCharsArrayFromString)));
-            Assert.True(emptyString.SequenceEqual(emptyString.TrimStart((ReadOnlySpan<char>)trimCharsArrayFromString)));
-            Assert.True(emptyString.SequenceEqual(emptyString.TrimEnd((ReadOnlySpan<char>)trimCharsArrayFromString)));
 
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> trimChars = trimCharsString.AsSpan();
@@ -6513,9 +6501,6 @@ namespace System.Tests
                 Assert.True(s1.SequenceEqual(s1.Trim(trimCharsString)));
                 Assert.True(s1.SequenceEqual(s1.TrimStart(trimCharsString)));
                 Assert.True(s1.SequenceEqual(s1.TrimEnd(trimCharsString)));
-                Assert.True(s1.SequenceEqual(s1.Trim((ReadOnlySpan<char>)trimCharsString)));
-                Assert.True(s1.SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)trimCharsString)));
-                Assert.True(s1.SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)trimCharsString)));
 
                 ReadOnlySpan<char> span = s1.AsSpan();
                 Assert.True(span.SequenceEqual(span.Trim(trimChars)));
@@ -6535,9 +6520,6 @@ namespace System.Tests
                 Assert.True(s2.SequenceEqual(s2.Trim(chars)));
                 Assert.True(s2.SequenceEqual(s2.TrimStart(chars)));
                 Assert.True(s2.SequenceEqual(s2.TrimEnd(chars)));
-                Assert.True(s2.SequenceEqual(s2.Trim((ReadOnlySpan<char>)chars)));
-                Assert.True(s2.SequenceEqual(s2.TrimStart((ReadOnlySpan<char>)chars)));
-                Assert.True(s2.SequenceEqual(s2.TrimEnd((ReadOnlySpan<char>)chars)));
 
                 ReadOnlySpan<char> span = s2.AsSpan();
                 Assert.True(span.SequenceEqual(span.Trim(chars)));
@@ -6550,9 +6532,6 @@ namespace System.Tests
             Assert.True(s3.SequenceEqual(s3.Trim(trimCharsFromString)));
             Assert.True(s3.SequenceEqual(s3.TrimStart(trimCharsFromString)));
             Assert.True(s3.SequenceEqual(s3.TrimEnd(trimCharsFromString)));
-            Assert.True(s3.SequenceEqual(s3.Trim((ReadOnlySpan<char>)trimCharsFromString)));
-            Assert.True(s3.SequenceEqual(s3.TrimStart((ReadOnlySpan<char>)trimCharsFromString)));
-            Assert.True(s3.SequenceEqual(s3.TrimEnd((ReadOnlySpan<char>)trimCharsFromString)));
 
             ReadOnlySpan<char> stringSpan = s3.AsSpan();
             ReadOnlySpan<char> trimCharsFromStringSpan = trimCharsFromString.AsSpan();
@@ -6577,9 +6556,6 @@ namespace System.Tests
                 Assert.True(string.Empty.SequenceEqual(s1.Trim(chars)), "G: " + length);
                 Assert.True(string.Empty.SequenceEqual(s1.TrimStart(chars)), "H: " + length);
                 Assert.True(string.Empty.SequenceEqual(s1.TrimEnd(chars)), "I: " + length);
-                Assert.True(string.Empty.SequenceEqual(s1.Trim((ReadOnlySpan<char>)chars)), "G: " + length);
-                Assert.True(string.Empty.SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)chars)), "H: " + length);
-                Assert.True(string.Empty.SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)chars)), "I: " + length);
 
                 ReadOnlySpan<char> span = s1.AsSpan();
                 Assert.True(ReadOnlySpan<char>.Empty.SequenceEqual(span.Trim(chars)), "G: " + length);
@@ -6592,9 +6568,6 @@ namespace System.Tests
             Assert.True(string.Empty.SequenceEqual(s2.Trim(trimCharsString)), "J");
             Assert.True(string.Empty.SequenceEqual(s2.TrimStart(trimCharsString)), "K");
             Assert.True(string.Empty.SequenceEqual(s2.TrimEnd(trimCharsString)), "L");
-            Assert.True(string.Empty.SequenceEqual(s2.Trim((ReadOnlySpan<char>)trimCharsString)), "J");
-            Assert.True(string.Empty.SequenceEqual(s2.TrimStart((ReadOnlySpan<char>)trimCharsString)), "K");
-            Assert.True(string.Empty.SequenceEqual(s2.TrimEnd((ReadOnlySpan<char>)trimCharsString)), "L");
 
             ReadOnlySpan<char> stringSpan = s2.AsSpan();
             ReadOnlySpan<char> trimChars = trimCharsString.AsSpan();
@@ -6619,9 +6592,6 @@ namespace System.Tests
                 Assert.True(s1.Substring(1).SequenceEqual(s1.Trim(chars)), "A: " + length);
                 Assert.True(s1.Substring(1).SequenceEqual(s1.TrimStart(chars)), "B: " + length);
                 Assert.True(s1.SequenceEqual(s1.TrimEnd(chars)), "C: " + length);
-                Assert.True(s1.Substring(1).SequenceEqual(s1.Trim((ReadOnlySpan<char>)chars)), "A: " + length);
-                Assert.True(s1.Substring(1).SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)chars)), "B: " + length);
-                Assert.True(s1.SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)chars)), "C: " + length);
 
                 ReadOnlySpan<char> span = s1.AsSpan();
                 Assert.True(span.Slice(1).SequenceEqual(span.Trim(chars)), "A: " + length);
@@ -6634,9 +6604,6 @@ namespace System.Tests
             Assert.True(s2.Substring(3).SequenceEqual(s2.Trim(trimCharsString)), "D");
             Assert.True(s2.Substring(3).SequenceEqual(s2.TrimStart(trimCharsString)), "E");
             Assert.True(s2.SequenceEqual(s2.TrimEnd(trimCharsString)), "F");
-            Assert.True(s2.Substring(3).SequenceEqual(s2.Trim((ReadOnlySpan<char>)trimCharsString)), "D");
-            Assert.True(s2.Substring(3).SequenceEqual(s2.TrimStart((ReadOnlySpan<char>)trimCharsString)), "E");
-            Assert.True(s2.SequenceEqual(s2.TrimEnd((ReadOnlySpan<char>)trimCharsString)), "F");
 
             ReadOnlySpan<char> stringSpan = s2.AsSpan();
             ReadOnlySpan<char> trimChars = trimCharsString.AsSpan();
@@ -6662,9 +6629,6 @@ namespace System.Tests
                 Assert.True(s1.Substring(0, length - 1).SequenceEqual(s1.Trim(chars)));
                 Assert.True(s1.SequenceEqual(s1.TrimStart(chars)));
                 Assert.True(s1.Substring(0, length - 1).SequenceEqual(s1.TrimEnd(chars)));
-                Assert.True(s1.Substring(0, length - 1).SequenceEqual(s1.Trim((ReadOnlySpan<char>)chars)));
-                Assert.True(s1.SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)chars)));
-                Assert.True(s1.Substring(0, length - 1).SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)chars)));
 
                 ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
                 Assert.True(span.Slice(0, length - 1).SequenceEqual(span.Trim(chars)));
@@ -6702,9 +6666,6 @@ namespace System.Tests
                 Assert.True(s1.Substring(1, length - 2).SequenceEqual(s1.Trim(chars)));
                 Assert.True(s1.Substring(1).SequenceEqual(s1.TrimStart(chars)));
                 Assert.True(s1.Substring(0, length - 1).SequenceEqual(s1.TrimEnd(chars)));
-                Assert.True(s1.Substring(1, length - 2).SequenceEqual(s1.Trim((ReadOnlySpan<char>)chars)));
-                Assert.True(s1.Substring(1).SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)chars)));
-                Assert.True(s1.Substring(0, length - 1).SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)chars)));
 
                 ReadOnlySpan<char> span = s1.AsSpan();
                 Assert.True(span.Slice(1, length - 2).SequenceEqual(span.Trim(chars)));
@@ -6716,9 +6677,6 @@ namespace System.Tests
             Assert.True(s2.Substring(5, 5).SequenceEqual(s2.Trim(chars)));
             Assert.True(s2.Substring(5).SequenceEqual(s2.TrimStart(chars)));
             Assert.True(s2.Substring(0, 10).SequenceEqual(s2.TrimEnd(chars)));
-            Assert.True(s2.Substring(5, 5).SequenceEqual(s2.Trim((ReadOnlySpan<char>)chars)));
-            Assert.True(s2.Substring(5).SequenceEqual(s2.TrimStart((ReadOnlySpan<char>)chars)));
-            Assert.True(s2.Substring(0, 10).SequenceEqual(s2.TrimEnd((ReadOnlySpan<char>)chars)));
 
             ReadOnlySpan<char> stringSpan = s2.AsSpan();
             ReadOnlySpan<char> trimChars = chars.AsSpan();
@@ -6744,9 +6702,6 @@ namespace System.Tests
                 Assert.True(s1.SequenceEqual(s1.Trim(chars)));
                 Assert.True(s1.SequenceEqual(s1.TrimStart(chars)));
                 Assert.True(s1.SequenceEqual(s1.TrimEnd(chars)));
-                Assert.True(s1.SequenceEqual(s1.Trim((ReadOnlySpan<char>)chars)));
-                Assert.True(s1.SequenceEqual(s1.TrimStart((ReadOnlySpan<char>)chars)));
-                Assert.True(s1.SequenceEqual(s1.TrimEnd((ReadOnlySpan<char>)chars)));
 
                 ReadOnlySpan<char> span = s1.AsSpan();
                 Assert.True(span.SequenceEqual(span.Trim(chars)));
@@ -6758,9 +6713,6 @@ namespace System.Tests
             Assert.True(s2.SequenceEqual(s2.Trim(chars)));
             Assert.True(s2.SequenceEqual(s2.TrimStart(chars)));
             Assert.True(s2.SequenceEqual(s2.TrimEnd(chars)));
-            Assert.True(s2.SequenceEqual(s2.Trim((ReadOnlySpan<char>)chars)));
-            Assert.True(s2.SequenceEqual(s2.TrimStart((ReadOnlySpan<char>)chars)));
-            Assert.True(s2.SequenceEqual(s2.TrimEnd((ReadOnlySpan<char>)chars)));
 
             ReadOnlySpan<char> stringSpan = s2.AsSpan();
             ReadOnlySpan<char> trimChars = chars.AsSpan();
@@ -6796,19 +6748,6 @@ namespace System.Tests
                 Assert.True(trimStartResultString.SequenceEqual(trimStartResultString.TrimStart(chars)));
                 Assert.True(trimEndResultString.SequenceEqual(trimEndResultString.TrimEnd(chars)));
 
-                s1 = new string(a);
-                trimResultString = s1.Trim((ReadOnlySpan<char>)chars);
-                trimStartResultString = s1.TrimStart((ReadOnlySpan<char>)chars);
-                trimEndResultString = s1.TrimEnd((ReadOnlySpan<char>)chars);
-                Assert.True(s1.Substring(1, length - 2).SequenceEqual(trimResultString));
-                Assert.True(s1.Substring(1).SequenceEqual(trimStartResultString));
-                Assert.True(s1.Substring(0, length - 1).SequenceEqual(trimEndResultString));
-
-                // 2nd attempt should do nothing
-                Assert.True(trimResultString.SequenceEqual(trimResultString.Trim((ReadOnlySpan<char>)chars)));
-                Assert.True(trimStartResultString.SequenceEqual(trimStartResultString.TrimStart((ReadOnlySpan<char>)chars)));
-                Assert.True(trimEndResultString.SequenceEqual(trimEndResultString.TrimEnd((ReadOnlySpan<char>)chars)));
-
                 ReadOnlySpan<char> span = s1.AsSpan();
                 ReadOnlySpan<char> trimResult = span.Trim(chars);
                 ReadOnlySpan<char> trimStartResult = span.TrimStart(chars);
@@ -6837,17 +6776,9 @@ namespace System.Tests
             Assert.True(trimEndStringResultString.SequenceEqual(trimEndStringResultString.TrimEnd(chars)));
 
             s2 = "ccedafffffbdaa";
-            trimStringResultString = s2.Trim((ReadOnlySpan<char>)chars);
-            trimStartStringResultString = s2.TrimStart((ReadOnlySpan<char>)chars);
-            trimEndStringResultString = s2.TrimEnd((ReadOnlySpan<char>)chars);
             Assert.True(s2.Substring(5, 5).SequenceEqual(trimStringResultString));
             Assert.True(s2.Substring(5).SequenceEqual(trimStartStringResultString));
             Assert.True(s2.Substring(0, 10).SequenceEqual(trimEndStringResultString));
-
-            // 2nd attempt should do nothing
-            Assert.True(trimStringResultString.SequenceEqual(trimStringResultString.Trim((ReadOnlySpan<char>)chars)));
-            Assert.True(trimStartStringResultString.SequenceEqual(trimStartStringResultString.TrimStart((ReadOnlySpan<char>)chars)));
-            Assert.True(trimEndStringResultString.SequenceEqual(trimEndStringResultString.TrimEnd((ReadOnlySpan<char>)chars)));
 
             ReadOnlySpan<char> stringSpan = s2.AsSpan();
             ReadOnlySpan<char> trimChars = chars.AsSpan();
@@ -6893,11 +6824,6 @@ namespace System.Tests
             Assert.True(s2.SequenceEqual(s2.Trim(chars)));
             Assert.True(s2.SequenceEqual(s2.TrimStart(chars)));
             Assert.True(s2.SequenceEqual(s2.TrimEnd(chars)));
-
-            s2 = testString.Substring(1, testString.Length - 2);
-            Assert.True(s2.SequenceEqual(s2.Trim((ReadOnlySpan<char>)chars)));
-            Assert.True(s2.SequenceEqual(s2.TrimStart((ReadOnlySpan<char>)chars)));
-            Assert.True(s2.SequenceEqual(s2.TrimEnd((ReadOnlySpan<char>)chars)));
 
             ReadOnlySpan<char> stringSpan = s2.AsSpan();
             ReadOnlySpan<char> trimChars = chars.AsSpan();

--- a/src/libraries/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -17,4 +17,16 @@
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:System.Resources.ResourceSet.Reader</Target>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.String.Trim(System.ReadOnlySpan{System.Char})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.String.TrimEnd(System.ReadOnlySpan{System.Char})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.String.TrimStart(System.ReadOnlySpan{System.Char})</Target>
+  </Suppression>
 </Suppressions>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5779,15 +5779,12 @@ namespace System
         public string Trim() { throw null; }
         public string Trim(char trimChar) { throw null; }
         public string Trim(params char[]? trimChars) { throw null; }
-        public string Trim(params System.ReadOnlySpan<char> trimChars) { throw null; }
         public string TrimEnd() { throw null; }
         public string TrimEnd(char trimChar) { throw null; }
         public string TrimEnd(params char[]? trimChars) { throw null; }
-        public string TrimEnd(params System.ReadOnlySpan<char> trimChars) { throw null; }
         public string TrimStart() { throw null; }
         public string TrimStart(char trimChar) { throw null; }
         public string TrimStart(params char[]? trimChars) { throw null; }
-        public string TrimStart(params System.ReadOnlySpan<char> trimChars) { throw null; }
         public bool TryCopyTo(System.Span<char> destination) { throw null; }
     }
     public abstract partial class StringComparer : System.Collections.Generic.IComparer<string?>, System.Collections.Generic.IEqualityComparer<string?>, System.Collections.IComparer, System.Collections.IEqualityComparer


### PR DESCRIPTION
Manual backport of #108537 to release/9.0

## Customer Impact

- [x] Customer reported
- [x] Found internally

Customers who have existing extension methods, string.Trim(string) (or TrimEnd, or TrimStart) find that their extension methods no longer get called after upgrading to .NET 9.  These extension methods almost always want to turn `"prefixinfixsuffix".TrimEnd("suffix")` into `"prefixinfix"`, but our new method `public [instance] string [string::]TrimEnd(ReadOnlySpan<char> value)` has higher binding order over their extension method, and it produces the result `"prefixin"`, as it is instead treating the "suffix" as a set of characters to remove from the end of the string (equivalent to `"prefixinfixsuffix".TrimEnd('s', 'u', 'f', 'f', 'i', 'x')`, rather than a specific sequence of characters.

## Regression

- [x] Yes
- [ ] No

Customers who had applicable extension methods experience these new overloads as a regression from previous versions.

## Testing

As the tests for these methods no longer compile, they are also removed.

## Risk

This change is breaking.  Any callers who specifically call Trim, TrimStart, or TrimEnd with a `ReadOnlySpan<char>` will have to change their code.  Two such sites were identified in dotnet/wpf and have already been mitigated.

Callers which were calling the new methods via params syntax will not experience a runtime break with this change, as it removes the ref but not the implementation (yet).  When those callers recompile they will switch (back) to the `Trim(params char[])` overload with no action required on their part.

As this change only removes things, the risk that the change does not solve the problem is low. The risk that it requires unanticipated followup in dotnet/runtime is also low.  While other dotnet/* repositories have been checked for breaks, some may have been missed, and they will break automatic ingestion and have to be fixed as they surface.