### PR TITLE
[cdac] Lazily read global string/object method table pointers

### DIFF
--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -27,6 +27,9 @@ internal sealed unsafe partial class SOSDacImpl
       ISOSDacInterface11, ISOSDacInterface12, ISOSDacInterface13, ISOSDacInterface14, ISOSDacInterface15
 {
     private readonly Target _target;
+
+    // When this class is created, the runtime may not have loaded the string and object method tables and set the global pointers.
+    // They should be set when actually requested via a DAC API, so we lazily read the global pointers.
     private readonly Lazy<TargetPointer> _stringMethodTable;
     private readonly Lazy<TargetPointer> _objectMethodTable;
 


### PR DESCRIPTION
When the [c]DAC is created, the string and object method tables may not be loaded and the global pointers set yet. We don't actually need them at creation of `SOSDacImpl`, so but we were always reading those global pointers and expecting them to be set. Switch reading of the string and object method table pointers to be lazy,

cc @AaronRobinsonMSFT @davidwrighton 