### PR TITLE
Add TryAdd and TryGetValue overloads with `out int index` to OrderedDictionary

### DIFF
--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -174,7 +174,9 @@ namespace System.Collections.Generic
         public void TrimExcess() { }
         public void TrimExcess(int capacity) { }
         public bool TryAdd(TKey key, TValue value) { throw null; }
+        public bool TryAdd(TKey key, TValue value, out int index) { throw null; }
         public bool TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value) { throw null; }
+        public bool TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value, out int index) { throw null; }
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
         {
             private object _dummy;

--- a/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
@@ -377,7 +377,7 @@ namespace System.Collections.Generic
             {
                 ThrowIfNull(key);
 
-                bool modified = TryInsert(index: -1, key, value, InsertionBehavior.OverwriteExisting);
+                bool modified = TryInsert(index: -1, key, value, InsertionBehavior.OverwriteExisting, out _);
                 Debug.Assert(modified);
             }
         }
@@ -392,8 +392,9 @@ namespace System.Collections.Generic
         /// - OverwriteExisting: If the key already exists, overwrites its value with the specified value, e.g. this[key] = value
         /// - ThrowOnExisting: If the key already exists, throws an exception, e.g. Add(key, value)
         /// </param>
+        /// <param name="keyIndex">The index of the added or existing key. This is always a valid index into the dictionary.</param>
         /// <returns>true if the collection was updated; otherwise, false.</returns>
-        private bool TryInsert(int index, TKey key, TValue value, InsertionBehavior behavior)
+        private bool TryInsert(int index, TKey key, TValue value, InsertionBehavior behavior, out int keyIndex)
         {
             // Search for the key in the dictionary.
             uint hashCode = 0, collisionCount = 0;
@@ -402,6 +403,9 @@ namespace System.Collections.Generic
             // Handle the case where the key already exists, based on the requested behavior.
             if (i >= 0)
             {
+                keyIndex = i;
+                Debug.Assert(0 <= keyIndex && keyIndex < _count);
+
                 Debug.Assert(_entries is not null);
 
                 switch (behavior)
@@ -467,6 +471,9 @@ namespace System.Collections.Generic
 
             RehashIfNecessary(collisionCount, entries);
 
+            keyIndex = index;
+            Debug.Assert(0 <= keyIndex && keyIndex < _count);
+
             return true;
         }
 
@@ -479,7 +486,7 @@ namespace System.Collections.Generic
         {
             ThrowIfNull(key);
 
-            TryInsert(index: -1, key, value, InsertionBehavior.ThrowOnExisting);
+            TryInsert(index: -1, key, value, InsertionBehavior.ThrowOnExisting, out _);
         }
 
         /// <summary>Adds the specified key and value to the dictionary if the key doesn't already exist.</summary>
@@ -487,11 +494,19 @@ namespace System.Collections.Generic
         /// <param name="value">The value of the element to add. The value can be null for reference types.</param>
         /// <exception cref="ArgumentNullException">key is null.</exception>
         /// <returns>true if the key didn't exist and the key and value were added to the dictionary; otherwise, false.</returns>
-        public bool TryAdd(TKey key, TValue value)
+        public bool TryAdd(TKey key, TValue value) => TryAdd(key, value, out _);
+
+        /// <summary>Adds the specified key and value to the dictionary if the key doesn't already exist.</summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add. The value can be null for reference types.</param>
+        /// <param name="index">The index of added or existing <paramref name="key"/>. This is always a valid index into the dictionary.</param>
+        /// <exception cref="ArgumentNullException">key is null.</exception>
+        /// <returns>true if the key didn't exist and the key and value were added to the dictionary; otherwise, false.</returns>
+        public bool TryAdd(TKey key, TValue value, out int index)
         {
             ThrowIfNull(key);
 
-            return TryInsert(index: -1, key, value, InsertionBehavior.IgnoreInsertion);
+            return TryInsert(index: -1, key, value, InsertionBehavior.IgnoreInsertion, out index);
         }
 
         /// <summary>Adds each element of the enumerable to the dictionary.</summary>
@@ -714,7 +729,7 @@ namespace System.Collections.Generic
 
             ThrowIfNull(key);
 
-            TryInsert(index, key, value, InsertionBehavior.ThrowOnExisting);
+            TryInsert(index, key, value, InsertionBehavior.ThrowOnExisting, out _);
         }
 
         /// <summary>Removes the value with the specified key from the <see cref="OrderedDictionary{TKey, TValue}"/>.</summary>
@@ -896,12 +911,22 @@ namespace System.Collections.Generic
         /// otherwise, the default value for the type of the value parameter.
         /// </param>
         /// <returns>true if the <see cref="OrderedDictionary{TKey, TValue}"/> contains an element with the specified key; otherwise, false.</returns>
