### PR TITLE
Cleanup NET8_0_OR_GREATER ifdef in json converters

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
@@ -57,11 +57,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
         {
-#if NET8_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[FormatLength];
-#else
-            Span<char> buffer = stackalloc char[FormatLength];
-#endif
             bool formattedSuccessfully = value.TryFormat(buffer, out int charsWritten, "O", CultureInfo.InvariantCulture);
             Debug.Assert(formattedSuccessfully && charsWritten == FormatLength);
             writer.WriteStringValue(buffer);
@@ -69,11 +65,7 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
         {
-#if NET8_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[FormatLength];
-#else
-            Span<char> buffer = stackalloc char[FormatLength];
-#endif
             bool formattedSuccessfully = value.TryFormat(buffer, out int charsWritten, "O", CultureInfo.InvariantCulture);
             Debug.Assert(formattedSuccessfully && charsWritten == FormatLength);
             writer.WritePropertyName(buffer);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int128Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int128Converter.cs
@@ -37,31 +37,20 @@ namespace System.Text.Json.Serialization.Converters
         {
             int bufferLength = reader.ValueLength;
 
-#if NET8_0_OR_GREATER
             byte[]? rentedBuffer = null;
             Span<byte> buffer = bufferLength <= JsonConstants.StackallocByteThreshold
                 ? stackalloc byte[JsonConstants.StackallocByteThreshold]
                 : (rentedBuffer = ArrayPool<byte>.Shared.Rent(bufferLength));
-#else
-            char[]? rentedBuffer = null;
-            Span<char> buffer = bufferLength <= JsonConstants.StackallocCharThreshold
-                ? stackalloc char[JsonConstants.StackallocCharThreshold]
-                : (rentedBuffer = ArrayPool<char>.Shared.Rent(bufferLength));
-#endif
 
             int written = reader.CopyValue(buffer);
-            if (!TryParse(buffer.Slice(0, written), out Int128 result))
+            if (!Int128.TryParse(buffer.Slice(0, written), CultureInfo.InvariantCulture, out Int128 result))
             {
                 ThrowHelper.ThrowFormatException(NumericType.Int128);
             }
 
             if (rentedBuffer != null)
             {
-#if NET8_0_OR_GREATER
                 ArrayPool<byte>.Shared.Return(rentedBuffer);
-#else
-                ArrayPool<char>.Shared.Return(rentedBuffer);
-#endif
             }
 
             return result;
@@ -69,11 +58,7 @@ namespace System.Text.Json.Serialization.Converters
 
         private static void WriteCore(Utf8JsonWriter writer, Int128 value)
         {
-#if NET8_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[MaxFormatLength];
-#else
-            Span<char> buffer = stackalloc char[MaxFormatLength];
-#endif
             Format(buffer, value, out int written);
             writer.WriteRawValue(buffer.Slice(0, written));
         }
@@ -86,11 +71,7 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, Int128 value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
         {
-#if NET8_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[MaxFormatLength];
-#else
-            Span<char> buffer = stackalloc char[MaxFormatLength];
-#endif
             Format(buffer, value, out int written);
             writer.WritePropertyName(buffer);
         }
@@ -110,13 +91,8 @@ namespace System.Text.Json.Serialization.Converters
         {
             if ((JsonNumberHandling.WriteAsString & handling) != 0)
             {
-#if NET8_0_OR_GREATER
                 const byte Quote = JsonConstants.Quote;
                 Span<byte> buffer = stackalloc byte[MaxFormatLength + 2];
-#else
-                const char Quote = (char)JsonConstants.Quote;
-                Span<char> buffer = stackalloc char[MaxFormatLength + 2];
-#endif
                 buffer[0] = Quote;
                 Format(buffer.Slice(1), value, out int written);
 
@@ -133,24 +109,8 @@ namespace System.Text.Json.Serialization.Converters
         internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
             GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
 
-        // Int128.TryParse(ROS<byte>) is not available on .NET 7, only Int128.TryParse(ROS<char>).
-        private static bool TryParse(
-#if NET8_0_OR_GREATER
-            ReadOnlySpan<byte> buffer,
-#else
-            ReadOnlySpan<char> buffer,
-#endif
-            out Int128 result)
-        {
-            return Int128.TryParse(buffer, CultureInfo.InvariantCulture, out result);
-        }
-
         private static void Format(
-#if NET8_0_OR_GREATER
             Span<byte> destination,
-#else
-            Span<char> destination,
-#endif
             Int128 value, out int written)
         {
             bool formattedSuccessfully = value.TryFormat(destination, out written, provider: CultureInfo.InvariantCulture);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt128Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt128Converter.cs
@@ -37,30 +37,20 @@ namespace System.Text.Json.Serialization.Converters
         {
             int bufferLength = reader.ValueLength;
 
-#if NET8_0_OR_GREATER
             byte[]? rentedBuffer = null;
             Span<byte> buffer = bufferLength <= JsonConstants.StackallocByteThreshold
                 ? stackalloc byte[JsonConstants.StackallocByteThreshold]
                 : (rentedBuffer = ArrayPool<byte>.Shared.Rent(bufferLength));
-#else
-            char[]? rentedBuffer = null;
-            Span<char> buffer = bufferLength <= JsonConstants.StackallocCharThreshold
-                ? stackalloc char[JsonConstants.StackallocCharThreshold]
-                : (rentedBuffer = ArrayPool<char>.Shared.Rent(bufferLength));
-#endif
+
             int written = reader.CopyValue(buffer);
-            if (!TryParse(buffer.Slice(0, written), out UInt128 result))
+            if (!UInt128.TryParse(buffer.Slice(0, written), CultureInfo.InvariantCulture, out UInt128 result))
             {
                 ThrowHelper.ThrowFormatException(NumericType.UInt128);
             }
 
             if (rentedBuffer != null)
             {
-#if NET8_0_OR_GREATER
                 ArrayPool<byte>.Shared.Return(rentedBuffer);
-#else
-                ArrayPool<char>.Shared.Return(rentedBuffer);
-#endif
             }
 
             return result;
@@ -68,11 +58,7 @@ namespace System.Text.Json.Serialization.Converters
 
         private static void WriteCore(Utf8JsonWriter writer, UInt128 value)
         {
-#if NET8_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[MaxFormatLength];
-#else
-            Span<char> buffer = stackalloc char[MaxFormatLength];
-#endif
             Format(buffer, value, out int written);
             writer.WriteRawValue(buffer.Slice(0, written));
         }
@@ -85,11 +71,7 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, UInt128 value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
         {
-#if NET8_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[MaxFormatLength];
-#else
-            Span<char> buffer = stackalloc char[MaxFormatLength];
-#endif
             Format(buffer, value, out int written);
             writer.WritePropertyName(buffer);
         }
@@ -109,13 +91,8 @@ namespace System.Text.Json.Serialization.Converters
         {
             if ((JsonNumberHandling.WriteAsString & handling) != 0)
             {
-#if NET8_0_OR_GREATER
                 const byte Quote = JsonConstants.Quote;
                 Span<byte> buffer = stackalloc byte[MaxFormatLength + 2];
-#else
-                const char Quote = (char)JsonConstants.Quote;
-                Span<char> buffer = stackalloc char[MaxFormatLength + 2];
-#endif
                 buffer[0] = Quote;
                 Format(buffer.Slice(1), value, out int written);
 
@@ -132,24 +109,8 @@ namespace System.Text.Json.Serialization.Converters
         internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
             GetSchemaForNumericType(JsonSchemaType.Integer, numberHandling);
 
-        // UInt128.TryParse(ROS<byte>) is not available on .NET 7, only UInt128.TryParse(ROS<char>).
-        private static bool TryParse(
-#if NET8_0_OR_GREATER
-            ReadOnlySpan<byte> buffer,
-#else
-            ReadOnlySpan<char> buffer,
-#endif
-            out UInt128 result)
-        {
-            return UInt128.TryParse(buffer, CultureInfo.InvariantCulture, out result);
-        }
-
         private static void Format(
-#if NET8_0_OR_GREATER
             Span<byte> destination,
-#else
-            Span<char> destination,
-#endif
             UInt128 value, out int written)
         {
             bool formattedSuccessfully = value.TryFormat(destination, out written, provider: CultureInfo.InvariantCulture);


### PR DESCRIPTION
Since these types don't exist in netstandard and net7.0 has been dropped, these converters are now always compiled with NET8_0_OR_GREATER.