### PR TITLE
Build the cdac as part of clr.tools instead of as a prereq to the runtime native build

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -382,7 +382,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+tools.cdacreader+'))">
-    <ProjectToBuild Include="$(RepoRoot)\src\native\managed\compile-native.proj" Category="tools" />
+    <ProjectToBuild Include="$(SharedNativeRoot)managed\compile-native.proj" Category="tools" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+tools.cdacreadertests+'))">

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -381,7 +381,7 @@
       Test="true" Category="clr" Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(NativeAotSupported)' == 'true'"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(_subset.Contains('+tools.cdacreader+'))">
+  <ItemGroup Condition="$(_subset.Contains('+tools.cdacreader+'))">
     <ProjectToBuild Include="$(RepoRoot)\src\native\managed\compile-native.proj" Category="tools" />
   </ItemGroup>
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -369,6 +369,8 @@
     <ProjectToBuild Condition="'$(TargetOS)' == 'windows' or ('$(TargetOS)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')) or '$(TargetOS)' == 'osx'" Include="$(CoreClrProjectRoot)tools\SuperFileCheck\SuperFileCheck.csproj" Category="clr" />
 
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\cdac-build-tool\cdac-build-tool.csproj" Category="clr" />
+
+    <ProjectToBuild Include="$(RepoRoot)\src\native\managed\compile-native.proj" Category="clr" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+clr.toolstests+'))">

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -87,7 +87,7 @@
     <!-- Respect the DotNetBuildTests product flag when building the product. -->
     <DefaultLibrariesSubsets Condition="'$(DotNetBuildTests)' == 'true'">$(DefaultLibrariesSubsets)+libs.tests</DefaultLibrariesSubsets>
 
-    <DefaultToolsSubsets>tools.illink</DefaultToolsSubsets>
+    <DefaultToolsSubsets>tools.illink+tools.cdacreader</DefaultToolsSubsets>
 
     <DefaultHostSubsets>host.native+host.tools+host.pkg</DefaultHostSubsets>
     <DefaultHostSubsets Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(DefaultHostSubsets)+host.pretest+host.tests</DefaultHostSubsets>
@@ -179,6 +179,7 @@
     <!-- Tools -->
     <SubsetName Include="Tools" Description="Additional runtime tools projects. Equivalent to: $(DefaultToolsSubsets)" />
     <SubsetName Include="Tools.ILLink" Description="The projects that produce illink and analyzer tools for trimming." />
+    <SubsetName Include="Tools.CdacReader" Description="The cDAC reader." />
     <SubsetName Include="Tools.ILLinkTests" OnDemand="true" Description="Unit tests for the tools.illink subset." />
 
     <SubsetName Include="Tools.CdacReaderTests" OnDemand="true" Description="Units tests for the cDAC reader." />
@@ -369,8 +370,6 @@
     <ProjectToBuild Condition="'$(TargetOS)' == 'windows' or ('$(TargetOS)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')) or '$(TargetOS)' == 'osx'" Include="$(CoreClrProjectRoot)tools\SuperFileCheck\SuperFileCheck.csproj" Category="clr" />
 
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\cdac-build-tool\cdac-build-tool.csproj" Category="clr" />
-
-    <ProjectToBuild Include="$(RepoRoot)\src\native\managed\compile-native.proj" Category="clr" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+clr.toolstests+'))">
@@ -380,6 +379,10 @@
       Test="true" Category="clr" Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(NativeAotSupported)' == 'true'"/>
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.Trimming.Tests\ILCompiler.Trimming.Tests.csproj"
       Test="true" Category="clr" Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(NativeAotSupported)' == 'true'"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(_subset.Contains('+tools.cdacreader+'))">
+    <ProjectToBuild Include="$(RepoRoot)\src\native\managed\compile-native.proj" Category="tools" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+tools.cdacreadertests+'))">

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -692,7 +692,7 @@ extends:
           jobParameters:
             timeoutInMinutes: 120
             nameSuffix: CLR_Tools_Tests
-            buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests+tools.cdacreadertests -c $(_BuildConfig) -test
+            buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests+tools.cdacreader+tools.cdacreadertests -c $(_BuildConfig) -test
             enablePublishTestResults: true
             testResultsFormat: 'xunit'
             # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT

--- a/src/coreclr/runtime-prereqs.proj
+++ b/src/coreclr/runtime-prereqs.proj
@@ -14,7 +14,6 @@
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\native\managed\compile-native.proj" ReferenceOutputAssembly="false"/>
     <ProjectReference Include="tools\cdac-build-tool\cdac-build-tool.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/104158

This will also allow us to take a dependency on native components from the cdacreader project when necessary without too much difficulty (ie. native unwinder)