### PR TITLE
Stop using LINQ in Tensors

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -639,29 +638,18 @@ namespace System.Numerics.Tensors
         /// <summary>
         /// Get a string representation of the tensor.
         /// </summary>
-        private string ToMetadataString()
+        private void ToMetadataString(StringBuilder sb)
         {
-            var sb = new StringBuilder("[");
+            sb.Append('[');
 
-            int n = Rank;
-            if (n == 0)
+            for (int i = 0; i < Rank; i++)
             {
-                sb.Append(']');
+                sb.Append(Lengths[i]);
+                if (i + 1 < Rank)
+                    sb.Append('x');
             }
-            else
-            {
-                for (int i = 0; i < n; i++)
-                {
-                    sb.Append(Lengths[i]);
-                    if (i + 1 < n)
-                        sb.Append('x');
-                }
 
-                sb.Append(']');
-            }
-            sb.Append($", type = {typeof(T)}, isPinned = {IsPinned}");
-
-            return sb.ToString();
+            sb.Append($"], type = {typeof(T)}, isPinned = {IsPinned}");
         }
 
         /// <summary>
@@ -671,12 +659,15 @@ namespace System.Numerics.Tensors
         /// <returns>A <see cref="string"/> representation of the <see cref="Tensor{T}"/></returns>
         public string ToString(params ReadOnlySpan<nint> maximumLengths)
         {
-            if (maximumLengths.Length == 0)
-                maximumLengths = (from number in Enumerable.Range(0, Rank) select (nint)5).ToArray();
+            if (maximumLengths.IsEmpty)
+            {
+                maximumLengths = Rank <= TensorShape.MaxInlineRank ? stackalloc nint[Rank] : new nint[Rank];
+            }
+
             var sb = new StringBuilder();
-            sb.AppendLine(ToMetadataString());
+            ToMetadataString(sb);
             sb.AppendLine("{");
-            sb.Append(AsTensorSpan().ToString(maximumLengths));
+            ((ReadOnlyTensorSpan<T>)AsTensorSpan()).ToString(sb, maximumLengths);
             sb.AppendLine("}");
             return sb.ToString();
         }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -3533,7 +3532,8 @@ namespace System.Numerics.Tensors
         /// <param name="tensor">The <see cref="TensorSpan{T}"/> you want to represent as a string.</param>
         /// <param name="maximumLengths">Maximum Length of each dimension</param>
         /// <returns>A <see cref="string"/> representation of the <paramref name="tensor"/></returns>
-        public static string ToString<T>(this in TensorSpan<T> tensor, params ReadOnlySpan<nint> maximumLengths) => ((ReadOnlyTensorSpan<T>)tensor).ToString(maximumLengths);
+        public static string ToString<T>(this in TensorSpan<T> tensor, params ReadOnlySpan<nint> maximumLengths) =>
+            ((ReadOnlyTensorSpan<T>)tensor).ToString(maximumLengths);
 
         /// <summary>
         /// Creates a <see cref="string"/> representation of the <see cref="ReadOnlyTensorSpan{T}"/>."/>
@@ -3543,11 +3543,16 @@ namespace System.Numerics.Tensors
         /// <param name="maximumLengths">Maximum Length of each dimension</param>
         public static string ToString<T>(this in ReadOnlyTensorSpan<T> tensor, params ReadOnlySpan<nint> maximumLengths)
         {
+            StringBuilder sb = new();
+            ToString(in tensor, sb, maximumLengths);
+            return sb.ToString();
+        }
 
+        internal static void ToString<T>(this in ReadOnlyTensorSpan<T> tensor, StringBuilder sb, params ReadOnlySpan<nint> maximumLengths)
+        {
             if (maximumLengths.Length != tensor.Rank)
                 ThrowHelper.ThrowArgument_DimensionsNotSame(nameof(tensor));
 
-            var sb = new StringBuilder();
             scoped Span<nint> curIndexes;
             nint[]? curIndexesArray;
             if (tensor.Rank > 6)
@@ -3579,8 +3584,6 @@ namespace System.Numerics.Tensors
 
             if (curIndexesArray != null)
                 ArrayPool<nint>.Shared.Return(curIndexesArray);
-
-            return sb.ToString();
         }
 
         /// <summary>
