### PR TITLE
JIT: move QMARK expansion before morph

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -660,10 +660,10 @@ void Compiler::optAssertionInit(bool isLocalProp)
         if (optCrossBlockLocalAssertionProp)
         {
             // We may need a fairly large table.
-            // Allow for roughly one assertion per local, up to the tracked limit.
+            // Allow for roughly 1.5 assertions per local, up to the tracked limit.
             // (empirical studies show about 0.6 asserions/local)
             //
-            optMaxAssertionCount = (AssertionIndex)min(maxTrackedLocals, ((lvaCount / 64) + 1) * 64);
+            optMaxAssertionCount = (AssertionIndex)min(maxTrackedLocals, ((lvaCount / 64) + 1) * 96);
         }
         else
         {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4733,6 +4733,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     fgStress64RsltMul();
 #endif // DEBUG
 
+    // Expand QMarks
+    //
+    DoPhase(this, PHASE_EXPAND_QMARKS, &Compiler::fgExpandQmarkNodes);
+
     // Morph the trees in all the blocks of the method
     //
     unsigned const preMorphBBCount = fgBBcount;
@@ -4746,8 +4750,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
         // Decide the kind of code we want to generate
         fgSetOptions();
-
-        fgExpandQmarkNodes();
 
 #ifdef DEBUG
         compCurBB = nullptr;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3787,7 +3787,6 @@ public:
     typedef fgWalkResult(fgWalkPreFn)(GenTree** pTree, fgWalkData* data);
     typedef fgWalkResult(fgWalkPostFn)(GenTree** pTree, fgWalkData* data);
 
-    static fgWalkPreFn gtMarkColonCond;
     static fgWalkPreFn gtClearColonCond;
 
     struct FindLinkData
@@ -5509,7 +5508,7 @@ public:
 
     GenTreeQmark* fgGetTopLevelQmark(GenTree* expr, GenTree** ppDst = nullptr);
     bool fgExpandQmarkStmt(BasicBlock* block, Statement* stmt);
-    void fgExpandQmarkNodes();
+    PhaseStatus fgExpandQmarkNodes();
 
     bool fgSimpleLowerCastOfSmpOp(LIR::Range& range, GenTreeCast* cast);
 

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -51,6 +51,7 @@ CompPhaseNameMacro(PHASE_FWD_SUB,                    "Forward Substitution",    
 CompPhaseNameMacro(PHASE_IMPBYREF_COPY_OMISSION,     "Identify candidates for implicit byref copy omission", false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_IMPBYREF,             "Morph - ByRefs",                 false, -1, false)
 CompPhaseNameMacro(PHASE_PROMOTE_STRUCTS,            "Morph - Promote Structs",        false, -1, false)
+CompPhaseNameMacro(PHASE_EXPAND_QMARKS,              "Morph - Qmark Expansion",        false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_GLOBAL,               "Morph - Global",                 false, -1, false)
 CompPhaseNameMacro(PHASE_POST_MORPH,                 "Post-Morph",                     false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_END,                  "Morph - Finish",                 false, -1, true)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17491,21 +17491,6 @@ void dispNodeList(GenTree* list, bool verbose)
 #endif
 
 /*****************************************************************************
- * Callback to mark the nodes of a qmark-colon subtree that are conditionally
- * executed.
- */
-
-/* static */
-Compiler::fgWalkResult Compiler::gtMarkColonCond(GenTree** pTree, fgWalkData* data)
-{
-    assert(data->pCallbackData == nullptr);
-
-    (*pTree)->gtFlags |= GTF_COLON_COND;
-
-    return WALK_CONTINUE;
-}
-
-/*****************************************************************************
  * Callback to clear the conditionally executed flags of nodes that no longer
    will be conditionally executed. Note that when we find another colon we must
    stop, as the nodes below this one WILL be conditionally executed. This callback


### PR DESCRIPTION
* Add logic to propagate boolean range assertions for locals assigned values of 0 or 1.
* Increase local assertion prop table size to make sure there's room
* Remove logic in morph for handling qmark/colon