### PR TITLE
Make ordered dictionary pointers always point to the front of the dictionary

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
@@ -448,8 +448,7 @@ namespace System.Collections.Generic
             }
 
             // Shift up all entries above this one, and fix up the buckets or Next pointers that point to the
-            // shifted entries. Because the Next pointers point backwards, we can do this in a single pass starting
-            // from the back.
+            // shifted entries. Because a Next pointer always points to a lower index, we can do this in a single pass.
             for (i = _count - 1; i >= index; --i)
             {
                 ShiftEntry(i, shiftAmount: 1, modifyIndex: index);
@@ -649,7 +648,7 @@ namespace System.Collections.Generic
                 }
                 while (prev > i);
 
-                // Next pointers point backwards so if this invariant is violated,
+                // Next pointers point to lower indexes so if this invariant is violated,
                 // then a concurrent operation must have happened to corrupt the chain.
                 // Break out of the loop and throw, rather than potentially looping forever.
                 goto ConcurrentOperation;
@@ -680,7 +679,7 @@ namespace System.Collections.Generic
                 }
                 while (prev > i);
 
-                // Next pointers point backwards so if this invariant is violated,
+                // Next pointers point to lower indexes so if this invariant is violated,
                 // then a concurrent operation must have happened to corrupt the chain.
                 // Break out of the loop and throw, rather than potentially looping forever.
                 goto ConcurrentOperation;
@@ -763,7 +762,7 @@ namespace System.Collections.Generic
             RemoveEntryFromChain(index);
 
             // Shift down all entries above this one, and fix up the buckets or Next pointers that point to
-            // the shifted entries. Because the Next pointers point backwards, we can do this in a single pass.
+            // the shifted entries. Because the Next pointers point to lower indexes, we can do this in a single pass.
             Entry[]? entries = _entries;
             Debug.Assert(entries is not null);
             for (int i = index + 1; i < count; i++)
@@ -967,7 +966,7 @@ namespace System.Collections.Generic
                     nextEntryIndex = ref entries[currentEntryIndex].Next;
                 }
 
-                // Next pointers point backwards so if this invariant is violated,
+                // Next pointers point to lower indexes so if this invariant is violated,
                 // then a concurrent operation must have happened to corrupt the chain.
                 ThrowHelper.ThrowConcurrentOperation();
             }
@@ -1013,7 +1012,7 @@ namespace System.Collections.Generic
                     nextEntryIndex = ref entries[currentEntryIndex].Next;
                 }
 
-                // Next pointers point backwards so if this invariant is violated,
+                // Next pointers point to lower indexes so if this invariant is violated,
                 // then a concurrent operation must have happened to corrupt the chain.
                 ThrowHelper.ThrowConcurrentOperation();
             }
@@ -1379,7 +1378,7 @@ namespace System.Collections.Generic
         {
             /// <summary>
             /// The index of the next entry in the chain, or -1 if this is the last entry in the chain.
-            /// The next pointer of an entry always points behind it.
+            /// The next pointer of an entry always points to a lower index.
             /// </summary>
             public int Next;
             /// <summary>Cached hash code of <see cref="Key"/>.</summary>

--- a/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
@@ -329,6 +329,53 @@ namespace System.Collections.Tests
 
         #endregion
 
+        #region Insert
+
+        [Fact]
+        public void OrderedDictionary_Insert_Collisions()
+        {
+            int N = 5;
+            for (int insertLocation = 0; insertLocation <= N; insertLocation++)
+            {
+                var dict = new OrderedDictionary<TKey, TValue>(new BadComparer());
+
+                for (var i = 0; i < 5; i++)
+                {
+                    TKey key = CreateTKey(i); TValue value = CreateTValue(i);
+                    dict[key] = value;
+                }
+
+                Assert.Equal(5, dict.Count);
+
+                TKey key1 = CreateTKey(5); TValue value1 = CreateTValue(5);
+                dict.Insert(index: insertLocation, key1, value1);
+
+                Assert.Equal(6, dict.Count);
+                for (var i = 0; i <= 5; i++)
+                {
+                    TKey key = CreateTKey(i);
+                    Assert.True(dict.ContainsKey(key));
+                }
+
+                dict.RemoveAt(index: insertLocation);
+
+                Assert.Equal(5, dict.Count);
+                for (var i = 0; i < 5; i++)
+                {
+                    TKey key = CreateTKey(i);
+                    Assert.True(dict.ContainsKey(key));
+                }
+            }
+        }
+
+        class BadComparer : IEqualityComparer<TKey>
+        {
+            public bool Equals(TKey? x, TKey? y) => EqualityComparer<TKey>.Default.Equals(x, y);
+            public int GetHashCode(TKey obj) => 42;
+        }
+
+        #endregion
+
         #region Remove(..., out TValue)
 
         [Theory]
@@ -346,6 +393,33 @@ namespace System.Collections.Tests
             }
 
             Assert.False(dictionary.Remove(pair.Key, out _));
+        }
+
+        [Fact]
+        public void OrderedDictionary_Remove_Collisions()
+        {
+            int N = 5;
+            for (int removeLocation = 0; removeLocation < N; removeLocation++)
+            {
+                var dict = new OrderedDictionary<TKey, TValue>(new BadComparer());
+
+                for (var i = 0; i < 5; i++)
+                {
+                    TKey key = CreateTKey(i); TValue value = CreateTValue(i);
+                    dict[key] = value;
+                }
+
+                Assert.Equal(5, dict.Count);
+
+                dict.RemoveAt(index: removeLocation);
+
+                Assert.Equal(4, dict.Count);
+                for (var i = 0; i < 5; i++)
+                {
+                    TKey key = CreateTKey(i);
+                    Assert.Equal(i != removeLocation, dict.ContainsKey(key));
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
Improves worst case behavior of InsertAt from O(n^2) to O(n). The scenario that causes this is a pathological case that will likely never be hit in the real world, but at the same time, it doesn't cost much to fix it (e.g. PR just fixes it with no significant downside). Specifically, if n different keys all with the same hash are added to the front, each insert causes the whole list to shift. Each of these inserts should be O(n) but shifting a single element is done by getting the head of its hash bucket and traversing it until that element it found (in order to finally update the pointer to it). Every element is shifted during a front insert and every element is part of the same bucket list, so there are 1+2+...+n nodes traversed or O(n^2).

This PR fixes that issue by maintaining the invariant that pointers in entries always point to the front of the dictionary. Because of this, shifting elements is an O(1) local operation per element (change its next pointer and its bucket if it is the head of the bucket chain) and shifting n elements is O(n) in all cases.

This also makes concurrent operation checks easier. The original code checks for bucket chain cycles by seeing if traversal walks through more than `entries.Length` items, but there's now a stronger invariant that all bucket chain entries point to the front (this implies no cycles and also guarantees traversal termination).