### PR TITLE
JIT: Read back all replacements before statements with implicit EH control flow

### DIFF
--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -290,6 +290,7 @@ private:
     bool VisitOverlappingReplacements(unsigned lcl, unsigned offs, unsigned size, Func func);
 
     void      InsertPreStatementReadBacks();
+    void      InsertPreStatementReadBackIfNecessary(unsigned aggLclNum, Replacement& rep);
     void      InsertPreStatementWriteBacks();
     GenTree** InsertMidTreeReadBacks(GenTree** use);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_108969/Runtime_108969.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_108969/Runtime_108969.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_108969
+{
+    [Fact]
+    public static int TestEntryPoint() => Foo(null);
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Foo(object o)
+    {
+        S v = default;
+        try
+        {
+            v = Bar();
+
+            // "(int?)o" creates a QMARK with a branch that may throw; we would
+            // end up reading back v.A inside the QMARK
+            Use((int?)o);
+        }
+        catch (Exception)
+        {
+        }
+
+        // Induce promotion of v.A field
+        Use(v.A);
+        Use(v.A);
+        Use(v.A);
+        Use(v.A);
+        Use(v.A);
+        Use(v.A);
+        return v.A;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static S Bar()
+    {
+        return new S { A = 100 };
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Use<T>(T x)
+    {
+    }
+
+    private struct S
+    {
+        public int A, B, C, D;
+    }
+
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_108969/Runtime_108969.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_108969/Runtime_108969.cs
@@ -52,5 +52,4 @@ public class Runtime_108969
     {
         public int A, B, C, D;
     }
-
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_108969/Runtime_108969.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_108969/Runtime_108969.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Physical promotion sometimes needs to insert read backs of all stale
pending replacements when it encounters potential implicit EH control
flow (that is, intra-function control flow because of locally caught
exceptions). It would be possible for this to interact with QMARKs such
that we inserted readbacks inside one of the branches, yet believed we
had read back the replacement on all paths.

The fix here is to indiscriminately start reading back all replacements
before a statement that may cause potential intra-function control flow
to occur.

Fix #108969