### PR TITLE
[release/8.0] Fix stress-http pipeline

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -128,6 +128,10 @@ extends:
           displayName: Build CLR and Libraries
 
         - powershell: |
+            $env:CLIENT_DUMPS_SHARE="$(Build.ArtifactStagingDirectory)/dumps/client/"
+            $env:SERVER_DUMPS_SHARE="$(Build.ArtifactStagingDirectory)/dumps/server/"
+            New-Item -Force $env:CLIENT_DUMPS_SHARE -ItemType Directory
+            New-Item -Force $env:SERVER_DUMPS_SHARE -ItemType Directory
             $(httpStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
             echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
           name: buildStress

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -38,7 +38,7 @@ extends:
           DUMPS_SHARE_MOUNT_ROOT: "/dumps-share"
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-2204-open
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
         steps:
         - checkout: self

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/run-docker-compose.ps1
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/run-docker-compose.ps1
@@ -16,6 +16,13 @@ Param(
 $REPO_ROOT_DIR = $(git -C "$PSScriptRoot" rev-parse --show-toplevel)
 $COMPOSE_FILE = "$PSScriptRoot/docker-compose.yml"
 
+# This is a workaround for an issue with 1es-windows-2022-open, which should be eventually removed.
+# See comments in <repo>/eng/pipelines/libraries/stress/http.yml for more info.
+$dockerComposeCmd = $env:DOCKER_COMPOSE_CMD
+if (!(Test-Path $dockerComposeCmd)) {
+    $dockerComposeCmd = "docker-compose"
+}
+
 # Build runtime libraries and place in a docker image
 
 if ($buildCurrentLibraries)
@@ -60,7 +67,7 @@ if ($useWindowsContainers)
 $originalErrorPreference = $ErrorActionPreference
 $ErrorActionPreference = 'Continue'
 try {
-	docker-compose --log-level DEBUG --file "$COMPOSE_FILE" build $BUILD_ARGS.Split() 2>&1 | ForEach-Object { "$_" }
+	& $dockerComposeCmd --log-level DEBUG --file "$COMPOSE_FILE" build $BUILD_ARGS.Split() 2>&1 | ForEach-Object { "$_" }
 	if ($LASTEXITCODE -ne 0) {
 		throw "docker-compose exited with error code $LASTEXITCODE"
 	}
@@ -89,5 +96,5 @@ if (!$buildOnly)
 
     $env:HTTPSTRESS_CLIENT_ARGS = $clientStressArgs
     $env:HTTPSTRESS_SERVER_ARGS = $serverStressArgs
-    docker-compose --file "$COMPOSE_FILE" up --abort-on-container-exit
+    & $dockerComposeCmd --file "$COMPOSE_FILE" up --abort-on-container-exit
 }


### PR DESCRIPTION
Fixes regular `runtime-libraries stress-http` runs

## Customer Impact

- [ ] Customer reported
- [x] Found internally

None, test-only change

## Regression

- [ ] Yes
- [x] No

## Testing

stress-http pipeline runs green on this PR.

## Risk

Low, test-only change.
