### PR TITLE
Enable using -sign in VMR scenarios

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -42,8 +42,9 @@
            This allows to build the repository using './build.sh <args> /p:DotNetBuildSourceOnly=true'.
            Properties that control flags from the VMR build, and the expected output for the VMR build should be added to this file. -->
 
-      <!-- Enable regular Arcade publishing in VMR build -->
+      <!-- Enable regular Arcade signing and publishing in VMR build -->
       <InnerBuildArgs Condition="'$(DotNetBuildOrchestrator)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)publish</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DotNetBuildOrchestrator)' == 'true' and '$(Sign)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)sign</InnerBuildArgs>
 
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)arch $(TargetArch)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)os $(TargetOS)</InnerBuildArgs>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,21 +1,9 @@
 <Project>
   <PropertyGroup>
-    <!--
-      Windows arm/arm64 jobs don't have MSIs to sign. Keep it simple: allow not finding any matches
-      here and rely on overall signing validation.
-
-      During post build signing, there are no packages to sign during SignFinalPackages.
-    -->
-    <AllowEmptySignList>true</AllowEmptySignList>
+    <EnableDefaultArtifacts Condition="'$(DotNetBuild)' != 'true'">false</EnableDefaultArtifacts>
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-      Replace the default items to sign with the specific set we want. This allows the build to call
-      Arcade's Sign.proj multiple times for different sets of files as the build progresses.
-    -->
-    <ItemsToSign Remove="@(ItemsToSign)" />
-
     <!-- apphost and comhost template files are not signed, by design. -->
     <FileSignInfo Include="apphost.exe;singlefilehost.exe;comhost.dll" CertificateName="None" />
 
@@ -37,12 +25,6 @@
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
 
-    <!-- Exclude symbol packages from have a NuGet signature. These are never pushed to NuGet.org or
-         other feeds (in fact, that have identical identity to their non-symbol variant) -->
-    <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
-    <DownloadedSymbolPackagesWithoutPaths Include="@(DownloadedSymbolPackages->'%(Filename)%(Extension)')" />
-    <FileSignInfo Include="@(DownloadedSymbolPackagesWithoutPaths->Distinct())" CertificateName="None" />
-
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />
     <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
@@ -55,14 +37,30 @@
     <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(PrepareArtifacts)' == 'true'">
-    <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.msi" />
-    <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.exe" />
-    <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.nupkg" />
-    <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.zip" />
-
-    <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
-    <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" Condition="'$(PostBuildSign)' == 'true'" />
-    <ItemsToSign Include="@(ItemsToSignWithPaths->Distinct())" Condition="'$(PostBuildSign)' != 'true'" />
+  <!-- In build signing and publishing without a join point -->
+  <ItemGroup Condition="'$(DotNetBuild)' == 'true'">
+    <Artifact Include="$(ArtifactsPackagesDir)**\*.tar.gz;
+                       $(ArtifactsPackagesDir)**\*.zip;
+                       $(ArtifactsPackagesDir)**\*.deb;
+                       $(ArtifactsPackagesDir)**\*.rpm;
+                       $(ArtifactsPackagesDir)**\*.pkg;
+                       $(ArtifactsPackagesDir)**\*.exe;
+                       $(ArtifactsPackagesDir)**\*.msi"
+              Exclude="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz"
+              IsShipping="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping'))">
+      <!-- Exclude wixpack.zip files from checksum generation -->
+      <ChecksumPath Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.wixpack.zip')) != 'true'">%(FullPath).sha512</ChecksumPath>
+    </Artifact>
   </ItemGroup>
+
+  <!-- Only the following artifacts should be signed.
+       Set SkipPublish=true as those artifacts are added again in Publishing.props. -->
+  <ItemGroup Condition="'$(DotNetBuild)' != 'true'">
+    <Artifact Include="$(DownloadDirectory)**\*.msi;
+                       $(DownloadDirectory)**\*.exe;
+                       $(DownloadDirectory)**\*.nupkg;
+                       $(DownloadDirectory)**\*.zip"
+              SkipPublish="true" />
+  </ItemGroup>
+
 </Project>

--- a/eng/SubsetValidation.targets
+++ b/eng/SubsetValidation.targets
@@ -5,12 +5,6 @@
     Each subset has its own '<subset>Project' items so that a project in the build can depend
     on a whole subset, and the dependency on the subset is disregarded automatically when Subset
     doesn't contain it.
