### PR TITLE
[ilasm] Don't try to overrun the buffer in emitMetaData

### DIFF
--- a/src/coreclr/md/ceefilegen/cceegen.cpp
+++ b/src/coreclr/md/ceefilegen/cceegen.cpp
@@ -439,7 +439,7 @@ HRESULT CCeeGen::emitMetaData(IMetaDataEmit *emitter, CeeSection* section, DWORD
         IfFailGoto((HRESULT)metaStream->Seek(disp, STREAM_SEEK_SET, NULL), Exit);
     }
     ULONG metaDataLen;
-    IfFailGoto((HRESULT)metaStream->Read(buffer, buffLen+1, &metaDataLen), Exit);
+    IfFailGoto((HRESULT)metaStream->Read(buffer, buffLen, &metaDataLen), Exit);
 
     _ASSERTE(metaDataLen <= buffLen);
 


### PR DESCRIPTION
This may fix the System.BadImageFormatException failures in https://github.com/dotnet/runtime/pull/108636 that were being caused by ilasm producing malformed DLLs in some cases. I'm not sure why this +1 was there to begin with but it seems wrong. I tried a few different ways of compensating for it (padding the destination buffer, etc) but those all introduced new problems.

In a local test, a checked build of ilasm will assert when building mcc_i06.il + common.il before this change, but after this change it successfully assembles the two IL files. I can't easily verify whether this will fix the CI failures for real though.

Running this through CI to see if we rely on the +1 for some reason.