### PR TITLE
Update host test RID fallbacks to include arm64

### DIFF
--- a/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
+++ b/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
@@ -351,13 +351,17 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 WithRuntimeFallbacks("win10-x64", "win10", "win-x64", "win", "any")
                 .WithRuntimeFallbacks("win10-x86", "win10", "win-x86", "win", "any")
                 .WithRuntimeFallbacks("win10", "win", "any")
+                .WithRuntimeFallbacks("win-arm64", "win", "any")
                 .WithRuntimeFallbacks("win-x64", "win", "any")
                 .WithRuntimeFallbacks("win-x86", "win", "any")
                 .WithRuntimeFallbacks("win", "any")
+                .WithRuntimeFallbacks("linux-arm64", "linux", "any")
                 .WithRuntimeFallbacks("linux-x64", "linux", "any")
-                .WithRuntimeFallbacks("linux-musl-x64", "linux", "any")
+                .WithRuntimeFallbacks("linux-musl-arm64", "linux-musl", "linux", "any")
+                .WithRuntimeFallbacks("linux-musl-x64", "linux-musl", "linux", "any")
                 .WithRuntimeFallbacks("linux", "any")
                 .WithRuntimeFallbacks("osx.10.12-x64", "osx-x64", "osx", "any")
+                .WithRuntimeFallbacks("osx-arm64", "osx", "any")
                 .WithRuntimeFallbacks("osx-x64", "osx", "any");
         }
 


### PR DESCRIPTION
When running against a mock coreclr, host tests create a minimal Microsoft.NETCore.App.deps.json that also includes a sparse fallback RID graph. That graph gets used in tests for RID-specific asset resolution that target explicitly enabling the RID fallback graph. This change adds arm64 to the mock RID fallback graph, which should allow those tests to run properly on arm64.

Contributes to https://github.com/dotnet/runtime/issues/77800

cc @dotnet/appmodel @AaronRobinsonMSFT 