### PR TITLE
[cmake] add osx support in CMakePresets.json

### DIFF
--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -40,8 +40,7 @@
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
           "hostOS": [
-            "macOS",
-            "OSX"
+            "macOS"
           ]
         }
       }

--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -38,10 +38,7 @@
         "CLR_CMAKE_TARGET_OS": "darwin"
       },
       "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "hostOS": [
-            "macOS"
-          ]
+        "jetbrains.com/clion": {
         }
       }
     },

--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -215,7 +215,7 @@
     },
     {
       "name": "osx.arm64.Release",
-      "displayName": "macos.arm64.Release",
+      "displayName": "osx.arm64.Release",
       "inherits": [
         "osx-base",
         "Release",

--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -31,6 +31,21 @@
       }
     },
     {
+      "name": "osx-base",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CLR_CMAKE_TARGET_OS": "darwin"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "macOS"
+          ]
+        }
+      }
+    },
+    {
       "name": "Debug",
       "hidden": true,
       "cacheVariables": {
@@ -161,6 +176,60 @@
       "displayName": "windows.arm64.Checked",
       "inherits": [
         "windows-base",
+        "Checked",
+        "ARM64"
+      ]
+    },
+    {
+      "name": "osx.x64.Debug",
+      "displayName": "osx.x64.Debug",
+      "inherits": [
+        "osx-base",
+        "Debug",
+        "x64"
+      ]
+    },
+    {
+      "name": "osx.x64.Release",
+      "displayName": "osx.x64.Release",
+      "inherits": [
+        "osx-base",
+        "Release",
+        "x64"
+      ]
+    },
+    {
+      "name": "osx.x64.Checked",
+      "displayName": "osx.x64.Checked",
+      "inherits": [
+        "osx-base",
+        "Checked",
+        "x64"
+      ]
+    },
+    {
+      "name": "osx.arm64.Debug",
+      "displayName": "osx.arm64.Debug",
+      "inherits": [
+        "osx-base",
+        "Debug",
+        "ARM64"
+      ]
+    },
+    {
+      "name": "osx.arm64.Release",
+      "displayName": "macos.arm64.Release",
+      "inherits": [
+        "osx-base",
+        "Release",
+        "ARM64"
+      ]
+    },
+    {
+      "name": "osx.arm64.Checked",
+      "displayName": "osx.arm64.Checked",
+      "inherits": [
+        "osx-base",
         "Checked",
         "ARM64"
       ]

--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -38,7 +38,11 @@
         "CLR_CMAKE_TARGET_OS": "darwin"
       },
       "vendor": {
-        "jetbrains.com/clion": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "macOS",
+            "OSX"
+          ]
         }
       }
     },


### PR DESCRIPTION
This fixes #108987 .

I have tested and it works well.