### PR TITLE
Add forwarding support for WasmLinkage on LibraryImport

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
@@ -73,5 +73,19 @@ namespace Microsoft.Interop
                 return _defaultDllImportSearchPathsAttrType.Value;
             }
         }
+
+        private Optional<INamedTypeSymbol?> _wasmImportLinkageAttrType;
+        public INamedTypeSymbol? WasmImportLinkageAttrType
+        {
+            get
+            {
+                if (_wasmImportLinkageAttrType.HasValue)
+                {
+                    return _wasmImportLinkageAttrType.Value;
+                }
+                _wasmImportLinkageAttrType = new Optional<INamedTypeSymbol?>(Compilation.GetTypeByMetadataName(TypeNames.WasmImportLinkageAttribute));
+                return _wasmImportLinkageAttrType.Value;
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Interop
 
         private static NameSyntax? _UnmanagedCallersOnlyAttribute;
         public static NameSyntax UnmanagedCallersOnlyAttribute => _UnmanagedCallersOnlyAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.UnmanagedCallersOnlyAttribute);
+
+        private static NameSyntax? _WasmImportLinkageAttribute;
+        public static NameSyntax WasmImportLinkageAttribute => _WasmImportLinkageAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.WasmImportLinkageAttribute);
     }
 
     public static class TypeSyntaxes
@@ -312,5 +315,6 @@ namespace Microsoft.Interop
         public const string CallConvMemberFunctionName = "System.Runtime.CompilerServices.CallConvMemberFunction";
         public const string Nint = "nint";
         public const string ComVariantMarshaller = "System.Runtime.InteropServices.Marshalling.ComVariantMarshaller";
+        public const string WasmImportLinkageAttribute = "System.Runtime.InteropServices.WasmImportLinkageAttribute";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
@@ -21,6 +21,7 @@ namespace LibraryImportGenerator.UnitTests
         [Theory]
         [InlineData("SuppressGCTransition", "System.Runtime.InteropServices.SuppressGCTransitionAttribute")]
         [InlineData("UnmanagedCallConv", "System.Runtime.InteropServices.UnmanagedCallConvAttribute")]
+        [InlineData("WasmImportLinkage", "System.Runtime.InteropServices.WasmImportLinkageAttribute")]
         public async Task KnownParameterlessAttribute(string attributeSourceName, string attributeMetadataName)
         {
             string source = $$"""


### PR DESCRIPTION
Fixes #109181

Given that there is no impact in product code today with this generator change, I feel that it may meet the servicing bar (as we've serviced similar generator changes like this before), but it's not worth rushing into GA. If the generator shipped out of band (like in roslyn-analyzers), we'd meet the bar for the next "SDK band" release with a change like this.