### PR TITLE
Expose additional JIT metrics

### DIFF
--- a/src/coreclr/gcinfo/gcinfoencoder.cpp
+++ b/src/coreclr/gcinfo/gcinfoencoder.cpp
@@ -462,6 +462,7 @@ GcInfoEncoder::GcInfoEncoder(
     m_pCallSiteSizes = NULL;
     m_NumCallSites = 0;
 #endif
+    m_BlockSize = 0;
 
     m_GSCookieStackSlot = NO_GS_COOKIE;
     m_GSCookieValidRangeStart = 0;
@@ -2576,9 +2577,14 @@ BYTE* GcInfoEncoder::Emit()
 
 void * GcInfoEncoder::eeAllocGCInfo (size_t        blockSize)
 {
+    m_BlockSize = blockSize;
     return m_pCorJitInfo->allocGCInfo(blockSize);
 }
 
+size_t GcInfoEncoder::GetEncodedGCInfoSize() const
+{
+    return m_BlockSize;
+}
 
 BitStreamWriter::BitStreamWriter( IAllocator* pAllocator )
 {

--- a/src/coreclr/inc/gcinfoencoder.h
+++ b/src/coreclr/inc/gcinfoencoder.h
@@ -468,6 +468,12 @@ public:
     //
     BYTE* Emit();
 
+    //
+    // Return the size in bytes of the constructed GC info. This is the size passed
+    // to the VM via `allocGCInfo`. It is only valid after `Emit` is called.
+    //
+    size_t GetEncodedGCInfoSize() const;
+
 private:
 
     friend struct CompareLifetimeTransitionsByOffsetThenSlot;
@@ -533,6 +539,8 @@ private:
     BYTE* m_pCallSiteSizes;
     UINT32 m_NumCallSites;
 #endif // PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
+
+    size_t m_BlockSize; // The byte size passed to the `allocGCInfo` call
 
     void GrowSlotTable();
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4138,7 +4138,7 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned            codeSize,
     // GC Encoder automatically puts the GC info in the right spot using ICorJitInfo::allocGCInfo(size_t)
     // let's save the values anyway for debugging purposes
     compiler->compInfoBlkAddr = gcInfoEncoder->Emit();
-    compiler->compInfoBlkSize = 0; // not exposed by the GCEncoder interface
+    compiler->compInfoBlkSize = gcInfoEncoder->GetEncodedGCInfoSize();
 }
 
 // clang-format off

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2288,6 +2288,7 @@ void CodeGen::genEmitUnwindDebugGCandEH()
 
     // Create and store the GC info for this method.
     genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
+    compiler->Metrics.GCInfoBytes = compiler->compInfoBlkSize;
 
     /* Tell the emitter that we're done with this function */
 
@@ -2420,6 +2421,7 @@ void CodeGen::genReportEH()
 
     // Tell the VM how many EH clauses to expect.
     compiler->eeSetEHcount(EHCount);
+    compiler->Metrics.EHClauseCount = (int)EHCount;
 
     struct EHClauseInfo
     {

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2288,7 +2288,7 @@ void CodeGen::genEmitUnwindDebugGCandEH()
 
     // Create and store the GC info for this method.
     genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
-    compiler->Metrics.GCInfoBytes = compiler->compInfoBlkSize;
+    compiler->Metrics.GCInfoBytes = (int)compiler->compInfoBlkSize;
 
     /* Tell the emitter that we're done with this function */
 

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -6488,7 +6488,7 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned            codeSize,
     // GC Encoder automatically puts the GC info in the right spot using ICorJitInfo::allocGCInfo(size_t)
     // let's save the values anyway for debugging purposes
     compiler->compInfoBlkAddr = gcInfoEncoder->Emit();
-    compiler->compInfoBlkSize = 0; // not exposed by the GCEncoder interface
+    compiler->compInfoBlkSize = gcInfoEncoder->GetEncodedGCInfoSize();
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -6488,7 +6488,7 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned            codeSize,
     // GC Encoder automatically puts the GC info in the right spot using ICorJitInfo::allocGCInfo(size_t)
     // let's save the values anyway for debugging purposes
     compiler->compInfoBlkAddr = gcInfoEncoder->Emit();
-    compiler->compInfoBlkSize = 0; // not exposed by the GCEncoder interface
+    compiler->compInfoBlkSize = gcInfoEncoder->GetEncodedGCInfoSize();
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -8880,7 +8880,7 @@ void CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize 
     // GC Encoder automatically puts the GC info in the right spot using ICorJitInfo::allocGCInfo(size_t)
     // let's save the values anyway for debugging purposes
     compiler->compInfoBlkAddr = gcInfoEncoder->Emit();
-    compiler->compInfoBlkSize = 0; // not exposed by the GCEncoder interface
+    compiler->compInfoBlkSize = gcInfoEncoder->GetEncodedGCInfoSize();
 }
 #endif // !JIT32_GCENCODER
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6846,6 +6846,10 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
     args.xcptnsCount  = xcptnsCount;
     args.flag         = allocMemFlag;
 
+    comp->Metrics.AllocatedHotCodeBytes  = args.hotCodeSize;
+    comp->Metrics.AllocatedColdCodeBytes = args.coldCodeSize;
+    comp->Metrics.ReadOnlyDataBytes      = args.roDataSize;
+
     emitComp->eeAllocMem(&args, emitConsDsc.alignment);
 
     codeBlock       = (BYTE*)args.hotCodeBlock;
@@ -7679,6 +7683,8 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
     *prologSize = emitCodeOffset(emitPrologIG, emitPrologEndPos);
 
     /* Return the amount of code we've generated */
+
+    comp->Metrics.ActualCodeBytes = actualCodeSize;
 
     return actualCodeSize;
 }

