### PR TITLE
Ignore *.pp files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ msbuild.log
 msbuild.err
 msbuild.wrn
 *.binlog
+*.pp
 .deps/
 .dirstamp
 .libs/


### PR DESCRIPTION
Files with the *.pp extension are pre-processed msbuild files that contain all the aggregated/inlined msbuild files involved in a build. They're useful for analysis/investigation of infra issues, and normally we would not merge such files to the repo, just like *.binlog files. I noticed we weren't ignoring them in .gitignore, so I'm adding them.