### PR TITLE
arm64: load 64bit constants from data section instead of 4 movz/k instructions

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2257,6 +2257,16 @@ void CodeGen::instGen_Set_Reg_To_Imm(emitAttr       size,
             GetEmitter()->emitIns_R_I(INS_mov, size, reg, imm, INS_OPTS_NONE,
                                       INS_SCALABLE_OPTS_NONE DEBUGARG(targetHandle) DEBUGARG(gtFlags));
         }
+        else if ((size == EA_8BYTE) && !compiler->getNeedsGSSecurityCookie()
+                 /* && compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_SIZE_OPT) */)
+        {
+            // TODO: if the algorithm below only needs, say, two movz/movk instructions,
+            // then we should use that instead of the data section load?
+            CORINFO_FIELD_HANDLE hnd =
+                Compiler::eeFindJitDataOffs(GetEmitter()->emitDataConst(&imm, EA_8BYTE, 8, TYP_LONG));
+            GetEmitter()->emitIns_R_C(INS_ldr, EA_8BYTE, reg, REG_NA, hnd, 0);
+            return;
+        }
         else
         {
             // Arm64 allows any arbitrary 16-bit constant to be loaded into a register halfword


### PR DESCRIPTION
Experiment: I am just curious about the size wins and performance impact
```cs
static long Test() => 0xBAA293549432543L;
```
```diff
-movz    x0, #0x2543
-movk    x0, #0x4943 LSL #16
-movk    x0, #0x2935 LSL #32
-movk    x0, #0xBAA LSL #48
+ldr     x0, [@RWD00]
```

SPMI diffs:
<img width="687" alt="Screenshot 2024-11-01 at 19 48 35" src="https://github.com/user-attachments/assets/a3da87c1-6608-4f1a-9714-4db6b6984078">

Although, the diffs don't take data section into account (8 bytes + potential alignment but with ability to use a single shared constant for multiple places in a method) => on average it's still a size win.

Unfortunately, it makes not much sense for R2R/NAOT since those mostly use relocatable constants and rarely need raw 64bit constants.