### PR TITLE
Native AOT: marshal empty array as non-null

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1378,15 +1378,10 @@ namespace Internal.TypeSystem.Interop
                 ILLocalVariable vPinnedFirstElement = emitter.NewLocal(ManagedElementType.MakeByRefType(), true);
 
                 LoadManagedValue(codeStream);
-                codeStream.Emit(ILOpcode.ldlen);
-                codeStream.Emit(ILOpcode.conv_i4);
-                codeStream.Emit(ILOpcode.brfalse, lNullArray);
-
-                LoadManagedValue(codeStream);
                 codeStream.Emit(ILOpcode.call, emitter.NewToken(getArrayDataReferenceMethod));
                 codeStream.EmitStLoc(vPinnedFirstElement);
 
-                // Fall through. If array didn't have elements, vPinnedFirstElement is zeroinit.
+                // Fall through. If array is null, vPinnedFirstElement is zeroinit.
                 codeStream.EmitLabel(lNullArray);
                 codeStream.EmitLdLoc(vPinnedFirstElement);
                 codeStream.Emit(ILOpcode.conv_i);

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -407,6 +407,9 @@ namespace PInvokeTests
             int[] empty = new int[0];
             ThrowIfNotEquals(0, CheckIncremental(empty, 0), "Empty array marshalling failed");
 
+            int[] nullArray = null;
+            ThrowIfNotEquals(1, CheckIncremental(nullArray, 0), "Null array marshalling failed");
+
             Console.WriteLine("Testing marshalling blittable struct arrays");
 
             Foo[] arr_foo = null;

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -404,6 +404,9 @@ namespace PInvokeTests
 
             ThrowIfNotEquals(0, CheckIncremental(arr, ArraySize), "Array marshalling failed");
 
+            int[] empty = new int[0];
+            ThrowIfNotEquals(0, CheckIncremental(empty, 0), "Empty array marshalling failed");
+
             Console.WriteLine("Testing marshalling blittable struct arrays");
 
             Foo[] arr_foo = null;


### PR DESCRIPTION
Fixes a discrepancy where coreclr marshals empty blittable arrays as non-null, but native AOT marshals them as null. With the fix, native AOT marshals them as non-null.