### PR TITLE
Forward NetCoreAppToolCurrentVersion in DotNetBuild.props

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -97,6 +97,8 @@
       <InnerBuildArgs Condition="$(UseSystemLibs.Contains('+rapidjson+'))">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_RAPIDJSON=true</InnerBuildArgs>
       <InnerBuildArgs Condition="$(UseSystemLibs.Contains('+zlib+'))">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_ZLIB=true</InnerBuildArgs>
 
+      <!-- Needed until https://github.com/dotnet/runtime/issues/109329 is fixed. -->
+      <InnerBuildArgs Condition="'$(NetCoreAppToolCurrent)' != ''">$(InnerBuildArgs) /p:NetCoreAppToolCurrent=$(NetCoreAppToolCurrent)</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -98,7 +98,7 @@
       <InnerBuildArgs Condition="$(UseSystemLibs.Contains('+zlib+'))">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_ZLIB=true</InnerBuildArgs>
 
       <!-- Needed until https://github.com/dotnet/runtime/issues/109329 is fixed. -->
-      <InnerBuildArgs Condition="'$(NetCoreAppToolCurrent)' != ''">$(InnerBuildArgs) /p:NetCoreAppToolCurrent=$(NetCoreAppToolCurrent)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(NetCoreAppToolCurrentVersion)' != ''">$(InnerBuildArgs) /p:NetCoreAppToolCurrentVersion=$(NetCoreAppToolCurrentVersion)</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/src/coreclr/tools/cdac-build-tool/cdac-build-tool.csproj
+++ b/src/coreclr/tools/cdac-build-tool/cdac-build-tool.csproj
@@ -14,7 +14,6 @@
     <IsShipping>false</IsShipping> <!-- This tool is an implementation detail of the build process, it does not ship -->
     <Description>.NET runtime data contract build tool</Description>
     <RootNamespace>Microsoft.DotNet.Diagnostics.DataContract</RootNamespace>
-    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replaces https://github.com/dotnet/runtime/pull/109265
Needed for https://github.com/dotnet/sdk/pull/43015