### PR TITLE
Handle building host test assets with stabilized package versions

### DIFF
--- a/src/installer/tests/Assets/Projects/Directory.Build.targets
+++ b/src/installer/tests/Assets/Projects/Directory.Build.targets
@@ -12,8 +12,15 @@
   <Target Name="UpdateRuntimeFrameworkVersion"
           Condition="'$(UseLocalTargetingRuntimePack)' == 'true'"
           AfterTargets="ResolveTargetingPackAssets">
+    <PropertyGroup>
+      <_UpdatedVersion>$(Version)</_UpdatedVersion>
+      <!-- When package versions are stabilized, they do not have version suffixes. Because these are
+           non-shipping tests assets, the Version property will still include suffixes (unlike for shipping
+           assets), so we explicitly use the ProductVersion (without suffixes) in the stabilized case. -->
+      <_UpdatedVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</_UpdatedVersion>
+    </PropertyGroup>
     <ItemGroup>
-      <RuntimeFramework Version="$(Version)"
+      <RuntimeFramework Version="$(_UpdatedVersion)"
                         Condition="'%(RuntimeFramework.FrameworkName)' == '$(LocalFrameworkOverrideName)'" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Host test assets are built against the live runtime build, such that the live runtime version is written into their runtimeconfig.json files. The tests are run using a .NET install layout created via the `PublishToDisk` target for `Microsoft.NETCore.App.Bundle.bundleproj`. With stabilized package versions, these ended up with two different versions - the test assets had a version that still included the version suffix (for example, `-ci`) while the install layout had the stable version without a suffix.

We were relying on the `Version` property in both cases. However, that is computed differently for non-shipping (like the test assets) versus shipping (like the install layout) projects, such that with stabilized package versions, non-shipping assets still had the version suffix while shipping assets did not. This change updates the host test assets build to explicitly check for stabilized package versions and use the `ProductVersion` property (which has no suffixes) in that case.

See https://github.com/dotnet/runtime/issues/108994. We will need to backport to fix the tests in 9.0.

cc @dotnet/appmodel @AaronRobinsonMSFT 