### PR TITLE
Use default timeout of 30s.

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -103,7 +103,7 @@ internal class BrowserRunner : IAsyncDisposable
     public async Task<IBrowser> SpawnBrowserAsync(
         string browserUrl,
         bool headless = true,
-        int timeout = 10000,
+        int? timeout = null,
         int maxRetries = 3
     ) {
         var url = new Uri(browserUrl);


### PR DESCRIPTION
Backport of [#108723](https://github.com/dotnet/runtime/pull/108474) to release/9.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

This impacts only testing with WasmBuildTests on WASM. We have problems with time outs and we mitigated the issue on net10 by setting the timeout of launching the Playwright browser to default value (30s). Net9 is still caught in https://github.com/dotnet/runtime/issues/107771, so it’s worth aligning the change.

## Regression

- [ ] Yes
- [x] No


## Testing

CI

## Risk

Low, it's only an infra change. It can in the worst case cause a slightly longer runs of CI.