-        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => TryGetValue(key, out value, out _);
+
+        /// <summary>Gets the value associated with the specified key.</summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="value">
+        /// When this method returns, contains the value associated with the specified key, if the key is found;
+        /// otherwise, the default value for the type of the value parameter.
+        /// </param>
+        /// <param name="index">The index of <paramref name="key"/> if found; otherwise, -1.</param>
+        /// <returns>true if the <see cref="OrderedDictionary{TKey, TValue}"/> contains an element with the specified key; otherwise, false.</returns>
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value, out int index)
         {
             ThrowIfNull(key);
 
             // Find the key.
-            int index = IndexOf(key);
+            index = IndexOf(key);
             if (index >= 0)
             {
                 // It exists. Return its value.

--- a/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
@@ -499,7 +499,7 @@ namespace System.Collections.Generic
         /// <summary>Adds the specified key and value to the dictionary if the key doesn't already exist.</summary>
         /// <param name="key">The key of the element to add.</param>
         /// <param name="value">The value of the element to add. The value can be null for reference types.</param>
-        /// <param name="index">The index of added or existing <paramref name="key"/>. This is always a valid index into the dictionary.</param>
+        /// <param name="index">The index of the added or existing <paramref name="key"/>. This is always a valid index into the dictionary.</param>
         /// <exception cref="ArgumentNullException">key is null.</exception>
         /// <returns>true if the key didn't exist and the key and value were added to the dictionary; otherwise, false.</returns>
         public bool TryAdd(TKey key, TValue value, out int index)

--- a/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
@@ -187,6 +187,80 @@ namespace System.Collections.Tests
 
             Assert.True(valuesEnum.MoveNext());
         }
+
+        [Fact]
+        public void TryAdd_ItemAlreadyExists_IndexCorrect()
+        {
+            var dictionary = new OrderedDictionary<TKey, TValue>();
+
+            for (int i = 0; i < 3; i++)
+            {
+                dictionary.Add(CreateTKey(i), CreateTValue(i));
+            }
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.False(dictionary.TryAdd(CreateTKey(i), CreateTValue(i), out var index));
+                Assert.Equal(i, index);
+            }
+        }
+
+        [Fact]
+        public void TryAdd_NewItem_IndexCorrect()
+        {
+            var dictionary = new OrderedDictionary<TKey, TValue>();
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.True(dictionary.TryAdd(CreateTKey(i), CreateTValue(i), out var index));
+                Assert.Equal(i, index);
+            }
+        }
+
+        #endregion
+
+        #region TryGetValue
+
+        [Fact]
+        public void TryGetValue_ExistingItem()
+        {
+            var dictionary = new OrderedDictionary<TKey, TValue>();
+
+            for (int i = 0; i < 3; i++)
+            {
+                dictionary.Add(CreateTKey(i), CreateTValue(i));
+            }
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.True(dictionary.TryGetValue(CreateTKey(i), out var value, out var index));
+                Assert.Equal(CreateTValue(i), value);
+                Assert.Equal(i, index);
+            }
+        }
+
+        [Fact]
+        public void TryGetValue_MissingItem()
+        {
+            var dictionary = new OrderedDictionary<TKey, TValue>();
+
+            for (int i = 0; i < 3; i++)
+            {
+                var key = CreateTKey(i);
+                var value = CreateTValue(i);
+
+                Assert.False(dictionary.TryGetValue(key, out var v, out var index));
+                Assert.Equal(default(TValue), v);
+                Assert.Equal(-1, index);
+
+                dictionary.Add(key, value);
+
+                Assert.True(dictionary.TryGetValue(key, out v, out index));
+                Assert.Equal(value, v);
+                Assert.Equal(i, index);
+            }
+        }
+
         #endregion
 
         #region ContainsValue

--- a/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/OrderedDictionary/OrderedDictionary.Generic.Tests.cs
@@ -200,7 +200,7 @@ namespace System.Collections.Tests
 
             for (int i = 0; i < 3; i++)
             {
-                Assert.False(dictionary.TryAdd(CreateTKey(i), CreateTValue(i), out var index));
+                Assert.False(dictionary.TryAdd(CreateTKey(i), CreateTValue(i), out int index));
                 Assert.Equal(i, index);
             }
         }
@@ -212,7 +212,7 @@ namespace System.Collections.Tests
 
             for (int i = 0; i < 3; i++)
             {
-                Assert.True(dictionary.TryAdd(CreateTKey(i), CreateTValue(i), out var index));
+                Assert.True(dictionary.TryAdd(CreateTKey(i), CreateTValue(i), out int index));
                 Assert.Equal(i, index);
             }
         }
