### PR TITLE
Unify DefineConstants

### DIFF
--- a/src/coreclr/tools/ILVerification/ILVerification.csproj
+++ b/src/coreclr/tools/ILVerification/ILVerification.csproj
@@ -10,7 +10,6 @@
     <SignAssembly>true</SignAssembly>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <RunAnalyzers>false</RunAnalyzers>
-    <DefineConstants>NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 
   <Import Project="ILVerification.projitems" />

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/TypeEquivalenceAssembly/TypeEquivalenceAssembly1.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/TypeEquivalenceAssembly/TypeEquivalenceAssembly1.csproj
@@ -11,7 +11,7 @@
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <RunAnalyzers>false</RunAnalyzers>
-    <DefineConstants>TYPEEQUIVALENCEASSEMBLY_1</DefineConstants>
+    <DefineConstants>$(DefineConstants);TYPEEQUIVALENCEASSEMBLY_1</DefineConstants>
     <!-- This assembly has no LibraryImports and uses a custom corelib, so disable the generator. -->
     <EnableLibraryImportGenerator>false</EnableLibraryImportGenerator>
   </PropertyGroup>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/TypeEquivalenceAssembly/TypeEquivalenceAssembly2.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/TypeEquivalenceAssembly/TypeEquivalenceAssembly2.csproj
@@ -11,7 +11,6 @@
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <RunAnalyzers>false</RunAnalyzers>
-    <DefineConstants>TYPEEQUIVALENCEASSEMBLY_2</DefineConstants>
     <!-- This assembly has no LibraryImports and uses a custom corelib, so disable the generator. -->
     <EnableLibraryImportGenerator>false</EnableLibraryImportGenerator>
   </PropertyGroup>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);0436</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
+    <StringResourcesPath>..\..\src\Resources\Strings.resx</StringResourcesPath>
     <TargetFramework>$(NetCoreAppCurrent)-windows</TargetFramework>
-    <DefineConstants>UNITTEST</DefineConstants>
+    <DefineConstants>$(DefineConstants);UNITTEST</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <DefaultReferenceExclusion Include="System.Net.Http.WinHttpHandler" />

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XsdDataContractExporterTests/SerializationTypes/SerializationTypes.csproj
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XsdDataContractExporterTests/SerializationTypes/SerializationTypes.csproj
@@ -4,7 +4,7 @@
 		XsdDataContractExporter that take an 'Assembly' as input. -->
     <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>UseSeparateAssemblyNamespace;HideTypesWithoutSerializableAttribute</DefineConstants>
+    <DefineConstants>$(DefineConstants);UseSeparateAssemblyNamespace;HideTypesWithoutSerializableAttribute</DefineConstants>
     <NoWarn>$(NoWarn);169;414</NoWarn>
     <!--
       This assembly does not have any P/Invokes and there are tests that depend on the specific number of enum types in this assembly.

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
@@ -3,7 +3,7 @@
     <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants >WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/baseservices/exceptions/WindowsEventLog/WindowsEventLog_TargetWindows.csproj
+++ b/src/tests/baseservices/exceptions/WindowsEventLog/WindowsEventLog_TargetWindows.csproj
@@ -5,7 +5,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
 
-    <DefineConstants >WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/baseservices/typeequivalence/istypeequivalent/typeequivalenttypes_2.csproj
+++ b/src/tests/baseservices/typeequivalence/istypeequivalent/typeequivalenttypes_2.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);TYPEEQUIVALENCEASSEMBLY_2</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
A followup on https://github.com/dotnet/runtime/pull/109539 where it seems unintentional to not capture contextual constants. Also removed unused and redundant ones.

Query:
```sh
$ git grep -B1 -P '<DefineConstants(?![^<]*\$\(\s*DefineConstants\s*\))[^<]*</DefineConstants>(?!.*DefineConstants)'
```

cc @akoeplinger, @ilonatommy