### PR TITLE
Fix the ListenerElement.Attributes property

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Diagnostics/ListenerElementsCollection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Diagnostics/ListenerElementsCollection.cs
@@ -106,7 +106,7 @@ namespace System.Diagnostics
             _properties.Add(s_propOutputOpts);
         }
 
-        public StringDictionary Attributes => _attributes ?? new StringDictionary();
+        public StringDictionary Attributes => _attributes ??= new StringDictionary();
 
         [ConfigurationProperty("filter")]
         public FilterElement Filter => (FilterElement)this[s_propFilter];

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPropertyAttributeTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPropertyAttributeTests.cs
@@ -82,6 +82,7 @@ namespace System.ConfigurationTests
 </configuration>";
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "ListenerElement uses HashTable not StringDictionary")]
         public void CustomAttributeIsPresent()
         {
             using (var temp = new TempConfig(AttributeConfiguration))

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPropertyAttributeTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPropertyAttributeTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Specialized;
 using System.Configuration;
+using System.Reflection;
 using Xunit;
 
 namespace System.ConfigurationTests
@@ -65,6 +67,42 @@ namespace System.ConfigurationTests
             Assert.False(attribute.IsKey);
 
             Assert.Equal(ConfigurationPropertyOptions.None, attribute.Options);
+        }
+
+        public static string AttributeConfiguration =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+  <system.diagnostics>
+    <trace>
+      <listeners>
+        <add name=""delimited"" type=""System.Diagnostics.DelimitedListTraceListener"" delimiter="":"" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
+</configuration>";
+
+        [Fact]
+        public void CustomAttributeIsPresent()
+        {
+            using (var temp = new TempConfig(AttributeConfiguration))
+            {
+                ConfigurationSection section = ConfigurationManager.OpenExeConfiguration(temp.ExePath).GetSection("system.diagnostics");
+                ConfigurationElementCollection listeners = (ConfigurationElementCollection)GetPropertyValue(GetPropertyValue(section, "Trace"), "Listeners");
+                Assert.Equal(2, listeners.Count);
+
+                ConfigurationElement[] items = new ConfigurationElement[2];
+                listeners.CopyTo(items, 0);
+                Assert.Equal("delimited", GetPropertyValue(items[1], "Name"));
+                StringDictionary attributes = (StringDictionary)GetPropertyValue(items[1], "Attributes");
+                Assert.Equal(1, attributes.Count);
+
+                // Verify the attribute is present.
+                Assert.Equal(":", attributes["delimiter"]);
+
+                static object GetPropertyValue(object obj, string propertyName) => obj.GetType().
+                    GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance).
+                    GetValue(obj);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/108428

Fix typo causing the Attributes property to always return `null`.