-
-    %(ProjectToBuild.SignPhase): Indicates this project must be built before a certain signing
-      phase. Projects can depend on 'signing/stages/Sign<stage>.proj' to wait until all projects
-      that are part of a stage are complete. This allows the build to perform complex container
-      signing that isn't (can't be?) supported by Arcade's single pass, such as MSIs and bundles:
-      https://github.com/dotnet/arcade/issues/388
   -->
 
   <Target Name="FindInvalidSpecifiedSubsetNames">

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -462,17 +462,17 @@
 
   <!-- Host sets -->
   <ItemGroup Condition="$(_subset.Contains('+host.native+'))">
-    <CorehostProjectToBuild Include="$(SharedNativeRoot)corehost\corehost.proj" SignPhase="Binaries" />
+    <CorehostProjectToBuild Include="$(SharedNativeRoot)corehost\corehost.proj" />
     <ProjectToBuild Include="@(CorehostProjectToBuild)" AdditionalProperties="$(TargetCxxLibraryProperties)" Pack="true" Category="host" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+host.tools+'))">
-    <ManagedProjectToBuild Include="$(InstallerProjectRoot)managed\**\*.csproj" SignPhase="Binaries" />
+    <ManagedProjectToBuild Include="$(InstallerProjectRoot)managed\**\*.csproj" />
     <ProjectToBuild Include="@(ManagedProjectToBuild)" BuildInParallel="true" Pack="true" Category="host" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+host.pkg+')) and '$(BuildOnlyPgoInstrumentedAssets)' != 'true'">
-    <PkgprojProjectToBuild Include="$(InstallerProjectRoot)pkg\projects\host-packages.proj" SignPhase="MsiFiles" />
+    <PkgprojProjectToBuild Include="$(InstallerProjectRoot)pkg\projects\host-packages.proj" />
     <ProjectToBuild Include="@(PkgprojProjectToBuild)" Pack="true" Category="host" />
   </ItemGroup>
 

--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -15,12 +15,9 @@
 
   <!-- When doing post build sign, pull in the arcade sign.props file, which will
        create some initial sign groups and then pulls in the repo's custom Signing.props overrides.
-       Before importing the signing props. Set PrepareArtifactst=true. Depending on context (SDK project vs. not),
+       Before importing the signing props. Depending on context (SDK project vs. not),
        the initial imports of livebuilds.targets and Configuration.props are already imported and thus cannot
        be imported again. Without those imports, the globbing of files to sign will not work properly. -->
-  <PropertyGroup>
-    <PrepareArtifacts>true</PrepareArtifacts>
-  </PropertyGroup>
   <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <Import Project="$(RepositoryEngineeringDir)Publishing.props" Condition="Exists('$(RepositoryEngineeringDir)Publishing.props')" />
@@ -68,18 +65,13 @@
     </ItemsToPush>
   </ItemDefinitionGroup>
 
-  <!--
-    Run Arcade's signing project directly. The 'eng/Signing.props' extensibility props file checks
-    if '$(<StageName>)' == 'true' and points Arcade to the correct files.
-  -->
   <Target Name="SignArtifacts"
           Condition="'$(PostBuildSign)' != 'true'" >
     <MSBuild
       Projects="$(ArcadeSdkSignProject)"
       Targets="Sign"
       Properties="
-        DownloadDirectory=$(DownloadDirectory);
-        PrepareArtifacts=$(PrepareArtifacts)" />
+        DownloadDirectory=$(DownloadDirectory)" />
   </Target>
 
   <!--


### PR DESCRIPTION
Enable signing using the Arcade signing infra in VMR scenarios. This does not move the dotnet-runtime-official pipeline to use the Arcade signing infra, similar to how https://github.com/dotnet/runtime/pull/99432 did not enable `-publish` in dotnet-runtime-official.

This PR adds the `-sign` flag to the inner invocation when the outer invocation is invoked with the `-sign` flag to ensure we go down the Arcade signing and publishing route as expected.

Based on the work in https://github.com/dotnet/runtime/pull/100004

Fixes https://github.com/dotnet/runtime/issues/108605

Runtime official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2561356&view=results