### PR TITLE
Adding info to debug WindowsAlternateDataStreamOverwrite failure

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
@@ -237,6 +237,17 @@ namespace System.IO.Tests
             File.WriteAllText(testFile2DefaultStream, "Bar");
             Assert.Throws<IOException>(() => Copy(testFile2DefaultStream, testFileAlternateStream));
 
+            try
+            {
+                Copy(testFile2DefaultStream, testFileAlternateStream);
+                Assert.Fail();
+            }
+            catch (IOException e)
+            {
+                // Error code for "the file exists".
+                Assert.Equal(-2147024816, e.HResult);
+            }
+
             // This always throws as you can't copy an alternate stream out (oddly)
             Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2));
             Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2 + alternateStream));
@@ -344,44 +355,6 @@ namespace System.IO.Tests
             InlineData("::$DATA", ":bar"),
             InlineData("::$DATA", ":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void WindowsAlternateDataStreamOverwriteFat32(string defaultStream, string alternateStream)
-        {
-            Console.WriteLine($"Platform: {PlatformDetection.IsNativeAot}");
-            Console.WriteLine($"Process Architecture: {RuntimeInformation.ProcessArchitecture}");
-            Console.WriteLine($"OS Architecture: {RuntimeInformation.OSArchitecture}");
-
-            string testDir = Path.Combine("F:\\tests", GetTestFileName());
-            DirectoryInfo testDirectory = Directory.CreateDirectory(testDir);
-            string testFile = Path.Combine(testDirectory.FullName, GetTestFileName());
-            string testFileDefaultStream = testFile + defaultStream;
-            string testFileAlternateStream = testFile + alternateStream;
-
-            // Copy the default stream into an alternate stream
-            File.WriteAllText(testFileDefaultStream, "Foo");
-            Copy(testFileDefaultStream, testFileAlternateStream);
-            Assert.Equal(testFile, testDirectory.GetFiles().Single().FullName);
-            Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
-            Assert.Equal("Foo", File.ReadAllText(testFileAlternateStream));
-
-            // Copy another file over the alternate stream
-            string testFile2 = Path.Combine(testDirectory.FullName, GetTestFileName());
-            string testFile2DefaultStream = testFile2 + defaultStream;
-            File.WriteAllText(testFile2DefaultStream, "Bar");
-            Copy(testFile2DefaultStream, testFileAlternateStream, overwrite: true);
-            Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
-            Assert.Equal("Bar", File.ReadAllText(testFileAlternateStream));
-
-            // This always throws as you can't copy an alternate stream out (oddly)
-            Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2, overwrite: true));
-            Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2 + alternateStream, overwrite: true));
-        }
-
-        [Theory,
-            InlineData("", ":bar"),
-            InlineData("", ":bar:$DATA"),
-            InlineData("::$DATA", ":bar"),
-            InlineData("::$DATA", ":bar:$DATA")]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsAlternateDataStreamOverwrite(string defaultStream, string alternateStream)
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
@@ -391,6 +364,8 @@ namespace System.IO.Tests
 
             // Copy the default stream into an alternate stream
             File.WriteAllText(testFileDefaultStream, "Foo");
+            Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
+            Console.WriteLine($"Copying default stream into alternate stream.");
             Copy(testFileDefaultStream, testFileAlternateStream);
             Assert.Equal(testFile, testDirectory.GetFiles().Single().FullName);
             Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
@@ -400,6 +375,11 @@ namespace System.IO.Tests
             string testFile2 = Path.Combine(testDirectory.FullName, GetTestFileName());
             string testFile2DefaultStream = testFile2 + defaultStream;
             File.WriteAllText(testFile2DefaultStream, "Bar");
+            Assert.Equal("Bar", File.ReadAllText(testFile2DefaultStream));
+            Assert.Equal("Foo", File.ReadAllText(testFileAlternateStream));
+            Console.WriteLine($"Attributes for {testFile2DefaultStream}:{File.GetAttributes(testFile2DefaultStream)}");
+            Console.WriteLine($"Attributes for {testFileAlternateStream}:{File.GetAttributes(testFileAlternateStream)}");
+            Console.WriteLine($"Overwriting alternate stream.");
             Copy(testFile2DefaultStream, testFileAlternateStream, overwrite: true);
             Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
             Assert.Equal("Bar", File.ReadAllText(testFileAlternateStream));

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.IO.Tests
 {
@@ -286,6 +287,12 @@ namespace System.IO.Tests
 
     public class File_Copy_str_str_b : File_Copy_str_str
     {
+        private ITestOutputHelper _output;
+        public File_Copy_str_str_b(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         protected override void Copy(string source, string dest)
         {
             File.Copy(source, dest, false);
@@ -364,7 +371,7 @@ namespace System.IO.Tests
             // Copy the default stream into an alternate stream
             File.WriteAllText(testFileDefaultStream, "Foo");
             Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
-            Console.WriteLine($"Copying default stream into alternate stream.");
+            _output.WriteLine("Copying default stream into alternate stream.");
             Copy(testFileDefaultStream, testFileAlternateStream);
             Assert.Equal(testFile, testDirectory.GetFiles().Single().FullName);
             Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
@@ -376,9 +383,9 @@ namespace System.IO.Tests
             File.WriteAllText(testFile2DefaultStream, "Bar");
             Assert.Equal("Bar", File.ReadAllText(testFile2DefaultStream));
             Assert.Equal("Foo", File.ReadAllText(testFileAlternateStream));
-            Console.WriteLine($"Attributes for {testFile2DefaultStream}:{File.GetAttributes(testFile2DefaultStream)}");
-            Console.WriteLine($"Attributes for {testFileAlternateStream}:{File.GetAttributes(testFileAlternateStream)}");
-            Console.WriteLine($"Overwriting alternate stream.");
+            _output.WriteLine($"Attributes for '{testFile2DefaultStream}': {File.GetAttributes(testFile2DefaultStream)}");
+            _output.WriteLine($"Attributes for '{testFileAlternateStream}': {File.GetAttributes(testFileAlternateStream)}");
+            _output.WriteLine("Overwriting alternate stream.");
             Copy(testFile2DefaultStream, testFileAlternateStream, overwrite: true);
             Assert.Equal("Foo", File.ReadAllText(testFileDefaultStream));
             Assert.Equal("Bar", File.ReadAllText(testFileAlternateStream));

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/CopyTo.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/CopyTo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.IO.Tests
 {
@@ -16,6 +17,11 @@ namespace System.IO.Tests
 
     public class FileInfo_CopyTo_str_b : File_Copy_str_str_b
     {
+        public FileInfo_CopyTo_str_b(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
         protected override void Copy(string source, string dest)
         {
             new FileInfo(source).CopyTo(dest, false);


### PR DESCRIPTION
Adding info for: #83659 

- Adding assertion on HRESULT in the non-overwrite case to confirm that it does not have the same issue as the WindowsAlternateDataStreamOverwrite
- Adding logging of attributes
- Assertion on contents of files to determine whether everything is written/accessible before copy

I wasn't able to repro this after trying to run nativeaot build on arm64. Confirmed that it wasn't FAT32 issue (tried mounting volume and it gives a different error) and that the tests were running nativeaot (checked PlatformDetection.IsNativeAot). Hopefully adding the above will give some more info next time this fails.