### PR TITLE
[LoongArch64] Sync with PR#107282: Transfer arguments between calling conventions in shuffling thunks.

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1022,9 +1022,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                         varDsc->SetOtherArgReg(
                             genMapRegArgNumToRegNum(secondAllocatedRegArgNum, argRegTypeInStruct2, info.compCallConv));
 
-#ifdef TARGET_LOONGARCH64
                         varDsc->lvIsMultiRegArg = true;
-#endif
                     }
                     else if (cSlotsToEnregister > 1)
                     {
@@ -1047,9 +1045,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                         varDsc->SetOtherArgReg(
                             genMapRegArgNumToRegNum(firstAllocatedRegArgNum + 1, TYP_I_IMPL, info.compCallConv));
 
-#ifdef TARGET_LOONGARCH64
                         varDsc->lvIsMultiRegArg = true;
-#endif
                     }
 
                     assert(cSlots <= 2);

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1021,6 +1021,10 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                         secondAllocatedRegArgNum = varDscInfo->allocRegArg(argRegTypeInStruct2, 1);
                         varDsc->SetOtherArgReg(
                             genMapRegArgNumToRegNum(secondAllocatedRegArgNum, argRegTypeInStruct2, info.compCallConv));
+
+#ifdef TARGET_LOONGARCH64
+                        varDsc->lvIsMultiRegArg = true;
+#endif
                     }
                     else if (cSlotsToEnregister > 1)
                     {
@@ -1042,6 +1046,10 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                     {
                         varDsc->SetOtherArgReg(
                             genMapRegArgNumToRegNum(firstAllocatedRegArgNum + 1, TYP_I_IMPL, info.compCallConv));
+
+#ifdef TARGET_LOONGARCH64
+                        varDsc->lvIsMultiRegArg = true;
+#endif
                     }
 
                     assert(cSlots <= 2);

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -337,7 +337,7 @@ struct ShuffleGraphNode
 
 BOOL AddNextShuffleEntryToArray(ArgLocDesc sArgSrc, ArgLocDesc sArgDst, SArray<ShuffleEntry> * pShuffleEntryArray, ShuffleComputationType shuffleType)
 {
-#if defined(TARGET_RISCV64)
+#if defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
     if (sArgSrc.m_structFields.flags != sArgDst.m_structFields.flags)
     {
         _ASSERT(sArgSrc.m_structFields.flags == FpStruct::UseIntCallConv
@@ -347,7 +347,7 @@ BOOL AddNextShuffleEntryToArray(ArgLocDesc sArgSrc, ArgLocDesc sArgDst, SArray<S
         // calling conventions is handled by IL stubs.
         return FALSE;
     }
-#endif // TARGET_RISCV64
+#endif // TARGET_RISCV64 || TARGET_LOONGARCH64
 
     ShuffleEntry entry;
     ZeroMemory(&entry, sizeof(entry));
@@ -825,7 +825,7 @@ LoaderHeap *DelegateEEClass::GetStubHeap()
     return GetInvokeMethod()->GetLoaderAllocator()->GetStubHeap();
 }
 
-#if defined(TARGET_RISCV64)
+#if defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
 static Stub* CreateILDelegateShuffleThunk(MethodDesc* pDelegateMD, bool callTargetWithThis)
 {
     SigTypeContext typeContext(pDelegateMD);
@@ -885,7 +885,7 @@ static Stub* CreateILDelegateShuffleThunk(MethodDesc* pDelegateMD, bool callTarg
 
     return Stub::NewStub(JitILStub(pStubMD), NEWSTUB_FL_SHUFFLE_THUNK);
 }
-#endif // TARGET_RISCV64
+#endif // TARGET_RISCV64 || TARGET_LOONGARCH64
 
 static PCODE SetupShuffleThunk(MethodTable * pDelMT, MethodDesc *pTargetMeth)
 {
@@ -927,12 +927,12 @@ static PCODE SetupShuffleThunk(MethodTable * pDelMT, MethodDesc *pTargetMeth)
     }
     else
     {
-#if defined(TARGET_RISCV64)
+#if defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
         pShuffleThunk = CreateILDelegateShuffleThunk(pMD, isInstRetBuff);
 #else
         _ASSERTE(FALSE);
         return (PCODE)NULL;
-#endif // TARGET_RISCV64
+#endif // TARGET_RISCV64 || TARGET_LOONGARCH64
     }
 
     if (!pShuffleThunk)

--- a/src/coreclr/vm/loongarch64/cgencpu.h
+++ b/src/coreclr/vm/loongarch64/cgencpu.h
@@ -340,21 +340,6 @@ struct IntReg
     WORD Mask() const { return 1 << reg; }
 };
 
-struct FloatReg
-{
-    int reg;
-    FloatReg(int reg):reg(reg)
-    {
-        _ASSERTE(0 <= reg && reg < 32);
-    }
-
-    operator int () { return reg; }
-    operator int () const { return reg; }
-    int operator == (FloatReg other) { return reg == other.reg; }
-    int operator != (FloatReg other) { return reg != other.reg; }
-    WORD Mask() const { return 1 << reg; }
-};
-
 struct VecReg
 {
     int reg;
@@ -423,8 +408,6 @@ public:
     void EmitLoadStoreRegPairImm(DWORD flags, VecReg Vt1, VecReg Vt2, IntReg Xn, int offset=0);
 
     void EmitLoadStoreRegImm(DWORD flags, IntReg Rt, IntReg Rn, int offset=0, int log2Size = 3);
-
-    void EmitLoadFloatRegImm(FloatReg ft, IntReg base, int offset);
 };
 
 

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1187,7 +1187,7 @@ void StubLinkerCPU::EmitMovConstant(IntReg target, UINT64 constant)
 void StubLinkerCPU::EmitJumpRegister(IntReg regTarget)
 {
     // jirl $r0,$regTarget,0
-    Emit32(0x4c000000 | (regTarget.reg << 5));
+    Emit32(0x4c000000 | (regTarget << 5));
 }
 
 void StubLinkerCPU::EmitLoadStoreRegPairImm(DWORD flags, IntReg Rt1, IntReg Rt2, IntReg Rn, int offset)
@@ -1267,6 +1267,34 @@ void StubLinkerCPU::Init()
     //new (gLoadFromLabelIF) LoadFromLabelInstructionFormat();
 }
 
+static bool InRegister(UINT16 ofs)
+{
+    _ASSERTE(ofs != ShuffleEntry::SENTINEL);
+    return (ofs & ShuffleEntry::REGMASK);
+}
+
+static bool IsRegisterFloating(UINT16 ofs)
+{
+    _ASSERTE(InRegister(ofs));
+    return (ofs & ShuffleEntry::FPREGMASK);
+}
+
+static int GetRegister(UINT16 ofs)
+{
+    _ASSERTE(InRegister(ofs));
+    if (ofs & ShuffleEntry::FPREGMASK)
+    {
+        return (ofs & ShuffleEntry::OFSREGMASK);
+    }
+    return (ofs & ShuffleEntry::OFSREGMASK) + 4; // First GPR argument register: a0
+}
+
+static unsigned GetStackSlot(UINT16 ofs)
+{
+    _ASSERTE(!InRegister(ofs));
+    return ofs;
+}
+
 // Emits code to adjust arguments for static delegate target.
 VOID StubLinkerCPU::EmitShuffleThunk(ShuffleEntry *pShuffleEntryArray)
 {
@@ -1277,109 +1305,43 @@ VOID StubLinkerCPU::EmitShuffleThunk(ShuffleEntry *pShuffleEntryArray)
     // addi.d  t8, a0, DelegateObject::GetOffsetOfMethodPtrAux() - load the indirection cell into t8 used by ResolveWorkerAsmStub
     EmitAddImm(20/*$t8*/, 4, DelegateObject::GetOffsetOfMethodPtrAux());
 
-    int delay_index[8] = {-1};
-    bool is_store = false;
-    UINT16 index = 0;
-    int i = 0;
-    for (ShuffleEntry* pEntry = pShuffleEntryArray; pEntry->srcofs != ShuffleEntry::SENTINEL; pEntry++, i++)
+    const ShuffleEntry* entry = pShuffleEntryArray;
+    // Shuffle integer argument registers
+    for (; entry->srcofs != ShuffleEntry::SENTINEL && InRegister(entry->dstofs) && InRegister(entry->srcofs); ++entry)
     {
-        if (pEntry->srcofs & ShuffleEntry::REGMASK)
+        _ASSERTE(!IsRegisterFloating(entry->srcofs));
+        _ASSERTE(!IsRegisterFloating(entry->dstofs));
+        IntReg src = GetRegister(entry->srcofs);
+        IntReg dst = GetRegister(entry->dstofs);
+        _ASSERTE((src - dst) == 1 || (src - dst) == 2);
+        EmitMovReg(dst, src);
+    }
+
+    if (entry->srcofs != ShuffleEntry::SENTINEL)
+    {
+        _ASSERTE(!IsRegisterFloating(entry->dstofs));
+        _ASSERTE(GetStackSlot(entry->srcofs) == 0);
+        _ASSERTE(11/*a7*/ == GetRegister(entry->dstofs));
+        //  ld.d a7, sp, 0
+        EmitLoadStoreRegImm(eLOAD, IntReg(11)/*a7*/, RegSp, 0);
+        ++entry;
+
+        // All further shuffling is (stack) <- (stack+1)
+        for (unsigned dst = 0; entry->srcofs != ShuffleEntry::SENTINEL; ++entry, ++dst)
         {
-            // Source in register, destination in register
+            unsigned src = dst + 1;
+            _ASSERTE(src == GetStackSlot(entry->srcofs));
+            _ASSERTE(dst == GetStackSlot(entry->dstofs));
 
-            // Both the srcofs and dstofs must be of the same kind of registers - float or general purpose.
-            // If source is present in register then destination may be a stack-slot.
-            _ASSERTE(((pEntry->dstofs & ShuffleEntry::FPREGMASK) == (pEntry->srcofs & ShuffleEntry::FPREGMASK)) || !(pEntry->dstofs & (ShuffleEntry::FPREGMASK | ShuffleEntry::REGMASK)));
-            _ASSERTE((pEntry->dstofs & ShuffleEntry::OFSREGMASK) <= 8);//should amend for offset!
-            _ASSERTE((pEntry->srcofs & ShuffleEntry::OFSREGMASK) <= 8);
-
-            if (pEntry->srcofs & ShuffleEntry::FPREGMASK)
-            {
-                // FirstFloatReg is 0;
-                int j = 1;
-                while (pEntry[j].srcofs & ShuffleEntry::FPREGMASK)
-                {
-                    j++;
-                }
-                assert((pEntry->dstofs - pEntry->srcofs) == index);
-                assert(8 > index);
-
-                int tmp_reg = 11;//f11.
-                ShuffleEntry* tmp_entry = pShuffleEntryArray + delay_index[0];
-                while (index)
-                {
-                    // fld.d/s(Ft, sp, offset);
-                    Emit32(emitIns_O_R_R_I(0xae, tmp_reg++, 3/*sp*/, tmp_entry->srcofs << 3));
-
-                    index--;
-                    tmp_entry++;
-                }
-
-                j -= 1;
-                tmp_entry = pEntry + j;
-                i += j;
-                while (pEntry[j].srcofs & ShuffleEntry::FPREGMASK)
-                {
-                    if (pEntry[j].dstofs & ShuffleEntry::FPREGMASK)// fmov.d fd, fs
-                        Emit32(0x01149800 | (pEntry[j].dstofs & ShuffleEntry::OFSREGMASK) | ((pEntry[j].srcofs & ShuffleEntry::OFSREGMASK) << 5));
-                    else //// fst.d(Ft, Rn, offset);
-                        Emit32(emitIns_O_R_R_I(0xaf, (pEntry[j].srcofs & ShuffleEntry::OFSREGMASK), 3, pEntry[j].dstofs * sizeof(long)));
-                    j--;
-                }
-                while (tmp_reg > 11)
-                {
-                    tmp_reg--;
-                    // fmov.d fd, fs
-                    Emit32(0x01149800 | index | (tmp_reg << 5));
-                    index++;
-                }
-                index = 0;
-                pEntry = tmp_entry;
-            }
-            else
-            {
-                // 4 is the offset of FirstGenArgReg to FirstGenReg
-                assert(pEntry->dstofs & ShuffleEntry::REGMASK);
-                assert((pEntry->dstofs & ShuffleEntry::OFSMASK) < (pEntry->srcofs & ShuffleEntry::OFSMASK));
-                EmitMovReg(IntReg((pEntry->dstofs & ShuffleEntry::OFSMASK) + 4), IntReg((pEntry->srcofs & ShuffleEntry::OFSMASK) + 4));
-            }
-        }
-        else if (pEntry->dstofs & ShuffleEntry::REGMASK)
-        {
-            // source must be on the stack
-            _ASSERTE(!(pEntry->srcofs & ShuffleEntry::REGMASK));
-
-            if (pEntry->dstofs & ShuffleEntry::FPREGMASK)
-            {
-                if (!is_store)
-                {
-                    delay_index[index++] = i;
-                    continue;
-                }
-                EmitLoadFloatRegImm(FloatReg((pEntry->dstofs & ShuffleEntry::OFSREGMASK)), RegSp, pEntry->srcofs * sizeof(void*));
-            }
-            else
-            {
-                assert(pEntry->dstofs & ShuffleEntry::REGMASK);
-                EmitLoadStoreRegImm(eLOAD, IntReg((pEntry->dstofs & ShuffleEntry::OFSMASK) + 4), RegSp, pEntry->srcofs * sizeof(void*));
-            }
-        }
-        else
-        {
-            // source must be on the stack
-            _ASSERTE(!(pEntry->srcofs & ShuffleEntry::REGMASK));
-
-            // dest must be on the stack
-            _ASSERTE(!(pEntry->dstofs & ShuffleEntry::REGMASK));
-
-            EmitLoadStoreRegImm(eLOAD, IntReg(16)/*t4*/, RegSp, pEntry->srcofs * sizeof(void*));
-            EmitLoadStoreRegImm(eSTORE, IntReg(16)/*t4*/, RegSp, pEntry->dstofs * sizeof(void*));
+            //  ld.d t4, sp, src * sizeof(void*)
+            EmitLoadStoreRegImm(eLOAD, IntReg(16)/*t4*/, RegSp, src * sizeof(void*));
+            //  st.d t4, sp, dst * sizeof(void*)
+            EmitLoadStoreRegImm(eSTORE, IntReg(16)/*t4*/, RegSp, dst * sizeof(void*));
         }
     }
 
-    // Tailcall to target
     // jirl  $r0,$r21,0
-    EmitJumpRegister(21);
+    EmitJumpRegister(21); // Tailcall to target
 }
 
 // Emits code to adjust arguments for static delegate target.

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1282,10 +1282,7 @@ static bool IsRegisterFloating(UINT16 ofs)
 static int GetRegister(UINT16 ofs)
 {
     _ASSERTE(InRegister(ofs));
-    if (ofs & ShuffleEntry::FPREGMASK)
-    {
-        return (ofs & ShuffleEntry::OFSREGMASK);
-    }
+    _ASSERTE(!(ofs & ShuffleEntry::FPREGMASK));
     return (ofs & ShuffleEntry::OFSREGMASK) + 4; // First GPR argument register: a0
 }
 

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1240,13 +1240,6 @@ void StubLinkerCPU::EmitLoadStoreRegImm(DWORD flags, int regNum, IntReg Rn, int 
     }
 }
 
-void StubLinkerCPU::EmitLoadFloatRegImm(FloatReg ft, IntReg base, int offset)
-{
-    // fld.d ft,base,offset
-    _ASSERTE(offset <= 2047 && offset >= -2048);
-    Emit32(0x2b800000 | (base.reg << 5) | ((offset & 0xfff)<<10) | ft.reg);
-}
-
 void StubLinkerCPU::EmitMovReg(IntReg Rd, IntReg Rm)
 {
     // ori(Rd, Rm, 0);


### PR DESCRIPTION
[LoongArch64] Sync with [PR#107282](https://github.com/dotnet/runtime/pull/107282): Transfer arguments between calling conventions in shuffling thunks.
* Set 'varDsc->lvIsMultiRegArg = true' when passing struct with two regs in 'Compiler::lvaInitUserArgs()' to avoid changing passing struct with two regs into one regs in Prolog.