### PR TITLE
JIT: Don't split up partially-hot call-finally pairs during 3-opt layout

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5052,6 +5052,14 @@ void Compiler::ThreeOptLayout::Run()
         return;
     }
 
+    // If only the first block of a call-finally pair is hot, include the whole pair in the hot section anyway.
+    // This ensures the call-finally pair won't be split up when swapping partitions.
+    if (finalBlock->isBBCallFinallyPair())
+    {
+        finalBlock = finalBlock->Next();
+        numBlocksUpperBound++;
+    }
+
     assert(numBlocksUpperBound != 0);
     blockOrder = new (compiler, CMK_BasicBlock) BasicBlock*[numBlocksUpperBound];
     tempOrder  = new (compiler, CMK_BasicBlock) BasicBlock*[numBlocksUpperBound];


### PR DESCRIPTION
Fixes #109574. When identifying the span of hot blocks to reorder with 3-opt, make sure the hot section does not end between a call-finally pair; otherwise, swapping partitions will split the pair up.