### PR TITLE
JIT: account for newly unreachable blocks in morph

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5450,8 +5450,20 @@ public:
 
     FoldResult fgFoldConditional(BasicBlock* block);
 
+    struct MorphUnreachableInfo
+    {
+        MorphUnreachableInfo(Compiler* comp);
+        void SetUnreachable(BasicBlock* block);
+        bool IsUnreachable(BasicBlock* block);
+
+    private:
+
+        BitVecTraits m_traits;
+        BitVec m_vec;
+    };
+
     PhaseStatus fgMorphBlocks();
-    void fgMorphBlock(BasicBlock* block, BlockSet* unreachable = nullptr);
+    void fgMorphBlock(BasicBlock* block, MorphUnreachableInfo* unreachableInfo = nullptr);
     void fgMorphStmts(BasicBlock* block);
 
     void fgMergeBlockReturn(BasicBlock* block);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5451,7 +5451,7 @@ public:
     FoldResult fgFoldConditional(BasicBlock* block);
 
     PhaseStatus fgMorphBlocks();
-    void fgMorphBlock(BasicBlock* block);
+    void fgMorphBlock(BasicBlock* block, BlockSet* unreachable = nullptr);
     void fgMorphStmts(BasicBlock* block);
 
     void fgMergeBlockReturn(BasicBlock* block);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13208,33 +13208,50 @@ void Compiler::fgMorphStmts(BasicBlock* block)
 }
 
 //------------------------------------------------------------------------
+// MorphUnreachbleInfo: construct info for unreachability tracking during morph
+//
+// Arguments:
+//    comp - compiler object
+//
+Compiler::MorphUnreachableInfo::MorphUnreachableInfo(Compiler* comp)
+    : m_traits(comp->m_dfsTree->GetPostOrderCount(), comp)
+    , m_vec(BitVecOps::MakeEmpty(&m_traits)){};
+
+//------------------------------------------------------------------------
+// SetUnreachable: during morph, mark a block as unreachable
+//
+// Arguments:
+//    block - block in question
+//
+void Compiler::MorphUnreachableInfo::SetUnreachable(BasicBlock* block)
+{
+    BitVecOps::AddElemD(&m_traits, m_vec, block->bbPostorderNum);
+}
+
+//------------------------------------------------------------------------
+// IsUnreachable: during morph, see if a block is now known to be unreachable
+//
+// Arguments:
+//    block - block in question
+//
+// Returns:
+//    true if so
+//
+bool Compiler::MorphUnreachableInfo::IsUnreachable(BasicBlock* block)
+{
+    return BitVecOps::IsMember(&m_traits, m_vec, block->bbPostorderNum);
+}
+
+//------------------------------------------------------------------------
 // fgMorphBlock: Morph a basic block
 //
 // Arguments:
 //    block - block in question
-//    unreachable - [optional] set of blocks proven to be unreachable
+//    unreachableInfo - [optional] info on blocks proven unreachable
 //
