### PR TITLE
Fix test build fail

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -308,7 +308,7 @@ public sealed class MemberDataTest : ITestInfo
         CodeBuilder builder = new();
 
         builder.AppendLine();
-        builder.AppendLine($@"foreach (object[] {_loopVarIdentifier} in {_memberInvocation})");
+        builder.AppendLine($@"foreach (object {_loopVarIdentifier} in {_memberInvocation})");
 
         using (builder.NewBracesScope())
         {

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -1002,7 +1002,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                         const string argumentVariableIdentifier = "testArguments";
                         // The display name for the test is an interpolated string that includes the arguments.
                         string displayNameOverride = $@"$""{alias}::{method.ContainingType.ToDisplayString(FullyQualifiedWithoutGlobalNamespace)}.{method.Name}({{string.Join("","", {argumentVariableIdentifier})}})""";
-                        var argsAsCode = method.Parameters.Select((p, i) => $"({p.Type.ToDisplayString()}){argumentVariableIdentifier}[{i}]").ToImmutableArray();
+                        var argsAsCode = method.Parameters.Select((p, i) => $"({p.Type.ToDisplayString()}){argumentVariableIdentifier}").ToImmutableArray();
                         testCasesBuilder.Add(new MemberDataTest(membersByName[0], new BasicTestMethod(method, alias, argsAsCode, displayNameOverride), alias, argumentVariableIdentifier));
                         break;
                     }

--- a/src/tests/Loader/StartupHooks/StartupHookTests.cs
+++ b/src/tests/Loader/StartupHooks/StartupHookTests.cs
@@ -175,8 +175,10 @@ public unsafe class StartupHookTests
 
     [Theory]
     [MemberData(nameof(InvalidSimpleAssemblyNameData))]
-    public static void InvalidSimpleAssemblyName(string name, bool failsSimpleNameCheck)
+    public static void InvalidSimpleAssemblyName(object[] arg)
     {
+        string name = (string)arg[0];
+        bool failsSimpleNameCheck = (bool)arg[1];
         Console.WriteLine($"Running {nameof(InvalidSimpleAssemblyName)}({name}, {failsSimpleNameCheck})...");
 
         AppContext.SetData(StartupHookKey, $"{Hook.Basic.Value}{Path.PathSeparator}{name}");
@@ -231,12 +233,12 @@ public unsafe class StartupHookTests
 
     [Theory]
     [MemberData(nameof(IncorrectInitializeSignatureData))]
-    public static void IncorrectInitializeSignature(Hook hook)
+    public static void IncorrectInitializeSignature(Hook[] hook)
     {
-        Console.WriteLine($"Running {nameof(IncorrectInitializeSignature)}({hook.Name})...");
+        Console.WriteLine($"Running {nameof(IncorrectInitializeSignature)}({hook[0].Name})...");
 
-        AppContext.SetData(StartupHookKey, hook.Value);
+        AppContext.SetData(StartupHookKey, hook[0].Value);
         var ex = Assert.Throws<ArgumentException>(() => ProcessStartupHooks(string.Empty));
-        Assert.Equal($"The signature of the startup hook 'StartupHook.Initialize' in assembly '{hook.Value}' was invalid. It must be 'public static void Initialize()'.", ex.Message);
+        Assert.Equal($"The signature of the startup hook 'StartupHook.Initialize' in assembly '{hook[0].Value}' was invalid. It must be 'public static void Initialize()'.", ex.Message);
     }
 }


### PR DESCRIPTION
With `BuildAllTestsAsStandalone` after #108968 is true, test build fails. It fixes build fails in `StartupHookTests` and `ILVerificationTests`.

Error message
```
/runtime/artifacts/tests/coreclr/obj/linux.riscv64.Release/Managed/ilverify/ILVerificationTests/XUnitWrapperGenerator/XUnitWrapperGenerator.XUnitWrapperGenerator/SimpleRunner.g.cs(8,13): error CS0030: Cannot convert type 'ILVerification.Tests.TestCase' to 'object[]' [/runtime/src/tests/ilverify/ILVerificationTests.csproj] [/runtime/src/tests/build.proj]
/runtime/artifacts/tests/coreclr/obj/linux.riscv64.Release/Managed/ilverify/ILVerificationTests/XUnitWrapperGenerator/XUnitWrapperGenerator.XUnitWrapperGenerator/SimpleRunner.g.cs(13,13): error CS0030: Cannot convert type 'ILVerification.Tests.TestCase' to 'object[]' [/runtime/src/tests/ilverify/ILVerificationTests.csproj] [/runtime/src/tests/build.proj]
/runtime/artifacts/tests/coreclr/obj/linux.riscv64.Release/Managed/ilverify/ILVerificationTests/XUnitWrapperGenerator/XUnitWrapperGenerator.XUnitWrapperGenerator/SimpleRunner.g.cs(18,13): error CS0030: Cannot convert type 'ILVerification.Tests.TestCase' to 'object[]' [/runtime/src/tests/ilverify/ILVerificationTests.csproj] [/runtime/src/tests/build.proj]
/runtime/artifacts/tests/coreclr/obj/linux.riscv64.Release/Managed/ilverify/ILVerificationTests/XUnitWrapperGenerator/XUnitWrapperGenerator.XUnitWrapperGenerator/SimpleRunner.g.cs(23,13): error CS0030: Cannot convert type 'ILVerification.Tests.TestCase' to 'object[]' [/runtime/src/tests/ilverify/ILVerificationTests.csproj] [/runtime/src/tests/build.proj]
/runtime/src/tests/Common/dir.traversal.targets(25,5): error : (No message specified) [/runtime/src/tests/build.proj] [/runtime/src/tests/build.proj]
/runtime/src/tests/build.proj(629,5): error MSB3073: The command ""/runtime/dotnet.sh" msbuild /runtime/src/tests/build.proj /t:Build "/p:TargetArchitecture=riscv64" "/p:Configuration=Release" "/p:LibrariesConfiguration=Release" "/p:TasksConfiguration=Release" "/p:TargetOS=linux" "/p:ToolsOS=" "/p:PackageOS=" "/p:RuntimeFlavor=coreclr" "/p:RuntimeVariant=" "/p:CLRTestBuildAllTargets=" "/p:UseCodeFlowEnforcement=" "/p:__TestGroupToBuild=1" "/p:__SkipRestorePackages=1" /nodeReuse:false /maxcpucount /bl:/runtime/artifacts//log/Release/InnerManagedTestBuild.1.binlog "/p:CrossBuild=true"" exited with code 1.
    0 Warning(s)
    6 Error(s)
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung