### PR TITLE
[wasm] Enable few tests

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2992,12 +2992,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/mandelbrot/mandelbrot-7/**">
             <Issue>https://github.com/dotnet/runtime/issues/41472</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/GC/API/GCHandleCollector/Usage/**">
-            <Issue>https://github.com/dotnet/runtime/issues/84786</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventcounter/regression-25709/**">
-            <Issue>https://github.com/dotnet/runtime/issues/84786</Issue>
-        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/GC/Stress/Framework/ReliabilityFramework/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
We disabled these when we bumped emscripten 3.1.34. They don't fail anymore, possibly due to the bump to 3.1.56. We can enable them again.