### PR TITLE
Reapply "Fix missing analyzer warning for generics in containing type"

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
@@ -14,7 +14,10 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 	{
 		public static void ProcessGenericArgumentDataFlow (Location location, INamedTypeSymbol type, Action<Diagnostic> reportDiagnostic)
 		{
-			ProcessGenericArgumentDataFlow (location, type.TypeArguments, type.TypeParameters, reportDiagnostic);
+			while (type is { IsGenericType: true }) {
+				ProcessGenericArgumentDataFlow (location, type.TypeArguments, type.TypeParameters, reportDiagnostic);
+				type = type.ContainingType;
+			}
 		}
 
 		public static void ProcessGenericArgumentDataFlow (Location location, IMethodSymbol method, Action<Diagnostic> reportDiagnostic)
@@ -55,7 +58,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public static bool RequiresGenericArgumentDataFlow (INamedTypeSymbol type)
 		{
-			if (type.IsGenericType) {
+			while (type is { IsGenericType: true }) {
 				if (RequiresGenericArgumentDataFlow (type.TypeParameters))
 					return true;
 
@@ -64,6 +67,8 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 						&& RequiresGenericArgumentDataFlow (namedTypeSymbol))
 						return true;
 				}
+
+				type = type.ContainingType;
 			}
 
 			return false;

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresCapabilityTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresCapabilityTests.cs
@@ -65,6 +65,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task RequiresInRootAllAssembly ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task RequiresOnAttribute ()
 		{
 			return RunTest (nameof (RequiresOnAttribute));

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
@@ -32,6 +32,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task ModifierDataFlow ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task StaticInterfaceMethodDataflow ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -867,7 +867,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 				[ExpectedWarning ("IL2091")]
 				public void UseNestedTypeArgument () {
-					new Generic<GenericRequires<T>.Nested> ();
+					new GenericTypeArgument<GenericRequires<T>.Nested> ();
 				}
 
 				[ExpectedWarning ("IL2091")]
@@ -889,6 +889,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 					public static event Action<T>? Event;
 				}
+			}
+
+			class GenericTypeArgument<T>
+			{
 			}
 
 			public static void Test ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -48,6 +48,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			TestNoWarningsInRUCMethod<TestType> ();
 			TestNoWarningsInRUCType<TestType, TestType> ();
+			TestGenericParameterFlowsToNestedType.Test ();
 		}
 
 		static void TestSingleGenericParameterOnType ()
@@ -847,6 +848,59 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			rucType.InstanceMethodRequiresPublicMethods<T> ();
 			rucType.VirtualMethod ();
 			rucType.VirtualMethodRequiresPublicMethods<T> ();
+		}
+
+		class TestGenericParameterFlowsToNestedType
+		{
+			class Generic<T> {
+				[ExpectedWarning ("IL2091")]
+				public T CallNestedMethod () => GenericRequires<T>.Nested.Method ();
+
+				[ExpectedWarning ("IL2091")]
+				public T AccessNestedField () => GenericRequires<T>.Nested.Field;
+
+				[ExpectedWarning ("IL2091")]
+				public T AccessNestedProperty () => GenericRequires<T>.Nested.Property;
+
+				[ExpectedWarning ("IL2091")]
+				public void AccessNestedEvent () => GenericRequires<T>.Nested.Event += null;
+
+				[ExpectedWarning ("IL2091")]
+				public void UseNestedTypeArgument () {
+					new Generic<GenericRequires<T>.Nested> ();
+				}
+
+				[ExpectedWarning ("IL2091")]
+				public class DerivedFromNestedType : GenericRequires<T>.Nested
+				{
+					[ExpectedWarning ("IL2091")]
+					public DerivedFromNestedType () {
+					}
+				}
+			}
+
+			class GenericRequires<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> {
+				public class Nested {
+					public static T? Method () => default;
+
+					public static T? Field = default;
+
+					public static T? Property { get; set; } = default;
+
+					public static event Action<T>? Event;
+				}
+			}
+
+			public static void Test ()
+			{
+				var instance = new Generic<string> ();
+				instance.CallNestedMethod ();
+				instance.AccessNestedField ();
+				instance.AccessNestedProperty ();
+				instance.AccessNestedEvent ();
+				instance.UseNestedTypeArgument ();
+				new Generic<string>.DerivedFromNestedType ();
+			}
 		}
 
 		[RequiresUnreferencedCode ("message")]


### PR DESCRIPTION
This time, avoid generic cycles in the new testcase.

The generic cycle was causing timeouts in the CLR_Tools_Tests, or stack overflows when running the ILCompiler tests locally, because generic cycle detection was disabled for the ILC tests in https://github.com/dotnet/runtime/pull/79176.