### PR TITLE
[cdac] Implement `IXCLRDataProcess::GetTaskByOSThreadID`

### DIFF
--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ThreadFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ThreadFactory.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+internal sealed class ThreadFactory : IContractFactory<IThread>
+{
+    IThread IContractFactory<IThread>.CreateContract(Target target, int version)
+    {
+        TargetPointer threadStorePointer = target.ReadGlobalPointer(Constants.Globals.ThreadStore);
+        TargetPointer threadStore = target.ReadPointer(threadStorePointer);
+        return version switch
+        {
+            1 => new Thread_1(target, threadStore),
+            _ => default(Thread),
+        };
+    }
+}

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -5,20 +5,6 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ThreadFactory : IContractFactory<IThread>
-{
-    IThread IContractFactory<IThread>.CreateContract(Target target, int version)
-    {
-        TargetPointer threadStorePointer = target.ReadGlobalPointer(Constants.Globals.ThreadStore);
-        TargetPointer threadStore = target.ReadPointer(threadStorePointer);
-        return version switch
-        {
-            1 => new Thread_1(target, threadStore),
-            _ => default(Thread),
-        };
-    }
-}
-
 internal readonly struct Thread_1 : IThread
 {
     private readonly Target _target;

--- a/src/native/managed/cdacreader/src/Legacy/ClrDataTask.cs
+++ b/src/native/managed/cdacreader/src/Legacy/ClrDataTask.cs
@@ -13,11 +13,11 @@ internal sealed unsafe partial class ClrDataTask : IXCLRDataTask
     private readonly Target _target;
     private readonly IXCLRDataTask? _legacyImpl;
 
-    public ClrDataTask(TargetPointer address, Target target, object? legacyImpl)
+    public ClrDataTask(TargetPointer address, Target target, IXCLRDataTask? legacyImpl)
     {
         _address = address;
         _target = target;
-        _legacyImpl = legacyImpl as IXCLRDataTask;
+        _legacyImpl = legacyImpl;
     }
 
     public int GetProcess(/*IXCLRDataProcess*/ void** process)

--- a/src/native/managed/cdacreader/src/Legacy/ClrDataTask.cs
+++ b/src/native/managed/cdacreader/src/Legacy/ClrDataTask.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Microsoft.Diagnostics.DataContractReader.Legacy;
+
+[GeneratedComClass]
+internal sealed unsafe partial class ClrDataTask : IXCLRDataTask
+{
+    private readonly TargetPointer _address;
+    private readonly Target _target;
+    private readonly IXCLRDataTask? _legacyImpl;
+
+    public ClrDataTask(TargetPointer address, Target target, object? legacyImpl)
+    {
+        _address = address;
+        _target = target;
+        _legacyImpl = legacyImpl as IXCLRDataTask;
+    }
+
+    public int GetProcess(/*IXCLRDataProcess*/ void** process)
+        => _legacyImpl is not null ? _legacyImpl.GetProcess(process) : HResults.E_NOTIMPL;
+    public int GetCurrentAppDomain(/*IXCLRDataAppDomain*/ void** appDomain)
+        => _legacyImpl is not null ? _legacyImpl.GetCurrentAppDomain(appDomain) : HResults.E_NOTIMPL;
+    public int GetUniqueID(ulong* id)
+        => _legacyImpl is not null ? _legacyImpl.GetUniqueID(id) : HResults.E_NOTIMPL;
+    public int GetFlags(uint* flags)
+        => _legacyImpl is not null ? _legacyImpl.GetFlags(flags) : HResults.E_NOTIMPL;
+    public int IsSameObject(IXCLRDataTask* task)
+        => _legacyImpl is not null ? _legacyImpl.IsSameObject(task) : HResults.E_NOTIMPL;
+    public int GetManagedObject(/*IXCLRDataValue*/ void** value)
+        => _legacyImpl is not null ? _legacyImpl.GetManagedObject(value) : HResults.E_NOTIMPL;
+    public int GetDesiredExecutionState(uint* state)
+        => _legacyImpl is not null ? _legacyImpl.GetDesiredExecutionState(state) : HResults.E_NOTIMPL;
+    public int SetDesiredExecutionState(uint state)
+        => _legacyImpl is not null ? _legacyImpl.SetDesiredExecutionState(state) : HResults.E_NOTIMPL;
+    public int CreateStackWalk(uint flags, /*IXCLRDataStackWalk*/ void** stackWalk)
+        => _legacyImpl is not null ? _legacyImpl.CreateStackWalk(flags, stackWalk) : HResults.E_NOTIMPL;
+    public int GetOSThreadID(uint* id)
+        => _legacyImpl is not null ? _legacyImpl.GetOSThreadID(id) : HResults.E_NOTIMPL;
+    public int GetContext(uint contextFlags, uint contextBufSize, uint* contextSize, byte* contextBuffer)
+        => _legacyImpl is not null ? _legacyImpl.GetContext(contextFlags, contextBufSize, contextSize, contextBuffer) : HResults.E_NOTIMPL;
+    public int SetContext(uint contextSize, byte* context)
+        => _legacyImpl is not null ? _legacyImpl.SetContext(contextSize, context) : HResults.E_NOTIMPL;
+    public int GetCurrentExceptionState(/*IXCLRDataExceptionState*/ void** exception)
+        => _legacyImpl is not null ? _legacyImpl.GetCurrentExceptionState(exception) : HResults.E_NOTIMPL;
+    public int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer)
+        => _legacyImpl is not null ? _legacyImpl.Request(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer) : HResults.E_NOTIMPL;
+    public int GetName(uint bufLen, uint* nameLen, char* nameBuffer)
+        => _legacyImpl is not null ? _legacyImpl.GetName(bufLen, nameLen, nameBuffer) : HResults.E_NOTIMPL;
+    public int GetLastExceptionState(/*IXCLRDataExceptionState*/ void** exception)
+        => _legacyImpl is not null ? _legacyImpl.GetLastExceptionState(exception) : HResults.E_NOTIMPL;
+}

