### PR TITLE
Block exporting DllMain

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
@@ -48,7 +48,7 @@ namespace ILCompiler
                         && comparer.Equals(nsHandle, "System.Runtime.InteropServices"))
                     {
                         var method = (EcmaMethod)_module.GetMethod(ca.Parent);
-                        string name = method.GetUnmanagedCallersOnlyExportName();
+                        string? name = method.GetUnmanagedCallersOnlyExportName();
 
                         if (name == "DllMain")
                             throw new InvalidOperationException("Exporting DllMain from managed code is not supported!");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
@@ -48,7 +48,12 @@ namespace ILCompiler
                         && comparer.Equals(nsHandle, "System.Runtime.InteropServices"))
                     {
                         var method = (EcmaMethod)_module.GetMethod(ca.Parent);
-                        if (method.GetUnmanagedCallersOnlyExportName() != null)
+                        string name = method.GetUnmanagedCallersOnlyExportName();
+
+                        if (name == "DllMain")
+                            throw new InvalidOperationException("Exporting DllMain from managed code is not supported!");
+
+                        if (name != null)
                             yield return method;
                     }
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 
@@ -48,7 +49,7 @@ namespace ILCompiler
                         && comparer.Equals(nsHandle, "System.Runtime.InteropServices"))
                     {
                         var method = (EcmaMethod)_module.GetMethod(ca.Parent);
-                        string? name = method.GetUnmanagedCallersOnlyExportName();
+                        string name = method.GetUnmanagedCallersOnlyExportName();
 
                         if (name == "DllMain")
                             throw new InvalidOperationException("Exporting DllMain from managed code is not supported!");


### PR DESCRIPTION
Try to block defining DllMain in NativeAOT.

@jkotas @MichalStrehovsky would this make sense?

Closes #109543