### PR TITLE
Enable all configurations inner loop

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -298,24 +298,23 @@ jobs:
 
 # Runtime-dev-innerloop build
 
-# disabled against https://github.com/dotnet/runtime/issues/108821
-#- ${{ if containsValue(parameters.platforms, 'linux_x64_dev_innerloop') }}:
-#  - template: xplat-setup.yml
-#    parameters:
-#      jobTemplate: ${{ parameters.jobTemplate }}
-#      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#      variables: ${{ parameters.variables }}
-#      osGroup: linux
-#      archType: x64
-#      targetRid: linux-x64
-#      platform: linux_x64
-#      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#      container: linux_x64_dev_innerloop
-#      jobParameters:
-#        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#        buildConfig: ${{ parameters.buildConfig }}
-#        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_x64_dev_innerloop') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_x64_dev_innerloop
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 - ${{ if containsValue(parameters.platforms, 'linux_musl_x64_dev_innerloop') }}:
   - template: xplat-setup.yml

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -82,7 +82,7 @@ extends:
                 eq(variables['isRollingBuild'], true))
 
       #
-      # Build Libraries AllConfigurations. This exercises the code path where we build libraries and tests for all
+      # Build Libraries AllConfigurations. This exercises the code path where we build libraries for all
       # configurations on a non Windows operating system.
       #
       - template: /eng/pipelines/common/platform-matrix.yml
@@ -93,7 +93,7 @@ extends:
           - linux_x64_dev_innerloop
           jobParameters:
             nameSuffix: Libraries_AllConfigurations
-            buildArgs: -subset libs+libs.tests -allconfigurations
+            buildArgs: -subset libs -allconfigurations
             timeoutInMinutes: 120
             condition:
               or(


### PR DESCRIPTION
Related: https://github.com/dotnet/runtime/issues/108821

Reverts https://github.com/dotnet/runtime/pull/108581

Rather than disable the entire leg, let's try just disabling the build of tests.  It's possible the build of tests concurrent with the product was what was causing the OOMs.  I see the tests running lots of resource intensive tools which could cause this problem.

We do have other coverage of `libs.tests` on linux so we don't necessarily need that here.

We'll want to run `runtime_dev_innerloop` enough to convince ourselves this is safe.

@jkotas @steveisok 