### PR TITLE
SPMI: Use Helix work directory for SPMI download

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -106,8 +106,8 @@ void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolv
 {
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
-    pResolvedToken->tokenType    = kind;
     pResolvedToken->token        = getU4LittleEndian(addr);
+    pResolvedToken->tokenType    = kind;
 
     info.compCompHnd->resolveToken(pResolvedToken);
 }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -106,8 +106,8 @@ void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolv
 {
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
-    pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
+    pResolvedToken->token        = getU4LittleEndian(addr);
 
     info.compCompHnd->resolveToken(pResolvedToken);
 }

--- a/src/coreclr/scripts/superpmi-diffs.proj
+++ b/src/coreclr/scripts/superpmi-diffs.proj
@@ -28,11 +28,13 @@
     <Python>%HELIX_PYTHONPATH%</Python>
     <ProductDirectory>%HELIX_CORRELATION_PAYLOAD%</ProductDirectory>
     <SuperpmiLogsLocation>%HELIX_WORKITEM_UPLOAD_ROOT%</SuperpmiLogsLocation>
+    <HelixWorkDir>%HELIX_WORKITEM_ROOT%</HelixWorkDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <Python>$HELIX_PYTHONPATH</Python>
     <ProductDirectory>$HELIX_CORRELATION_PAYLOAD</ProductDirectory>
     <SuperpmiLogsLocation>$HELIX_WORKITEM_UPLOAD_ROOT</SuperpmiLogsLocation>
+    <HelixWorkDir>$HELIX_WORKITEM_ROOT</HelixWorkDir>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -56,7 +58,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <WorkItemCommand>$(Python) $(ProductDirectory)/superpmi_diffs.py -type $(SuperPmiDiffType) -base_jit_directory $(ProductDirectory)/base -diff_jit_directory $(ProductDirectory)/diff $(SuperPmiBaseJitOptionsArg) $(SuperPmiDiffJitOptionsArg) -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
+    <WorkItemCommand>$(Python) $(ProductDirectory)/superpmi_diffs.py -type $(SuperPmiDiffType) -base_jit_directory $(ProductDirectory)/base -diff_jit_directory $(ProductDirectory)/diff $(SuperPmiBaseJitOptionsArg) $(SuperPmiDiffJitOptionsArg) -work_directory $(HelixWorkDir) -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
     <WorkItemTimeout>5:00</WorkItemTimeout>
   </PropertyGroup>
 

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -108,7 +108,7 @@ class Diff:
         self.python_path = sys.executable
         self.script_dir = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 
-        self.spmi_location = os.path.join(self.work_directory, "artifacts", "spmi")
+        self.spmi_location = os.path.join(coreclr_args.work_directory, "artifacts", "spmi")
 
         self.log_directory = coreclr_args.log_directory
         self.host_os = "windows" if platform.system() == "Windows" else "linux"

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -28,6 +28,7 @@ parser.add_argument("-base_jit_directory", help="path to the directory containin
 parser.add_argument("-diff_jit_directory", help="path to the directory containing diff clrjit binaries")
 parser.add_argument("-base_jit_options", help="Semicolon separated list of base jit options (in format A=B without DOTNET_ prefix)")
 parser.add_argument("-diff_jit_options", help="Semicolon separated list of diff jit options (in format A=B without DOTNET_ prefix)")
+parser.add_argument("-work_directory", help="path to directory to use for temporary files")
 parser.add_argument("-log_directory", help="path to the directory containing superpmi log files")
 
 
@@ -79,6 +80,11 @@ def setup_args(args):
                         "Unable to set diff_jit_options")
 
     coreclr_args.verify(args,
+                        "work_directory",
+                        lambda work_directory: os.path.isdir(work_directory),
+                        "work_directory doesn't exist")
+
+    coreclr_args.verify(args,
                         "log_directory",
                         lambda log_directory: True,
                         "log_directory doesn't exist")
@@ -102,9 +108,7 @@ class Diff:
         self.python_path = sys.executable
         self.script_dir = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 
-        # It doesn't really matter where we put the downloaded SPMI artifacts.
-        # Here, they are put in <correlation_payload>/artifacts/spmi.
-        self.spmi_location = os.path.join(self.script_dir, "artifacts", "spmi")
+        self.spmi_location = os.path.join(self.work_directory, "artifacts", "spmi")
 
         self.log_directory = coreclr_args.log_directory
         self.host_os = "windows" if platform.system() == "Windows" else "linux"


### PR DESCRIPTION
The correlation payload directory can have collections left over from other workitems.

For example, the windows-x64 superpmi-diffs run at https://dev.azure.com/dnceng-public/public/_build/results?buildId=856222&view=ms.vss-build-web.run-extensions-tab ran over smoke_tests multiple times because a previous work item had already downloaded that collection.