### PR TITLE
Do not override `DefineConstants` in WBT

### DIFF
--- a/src/mono/wasi/Wasi.Build.Tests/Wasi.Build.Tests.csproj
+++ b/src/mono/wasi/Wasi.Build.Tests/Wasi.Build.Tests.csproj
@@ -7,7 +7,7 @@
     <TestFramework>xunit</TestFramework>
     <EnableDefaultItems>true</EnableDefaultItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <DefineConstants Condition="'$(ContinuousIntegrationBuild)' != 'true'">TEST_DEBUG_CONFIG_ALSO</DefineConstants>
+    <DefineConstants Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(DefineConstants);TEST_DEBUG_CONFIG_ALSO</DefineConstants>
     <!-- This project should not build against the live built .NETCoreApp targeting pack as it contributes to the build itself. -->
     <UseLocalTargetingRuntimePack>false</UseLocalTargetingRuntimePack>
 
@@ -21,7 +21,7 @@
     <UseDefaultTestHost>true</UseDefaultTestHost>
 
     <EnableRunSettingsSupport>false</EnableRunSettingsSupport>
-    <DefineConstants>TARGET_WASI</DefineConstants>
+    <DefineConstants>$(DefineConstants);TARGET_WASI</DefineConstants>
     <_MonoSrcWasmDir>$([MSBuild]::NormalizeDirectory($(MonoProjectRoot), 'wasm'))</_MonoSrcWasmDir>
 
     <InstallWasmtimeForTests Condition="'$(InstallWasmtimeForTests)' == '' and

--- a/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -7,7 +7,7 @@
     <TestFramework>xunit</TestFramework>
     <EnableDefaultItems>true</EnableDefaultItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <DefineConstants Condition="'$(ContinuousIntegrationBuild)' != 'true'">TEST_DEBUG_CONFIG_ALSO</DefineConstants>
+    <DefineConstants Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(DefineConstants);TEST_DEBUG_CONFIG_ALSO</DefineConstants>
     <!-- This project should not build against the live built .NETCoreApp targeting pack as it contributes to the build itself. -->
     <UseLocalTargetingRuntimePack>false</UseLocalTargetingRuntimePack>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/108935.

It looks like we had out-of-CI testing with debug disabled for wasi. Thanks @carlossanlop.
