### PR TITLE
Fix ForceUTF8Encoding to only apply to certain AttributeTypes

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
@@ -105,11 +105,17 @@ namespace System.Security.Cryptography
 
         // X500 Names
         internal const string CommonName = "2.5.4.3";
+        internal const string Surname = "2.5.4.4";
         internal const string CountryOrRegionName = "2.5.4.6";
         internal const string LocalityName = "2.5.4.7";
         internal const string StateOrProvinceName = "2.5.4.8";
+        internal const string Street = "2.5.4.9";
         internal const string Organization = "2.5.4.10";
         internal const string OrganizationalUnit = "2.5.4.11";
+        internal const string Title = "2.5.4.12";
+        internal const string GivenName = "2.5.4.42";
+        internal const string Initials = "2.5.4.43";
+
         internal const string EmailAddress = "1.2.840.113549.1.9.1";
 
         // Cert Extensions

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
@@ -555,6 +555,7 @@ namespace System.Security.Cryptography.X509Certificates
                 case Oids.Surname:
                 case Oids.Street:
                 case Oids.Title:
+                case Oids.Initials:
                     return true;
                 default:
                     return false;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
@@ -522,7 +522,7 @@ namespace System.Security.Cryptography.X509Certificates
                         throw new CryptographicException(SR.Cryptography_Invalid_IA5String);
                     }
                 }
-                else if (forceUtf8Encoding)
+                else if (forceUtf8Encoding && IsForceUtf8Eligible(tagOid))
                 {
                     writer.WriteCharacterString(UniversalTagNumber.UTF8String, data);
                 }
@@ -540,6 +540,25 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             return writer.Encode();
+        }
+
+        private static bool IsForceUtf8Eligible(ReadOnlySpan<char> oid)
+        {
+            switch (oid)
+            {
+                case Oids.CommonName:
+                case Oids.GivenName:
+                case Oids.LocalityName:
+                case Oids.Organization:
+                case Oids.OrganizationalUnit:
+                case Oids.StateOrProvinceName:
+                case Oids.Surname:
+                case Oids.Street:
+                case Oids.Title:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         private static int ExtractValue(ReadOnlySpan<char> chars, Span<char> destination)

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/NameTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/NameTests.cs
@@ -109,7 +109,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("ST=Main", UniversalTagNumber.UTF8String)]
         [InlineData("T=Pancake", UniversalTagNumber.UTF8String)]
         [InlineData("CN=Foo", UniversalTagNumber.UTF8String)]
+        [InlineData("I=DD", UniversalTagNumber.UTF8String)]
         [InlineData("E=noone@example.com", UniversalTagNumber.IA5String)]
+        [InlineData("OID.2.5.4.11=ProdSec", UniversalTagNumber.UTF8String)]
+        [InlineData("OID.2.5.4.43=DD", UniversalTagNumber.UTF8String)]
         [InlineData("OID.1.2.3.4=sample", UniversalTagNumber.PrintableString)]
         [InlineData("C=US", UniversalTagNumber.PrintableString)]
         public static void ForceUtf8EncodingForEligibleComponents(string distinguishedName, UniversalTagNumber tagNumber)


### PR DESCRIPTION
Reported in https://github.com/dotnet/runtime/issues/109156.

According to https://learn.microsoft.com/en-us/windows/win32/api/certenroll/ne-certenroll-x500nameflags, the ForceUTF8Encoding option only applies to certain attributes.

This changes the managed encoder to match the behavior of Windows.

Closes #109156