### PR TITLE
Permit unencrypted key exports from CNG

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSACng.ImportExport.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSACng.ImportExport.cs
@@ -310,7 +310,9 @@ namespace System.Security.Cryptography
 
         public override DSAParameters ExportParameters(bool includePrivateParameters)
         {
-            if (includePrivateParameters && EncryptedOnlyExport)
+            bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(Key);
+
+            if (includePrivateParameters && encryptedOnlyExport)
             {
                 const string TemporaryExportPassword = "DotnetExportPhrase";
                 byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
@@ -433,15 +435,6 @@ namespace System.Security.Cryptography
             {
                 if (magic != KeyBlobMagicNumber.BCRYPT_DSA_PUBLIC_MAGIC && magic != KeyBlobMagicNumber.BCRYPT_DSA_PUBLIC_MAGIC_V2)
                     throw new CryptographicException(SR.Cryptography_NotValidPublicOrPrivateKey);
-            }
-        }
-
-        private bool EncryptedOnlyExport
-        {
-            get
-            {
-                const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
-                return (Key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
             }
         }
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.ImportExport.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.ImportExport.cs
@@ -66,50 +66,12 @@ namespace System.Security.Cryptography
 
         public override ECParameters ExportExplicitParameters(bool includePrivateParameters)
         {
-            byte[] blob = ExportFullKeyBlob(includePrivateParameters);
-
-            try
-            {
-                ECParameters ecparams = default;
-                ECCng.ExportPrimeCurveParameters(ref ecparams, blob, includePrivateParameters);
-                return ecparams;
-            }
-            finally
-            {
-                Array.Clear(blob);
-            }
+            return ECCng.ExportExplicitParameters(Key, includePrivateParameters);
         }
 
         public override ECParameters ExportParameters(bool includePrivateParameters)
         {
-            ECParameters ecparams = default;
-
-            string? curveName = GetCurveName(out string? oidValue);
-            byte[]? blob = null;
-
-            try
-            {
-                if (string.IsNullOrEmpty(curveName))
-                {
-                    blob = ExportFullKeyBlob(includePrivateParameters);
-                    ECCng.ExportPrimeCurveParameters(ref ecparams, blob, includePrivateParameters);
-                }
-                else
-                {
-                    blob = ExportKeyBlob(includePrivateParameters);
-                    ECCng.ExportNamedCurveParameters(ref ecparams, blob, includePrivateParameters);
-                    ecparams.Curve = ECCurve.CreateFromOid(new Oid(oidValue, curveName));
-                }
-
-                return ecparams;
-            }
-            finally
-            {
-                if (blob != null)
-                {
-                    Array.Clear(blob);
-                }
-            }
+            return ECCng.ExportParameters(Key, includePrivateParameters);
         }
 
         public override void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead)

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaCng.ImportExport.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaCng.ImportExport.cs
@@ -130,7 +130,7 @@ namespace System.Security.Cryptography
             }
             else
             {
-                if (includePrivateParameters && PlaintextOnlyExport)
+                if (includePrivateParameters && EncryptedOnlyExport)
                 {
                     byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
                     EccKeyFormatHelper.ReadEncryptedPkcs8(
@@ -293,7 +293,7 @@ namespace System.Security.Cryptography
                 out bytesWritten);
         }
 
-        private bool PlaintextOnlyExport
+        private bool EncryptedOnlyExport
         {
             get
             {
@@ -306,7 +306,7 @@ namespace System.Security.Cryptography
         {
             ECParameters ecparams = default;
 
-            if (PlaintextOnlyExport)
+            if (EncryptedOnlyExport)
             {
                 // We can't ask CNG for the explicit parameters when performing a PKCS#8 export. Instead,
                 // we ask CNG for the explicit parameters for the public part only, since the parameters are public.

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -180,7 +180,9 @@ namespace System.Security.Cryptography
         /// </summary>
         public override RSAParameters ExportParameters(bool includePrivateParameters)
         {
-            if (includePrivateParameters && EncryptedOnlyExport)
+            bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(Key);
+
+            if (includePrivateParameters && encryptedOnlyExport)
             {
                 const string TemporaryExportPassword = "DotnetExportPhrase";
                 byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
@@ -196,15 +198,6 @@ namespace System.Security.Cryptography
             RSAParameters rsaParams = default;
             rsaParams.FromBCryptBlob(rsaBlob, includePrivateParameters);
             return rsaParams;
-        }
-
-        private bool EncryptedOnlyExport
-        {
-            get
-            {
-                const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
-                return (Key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
-            }
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -180,7 +180,7 @@ namespace System.Security.Cryptography
         /// </summary>
         public override RSAParameters ExportParameters(bool includePrivateParameters)
         {
-            if (includePrivateParameters && PlaintextOnlyExport)
+            if (includePrivateParameters && EncryptedOnlyExport)
             {
                 const string TemporaryExportPassword = "DotnetExportPhrase";
                 byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
@@ -198,7 +198,7 @@ namespace System.Security.Cryptography
             return rsaParams;
         }
 
-        private bool PlaintextOnlyExport
+        private bool EncryptedOnlyExport
         {
             get
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngPkcs8.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngPkcs8.cs
@@ -43,5 +43,11 @@ namespace System.Security.Cryptography
                 Key = key,
             };
         }
+
+        internal static bool AllowsOnlyEncryptedExport(CngKey key)
+        {
+            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
+            return (key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSACng.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSACng.ImportExport.cs
@@ -50,6 +50,18 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
+             if (EncryptedOnlyExport)
+            {
+                const string TemporaryExportPassword = "DotnetExportPhrase";
+                byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
+                DSAKeyFormatHelper.ReadEncryptedPkcs8(
+                    exported,
+                    TemporaryExportPassword,
+                    out _,
+                    out DSAParameters dsaParameters);
+                return DSAKeyFormatHelper.WritePkcs8(dsaParameters).TryEncode(destination, out bytesWritten);
+            }
+
             return Key.TryExportKeyBlob(
                 Interop.NCrypt.NCRYPT_PKCS8_PRIVATE_KEY_BLOB,
                 destination,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSACng.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSACng.ImportExport.cs
@@ -50,7 +50,9 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
-             if (EncryptedOnlyExport)
+            bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(Key);
+
+            if (encryptedOnlyExport)
             {
                 const string TemporaryExportPassword = "DotnetExportPhrase";
                 byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECCng.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECCng.ImportExport.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using static Interop.BCrypt;
 
 namespace System.Security.Cryptography
@@ -75,6 +76,101 @@ namespace System.Security.Cryptography
             }
 
             return blob;
+        }
+
+        internal static ECParameters ExportExplicitParameters(CngKey key, bool includePrivateParameters)
+        {
+            if (includePrivateParameters)
+            {
+                return ExportPrivateExplicitParameters(key);
+            }
+            else
+            {
+                byte[] blob = ExportFullKeyBlob(key, includePrivateParameters: false);
+                ECParameters ecparams = default;
+                ExportPrimeCurveParameters(ref ecparams, blob, includePrivateParameters: false);
+                return ecparams;
+            }
+        }
+
+        internal static ECParameters ExportParameters(CngKey key, bool includePrivateParameters)
+        {
+            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
+            bool encryptedOnlyExport = (key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+            ECParameters ecparams = default;
+
+            const string TemporaryExportPassword = "DotnetExportPhrase";
+            string? curveName = key.GetCurveName(out string? oidValue);
+
+            if (string.IsNullOrEmpty(curveName))
+            {
+                if (includePrivateParameters)
+                {
+                    ecparams = ExportPrivateExplicitParameters(key);
+                }
+                else
+                {
+                    byte[] fullKeyBlob = ExportFullKeyBlob(key, includePrivateParameters: false);
+                    ECCng.ExportPrimeCurveParameters(ref ecparams, fullKeyBlob, includePrivateParameters: false);
+                }
+            }
+            else
+            {
+                if (includePrivateParameters && encryptedOnlyExport)
+                {
+                    byte[] exported = key.ExportPkcs8KeyBlob(TemporaryExportPassword, 1);
+                    EccKeyFormatHelper.ReadEncryptedPkcs8(
+                        exported,
+                        TemporaryExportPassword,
+                        out _,
+                        out ecparams);
+                }
+                else
+                {
+                    byte[] keyBlob = ExportKeyBlob(key, includePrivateParameters);
+                    ECCng.ExportNamedCurveParameters(ref ecparams, keyBlob, includePrivateParameters);
+                    ecparams.Curve = ECCurve.CreateFromOid(new Oid(oidValue, curveName));
+                }
+            }
+
+            return ecparams;
+        }
+
+        private static ECParameters ExportPrivateExplicitParameters(CngKey key)
+        {
+            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
+            bool encryptedOnlyExport = (key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+
+            ECParameters ecparams = default;
+
+            if (encryptedOnlyExport)
+            {
+                // We can't ask CNG for the explicit parameters when performing a PKCS#8 export. Instead,
+                // we ask CNG for the explicit parameters for the public part only, since the parameters are public.
+                // Then we ask CNG by encrypted PKCS#8 for the private parameters (D) and combine the explicit public
+                // key along with the private key.
+                const string TemporaryExportPassword = "DotnetExportPhrase";
+                byte[] publicKeyBlob = ExportFullKeyBlob(key, includePrivateParameters: false);
+                ExportPrimeCurveParameters(ref ecparams, publicKeyBlob, includePrivateParameters: false);
+
+                byte[] exported = key.ExportPkcs8KeyBlob(TemporaryExportPassword, 1);
+                EccKeyFormatHelper.ReadEncryptedPkcs8(
+                    exported,
+                    TemporaryExportPassword,
+                    out _,
+                    out ECParameters localParameters);
+
+                Debug.Assert(ecparams.Q.X.AsSpan().SequenceEqual(localParameters.Q.X));
+                Debug.Assert(ecparams.Q.Y.AsSpan().SequenceEqual(localParameters.Q.Y));
+                ecparams.D = localParameters.D;
+            }
+            else
+            {
+                byte[] blob = ExportFullKeyBlob(key, includePrivateParameters: true);
+                ExportPrimeCurveParameters(ref ecparams, blob, includePrivateParameters: true);
+            }
+
+            return ecparams;
         }
 
         private static unsafe void FixupGenericBlob(byte[] blob)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECCng.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECCng.ImportExport.cs
@@ -95,8 +95,6 @@ namespace System.Security.Cryptography
 
         internal static ECParameters ExportParameters(CngKey key, bool includePrivateParameters)
         {
-            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
-            bool encryptedOnlyExport = (key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
             ECParameters ecparams = default;
 
             const string TemporaryExportPassword = "DotnetExportPhrase";
@@ -116,6 +114,8 @@ namespace System.Security.Cryptography
             }
             else
             {
+                bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(key);
+
                 if (includePrivateParameters && encryptedOnlyExport)
                 {
                     byte[] exported = key.ExportPkcs8KeyBlob(TemporaryExportPassword, 1);
@@ -138,8 +138,7 @@ namespace System.Security.Cryptography
 
         private static ECParameters ExportPrivateExplicitParameters(CngKey key)
         {
-            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
-            bool encryptedOnlyExport = (key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+            bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(key);
 
             ECParameters ecparams = default;
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
@@ -206,6 +206,21 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
+            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
+            bool encryptedOnlyExport = (Key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+
+            if (encryptedOnlyExport)
+            {
+                const string TemporaryExportPassword = "DotnetExportPhrase";
+                byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
+                EccKeyFormatHelper.ReadEncryptedPkcs8(
+                    exported,
+                    TemporaryExportPassword,
+                    out _,
+                    out ECParameters ecParameters);
+                return EccKeyFormatHelper.WritePkcs8PrivateKey(ecParameters).TryEncode(destination, out bytesWritten);
+            }
+
             return Key.TryExportKeyBlob(
                 Interop.NCrypt.NCRYPT_PKCS8_PRIVATE_KEY_BLOB,
                 destination,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
@@ -206,8 +206,7 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
-            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
-            bool encryptedOnlyExport = (Key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+            bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(Key);
 
             if (encryptedOnlyExport)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaCng.cs
@@ -151,8 +151,7 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
-            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
-            bool encryptedOnlyExport = (Key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+            bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(Key);
 
             if (encryptedOnlyExport)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaCng.cs
@@ -151,6 +151,21 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
+            const CngExportPolicies Exportable = CngExportPolicies.AllowPlaintextExport | CngExportPolicies.AllowExport;
+            bool encryptedOnlyExport = (Key.ExportPolicy & Exportable) == CngExportPolicies.AllowExport;
+
+            if (encryptedOnlyExport)
+            {
+                const string TemporaryExportPassword = "DotnetExportPhrase";
+                byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
+                EccKeyFormatHelper.ReadEncryptedPkcs8(
+                    exported,
+                    TemporaryExportPassword,
+                    out _,
+                    out ECParameters ecParameters);
+                return EccKeyFormatHelper.WritePkcs8PrivateKey(ecParameters).TryEncode(destination, out bytesWritten);
+            }
+
             return Key.TryExportKeyBlob(
                 Interop.NCrypt.NCRYPT_PKCS8_PRIVATE_KEY_BLOB,
                 destination,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -52,6 +52,18 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
+            if (PlaintextOnlyExport)
+            {
+                const string TemporaryExportPassword = "DotnetExportPhrase";
+                byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);
+                RSAKeyFormatHelper.ReadEncryptedPkcs8(
+                    exported,
+                    TemporaryExportPassword,
+                    out _,
+                    out RSAParameters rsaParameters);
+                return RSAKeyFormatHelper.WritePkcs8PrivateKey(rsaParameters).TryEncode(destination, out bytesWritten);
+            }
+
             return Key.TryExportKeyBlob(
                 Interop.NCrypt.NCRYPT_PKCS8_PRIVATE_KEY_BLOB,
                 destination,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -52,7 +52,9 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
-            if (EncryptedOnlyExport)
+            bool encryptedOnlyExport = CngPkcs8.AllowsOnlyEncryptedExport(Key);
+
+            if (encryptedOnlyExport)
             {
                 const string TemporaryExportPassword = "DotnetExportPhrase";
                 byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography
 
         public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
-            if (PlaintextOnlyExport)
+            if (EncryptedOnlyExport)
             {
                 const string TemporaryExportPassword = "DotnetExportPhrase";
                 byte[] exported = ExportEncryptedPkcs8(TemporaryExportPassword, 1);

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Security.Cryptography.Dsa.Tests;
 using System.Security.Cryptography.EcDsa.Tests;
 using System.Security.Cryptography.Pkcs;
 using Xunit;
@@ -379,7 +380,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
                 using RSA key = cert.GetRSAPrivateKey();
-                byte[] exported = rsa.ExportPkcs8PrivateKey();
+                byte[] exported = key.ExportPkcs8PrivateKey();
 
                 using RSA imported = RSA.Create();
                 imported.ImportPkcs8PrivateKey(exported, out _);
@@ -401,7 +402,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
                 using ECDsa key = cert.GetECDsaPrivateKey();
-                byte[] exported = ecdsa.ExportPkcs8PrivateKey();
+                byte[] exported = key.ExportPkcs8PrivateKey();
 
                 using ECDsa imported = ECDsa.Create();
                 imported.ImportPkcs8PrivateKey(exported, out _);
@@ -441,44 +442,168 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void ECDH_Export_DefaultKeyStorePermitsUnencryptedExports_ExportParameters(bool explicitParameters)
+        {
+            if (explicitParameters && !ECDsaFactory.ExplicitCurvesSupported)
+            {
+                return;
+            }
+
+            (byte[] pkcs12, ECDiffieHellman ecdh) = CreateSimplePkcs12<ECDiffieHellman>();
+
+            using (ecdh)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using ECDiffieHellman key = cert.GetECDiffieHellmanPrivateKey();
+
+                ECParameters actual = explicitParameters ? key.ExportExplicitParameters(true) : key.ExportParameters(true);
+                ECParameters expected = explicitParameters ? ecdh.ExportExplicitParameters(true) : ecdh.ExportParameters(true);
+
+                Assert.Equal(expected.D, actual.D);
+                Assert.Equal(expected.Q.X, actual.Q.X);
+                Assert.Equal(expected.Q.Y, actual.Q.Y);
+            }
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void ECDH_Export_DefaultKeyStorePermitsUnencryptedExports_Pkcs8PrivateKey()
+        {
+            (byte[] pkcs12, ECDiffieHellman ecdh) = CreateSimplePkcs12<ECDiffieHellman>();
+
+            using (ecdh)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using ECDiffieHellman key = cert.GetECDiffieHellmanPrivateKey();
+                byte[] exported = key.ExportPkcs8PrivateKey();
+
+                using ECDiffieHellman imported = ECDiffieHellman.Create();
+                imported.ImportPkcs8PrivateKey(exported, out _);
+                ECParameters actual = imported.ExportParameters(true);
+                ECParameters expected = ecdh.ExportParameters(true);
+
+                Assert.Equal(expected.D, actual.D);
+                Assert.Equal(expected.Q.X, actual.Q.X);
+                Assert.Equal(expected.Q.Y, actual.Q.Y);
+            }
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void DSA_Export_DefaultKeyStorePermitsUnencryptedExports_ExportParameters()
+        {
+            (byte[] pkcs12, DSA dsa) = CreateSimplePkcs12<DSA>();
+
+            using (dsa)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using DSA key = cert.GetDSAPrivateKey();
+                DSAParameters expected = dsa.ExportParameters(true);
+                DSAParameters actual = key.ExportParameters(true);
+
+                Assert.Equal(expected.X, actual.X);
+            }
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void DSA_Export_DefaultKeyStorePermitsUnencryptedExports_Pkcs8PrivateKey()
+        {
+            (byte[] pkcs12, DSA dsa) = CreateSimplePkcs12<DSA>();
+
+            using (dsa)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using DSA key = cert.GetDSAPrivateKey();
+                byte[] exported = key.ExportPkcs8PrivateKey();
+
+                using DSA imported = DSA.Create();
+                imported.ImportPkcs8PrivateKey(exported, out _);
+                DSAParameters actual = imported.ExportParameters(true);
+                DSAParameters expected = dsa.ExportParameters(true);
+
+                Assert.Equal(expected.X, actual.X);
+            }
+        }
+
         private static (byte[] Pkcs12, TKey key) CreateSimplePkcs12<TKey>() where TKey : AsymmetricAlgorithm
         {
-            CertificateRequest req;
-            TKey key;
-
-            if (typeof(TKey) == typeof(ECDsa))
+            using (ECDsa ca = ECDsa.Create(ECCurve.NamedCurves.nistP256))
             {
-                ECDsa ecKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
-                req = new("CN=simple", ecKey, HashAlgorithmName.SHA256);
-                key = (TKey)(object)ecKey;
-            }
-            else if (typeof(TKey) == typeof(RSA))
-            {
-                RSA rsaKey = RSA.Create(2048);
-                req = new("CN=simple", rsaKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-                key = (TKey)(object)rsaKey;
-            }
-            else
-            {
-                throw new InvalidOperationException();
-            }
+                CertificateRequest issuerRequest = new CertificateRequest(
+                    new X500DistinguishedName("CN=root"),
+                    ca,
+                    HashAlgorithmName.SHA256);
 
-            using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(30));
-            Pkcs9LocalKeyId keyId = new([1]);
-            PbeParameters pbe = new(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 1);
+                issuerRequest.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(true, false, 0, true));
 
-            Pkcs12Builder builder = new();
-            Pkcs12SafeContents certContainer = new();
-            Pkcs12SafeContents keyContainer = new();
-            Pkcs12SafeBag certBag = certContainer.AddCertificate(cert);
-            Pkcs12SafeBag keyBag = keyContainer.AddShroudedKey(key, "", pbe);
-            certBag.Attributes.Add(keyId);
-            keyBag.Attributes.Add(keyId);
-            builder.AddSafeContentsEncrypted(certContainer, "", pbe);
-            builder.AddSafeContentsUnencrypted(keyContainer);
+                DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+                DateTimeOffset notAfter = notBefore.AddDays(30);
+                byte[] serial = [1, 2, 3, 4, 5, 6, 7, 8];
+                X509SignatureGenerator generator = X509SignatureGenerator.CreateForECDsa(ca);
 
-            builder.SealWithMac("", pbe.HashAlgorithm, pbe.IterationCount);
-            return (builder.Encode(), key);
+                using (X509Certificate2 issuer = issuerRequest.CreateSelfSigned(notBefore, notAfter))
+                {
+                    CertificateRequest req;
+                    TKey key;
+
+                    if (typeof(TKey) == typeof(ECDsa))
+                    {
+                        ECDsa ecKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+                        req = new("CN=simple", ecKey, HashAlgorithmName.SHA256);
+                        key = (TKey)(object)ecKey;
+                    }
+                    else if (typeof(TKey) == typeof(RSA))
+                    {
+                        RSA rsaKey = RSA.Create(2048);
+                        req = new("CN=simple", rsaKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                        key = (TKey)(object)rsaKey;
+                    }
+                    else if (typeof(TKey) == typeof(ECDiffieHellman))
+                    {
+                        ECDiffieHellman ecKey = ECDiffieHellman.Create(ECCurve.NamedCurves.nistP256);
+                        req = new CertificateRequest(new X500DistinguishedName("CN=simple"), new PublicKey(ecKey), HashAlgorithmName.SHA256);
+                        req.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyAgreement, true));
+                        key = (TKey)(object)ecKey;
+                    }
+                    else if (typeof(TKey) == typeof(DSA))
+                    {
+                        DSA dsaKey = DSA.Create();
+                        dsaKey.ImportParameters(DSATestData.GetDSA1024Params());
+                        req = new CertificateRequest(new X500DistinguishedName("CN=simple"), new PublicKey(dsaKey), HashAlgorithmName.SHA256);
+                        req.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true));
+                        key = (TKey)(object)dsaKey;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    req.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, true));
+
+                    using X509Certificate2 cert = req.Create(issuer.SubjectName, generator, notBefore, notAfter, serial);
+                    Pkcs9LocalKeyId keyId = new([1]);
+                    PbeParameters pbe = new(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 1);
+
+                    Pkcs12Builder builder = new();
+                    Pkcs12SafeContents certContainer = new();
+                    Pkcs12SafeContents keyContainer = new();
+                    Pkcs12SafeBag certBag = certContainer.AddCertificate(cert);
+                    Pkcs12SafeBag keyBag = keyContainer.AddShroudedKey(key, "", pbe);
+                    certBag.Attributes.Add(keyId);
+                    keyBag.Attributes.Add(keyId);
+                    builder.AddSafeContentsEncrypted(certContainer, "", pbe);
+                    builder.AddSafeContentsUnencrypted(keyContainer);
+
+                    builder.SealWithMac("", pbe.HashAlgorithm, pbe.IterationCount);
+                    return (builder.Encode(), key);
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -539,8 +539,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     ca,
                     HashAlgorithmName.SHA256);
 
-                issuerRequest.CertificateExtensions.Add(
-                    new X509BasicConstraintsExtension(true, false, 0, true));
+                issuerRequest.CertificateExtensions.Add(X509BasicConstraintsExtension.CreateForCertificateAuthority());
 
                 DateTimeOffset notBefore = DateTimeOffset.UtcNow;
                 DateTimeOffset notAfter = notBefore.AddDays(30);

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Security.Cryptography.EcDsa.Tests;
 using System.Security.Cryptography.Pkcs;
 using Xunit;
 
@@ -419,6 +420,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
         public static void ECDsa_Export_DefaultKeyStorePermitsUnencryptedExports_ExportParameters(bool explicitParameters)
         {
+            if (explicitParameters && !ECDsaFactory.ExplicitCurvesSupported)
+            {
+                return;
+            }
+
             (byte[] pkcs12, ECDsa ecdsa) = CreateSimplePkcs12<ECDsa>();
 
             using (ecdsa)

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Security.Cryptography.Pkcs;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
@@ -347,6 +348,131 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 string pem = cert.ExportCertificatePem();
                 Assert.Equal(TestData.CertRfc7468Wrapped, pem);
             }
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void RSA_Export_DefaultKeyStorePermitsUnencryptedExports_ExportParameters()
+        {
+            (byte[] pkcs12, RSA rsa) = CreateSimplePkcs12<RSA>();
+
+            using (rsa)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using RSA key = cert.GetRSAPrivateKey();
+                RSAParameters expected = rsa.ExportParameters(true);
+                RSAParameters actual = key.ExportParameters(true);
+
+                Assert.Equal(expected.Modulus, actual.Modulus);
+                Assert.Equal(expected.D, actual.D);
+            }
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void RSA_Export_DefaultKeyStorePermitsUnencryptedExports_Pkcs8PrivateKey()
+        {
+            (byte[] pkcs12, RSA rsa) = CreateSimplePkcs12<RSA>();
+
+            using (rsa)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using RSA key = cert.GetRSAPrivateKey();
+                byte[] exported = rsa.ExportPkcs8PrivateKey();
+
+                using RSA imported = RSA.Create();
+                imported.ImportPkcs8PrivateKey(exported, out _);
+                RSAParameters actual = imported.ExportParameters(true);
+                RSAParameters expected = rsa.ExportParameters(true);
+
+                Assert.Equal(expected.Modulus, actual.Modulus);
+                Assert.Equal(expected.D, actual.D);
+            }
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void ECDsa_Export_DefaultKeyStorePermitsUnencryptedExports_Pkcs8PrivateKey()
+        {
+            (byte[] pkcs12, ECDsa ecdsa) = CreateSimplePkcs12<ECDsa>();
+
+            using (ecdsa)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using ECDsa key = cert.GetECDsaPrivateKey();
+                byte[] exported = ecdsa.ExportPkcs8PrivateKey();
+
+                using ECDsa imported = ECDsa.Create();
+                imported.ImportPkcs8PrivateKey(exported, out _);
+                ECParameters actual = imported.ExportParameters(true);
+                ECParameters expected = ecdsa.ExportParameters(true);
+
+                Assert.Equal(expected.D, actual.D);
+                Assert.Equal(expected.Q.X, actual.Q.X);
+                Assert.Equal(expected.Q.Y, actual.Q.Y);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "The PKCS#12 Exportable flag is not supported on iOS/MacCatalyst/tvOS")]
+        public static void ECDsa_Export_DefaultKeyStorePermitsUnencryptedExports_ExportParameters(bool explicitParameters)
+        {
+            (byte[] pkcs12, ECDsa ecdsa) = CreateSimplePkcs12<ECDsa>();
+
+            using (ecdsa)
+            {
+                using X509Certificate2 cert = new X509Certificate2(pkcs12, "", X509KeyStorageFlags.Exportable);
+                using ECDsa key = cert.GetECDsaPrivateKey();
+
+                ECParameters actual = explicitParameters ? key.ExportExplicitParameters(true) : key.ExportParameters(true);
+                ECParameters expected = explicitParameters ? ecdsa.ExportExplicitParameters(true) : ecdsa.ExportParameters(true);
+
+                Assert.Equal(expected.D, actual.D);
+                Assert.Equal(expected.Q.X, actual.Q.X);
+                Assert.Equal(expected.Q.Y, actual.Q.Y);
+            }
+        }
+
+        private static (byte[] Pkcs12, TKey key) CreateSimplePkcs12<TKey>() where TKey : AsymmetricAlgorithm
+        {
+            CertificateRequest req;
+            TKey key;
+
+            if (typeof(TKey) == typeof(ECDsa))
+            {
+                ECDsa ecKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+                req = new("CN=simple", ecKey, HashAlgorithmName.SHA256);
+                key = (TKey)(object)ecKey;
+            }
+            else if (typeof(TKey) == typeof(RSA))
+            {
+                RSA rsaKey = RSA.Create(2048);
+                req = new("CN=simple", rsaKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                key = (TKey)(object)rsaKey;
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+
+            using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(30));
+            Pkcs9LocalKeyId keyId = new([1]);
+            PbeParameters pbe = new(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 1);
+
+            Pkcs12Builder builder = new();
+            Pkcs12SafeContents certContainer = new();
+            Pkcs12SafeContents keyContainer = new();
+            Pkcs12SafeBag certBag = certContainer.AddCertificate(cert);
+            Pkcs12SafeBag keyBag = keyContainer.AddShroudedKey(key, "", pbe);
+            certBag.Attributes.Add(keyId);
+            keyBag.Attributes.Add(keyId);
+            builder.AddSafeContentsEncrypted(certContainer, "", pbe);
+            builder.AddSafeContentsUnencrypted(keyContainer);
+
+            builder.SealWithMac("", pbe.HashAlgorithm, pbe.IterationCount);
+            return (builder.Encode(), key);
         }
     }
 }


### PR DESCRIPTION
CNG, by default, loads PKCS#12 certificate private keys as "AllowExport", not "AllowsPlaintextExport". When users attempt to export the private key from a loaded PKCS#12, they will receive an error that the operation is not permitted because they are expected to perform an encrypted export.

This is counter-intuitive to some people, as the general expectation is that they can export private keys they just loaded. Starting in .NET 9, we are loading more PKCS#12 private keys in CNG instead of the legacy CSP, meaning users will hit this problem more. This is also a regression from .NET 8. The default provider changed, meaning keys that were once exportable no longer are.

This pull request makes a change similar to what we do for macOS. If a user asks for an unencrypted export of the private key, and the key does not permit that, we will ask CNG for an encrypted export of the private key and decrypt it for them. This makes the unencrypted exports "just work", as they do on other platforms.

Fixes #109059