### PR TITLE
Use the SDK support for packaging up PGO data in a way that can be consumed in other projects

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -123,9 +123,7 @@
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
       </CoreCLRCrossTargetFiles>
       <CoreCLROptimizationFiles Include="$(CoreCLRArtifactsPath)StandardOptimizationData.mibc"
-                                Condition="Exists('$(CoreCLRArtifactsPath)StandardOptimizationData.mibc')">
-        <TargetPath>tools</TargetPath>
-      </CoreCLROptimizationFiles>
+                                Condition="Exists('$(CoreCLRArtifactsPath)StandardOptimizationData.mibc')" />
     </ItemGroup>
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles);@(CoreCLRCrossTargetFiles);@(CoreCLROptimizationFiles)" />
@@ -187,18 +185,6 @@
   <PropertyGroup>
     <PublishReadyToRunComposite Condition="$(ForcePublishReadyToRunComposite) == 'true'">true</PublishReadyToRunComposite>
   </PropertyGroup>
-
-  <!-- Put the mibc file into tools and not into PgoData, which will also hide it from being part of the RuntimeList.xml -->
-  <Target Name="RemoveMibcFromRuntimeListXml"
-          AfterTargets="GetFilesToPackage">
-    <ItemGroup>
-      <FilesToPackageMibcData Include="@(FilesToPackage)" Condition="'%(FilesToPackage.Identity)' == '$(CoreCLRArtifactsPath)StandardOptimizationData.mibc'">
-        <TargetPath>tools</TargetPath>
-      </FilesToPackageMibcData>
-      <FilesToPackage Remove="$(CoreCLRArtifactsPath)StandardOptimizationData.mibc"/>
-      <FilesToPackage Include="@(FilesToPackageMibcData)"/>
-    </ItemGroup>
-  </Target>
 
   <Target Name="IncludeSymbolFilesInNativeAOTPackage"
           Condition="'$(BuildNativeAOTRuntimePack)' == 'true'"


### PR DESCRIPTION
Undoes a workaround (added in #53171) from when this support was introduced and we hadn't consumed a new-enough SDK. We definitely have now, so let the PGO flow!