### PR TITLE
Initialize m_fInPlaceSS

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -4413,6 +4413,9 @@ DebuggerPatchSkip::DebuggerPatchSkip(Thread *thread,
                                      DebuggerControllerPatch *patch)
   : DebuggerController(thread, AppDomain::GetCurrentDomain()),
     m_address(patch->address)
+#ifdef OUT_OF_PROCESS_SETTHREADCONTEXT
+    ,m_fInPlaceSS(false)
+#endif
 {
     LOG((LF_CORDB, LL_INFO10000,
          "DPS::DPS: Patch skip 0x%p\n", patch->address));


### PR DESCRIPTION
A recent fix added a new field to the DebuggerPatchSkip object and missed initializing it false. This causes the new in-place patch skipping logic activate at random depending on the value of uninitialized memory. Fixing this by initializing the variable.