### PR TITLE
[release/8.0-staging] Fix Version.Details.xml SHA typo

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -82,7 +82,7 @@
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.430701">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759b</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.23509.2">


### PR DESCRIPTION
The last time this SHA was modified, was in [June 2023](https://github.com/dotnet/runtime/pull/84229/files), where it was manually modified with a typo at the end (extra `b`, leftover from writing over the previous commit SHA which ended in a `b` too).

The darc subscription for System.CommandLine is turned off in the release/8.0 and staging branches, so it makes sense that it has not been updated since then.

The correct SHA is the same that is consumed by the Dependency entry above this one: https://github.com/dotnet/runtime/blob/82d4dbfc06a745b9404152b3281eb9559ca1f0d3/eng/Version.Details.xml#L81

@vseanreesermsft noticed this when running a script that was unable to find a build that matched this commit.