### PR TITLE
SPMI: Sort summary by collection name

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -106,8 +106,8 @@ void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolv
 {
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
-    pResolvedToken->tokenType    = kind;
     pResolvedToken->token        = getU4LittleEndian(addr);
+    pResolvedToken->tokenType    = kind;
 
     info.compCompHnd->resolveToken(pResolvedToken);
 }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -106,8 +106,8 @@ void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolv
 {
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
-    pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
+    pResolvedToken->token        = getU4LittleEndian(addr);
 
     info.compCompHnd->resolveToken(pResolvedToken);
 }

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -4164,7 +4164,7 @@ def summarize_json_summaries(coreclr_args):
                 summarizable_asm_diffs.extend(asm_diffs)
 
         # Sort by collection name
-        summarizable_asm_diffs.sort(key=lambda t: t[2][0])
+        summarizable_asm_diffs.sort(key=lambda t: t[0])
 
         with open(overall_md_summary_file, "w") as write_fh:
             write_asmdiffs_markdown_summary(write_fh, base_jit_options, diff_jit_options, summarizable_asm_diffs, True)
@@ -4186,7 +4186,7 @@ def summarize_json_summaries(coreclr_args):
                 summarizable_tp_diffs.extend(tp_diffs)
 
         # Sort by collection name
-        summarizable_tp_diffs.sort(key=lambda t: t[4][0])
+        summarizable_tp_diffs.sort(key=lambda t: t[0])
 
         with open(overall_md_summary_file, "w") as write_fh:
             write_tpdiff_markdown_summary(write_fh, base_jit_build_string_decoded, diff_jit_build_string_decoded, base_jit_options, diff_jit_options, summarizable_tp_diffs, True)

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -4163,6 +4163,9 @@ def summarize_json_summaries(coreclr_args):
                 (base_jit_options, diff_jit_options, asm_diffs) = json.load(fh)
                 summarizable_asm_diffs.extend(asm_diffs)
 
+        # Sort by collection name
+        summarizable_asm_diffs.sort(key=lambda t: t[2][0])
+
         with open(overall_md_summary_file, "w") as write_fh:
             write_asmdiffs_markdown_summary(write_fh, base_jit_options, diff_jit_options, summarizable_asm_diffs, True)
             logging.info("  Summary Markdown file: %s", overall_md_summary_file)
@@ -4181,6 +4184,9 @@ def summarize_json_summaries(coreclr_args):
             with open(json_file, "r") as fh:
                 (base_jit_build_string_decoded, diff_jit_build_string_decoded, base_jit_options, diff_jit_options, tp_diffs) = json.load(fh)
                 summarizable_tp_diffs.extend(tp_diffs)
+
+        # Sort by collection name
+        summarizable_tp_diffs.sort(key=lambda t: t[4][0])
 
         with open(overall_md_summary_file, "w") as write_fh:
             write_tpdiff_markdown_summary(write_fh, base_jit_build_string_decoded, diff_jit_build_string_decoded, base_jit_options, diff_jit_options, summarizable_tp_diffs, True)


### PR DESCRIPTION
These are already sorted by work item order, which themselves are sorted by collection name, but the work items end up sorted as "0 1 10 2 3", which breaks the ordering. Just sort them again when summarizing.