### PR TITLE
[debugger] Opening the inspector session can fail with other exceptions than cancellation

### DIFF
--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -196,6 +196,10 @@ namespace DebuggerTests
                 scripts = SubscribeToScripts(insp);
                 await insp.OpenSessionAsync(fn,  $"http://{TestHarnessProxy.Endpoint.Authority}/{driver}", TestTimeout);
             }
+            catch (Exception other)
+            {
+                throw new Exception($"Debugger inspector failed opening the session: {other}");
+            }
         }
 
         public virtual async Task DisposeAsync()

--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -184,21 +184,24 @@ namespace DebuggerTests
             try {
                 await insp.OpenSessionAsync(fn,  $"http://{TestHarnessProxy.Endpoint.Authority}/{driver}", TestTimeout);
             }
-            catch (TaskCanceledException exc) //if timed out for some reason let's try again
+            catch (Exception exc) //if failed some reason let's try again
             {
                 if (!retry)
-                    throw exc;
+                    throw new Exception($"Debugger inspector session opening failed and will not be retried: {other}");
                 retry = false;
                 _testOutput.WriteLine($"Let's retry: {exc.ToString()}");
-                Id = Interlocked.Increment(ref s_idCounter);
-                insp = new Inspector(Id, _testOutput);
-                cli = insp.Client;
-                scripts = SubscribeToScripts(insp);
-                await insp.OpenSessionAsync(fn,  $"http://{TestHarnessProxy.Endpoint.Authority}/{driver}", TestTimeout);
-            }
-            catch (Exception other)
-            {
-                throw new Exception($"Debugger inspector failed opening the session: {other}");
+                try
+                {
+                    Id = Interlocked.Increment(ref s_idCounter);
+                    insp = new Inspector(Id, _testOutput);
+                    cli = insp.Client;
+                    scripts = SubscribeToScripts(insp);
+                    await insp.OpenSessionAsync(fn,  $"http://{TestHarnessProxy.Endpoint.Authority}/{driver}", TestTimeout);
+                }
+                catch (Exception secondEx)
+                {
+                    throw new Exception($"Debugger inspector session opening failed: {secondEx}");
+                }
             }
         }
 

--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -187,7 +187,7 @@ namespace DebuggerTests
             catch (Exception exc) //if failed some reason let's try again
             {
                 if (!retry)
-                    throw new Exception($"Debugger inspector session opening failed and will not be retried: {other}");
+                    throw new Exception($"Debugger inspector session opening failed and will not be retried: {exc}");
                 retry = false;
                 _testOutput.WriteLine($"Let's retry: {exc.ToString()}");
                 try


### PR DESCRIPTION
The goal is similar to https://github.com/dotnet/runtime/pull/109011.
Based on the log: https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-109053-merge-02f7660120d6447d98/chrome-DebuggerTests.EvaluateOnCallFrameTests/1/console.d884ef3d.log?helixlogtype=result

```
A total of 1 test files matched the specified pattern.
[xUnit.net 00:49:45.27]     DebuggerTests.EvaluateOnCallFrameTests.EvaluateIndexingMultidimensional [FAIL]
  Failed DebuggerTests.EvaluateOnCallFrameTests.EvaluateIndexingMultidimensional [1 ms]
  Error Message:
   System.ArgumentException : {
  "reason": "Render process gone.",
  "__forMethod": "Inspector.detached"
}
  Stack Trace:
     at DebuggerTests.Inspector.OpenSessionAsync(Func`3 getInitCmds, String urlToInspect, TimeSpan span) in /_/src/mono/browser/debugger/DebuggerTestSuite/Inspector.cs:line 377
   at DebuggerTests.DebuggerTestBase.InitializeAsync() in /_/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 185

...
[EXECUTION TIMED OUT]
Exit Code:-3Executor timed out after 3000 seconds and was killed
```

`insp.OpenSessionAsync` can fail with exceptions other than `TaskCanceledException`. We are extending the exception types for which we are retrying the session opening and adding fixed prefixes to exceptions, in case we had to capture them with `Known Issue`.

If the retry helps, then it will mitigate https://github.com/dotnet/runtime/issues/108072, https://github.com/dotnet/runtime/issues/108078