### PR TITLE
Bump Android devcontainer from Jammy to Noble

### DIFF
--- a/.devcontainer/android/Dockerfile
+++ b/.devcontainer/android/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="8.0-jammy"
+ARG VARIANT="8.0-noble"
 FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 
 # Set up machine requirements to build the repo

--- a/.devcontainer/android/devcontainer.json
+++ b/.devcontainer/android/devcontainer.json
@@ -4,7 +4,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VARIANT": "8.0-jammy"
+			"VARIANT": "8.0-noble"
 		}
 	},
     // The container needs to run privileged in order to use Linux KVM to create Android emulators.


### PR DESCRIPTION
At some point, the Android build started requiring Clang 17 or newer. Ubuntu Jammy has Clang 14, so building Android in the codespace is broken currently.

This bumps the Android dev container to use Noble, which has Clang 18.1.

Here is a screenshot of the Android Codespace running System.IO.Hashing tests on the noble image.

<img width="1062" alt="Screenshot 2024-10-23 at 12 41 31 PM" src="https://github.com/user-attachments/assets/6ebde935-eefd-481c-a80f-cdb20b5004cb">
