### PR TITLE
[ActivityInfo] Avoid writing extra byte by updating length

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -464,6 +464,7 @@ namespace System.Diagnostics.Tracing
                         {
                             // Indicate this is a 1 byte multicode with 4 high order bits in the lower nibble.
                             *ptr = (byte)(((uint)NumberListCodes.MultiByte1 << 4) + (id >> 8));
+                            len--;          // The id's 4 high order bits were written into the multicode byte, so update the length.
                             id &= 0xFF;     // Now we only want the low order bits.
                         }
                         ptr++;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/109078

It was discovered that in some scenarios, the ActivityTracker.AddIdToGuid method's optimization logic fails to update the number of encoded bytes counter for (0xFF, 0xFFF] IDs. As a result, an extra 0x00 byte is encoded in the Guid, which is interpreted as the end of the list.

This PR updates the `len` variable accordingly, so only one byte is written after bundling the (0xFF, 0xFFF] ID's 4 high order bits into the multicode indicating byte.

Before
`1/4/2000/1` -> `14` `c7` `d0` `00` `10`

After
`1/4/2000/1` -> `14` `c7` `d0` `10`