### PR TITLE
Bump TraceEvent package version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,7 +165,7 @@
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
     <SystemCommandLineVersion>2.0.0-beta4.24528.1</SystemCommandLineVersion>
-    <TraceEventVersion>3.1.7</TraceEventVersion>
+    <TraceEventVersion>3.1.16</TraceEventVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>
     <MicrosoftDiagnosticsToolsRuntimeClientVersion>1.0.4-preview6.19326.1</MicrosoftDiagnosticsToolsRuntimeClientVersion>

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
@@ -2,8 +2,10 @@
 // As of https://github.com/dotnet/runtime/pull/64358, InternalsVisibleTo MSBuild Item does not seem to work in Dotnet/Runtime like it does on Dotnet/Diagnostics
 using System;
 using System.IO;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("common")]
 [assembly: InternalsVisibleTo("enabledisable")]
+[assembly: AssemblyVersionAttribute("99.99.99.99")]
 #endif


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/107315

This PR aims to bump the TraceEvent package version to include the changes introduced by https://github.com/microsoft/perfview/pull/2111 which prevents "System.Private.CoreLib" module names associated with TraceEvents from being incorrectly trimmed to "System.Private".