### PR TITLE
[debugger] Throw with short and easily caught message in debugger tests.

### DIFF
--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -287,13 +287,21 @@ namespace DebuggerTests
         {
             try
             {
-                return await insp.WaitFor(what);
+                var timeout = Task.Delay(10000);
+                var waitForTask = insp.WaitFor(what);
+                var completedTask = await Task.WhenAny(waitForTask, timeout);
+                if (completedTask == timeout)
+                {
+                    throw new TimeoutException($"Debugger inspector waiting for {what} timed out after 10 seconds");
+                }
+                return await completedTask;
             }
             catch
             {
                 throw new Exception($"Debugger inspector waiting for {what} failed");
             }
         }
+
         public async Task WaitForConsoleMessage(string message)
         {
             object llock = new();

--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -294,7 +294,7 @@ namespace DebuggerTests
                 {
                     throw new TimeoutException($"Debugger inspector waiting for {what} timed out after 10 seconds");
                 }
-                return await completedTask;
+                return await waitForTask;
             }
             catch
             {

--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -285,7 +285,14 @@ namespace DebuggerTests
 
         internal virtual async Task<JObject> WaitFor(string what)
         {
-            return await insp.WaitFor(what);
+            try
+            {
+                return await insp.WaitFor(what);
+            }
+            catch
+            {
+                new Exception($"Waiting for {what} failed");
+            }
         }
         public async Task WaitForConsoleMessage(string message)
         {

--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -291,7 +291,7 @@ namespace DebuggerTests
             }
             catch
             {
-                new Exception($"Waiting for {what} failed");
+                new Exception($"Debugger inspector waiting for {what} failed");
             }
         }
         public async Task WaitForConsoleMessage(string message)

--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -291,7 +291,7 @@ namespace DebuggerTests
             }
             catch
             {
-                new Exception($"Debugger inspector waiting for {what} failed");
+                throw new Exception($"Debugger inspector waiting for {what} failed");
             }
         }
         public async Task WaitForConsoleMessage(string message)


### PR DESCRIPTION
Based on a few logs that had failures connected with `internal virtual async Task<JObject> WaitFor(string what)`, e.g.:
- https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-107769-merge-ca3f5c019c784602bd/chrome-DebuggerTests.SetNextIpTests/1/console.f183cc1e.log?helixlogtype=result
- https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-107769-merge-ca3f5c019c784602bd/chrome-DebuggerTests.AsyncTests/1/console.636f3cf1.log?helixlogtype=result

The logs that look like this:
https://dotnet.github.io/core-eng/helix-workitem-deadletter.txt

```
If you’re reading this, that means the Helix work item you’re trying to find the logs for has dead-lettered.

What this means:

- All attempts to retry execution of this work item were unable to complete.  This can be both for infrastructure reasons (problems within Azure) or issues with the work item (for instance, causing a machine to reboot unexpectedly or killing the Helix client on the machine will force a retry).
- No further work will be done for this specific work item, and its exit code is set to an artificial -1 (since it did not complete, there is no real exit code).
...etc
```
might be created due to too long logs. Typically, `WaitFor` throws with logging a long json text. If we would catch that error and rephrase it, it will be easier for `Known Issue` to catch the logs. The debugger tests are due to be migrated soon, so loosing the details about the json that is logged should not be a problem.