### PR TITLE
use `nameof` for `CallerArgumentExpression`

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_54956/Runtime_54956.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54956/Runtime_54956.cs
@@ -46,7 +46,7 @@ public unsafe class Runtime_54956
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static bool Test(Action action, [CallerArgumentExpression("action")] string expr = null)
+    static bool Test(Action action, [CallerArgumentExpression(nameof(action))] string expr = null)
     {
         try
         {

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Main.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Main.cs
@@ -12,7 +12,7 @@ success &= RunTest(DependencyInjectionPattern.Run);
 
 return success ? 100 : 1;
 
-static bool RunTest(Func<int> t, [CallerArgumentExpression("t")] string name = null)
+static bool RunTest(Func<int> t, [CallerArgumentExpression(nameof(t))] string name = null)
 {
     Console.WriteLine($"===== Running test {name} =====");
     bool success = true;

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
@@ -14,7 +14,7 @@ success &= RunTest(StackTraces.Run);
 
 return success ? 100 : 1;
 
-static bool RunTest(Func<int> t, [CallerArgumentExpression("t")] string name = null)
+static bool RunTest(Func<int> t, [CallerArgumentExpression(nameof(t))] string name = null)
 {
     Console.WriteLine($"===== Running test {name} =====");
     bool success = true;


### PR DESCRIPTION
use `nameof` for `CallerArgumentExpression`