@@ -3602,11 +3605,15 @@ namespace System.Numerics.Tensors
         {
             if (tensor.Lengths.Length < 2)
                 ThrowHelper.ThrowArgument_TransposeTooFewDimensions();
-            int[] dimension = Enumerable.Range(0, tensor.Rank).ToArray();
+
+            Span<int> dimension = tensor.Rank <= TensorShape.MaxInlineRank ? stackalloc int[tensor.Rank] : new int[tensor.Rank];
+            TensorSpanHelpers.FillRange(dimension);
+
             int temp = dimension[tensor.Rank - 1];
             dimension[tensor.Rank - 1] = dimension[tensor.Rank - 2];
             dimension[tensor.Rank - 2] = temp;
-            return PermuteDimensions(tensor, dimension.AsSpan());
+
+            return PermuteDimensions(tensor, dimension);
         }
         #endregion
 
@@ -3666,15 +3673,28 @@ namespace System.Numerics.Tensors
             if (dimension < 0)
                 dimension = tensor.Rank - dimension;
 
-            List<nint> tempLengths = tensor._lengths.ToList();
-            tempLengths.Insert(dimension, 1);
-            nint[] lengths = [.. tempLengths];
-            List<nint> tempStrides = tensor.Strides.ToArray().ToList();
+            Span<nint> lengths = tensor._lengths.Length + 1 <= TensorShape.MaxInlineRank ?
+                stackalloc nint[tensor._lengths.Length + 1] :
+                new nint[tensor._lengths.Length + 1];
+            tensor._lengths.AsSpan(0, dimension).CopyTo(lengths);
+            tensor._lengths.AsSpan(dimension).CopyTo(lengths.Slice(dimension + 1));
+            lengths[dimension] = 1;
+
+            Span<nint> strides = tensor.Strides.Length + 1 <= TensorShape.MaxInlineRank ?
+                stackalloc nint[tensor.Strides.Length + 1] :
+                new nint[tensor.Strides.Length + 1];
             if (dimension == tensor.Rank)
-                tempStrides.Add(tensor.Strides[dimension - 1]);
+            {
+                tensor.Strides.CopyTo(strides);
+                strides[dimension] = tensor.Strides[dimension - 1];
+            }
             else
-                tempStrides.Insert(dimension, tensor.Strides[dimension] * tensor.Lengths[dimension]);
-            nint[] strides = [.. tempStrides];
+            {
+                tensor.Strides.Slice(0, dimension).CopyTo(strides);
+                tensor.Strides.Slice(dimension).CopyTo(strides.Slice(dimension + 1));
+                strides[dimension] = tensor.Strides[dimension] * tensor.Lengths[dimension];
+            }
+
             return new Tensor<T>(tensor._values, lengths, strides);
         }
 
@@ -3690,15 +3710,28 @@ namespace System.Numerics.Tensors
             if (dimension < 0)
                 dimension = tensor.Rank - dimension;
 
-            List<nint> tempLengths = tensor.Lengths.ToArray().ToList();
-            tempLengths.Insert(dimension, 1);
-            nint[] lengths = [.. tempLengths];
-            List<nint> tempStrides = tensor.Strides.ToArray().ToList();
+            Span<nint> lengths = tensor.Lengths.Length + 1 <= TensorShape.MaxInlineRank ?
+                stackalloc nint[tensor.Lengths.Length + 1] :
+                new nint[tensor.Lengths.Length + 1];
+            tensor.Lengths.Slice(0, dimension).CopyTo(lengths);
+            tensor.Lengths.Slice(dimension).CopyTo(lengths.Slice(dimension + 1));
+            lengths[dimension] = 1;
+
+            Span<nint> strides = tensor.Strides.Length + 1 <= TensorShape.MaxInlineRank ?
+                stackalloc nint[tensor.Strides.Length + 1] :
+                new nint[tensor.Strides.Length + 1];
             if (dimension == tensor.Rank)
-                tempStrides.Add(tensor.Strides[dimension - 1]);
+            {
+                tensor.Strides.CopyTo(strides);
+                strides[dimension] = tensor.Strides[dimension - 1];
+            }
             else