--- a/src/coreclr/jit/jitmetadatalist.h
+++ b/src/coreclr/jit/jitmetadatalist.h
@@ -27,6 +27,8 @@
 //              Name,                                    type              flags
 JITMETADATAINFO(MethodFullName,                          const char*,      0)
 JITMETADATAINFO(TieringName,                             const char*,      0)
+JITMETADATAMETRIC(GCInfoBytes,                           int64_t,          JIT_METADATA_LOWER_IS_BETTER)
+JITMETADATAMETRIC(EHClauseCount,                         int,              0)
 JITMETADATAMETRIC(PhysicallyPromotedFields,              int,              0)
 JITMETADATAMETRIC(LoopsFoundDuringOpts,                  int,              0)
 JITMETADATAMETRIC(LoopsCloned,                           int,              0)

--- a/src/coreclr/jit/jitmetadatalist.h
+++ b/src/coreclr/jit/jitmetadatalist.h
@@ -27,7 +27,11 @@
 //              Name,                                    type              flags
 JITMETADATAINFO(MethodFullName,                          const char*,      0)
 JITMETADATAINFO(TieringName,                             const char*,      0)
-JITMETADATAMETRIC(GCInfoBytes,                           int64_t,          JIT_METADATA_LOWER_IS_BETTER)
+JITMETADATAMETRIC(ActualCodeBytes,                       int,              JIT_METADATA_LOWER_IS_BETTER)
+JITMETADATAMETRIC(AllocatedHotCodeBytes,                 int,              JIT_METADATA_LOWER_IS_BETTER)
+JITMETADATAMETRIC(AllocatedColdCodeBytes,                int,              JIT_METADATA_LOWER_IS_BETTER)
+JITMETADATAMETRIC(ReadOnlyDataBytes,                     int,              JIT_METADATA_LOWER_IS_BETTER)
+JITMETADATAMETRIC(GCInfoBytes,                           int,              JIT_METADATA_LOWER_IS_BETTER)
 JITMETADATAMETRIC(EHClauseCount,                         int,              0)
 JITMETADATAMETRIC(PhysicallyPromotedFields,              int,              0)
 JITMETADATAMETRIC(LoopsFoundDuringOpts,                  int,              0)

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1952,7 +1952,7 @@ def aggregate_diff_metrics(details_file):
     # Project out these fields for the saved diffs, to use for further
     # processing. Saving everything into memory is costly on memory when there
     # are a large number of diffs.
-    diffs_fields = ["Context", "Context size", "Base size", "Diff size", "Base PerfScore", "Diff PerfScore"]
+    diffs_fields = ["Context", "Context size", "Base ActualCodeBytes", "Diff ActualCodeBytes", "Base PerfScore", "Diff PerfScore"]
     diffs = []
 
     for row in read_csv(details_file):
@@ -1983,8 +1983,8 @@ def aggregate_diff_metrics(details_file):
             diff_dict["Failing compiles"] += 1
 
         if base_result == "Success" and diff_result == "Success":
