### PR TITLE
Exclude shared libs from ilcframework in nupkg

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -25,6 +25,9 @@
 
     <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
       <File Include="@(LibrariesRuntimeFiles)" TargetPath="framework" />
+      <!-- exclude shared libs as we only need static ones -->
+      <LibPackageExcludes Include="framework\%2A%2A\%2A$(LibSuffix)"/>
+
       <File Include="$(CoreCLRILCompilerDir)*" TargetPath="tools" />
       <File Include="$(CoreCLRAotSdkDir)*" TargetPath="sdk" />
       <File Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" TargetPath="mibc" />


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/108649#issuecomment-2401523930

shaves off 1MB from runtime pack on osx; before ` 39M	artifacts/packages/Release/Shipping/runtime.osx-arm64.Microsoft.DotNet.ILCompiler.10.0.0-dev.nupkg` now 38M.