### PR TITLE
Ship the minipal as a separate static lib to avoid circular dependencies

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -160,6 +160,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NativeLibrary Include="$(IlcSdkPath)$(EventPipeName)$(LibFileExt)" />
       <NativeLibrary Condition="'$(_targetArchitecture)' == 'x64'" Include="$(IlcSdkPath)$(VxSortSupportName)$(LibFileExt)" />
       <NativeLibrary Include="$(IlcSdkPath)$(StandaloneGCSupportName)$(LibFileExt)" />
+      <NativeLibrary Include="$(IlcSdkPath)libaotminipal.a" />
       <NativeLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' != 'true' and '$(StaticICULinking)' != 'true'" Include="$(IlcSdkPath)libstdc++compat.a" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -46,6 +46,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NativeLibrary Condition="'$(_targetArchitecture)' == 'x64'" Include="$(IlcSdkPath)$(VxSortSupportName)$(LibrarySuffix)" />
       <NativeLibrary Condition="'$(IlcMultiModule)' == 'true'" Include="$(SharedLibrary)" />
       <NativeLibrary Include="$(IlcSdkPath)$(StandaloneGCSupportName)$(LibrarySuffix)" />
+      <NativeLibrary Include="$(IlcSdkPath)aotminipal$(LibFileExt)" />
       <NativeLibrary Include="$(IlcSdkPath)zlibstatic$(LibFileExt)" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -28,11 +28,11 @@ endif (CLR_CMAKE_TARGET_WIN32)
 
 add_library(Runtime.WorkstationGC STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${RUNTIME_ARCH_ASM_OBJECTS})
 add_dependencies(Runtime.WorkstationGC aot_eventing_headers)
-target_link_libraries(Runtime.WorkstationGC PRIVATE minipal_objects_no_lto)
+target_link_libraries(Runtime.WorkstationGC PRIVATE aotminipal)
 
 add_library(Runtime.ServerGC STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${SERVER_GC_SOURCES} ${RUNTIME_ARCH_ASM_OBJECTS})
 add_dependencies(Runtime.ServerGC aot_eventing_headers)
-target_link_libraries(Runtime.ServerGC PRIVATE minipal_objects_no_lto)
+target_link_libraries(Runtime.ServerGC PRIVATE aotminipal)
 
 add_library(standalonegc-disabled STATIC ${STANDALONEGC_DISABLED_SOURCES})
 add_dependencies(standalonegc-disabled aot_eventing_headers)
@@ -62,15 +62,15 @@ if (CLR_CMAKE_TARGET_WIN32)
   add_library(Runtime.ServerGC.GuardCF STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${SERVER_GC_SOURCES} ${RUNTIME_ARCH_ASM_OBJECTS})
   target_compile_definitions(Runtime.ServerGC.GuardCF PRIVATE -DFEATURE_SVR_GC)
   set_target_properties(Runtime.ServerGC.GuardCF PROPERTIES CLR_CONTROL_FLOW_GUARD ON)
-  target_link_libraries(Runtime.ServerGC.GuardCF PRIVATE minipal_objects_no_lto)
+  target_link_libraries(Runtime.ServerGC.GuardCF PRIVATE aotminipal)
 
   if (CLR_CMAKE_TARGET_ARCH_AMD64)
     add_library(Runtime.VxsortEnabled.GuardCF STATIC ${VXSORT_SOURCES})
     set_target_properties(Runtime.VxsortEnabled.GuardCF PROPERTIES CLR_CONTROL_FLOW_GUARD ON)
   endif (CLR_CMAKE_TARGET_ARCH_AMD64)
 