-            base_size = int(row["Base size"])
-            diff_size = int(row["Diff size"])
+            base_size = int(row["Base ActualCodeBytes"])
+            diff_size = int(row["Diff ActualCodeBytes"])
             base_dict["Diffed code bytes"] += base_size
             diff_dict["Diffed code bytes"] += diff_size
 
@@ -2463,7 +2463,7 @@ class SuperPMIReplayAsmDiffs:
 
                     # If we are not specifying custom metrics then print a summary here, otherwise leave the summarization up to jit-analyze.
                     if self.coreclr_args.metrics is None:
-                        base_diff_sizes = [(int(r["Base size"]), int(r["Diff size"])) for r in diffs]
+                        base_diff_sizes = [(int(r["Base ActualCodeBytes"]), int(r["Diff ActualCodeBytes"])) for r in diffs]
                         (num_size_improvements, num_size_regressions, num_size_same, byte_improvements, byte_regressions) = calculate_size_improvements_regressions(base_diff_sizes)
 
                         num_diffs_str = "{:,d} contexts with diffs".format(len(diffs))
@@ -2686,8 +2686,8 @@ class SuperPMIReplayAsmDiffs:
             display_subset("Smallest {} contexts with binary differences:", smallest_contexts)
 
             if self.coreclr_args.metrics is None:
-                base_metric_name = "Base size"
-                diff_metric_name = "Diff size"
+                base_metric_name = "Base ActualCodeBytes"
+                diff_metric_name = "Diff ActualCodeBytes"
             else:
                 base_metric_name = "Base PerfScore"
                 diff_metric_name = "Diff PerfScore"
@@ -2718,7 +2718,7 @@ class SuperPMIReplayAsmDiffs:
             display_subset("Top {} regressions, percentage-wise:", top_regressions_pct)
 
             # 20 contexts without size diffs (possibly GC info diffs), sorted by size
-            zero_size_diffs = filter(lambda r: int(r["Diff size"]) == int(r["Base size"]), diffs)
+            zero_size_diffs = filter(lambda r: int(r["Diff ActualCodeBytes"]) == int(r["Base ActualCodeBytes"]), diffs)
             smallest_zero_size_contexts = sorted(zero_size_diffs, key=lambda r: int(r["Context size"]))[:20]
 
             display_subset("Smallest {} zero sized diffs:", smallest_zero_size_contexts)