--- a/src/native/managed/cdacreader/src/Legacy/IXCLRData.cs
+++ b/src/native/managed/cdacreader/src/Legacy/IXCLRData.cs
@@ -131,7 +131,7 @@ internal unsafe partial interface IXCLRDataProcess
     int EndEnumTasks(ulong handle);
 
     [PreserveSig]
-    int GetTaskByOSThreadID(uint osThreadID, /*IXCLRDataTask*/ void** task);
+    int GetTaskByOSThreadID(uint osThreadID, out IXCLRDataTask? task);
     [PreserveSig]
     int GetTaskByUniqueID(ulong taskID, /*IXCLRDataTask*/ void** task);
 

--- a/src/native/managed/cdacreader/src/Legacy/IXCLRData.cs
+++ b/src/native/managed/cdacreader/src/Legacy/IXCLRData.cs
@@ -309,3 +309,56 @@ internal unsafe partial interface IXCLRDataProcess2 : IXCLRDataProcess
     [PreserveSig]
     int SetGcNotification(GcEvtArgs gcEvtArgs);
 }
+
+[GeneratedComInterface]
+[Guid("A5B0BEEA-EC62-4618-8012-A24FFC23934C")]
+internal unsafe partial interface IXCLRDataTask
+{
+    [PreserveSig]
+    int GetProcess(/*IXCLRDataProcess*/ void** process);
+
+    [PreserveSig]
+    int GetCurrentAppDomain(/*IXCLRDataAppDomain*/ void** appDomain);
+
+    [PreserveSig]
+    int GetUniqueID(ulong* id);
+
+    [PreserveSig]
+    int GetFlags(uint* flags);
+
+    [PreserveSig]
+    int IsSameObject(IXCLRDataTask* task);
+
+    [PreserveSig]
+    int GetManagedObject(/*IXCLRDataValue*/ void** value);
+
+    [PreserveSig]
+    int GetDesiredExecutionState(uint* state);
+
+    [PreserveSig]
+    int SetDesiredExecutionState(uint state);
+
+    [PreserveSig]
+    int CreateStackWalk(uint flags, /*IXCLRDataStackWalk*/ void** stackWalk);
+
+    [PreserveSig]
+    int GetOSThreadID(uint* id);
+
+    [PreserveSig]
+    int GetContext(uint contextFlags, uint contextBufSize, uint* contextSize, byte* contextBuffer);
+
+    [PreserveSig]
+    int SetContext(uint contextSize, byte* context);
+
+    [PreserveSig]
+    int GetCurrentExceptionState(/*IXCLRDataExceptionState*/ void** exception);
+
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+
+    [PreserveSig]
+    int GetName(uint bufLen, uint* nameLen, char* nameBuffer);
+
+    [PreserveSig]
+    int GetLastExceptionState(/*IXCLRDataExceptionState*/ void** exception);
+}

