### PR TITLE
Delete duplicate blank issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/04_blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/04_blank_issue.md
@@ -1,8 +1,0 @@
----
-name: Blank issue
-about: Something that doesn't fit the other categories
-title: ''
-labels: ''
-assignees: ''
-
----


### PR DESCRIPTION
We already [pass](https://github.com/dotnet/runtime/blob/dfc2b85a00f3baf5ac52d7615bf857e6217011c8/.github/ISSUE_TEMPLATE/config.yml#L1) `blank_issues_enabled: true` in `.github/ISSUE_TEMPLATE/config.yml` so the `04_blank_issue.yml` template causes the "Blank issue" option to appear twice. This PR fixes the duplication by removing `04_blank_issue.yml`.

![image](https://github.com/user-attachments/assets/93d2318f-ae4c-467c-9d77-cb25ad2ef385)