### PR TITLE
Use floating tag for webassembly image

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -180,6 +180,6 @@ jobs:
 
     # Browser WebAssembly windows
     - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:
-      - (Windows.Amd64.Server2022.Open)windows.amd64.server2022.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-webassembly-20240702174122-7aba2af
+      - (Windows.Amd64.Server2022.Open)windows.amd64.server2022.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-webassembly
 
     ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Updates the reference container image tag to be the floating tag, which will be kept current for all updates. The previously used tag is pinned to a specific version which is considered EOL at this point.