### PR TITLE
Update all devcontainers to noble

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,22 +1,13 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 # For details on dotnet specific container, see: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet
 
-# [Choice] .NET version: 6.0, 7.0
-ARG VARIANT="6.0-jammy"
-FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
-
-# Set up machine requirements to build the repo and the gh CLI
-# Clang-16 up is required but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
-RUN apt-get update \
-    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
-    && apt-get install software-properties-common -y \
-    && add-apt-repository "deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main" -y \
-    && apt-get update \
-    && apt-get install clang-18 -y
+ARG VARIANT="8.0-noble"
+FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
+        clang \
         cmake \
         build-essential \
         python3 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
         git \
         lldb \
+        llvm \
         liblldb-dev \
         libunwind8 \
         libunwind8-dev \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 6.0, 7.0
-			"VARIANT": "6.0-jammy"
+			"VARIANT": "8.0-noble"
 		}
 	},
 	"hostRequirements": {

--- a/.devcontainer/libraries/devcontainer.json
+++ b/.devcontainer/libraries/devcontainer.json
@@ -4,8 +4,7 @@
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 6.0, 7.0
-			"VARIANT": "6.0-jammy"
+			"VARIANT": "8.0-noble"
 		}
 	},
 	"hostRequirements": {

--- a/.devcontainer/wasm-multiThreaded/Dockerfile
+++ b/.devcontainer/wasm-multiThreaded/Dockerfile
@@ -51,7 +51,7 @@ RUN sudo apt-get install libnss3 -y \
     && apt-get install libgbm-dev -y \
     && apt-get install libpango-1.0-0 -y \
     && apt-get install libcairo2 -y \
-    && apt-get install libasound2 -y
+    && apt-get install libasound2t64 -y
 
 # install firefox dependencies to run debugger tests:
 RUN sudo apt-get install libdbus-glib-1-2 -y \

--- a/.devcontainer/wasm-multiThreaded/Dockerfile
+++ b/.devcontainer/wasm-multiThreaded/Dockerfile
@@ -1,22 +1,13 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 # For details on dotnet specific container, see: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet
 
-# [Choice] .NET version: 6.0, 7.0
-ARG VARIANT="6.0-jammy"
-FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
-
-# Set up machine requirements to build the repo and the gh CLI
-# Clang-16 up is required but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
-RUN apt-get update \
-    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
-    && apt-get install software-properties-common -y \
-    && add-apt-repository "deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main" -y \
-    && apt-get update \
-    && apt-get install clang-18 -y
+ARG VARIANT="8.0-noble"
+FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
+        clang \
         cmake \
         build-essential \
         python3 \

--- a/.devcontainer/wasm-multiThreaded/Dockerfile
+++ b/.devcontainer/wasm-multiThreaded/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
         git \
         lldb \
+        llvm \
         liblldb-dev \
         libunwind8 \
         libunwind8-dev \

--- a/.devcontainer/wasm-multiThreaded/devcontainer.json
+++ b/.devcontainer/wasm-multiThreaded/devcontainer.json
@@ -4,8 +4,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 6.0, 7.0
-			"VARIANT": "6.0-jammy"
+			"VARIANT": "8.0-noble"
 		}
 	},
 	"hostRequirements": {

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -1,21 +1,12 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 # For details on dotnet specific container, see: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet
 
-# [Choice] .NET version: 6.0, 7.0
-ARG VARIANT="6.0-jammy"
-FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
-
-# Set up machine requirements to build the repo and the gh CLI
-# Clang-16 up is required but Ubuntu 22.04 comes with clang-14 highest, so add clang-18 sources
-RUN apt-get update \
-    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
-    && apt-get install software-properties-common -y \
-    && add-apt-repository "deb http://apt.llvm.org/$(lsb_release -s -c)/ llvm-toolchain-$(lsb_release -s -c)-18 main" -y \
-    && apt-get update \
-    && apt-get install clang-18 -y
+ARG VARIANT="8.0-noble"
+FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
+        clang \
         cmake \
         build-essential \
         python3 \

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -50,7 +50,7 @@ RUN sudo apt-get install libnss3 -y \
     && apt-get install libgbm-dev -y \
     && apt-get install libpango-1.0-0 -y \
     && apt-get install libcairo2 -y \
-    && apt-get install libasound2 -y
+    && apt-get install libasound2t64 -y
 
 # install firefox dependencies to run debugger tests:
 RUN sudo apt-get install libdbus-glib-1-2 -y \

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         curl \
         git \
         lldb \
+        llvm \
         liblldb-dev \
         libunwind8 \
         libunwind8-dev \

--- a/.devcontainer/wasm/devcontainer.json
+++ b/.devcontainer/wasm/devcontainer.json
@@ -4,8 +4,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 6.0, 7.0
-			"VARIANT": "6.0-jammy"
+			"VARIANT": "8.0-noble"
 		}
 	},
 	"hostRequirements": {


### PR DESCRIPTION
This PR

1. Updates the docker images used from Jammy to Noble.
2. Removes the llvm.org feed for Clang. Noble has Clang 18.1, so we don't need it outside of what the default package feed provides 
3. `libasound2` is ambiguous in the Noble feeds. Use `libasound2t64` to use the 64-bit time package, since Codespaces are all x86_64.