--- a/src/native/managed/cdacreader/tests/LoaderTests.cs
+++ b/src/native/managed/cdacreader/tests/LoaderTests.cs
@@ -26,8 +26,8 @@ public unsafe class LoaderTests
 
         // Add the modules
         MockLoader loader = new(builder);
-        TargetPointer moduleAddr = loader.AddModule(helpers, path: expected);
-        TargetPointer moduleAddrEmptyPath = loader.AddModule(helpers);
+        TargetPointer moduleAddr = loader.AddModule(path: expected);
+        TargetPointer moduleAddrEmptyPath = loader.AddModule();
 
         bool success = builder.TryCreateTarget(out ContractDescriptorTarget? target);
         Assert.True(success);
@@ -62,8 +62,8 @@ public unsafe class LoaderTests
 
         // Add the modules
         MockLoader loader = new(builder);
-        TargetPointer moduleAddr = loader.AddModule(helpers, fileName: expected);
-        TargetPointer moduleAddrEmptyName = loader.AddModule(helpers);
+        TargetPointer moduleAddr = loader.AddModule(fileName: expected);
+        TargetPointer moduleAddrEmptyName = loader.AddModule();
 
         bool success = builder.TryCreateTarget(out ContractDescriptorTarget? target);
         Assert.True(success);

--- a/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
+++ b/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
@@ -198,6 +198,18 @@ internal unsafe class TargetTestHelpers
         }
     }
 
