### PR TITLE
JIT: Add missing `lvTracked` check in `optLocalHasNonLoopUses`

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1284,6 +1284,11 @@ bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loo
         return true;
     }
 
+    if (!varDsc->lvTracked)
+    {
+        return true;
+    }
+
     BasicBlockVisit visitResult = loop->VisitRegularExitBlocks([=](BasicBlock* block) {
         if (VarSetOps::IsMember(this, block->bbLiveIn, varDsc->lvVarIndex))
         {


### PR DESCRIPTION
`optLocalHasNonLoopUses` checks if a local might be used after a loop by making use of its liveness information, but it does not check `lvTracked` before doing so. This is generally not a problem as there are other checks that the local is in SSA, and normally SSA implies `lvTracked`, but that's not the case for locals put into SSA by CSE.

Since it is possible to have CSE defs in a loop with uses outside the loop, this check is necessary for correctness. It is expected to regress a bunch of IV opts cases, but in the future we can get those back by computing the necessary liveness when we insert into SSA.