### PR TITLE
Improve handling of encoding of X.520 attributes

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
@@ -103,34 +103,52 @@ namespace System.Security.Cryptography
         // PKCS#7
         internal const string NoSignature = "1.3.6.1.5.5.7.6.2";
 
-        // X500 Names
-        internal const string CommonName = "2.5.4.3";
-        internal const string Surname = "2.5.4.4";
-        internal const string SerialNumber = "2.5.4.5";
-        internal const string CountryOrRegionName = "2.5.4.6";
-        internal const string LocalityName = "2.5.4.7";
-        internal const string StateOrProvinceName = "2.5.4.8";
-        internal const string StreetAddress = "2.5.4.9";
-        internal const string Organization = "2.5.4.10";
-        internal const string OrganizationalUnit = "2.5.4.11";
-        internal const string Title = "2.5.4.12";
-        internal const string Description = "2.5.4.13";
-        internal const string PostalCode = "2.5.4.17";
-        internal const string PostOfficeBox = "2.5.4.18";
-        internal const string PhysicalDeliveryOfficeName = "2.5.4.19";
-        internal const string TelephoneNumber = "2.5.4.20";
-        internal const string GivenName = "2.5.4.42";
-        internal const string Initials = "2.5.4.43";
-        internal const string GenerationQualifier = "2.5.4.44";
-        internal const string DnQualifier = "2.5.4.46";
-        internal const string HouseIdentifier = "2.5.4.51";
-        internal const string Pseudonym = "2.5.4.65";
-        internal const string CountryOrRegionName3C = "2.5.4.98";
-        internal const string CountryOrRegionName3N = "2.5.4.99";
-        internal const string DnsName = "2.5.4.100";
-        internal const string IntEmail = "2.5.4.104";
-        internal const string Jid = "2.5.4.105";
-        internal const string EmailAddress = "1.2.840.113549.1.9.1";
+        // X500 Names - T-REC X.520-201910
+        internal const string KnowledgeInformation = "2.5.4.2"; // 6.1.1 - id-at-knowledgeInformation
+        internal const string CommonName = "2.5.4.3"; // 6.2.2 - id-at-commonName
+        internal const string Surname = "2.5.4.4"; // 6.2.3 - id-at-surname
+        internal const string SerialNumber = "2.5.4.5"; // 6.2.9 - id-at-serialNumber
+        internal const string CountryOrRegionName = "2.5.4.6"; // 6.3.1 - id-at-countryName
+        internal const string LocalityName = "2.5.4.7"; // 6.3.4 - id-at-localityName
+        internal const string StateOrProvinceName = "2.5.4.8"; // 6.3.5 - id-at-stateOrProvinceName
+        internal const string StreetAddress = "2.5.4.9"; // 6.3.6 - id-at-streetAddress
+        internal const string Organization = "2.5.4.10"; // 6.4.1 - id-at-organizationName
+        internal const string OrganizationalUnit = "2.5.4.11"; // 6.4.2 - id-at-organizationalUnitName
+        internal const string Title = "2.5.4.12"; // 6.4.3 - id-at-title
+        internal const string Description = "2.5.4.13"; // 6.5.1 - id-at-description
+        internal const string BusinessCategory = "2.5.4.15"; // 6.5.4 - id-at-businessCategory
+        internal const string PostalCode = "2.5.4.17"; // 6.6.2 - id-at-postalCode
+        internal const string PostOfficeBox = "2.5.4.18"; // 6.6.3 - id-at-postOfficeBox
+        internal const string PhysicalDeliveryOfficeName = "2.5.4.19"; // 6.6.4 - id-at-physicalDeliveryOfficeName
+        internal const string TelephoneNumber = "2.5.4.20"; // 6.7.1 - id-at-telephoneNumber
+        internal const string X121Address = "2.5.4.24"; // 6.7.5 - id-at-x121Address
+        internal const string InternationalISDNNumber = "2.5.4.25"; // 6.7.6 - id-at-internationalISDNNumber
+        internal const string DestinationIndicator = "2.5.4.27"; // 6.7.8 - id-at-destinationIndicator
+        internal const string Name = "2.5.4.41"; // 6.2.1 - id-at-name
+        internal const string GivenName = "2.5.4.42"; // 6.2.4 - id-at-givenName
+        internal const string Initials = "2.5.4.43"; // 6.2.5 - id-at-initials
+        internal const string GenerationQualifier = "2.5.4.44"; // 6.2.6 - id-at-generationQualifier
+        internal const string DnQualifier = "2.5.4.46"; // 6.2.8 - id-at-dnQualifier
+        internal const string HouseIdentifier = "2.5.4.51"; // 6.3.7 - id-at-houseIdentifier
+        internal const string DmdName = "2.5.4.54"; // 6.11.1 - id-at-dmdName
+        internal const string Pseudonym = "2.5.4.65"; // 6.2.10 - id-at-pseudonym
+        internal const string UiiInUrn = "2.5.4.80"; // 6.13.3 - id-at-uiiInUrn
+        internal const string ContentUrl = "2.5.4.81"; // 6.13.4 - id-at-contentUrl
+        internal const string Uri = "2.5.4.83"; // 6.2.12 - id-at-uri
+        internal const string Urn = "2.5.4.86"; // 6.2.13 - id-at-urn
+        internal const string Url = "2.5.4.87"; // 6.2.14 - id-at-url
+        internal const string UrnC = "2.5.4.89"; // 6.12.4 - id-at-urnC
+        internal const string EpcInUrn = "2.5.4.94"; // 6.13.9 - id-at-epcInUrn
+        internal const string LdapUrl = "2.5.4.95"; // 6.13.10 - id-at-ldapUrl
+        internal const string OrganizationIdentifier = "2.5.4.97"; // 6.4.4 - id-at-organizationIdentifier
+        internal const string CountryOrRegionName3C = "2.5.4.98"; // 6.3.2 - id-at-countryCode3c
+        internal const string CountryOrRegionName3N = "2.5.4.99"; // 6.3.3 - id-at-countryCode3n
+        internal const string DnsName = "2.5.4.100"; // 6.2.15 - id-at-dnsName
+        internal const string IntEmail = "2.5.4.104"; // 6.2.16 - id-at-intEmail
+        internal const string JabberId = "2.5.4.105"; // 6.2.17 - id-at-jid
+
+        // RFC 2985
+        internal const string EmailAddress = "1.2.840.113549.1.9.1"; //  B.3.5
 
         // Cert Extensions
         internal const string BasicConstraints = "2.5.29.10";

