### PR TITLE
Fix ifdef for RawArrayData in NativeAOT Runtime.Base

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Array.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Array.cs
@@ -31,7 +31,7 @@ namespace System
     internal class RawArrayData
     {
         public uint Length; // Array._numComponents padded to IntPtr
-#if BIT64
+#if TARGET_64BIT
         public uint Padding;
 #endif
         public byte Data;


### PR DESCRIPTION
The `BIT64` preprocessor symbol is not defined nor used anywhere in this repository. This means that if you were to compile a Runtime.Base assembly for 64-bit, helpers like `RhpLdelemaRef` would calculate an incorrect address.

This PR fixes the problem by using the `TARGET_64BIT` preprocessor symbol instead. Just like the [System.Private.CoreLib version of this class](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs#L426-L433).