### PR TITLE
Fix typo `commmon` -> `common`

### DIFF
--- a/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
@@ -161,7 +161,7 @@ EXTERN_C void QCALLTYPE EventPipeInternal_DeleteProvider(intptr_t provHandle)
     }
 }
 
-// All the runtime redefine this enum, should move to commmon code.
+// All the runtime redefine this enum, should move to common code.
 // https://github.com/dotnet/runtime/issues/87069
 enum class ActivityControlCode
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPoolEventSource.cs
@@ -108,7 +108,7 @@ namespace System.Buffers
 
         /// <summary>
         /// Event raised when we attempt to free a buffer due to inactivity or memory pressure (by no longer
-        /// referencing it). It is possible (although not commmon) this buffer could be rented as we attempt
+        /// referencing it). It is possible (although not common) this buffer could be rented as we attempt
         /// to free it. A rent event before or after this event for the same ID, is a rare, but expected case.
         /// </summary>
         [Event(4, Level = EventLevel.Informational)]


### PR DESCRIPTION
Total of 2 occurrence of `commmon` in the repo.