### PR TITLE
JIT: Don't convert unreachable `BBJ_CALLFINALLYRET` blocks to `BBJ_THROW` during morph

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13379,12 +13379,11 @@ void Compiler::fgMorphBlock(BasicBlock* block, MorphUnreachableInfo* unreachable
                     unreachableInfo->SetUnreachable(block);
 
                     // Remove the block's IR and flow edges but don't mark the block as removed.
-                    // Convert to BBJ_THROW. But leave CALLFINALLY alone.
+                    // Convert to BBJ_THROW. But leave CALLFINALLY(RET) alone.
                     //
                     // If we clear out the block, there is nothing to morph, so just return.
                     //
-                    bool const isCallFinally = block->KindIs(BBJ_CALLFINALLY);
-                    if (!isCallFinally)
+                    if (!block->KindIs(BBJ_CALLFINALLY, BBJ_CALLFINALLYRET))
                     {
                         fgUnreachableBlock(block);
                         block->RemoveFlags(BBF_REMOVED);


### PR DESCRIPTION
Fix #109514. Fix #109515. Follow-up to #109394. Converting `BBJ_CALLFINALLYRET` blocks to `BBJ_THROW` without considering the block's corresponding `BBJ_CALLFINALLY` block breaks flowgraph invariants. The simplest solution seems to be to not convert such blocks to `BBJ_THROW`, and let early flowgraph opts convert the call-finally pair into a retless `BBJ_CALLFINALLY`.