### PR TITLE
Make System.Formats.Asn1 triple slash documentation the source of truth

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System.Formats.Asn1.csproj
+++ b/src/libraries/System.Formats.Asn1/src/System.Formats.Asn1.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);CP_NO_ZEROMEMORY</DefineConstants>
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.</PackageDescription>
   </PropertyGroup>

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/Asn1Tag.Accelerators.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/Asn1Tag.Accelerators.cs
@@ -43,7 +43,7 @@ namespace System.Formats.Asn1
             new Asn1Tag(ConstructedMask, (int)UniversalTagNumber.OctetString);
 
         /// <summary>
-        ///   Represents the universal class tag for a <see langword="null" /> value.
+        ///   Represents the universal class tag for a <c>Null</c> value.
         /// </summary>
         public static readonly Asn1Tag Null = new Asn1Tag(0, (int)UniversalTagNumber.Null);
 

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/Asn1Tag.Accelerators.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/Asn1Tag.Accelerators.cs
@@ -43,7 +43,7 @@ namespace System.Formats.Asn1
             new Asn1Tag(ConstructedMask, (int)UniversalTagNumber.OctetString);
 
         /// <summary>
-        ///   Represents the universal class tag for a Null value.
+        ///   Represents the universal class tag for a <see langword="null" /> value.
         /// </summary>
         public static readonly Asn1Tag Null = new Asn1Tag(0, (int)UniversalTagNumber.Null);
 

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnContentException.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnContentException.cs
@@ -6,24 +6,55 @@ using System.Runtime.Serialization;
 
 namespace System.Formats.Asn1
 {
+    /// <summary>
+    ///   The exception that is thrown when an encoded ASN.1 value cannot be successfully decoded.
+    /// </summary>
     [Serializable]
     public class AsnContentException : Exception
     {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="AsnContentException" /> class, using the default message.
+        /// </summary>
         public AsnContentException()
             : base(SR.ContentException_DefaultMessage)
         {
         }
 
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="AsnContentException" /> class, using the provided message.
+        /// </summary>
+        /// <param name="message">
+        ///   The error message that explains the reason for the exception.
+        /// </param>
         public AsnContentException(string? message)
             : base(message ?? SR.ContentException_DefaultMessage)
         {
         }
 
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="AsnContentException" /> class, using the provided message and
+        ///   exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">
+        ///   The error message that explains the reason for the exception.
+        /// </param>
+        /// <param name="inner">
+        ///   The exception that is the cause of the current exception.
+        /// </param>
         public AsnContentException(string? message, Exception? inner)
             : base(message ?? SR.ContentException_DefaultMessage, inner)
         {
         }
 
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="AsnContentException" /> class with serialized data.
+        /// </summary>
+        /// <param name="info">
+        ///   The object that holds the serialized object data.
+        /// </param>
+        /// <param name="context">
+        ///   The contextual information about the source or destination.
+        /// </param>
 #if NET8_0_OR_GREATER
         [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.BitString.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.BitString.cs
@@ -41,15 +41,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -122,24 +122,19 @@ namespace System.Formats.Asn1
         ///   value of the Bit String;
         ///   otherwise, <see langword="false"/>.
         /// </returns>
-        /// <remarks>
-        ///   The least significant bits in the last byte which are reported as "unused" by the
-        ///   <paramref name="unusedBitCount"/> value will be copied into <paramref name="destination"/>
-        ///   as unset bits, irrespective of their value in the encoded representation.
-        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -151,6 +146,11 @@ namespace System.Formats.Asn1
         ///
         ///   <paramref name="destination"/> overlaps <paramref name="source"/>.
         /// </exception>
+        /// <remarks>
+        ///   The least significant bits in the last byte which are reported as "unused" by the
+        ///   <paramref name="unusedBitCount"/> value will be copied into <paramref name="destination"/>
+        ///   as unset bits, irrespective of their value in the encoded representation.
+        /// </remarks>
         /// <seealso cref="TryReadPrimitiveBitString"/>
         /// <seealso cref="ReadBitString"/>
         public static bool TryReadBitString(
@@ -244,24 +244,19 @@ namespace System.Formats.Asn1
         /// <returns>
         ///   An array containing the contents of the Bit String value.
         /// </returns>
-        /// <remarks>
-        ///   The least significant bits in the last byte which are reported as "unused" by the
-        ///   <paramref name="unusedBitCount"/> value will be copied into the return value
-        ///   as unset bits, irrespective of their value in the encoded representation.
-        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -269,6 +264,11 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   The least significant bits in the last byte which are reported as "unused" by the
+        ///   <paramref name="unusedBitCount"/> value will be copied into the return value
+        ///   as unset bits, irrespective of their value in the encoded representation.
+        /// </remarks>
         /// <seealso cref="TryReadPrimitiveBitString"/>
         /// <seealso cref="TryReadBitString"/>
         public static byte[] ReadBitString(
@@ -696,15 +696,15 @@ namespace System.Formats.Asn1
         ///   <see langword="false"/> and does not advance the reader if it had a constructed encoding.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -760,15 +760,15 @@ namespace System.Formats.Asn1
         ///   <see langword="false"/> and the reader does not advance.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -816,15 +816,15 @@ namespace System.Formats.Asn1
         ///   A copy of the value in a newly allocated, precisely sized, array.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.BitString.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.BitString.cs
@@ -147,7 +147,7 @@ namespace System.Formats.Asn1
         ///   <paramref name="destination"/> overlaps <paramref name="source"/>.
         /// </exception>
         /// <remarks>
-        ///   The least significant bits in the last byte which are reported as "unused" by the
+        ///   The least significant bits in the last byte that are reported as "unused" by the
         ///   <paramref name="unusedBitCount"/> value will be copied into <paramref name="destination"/>
         ///   as unset bits, irrespective of their value in the encoded representation.
         /// </remarks>
@@ -265,7 +265,7 @@ namespace System.Formats.Asn1
         ///   the method.
         /// </exception>
         /// <remarks>
-        ///   The least significant bits in the last byte which are reported as "unused" by the
+        ///   The least significant bits in the last byte that are reported as "unused" by the
         ///   <paramref name="unusedBitCount"/> value will be copied into the return value
         ///   as unset bits, irrespective of their value in the encoded representation.
         /// </remarks>

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Boolean.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Boolean.cs
@@ -25,15 +25,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -93,15 +93,15 @@ namespace System.Formats.Asn1
         ///   The decoded value.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Enumerated.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Enumerated.cs
@@ -29,15 +29,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -64,6 +64,7 @@ namespace System.Formats.Asn1
         ///   the specified encoding rules, converting it to the
         ///   non-[<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TEnum"/>.
         /// </summary>
+        /// <typeparam name="TEnum">Destination enum type.</typeparam>
         /// <param name="source">The buffer containing encoded data.</param>
         /// <param name="ruleSet">The encoding constraints to use when interpreting the data.</param>
         /// <param name="bytesConsumed">
@@ -73,31 +74,26 @@ namespace System.Formats.Asn1
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 10).
         /// </param>
-        /// <typeparam name="TEnum">Destination enum type</typeparam>
         /// <returns>
         ///   The Enumerated value converted to a <typeparamref name="TEnum"/>.
         /// </returns>
-        /// <remarks>
-        ///   This method does not validate that the return value is defined within
-        ///   <typeparamref name="TEnum"/>.
-        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the encoded value is too big to fit in a <typeparamref name="TEnum"/> value.
+        ///   The encoded value is too big to fit in a <typeparamref name="TEnum"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <typeparamref name="TEnum"/> is not an enum type.
@@ -113,6 +109,10 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <typeparamref name="TEnum"/>.
+        /// </remarks>
         public static TEnum ReadEnumeratedValue<TEnum>(
             ReadOnlySpan<byte> source,
             AsnEncodingRules ruleSet,
@@ -150,24 +150,20 @@ namespace System.Formats.Asn1
         /// <returns>
         ///   The Enumerated value converted to a <paramref name="enumType"/>.
         /// </returns>
-        /// <remarks>
-        ///   This method does not validate that the return value is defined within
-        ///   <paramref name="enumType"/>.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the encoded value is too big to fit in a <paramref name="enumType"/> value.
+        ///   The encoded value is too big to fit in a <paramref name="enumType"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="enumType"/> is not an enum type.
@@ -186,6 +182,10 @@ namespace System.Formats.Asn1
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="enumType"/> is <see langword="null" />.
         /// </exception>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <paramref name="enumType"/>.
+        /// </remarks>
         public static Enum ReadEnumeratedValue(
             ReadOnlySpan<byte> source,
             AsnEncodingRules ruleSet,
@@ -275,15 +275,15 @@ namespace System.Formats.Asn1
         ///   The bytes of the Enumerated value, in signed big-endian form.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -307,31 +307,27 @@ namespace System.Formats.Asn1
         ///   Reads the next value as an Enumerated with a specified tag, converting it to the
         ///   non-[<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TEnum"/>.
         /// </summary>
+        /// <typeparam name="TEnum">Destination enum type.</typeparam>
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 10).
         /// </param>
-        /// <typeparam name="TEnum">Destination enum type</typeparam>
         /// <returns>
         ///   The Enumerated value converted to a <typeparamref name="TEnum"/>.
         /// </returns>
-        /// <remarks>
-        ///   This method does not validate that the return value is defined within
-        ///   <typeparamref name="TEnum"/>.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the encoded value is too big to fit in a <typeparamref name="TEnum"/> value.
+        ///   The encoded value is too big to fit in a <typeparamref name="TEnum"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <typeparamref name="TEnum"/> is not an enum type.
@@ -347,6 +343,10 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <typeparamref name="TEnum"/>.
+        /// </remarks>
         public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null) where TEnum : Enum
         {
             TEnum ret = AsnDecoder.ReadEnumeratedValue<TEnum>(_data.Span, RuleSet, out int consumed, expectedTag);
@@ -365,24 +365,20 @@ namespace System.Formats.Asn1
         /// <returns>
         ///   The Enumerated value converted to a <paramref name="enumType"/>.
         /// </returns>
-        /// <remarks>
-        ///   This method does not validate that the return value is defined within
-        ///   <paramref name="enumType"/>.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the encoded value is too big to fit in a <paramref name="enumType"/> value.
+        ///   The encoded value is too big to fit in a <paramref name="enumType"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="enumType"/> is not an enum type.
@@ -401,6 +397,10 @@ namespace System.Formats.Asn1
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="enumType"/> is <see langword="null" />.
         /// </exception>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <paramref name="enumType"/>.
+        /// </remarks>
         public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null)
         {
             Enum ret = AsnDecoder.ReadEnumeratedValue(_data.Span, RuleSet, enumType, out int consumed, expectedTag);

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Enumerated.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Enumerated.cs
@@ -64,7 +64,7 @@ namespace System.Formats.Asn1
         ///   the specified encoding rules, converting it to the
         ///   non-[<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TEnum"/>.
         /// </summary>
-        /// <typeparam name="TEnum">Destination enum type.</typeparam>
+        /// <typeparam name="TEnum">The destination enum type.</typeparam>
         /// <param name="source">The buffer containing encoded data.</param>
         /// <param name="ruleSet">The encoding constraints to use when interpreting the data.</param>
         /// <param name="bytesConsumed">
@@ -307,7 +307,7 @@ namespace System.Formats.Asn1
         ///   Reads the next value as an Enumerated with a specified tag, converting it to the
         ///   non-[<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TEnum"/>.
         /// </summary>
-        /// <typeparam name="TEnum">Destination enum type.</typeparam>
+        /// <typeparam name="TEnum">The destination enum type.</typeparam>
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 10).
         /// </param>

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.GeneralizedTime.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.GeneralizedTime.cs
@@ -29,15 +29,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -412,15 +412,15 @@ namespace System.Formats.Asn1
         ///   The decoded value.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
@@ -30,15 +30,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -80,15 +80,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -151,22 +151,22 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="true"/> if the Integer represents value is between
-        ///   <see cref="int.MinValue"/> and <see cref="int.MaxValue"/>, inclusive; otherwise,
+        ///   <see cref="int.MinValue">Int32.MinValue</see> and <see cref="int.MaxValue">Int32.MaxValue</see>, inclusive; otherwise,
         ///   <see langword="false"/>.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -217,22 +217,22 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="true"/> if the Integer represents value is between
-        ///   <see cref="uint.MinValue"/> and <see cref="uint.MaxValue"/>, inclusive; otherwise,
+        ///   <see cref="uint.MinValue">UInt32.MinValue</see> and <see cref="uint.MaxValue">UInt32.MaxValue</see>, inclusive; otherwise,
         ///   <see langword="false"/>.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -284,22 +284,22 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="true"/> if the Integer represents value is between
-        ///   <see cref="long.MinValue"/> and <see cref="long.MaxValue"/>, inclusive; otherwise,
+        ///   <see cref="long.MinValue">Int64.MinValue</see> and <see cref="long.MaxValue">Int64.MaxValue</see>, inclusive; otherwise,
         ///   <see langword="false"/>.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -343,22 +343,22 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="true"/> if the Integer represents value is between
-        ///   <see cref="ulong.MinValue"/> and <see cref="ulong.MaxValue"/>, inclusive; otherwise,
+        ///   <see cref="ulong.MinValue">UInt64.MinValue</see> and <see cref="ulong.MaxValue">UInt64.MaxValue</see>, inclusive; otherwise,
         ///   <see langword="false"/>.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -528,15 +528,15 @@ namespace System.Formats.Asn1
         ///   The bytes of the Integer value, in signed big-endian form.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -565,15 +565,15 @@ namespace System.Formats.Asn1
         ///   The decoded value.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -600,19 +600,19 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="false"/> and does not advance the reader if the value is not between
-        ///   <see cref="int.MinValue"/> and <see cref="int.MaxValue"/>, inclusive; otherwise
+        ///   <see cref="int.MinValue">Int32.MinValue</see> and <see cref="int.MaxValue">Int32.MaxValue</see>, inclusive; otherwise
         ///   <see langword="true"/> is returned and the reader advances.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -639,19 +639,19 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="false"/> and does not advance the reader if the value is not between
-        ///   <see cref="uint.MinValue"/> and <see cref="uint.MaxValue"/>, inclusive; otherwise
+        ///   <see cref="uint.MinValue">UInt32.MinValue</see> and <see cref="uint.MaxValue">UInt32.MaxValue</see>, inclusive; otherwise
         ///   <see langword="true"/> is returned and the reader advances.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -679,19 +679,19 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="false"/> and does not advance the reader if the value is not between
-        ///   <see cref="long.MinValue"/> and <see cref="long.MaxValue"/>, inclusive; otherwise
+        ///   <see cref="long.MinValue">Int64.MinValue</see> and <see cref="long.MaxValue">Int64.MaxValue</see>, inclusive; otherwise
         ///   <see langword="true"/> is returned and the reader advances.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -718,19 +718,19 @@ namespace System.Formats.Asn1
         /// </param>
         /// <returns>
         ///   <see langword="false"/> and does not advance the reader if the value is not between
-        ///   <see cref="ulong.MinValue"/> and <see cref="ulong.MaxValue"/>, inclusive; otherwise
+        ///   <see cref="ulong.MinValue">Int64.MinValue</see> and <see cref="ulong.MaxValue">Int64.MaxValue</see>, inclusive; otherwise
         ///   <see langword="true"/> is returned and the reader advances.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.NamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.NamedBitList.cs
@@ -15,6 +15,7 @@ namespace System.Formats.Asn1
         ///   the specified encoding rules, converting it to the
         ///   [<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TFlagsEnum"/>.
         /// </summary>
+        /// <typeparam name="TFlagsEnum">Destination enum type.</typeparam>
         /// <param name="source">The buffer containing encoded data.</param>
         /// <param name="ruleSet">The encoding constraints to use when interpreting the data.</param>
         /// <param name="bytesConsumed">
@@ -24,7 +25,6 @@ namespace System.Formats.Asn1
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 3).
         /// </param>
-        /// <typeparam name="TFlagsEnum">Destination enum type</typeparam>
         /// <returns>
         ///   The NamedBitList value converted to a <typeparamref name="TFlagsEnum"/>.
         /// </returns>
@@ -32,19 +32,19 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the encoded value is too big to fit in a <typeparamref name="TFlagsEnum"/> value.
+        ///   The encoded value is too big to fit in a <typeparamref name="TFlagsEnum"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <typeparamref name="TFlagsEnum"/> is not an enum type.
@@ -97,7 +97,7 @@ namespace System.Formats.Asn1
         ///     }
         ///   </code>
         ///
-        ///   Note that while the example here uses the KeyUsage NamedBitList from
+        ///   While the example here uses the KeyUsage NamedBitList from
         ///   <a href="https://tools.ietf.org/html/rfc3280#section-4.2.1.3">RFC 3280 (4.2.1.3)</a>,
         ///   the example enum uses values thar are different from
         ///   System.Security.Cryptography.X509Certificates.X509KeyUsageFlags.
@@ -142,19 +142,19 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///-
-        ///   the encoded value is too big to fit in a <paramref name="flagsEnumType"/> value.
+        ///   The encoded value is too big to fit in a <paramref name="flagsEnumType"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="flagsEnumType"/> is not an enum type.
@@ -294,15 +294,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -405,25 +405,25 @@ namespace System.Formats.Asn1
         ///   Reads the next value as a NamedBitList with a specified tag, converting it to the
         ///   [<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TFlagsEnum"/>.
         /// </summary>
+        /// <typeparam name="TFlagsEnum">Destination enum type.</typeparam>
         /// <param name="expectedTag">The tag to check for before reading.</param>
-        /// <typeparam name="TFlagsEnum">Destination enum type</typeparam>
         /// <returns>
         ///   The NamedBitList value converted to a <typeparamref name="TFlagsEnum"/>.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the encoded value is too big to fit in a <typeparamref name="TFlagsEnum"/> value.
+        ///   The encoded value is too big to fit in a <typeparamref name="TFlagsEnum"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <typeparamref name="TFlagsEnum"/> is not an enum type.
@@ -476,7 +476,7 @@ namespace System.Formats.Asn1
         ///     }
         ///   </code>
         ///
-        ///   Note that while the example here uses the KeyUsage NamedBitList from
+        ///   While the example here uses the KeyUsage NamedBitList from
         ///   <a href="https://tools.ietf.org/html/rfc3280#section-4.2.1.3">RFC 3280 (4.2.1.3)</a>,
         ///   the example enum uses values thar are different from
         ///   System.Security.Cryptography.X509Certificates.X509KeyUsageFlags.
@@ -497,25 +497,25 @@ namespace System.Formats.Asn1
         ///   Reads the next value as a NamedBitList with a specified tag, converting it to the
         ///   [<see cref="FlagsAttribute"/>] enum specified by <paramref name="flagsEnumType"/>.
         /// </summary>
-        /// <param name="expectedTag">The tag to check for before reading.</param>
         /// <param name="flagsEnumType">Type object representing the destination type.</param>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
         /// <returns>
         ///   The NamedBitList value converted to a <paramref name="flagsEnumType"/>.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the encoded value is too big to fit in a <paramref name="flagsEnumType"/> value.
+        ///   The encoded value is too big to fit in a <paramref name="flagsEnumType"/> value.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="flagsEnumType"/> is not an enum type.
@@ -556,15 +556,15 @@ namespace System.Formats.Asn1
         ///   The bits from the encoded value.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.NamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.NamedBitList.cs
@@ -15,7 +15,7 @@ namespace System.Formats.Asn1
         ///   the specified encoding rules, converting it to the
         ///   [<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TFlagsEnum"/>.
         /// </summary>
-        /// <typeparam name="TFlagsEnum">Destination enum type.</typeparam>
+        /// <typeparam name="TFlagsEnum">The destination enum type.</typeparam>
         /// <param name="source">The buffer containing encoded data.</param>
         /// <param name="ruleSet">The encoding constraints to use when interpreting the data.</param>
         /// <param name="bytesConsumed">
@@ -99,7 +99,7 @@ namespace System.Formats.Asn1
         ///
         ///   While the example here uses the KeyUsage NamedBitList from
         ///   <a href="https://tools.ietf.org/html/rfc3280#section-4.2.1.3">RFC 3280 (4.2.1.3)</a>,
-        ///   the example enum uses values thar are different from
+        ///   the example enum uses values that are different from
         ///   System.Security.Cryptography.X509Certificates.X509KeyUsageFlags.
         /// </remarks>
         public static TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(
@@ -405,7 +405,7 @@ namespace System.Formats.Asn1
         ///   Reads the next value as a NamedBitList with a specified tag, converting it to the
         ///   [<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TFlagsEnum"/>.
         /// </summary>
-        /// <typeparam name="TFlagsEnum">Destination enum type.</typeparam>
+        /// <typeparam name="TFlagsEnum">The destination enum type.</typeparam>
         /// <param name="expectedTag">The tag to check for before reading.</param>
         /// <returns>
         ///   The NamedBitList value converted to a <typeparamref name="TFlagsEnum"/>.
@@ -478,7 +478,7 @@ namespace System.Formats.Asn1
         ///
         ///   While the example here uses the KeyUsage NamedBitList from
         ///   <a href="https://tools.ietf.org/html/rfc3280#section-4.2.1.3">RFC 3280 (4.2.1.3)</a>,
-        ///   the example enum uses values thar are different from
+        ///   the example enum uses values that are different from
         ///   System.Security.Cryptography.X509Certificates.X509KeyUsageFlags.
         /// </remarks>
         public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null) where TFlagsEnum : Enum

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Null.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Null.cs
@@ -22,15 +22,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -71,15 +71,15 @@ namespace System.Formats.Asn1
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 5).
         /// </param>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.OctetString.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.OctetString.cs
@@ -36,15 +36,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -136,15 +136,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -247,15 +247,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -551,15 +551,15 @@ namespace System.Formats.Asn1
         ///   <see langword="false"/> and the reader does not advance.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -601,15 +601,15 @@ namespace System.Formats.Asn1
         ///   A copy of the value in a newly allocated, precisely sized, array.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -630,25 +630,25 @@ namespace System.Formats.Asn1
         ///   Attempts to read the next value as an OCTET STRING with a specified tag, returning the contents
         ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
         /// </summary>
-        /// <param name="expectedTag">The tag to check for before reading.</param>
         /// <param name="contents">
         ///   On success, receives a <see cref="ReadOnlyMemory{T}"/> over the original data
         ///   corresponding to the value of the OCTET STRING.
         /// </param>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
         /// <returns>
         ///   <see langword="true"/> and advances the reader if the OCTET STRING value had a primitive encoding,
         ///   <see langword="false"/> and does not advance the reader if it had a constructed encoding.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Oid.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Oid.cs
@@ -25,7 +25,7 @@ namespace System.Formats.Asn1
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 6).
         /// </param>
         /// <returns>
-        ///   The decoded object identifier in a dotted-decimal notation.
+        ///   The decoded object identifier in the dotted-decimal notation.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
@@ -345,7 +345,7 @@ namespace System.Formats.Asn1
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 6).
         /// </param>