@@ -2834,7 +2834,7 @@ def write_asmdiffs_markdown_summary(write_fh, base_jit_options, diff_jit_options
                 write_fh.write("|---|--:|--:|--:|--:|--:|--:|\n")
 
                 def write_row(name, diffs):
-                    base_diff_sizes = [(int(r["Base size"]), int(r["Diff size"])) for r in diffs]
+                    base_diff_sizes = [(int(r["Base ActualCodeBytes"]), int(r["Diff ActualCodeBytes"])) for r in diffs]
                     (num_improvements, num_regressions, num_same, byte_improvements, byte_regressions) = calculate_size_improvements_regressions(base_diff_sizes)
                     write_fh.write("|{}|{:,d}|{}|{}|{}|{}|{}|\n".format(
                         name,
@@ -2937,8 +2937,8 @@ def write_example_diffs_to_markdown_summary(write_fh, asm_diffs):
 
             with DetailsSection(write_fh, collection_name):
                 for (func_name, diff, diff_text) in examples_to_put_in_summary:
-                    base_size = int(diff["Base size"])
-                    diff_size = int(diff["Diff size"])
+                    base_size = int(diff["Base ActualCodeBytes"])
+                    diff_size = int(diff["Diff ActualCodeBytes"])
                     with DetailsSection(write_fh, "{} ({}) : {}".format(format_delta(base_size, diff_size), compute_and_format_pct(base_size, diff_size), func_name)):
                         write_fh.write(diff_text)
 

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -409,14 +409,6 @@ ReplayResults JitInstance::CompileMethod(MethodContext* MethodToCompile, int mcI
             pParam->pThis->mc->cr->recAllocGCInfoCapture();
 
             pParam->pThis->mc->cr->recMessageLog(jitResult == CORJIT_OK ? "Successful Compile" : "Successful Compile (BADCODE)");
-
-            pParam->results.NumCodeBytes   = NCodeSizeBlock;
-
-            // Extract the GCInfo size.
-            size_t size;
-            void* retval_unused;
-            pParam->pThis->mc->cr->repAllocGCInfo(&size, &retval_unused);
-            pParam->results.NumGCInfoBytes = size;
         }
         else
         {

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -410,7 +410,13 @@ ReplayResults JitInstance::CompileMethod(MethodContext* MethodToCompile, int mcI
 
             pParam->pThis->mc->cr->recMessageLog(jitResult == CORJIT_OK ? "Successful Compile" : "Successful Compile (BADCODE)");
 
-            pParam->results.NumCodeBytes = NCodeSizeBlock;
+            pParam->results.NumCodeBytes   = NCodeSizeBlock;
+
+            // Extract the GCInfo size.
+            size_t size;
+            void* retval_unused;
+            pParam->pThis->mc->cr->repAllocGCInfo(&size, &retval_unused);
+            pParam->results.NumGCInfoBytes = size;
         }
         else
         {

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.h
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.h
@@ -20,8 +20,6 @@ struct ReplayResults
 {
     ReplayResult Result = ReplayResult::Success;
     bool IsMinOpts = false;
-    uint32_t NumCodeBytes = 0;
-    size_t NumGCInfoBytes = 0;
     uint64_t NumExecutedInstructions = 0;
     CompileResult* CompileResults = nullptr;
 };

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.h
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.h
@@ -21,6 +21,7 @@ struct ReplayResults
     ReplayResult Result = ReplayResult::Success;
     bool IsMinOpts = false;
     uint32_t NumCodeBytes = 0;
+    size_t NumGCInfoBytes = 0;
     uint64_t NumExecutedInstructions = 0;
     CompileResult* CompileResults = nullptr;
 };

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -139,7 +139,7 @@ static const char* ResultToString(ReplayResult result)
 
 static void PrintDiffsCsvHeader(FileWriter& fw)
 {
-    fw.Print("Context,Context size,Method full name,Tier name,Base result,Diff result,MinOpts,Has diff,Base size,Diff size,Base GCInfo size,Diff GCInfo size,Base instructions,Diff instructions");
+    fw.Print("Context,Context size,Method full name,Tier name,Base result,Diff result,MinOpts,Has diff,Base instructions,Diff instructions");
 
 #define JITMETADATAINFO(name, type, flags)
 #define JITMETADATAMETRIC(name, type, flags) fw.Print(",Base " #name ",Diff " #name);
@@ -159,13 +159,11 @@ static void PrintDiffsCsvRow(
     fw.Printf("%d,%u,", context, contextSize);
     fw.PrintQuotedCsvField(baseRes.CompileResults->MethodFullName == nullptr ? "" : baseRes.CompileResults->MethodFullName);
     fw.Printf(
-        ",%s,%s,%s,%s,%s,%u,%u,%u,%u,%lld,%lld",
+        ",%s,%s,%s,%s,%s,%lld,%lld",
         baseRes.CompileResults->TieringName == nullptr ? "" : baseRes.CompileResults->TieringName,
         ResultToString(baseRes.Result), ResultToString(diffRes.Result),
         baseRes.IsMinOpts ? "True" : "False",
         hasDiff ? "True" : "False",
-        baseRes.NumCodeBytes, diffRes.NumCodeBytes,
-        (uint32_t)baseRes.NumGCInfoBytes, (uint32_t)diffRes.NumGCInfoBytes,
         baseRes.NumExecutedInstructions, diffRes.NumExecutedInstructions);
 
 #define JITMETADATAINFO(name, type, flags)
@@ -182,7 +180,7 @@ static void PrintDiffsCsvRow(
 
 static void PrintReplayCsvHeader(FileWriter& fw)
 {
-    fw.Printf("Context,Context size,Method full name,Tier name,Result,MinOpts,Size,GCInfo size,Instructions");
+    fw.Printf("Context,Context size,Method full name,Tier name,Result,MinOpts,Instructions");
 
 #define JITMETADATAINFO(name, type, flags)
 #define JITMETADATAMETRIC(name, type, flags) fw.Print("," #name);
@@ -199,11 +197,11 @@ static void PrintReplayCsvRow(
 {
     fw.Printf("%d,%u,", context, contextSize);
     fw.PrintQuotedCsvField(res.CompileResults->MethodFullName == nullptr ? "" : res.CompileResults->MethodFullName);
-    fw.Printf(",%s,%s,%s,%u,%u,%lld",
+    fw.Printf(",%s,%s,%s,%lld",
         res.CompileResults->TieringName == nullptr ? "" : res.CompileResults->TieringName,
         ResultToString(res.Result),
         res.IsMinOpts ? "True" : "False",
-        res.NumCodeBytes, (uint32_t)res.NumGCInfoBytes, res.NumExecutedInstructions);
+        res.NumExecutedInstructions);
 
 #define JITMETADATAINFO(name, type, flags)
 #define JITMETADATAMETRIC(name, type, flags) \

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -139,7 +139,7 @@ static const char* ResultToString(ReplayResult result)
 
 static void PrintDiffsCsvHeader(FileWriter& fw)
 {
-    fw.Print("Context,Context size,Method full name,Tier name,Base result,Diff result,MinOpts,Has diff,Base size,Diff size,Base instructions,Diff instructions");
+    fw.Print("Context,Context size,Method full name,Tier name,Base result,Diff result,MinOpts,Has diff,Base size,Diff size,Base GCInfo size,Diff GCInfo size,Base instructions,Diff instructions");
 
 #define JITMETADATAINFO(name, type, flags)
 #define JITMETADATAMETRIC(name, type, flags) fw.Print(",Base " #name ",Diff " #name);
@@ -159,12 +159,13 @@ static void PrintDiffsCsvRow(
     fw.Printf("%d,%u,", context, contextSize);
     fw.PrintQuotedCsvField(baseRes.CompileResults->MethodFullName == nullptr ? "" : baseRes.CompileResults->MethodFullName);
     fw.Printf(
-        ",%s,%s,%s,%s,%s,%u,%u,%lld,%lld",
+        ",%s,%s,%s,%s,%s,%u,%u,%u,%u,%lld,%lld",
         baseRes.CompileResults->TieringName == nullptr ? "" : baseRes.CompileResults->TieringName,
         ResultToString(baseRes.Result), ResultToString(diffRes.Result),
         baseRes.IsMinOpts ? "True" : "False",
         hasDiff ? "True" : "False",
         baseRes.NumCodeBytes, diffRes.NumCodeBytes,
+        (uint32_t)baseRes.NumGCInfoBytes, (uint32_t)diffRes.NumGCInfoBytes,
         baseRes.NumExecutedInstructions, diffRes.NumExecutedInstructions);
 
 #define JITMETADATAINFO(name, type, flags)
@@ -181,7 +182,7 @@ static void PrintDiffsCsvRow(
 
 static void PrintReplayCsvHeader(FileWriter& fw)
 {
-    fw.Printf("Context,Context size,Method full name,Tier name,Result,MinOpts,Size,Instructions");
+    fw.Printf("Context,Context size,Method full name,Tier name,Result,MinOpts,Size,GCInfo size,Instructions");
 
 #define JITMETADATAINFO(name, type, flags)
 #define JITMETADATAMETRIC(name, type, flags) fw.Print("," #name);
@@ -198,11 +199,11 @@ static void PrintReplayCsvRow(
 {
     fw.Printf("%d,%u,", context, contextSize);
     fw.PrintQuotedCsvField(res.CompileResults->MethodFullName == nullptr ? "" : res.CompileResults->MethodFullName);
-    fw.Printf(",%s,%s,%s,%u,%lld",
+    fw.Printf(",%s,%s,%s,%u,%u,%lld",
         res.CompileResults->TieringName == nullptr ? "" : res.CompileResults->TieringName,
         ResultToString(res.Result),
         res.IsMinOpts ? "True" : "False",
-        res.NumCodeBytes, res.NumExecutedInstructions);
+        res.NumCodeBytes, (uint32_t)res.NumGCInfoBytes, res.NumExecutedInstructions);
 
 #define JITMETADATAINFO(name, type, flags)
 #define JITMETADATAMETRIC(name, type, flags) \


### PR DESCRIPTION
Add the following metrics:

- ActualCodeBytes - the actual number of generated code bytes.
- AllocatedHotCodeBytes - the number of bytes allocated for hot code.
- AllocatedColdCodeBytes - the number of bytes allocated for cold code.
- ReadOnlyDataBytes - the number of bytes allocated for read-only data
- GCInfoBytes - the number of bytes allocated (in the VM) for GC info; the GC info block size.
- EHClauseCount - the number of EH clauses reported to the VM.

Note that `AllocatedCodeBytes` might be less than `AllocatedHotCodeBytes + AllocatedColdCodeBytes` if misestimated the size of instructions that were generated.

Removed the special-cased SuperPMI "size" metric in favor of the new `ActualCodeBytes` metric. Fixed up superpmi.py to use the new metric.
