### PR TITLE
[mono] Updated runtime test building doc

### DIFF
--- a/docs/workflow/testing/mono/testing.md
+++ b/docs/workflow/testing/mono/testing.md
@@ -17,7 +17,7 @@ To build the runtime tests for Mono JIT or interpreter:
 
 ```
 cd src/tests
-./build.sh mono <release|debug>
+./build.sh mono <release|debug> /p:LibrariesConfiguration=<release|debug>
 ```
 
 To build an individual test, test directory, or a whole subdirectory tree, use the `-test:`, `-dir:` or `-tree:` options (without the src/tests prefix).


### PR DESCRIPTION
Add information about `/p:LibrariesConfiguration` MSBuild argument to mono/testing doc