-        /// <returns>The object identifier value in a dotted decimal format string.</returns>
+        /// <returns>The decoded object identifier in the dotted-decimal notation.</returns>
         /// <exception cref="AsnContentException">
         ///   The next value does not have the correct tag.
         ///

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Oid.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Oid.cs
@@ -25,21 +25,21 @@ namespace System.Formats.Asn1
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 6).
         /// </param>
         /// <returns>
-        ///   The decoded object identifier, in dotted-decimal notation.
+        ///   The decoded object identifier in a dotted-decimal notation.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -345,16 +345,17 @@ namespace System.Formats.Asn1
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 6).
         /// </param>
+        /// <returns>The object identifier value in a dotted decimal format string.</returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Sequence.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Sequence.cs
@@ -27,24 +27,19 @@ namespace System.Formats.Asn1
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 16).
         /// </param>
-        /// <remarks>
-        ///   The nested content is not evaluated by this method, except for minimal processing to
-        ///   determine the location of an end-of-contents marker.
-        ///   Therefore, the contents may contain data which is not valid under the current encoding rules.
-        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -52,6 +47,11 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method, except for minimal processing to
+        ///   determine the location of an end-of-contents marker.
+        ///   Therefore, the contents may contain data which is not valid under the current encoding rules.
+        /// </remarks>
         public static void ReadSequence(
             ReadOnlySpan<byte> source,
             AsnEncodingRules ruleSet,
@@ -109,20 +109,16 @@ namespace System.Formats.Asn1
         ///   A new reader positioned at the first
         ///   value in the sequence (or with <see cref="HasData"/> == <see langword="false"/>).
         /// </returns>
-        /// <remarks>
-        ///   the nested content is not evaluated by this method, and may contain data
-        ///   which is not valid under the current encoding rules.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -130,6 +126,10 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method, and may contain data
+        ///   which is not valid under the current encoding rules.
+        /// </remarks>
         public AsnReader ReadSequence(Asn1Tag? expectedTag = null)
         {
             AsnDecoder.ReadSequence(

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Sequence.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Sequence.cs
@@ -50,7 +50,7 @@ namespace System.Formats.Asn1
         /// <remarks>
         ///   The nested content is not evaluated by this method, except for minimal processing to
         ///   determine the location of an end-of-contents marker.
-        ///   Therefore, the contents may contain data which is not valid under the current encoding rules.
+        ///   Therefore, the contents might contain data that's not valid under the current encoding rules.
         /// </remarks>
         public static void ReadSequence(
             ReadOnlySpan<byte> source,
@@ -127,8 +127,8 @@ namespace System.Formats.Asn1
         ///   the method.
         /// </exception>
         /// <remarks>
-        ///   The nested content is not evaluated by this method, and may contain data
-        ///   which is not valid under the current encoding rules.
+        ///   The nested content is not evaluated by this method, and might contain data
+        ///   that's not valid under the current encoding rules.
         /// </remarks>
         public AsnReader ReadSequence(Asn1Tag? expectedTag = null)
         {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.SetOf.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.SetOf.cs
@@ -56,7 +56,7 @@ namespace System.Formats.Asn1
         ///   The nested content is not evaluated by this method, except for minimal processing to
         ///   determine the location of an end-of-contents marker or verification of the content
         ///   sort order.
-        ///   Therefore, the contents may contain data which is not valid under the current encoding rules.
+        ///   Therefore, the contents might contain data that's not valid under the current encoding rules.
         /// </remarks>
         public static void ReadSetOf(
             ReadOnlySpan<byte> source,
@@ -162,7 +162,7 @@ namespace System.Formats.Asn1
         /// </exception>
         /// <remarks>
         ///   The nested content is not evaluated by this method (aside from sort order, when
-        ///   required), and may contain data which is not valid under the current encoding rules.
+        ///   required) and might contain data that's not valid under the current encoding rules.
         /// </remarks>
         public AsnReader ReadSetOf(Asn1Tag? expectedTag = null)
         {
@@ -205,7 +205,7 @@ namespace System.Formats.Asn1
         /// </exception>
         /// <remarks>
         ///   The nested content is not evaluated by this method (aside from sort order, when
-        ///   required), and may contain data which is not valid under the current encoding rules.
+        ///   required) and might contain data that's not valid under the current encoding rules.
         /// </remarks>
         public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null)
         {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.SetOf.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.SetOf.cs
@@ -32,25 +32,19 @@ namespace System.Formats.Asn1
         /// <param name="expectedTag">
         ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 17).
         /// </param>
-        /// <remarks>
-        ///   The nested content is not evaluated by this method, except for minimal processing to
-        ///   determine the location of an end-of-contents marker or verification of the content
-        ///   sort order.
-        ///   Therefore, the contents may contain data which is not valid under the current encoding rules.
-        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -58,6 +52,12 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method, except for minimal processing to
+        ///   determine the location of an end-of-contents marker or verification of the content
+        ///   sort order.
+        ///   Therefore, the contents may contain data which is not valid under the current encoding rules.
+        /// </remarks>
         public static void ReadSetOf(
             ReadOnlySpan<byte> source,
             AsnEncodingRules ruleSet,
@@ -143,20 +143,16 @@ namespace System.Formats.Asn1
         ///   A new reader positioned at the first
         ///   value in the set-of (or with <see cref="HasData"/> == <see langword="false"/>).
         /// </returns>
-        /// <remarks>
-        ///   the nested content is not evaluated by this method (aside from sort order, when
-        ///   required), and may contain data which is not valid under the current encoding rules.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -164,6 +160,10 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method (aside from sort order, when
+        ///   required), and may contain data which is not valid under the current encoding rules.
+        /// </remarks>
         public AsnReader ReadSetOf(Asn1Tag? expectedTag = null)
         {
             return ReadSetOf(_options.SkipSetSortOrderVerification, expectedTag);
@@ -186,20 +186,16 @@ namespace System.Formats.Asn1
         ///   A new reader positioned at the first
         ///   value in the set-of (or with <see cref="HasData"/> == <see langword="false"/>).
         /// </returns>
-        /// <remarks>
-        ///   the nested content is not evaluated by this method (aside from sort order, when
-        ///   required), and may contain data which is not valid under the current encoding rules.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -207,6 +203,10 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method (aside from sort order, when
+        ///   required), and may contain data which is not valid under the current encoding rules.
+        /// </remarks>
         public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null)
         {
             AsnDecoder.ReadSetOf(

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Text.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Text.cs
@@ -33,22 +33,19 @@ namespace System.Formats.Asn1
         ///   <see langword="true"/> if the character string value has a primitive encoding;
         ///   otherwise, <see langword="false"/>.
         /// </returns>
-        /// <remarks>
-        ///   This method does not determine if the string used only characters defined by the encoding.
-        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -56,6 +53,9 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not a character
         ///   string tag type.
         /// </exception>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
         /// <seealso cref="TryReadCharacterStringBytes"/>
         public static bool TryReadPrimitiveCharacterStringBytes(
             ReadOnlySpan<byte> source,
@@ -112,22 +112,19 @@ namespace System.Formats.Asn1
         ///   value of the unprocessed character string;
         ///   otherwise, <see langword="false"/>.
         /// </returns>
-        /// <remarks>
-        ///   This method does not determine if the string used only characters defined by the encoding.
-        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="ruleSet"/> is not defined.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -139,6 +136,9 @@ namespace System.Formats.Asn1
         ///
         ///   <paramref name="destination"/> overlaps <paramref name="source"/>.
         /// </exception>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
         /// <seealso cref="TryReadPrimitiveCharacterStringBytes"/>
         /// <seealso cref="ReadCharacterString"/>
         /// <seealso cref="TryReadCharacterString"/>
@@ -217,19 +217,19 @@ namespace System.Formats.Asn1
         ///   <paramref name="encodingType"/> is not a known character string type.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the string did not successfully decode.
+        ///   The string did not successfully decode.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -289,19 +289,19 @@ namespace System.Formats.Asn1
         ///   <paramref name="encodingType"/> is not a known character string type.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the string did not successfully decode.
+        ///   The string did not successfully decode.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -561,19 +561,16 @@ namespace System.Formats.Asn1
         ///   <see langword="true"/> and advances the reader if the character string value had a primitive encoding,
         ///   <see langword="false"/> and does not advance the reader if it had a constructed encoding.
         /// </returns>
-        /// <remarks>
-        ///   This method does not determine if the string used only characters defined by the encoding.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -581,6 +578,9 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not a character
         ///   string tag type.
         /// </exception>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
         /// <seealso cref="TryReadCharacterStringBytes"/>
         public bool TryReadPrimitiveCharacterStringBytes(
             Asn1Tag expectedTag,
@@ -620,19 +620,16 @@ namespace System.Formats.Asn1
         ///   length to receive the value, otherwise
         ///   <see langword="false"/> and the reader does not advance.
         /// </returns>
-        /// <remarks>
-        ///   This method does not determine if the string used only characters defined by the encoding.
-        /// </remarks>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -640,6 +637,9 @@ namespace System.Formats.Asn1
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not a character
         ///   string tag type.
         /// </exception>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
         /// <seealso cref="TryReadPrimitiveCharacterStringBytes"/>
         /// <seealso cref="ReadCharacterString"/>
         /// <seealso cref="TryReadCharacterString"/>
@@ -668,10 +668,10 @@ namespace System.Formats.Asn1
         ///   Reads the next value as character string with the specified tag and
         ///   encoding type, copying the decoded value into a provided destination buffer.
         /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
         /// <param name="encodingType">
         ///   One of the enumeration values representing the value type to process.
         /// </param>
-        /// <param name="destination">The buffer in which to write.</param>
         /// <param name="charsWritten">
         ///   On success, receives the number of chars written to <paramref name="destination"/>.
         /// </param>
@@ -688,19 +688,19 @@ namespace System.Formats.Asn1
         ///   <paramref name="encodingType"/> is not a known character string type.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the string did not successfully decode.
+        ///   The string did not successfully decode.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -748,19 +748,19 @@ namespace System.Formats.Asn1
         ///   <paramref name="encodingType"/> is not a known character string type.
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the string did not successfully decode.
+        ///   The string did not successfully decode.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.UtcTime.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.UtcTime.cs
@@ -36,15 +36,15 @@ namespace System.Formats.Asn1
         ///   <paramref name="twoDigitYearMax"/> is not in the range [99, 9999].
         /// </exception>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -252,15 +252,15 @@ namespace System.Formats.Asn1
         ///   The decoded value.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
@@ -295,15 +295,15 @@ namespace System.Formats.Asn1
         ///   The decoded value.
         /// </returns>
         /// <exception cref="AsnContentException">
-        ///   the next value does not have the correct tag.
+        ///   The next value does not have the correct tag.
         ///
         ///   -or-
         ///
-        ///   the length encoding is not valid under the current encoding rules.
+        ///   The length encoding is not valid under the current encoding rules.
         ///
         ///   -or-
         ///
-        ///   the contents are not valid under the current encoding rules.
+        ///   The contents are not valid under the current encoding rules.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 namespace System.Formats.Asn1
 {
     /// <summary>
-    ///   Provides stateless methods for decoding BER-, CER-, or DER-encoded ASN.1 data.
+    ///   Provides stateless methods for decoding BER-encoded, CER-encoded, and DER-encoded ASN.1 data.
     /// </summary>
     public static partial class AsnDecoder
     {
@@ -213,7 +213,7 @@ namespace System.Formats.Asn1
         /// <param name="source">The buffer containing encoded data.</param>
         /// <param name="ruleSet">The encoding constraints to use when interpreting the data.</param>
         /// <param name="bytesConsumed">
-        ///   When this method returns, the number of bytes from the beginning of <paramref name="source"/>
+        ///   When this method returns, contains the number of bytes from the beginning of <paramref name="source"/>
         ///   that contributed to the length.
         ///   This parameter is treated as uninitialized.
         /// </param>
@@ -251,12 +251,12 @@ namespace System.Formats.Asn1
         /// <param name="source">The buffer containing encoded data.</param>
         /// <param name="ruleSet">The encoding constraints to use when interpreting the data.</param>
         /// <param name="decodedLength">
-        ///   When this method returns, the decoded value of the length, or <see langword="null"/> if the
+        ///   When this method returns, contains the decoded value of the length, or <see langword="null"/> if the
         ///   encoded length represents the indefinite length.
         ///   This parameter is treated as uninitialized.
         /// </param>
         /// <param name="bytesConsumed">
-        ///   When this method returns, the number of bytes from the beginning of <paramref name="source"/>
+        ///   When this method returns, contains the number of bytes from the beginning of <paramref name="source"/>
         ///   that contributed to the length.
         ///   This parameter is treated as uninitialized.
         /// </param>
@@ -778,16 +778,16 @@ namespace System.Formats.Asn1
         /// <param name="data">The data to read.</param>
         /// <param name="ruleSet">The encoding constraints for the reader.</param>
         /// <param name="options">Additional options for the reader.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="ruleSet"/> is not defined.
+        /// </exception>
         /// <remarks>
-        ///   This constructor does not evaluate <paramref name="data"/> for correctness,
-        ///   any correctness checks are done as part of member methods.
+        ///   This constructor does not evaluate <paramref name="data"/> for correctness.
+        ///   Any correctness checks are done as part of member methods.
         ///
         ///   This constructor does not copy <paramref name="data"/>. The caller is responsible for
         ///   ensuring that the values do not change until the reader is finished.
         /// </remarks>
-        /// <exception cref="ArgumentOutOfRangeException">
-        ///   <paramref name="ruleSet"/> is not defined.
-        /// </exception>
         public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default)
         {
             AsnDecoder.CheckEncodingRules(ruleSet);

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnEncodingRules.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnEncodingRules.cs
@@ -10,17 +10,17 @@ namespace System.Formats.Asn1
     public enum AsnEncodingRules
     {
         /// <summary>
-        /// ITU-T X.690 Basic Encoding Rules
+        /// ITU-T X.690 Basic Encoding Rules.
         /// </summary>
         BER,
 
         /// <summary>
-        /// ITU-T X.690 Canonical Encoding Rules
+        /// ITU-T X.690 Canonical Encoding Rules.
         /// </summary>
         CER,
 
         /// <summary>
-        /// ITU-T X.690 Distinguished Encoding Rules
+        /// ITU-T X.690 Distinguished Encoding Rules.
         /// </summary>
         DER,
     }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Boolean.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Boolean.cs
@@ -16,7 +16,7 @@ namespace System.Formats.Asn1
         ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
         ///   <see cref="TagClass.Universal"/>, but
         ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
-        ///   the method
+        ///   the method.
         /// </exception>
         public void WriteBoolean(bool value, Asn1Tag? tag = null)
         {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Enumerated.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Enumerated.cs
@@ -44,8 +44,8 @@ namespace System.Formats.Asn1
         ///   Write a non-[<see cref="FlagsAttribute"/>] enum value as an Enumerated with
         ///   tag UNIVERSAL 10.
         /// </summary>
-        /// <param name="tag">The tag to write.</param>
         /// <param name="value">The boxed enumeration value to write.</param>
+        /// <param name="tag">The tag to write.</param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="value"/> is <see langword="null"/>.
         /// </exception>

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Integer.cs
@@ -76,11 +76,11 @@ namespace System.Formats.Asn1
         ///   the method.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///   the 9 most significant bits are all set.
+        ///   The 9 most significant bits are all set.
         ///
         ///   -or-
         ///
-        ///   the 9 most significant bits are all unset.
+        ///   The 9 most significant bits are all unset.
         /// </exception>
         public void WriteInteger(ReadOnlySpan<byte> value, Asn1Tag? tag = null)
         {
@@ -101,7 +101,7 @@ namespace System.Formats.Asn1
         ///   the method.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///   the 9 most significant bits are all unset.
+        ///   The 9 most significant bits are all unset.
         /// </exception>
         public void WriteIntegerUnsigned(ReadOnlySpan<byte> value, Asn1Tag? tag = null)
         {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.NamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.NamedBitList.cs
@@ -48,6 +48,9 @@ namespace System.Formats.Asn1
         ///   Write a [<see cref="FlagsAttribute"/>] enum value as a NamedBitList with
         ///   a specified tag.
         /// </summary>
+        /// <typeparam name="TEnum">
+        ///   The [<see cref="FlagsAttribute" />] enumeration type to write.
+        /// </typeparam>
         /// <param name="value">The enumeration value to write</param>
         /// <param name="tag">The tag to write, or <see langword="null"/> for the default tag (Universal 3).</param>
         /// <exception cref="ArgumentException">

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.OctetString.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.OctetString.cs
@@ -10,6 +10,7 @@ namespace System.Formats.Asn1
         /// <summary>
         ///   Begin writing an Octet String value with a specified tag.
         /// </summary>
+        /// <param name="tag">The tag to write, or <see langword="null"/> for the default tag (Universal 4).</param>
         /// <returns>
         ///   A disposable value which will automatically call <see cref="PopOctetString"/>.
         /// </returns>
@@ -22,7 +23,6 @@ namespace System.Formats.Asn1
         ///   This method does not necessarily create a Constructed encoding, and it is not invalid to
         ///   write values other than Octet String inside this Push/Pop.
         /// </remarks>
-        /// <param name="tag">The tag to write, or <see langword="null"/> for the default tag (Universal 4).</param>
         /// <seealso cref="PopOctetString"/>
         public Scope PushOctetString(Asn1Tag? tag = null)
         {
@@ -38,12 +38,6 @@ namespace System.Formats.Asn1
         ///   returning the writer to the parent context.
         /// </summary>
         /// <param name="tag">The tag to write, or <see langword="null"/> for the default tag (Universal 4).</param>
-        /// <remarks>
-        ///   In <see cref="AsnEncodingRules.BER"/> and <see cref="AsnEncodingRules.DER"/> modes
-        ///   the encoded contents will remain in a single primitive Octet String.
-        ///   In <see cref="AsnEncodingRules.CER"/> mode the contents will be broken up into
-        ///   multiple segments, when required.
-        /// </remarks>
         /// <exception cref="ArgumentException">
         ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
         ///   <see cref="TagClass.Universal"/>, but
@@ -53,6 +47,12 @@ namespace System.Formats.Asn1
         /// <exception cref="InvalidOperationException">
         ///   the writer is not currently positioned within an Octet String with the specified tag.
         /// </exception>
+        /// <remarks>
+        ///   In <see cref="AsnEncodingRules.BER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   the encoded contents will remain in a single primitive Octet String.
+        ///   In <see cref="AsnEncodingRules.CER"/> mode the contents will be broken up into
+        ///   multiple segments, when required.
+        /// </remarks>
         public void PopOctetString(Asn1Tag? tag = default)
         {
             CheckUniversalTag(tag, UniversalTagNumber.OctetString);

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.OctetString.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.OctetString.cs
@@ -48,9 +48,9 @@ namespace System.Formats.Asn1
         ///   the writer is not currently positioned within an Octet String with the specified tag.
         /// </exception>
         /// <remarks>
-        ///   In <see cref="AsnEncodingRules.BER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   In <see cref="AsnEncodingRules.BER"/> and <see cref="AsnEncodingRules.DER"/> modes,
         ///   the encoded contents will remain in a single primitive Octet String.
-        ///   In <see cref="AsnEncodingRules.CER"/> mode the contents will be broken up into
+        ///   In <see cref="AsnEncodingRules.CER"/> mode, the contents will be broken up into
         ///   multiple segments, when required.
         /// </remarks>
         public void PopOctetString(Asn1Tag? tag = default)

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.SetOf.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.SetOf.cs
@@ -21,7 +21,7 @@ namespace System.Formats.Asn1
         ///   the method.
         /// </exception>
         /// <remarks>
-        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes,
         ///   the writer will sort the Set-Of elements when the tag is closed.
         /// </remarks>
         /// <seealso cref="PopSetOf"/>
@@ -48,7 +48,7 @@ namespace System.Formats.Asn1
         ///   the writer is not currently positioned within a Set-Of with the specified tag.
         /// </exception>
         /// <remarks>
-        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes,
         ///   the writer will sort the Set-Of elements when the tag is closed.
         /// </remarks>
         /// <seealso cref="PushSetOf"/>

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.SetOf.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.SetOf.cs
@@ -14,16 +14,16 @@ namespace System.Formats.Asn1
         /// <returns>
         ///   A disposable value which will automatically call <see cref="PopSetOf"/>.
         /// </returns>
-        /// <remarks>
-        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
-        ///   the writer will sort the Set-Of elements when the tag is closed.
-        /// </remarks>
         /// <exception cref="ArgumentException">
         ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
         ///   <see cref="TagClass.Universal"/>, but
         ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
         ///   the method.
         /// </exception>
+        /// <remarks>
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   the writer will sort the Set-Of elements when the tag is closed.
+        /// </remarks>
         /// <seealso cref="PopSetOf"/>
         public Scope PushSetOf(Asn1Tag? tag = null)
         {
@@ -38,10 +38,6 @@ namespace System.Formats.Asn1
         ///   returning the writer to the parent context.
         /// </summary>
         /// <param name="tag">The tag to write, or <see langword="null"/> for the default tag (Universal 17).</param>
-        /// <remarks>
-        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
-        ///   the writer will sort the Set-Of elements when the tag is closed.
-        /// </remarks>
         /// <exception cref="ArgumentException">
         ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
         ///   <see cref="TagClass.Universal"/>, but
@@ -51,6 +47,10 @@ namespace System.Formats.Asn1
         /// <exception cref="InvalidOperationException">
         ///   the writer is not currently positioned within a Set-Of with the specified tag.
         /// </exception>
+        /// <remarks>
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   the writer will sort the Set-Of elements when the tag is closed.
+        /// </remarks>
         /// <seealso cref="PushSetOf"/>
         public void PopSetOf(Asn1Tag? tag = null)
         {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -855,7 +855,7 @@ namespace System.Formats.Asn1
             ///   Pops the ASN.1 scope.
             /// </summary>
             /// <exception cref="InvalidOperationException">
-            ///   The scope has already been popped.
+            ///   A scope was pushed within this scope, but has yet to be popped.
             /// </exception>
             public void Dispose()
             {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -828,6 +828,14 @@ namespace System.Formats.Asn1
             public static bool operator !=(StackFrame left, StackFrame right) => !left.Equals(right);
         }
 
+        /// <summary>
+        ///   Represents a pushed ASN.1 scope.
+        /// </summary>
+        /// <remarks>
+        ///   Instances of this type are expected to be created from a <c>Push</c> member on <see cref="AsnWriter"/>,
+        ///   not instantiated directly.
+        ///   Calling <see cref="Dispose" /> will call the corresponding <c>Pop</c> associated with the <c>Push</c>.
+        /// </remarks>
         public readonly struct Scope : IDisposable
         {
             private readonly AsnWriter _writer;
@@ -843,6 +851,12 @@ namespace System.Formats.Asn1
                 _depth = _writer._nestingStack.Count;
             }
 
+            /// <summary>
+            ///   Pops the ASN.1 scope.
+            /// </summary>
+            /// <exception cref="InvalidOperationException">
+            ///   The scope has already been popped.
+            /// </exception>
             public void Dispose()
             {
                 Debug.Assert(_writer == null || _writer._nestingStack != null);

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -52,7 +52,7 @@ namespace System.Formats.Asn1
         }
 
         /// <summary>
-        ///   Create a new <see cref="AsnWriter"/> with a given set of encoding rules and an initial capacity.
+        ///   Initializes a new instance of <see cref="AsnWriter" /> with a given set of encoding rules and an initial capacity.
         /// </summary>
         /// <param name="ruleSet">The encoding constraints for the writer.</param>
         /// <param name="initialCapacity">The minimum capacity with which to initialize the underlying buffer.</param>

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/TagClass.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/TagClass.cs
@@ -11,22 +11,22 @@ namespace System.Formats.Asn1
     public enum TagClass
     {
         /// <summary>
-        ///   The Universal tag class
+        ///   The Universal tag class.
         /// </summary>
         Universal = 0,
 
         /// <summary>
-        ///   The Application tag class
+        ///   The Application tag class.
         /// </summary>
         Application = 0b0100_0000,
 
         /// <summary>
-        ///   The Context-Specific tag class
+        ///   The Context-Specific tag class.
         /// </summary>
         ContextSpecific = 0b1000_0000,
 
         /// <summary>
-        ///   The Private tag class
+        ///   The Private tag class.
         /// </summary>
         Private = 0b1100_0000,
     }


### PR DESCRIPTION
The pull request makes the triple slash documentation for System.Formats.Asn1 the source of truth for documentation.

1. Use the `PortToTripleSlash` tool to update the C# documentation with the latest documentation from dotnet-api-docs.

    This made substantial changes that were largely formatting, which I reverted. I kept the changes to two things: actual content changes (text changes, missing documentation, etc) and re-ordering XML elements as appropriate (param elements not matching parameter order, putting remarks at the end)

2. Remove `<UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>`. The default value for this is true. I can't remember where, but I recall that our preference is to just remove it entirely, not explicitly set it to true.