@@ -233,7 +233,7 @@ namespace System.Collections.Tests
 
             for (int i = 0; i < 3; i++)
             {
-                Assert.True(dictionary.TryGetValue(CreateTKey(i), out var value, out var index));
+                Assert.True(dictionary.TryGetValue(CreateTKey(i), out TValue value, out int index));
                 Assert.Equal(CreateTValue(i), value);
                 Assert.Equal(i, index);
             }
@@ -249,7 +249,7 @@ namespace System.Collections.Tests
                 var key = CreateTKey(i);
                 var value = CreateTValue(i);
 
-                Assert.False(dictionary.TryGetValue(key, out var v, out var index));
+                Assert.False(dictionary.TryGetValue(key, out TValue v, out int index));
                 Assert.Equal(default(TValue), v);
                 Assert.Equal(-1, index);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -248,8 +248,17 @@ namespace System.Text.Json.Nodes
 
             OrderedDictionary<string, JsonNode?> dict = Dictionary;
 
-            if (!dict.TryAdd(propertyName, value, out int index))
+            if (
+#if NET10_0_OR_GREATER
+                !dict.TryAdd(propertyName, value, out int index)
+#else
+                !dict.TryAdd(propertyName, value)
+#endif
+                )
             {
+#if !NET10_0_OR_GREATER
+                int index = dict.IndexOf(propertyName);
+#endif
                 Debug.Assert(index >= 0);
                 JsonNode? replacedValue = dict.GetAt(index).Value;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -248,7 +248,7 @@ namespace System.Text.Json.Nodes
 
             OrderedDictionary<string, JsonNode?> dict = Dictionary;
 
-            if (!dict.TryAdd(propertyName, value, out var index))
+            if (!dict.TryAdd(propertyName, value, out int index))
             {
                 Debug.Assert(index >= 0);
                 JsonNode? replacedValue = dict.GetAt(index).Value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -248,9 +248,8 @@ namespace System.Text.Json.Nodes
 
             OrderedDictionary<string, JsonNode?> dict = Dictionary;
 
-            if (!dict.TryAdd(propertyName, value))
+            if (!dict.TryAdd(propertyName, value, out var index))
             {
-                int index = dict.IndexOf(propertyName);
                 Debug.Assert(index >= 0);
                 JsonNode? replacedValue = dict.GetAt(index).Value;
 


### PR DESCRIPTION
Fixes #107947 and #107944

Adds and consumes the following API:

```cs
namespace System.Collections.Generic;

public partial class OrderedDictionary<TKey, TValue>
{
    // Existing
    // public bool TryAdd(TKey key, TValue value);
    // public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value);
    public bool TryAdd(TKey key, TValue value, out int index);
    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value, out int index);
}
```

**Perf Impact:**

| Method       | Toolchain                                                                                                    | Count | Mean       | Error    | StdDev    | Ratio | RatioSD |
|------------- |------------------------------------------------------------------------------------------------------------- |------ |-----------:|---------:|----------:|------:|--------:|
| **AddAndUpdate** | **main** | **1**     |   **126.1 ns** |  **2.12 ns** |   **1.77 ns** |  **1.00** |    **0.02** |
| AddAndUpdate | pr  | 1     |   112.7 ns |  1.79 ns |   1.68 ns |  0.89 |    0.02 |
|              |            |                                                                                                              |       |            |          |           |       |         |
| **AddAndUpdate**  | **main** | **10**    |   **821.4 ns** | **11.77 ns** |   **9.83 ns** |  **1.00** |    **0.02** |
| AddAndUpdate | pr  | 10    |   668.0 ns | 13.07 ns |  10.92 ns |  0.81 |    0.02 |
|              |            |                                                                                                              |       |            |          |           |       |         |
| **AddAndUpdate**| **main** | **50**    | **3,886.8 ns** | **77.38 ns** | **163.21 ns** |  **1.00** |    **0.06** |
| AddAndUpdate  | pr  | 50    | 3,014.6 ns | 46.28 ns |  41.02 ns |  0.78 |    0.03 |

<details>
<summary><b>Expand for code</b></summary>

```cs
public class JsonObjectUpdate
{
    public string[] _keys = Array.Empty<string>();

    [Params(1, 10, 50)]
    public int Count;

    [GlobalSetup]
    public void Setup()
    {
        _keys = Enumerable.Range(1, Count).Select(i => $"prop{i}").ToArray();
    }

    [Benchmark]
    public JsonObject AddAndUpdate()
    {
        JsonObject obj = new JsonObject();

        foreach (var key in _keys)
        {
            obj[key] = default;
        }

        foreach (var key in _keys)
        {
            obj[key] = key;
        }

        return obj;
    }
}
```
</details>