-  set_target_properties(minipal_objects_no_lto PROPERTIES
-    COMPILE_PDB_NAME "minipal"
+  set_target_properties(aotminipal PROPERTIES
+    COMPILE_PDB_NAME "aotminipal"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
 endif (CLR_CMAKE_TARGET_WIN32)
 
@@ -122,12 +122,12 @@ install_static_library(Runtime.WorkstationGC aotsdk nativeaot)
 install_static_library(Runtime.ServerGC aotsdk nativeaot)
 install_static_library(standalonegc-disabled aotsdk nativeaot)
 install_static_library(standalonegc-enabled aotsdk nativeaot)
+install_static_library(aotminipal aotsdk nativeaot)
 if (CLR_CMAKE_TARGET_WIN32)
   install_static_library(Runtime.ServerGC.GuardCF aotsdk nativeaot)
   add_dependencies(Runtime.ServerGC.GuardCF aot_eventing_headers)
   install_static_library(standalonegc-disabled.GuardCF aotsdk nativeaot)
   install_static_library(standalonegc-enabled.GuardCF aotsdk nativeaot)
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/minipal.pdb" DESTINATION aotsdk COMPONENT nativeaot)
 endif (CLR_CMAKE_TARGET_WIN32)
 if (CLR_CMAKE_TARGET_ARCH_AMD64)
   install_static_library(Runtime.VxsortEnabled aotsdk nativeaot)

--- a/src/coreclr/nativeaot/Runtime/Portable/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Portable/CMakeLists.txt
@@ -6,7 +6,7 @@ project(PortableRuntime)
 add_definitions(-DUSE_PORTABLE_HELPERS)
 
 add_library(PortableRuntime STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES})
-target_link_libraries(PortableRuntime PRIVATE minipal_objects)
+target_link_libraries(PortableRuntime PRIVATE aotminipal)
 
 # Get the current list of definitions
 get_compile_definitions(DEFINITIONS)
@@ -16,6 +16,10 @@ if(WIN32)
     set(COMPILER_LANGUAGE "")
     set(PREPROCESSOR_FLAGS -EP -nologo)
     set(ASM_OFFSETS_CPP ${RUNTIME_DIR}/windows/AsmOffsets.cpp)
+
+    set_target_properties(aotminipal PROPERTIES
+        COMPILE_PDB_NAME "aotminipal"
+        COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
 else()
     set(COMPILER_LANGUAGE -x c++)
     set(PREPROCESSOR_FLAGS -E -P)
@@ -30,3 +34,4 @@ add_custom_command(
 )
 
 install_static_library(PortableRuntime aotsdk nativeaot)
+install_static_library(aotminipal aotsdk nativeaot)

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -146,6 +146,7 @@
     <PlatformManifestFileEntry Include="libRuntime.VxSortEnabled.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libstandalonegc-disabled.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libstandalonegc-enabled.a" IsNative="true" />
+    <PlatformManifestFileEntry Include="libaotminipal.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libstdc++compat.a" IsNative="true" />
     <!-- NativeAOT/Windows specific files -->
     <PlatformManifestFileEntry Include="bootstrapper.obj" IsNative="true" />
@@ -170,6 +171,7 @@
     <PlatformManifestFileEntry Include="System.Globalization.Native.Aot.GuardCF.lib" IsNative="true" />
     <PlatformManifestFileEntry Include="System.IO.Compression.Native.Aot.lib" IsNative="true" />
     <PlatformManifestFileEntry Include="System.IO.Compression.Native.Aot.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="aotminipal.lib" IsNative="true" />
     <!-- NativeAOT managed specific files -->
     <PlatformManifestFileEntry Include="System.Private.DisabledReflection.dll" />
     <PlatformManifestFileEntry Include="System.Private.Reflection.Execution.dll" />

--- a/src/native/minipal/CMakeLists.txt
+++ b/src/native/minipal/CMakeLists.txt
@@ -14,11 +14,11 @@ include_directories(${CLR_SRC_NATIVE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(minipal_objects OBJECT ${SOURCES})
 
-# Add a copy of the minipal object library with interprocedural optimization disabled
+# Add a copy of the minipal static library with interprocedural optimization disabled
 # for NativeAOT scenarios, where we ship static libraries that need to be able to be run with
 # a variety of toolchain versions, not only the exact one we built with.
-add_library(minipal_objects_no_lto OBJECT ${SOURCES})
-set_target_properties(minipal_objects_no_lto PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+add_library(aotminipal STATIC ${SOURCES})
+set_target_properties(aotminipal PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 
 # Provide a static library for our shared library and executable scenarios
 # for easier usability.


### PR DESCRIPTION
Both the NativeAOT runtime and eventpipe implementation depend on the minipal now, and the runtime has dependencies on eventpipe. I personally don't like the idea of just shoving the minipal into eventpipe (especially on the "disabled eventpipe" path that doesn't depend on the minipal), so I've extracted the minipal out of the runtime static lib and put it into its own to avoid circular dependencies.

Contributes to unblocking https://github.com/dotnet/sdk/pull/43015#issuecomment-2436805441