-void Compiler::fgMorphBlock(BasicBlock* block, BlockSet* unreachable)
+void Compiler::fgMorphBlock(BasicBlock* block, MorphUnreachableInfo* unreachableInfo)
 {
     JITDUMP("\nMorphing " FMT_BB "\n", block->bbNum);
-
-    // Helpers for reachability tracking
-    //
-    auto SetUnreachable = [=](BasicBlock* block) {
-        if (unreachable != nullptr)
-        {
-            BlockSetOps::AddElemD(this, *unreachable, block->bbNum);
-        }
-    };
-
-    auto IsReachable = [=](BasicBlock* block) {
-        if (unreachable == nullptr)
-        {
-            return false;
-        }
-        assert(m_dfsTree->Contains(block));
-        return !BlockSetOps::IsMember(this, *unreachable, block->bbNum);
-    };
 
     if (optLocalAssertionProp)
     {
@@ -13288,7 +13305,7 @@ void Compiler::fgMorphBlock(BasicBlock* block, BlockSet* unreachable)
                     // This pred was reachable in the pre-morph DFS, but might have
                     // become unreachable during morph. If so, we can ignore its assertion state.
                     //
-                    if (!IsReachable(pred))
+                    if (unreachableInfo->IsUnreachable(pred))
                     {
                         JITDUMP("Pred " FMT_BB " is no longer reachable\n", pred->bbNum);
                         continue;
@@ -13359,7 +13376,7 @@ void Compiler::fgMorphBlock(BasicBlock* block, BlockSet* unreachable)
                 if (!isReachable)
                 {
                     JITDUMP(FMT_BB " has no reachable preds, marking as unreachable\n", block->bbNum);
-                    SetUnreachable(block);
+                    unreachableInfo->SetUnreachable(block);
 
                     // Remove the block's IR and flow edges but don't mark the block as removed.
                     // Convert to BBJ_THROW. But leave CALLFINALLY for non-funclet EH alone.
@@ -13494,8 +13511,7 @@ PhaseStatus Compiler::fgMorphBlocks()
 
         // We will track which blocks become unreachable during morph
         //
-        EnsureBasicBlockEpoch();
-        BlockSet unreachable = BlockSetOps::MakeEmpty(this);
+        MorphUnreachableInfo unreachableInfo(this);
 
         // Allow edge creation to genReturnBB (target of return merging)
         // and the scratch block successor (target for tail call to loop).
@@ -13519,7 +13535,7 @@ PhaseStatus Compiler::fgMorphBlocks()
         for (unsigned i = m_dfsTree->GetPostOrderCount(); i != 0; i--)
         {
             BasicBlock* const block = m_dfsTree->GetPostOrder(i - 1);
-            fgMorphBlock(block, &unreachable);
+            fgMorphBlock(block, &unreachableInfo);
         }
         assert(bbNumMax == fgBBNumMax);
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13362,17 +13362,17 @@ void Compiler::fgMorphBlock(BasicBlock* block, BlockSet* unreachable)
                     SetUnreachable(block);
 
                     // Remove the block's IR and flow edges but don't mark the block as removed.
-                    // Convert to BBJ_THROW. But leave CALLFINALLY alone.
+                    // Convert to BBJ_THROW. But leave CALLFINALLY for non-funclet EH alone.
                     //
-                    // In any case, there is nothing to morph, so just return.
+                    // If we clear out the block, there is nothing to morph, so just return.
                     //
-                    if (!block->KindIs(BBJ_CALLFINALLY))
+                    if (UsesFunclets() || !block->KindIs(BBJ_CALLFINALLY))
                     {
                         fgUnreachableBlock(block);
                         block->RemoveFlags(BBF_REMOVED);
                         block->SetKindAndTargetEdge(BBJ_THROW);
+                        return;
                     }
-                    return;
                 }
             }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13379,11 +13379,12 @@ void Compiler::fgMorphBlock(BasicBlock* block, MorphUnreachableInfo* unreachable
                     unreachableInfo->SetUnreachable(block);
 
                     // Remove the block's IR and flow edges but don't mark the block as removed.
-                    // Convert to BBJ_THROW. But leave CALLFINALLY for non-funclet EH alone.
+                    // Convert to BBJ_THROW. But leave CALLFINALLY alone.
                     //
                     // If we clear out the block, there is nothing to morph, so just return.
                     //
-                    if (UsesFunclets() || !block->KindIs(BBJ_CALLFINALLY))
+                    bool const isCallFinally = block->KindIs(BBJ_CALLFINALLY);
+                    if (!isCallFinally)
                     {
                         fgUnreachableBlock(block);
                         block->RemoveFlags(BBF_REMOVED);


### PR DESCRIPTION
Morph can alter control flow, if (for instance) it can prove a block's conditional branch must go a certain way.

Take advantage of this to improve morph's cross-block assertion prop, by not considering unreachable predecessors when computing the incoming assertion state. This is similar to something we already do in value numbering, but there control flow isn't being altered.

Also, when we can prove that a block has become unreachable, remove the block IR and alter its jump kind, so we are not spending time morphing IR we'll subsequently just throw away.