### PR TITLE
Expose No-Op Logger Scope Provider and Scope

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
@@ -8,16 +8,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs"
-             Link="Common\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" />
-    <Compile Include="$(CommonPath)Extensions\Logging\NullExternalScopeProvider.cs"
-             Link="Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
-    <Compile Include="$(CommonPath)Extensions\Logging\NullScope.cs"
-             Link="Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Include="$(CommonPath)Extensions\Logging\DebuggerDisplayFormatting.cs"
-             Link="Common\src\Extensions\Logging\DebuggerDisplayFormatting.cs" />
-    <Compile Include="$(CommonPath)System\ThrowHelper.cs"
-             Link="Common\System\ThrowHelper.cs" />
+    <Compile Include="$(CommonPath)\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" Link="Common\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
+    <Compile Include="$(CommonPath)Extensions\Logging\NullExternalScopeProvider.cs" Link="Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Include="$(CommonPath)Extensions\Logging\DebuggerDisplayFormatting.cs" Link="Common\src\Extensions\Logging\DebuggerDisplayFormatting.cs" />
+    <Compile Include="$(CommonPath)System\ThrowHelper.cs" Link="Common\System\ThrowHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
@@ -9,19 +9,6 @@
 
   <ItemGroup>
     <Compile Include="$(CommonPath)\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" Link="Common\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
-    <Compile Include="$(CommonPath)Extensions\Logging\NullExternalScopeProvider.cs" Link="Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
-    <Compile Remove="C:\Projects\dotnet\runtime\src\libraries\Common\src\Extensions\Logging\NullScope.cs" />
     <Compile Include="$(CommonPath)Extensions\Logging\DebuggerDisplayFormatting.cs" Link="Common\src\Extensions\Logging\DebuggerDisplayFormatting.cs" />
     <Compile Include="$(CommonPath)System\ThrowHelper.cs" Link="Common\System\ThrowHelper.cs" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
@@ -8,9 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" Link="Common\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" />
-    <Compile Include="$(CommonPath)Extensions\Logging\DebuggerDisplayFormatting.cs" Link="Common\src\Extensions\Logging\DebuggerDisplayFormatting.cs" />
-    <Compile Include="$(CommonPath)System\ThrowHelper.cs" Link="Common\System\ThrowHelper.cs" />
+    <Compile Include="$(CommonPath)\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs"
+             Link="Common\Extensions\ProviderAliasUtilities\ProviderAliasUtilities.cs" />
+    <Compile Include="$(CommonPath)Extensions\Logging\DebuggerDisplayFormatting.cs"
+             Link="Common\src\Extensions\Logging\DebuggerDisplayFormatting.cs" />
+    <Compile Include="$(CommonPath)System\ThrowHelper.cs"
+             Link="Common\System\ThrowHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging/src/NullExternalScopeProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/NullExternalScopeProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging
     /// <summary>
     /// Scope provider that does nothing.
     /// </summary>
-    internal sealed class NullExternalScopeProvider : IExternalScopeProvider
+    public sealed class NullExternalScopeProvider : IExternalScopeProvider
     {
         private NullExternalScopeProvider()
         {

--- a/src/libraries/Microsoft.Extensions.Logging/src/NullScope.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/NullScope.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
-    /// An empty scope with no logic.
+    /// An empty scope without any logic.
     /// </summary>
     public sealed class NullScope : IDisposable
     {

--- a/src/libraries/Microsoft.Extensions.Logging/src/NullScope.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/NullScope.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,10 +6,13 @@ using System;
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
-    /// An empty scope without any logic
+    /// An empty scope with no logic.
     /// </summary>
-    internal sealed class NullScope : IDisposable
+    public sealed class NullScope : IDisposable
     {
+        /// <summary>
+        /// Provides a Null Scope Singleton.
+        /// </summary>
         public static NullScope Instance { get; } = new NullScope();
 
         private NullScope()


### PR DESCRIPTION
Fixes #108993 

This PR moves NullExternalLoggingProvider and NullScope from the common directory to be first class members of the Microsoft.Extensions.Logging library and changes their accessibility to `public`.

I would like guidance on how to handle the ref library - do I need to generate those myself (and if so, how?) or are these generated automatically?