### PR TITLE
Fix HostApiInvokerApp test app setting DllImportResolver for hostfxr

### DIFF
--- a/src/installer/tests/Assets/Projects/HostApiInvokerApp/Program.cs
+++ b/src/installer/tests/Assets/Projects/HostApiInvokerApp/Program.cs
@@ -61,10 +61,11 @@ namespace HostApiInvokerApp
 
             if (hostfxrPath is not null)
             {
+                Console.WriteLine($"Registering DLLImportResolver for {nameof(HostFXR.hostfxr)} -> {hostfxrPath}");
                 NativeLibrary.SetDllImportResolver(typeof(Program).Assembly, (libraryName, assembly, searchPath) =>
                 {
                     return libraryName == nameof(HostFXR.hostfxr)
-                        ? NativeLibrary.Load(libraryName, assembly, searchPath)
+                        ? NativeLibrary.Load(hostfxrPath, assembly, searchPath)
                         : default;
                 });
             }

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -782,7 +782,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 // paths to hostfxr so that it can handle resolving the library.
                 RuntimeConfig.FromFile(HostApiInvokerApp.RuntimeConfigJson)
                     .WithProperty("HOSTFXR_PATH", TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath)
-                    .WithProperty("HOSTFXR_PATH_TEST_BEHAVIOR", TestBehaviorEnabledDotNet.GreatestVersionHostFxrFilePath);
+                    .WithProperty("HOSTFXR_PATH_TEST_BEHAVIOR", TestBehaviorEnabledDotNet.GreatestVersionHostFxrFilePath)
+                    .Save();
 
                 SdkAndFrameworkFixture = new SdkAndFrameworkFixture();
             }


### PR DESCRIPTION
The test wasn't saving the modified runtime config, so the app didn't actually set the DllImportResolver. The app was also using the incorrect path in its implementation. Whether or not it is needed for the test to run properly is dependent on the platform (and how it handles trying to load an already loaded native binary). I found this when trying to run the host tests on linux-musl-x64.

Contributes to https://github.com/dotnet/runtime/issues/77800.

cc @dotnet/appmodel @AaronRobinsonMSFT 