### PR TITLE
[mono] Use sync unwind tables on all arm64 targets

### DIFF
--- a/src/mono/mono/mini/mini-llvm-cpp.cpp
+++ b/src/mono/mono/mini/mini-llvm-cpp.cpp
@@ -485,7 +485,7 @@ mono_llvm_add_func_attr (LLVMValueRef func, AttrKind kind)
 {
 	unwrap<Function> (func)->addFnAttr (convert_attr (kind));
 	if (kind == LLVM_ATTR_UW_TABLE)
-#if defined(TARGET_ARM64) && defined(TARGET_MACH)
+#if defined(TARGET_ARM64)
 		unwrap<Function> (func)->setUWTableKind (UWTableKind::Sync);
 #else
 		unwrap<Function> (func)->setUWTableKind (UWTableKind::Async);


### PR DESCRIPTION
This can help with https://github.com/dotnet/runtime/issues/109220