### PR TITLE
Enable rollforward for inbuild variant of crossgen2

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/crossgen2_inbuild.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_inbuild.csproj
@@ -4,6 +4,7 @@
     <OutputPath>$(RuntimeBinDir)/$(BuildArchitecture)/crossgen2/</OutputPath>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <UseAppHost>false</UseAppHost>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <Import Project="crossgen2.props" />
 </Project>


### PR DESCRIPTION
Fixes failures in source-build in dotnet/sdk#43015. Same fix was applied to cdac tool in dotnet/runtime#108946