-                tempStrides.Insert(dimension, tensor.Strides[dimension] * tensor.Lengths[dimension]);
-            nint[] strides = [.. tempStrides];
+            {
+                tensor.Strides.Slice(0, dimension).CopyTo(strides);
+                tensor.Strides.Slice(dimension).CopyTo(strides.Slice(dimension + 1));
+                strides[dimension] = tensor.Strides[dimension] * tensor.Lengths[dimension];
+            }
+
             return new TensorSpan<T>(ref tensor._reference, lengths, strides, tensor._shape._memoryLength);
         }
 
@@ -3714,15 +3747,28 @@ namespace System.Numerics.Tensors
             if (dimension < 0)
                 dimension = tensor.Rank - dimension;
 
-            List<nint> tempLengths = tensor.Lengths.ToArray().ToList();
-            tempLengths.Insert(dimension, 1);
-            nint[] lengths = [.. tempLengths];
-            List<nint> tempStrides = tensor.Strides.ToArray().ToList();
+            Span<nint> lengths = tensor.Lengths.Length + 1 <= TensorShape.MaxInlineRank ?
+                stackalloc nint[tensor.Lengths.Length + 1] :
+                new nint[tensor.Lengths.Length + 1];
+            tensor.Lengths.Slice(0, dimension).CopyTo(lengths);
+            tensor.Lengths.Slice(dimension).CopyTo(lengths.Slice(dimension + 1));
+            lengths[dimension] = 1;
+
+            Span<nint> strides = tensor.Strides.Length + 1 <= TensorShape.MaxInlineRank ?
+                stackalloc nint[tensor.Strides.Length + 1] :
+                new nint[tensor.Strides.Length + 1];
             if (dimension == tensor.Rank)
-                tempStrides.Add(tensor.Strides[dimension - 1]);
+            {
+                tensor.Strides.CopyTo(strides);
+                strides[dimension] = tensor.Strides[dimension - 1];
+            }
             else
-                tempStrides.Insert(dimension, tensor.Strides[dimension] * tensor.Lengths[dimension]);
-            nint[] strides = [.. tempStrides];
+            {
+                tensor.Strides.Slice(0, dimension).CopyTo(strides);
+                tensor.Strides.Slice(dimension).CopyTo(strides.Slice(dimension + 1));
+                strides[dimension] = tensor.Strides[dimension] * tensor.Lengths[dimension];
+            }
+
             return new ReadOnlyTensorSpan<T>(ref tensor._reference, lengths, strides, tensor._shape._memoryLength);
         }
         #endregion

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorHelpers.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace System.Numerics.Tensors
@@ -11,7 +10,6 @@ namespace System.Numerics.Tensors
     [Experimental(Experimentals.TensorTDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
     internal static class TensorHelpers
     {
-
         /// <summary>
         /// Counts the number of true elements in a boolean filter tensor so we know how much space we will need.
         /// </summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorSpanHelpers.cs
@@ -262,11 +262,44 @@ namespace System.Numerics.Tensors
         {
             if (addend <= 0 || curIndex < 0)
                 return;
+
             curIndexes[curIndex] -= addend;
             if (curIndexes[curIndex] < 0)
             {
                 curIndexes[curIndex] = shape[curIndex] - 1;
                 AdjustIndexes(curIndex - 1, 1, curIndexes, shape);
+            }
+        }
+
+        /// <summary>Fills <paramref name="lengths"/> with the corresponding lengths of the ranks in <paramref name="array"/>.</summary>
+        public static ReadOnlySpan<nint> FillLengths(Span<nint> lengths, Array array)
+        {
+            Debug.Assert(array is not null);
+            Debug.Assert(array.Rank == lengths.Length);
+
+            for (int i = 0; i < lengths.Length; i++)
+            {
+                lengths[i] = array.GetLength(i);
+            }
+
+            return lengths;
+        }
+
+        /// <summary>Fills <paramref name="span"/> with values <paramref name="span"/>[i] = i.</summary>
+        public static void FillRange(Span<int> span)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i] = i;
+            }
+        }
+
+        /// <summary>Fills <paramref name="span"/> with values <paramref name="span"/>[i] = i.</summary>
+        public static void FillRange(Span<nint> span)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i] = i;
             }
         }
     }


### PR DESCRIPTION
Using `IEnumerable<T>` and associated LINQ extensions for numerical processing is not appropriate at this level of the stack. The only remaining use after this PR is where the input provided by the user is already an `IEnumerable<T>` and `ToArray` is used to get the required `T[]`, which is fine.