### PR TITLE
Fix servicing version of Microsoft.Extensions.Hosting

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/Directory.Build.props
+++ b/src/libraries/Microsoft.Extensions.Hosting/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
-    <ServicingVersion>1</ServicingVersion>
+    <ServicingVersion>2</ServicingVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Microsoft.Extensions.Hosting.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Microsoft.Extensions.Hosting.csproj
@@ -5,10 +5,9 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <PackageDescription>Hosting and startup infrastructures for applications.</PackageDescription>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>1</ServicingVersion>
+    <!-- **IMPORTANT** ServicingVersion moved to ..\Directory.Build.props in order to share with test project. -->
     <!-- Use targeting pack references instead of granular ones in the project file. -->
     <DisableImplicitAssemblyReferences>false</DisableImplicitAssemblyReferences>
-    <!-- ServicingVersion moved to ..\Directory.Build.props in order to share with test project. -->
   </PropertyGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">


### PR DESCRIPTION
We discovered that the version of this was not bumped correctly.  It has no code changes -- we were only shipping it to help folks get other package updates lower in the stack.  If we have time to rebuild, we should take it.