### PR TITLE
Fix file name buffer size for PAL's CreateProcess

### DIFF
--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3630,10 +3630,16 @@ getFileName(
         wcEnd = *lpEnd;
         *lpEnd = 0x0000;
 
-        /* Convert to ASCII */
+        /* Convert to UTF-8 */
         int size = 0;
-        int length = (PAL_wcslen(lpCommandLine)+1) * 3 /* MaxWCharToAcpLengthFactor */;
-        lpFileName = lpFileNamePS.OpenStringBuffer(length);
+        int length = WideCharToMultiByte(CP_ACP, 0, lpCommandLine, -1, NULL, 0, NULL, NULL);
+        if (length == 0)
+        {
+            ERROR("Failed to calculate the required buffer length.\n");
+            return FALSE;
+        };
+
+        lpFileName = lpFileNamePS.OpenStringBuffer(length - 1);
         if (NULL == lpFileName)
         {
             ERROR("Not Enough Memory!\n");

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3632,7 +3632,7 @@ getFileName(
 
         /* Convert to ASCII */
         int size = 0;
-        int length = (PAL_wcslen(lpCommandLine)+1) * sizeof(WCHAR);
+        int length = (PAL_wcslen(lpCommandLine)+1) * 3 /* MaxWCharToAcpLengthFactor */;
         lpFileName = lpFileNamePS.OpenStringBuffer(length);
         if (NULL == lpFileName)
         {


### PR DESCRIPTION
The PAL was incorrectly using `sizeof(WCHAR)` to decide the max number of UTF-8 bytes that a single UTF-16 character could require when converting to UTF-8 in the CreateProcess implementation. This switches to using `WideCharToMultiByte` to calculate the required length.