### PR TITLE
Don't drop the warning/error code and type when overriding by binlog

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -189,13 +189,34 @@ namespace Wasm.Build.Tests
                 buildRoot.VisitAllChildren<TextNode>(m =>
                 {
                     if (m is Message || m is Error || m is Warning)
-                        outputBuilder.AppendLine(m.Title);
+                    {
+                        var context = GetBinlogMessageContext(m);
+                        outputBuilder.AppendLine($"{context}{m.Title}");
+                    }
                 });
 
                 res = new CommandResult(res.StartInfo, res.ExitCode, outputBuilder.ToString());
             }
 
             return (res, logFilePath);
+        }
+
+        private string GetBinlogMessageContext(TextNode node)
+        {
+            var currentNode = node;
+            while (currentNode != null)
+            {
+                if (currentNode is Error error)
+                {
+                    return $"{error.File}({error.LineNumber},{error.ColumnNumber}): error {error.Code}: ";
+                }
+                else if (currentNode is Warning warning)
+                {
+                    return $"{warning.File}({warning.LineNumber},{warning.ColumnNumber}): warning {warning.Code}: ";
+                }
+                currentNode = currentNode.Parent as TextNode;
+            }
+            return string.Empty;
         }
 
         protected bool IsDotnetWasmFromRuntimePack(BuildArgs buildArgs) =>


### PR DESCRIPTION
Follow-up for https://github.com/dotnet/runtime/pull/107280.

### Is there a test for it?
No, but PR https://github.com/dotnet/runtime/pull/109069 needs it for `PInvokeTableGeneratorTests` (it's checking specifically for e.g. `warning.*native function.*sum.*varargs` message, not `native function.*sum.*varargs`, etc). The change was tested there but got separated to decrease the number of changes in that PR.

### Before the change:
output contains
`Found a native function (sum) with varargs in variadic. Calling such functions is not supported, and will fail at runtime. Managed DllImports: `

### After the change:
output contains
`/workspaces/runtime/artifacts/bin/dotnet-latest/packs/Microsoft.NET.Runtime.WebAssembly.Sdk/10.0.0-dev/Sdk/WasmApp.Common.targets(793,5): warning WASM0001: Found a native function (sum) with varargs in variadic. Calling such functions is not supported, and will fail at runtime. Managed DllImports:`