### PR TITLE
Revert "Fix missing analyzer warning for generics in containing type"

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
@@ -14,10 +14,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 	{
 		public static void ProcessGenericArgumentDataFlow (Location location, INamedTypeSymbol type, Action<Diagnostic> reportDiagnostic)
 		{
-			while (type is { IsGenericType: true }) {
-				ProcessGenericArgumentDataFlow (location, type.TypeArguments, type.TypeParameters, reportDiagnostic);
-				type = type.ContainingType;
-			}
+			ProcessGenericArgumentDataFlow (location, type.TypeArguments, type.TypeParameters, reportDiagnostic);
 		}
 
 		public static void ProcessGenericArgumentDataFlow (Location location, IMethodSymbol method, Action<Diagnostic> reportDiagnostic)
@@ -58,7 +55,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public static bool RequiresGenericArgumentDataFlow (INamedTypeSymbol type)
 		{
-			while (type is { IsGenericType: true }) {
+			if (type.IsGenericType) {
 				if (RequiresGenericArgumentDataFlow (type.TypeParameters))
 					return true;
 
@@ -67,8 +64,6 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 						&& RequiresGenericArgumentDataFlow (namedTypeSymbol))
 						return true;
 				}
-
-				type = type.ContainingType;
 			}
 
 			return false;

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresCapabilityTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresCapabilityTests.cs
@@ -65,12 +65,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task RequiresInRootAllAssembly ()
-		{
-			return RunTest ();
-		}
-
-		[Fact]
 		public Task RequiresOnAttribute ()
 		{
 			return RunTest (nameof (RequiresOnAttribute));

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
@@ -32,12 +32,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task ModifierDataFlow ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task StaticInterfaceMethodDataflow ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -48,7 +48,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			TestNoWarningsInRUCMethod<TestType> ();
 			TestNoWarningsInRUCType<TestType, TestType> ();
-			TestGenericParameterFlowsToNestedType.Test ();
 		}
 
 		static void TestSingleGenericParameterOnType ()
@@ -848,59 +847,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			rucType.InstanceMethodRequiresPublicMethods<T> ();
 			rucType.VirtualMethod ();
 			rucType.VirtualMethodRequiresPublicMethods<T> ();
-		}
-
-		class TestGenericParameterFlowsToNestedType
-		{
-			class Generic<T> {
-				[ExpectedWarning ("IL2091")]
-				public T CallNestedMethod () => GenericRequires<T>.Nested.Method ();
-
-				[ExpectedWarning ("IL2091")]
-				public T AccessNestedField () => GenericRequires<T>.Nested.Field;
-
-				[ExpectedWarning ("IL2091")]
-				public T AccessNestedProperty () => GenericRequires<T>.Nested.Property;
-
-				[ExpectedWarning ("IL2091")]
-				public void AccessNestedEvent () => GenericRequires<T>.Nested.Event += null;
-
-				[ExpectedWarning ("IL2091")]
-				public void UseNestedTypeArgument () {
-					new Generic<GenericRequires<T>.Nested> ();
-				}
-
-				[ExpectedWarning ("IL2091")]
-				public class DerivedFromNestedType : GenericRequires<T>.Nested
-				{
-					[ExpectedWarning ("IL2091")]
-					public DerivedFromNestedType () {
-					}
-				}
-			}
-
-			class GenericRequires<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> {
-				public class Nested {
-					public static T? Method () => default;
-
-					public static T? Field = default;
-
-					public static T? Property { get; set; } = default;
-
-					public static event Action<T>? Event;
-				}
-			}
-
-			public static void Test ()
-			{
-				var instance = new Generic<string> ();
-				instance.CallNestedMethod ();
-				instance.AccessNestedField ();
-				instance.AccessNestedProperty ();
-				instance.AccessNestedEvent ();
-				instance.UseNestedTypeArgument ();
-				new Generic<string>.DerivedFromNestedType ();
-			}
 		}
 
 		[RequiresUnreferencedCode ("message")]


### PR DESCRIPTION
Reverts dotnet/runtime#109392 to see if it fixes timeouts in CLR_Tools_Tests.

It seems this change may have introduced timeouts in CLR_Tools_Tests that I failed to notice when marking the PR as green due to debugger test timeouts.