### PR TITLE
Fix unhandled exception test for composite r2r case

### DIFF
--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -98,7 +98,8 @@ namespace TestUnhandledExceptionTester
                 }
                 else if (unhandledType == "foreign")
                 {
-                    if (!lines[0].StartsWith("Unhandled exception. System.DllNotFoundException:"))
+                    if (!lines[0].StartsWith("Unhandled exception. System.DllNotFoundException:") &&
+                        !lines[0].StartsWith("Unhandled exception. System.EntryPointNotFoundException: Unable to find an entry point named 'HelloCpp'"))
                     {
                         throw new Exception("Missing Unhandled exception header");
                     }


### PR DESCRIPTION
The test fails when built as r2r composite on linux coreclr due to the fact that the unhandled exception differs in this case from regular non-composite or non-r2r builds. It gets System.EntryPointNotFoundException instead of System.DllNotFoundException due to a different order the resolving happens in this case.

This change fixes that by modifying the unhandledTester to accept both of these cases as success.