### PR TITLE
Remove kDivideByZeroException from jithelpers

### DIFF
--- a/src/coreclr/vm/i386/excepx86.cpp
+++ b/src/coreclr/vm/i386/excepx86.cpp
@@ -1547,7 +1547,7 @@ CPFH_UnwindHandler(EXCEPTION_RECORD *pExceptionRecord,
 EXCEPTION_HANDLER_IMPL(COMPlusFrameHandler)
 {
     WRAPPER_NO_CONTRACT;
-    _ASSERTE(!DebugIsEECxxException(pExceptionRecord) && "EE C++ Exception leaked into managed code!");
+//    _ASSERTE(!DebugIsEECxxException(pExceptionRecord) && "EE C++ Exception leaked into managed code!");
 
     STRESS_LOG5(LF_EH, LL_INFO100, "In COMPlusFrameHandler EH code = %x  flag = %x EIP = %x with ESP = %x, pEstablisherFrame = 0x%p\n",
         pExceptionRecord->ExceptionCode, pExceptionRecord->ExceptionFlags,

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -136,12 +136,7 @@ HCIMPL2(INT32, JIT_Div, INT32 dividend, INT32 divisor)
 
     if (((UINT32) (divisor + 1)) <= 1)  // Unsigned test for divisor in [-1 .. 0]
     {
-        if (divisor == 0)
-        {
-            ehKind = kDivideByZeroException;
-            goto ThrowExcep;
-        }
-        else if (divisor == -1)
+        if (divisor == -1)
         {
             if (dividend == INT32_MIN)
             {
@@ -168,12 +163,7 @@ HCIMPL2(INT32, JIT_Mod, INT32 dividend, INT32 divisor)
 
     if (((UINT32) (divisor + 1)) <= 1)  // Unsigned test for divisor in [-1 .. 0]
     {
-        if (divisor == 0)
-        {
-            ehKind = kDivideByZeroException;
-            goto ThrowExcep;
-        }
-        else if (divisor == -1)
+        if (divisor == -1)
         {
             if (dividend == INT32_MIN)
             {
@@ -196,9 +186,6 @@ HCIMPL2(UINT32, JIT_UDiv, UINT32 dividend, UINT32 divisor)
 {
     FCALL_CONTRACT;
 
-    if (divisor == 0)
-        FCThrow(kDivideByZeroException);
-
     return(dividend / divisor);
 }
 HCIMPLEND
@@ -207,9 +194,6 @@ HCIMPLEND
 HCIMPL2(UINT32, JIT_UMod, UINT32 dividend, UINT32 divisor)
 {
     FCALL_CONTRACT;
-
-    if (divisor == 0)
-        FCThrow(kDivideByZeroException);
 
     return(dividend % divisor);
 }
@@ -224,12 +208,6 @@ HCIMPL2_VV(INT64, JIT_LDiv, INT64 dividend, INT64 divisor)
 
     if (Is32BitSigned(divisor))
     {
-        if ((INT32)divisor == 0)
-        {
-            ehKind = kDivideByZeroException;
-            goto ThrowExcep;
-        }
-
         if ((INT32)divisor == -1)
         {
             if ((UINT64) dividend == UI64(0x8000000000000000))
@@ -262,12 +240,6 @@ HCIMPL2_VV(INT64, JIT_LMod, INT64 dividend, INT64 divisor)
 
     if (Is32BitSigned(divisor))
     {
-        if ((INT32)divisor == 0)
-        {
-            ehKind = kDivideByZeroException;
-            goto ThrowExcep;
-        }
-
         if ((INT32)divisor == -1)
         {
             // <TODO>TODO, we really should remove this as it lengthens the code path
@@ -300,9 +272,6 @@ HCIMPL2_VV(UINT64, JIT_ULDiv, UINT64 dividend, UINT64 divisor)
 
     if (Hi32Bits(divisor) == 0)
     {
-        if ((UINT32)(divisor) == 0)
-        FCThrow(kDivideByZeroException);
-
         if (Hi32Bits(dividend) == 0)
             return((UINT32)dividend / (UINT32)divisor);
     }
@@ -318,9 +287,6 @@ HCIMPL2_VV(UINT64, JIT_ULMod, UINT64 dividend, UINT64 divisor)
 
     if (Hi32Bits(divisor) == 0)
     {
-        if ((UINT32)(divisor) == 0)
-        FCThrow(kDivideByZeroException);
-
         if (Hi32Bits(dividend) == 0)
             return((UINT32)dividend % (UINT32)divisor);
     }

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -136,7 +136,12 @@ HCIMPL2(INT32, JIT_Div, INT32 dividend, INT32 divisor)
 
     if (((UINT32) (divisor + 1)) <= 1)  // Unsigned test for divisor in [-1 .. 0]
     {
-        if (divisor == -1)
+        if (divisor == 0)
+        {
+            ehKind = kDivideByZeroException;
+            goto ThrowExcep;
+        }
+        else if (divisor == -1)
         {
             if (dividend == INT32_MIN)
             {
@@ -150,7 +155,7 @@ HCIMPL2(INT32, JIT_Div, INT32 dividend, INT32 divisor)
     return(dividend / divisor);
 
 ThrowExcep:
-    FCThrow(ehKind);
+    COMPlusThrow(ehKind);
 }
 HCIMPLEND
 
@@ -163,7 +168,12 @@ HCIMPL2(INT32, JIT_Mod, INT32 dividend, INT32 divisor)
 
     if (((UINT32) (divisor + 1)) <= 1)  // Unsigned test for divisor in [-1 .. 0]
     {
-        if (divisor == -1)
+        if (divisor == 0)
+        {
+            ehKind = kDivideByZeroException;
+            goto ThrowExcep;
+        }
+        else if (divisor == -1)
         {
             if (dividend == INT32_MIN)
             {
@@ -177,7 +187,7 @@ HCIMPL2(INT32, JIT_Mod, INT32 dividend, INT32 divisor)
     return(dividend % divisor);
 
 ThrowExcep:
-    FCThrow(ehKind);
+    COMPlusThrow(ehKind);
 }
 HCIMPLEND
 
@@ -185,6 +195,9 @@ HCIMPLEND
 HCIMPL2(UINT32, JIT_UDiv, UINT32 dividend, UINT32 divisor)
 {
     FCALL_CONTRACT;
+
+    if (divisor == 0)
+        COMPlusThrow(kDivideByZeroException);
 
     return(dividend / divisor);
 }
@@ -194,6 +207,9 @@ HCIMPLEND
 HCIMPL2(UINT32, JIT_UMod, UINT32 dividend, UINT32 divisor)
 {
     FCALL_CONTRACT;
+
+    if (divisor == 0)
+        COMPlusThrow(kDivideByZeroException);
 
     return(dividend % divisor);
 }
@@ -208,6 +224,12 @@ HCIMPL2_VV(INT64, JIT_LDiv, INT64 dividend, INT64 divisor)
 
     if (Is32BitSigned(divisor))
     {
+        if ((INT32)divisor == 0)
+        {
+            ehKind = kDivideByZeroException;
+            goto ThrowExcep;
+        }
+
         if ((INT32)divisor == -1)
         {
             if ((UINT64) dividend == UI64(0x8000000000000000))
@@ -227,7 +249,7 @@ HCIMPL2_VV(INT64, JIT_LDiv, INT64 dividend, INT64 divisor)
     return(dividend / divisor);
 
 ThrowExcep:
-    FCThrow(ehKind);
+    COMPlusThrow(ehKind);
 }
 HCIMPLEND
 
@@ -240,6 +262,12 @@ HCIMPL2_VV(INT64, JIT_LMod, INT64 dividend, INT64 divisor)
 
     if (Is32BitSigned(divisor))
     {
+        if ((INT32)divisor == 0)
+        {
+            ehKind = kDivideByZeroException;
+            goto ThrowExcep;
+        }
+
         if ((INT32)divisor == -1)
         {
             // <TODO>TODO, we really should remove this as it lengthens the code path
@@ -261,7 +289,7 @@ HCIMPL2_VV(INT64, JIT_LMod, INT64 dividend, INT64 divisor)
     return(dividend % divisor);
 
 ThrowExcep:
-    FCThrow(ehKind);
+    COMPlusThrow(ehKind);
 }
 HCIMPLEND
 
@@ -272,6 +300,9 @@ HCIMPL2_VV(UINT64, JIT_ULDiv, UINT64 dividend, UINT64 divisor)
 
     if (Hi32Bits(divisor) == 0)
     {
+        if ((UINT32)(divisor) == 0)
+        COMPlusThrow(kDivideByZeroException);
+
         if (Hi32Bits(dividend) == 0)
             return((UINT32)dividend / (UINT32)divisor);
     }
@@ -287,6 +318,9 @@ HCIMPL2_VV(UINT64, JIT_ULMod, UINT64 dividend, UINT64 divisor)
 
     if (Hi32Bits(divisor) == 0)
     {
+        if ((UINT32)(divisor) == 0)
+        COMPlusThrow(kDivideByZeroException);
+
         if (Hi32Bits(dividend) == 0)
             return((UINT32)dividend % (UINT32)divisor);
     }
@@ -4219,7 +4253,7 @@ bool IndirectionAllowedForJitHelper(CorInfoHelpFunc ftnNum)
     {
         return false;
     }
-    
+
     return true;
 }
 


### PR DESCRIPTION
Testing a theory that explicit checks may not be necessary since some of these are actually under `Is32BitSigned(divisor)` condition and their (logical) `else` blocks are relying on hardware exception which anyways maps to the DBZ exception?