### PR TITLE
Change the PAGE_SIZE to obtain from 'Environment.SystemPageSize' for CoreRoot testcases: 'MisSizedStructs_ArmArch' and 'Runtime_65937'.

### DIFF
--- a/src/tests/JIT/Directed/StructABI/MisSizedStructs_ArmArch.cs
+++ b/src/tests/JIT/Directed/StructABI/MisSizedStructs_ArmArch.cs
@@ -37,7 +37,7 @@ public unsafe class MisSizedStructs_ArmSplit
         const int PROT_WRITE = 0x2;
         const int MAP_PRIVATE = 0x02;
         const int MAP_ANONYMOUS = 0x20;
-        const int PAGE_SIZE = 0x1000;
+        uint PAGE_SIZE = (uint)Environment.SystemPageSize;
 
         byte* pages = (byte*)mmap(null, 2 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_65937/Runtime_65937.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_65937/Runtime_65937.cs
@@ -22,7 +22,7 @@ public unsafe class Runtime_65937
         const int PROT_WRITE = 0x2;
         const int MAP_PRIVATE = 0x02;
         const int MAP_ANONYMOUS = 0x20;
-        const int PAGE_SIZE = 0x1000;
+        uint PAGE_SIZE = (uint)Environment.SystemPageSize;
 
         byte* pages = (byte*)mmap(null, 2 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 


### PR DESCRIPTION
Change the PAGE_SIZE to obtain from 'Environment.SystemPageSize' for CoreRoot testcases: 'MisSizedStructs_ArmArch' and 'Runtime_65937'.