### PR TITLE
Add support for building with Clang 19

### DIFF
--- a/src/coreclr/vm/comreflectioncache.hpp
+++ b/src/coreclr/vm/comreflectioncache.hpp
@@ -26,6 +26,7 @@ public:
 
     void Init();
 
+#ifndef DACCESS_COMPILE
     BOOL GetFromCache(Element *pElement, CacheType& rv)
     {
         CONTRACTL
@@ -102,6 +103,7 @@ public:
         AdjustStamp(TRUE);
         this->LeaveWrite();
     }
+#endif // !DACCESS_COMPILE
 
 private:
     // Lock must have been taken before calling this.
@@ -141,6 +143,7 @@ private:
         return CacheSize;
     }
 
+#ifndef DACCESS_COMPILE
     void AdjustStamp(BOOL hasWriterLock)
     {
         CONTRACTL
@@ -170,6 +173,7 @@ private:
         if (!hasWriterLock)
             this->LeaveWrite();
     }
+#endif // !DACCESS_COMPILE
 
     void UpdateHashTable(SIZE_T hash, int slot)
     {

--- a/src/native/libs/CMakeLists.txt
+++ b/src/native/libs/CMakeLists.txt
@@ -128,6 +128,8 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
         add_compile_options(-Wno-cast-align)
         add_compile_options(-Wno-typedef-redefinition)
         add_compile_options(-Wno-c11-extensions)
+        add_compile_options(-Wno-pre-c11-compat) # fixes build on Debian
+        add_compile_options(-Wno-unknown-warning-option) # unknown warning option '-Wno-pre-c11-compat'
         add_compile_options(-Wno-thread-safety-analysis)
         if (CLR_CMAKE_TARGET_BROWSER)
             add_compile_options(-Wno-unsafe-buffer-usage)

--- a/src/native/libs/CMakeLists.txt
+++ b/src/native/libs/CMakeLists.txt
@@ -128,8 +128,12 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
         add_compile_options(-Wno-cast-align)
         add_compile_options(-Wno-typedef-redefinition)
         add_compile_options(-Wno-c11-extensions)
-        add_compile_options(-Wno-pre-c11-compat) # fixes build on Debian
-        add_compile_options(-Wno-unknown-warning-option) # unknown warning option '-Wno-pre-c11-compat'
+
+        check_c_compiler_flag(-Wpre-c11-compat COMPILER_SUPPORTS_W_PRE_C11_COMPAT)
+        if (COMPILER_SUPPORTS_W_PRE_C11_COMPAT)
+            add_compile_options(-Wno-pre-c11-compat)
+        endif()
+
         add_compile_options(-Wno-thread-safety-analysis)
         if (CLR_CMAKE_TARGET_BROWSER)
             add_compile_options(-Wno-unsafe-buffer-usage)


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/105141 to release/8.0
Upstreaming [.NET 8.0 Fedora 41 patch](https://src.fedoraproject.org/rpms/dotnet8.0/blob/rawhide/f/runtime-clang-19.patch)

This is required so that source-build can build/test on Fedora 41 (https://github.com/dotnet/source-build/issues/4593).
