### PR TITLE
JIT: Use `BitVec` with `bbPostorderNum` key to track visited blocks during value numbering

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5798,7 +5798,7 @@ public:
     // Utility functions for fgValueNumber.
 
     // Value number a block or blocks in a loop
-    void fgValueNumberBlocks(BasicBlock* block, BlockSet& visitedBlocks);
+    void fgValueNumberBlocks(BasicBlock* block, BitVec& visitedBlocks, BitVecTraits* traits);
 
     // Perform value-numbering for the trees in "blk".
     void fgValueNumberBlock(BasicBlock* blk);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10889,7 +10889,7 @@ PhaseStatus Compiler::fgValueNumber()
     // before itself whenever possible.
     //
     BitVecTraits traits = m_dfsTree->PostOrderTraits();
-    BitVec     visitedBlocks(BitVecOps::MakeEmpty(&traits));
+    BitVec       visitedBlocks(BitVecOps::MakeEmpty(&traits));
     BasicBlock** postOrder      = m_dfsTree->GetPostOrder();
     unsigned     postOrderCount = m_dfsTree->GetPostOrderCount();
     for (unsigned i = postOrderCount; i != 0; i--)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10888,14 +10888,14 @@ PhaseStatus Compiler::fgValueNumber()
     // Visiting that in reverse will ensure we visit a block's predecessors
     // before itself whenever possible.
     //
-    EnsureBasicBlockEpoch();
-    BlockSet     visitedBlocks(BlockSetOps::MakeEmpty(this));
+    BitVecTraits traits = m_dfsTree->PostOrderTraits();
+    BitVec     visitedBlocks(BitVecOps::MakeEmpty(&traits));
     BasicBlock** postOrder      = m_dfsTree->GetPostOrder();
     unsigned     postOrderCount = m_dfsTree->GetPostOrderCount();
     for (unsigned i = postOrderCount; i != 0; i--)
     {
         BasicBlock* const block = postOrder[i - 1];
-        fgValueNumberBlocks(block, visitedBlocks);
+        fgValueNumberBlocks(block, visitedBlocks, &traits);
     }
 
 #ifdef DEBUG
@@ -10914,6 +10914,7 @@ PhaseStatus Compiler::fgValueNumber()
 // Arguments:
 //   block -- block to value number (may already have been numbered)
 //   visitedBlocks -- blocks that have already had VNs assigned
+//   traits        -- pointer to BitVecTraits describing visitedBlocks
 //
 // Notes:
 //
@@ -10922,11 +10923,11 @@ PhaseStatus Compiler::fgValueNumber()
 //   header, we switch to visiting the loop blocks in RPO, and once we finish
 //   that visitation, we try and refine loop header PHIs.
 //
-void Compiler::fgValueNumberBlocks(BasicBlock* block, BlockSet& visitedBlocks)
+void Compiler::fgValueNumberBlocks(BasicBlock* block, BitVec& visitedBlocks, BitVecTraits* traits)
 {
     // Because we're not following the strict RPO, we may have already visisted this block.
     //
-    if (BlockSetOps::IsMember(this, visitedBlocks, block->bbNum))
+    if (BitVecOps::IsMember(traits, visitedBlocks, block->bbPostorderNum))
     {
         return;
     }
@@ -10961,7 +10962,7 @@ void Compiler::fgValueNumberBlocks(BasicBlock* block, BlockSet& visitedBlocks)
 
     // Mark block as visited
     //
-    BlockSetOps::AddElemD(this, visitedBlocks, block->bbNum);
+    BitVecOps::AddElemD(traits, visitedBlocks, block->bbPostorderNum);
 
     // Is block the head of a loop?
     //
@@ -10971,7 +10972,7 @@ void Compiler::fgValueNumberBlocks(BasicBlock* block, BlockSet& visitedBlocks)
         // Yes. Visit all other loop blocks using the within-loop RPO.
         //
         loop->VisitLoopBlocksReversePostOrder([&](BasicBlock* block) {
-            fgValueNumberBlocks(block, visitedBlocks);
+            fgValueNumberBlocks(block, visitedBlocks, traits);
             return BasicBlockVisit::Continue;
         });
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10912,9 +10912,9 @@ PhaseStatus Compiler::fgValueNumber()
 // fgValueNumberBlocks: Run value numbering for a block or blocks in a loop
 //
 // Arguments:
-//   block -- block to value number (may already have been numbered)
-//   visitedBlocks -- blocks that have already had VNs assigned
-//   traits        -- pointer to BitVecTraits describing visitedBlocks
+//   block - block to value number (may already have been numbered)
+//   visitedBlocks - blocks that have already had VNs assigned
+//   traits - pointer to BitVecTraits describing visitedBlocks
 //
 // Notes:
 //


### PR DESCRIPTION
In the spirit of #108932, use a `BitVec` indexed by `BasicBlock::bbPostorderNum` instead of a `BlockSet` indexed by `BasicBlock::bbNum` to track blocks that have already undergone value numbering.