### PR TITLE
Unify corerun's implementation of the native debugger check with the minipal for all platforms

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.hpp
+++ b/src/coreclr/hosts/corerun/corerun.hpp
@@ -37,19 +37,11 @@ namespace pal
 
     template<typename T>
     using malloc_ptr = std::unique_ptr<T, free_delete>;
-
-    enum class debugger_state_t
-    {
-        na,
-        attached,
-        not_attached,
-    };
 }
 
 #ifdef TARGET_WINDOWS
 #define CDECL __cdecl
 #include <Windows.h>
-#include <minipal/debugger.h>
 
 #define DLL_EXPORT __declspec(dllexport)
 #define MAIN __cdecl wmain
@@ -135,11 +127,6 @@ namespace pal
     inline uint32_t get_process_id()
     {
         return (uint32_t)::GetCurrentProcessId();
-    }
-
-    inline debugger_state_t is_debugger_attached()
-    {
-        return (minipal_is_native_debugger_present() == TRUE) ? debugger_state_t::attached : debugger_state_t::not_attached;
     }
 
     inline bool does_file_exist(const string_t& file_path)
@@ -419,85 +406,6 @@ namespace pal
     inline uint32_t get_process_id()
     {
         return (uint32_t)getpid();
-    }
-
-    inline debugger_state_t is_debugger_attached()
-    {
-#if defined(__APPLE__)
-        // Taken from https://developer.apple.com/library/archive/qa/qa1361/_index.html
-        int                 junk;
-        int                 mib[4];
-        struct kinfo_proc   info;
-        size_t              size;
-
-        // Initialize the flags so that, if sysctl fails for some bizarre
-        // reason, we get a predictable result.
-
-        info.kp_proc.p_flag = 0;
-
-        // Initialize mib, which tells sysctl the info we want, in this case
-        // we're looking for information about a specific process ID.
-
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_PROC;
-        mib[2] = KERN_PROC_PID;
-        mib[3] = getpid();
-
-        // Call sysctl.
-
-        size = sizeof(info);
-        junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
-        assert(junk == 0);
-
-        // We're being debugged if the P_TRACED flag is set.
-
-        return ( (info.kp_proc.p_flag & P_TRACED) != 0 ) ? debugger_state_t::attached : debugger_state_t::not_attached;
-
-#else // !__APPLE__
-        // Use procfs to detect if there is a tracer process.
-        // See https://www.kernel.org/doc/html/latest/filesystems/proc.html
-        char status[2048];
-        int fd = ::open("/proc/self/status", O_RDONLY);
-        if (fd == -1)
-        {
-            // If the file can't be opened assume we are on a not supported platform.
-            return debugger_state_t::na;
-        }
-
-        // Attempt to read
-        ssize_t bytes_read = ::read(fd, status, sizeof(status) - 1);
-        ::close(fd);
-
-        if (bytes_read > 0)
-        {
-            // We have data. At this point we can likely make a strong decision.
-            const char tracer_pid_name[] = "TracerPid:";
-            // null terminate status
-            status[bytes_read] = '\0';
-            const char* tracer_pid_ptr = ::strstr(status, tracer_pid_name);
-            if (tracer_pid_ptr == nullptr)
-                return debugger_state_t::not_attached;
-
-            // The number after the name is the process ID of the
-            // tracer application or 0 if none exists.
-            const char* curr = tracer_pid_ptr + (sizeof(tracer_pid_name) - 1);
-            const char* end = status + bytes_read;
-            for (;curr < end; ++curr)
-            {
-                if (::isspace(*curr))
-                    continue;
-
-                // Check the first non-space if it is 0. If so, we have
-                // a non-zero process ID and a tracer is attached.
-                return (::isdigit(*curr) && *curr != '0') ? debugger_state_t::attached : debugger_state_t::not_attached;
-            }
-        }
-
-        // The read in data is either incomplete (i.e. small buffer) or
-        // the returned content is not expected. Let's fallback to not available.
-        return debugger_state_t::na;
-
-#endif // !__APPLE__
     }
 
     inline bool does_file_exist(const char_t* file_path)

--- a/src/native/minipal/debugger.c
+++ b/src/native/minipal/debugger.c
@@ -52,6 +52,7 @@ bool minipal_can_check_for_native_debugger(void)
     return true;
 #else
     return false;
+#endif
 }
 
 bool minipal_is_native_debugger_present(void)

--- a/src/native/minipal/debugger.c
+++ b/src/native/minipal/debugger.c
@@ -17,27 +17,42 @@
 
 #if defined(_WIN32)
 #include <windows.h>
+#define MINIPAL_DEBUGGER_PRESENT_CHECK
 #elif defined(__linux__)
 #include <stdio.h>
+#define MINIPAL_DEBUGGER_PRESENT_CHECK
 #elif defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #include <sys/types.h>
+#define MINIPAL_DEBUGGER_PRESENT_CHECK
 #elif defined(__NetBSD__)
 #include <kvm.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <sys/proc.h>
+#define MINIPAL_DEBUGGER_PRESENT_CHECK
 #elif defined(__sun)
 #include <fcntl.h>
 #include <procfs.h>
 #include <errno.h>
+#define MINIPAL_DEBUGGER_PRESENT_CHECK
 #elif defined(_AIX)
 #include <sys/proc.h>
 #include <sys/types.h>
 #include <sys/procfs.h>
+#define MINIPAL_DEBUGGER_PRESENT_CHECK
 #elif defined(__HAIKU__)
 #include <OS.h>
+#define MINIPAL_DEBUGGER_PRESENT_CHECK
 #endif
+
+bool minipal_can_check_for_native_debugger(void)
+{
+#if defined(MINIPAL_DEBUGGER_PRESENT_CHECK)
+    return true;
+#else
+    return false;
+}
 
 bool minipal_is_native_debugger_present(void)
 {

--- a/src/native/minipal/debugger.h
+++ b/src/native/minipal/debugger.h
@@ -11,6 +11,13 @@ extern "C" {
 #endif
 
 /**
+ * Check if the minipal can check for a native debugger.
+ *
+ * @return true if the minipal can check if a native debugger is attached, false otherwise.
+ */
+bool minipal_can_check_for_native_debugger(void);
+
+/**
  * Check if a native debugger is attached to the current process.
  *
  * @return true if a debugger is attached, false otherwise.


### PR DESCRIPTION
Deduplicate the non-Windows path so new platforms only need to add support in one place.