### PR TITLE
Introduce a mechanism to disable CLR tests under SuperPMI collection

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -127,6 +127,19 @@ then
   exit $(IncompatibleTestBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
+      <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(SuperPmiCollectIncompatible)' == 'true'"><![CDATA[
+$(BashCLRTestEnvironmentCompatibilityCheck)
+if [ ! -z "$SuperPMIShimPath" ]
+then
+  echo SKIPPING EXECUTION BECAUSE SuperPMIShimPath IS SET
+  exit $(IncompatibleTestBashScriptExitCode)
+fi
+if [ ! -z "$spmi_enable_collection" ]
+then
+  echo SKIPPING EXECUTION BECAUSE spmi_enable_collection IS SET
+  exit $(IncompatibleTestBashScriptExitCode)
+fi
+      ]]></BashCLRTestEnvironmentCompatibilityCheck>
 
       <BashCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
 <![CDATA[

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -134,6 +134,20 @@ IF NOT "%CrossGen2SynthesizePgo%"=="" (
 )
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
 
+      <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(SuperPmiCollectIncompatible)' == 'true'"><![CDATA[
+$(BatchCLRTestEnvironmentCompatibilityCheck)
+IF NOT "%SuperPMIShimPath%"=="" (
+  ECHO SKIPPING EXECUTION BECAUSE SuperPMIShimPath IS SET
+  popd
+  Exit /b 0
+)
+IF NOT "%spmi_enable_collection%"=="" (
+  ECHO SKIPPING EXECUTION BECAUSE spmi_enable_collection IS SET
+  popd
+  Exit /b 0
+)
+      ]]></BatchCLRTestEnvironmentCompatibilityCheck>
+
       <BatchCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
         <![CDATA[
 set CLRTestExpectedExitCode=$(CLRTestExitCode)

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.csproj
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for GCStressIncompatible -->
+    <!-- Needed for GCStressIncompatible, SuperPMICollectIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>false</Optimize>
     <!-- Fails in many GCStress jobs. https://github.com/dotnet/runtime/issues/46279 -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- Exception handling in this test is incompatible with SuperPMI collection. See https://github.com/dotnet/runtime/issues/108215. -->
+    <SuperPMICollectIncompatible>true</SuperPMICollectIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="stackoverflowtester.cs" />
   </ItemGroup>
 </Project>
-


### PR DESCRIPTION
It should be _extremely_ rare to need to disable a test during SuperPMI collection. However, one case was found, so introduce the ability to do so.

Use `<SuperPmiCollectIncompatible>true</SuperPmiCollectIncompatible>` in a test project file.

(which also requires `<RequiresProcessIsolation>true</RequiresProcessIsolation>`)

Fixes #108215