--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
@@ -105,11 +105,31 @@ namespace System.Security.Cryptography
 
         // X500 Names
         internal const string CommonName = "2.5.4.3";
+        internal const string Surname = "2.5.4.4";
+        internal const string SerialNumber = "2.5.4.5";
         internal const string CountryOrRegionName = "2.5.4.6";
         internal const string LocalityName = "2.5.4.7";
         internal const string StateOrProvinceName = "2.5.4.8";
+        internal const string StreetAddress = "2.5.4.9";
         internal const string Organization = "2.5.4.10";
         internal const string OrganizationalUnit = "2.5.4.11";
+        internal const string Title = "2.5.4.12";
+        internal const string Description = "2.5.4.13";
+        internal const string PostalCode = "2.5.4.17";
+        internal const string PostOfficeBox = "2.5.4.18";
+        internal const string PhysicalDeliveryOfficeName = "2.5.4.19";
+        internal const string TelephoneNumber = "2.5.4.20";
+        internal const string GivenName = "2.5.4.42";
+        internal const string Initials = "2.5.4.43";
+        internal const string GenerationQualifier = "2.5.4.44";
+        internal const string DnQualifier = "2.5.4.46";
+        internal const string HouseIdentifier = "2.5.4.51";
+        internal const string Pseudonym = "2.5.4.65";
+        internal const string CountryOrRegionName3C = "2.5.4.98";
+        internal const string CountryOrRegionName3N = "2.5.4.99";
+        internal const string DnsName = "2.5.4.100";
+        internal const string IntEmail = "2.5.4.104";
+        internal const string Jid = "2.5.4.105";
         internal const string EmailAddress = "1.2.840.113549.1.9.1";
 
         // Cert Extensions

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
@@ -585,36 +585,58 @@ namespace System.Security.Cryptography.X509Certificates
 
         private static Dictionary<string, EncodingRules> CreateEncodingRulesLookup()
         {
-            const int LookupDictionarySize = 27;
+            // Attributes that are not "obsolete" from ITU T-REC X.520-2019.
+            // Attributes that are included are attributes that are string-like and can be represented by a String,
+            // and are not obsolete.
+            // Windows does not have any restrictions on encoding non-string encodable types, it will encode them
+            // anyway, such as OID.2.5.4.14=test will encode test as a PrintableString, even though the OID is a SET.
+            // To maintain similar behavior as Windows, those types will remain treated as unknown.
+            const int LookupDictionarySize = 43;
             Dictionary<string, EncodingRules> lookup = new(LookupDictionarySize, StringComparer.Ordinal)
             {
-                { Oids.EmailAddress, EncodingRules.IA5String },
+                { Oids.KnowledgeInformation, EncodingRules.DirectoryString },
                 { Oids.CommonName, EncodingRules.DirectoryString },
                 { Oids.Surname, EncodingRules.DirectoryString },
-                { Oids.GivenName, EncodingRules.DirectoryString },
-                { Oids.Initials, EncodingRules.DirectoryString },
-                { Oids.GenerationQualifier, EncodingRules.DirectoryString },
-                { Oids.DnQualifier, EncodingRules.PrintableString },
                 { Oids.SerialNumber, EncodingRules.PrintableString },
-                { Oids.Pseudonym, EncodingRules.DirectoryString },
-                { Oids.DnsName, EncodingRules.UTF8String },
-                { Oids.IntEmail, EncodingRules.UTF8String },
-                { Oids.Jid, EncodingRules.UTF8String },
                 { Oids.CountryOrRegionName, EncodingRules.PrintableString },
-                { Oids.CountryOrRegionName3C, EncodingRules.PrintableString },
-                { Oids.CountryOrRegionName3N, EncodingRules.NumericString },
                 { Oids.LocalityName, EncodingRules.DirectoryString },
                 { Oids.StateOrProvinceName, EncodingRules.DirectoryString },
                 { Oids.StreetAddress, EncodingRules.DirectoryString },
-                { Oids.HouseIdentifier, EncodingRules.DirectoryString },
                 { Oids.Organization, EncodingRules.DirectoryString },
                 { Oids.OrganizationalUnit, EncodingRules.DirectoryString },
                 { Oids.Title, EncodingRules.DirectoryString },
                 { Oids.Description, EncodingRules.DirectoryString },
+                { Oids.BusinessCategory, EncodingRules.DirectoryString },
                 { Oids.PostalCode, EncodingRules.DirectoryString },
                 { Oids.PostOfficeBox, EncodingRules.DirectoryString },
                 { Oids.PhysicalDeliveryOfficeName, EncodingRules.DirectoryString },
                 { Oids.TelephoneNumber, EncodingRules.PrintableString },
+                { Oids.X121Address, EncodingRules.NumericString },
+                { Oids.InternationalISDNNumber, EncodingRules.NumericString },
+                { Oids.DestinationIndicator, EncodingRules.PrintableString },
+                { Oids.Name, EncodingRules.DirectoryString },
+                { Oids.GivenName, EncodingRules.DirectoryString },
+                { Oids.Initials, EncodingRules.DirectoryString },
+                { Oids.GenerationQualifier, EncodingRules.DirectoryString },
+                { Oids.DnQualifier, EncodingRules.PrintableString },
+                { Oids.HouseIdentifier, EncodingRules.DirectoryString },
+                { Oids.DmdName, EncodingRules.DirectoryString },
+                { Oids.Pseudonym, EncodingRules.DirectoryString },
+                { Oids.UiiInUrn, EncodingRules.UTF8String },
+                { Oids.ContentUrl, EncodingRules.UTF8String },
+                { Oids.Uri, EncodingRules.UTF8String },
+                { Oids.Urn, EncodingRules.UTF8String },
+                { Oids.Url, EncodingRules.UTF8String },
+                { Oids.UrnC, EncodingRules.PrintableString },
+                { Oids.EpcInUrn, EncodingRules.DirectoryString },
+                { Oids.LdapUrl, EncodingRules.UTF8String },
+                { Oids.OrganizationIdentifier, EncodingRules.DirectoryString },
+                { Oids.CountryOrRegionName3C, EncodingRules.PrintableString },
+                { Oids.CountryOrRegionName3N, EncodingRules.NumericString },
+                { Oids.DnsName, EncodingRules.UTF8String },
+                { Oids.IntEmail, EncodingRules.UTF8String },
+                { Oids.JabberId, EncodingRules.UTF8String },
+                { Oids.EmailAddress, EncodingRules.IA5String },
             };
 
             Debug.Assert(lookup.Count == LookupDictionarySize);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
@@ -586,8 +586,7 @@ namespace System.Security.Cryptography.X509Certificates
         private static Dictionary<string, EncodingRules> CreateEncodingRulesLookup()
         {
             // Attributes that are not "obsolete" from ITU T-REC X.520-2019.
-            // Attributes that are included are attributes that are string-like and can be represented by a String,
-            // and are not obsolete.
+            // Attributes that are included are attributes that are string-like and can be represented by a String.
             // Windows does not have any restrictions on encoding non-string encodable types, it will encode them
             // anyway, such as OID.2.5.4.14=test will encode test as a PrintableString, even though the OID is a SET.
             // To maintain similar behavior as Windows, those types will remain treated as unknown.

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/NameTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/NameTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Formats.Asn1;
 using Test.Cryptography;
 using Xunit;
 
@@ -126,6 +127,43 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
 
             Assert.Equal(expected, formatted);
+        }
+
+        [Theory]
+        [InlineData("G=DotNet", UniversalTagNumber.UTF8String)]
+        [InlineData("L=Alexandria", UniversalTagNumber.UTF8String)]
+        [InlineData("O=GitHub", UniversalTagNumber.UTF8String)]
+        [InlineData("OU=ProdSec", UniversalTagNumber.UTF8String)]
+        [InlineData("S=Virginia", UniversalTagNumber.UTF8String)]
+        [InlineData("SN=Doe", UniversalTagNumber.UTF8String)]
+        [InlineData("ST=Main", UniversalTagNumber.UTF8String)]
+        [InlineData("T=Pancake", UniversalTagNumber.UTF8String)]
+        [InlineData("CN=Foo", UniversalTagNumber.UTF8String)]
+        [InlineData("I=DD", UniversalTagNumber.UTF8String)]
+        [InlineData("E=noone@example.com", UniversalTagNumber.IA5String)]
+        [InlineData("OID.2.5.4.11=ProdSec", UniversalTagNumber.UTF8String)]
+        [InlineData("OID.2.5.4.43=DD", UniversalTagNumber.UTF8String)]
+        [InlineData("OID.2.25.77135202736018529853602245419149860647=sample", UniversalTagNumber.UTF8String)]
+        [InlineData("C=US", UniversalTagNumber.PrintableString)]
+        [InlineData("OID.2.5.4.20=\"+0 (555) 555-1234\"", UniversalTagNumber.PrintableString)]
+        [InlineData("OID.2.5.4.99=840", UniversalTagNumber.NumericString)]
+        [InlineData("OID.2.5.4.98=USA", UniversalTagNumber.PrintableString)]
+        [InlineData("SERIALNUMBER=1234ABC", UniversalTagNumber.PrintableString)]
+        public static void ForceUtf8EncodingForEligibleComponents(string distinguishedName, UniversalTagNumber tagNumber)
+        {
+            X500DistinguishedName name = new(distinguishedName, X500DistinguishedNameFlags.ForceUTF8Encoding);
+            byte[] encoded = name.RawData;
+
+            AsnValueReader reader = new(encoded, AsnEncodingRules.DER);
+            AsnValueReader component = reader.ReadSequence();
+            reader.ThrowIfNotEmpty();
+            AsnValueReader rdn = component.ReadSetOf();
+            component.ThrowIfNotEmpty();
+            AsnValueReader value = rdn.ReadSequence();
+            rdn.ThrowIfNotEmpty();
+
+            value.ReadObjectIdentifier();
+            Assert.Equal(new Asn1Tag(tagNumber), value.PeekTag());
         }
     }
 }


### PR DESCRIPTION
Our managed encoder for distinguished names took a loose approach to encoding names which could result in violating the encoding rules of certain X.520 attributes. For example, the "countryName" attribute (2.5.4.6) is a PrintableString, and only a PrintableString. However, the `ForceUTF8Encoding` flag would result in a UTF8String, which is not permitted.

This PR brings our managed encoder to align more similarly with Windows, but makes some deviations.

1. We are now aware of X.520 attribute encoding rules. The `ForceUTF8Encoding` flag will only work on things that can be encoded as UTF-8. That means `DirectoryString` and attributes that are unknown.
2. Previously, even without `ForceUTF8String`, we would encode something as a UTF8String if it could not be represented as a PrintableString. Now, if you attempt to encode a PrintableString (or NumericString) with characters that are outside of the encoding rules, an exception is thrown instead of promoting it to UTF-8. This behavior matches Windows and aligns more with the specification. It is a breaking change however.


I expect few if anyone to be bothered by the stricter encoding requirements. Windows already had them, with the exception of two attributes (countryName3C and countryName3N). The breaking change doc will explain developers can use `X500DistinguishedNameBuilder` which offers an escape hatch and overriding of opinions on how to encode a particular component.

Fixes #109156 