### PR TITLE
JIT: Fix up `BBJ_CALLFINALLY/BBJ_CALLFINALLYRET` pairs after reordering blocks

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6247,12 +6247,13 @@ public:
     bool fgComputeCalledCount(weight_t returnWeight);
 
     bool fgReorderBlocks(bool useProfile);
-    void fgDoReversePostOrderLayout();
-    void fgMoveColdBlocks();
 
+    template <bool hasEH>
+    void fgDoReversePostOrderLayout();
     template <bool hasEH>
     void fgMoveHotJumps();
 
+    void fgMoveColdBlocks();
     bool fgFuncletsAreCold();
 
     PhaseStatus fgDetermineFirstColdBlock();


### PR DESCRIPTION
Follow-up to #108914. When swapping partitions, if a partition ends with the first block of a call-finally pair, 3-opt will break up the pair. We'd rather not inhibit reordering to preserve EH semantics that can be re-established later, so strip out the existing call-finally fixup logic, and do the required repairs after layout runs.

This had small diffs locally from changes to `fgMoveHotJumps`. I'm not particularly interested in such diffs, since I plan to get rid of this layout pass altogether once we have 3-opt running.