+    internal void Write(Span<byte> dest, int i)
+    {
+        if (Arch.IsLittleEndian)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(dest, i);
+        }
+        else
+        {
+            BinaryPrimitives.WriteInt32BigEndian(dest, i);
+        }
+    }
+
     internal void Write(Span<byte> dest, uint u)
     {
         if (Arch.IsLittleEndian)

--- a/src/native/managed/cdacreader/tests/ThreadTests.cs
+++ b/src/native/managed/cdacreader/tests/ThreadTests.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
+
+using MockThread = MockDescriptors.Thread;
+
+public unsafe class ThreadTests
+{
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetThreadStoreData(MockTarget.Architecture arch)
+    {
+        // Set up the target
+        TargetTestHelpers helpers = new(arch);
+        MockMemorySpace.Builder builder = new(helpers);
+        MockThread thread = new(builder);
+        builder = builder
+            .SetContracts([nameof(Contracts.Thread)])
+            .SetTypes(thread.Types)
+            .SetGlobals(thread.Globals);
+
+        int threadCount = 15;
+        int unstartedCount = 1;
+        int backgroundCount = 2;
+        int pendingCount = 3;
+        int deadCount = 4;
+
+        // Set thread store data
+        thread.SetThreadCounts(
+            threadCount,
+            unstartedCount,
+            backgroundCount,
+            pendingCount,
+            deadCount);
+
+        bool success = builder.TryCreateTarget(out ContractDescriptorTarget? target);
+        Assert.True(success);
+
+        // Validate the expected thread counts
+        Contracts.IThread contract = target.Contracts.Thread;
+        Assert.NotNull(contract);
+
+        Contracts.ThreadStoreCounts counts = contract.GetThreadCounts();
+        Assert.Equal(unstartedCount, counts.UnstartedThreadCount);
+        Assert.Equal(backgroundCount, counts.BackgroundThreadCount);
+        Assert.Equal(pendingCount, counts.PendingThreadCount);
+        Assert.Equal(deadCount, counts.DeadThreadCount);
+
+        Contracts.ThreadStoreData data = contract.GetThreadStoreData();
+        Assert.Equal(threadCount, data.ThreadCount);
+        Assert.Equal(thread.FinalizerThreadAddress, data.FinalizerThread);
+        Assert.Equal(thread.GCThreadAddress, data.GCThread);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetThreadData(MockTarget.Architecture arch)
+    {
+        // Set up the target
+        TargetTestHelpers helpers = new(arch);
+        MockMemorySpace.Builder builder = new(helpers);
+        MockThread thread = new(builder);
+        builder = builder
+            .SetContracts([nameof(Contracts.Thread)])
+            .SetTypes(thread.Types)
+            .SetGlobals(thread.Globals);
+
+        uint id = 1;
+        TargetNUInt osId = new TargetNUInt(1234);
+
+        // Add thread
+        TargetPointer addr = thread.AddThread(id, osId);
+
+        bool success = builder.TryCreateTarget(out ContractDescriptorTarget? target);
+        Assert.True(success);
+
+        // Validate the expected thread counts
+        Contracts.IThread contract = target.Contracts.Thread;
+        Assert.NotNull(contract);
+
+        Contracts.ThreadData data= contract.GetThreadData(addr);
+        Assert.Equal(id, data.Id);
+        Assert.Equal(osId, data.OSId);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void IterateThreads(MockTarget.Architecture arch)
+    {
+        // Set up the target
+        TargetTestHelpers helpers = new(arch);
+        MockMemorySpace.Builder builder = new(helpers);
+        MockThread thread = new(builder);
+        builder = builder
+            .SetContracts([nameof(Contracts.Thread)])
+            .SetTypes(thread.Types)
+            .SetGlobals(thread.Globals);
+
+        // Add threads
+        uint expectedCount = 10;
+        uint osIdStart = 1000;
+        for (uint i = 1; i <= expectedCount; i++)
+        {
+            thread.AddThread(i, new TargetNUInt(i + osIdStart));
+        }
+
+        bool success = builder.TryCreateTarget(out ContractDescriptorTarget? target);
+        Assert.True(success);
+
+        // Validate the expected thread counts
+        Contracts.IThread contract = target.Contracts.Thread;
+        Assert.NotNull(contract);
+
+        TargetPointer currentThread = contract.GetThreadStoreData().FirstThread;
+        uint count = 0;
+        while (currentThread != TargetPointer.Null)
+        {
+            count++;
+            Contracts.ThreadData threadData = contract.GetThreadData(currentThread);
+            Assert.Equal(count, threadData.Id);
+            Assert.Equal(count + osIdStart, threadData.OSId.Value);
+            currentThread = threadData.NextThread;
+        }
+
+        Assert.Equal(expectedCount, count);
+    }
+}


### PR DESCRIPTION
- Add `ClrDataTask` to cDAC as its implementation of `IXCLRDataTask`
  - Currently delegates everything to legacy implementation
- Implement `IXCLRDataProcess::GetTaskByOSThreadID`
  - Uses `Thread` contract to find the address of the thread corresponding to the specified OS thread ID.
  - Gets the result from the legacy DAC and passes it to the cDAC `ClrDataTask`
- Add tests for `Thread` contract

Contributes to https://github.com/dotnet/runtime/issues/108553

cc @AaronRobinsonMSFT @davidwrighton 