### PR TITLE
[EventTrace] Update check for provider triggered GC

### DIFF
--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -224,6 +224,15 @@ struct ProfilingScanContext;
 #include <evntrace.h>
 #include <evntprov.h>
 #endif //!FEATURE_NATIVEAOT
+#else // !defined(HOST_UNIX)
+
+//
+// ETW and EventPipe Event Notification Callback Control Code Keywords
+//
+#define EVENT_CONTROL_CODE_DISABLE_PROVIDER 0
+#define EVENT_CONTROL_CODE_ENABLE_PROVIDER 1
+#define EVENT_CONTROL_CODE_CAPTURE_STATE 2
+
 #endif //!defined(HOST_UNIX)
 
 

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -205,7 +205,7 @@ void EtwCallbackCommon(
         ctxToUpdate->EventPipeProvider.IsEnabled = ControlCode;
 
         // For EventPipe, ControlCode can only be either 0 or 1.
-        _ASSERTE(ControlCode == 0 || ControlCode == 1);
+        _ASSERTE(ControlCode == EVENT_CONTROL_CODE_DISABLE_PROVIDER || ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER);
     }
 
     if (

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -230,14 +230,13 @@ void EtwCallbackCommon(
 #ifdef FEATURE_ETW
     // Special check for a profiler requested GC.
     // A full GC will be forced if:
-    // 1. The runtime has started and is not shutting down.
+    // 1. The GC Heap is initialized.
     // 2. The public provider is requesting GC.
     // 3. The provider's ManagedHeapCollectKeyword is enabled.
     // 4. For an ETW provider, the control code is to enable or capture the state of the provider.
     bool bValidGCRequest =
-        g_fEEStarted && !g_fEEShutDown &&
-        bIsPublicTraceHandle &&
         GCHeapUtilities::IsGCHeapInitialized() &&
+        bIsPublicTraceHandle &&
         ((MatchAnyKeyword & CLR_MANAGEDHEAPCOLLECT_KEYWORD) != 0) &&
         ((ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER) ||
          (ControlCode == EVENT_CONTROL_CODE_CAPTURE_STATE)) &&

--- a/src/coreclr/nativeaot/Runtime/eventtracebase.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracebase.h
@@ -127,6 +127,13 @@ bool DotNETRuntimeProvider_IsEnabled(unsigned char level, unsigned long long key
     DotNETRuntimeProvider_IsEnabled(Level, Keyword)
 #endif // FEATURE_ETW
 
+//
+// ETW and EventPipe Event Notification Callback Control Code Keywords
+//
+#define EVENT_CONTROL_CODE_DISABLE_PROVIDER 0
+#define EVENT_CONTROL_CODE_ENABLE_PROVIDER 1
+#define EVENT_CONTROL_CODE_CAPTURE_STATE 2
+
 #else // FEATURE_EVENT_TRACE
 
 #include "etmdummy.h"

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2401,6 +2401,8 @@ VOID ParseFilterDataClientSequenceNumber(
 // Common handler for all ETW or EventPipe event notifications. Based on the provider that
 // was enabled/disabled, this implementation forwards the event state change onto GCHeapUtilities
 // which will inform the GC to update its local state about what events are enabled.
+// NOTE: When multiple ETW or EventPipe sessions are enabled, the ControlCode will be
+// EVENT_CONTROL_CODE_ENABLE_PROVIDER even if the session invoking this callback is being disabled.
 VOID EtwCallbackCommon(
     CallbackProviderIndex ProviderIndex,
     ULONG ControlCode,

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2450,13 +2450,10 @@ VOID EtwCallbackCommon(
         ctxToUpdate->EventPipeProvider.IsEnabled = ControlCode;
 
         // For EventPipe, ControlCode can only be either 0 or 1.
-        _ASSERTE(ControlCode == 0 || ControlCode == 1);
+        _ASSERTE(ControlCode == EVENT_CONTROL_CODE_DISABLE_PROVIDER || ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER);
     }
 
-    if (
-#if !defined(HOST_UNIX)
-        (ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER || ControlCode == EVENT_CONTROL_CODE_DISABLE_PROVIDER) &&
-#endif
+    if ((ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER || ControlCode == EVENT_CONTROL_CODE_DISABLE_PROVIDER) &&
         (ProviderIndex == DotNETRuntime || ProviderIndex == DotNETRuntimePrivate))
     {
 #if !defined(HOST_UNIX)
@@ -2484,10 +2481,8 @@ VOID EtwCallbackCommon(
         g_fEEStarted && !g_fEEShutDown &&
         bIsPublicTraceHandle &&
         ((MatchAnyKeyword & CLR_MANAGEDHEAPCOLLECT_KEYWORD) != 0) &&
-#if !defined(HOST_UNIX)
         ((ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER) ||
          (ControlCode == EVENT_CONTROL_CODE_CAPTURE_STATE)) &&
-#endif // !defined(HOST_UNIX)
         ((Change == EtwSessionChangeUnknown) ||
          (Change == EventPipeSessionEnable));
 

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2407,8 +2407,7 @@ VOID EtwCallbackCommon(
     UCHAR Level,
     ULONGLONG MatchAnyKeyword,
     PVOID pFilterData,
-    BOOL isEventPipeCallback,
-    SessionChange change)
+    SessionChange Change)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -2444,7 +2443,7 @@ VOID EtwCallbackCommon(
     // This callback gets called on both ETW/EventPipe session enable/disable.
     // We need toupdate the EventPipe provider context if we are in a callback
     // from EventPipe, but not from ETW.
-    if (isEventPipeCallback)
+    if (Change == EventPipeSessionEnable || Change == EventPipeSessionDisable)
     {
         ctxToUpdate->EventPipeProvider.Level = Level;
         ctxToUpdate->EventPipeProvider.EnabledKeywordsBitmask = MatchAnyKeyword;
@@ -2531,7 +2530,7 @@ VOID EventPipeEtwCallbackDotNETRuntimeStress(
 
     SessionChange change = SourceId == NULL ? EventPipeSessionDisable : EventPipeSessionEnable;
 
-    EtwCallbackCommon(DotNETRuntimeStress, ControlCode, Level, MatchAnyKeyword, FilterData, true, change);
+    EtwCallbackCommon(DotNETRuntimeStress, ControlCode, Level, MatchAnyKeyword, FilterData, change);
 }
 
 VOID EventPipeEtwCallbackDotNETRuntime(
@@ -2547,7 +2546,7 @@ VOID EventPipeEtwCallbackDotNETRuntime(
 
     SessionChange change = SourceId == NULL ? EventPipeSessionDisable : EventPipeSessionEnable;
 
-    EtwCallbackCommon(DotNETRuntime, ControlCode, Level, MatchAnyKeyword, FilterData, true, change);
+    EtwCallbackCommon(DotNETRuntime, ControlCode, Level, MatchAnyKeyword, FilterData, change);
 }
 
 VOID EventPipeEtwCallbackDotNETRuntimeRundown(
@@ -2563,7 +2562,7 @@ VOID EventPipeEtwCallbackDotNETRuntimeRundown(
 
     SessionChange change = SourceId == NULL ? EventPipeSessionDisable : EventPipeSessionEnable;
 
-    EtwCallbackCommon(DotNETRuntimeRundown, ControlCode, Level, MatchAnyKeyword, FilterData, true, change);
+    EtwCallbackCommon(DotNETRuntimeRundown, ControlCode, Level, MatchAnyKeyword, FilterData, change);
 }
 
 VOID EventPipeEtwCallbackDotNETRuntimePrivate(
@@ -2579,7 +2578,7 @@ VOID EventPipeEtwCallbackDotNETRuntimePrivate(
 
     SessionChange change = SourceId == NULL ? EventPipeSessionDisable : EventPipeSessionEnable;
 
-    EtwCallbackCommon(DotNETRuntimePrivate, ControlCode, Level, MatchAnyKeyword, FilterData, true, change);
+    EtwCallbackCommon(DotNETRuntimePrivate, ControlCode, Level, MatchAnyKeyword, FilterData, change);
 }
 
 
@@ -2735,7 +2734,7 @@ extern "C"
             return;
         }
 
-        EtwCallbackCommon(providerIndex, ControlCode, Level, MatchAnyKeyword, FilterData, false, SessionChange.EtwSessionChangeUnknown);
+        EtwCallbackCommon(providerIndex, ControlCode, Level, MatchAnyKeyword, FilterData, EtwSessionChangeUnknown);
 
         // A manifest based provider can be enabled to multiple event tracing sessions
         // As long as there is atleast 1 enabled session, IsEnabled will be TRUE

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2792,10 +2792,7 @@ extern "C"
 
     }
 }
-#endif // FEATURE_NATIVEAOT
-
-#endif // HOST_UNIX
-#ifndef FEATURE_NATIVEAOT
+#endif // !defined(HOST_UNIX)
 
 /****************************************************************************/
 /* This is called by the runtime when an exception is thrown */


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/99487

This PR follows-up on https://github.com/dotnet/runtime/pull/102612/files#r1649499169 by returning the control code filtering for ETW providers and leveraging EventPipe SessionId's to differentiate between a EventPipe session being enabled or disabled to determine whether or not a GC should be forced.

## Testing

Checked whether [ForceGC](https://github.com/dotnet/runtime/blob/6d23ef4d68bbcdb38fdc22218d1073c5083ac6a1/src/coreclr/vm/eventtrace.cpp#L2423) was hit following each step.
1. Enabled an EventPipe session with `dotnet-trace collect -n sampleApp --providers Microsoft-Windows-DotNETRuntime:800000`.
2. Enabled a second EventPipe session with `dotnet-trace collect -n sampleApp --providers Microsoft-Windows-DotNETRuntime:800000`.
3. Disabled one of the EventPipe sessions by pressing Enter in one of the dotnet-trace windows.

### Debugging a simple .NET app before the changes
1. hit
2. hit
3. **HIT**.

### While debugging a simple .NET app built with the changes
1. hit
2. hit
3. **NOT HIT**