### PR TITLE
Remove HelperMethodFrames (HMF) from Reflection code paths

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.Emit
 
         internal void GetCallableMethod(RuntimeModule module, DynamicMethod dm)
         {
-            dm._methodHandle = ModuleHandle.GetDynamicMethod(dm,
+            dm._methodHandle = ModuleHandle.GetDynamicMethod(
                                           module,
                                           m_methodBuilder.Name,
                                           (byte[])m_scope[m_methodSigToken]!,
@@ -861,7 +861,7 @@ namespace System.Reflection.Emit
         #region Internal Methods
         internal void GetCallableMethod(RuntimeModule module, DynamicMethod dm)
         {
-            dm._methodHandle = ModuleHandle.GetDynamicMethod(dm,
+            dm._methodHandle = ModuleHandle.GetDynamicMethod(
                 module, m_method.Name, (byte[])m_scope[m_methodSignature]!, new DynamicResolver(this));
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1446,10 +1446,14 @@ namespace System
             return methodInfo!;
         }
 
-        #region Internal FCalls
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern int GetToken(RuntimeModule module);
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_GetToken")]
+        [SuppressGCTransition]
+        private static partial int GetToken(QCallModule module);
 
+        internal static int GetToken(RuntimeModule module)
+            => GetToken(new QCallModule(ref module));
+
+        #region Internal FCalls
         private static void ValidateModulePointer(RuntimeModule module)
         {
             // Make sure we have a valid Module to resolve against.

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1453,7 +1453,6 @@ namespace System
         internal static int GetToken(RuntimeModule module)
             => GetToken(new QCallModule(ref module));
 
-        #region Internal FCalls
         private static void ValidateModulePointer(RuntimeModule module)
         {
             // Make sure we have a valid Module to resolve against.
@@ -1651,11 +1650,14 @@ namespace System
             machine = (ImageFileMachine)lMachine;
         }
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern int GetMDStreamVersion(RuntimeModule module);
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_GetMDStreamVersion")]
+        [SuppressGCTransition]
+        private static partial int GetMDStreamVersion(QCallModule module);
+
+        internal static int GetMDStreamVersion(RuntimeModule module)
+            => GetMDStreamVersion(new QCallModule(ref module));
 
         public int MDStreamVersion => GetMDStreamVersion(GetRuntimeModule());
-        #endregion
     }
 
     internal sealed unsafe class Signature

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1421,28 +1421,21 @@ namespace System
         private static partial void GetDynamicMethod(
             QCallModule module,
             string name,
-            byte* sig,
+            byte[] sig,
             int sigLen,
             ObjectHandleOnStack resolver,
             ObjectHandleOnStack result);
 
-        internal static IRuntimeMethodInfo GetDynamicMethod(Reflection.Emit.DynamicMethod method, RuntimeModule module, string name, byte[] sig, Resolver resolver)
+        internal static IRuntimeMethodInfo GetDynamicMethod(RuntimeModule module, string name, byte[] sig, Resolver resolver)
         {
-            if (module is null)
-            {
-                throw new ArgumentNullException(SR.Arg_InvalidHandle);
-            }
-
             IRuntimeMethodInfo? methodInfo = null;
-            fixed (byte* pSig = sig)
             GetDynamicMethod(
                 new QCallModule(ref module),
                 name,
-                pSig,
+                sig,
                 sig.Length,
                 ObjectHandleOnStack.Create(ref resolver),
                 ObjectHandleOnStack.Create(ref methodInfo));
-            GC.KeepAlive(method);
             return methodInfo!;
         }
 

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -186,10 +186,6 @@ FCFuncStart(gCOMFieldHandleNewFuncs)
     FCFuncElement("GetStaticFieldAddress", RuntimeFieldHandle::GetStaticFieldAddress)
 FCFuncEnd()
 
-FCFuncStart(gCOMModuleHandleFuncs)
-    FCFuncElement("GetMDStreamVersion", ModuleHandle::GetMDStreamVersion)
-FCFuncEnd()
-
 FCFuncStart(gRuntimeAssemblyFuncs)
     FCFuncElement("GetIsDynamic", AssemblyNative::GetIsDynamic)
     FCFuncElement("GetManifestModule", AssemblyHandle::GetManifestModule)
@@ -423,7 +419,6 @@ FCClassElement("Math", "System", gMathFuncs)
 FCClassElement("MathF", "System", gMathFFuncs)
 FCClassElement("MetadataImport", "System.Reflection", gMetaDataImport)
 FCClassElement("MethodTable", "System.Runtime.CompilerServices", gMethodTableFuncs)
-FCClassElement("ModuleHandle", "System", gCOMModuleHandleFuncs)
 FCClassElement("Monitor", "System.Threading", gMonitorFuncs)
 
 FCClassElement("RuntimeAssembly", "System.Reflection", gRuntimeAssemblyFuncs)

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -187,7 +187,6 @@ FCFuncStart(gCOMFieldHandleNewFuncs)
 FCFuncEnd()
 
 FCFuncStart(gCOMModuleHandleFuncs)
-    FCFuncElement("GetToken", ModuleHandle::GetToken)
     FCFuncElement("GetMDStreamVersion", ModuleHandle::GetMDStreamVersion)
 FCFuncEnd()
 

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -188,7 +188,6 @@ FCFuncEnd()
 
 FCFuncStart(gCOMModuleHandleFuncs)
     FCFuncElement("GetToken", ModuleHandle::GetToken)
-    FCFuncElement("GetDynamicMethod", ModuleHandle::GetDynamicMethod)
     FCFuncElement("GetMDStreamVersion", ModuleHandle::GetMDStreamVersion)
 FCFuncEnd()
 

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -169,6 +169,7 @@ static const Entry s_QCall[] =
     DllImportEntry(ModuleBuilder_GetArrayMethodToken)
     DllImportEntry(ModuleBuilder_SetFieldRVAContent)
     DllImportEntry(ModuleHandle_GetModuleType)
+    DllImportEntry(ModuleHandle_GetToken)
     DllImportEntry(ModuleHandle_ResolveType)
     DllImportEntry(ModuleHandle_ResolveMethod)
     DllImportEntry(ModuleHandle_ResolveField)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -173,6 +173,7 @@ static const Entry s_QCall[] =
     DllImportEntry(ModuleHandle_ResolveMethod)
     DllImportEntry(ModuleHandle_ResolveField)
     DllImportEntry(ModuleHandle_GetPEKind)
+    DllImportEntry(ModuleHandle_GetDynamicMethod)
     DllImportEntry(AssemblyHandle_GetManifestModuleSlow)
     DllImportEntry(TypeBuilder_DefineGenericParam)
     DllImportEntry(TypeBuilder_DefineType)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -168,6 +168,7 @@ static const Entry s_QCall[] =
     DllImportEntry(ModuleBuilder_GetMemberRefFromSignature)
     DllImportEntry(ModuleBuilder_GetArrayMethodToken)
     DllImportEntry(ModuleBuilder_SetFieldRVAContent)
+    DllImportEntry(ModuleHandle_GetMDStreamVersion)
     DllImportEntry(ModuleHandle_GetModuleType)
     DllImportEntry(ModuleHandle_GetToken)
     DllImportEntry(ModuleHandle_ResolveType)

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2750,7 +2750,7 @@ extern "C" void QCALLTYPE ModuleHandle_GetDynamicMethod(QCall::ModuleHandle pMod
     BEGIN_QCALL;
 
     // Make a copy of the name
-    INT32 nameLen = (INT32)strlen(name) + 1;
+    size_t nameLen = strlen(name) + 1;
     NewArrayHolder<char> pName(new char[nameLen]);
     memcpy(pName, name, nameLen * sizeof(char));
 

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2677,21 +2677,12 @@ extern "C" void QCALLTYPE ModuleHandle_GetModuleType(QCall::ModuleHandle pModule
     return;
 }
 
-FCIMPL1(INT32, ModuleHandle::GetToken, ReflectModuleBaseObject * pModuleUNSAFE) {
-    CONTRACTL {
-        FCALL_CHECK;
-    }
-    CONTRACTL_END;
+extern "C" INT32 QCALLTYPE ModuleHandle_GetToken(QCall::ModuleHandle pModule)
+{
+    QCALL_CONTRACT_NO_GC_TRANSITION;
 
-    REFLECTMODULEBASEREF refModule = (REFLECTMODULEBASEREF)ObjectToOBJECTREF(pModuleUNSAFE);
-
-    if (refModule == NULL)
-        FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
-
-    Module *pModule = refModule->GetModule();
     return pModule->GetMDImport()->GetModuleFromScope();
 }
-FCIMPLEND
 
 extern "C" void QCALLTYPE ModuleHandle_ResolveType(QCall::ModuleHandle pModule, INT32 tkType, TypeHandle *typeArgs, INT32 typeArgsCount, TypeHandle *methodArgs, INT32 methodArgsCount, QCall::ObjectHandleOnStack retType)
 {

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2638,19 +2638,12 @@ extern "C" void QCALLTYPE ModuleHandle_GetPEKind(QCall::ModuleHandle pModule, DW
     END_QCALL;
 }
 
-FCIMPL1(INT32, ModuleHandle::GetMDStreamVersion, ReflectModuleBaseObject * pModuleUNSAFE)
+extern "C" INT32 QCALLTYPE ModuleHandle_GetMDStreamVersion(QCall::ModuleHandle pModule)
 {
-    FCALL_CONTRACT;
+    QCALL_CONTRACT_NO_GC_TRANSITION;
 
-    REFLECTMODULEBASEREF refModule = (REFLECTMODULEBASEREF)ObjectToOBJECTREF(pModuleUNSAFE);
-
-    if (refModule == NULL)
-        FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
-
-    Module *pModule = refModule->GetModule();
     return pModule->GetMDImport()->GetMetadataStreamVersion();
 }
-FCIMPLEND
 
 extern "C" void QCALLTYPE ModuleHandle_GetModuleType(QCall::ModuleHandle pModule, QCall::ObjectHandleOnStack retType)
 {

--- a/src/coreclr/vm/runtimehandles.h
+++ b/src/coreclr/vm/runtimehandles.h
@@ -308,10 +308,9 @@ extern "C" void QCALLTYPE RuntimeFieldHandle_SetValueDirect(FieldDesc* fieldDesc
 extern "C" BOOL QCALLTYPE RuntimeFieldHandle_GetRVAFieldInfo(FieldDesc* pField, void** address, UINT* size);
 extern "C" void QCALLTYPE RuntimeFieldHandle_GetFieldDataReference(FieldDesc* pField, QCall::ObjectHandleOnStack instance, QCall::ByteRefOnStack offset);
 
-class ModuleHandle {
-
+class ModuleHandle
+{
 public:
-    static FCDECL5(ReflectMethodObject*, GetDynamicMethod, ReflectMethodObject *pMethodUNSAFE, ReflectModuleBaseObject *pModuleUNSAFE, StringObject *name, U1Array *sig, Object *resolver);
     static FCDECL1(INT32, GetToken, ReflectModuleBaseObject *pModuleUNSAFE);
     static FCDECL1(INT32, GetMDStreamVersion, ReflectModuleBaseObject * pModuleUNSAFE);
 };
@@ -324,9 +323,9 @@ extern "C" MethodDesc * QCALLTYPE ModuleHandle_ResolveMethod(QCall::ModuleHandle
 
 extern "C" void QCALLTYPE ModuleHandle_ResolveField(QCall::ModuleHandle pModule, INT32 tkMemberRef, TypeHandle *typeArgs, INT32 typeArgsCount, TypeHandle *methodArgs, INT32 methodArgsCount, QCall::ObjectHandleOnStack retField);
 
-extern "C" void QCALLTYPE ModuleHandle_GetAssembly(QCall::ModuleHandle pModule, QCall::ObjectHandleOnStack retAssembly);
-
 extern "C" void QCALLTYPE ModuleHandle_GetPEKind(QCall::ModuleHandle pModule, DWORD* pdwPEKind, DWORD* pdwMachine);
+
+extern "C" void QCALLTYPE ModuleHandle_GetDynamicMethod(QCall::ModuleHandle pModule, const char* name, byte* sig, INT32 sigLen, QCall::ObjectHandleOnStack resolver, QCall::ObjectHandleOnStack result);
 
 class AssemblyHandle
 {

--- a/src/coreclr/vm/runtimehandles.h
+++ b/src/coreclr/vm/runtimehandles.h
@@ -308,12 +308,7 @@ extern "C" void QCALLTYPE RuntimeFieldHandle_SetValueDirect(FieldDesc* fieldDesc
 extern "C" BOOL QCALLTYPE RuntimeFieldHandle_GetRVAFieldInfo(FieldDesc* pField, void** address, UINT* size);
 extern "C" void QCALLTYPE RuntimeFieldHandle_GetFieldDataReference(FieldDesc* pField, QCall::ObjectHandleOnStack instance, QCall::ByteRefOnStack offset);
 
-class ModuleHandle
-{
-public:
-    static FCDECL1(INT32, GetMDStreamVersion, ReflectModuleBaseObject * pModuleUNSAFE);
-};
-
+extern "C" INT32 QCALLTYPE ModuleHandle_GetMDStreamVersion(QCall::ModuleHandle pModule);
 extern "C" void QCALLTYPE ModuleHandle_GetModuleType(QCall::ModuleHandle pModule, QCall::ObjectHandleOnStack retType);
 
 extern "C" INT32 QCALLTYPE ModuleHandle_GetToken(QCall::ModuleHandle pModule);

--- a/src/coreclr/vm/runtimehandles.h
+++ b/src/coreclr/vm/runtimehandles.h
@@ -311,11 +311,12 @@ extern "C" void QCALLTYPE RuntimeFieldHandle_GetFieldDataReference(FieldDesc* pF
 class ModuleHandle
 {
 public:
-    static FCDECL1(INT32, GetToken, ReflectModuleBaseObject *pModuleUNSAFE);
     static FCDECL1(INT32, GetMDStreamVersion, ReflectModuleBaseObject * pModuleUNSAFE);
 };
 
 extern "C" void QCALLTYPE ModuleHandle_GetModuleType(QCall::ModuleHandle pModule, QCall::ObjectHandleOnStack retType);
+
+extern "C" INT32 QCALLTYPE ModuleHandle_GetToken(QCall::ModuleHandle pModule);
 
 extern "C" void QCALLTYPE ModuleHandle_ResolveType(QCall::ModuleHandle pModule, INT32 tkType, TypeHandle *typeArgs, INT32 typeArgsCount, TypeHandle *methodArgs, INT32 methodArgsCount, QCall::ObjectHandleOnStack retType);
 


### PR DESCRIPTION
Convert `ModuleHandle::GetDynamicMethod` to QCall.
Convert `ModuleHandle::GetToken` to QCall.
Convert `ModuleHandle::GetMDStreamVersion` to QCall.