### PR TITLE
Implement `DAMT.*WithInherited`

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -34,13 +34,15 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.NonPublicConstructors))
             {
-                foreach (var c in typeDefinition.GetConstructorsOnType(filter: null, bindingFlags: BindingFlags.NonPublic))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.NonPublicConstructorsWithInherited);
+                foreach (var c in typeDefinition.ApplyIncludeInherited(t => t.GetConstructorsOnType(filter: null, bindingFlags: BindingFlags.NonPublic), withInherited))
                     yield return c;
             }
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.PublicConstructors))
             {
-                foreach (var c in typeDefinition.GetConstructorsOnType(filter: null, bindingFlags: BindingFlags.Public))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.PublicConstructorsWithInherited);
+                foreach (var c in typeDefinition.ApplyIncludeInherited(t => t.GetConstructorsOnType(filter: null, bindingFlags: BindingFlags.Public), withInherited))
                     yield return c;
             }
 
@@ -52,7 +54,8 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.NonPublicMethods))
             {
-                foreach (var m in typeDefinition.GetMethodsOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.NonPublicMethodsWithInherited);
+                foreach (var m in typeDefinition.ApplyIncludeInherited(t => t.GetMethodsOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
                     yield return m;
             }
 
@@ -64,7 +67,8 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.NonPublicFields))
             {
-                foreach (var f in typeDefinition.GetFieldsOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.NonPublicFieldsWithInherited);
+                foreach (var f in typeDefinition.ApplyIncludeInherited(t => t.GetFieldsOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
                     yield return f;
             }
 
@@ -76,7 +80,8 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.NonPublicNestedTypes))
             {
-                foreach (var t in typeDefinition.GetNestedTypesOnType(filter: null, bindingFlags: BindingFlags.NonPublic))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.NonPublicNestedTypesWithInherited);
+                foreach (var t in typeDefinition.ApplyIncludeInherited(t => t.GetNestedTypesOnType(filter: null, bindingFlags: BindingFlags.NonPublic), withInherited))
                 {
                     yield return t;
                     var members = new List<TypeSystemEntity>();
@@ -88,7 +93,8 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.PublicNestedTypes))
             {
-                foreach (var t in typeDefinition.GetNestedTypesOnType(filter: null, bindingFlags: BindingFlags.Public))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.PublicNestedTypesWithInherited);
+                foreach (var t in typeDefinition.ApplyIncludeInherited(t => t.GetNestedTypesOnType(filter: null, bindingFlags: BindingFlags.Public), withInherited))
                 {
                     yield return t;
                     var members = new List<TypeSystemEntity>();
@@ -100,7 +106,8 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.NonPublicProperties))
             {
-                foreach (var p in typeDefinition.GetPropertiesOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.NonPublicPropertiesWithInherited);
+                foreach (var p in typeDefinition.ApplyIncludeInherited(t => t.GetPropertiesOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
                     yield return p;
             }
 
@@ -112,7 +119,8 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.NonPublicEvents))
             {
-                foreach (var e in typeDefinition.GetEventsOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+                bool withInherited = !declaredOnly && memberTypes.HasFlag(DynamicallyAccessedMemberTypesEx.NonPublicEventsWithInherited);
+                foreach (var e in typeDefinition.ApplyIncludeInherited(t => t.GetEventsOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
                     yield return e;
             }
 
@@ -502,6 +510,20 @@ namespace ILCompiler.Dataflow
             {
                 return null;
             }
+        }
+
+        private static IEnumerable<T> ApplyIncludeInherited<T>(this TypeDesc type, Func<TypeDesc, IEnumerable<T>> selector, bool includeBases)
+        {
+            do
+            {
+                foreach (var m in selector(type))
+                    yield return m;
+
+                if (!includeBases)
+                    yield break;
+
+                type = type.TryGetBaseType();
+            } while (type != null);
         }
 
         private static DefType[] TryGetExplicitlyImplementedInterfaces(this TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -139,6 +139,7 @@
     <Compile Include="..\..\Common\TypeSystem\Interop\UnmanagedCallingConventions.cs" Link="Interop\UnmanagedCallingConventions.cs" />
     <Compile Include="..\ILCompiler.Reflection.ReadyToRun\PEReaderExtensions.cs" Link="Reflection\PEReaderExtensions.cs" />
     <Compile Include="$(ToolsProjectRoot)illink\src\ILLink.Shared\ClosedAttribute.cs" Link="ILLink.Shared\ClosedAttribute.cs" />
+    <Compile Include="$(ToolsProjectRoot)illink\src\ILLink.Shared\DynamicallyAccessedMemberTypesEx.cs" Link="ILLink.Shared\DynamicallyAccessedMemberTypesEx.cs" />
     <Compile Include="$(ToolsProjectRoot)illink\src\ILLink.Shared\ParameterIndex.cs" Link="ILLink.Shared\ParameterIndex.cs" />
     <Compile Include="$(ToolsProjectRoot)illink\src\ILLink.Shared\TrimAnalysis\ReferenceKind.cs" Link="ILLink.Shared\TrimAnalysis\ReferenceKind.cs" />
     <Compile Include="$(ToolsProjectRoot)illink\src\ILLink.Shared\TypeSystemProxy\GenericParameterProxy.cs" Link="ILLink.Shared\TypeSystemProxy\GenericParameterProxy.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -93,6 +93,76 @@ namespace System.Diagnostics.CodeAnalysis
         Interfaces = 0x2000,
 
         /// <summary>
+        /// Specifies all non-public constructors, including those inherited from base classes.
+        /// </summary>
+        NonPublicConstructorsWithInherited = NonPublicConstructors | 0x4000,
+
+        /// <summary>
+        /// Specifies all non-public methods, including those inherited from base classes.
+        /// </summary>
+        NonPublicMethodsWithInherited = NonPublicMethods | 0x8000,
+
+        /// <summary>
+        /// Specifies all non-public fields, including those inherited from base classes.
+        /// </summary>
+        NonPublicFieldsWithInherited = NonPublicFields | 0x10000,
+
+        /// <summary>
+        /// Specifies all non-public nested types, including those inherited from base classes.
+        /// </summary>
+        NonPublicNestedTypesWithInherited = NonPublicNestedTypes | 0x20000,
+
+        /// <summary>
+        /// Specifies all non-public properties, including those inherited from base classes.
+        /// </summary>
+        NonPublicPropertiesWithInherited = NonPublicProperties | 0x40000,
+
+        /// <summary>
+        /// Specifies all non-public events, including those inherited from base classes.
+        /// </summary>
+        NonPublicEventsWithInherited = NonPublicEvents | 0x80000,
+
+        /// <summary>
+        /// Specifies all public constructors, including those inherited from base classes.
+        /// </summary>
+        PublicConstructorsWithInherited = PublicConstructors | 0x100000,
+
+        /// <summary>
+        /// Specifies all public nested types, including those inherited from base classes.
+        /// </summary>
+        PublicNestedTypesWithInherited = PublicNestedTypes | 0x200000,
+
+        /// <summary>
+        /// Specifies all constructors, including those inherited from base classes.
+        /// </summary>
+        AllConstructors = PublicConstructorsWithInherited | NonPublicConstructorsWithInherited,
+
+        /// <summary>
+        /// Specifies all methods, including those inherited from base classes.
+        /// </summary>
+        AllMethods = PublicMethods | NonPublicMethodsWithInherited,
+
+        /// <summary>
+        /// Specifies all fields, including those inherited from base classes.
+        /// </summary>
+        AllFields = PublicFields | NonPublicFieldsWithInherited,
+
+        /// <summary>
+        /// Specifies all nested types, including those inherited from base classes.
+        /// </summary>
+        AllNestedTypes = PublicNestedTypesWithInherited | NonPublicNestedTypesWithInherited,
+
+        /// <summary>
+        /// Specifies all properties, including those inherited from base classes.
+        /// </summary>
+        AllProperties = PublicProperties | NonPublicPropertiesWithInherited,
+
+        /// <summary>
+        /// Specifies all events, including those inherited from base classes.
+        /// </summary>
+        AllEvents = PublicEvents | NonPublicEventsWithInherited,
+
+        /// <summary>
         /// Specifies all members.
         /// </summary>
         All = ~None

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8842,6 +8842,20 @@ namespace System.Diagnostics.CodeAnalysis
         PublicEvents = 2048,
         NonPublicEvents = 4096,
         Interfaces = 8192,
+        NonPublicConstructorsWithInherited = 16388,
+        NonPublicMethodsWithInherited = 32784,
+        AllMethods = 32792,
+        NonPublicFieldsWithInherited = 65600,
+        AllFields = 65632,
+        NonPublicNestedTypesWithInherited = 131328,
+        NonPublicPropertiesWithInherited = 263168,
+        AllProperties = 263680,
+        NonPublicEventsWithInherited = 528384,
+        AllEvents = 530432,
+        PublicConstructorsWithInherited = 1048579,
+        AllConstructors = 1064967,
+        PublicNestedTypesWithInherited = 2097280,
+        AllNestedTypes = 2228608,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Constructor | System.AttributeTargets.Field | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
     public sealed partial class DynamicDependencyAttribute : System.Attribute

--- a/src/tools/illink/src/ILLink.Shared/DynamicallyAccessedMemberTypesEx.cs
+++ b/src/tools/illink/src/ILLink.Shared/DynamicallyAccessedMemberTypesEx.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+	public static class DynamicallyAccessedMemberTypesEx
+	{
+		/// <summary>
+		/// Specifies all non-public constructors, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes NonPublicConstructorsWithInherited = DynamicallyAccessedMemberTypes.NonPublicConstructors | (DynamicallyAccessedMemberTypes) 0x4000;
+
+		/// <summary>
+		/// Specifies all non-public methods, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes NonPublicMethodsWithInherited = DynamicallyAccessedMemberTypes.NonPublicMethods | (DynamicallyAccessedMemberTypes) 0x8000;
+
+		/// <summary>
+		/// Specifies all non-public fields, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes NonPublicFieldsWithInherited = DynamicallyAccessedMemberTypes.NonPublicFields | (DynamicallyAccessedMemberTypes) 0x10000;
+
+		/// <summary>
+		/// Specifies all non-public nested types, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes NonPublicNestedTypesWithInherited = DynamicallyAccessedMemberTypes.NonPublicNestedTypes | (DynamicallyAccessedMemberTypes) 0x20000;
+
+		/// <summary>
+		/// Specifies all non-public properties, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes NonPublicPropertiesWithInherited = DynamicallyAccessedMemberTypes.NonPublicProperties | (DynamicallyAccessedMemberTypes) 0x40000;
+
+		/// <summary>
+		/// Specifies all non-public events, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes NonPublicEventsWithInherited = DynamicallyAccessedMemberTypes.NonPublicEvents | (DynamicallyAccessedMemberTypes) 0x80000;
+
+		/// <summary>
+		/// Specifies all public constructors, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes PublicConstructorsWithInherited = DynamicallyAccessedMemberTypes.PublicConstructors | (DynamicallyAccessedMemberTypes) 0x100000;
+
+		/// <summary>
+		/// Specifies all public nested types, including those inherited from base classes.
+		/// </summary>
+		public const DynamicallyAccessedMemberTypes PublicNestedTypesWithInherited = DynamicallyAccessedMemberTypes.PublicNestedTypes | (DynamicallyAccessedMemberTypes) 0x200000;
+	}
+}

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -947,21 +947,45 @@ namespace ILLink.Shared.TrimAnalysis
 							else {
 								// PublicConstructors are not propagated to base type
 
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.PublicConstructorsWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.PublicConstructorsWithInherited;
+
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicConstructorsWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.NonPublicConstructorsWithInherited;
+
 								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicEvents))
 									propagatedMemberTypes |= DynamicallyAccessedMemberTypes.PublicEvents;
+
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicEventsWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.NonPublicEventsWithInherited;
 
 								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicFields))
 									propagatedMemberTypes |= DynamicallyAccessedMemberTypes.PublicFields;
 
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicFieldsWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.NonPublicFieldsWithInherited;
+
 								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicMethods))
 									propagatedMemberTypes |= DynamicallyAccessedMemberTypes.PublicMethods;
 
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicMethodsWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.NonPublicMethodsWithInherited;
+
 								// PublicNestedTypes are not propagated to base type
+
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.PublicNestedTypesWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.PublicNestedTypesWithInherited;
+
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicNestedTypesWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.NonPublicNestedTypesWithInherited;
 
 								// PublicParameterlessConstructor is not propagated to base type
 
 								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicProperties))
 									propagatedMemberTypes |= DynamicallyAccessedMemberTypes.PublicProperties;
+
+								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicPropertiesWithInherited))
+									propagatedMemberTypes |= DynamicallyAccessedMemberTypesEx.NonPublicPropertiesWithInherited;
 
 								if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.Interfaces))
 									propagatedMemberTypes |= DynamicallyAccessedMemberTypes.Interfaces;

--- a/src/tools/illink/src/linker/CompatibilitySuppressions.xml
+++ b/src/tools/illink/src/linker/CompatibilitySuppressions.xml
@@ -3,6 +3,10 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypesEx</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:ILLink.Shared.DataFlow.Box`1</Target>
   </Suppression>
   <Suppression>

--- a/src/tools/illink/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -31,12 +31,14 @@ namespace Mono.Linker
 			var declaredOnlyFlags = declaredOnly ? BindingFlags.DeclaredOnly : BindingFlags.Default;
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicConstructors)) {
-				foreach (var c in typeDefinition.GetConstructorsOnType (filter: null, bindingFlags: BindingFlags.NonPublic))
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicConstructorsWithInherited);
+				foreach (var c in typeDefinition.ApplyIncludeInherited (context, t => t.GetConstructorsOnType (filter: null, bindingFlags: BindingFlags.NonPublic), withInherited))
 					yield return c;
 			}
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicConstructors)) {
-				foreach (var c in typeDefinition.GetConstructorsOnType (filter: null, bindingFlags: BindingFlags.Public))
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.PublicConstructorsWithInherited);
+				foreach (var c in typeDefinition.ApplyIncludeInherited (context, t => t.GetConstructorsOnType (filter: null, bindingFlags: BindingFlags.Public), withInherited))
 					yield return c;
 			}
 
@@ -46,7 +48,8 @@ namespace Mono.Linker
 			}
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicMethods)) {
-				foreach (var m in typeDefinition.GetMethodsOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicMethodsWithInherited);
+				foreach (var m in typeDefinition.ApplyIncludeInherited (context, t => t.GetMethodsOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
 					yield return m;
 			}
 
@@ -56,7 +59,8 @@ namespace Mono.Linker
 			}
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicFields)) {
-				foreach (var f in typeDefinition.GetFieldsOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicFieldsWithInherited);
+				foreach (var f in typeDefinition.ApplyIncludeInherited (context, t => t.GetFieldsOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
 					yield return f;
 			}
 
@@ -66,7 +70,8 @@ namespace Mono.Linker
 			}
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)) {
-				foreach (var nested in typeDefinition.GetNestedTypesOnType (context, filter: null, bindingFlags: BindingFlags.NonPublic)) {
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicNestedTypesWithInherited);
+				foreach (var nested in typeDefinition.ApplyIncludeInherited (context, t => t.GetNestedTypesOnType (context, filter: null, bindingFlags: BindingFlags.NonPublic), withInherited)) {
 					yield return nested;
 					var members = new List<IMetadataTokenProvider> ();
 					nested.GetAllOnType (context, declaredOnly: false, members);
@@ -76,7 +81,8 @@ namespace Mono.Linker
 			}
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicNestedTypes)) {
-				foreach (var nested in typeDefinition.GetNestedTypesOnType (context, filter: null, bindingFlags: BindingFlags.Public)) {
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.PublicNestedTypesWithInherited);
+				foreach (var nested in typeDefinition.ApplyIncludeInherited (context, t => t.GetNestedTypesOnType (context, filter: null, bindingFlags: BindingFlags.Public), withInherited)) {
 					yield return nested;
 					var members = new List<IMetadataTokenProvider> ();
 					nested.GetAllOnType (context, declaredOnly: false, members);
@@ -86,7 +92,8 @@ namespace Mono.Linker
 			}
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicProperties)) {
-				foreach (var p in typeDefinition.GetPropertiesOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicPropertiesWithInherited);
+				foreach (var p in typeDefinition.ApplyIncludeInherited (context, t => t.GetPropertiesOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
 					yield return p;
 			}
 
@@ -96,7 +103,8 @@ namespace Mono.Linker
 			}
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicEvents)) {
-				foreach (var e in typeDefinition.GetEventsOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags))
+				bool withInherited = !declaredOnly && memberTypes.HasFlag (DynamicallyAccessedMemberTypesEx.NonPublicEventsWithInherited);
+				foreach (var e in typeDefinition.ApplyIncludeInherited (context, t => t.GetEventsOnTypeHierarchy (context, filter: null, bindingFlags: BindingFlags.NonPublic | declaredOnlyFlags), withInherited))
 					yield return e;
 			}
 
@@ -422,6 +430,20 @@ namespace Mono.Linker
 				foreach (var e in type.Events)
 					members.Add (e);
 			}
+		}
+
+		private static IEnumerable<T> ApplyIncludeInherited<T> (this TypeDefinition thisType, LinkContext context, Func<TypeDefinition, IEnumerable<T>> selector, bool includeBases)
+		{
+			TypeDefinition? type = thisType;
+			do {
+				foreach (var m in selector (type))
+					yield return m;
+
+				if (!includeBases)
+					yield break;
+
+				type = context.TryResolve (type.BaseType);
+			} while (type != null);
 		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Helpers/DataFlowTypeExtensions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Helpers/DataFlowTypeExtensions.cs
@@ -12,6 +12,8 @@ namespace Mono.Linker.Tests.Cases.Expectations.Helpers
 
 		public static void RequiresPublicConstructors ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] this Type type) { }
 
+		public static void RequiresPublicConstructorsWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.PublicConstructorsWithInherited)] this Type type) { }
+
 		public static void RequiresPublicEvents ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)] this Type type) { }
 
 		public static void RequiresPublicFields ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] this Type type) { }
@@ -20,21 +22,35 @@ namespace Mono.Linker.Tests.Cases.Expectations.Helpers
 
 		public static void RequiresPublicNestedTypes ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)] this Type type) { }
 
+		public static void RequiresPublicNestedTypesWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.PublicNestedTypesWithInherited)] this Type type) { }
+
 		public static void RequiresPublicParameterlessConstructor ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type) { }
 
 		public static void RequiresPublicProperties ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] this Type type) { }
 
 		public static void RequiresNonPublicEvents ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicEvents)] this Type type) { }
 
+		public static void RequiresNonPublicEventsWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicEventsWithInherited)] this Type type) { }
+
 		public static void RequiresNonPublicFields ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicFields)] this Type type) { }
+
+		public static void RequiresNonPublicFieldsWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicFieldsWithInherited)] this Type type) { }
 
 		public static void RequiresNonPublicMethods ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] this Type type) { }
 
+		public static void RequiresNonPublicMethodsWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicMethodsWithInherited)] this Type type) { }
+
 		public static void RequiresNonPublicNestedTypes ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)] this Type type) { }
+
+		public static void RequiresNonPublicNestedTypesWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicNestedTypesWithInherited)] this Type type) { }
 
 		public static void RequiresNonPublicConstructors ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)] this Type type) { }
 
+		public static void RequiresNonPublicConstructorsWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicConstructorsWithInherited)] this Type type) { }
+
 		public static void RequiresNonPublicProperties ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties)] this Type type) { }
+
+		public static void RequiresNonPublicPropertiesWithInherited ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicPropertiesWithInherited)] this Type type) { }
 
 		public static void RequiresInterfaces ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] this Type type) { }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -1,2 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="..\..\src\ILLink.Shared\DynamicallyAccessedMemberTypesEx.cs" Link="Support\DynamicallyAccessedMemberTypesEx.cs" />
+  </ItemGroup>
 </Project>

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -31,29 +31,29 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireNonPublicConstructors (typeof (NonPublicConstructorsType));
 			RequireNonPublicConstructors (typeof (NonPublicConstructorsBeforeFieldInitType));
 			RequireNonPublicConstructorsWithInherited (typeof (NonPublicConstructorsWithInheritedType));
-			RequireAllConstructors (typeof (AllConstructorsType));
-			RequireAllConstructors (typeof (AllConstructorsBeforeFieldInitType));
+			RequirePublicAndNonPublicConstructors (typeof (AllConstructorsType));
+			RequirePublicAndNonPublicConstructors (typeof (AllConstructorsBeforeFieldInitType));
 			RequirePublicMethods (typeof (PublicMethodsType));
 			RequireNonPublicMethods (typeof (NonPublicMethodsType));
 			RequireNonPublicMethodsWithInherited (typeof (NonPublicMethodsWithInheritedType));
-			RequireAllMethods (typeof (AllMethodsType));
+			RequirePublicAndNonPublicMethods (typeof (AllMethodsType));
 			RequirePublicFields (typeof (PublicFieldsType));
 			RequireNonPublicFields (typeof (NonPublicFieldsType));
 			RequireNonPublicFieldsWithInherited (typeof (NonPublicFieldsWithInheritedType));
-			RequireAllFields (typeof (AllFieldsType));
+			RequirePublicAndNonPublicFields (typeof (AllFieldsType));
 			RequirePublicNestedTypes (typeof (PublicNestedTypesType));
 			RequirePublicNestedTypesWithInherited (typeof (PublicNestedTypesWithInheritedType));
 			RequireNonPublicNestedTypes (typeof (NonPublicNestedTypesType));
 			RequireNonPublicNestedTypesWithInherited (typeof (NonPublicNestedTypesWithInheritedType));
-			RequireAllNestedTypes (typeof (AllNestedTypesType));
+			RequirePublicAndNonPublicNestedTypes (typeof (AllNestedTypesType));
 			RequirePublicProperties (typeof (PublicPropertiesType));
 			RequireNonPublicProperties (typeof (NonPublicPropertiesType));
 			RequireNonPublicPropertiesWithInherited (typeof (NonPublicPropertiesWithInheritedType));
-			RequireAllProperties (typeof (AllPropertiesType));
+			RequirePublicAndNonPublicProperties (typeof (AllPropertiesType));
 			RequirePublicEvents (typeof (PublicEventsType));
 			RequireNonPublicEvents (typeof (NonPublicEventsType));
 			RequireNonPublicEventsWithInherited (typeof (NonPublicEventsWithInheritedType));
-			RequireAllEvents (typeof (AllEventsType));
+			RequirePublicAndNonPublicEvents (typeof (AllEventsType));
 			RequireInterfaces (typeof (InterfacesType));
 			RequireAll (typeof (AllType));
 			RequireAll (typeof (RequireAllWithRecursiveTypeReferences));
@@ -313,7 +313,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 
 		[Kept]
-		private static void RequireAllConstructors (
+		private static void RequirePublicAndNonPublicConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
@@ -771,7 +771,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		private static void RequireAllMethods (
+		private static void RequirePublicAndNonPublicMethods (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
@@ -1268,7 +1268,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		private static void RequireAllFields (
+		private static void RequirePublicAndNonPublicFields (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
@@ -1575,7 +1575,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		private static void RequireAllNestedTypes (
+		private static void RequirePublicAndNonPublicNestedTypes (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
@@ -1807,7 +1807,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		private static void RequireAllProperties (
+		private static void RequirePublicAndNonPublicProperties (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
@@ -2093,7 +2093,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		private static void RequireAllEvents (
+		private static void RequirePublicAndNonPublicEvents (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -27,24 +27,32 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicConstructors (typeof (PublicConstructorsType));
 			RequirePublicConstructors (typeof (PublicConstructorsBeforeFieldInitType));
 			RequirePublicConstructors (typeof (PublicConstructorsPrivateParameterlessConstructorType));
+			RequirePublicConstructorsWithInherited (typeof (PublicConstructorsWithInheritedType));
 			RequireNonPublicConstructors (typeof (NonPublicConstructorsType));
 			RequireNonPublicConstructors (typeof (NonPublicConstructorsBeforeFieldInitType));
+			RequireNonPublicConstructorsWithInherited (typeof (NonPublicConstructorsWithInheritedType));
 			RequireAllConstructors (typeof (AllConstructorsType));
 			RequireAllConstructors (typeof (AllConstructorsBeforeFieldInitType));
 			RequirePublicMethods (typeof (PublicMethodsType));
 			RequireNonPublicMethods (typeof (NonPublicMethodsType));
+			RequireNonPublicMethodsWithInherited (typeof (NonPublicMethodsWithInheritedType));
 			RequireAllMethods (typeof (AllMethodsType));
 			RequirePublicFields (typeof (PublicFieldsType));
 			RequireNonPublicFields (typeof (NonPublicFieldsType));
+			RequireNonPublicFieldsWithInherited (typeof (NonPublicFieldsWithInheritedType));
 			RequireAllFields (typeof (AllFieldsType));
 			RequirePublicNestedTypes (typeof (PublicNestedTypesType));
+			RequirePublicNestedTypesWithInherited (typeof (PublicNestedTypesWithInheritedType));
 			RequireNonPublicNestedTypes (typeof (NonPublicNestedTypesType));
+			RequireNonPublicNestedTypesWithInherited (typeof (NonPublicNestedTypesWithInheritedType));
 			RequireAllNestedTypes (typeof (AllNestedTypesType));
 			RequirePublicProperties (typeof (PublicPropertiesType));
 			RequireNonPublicProperties (typeof (NonPublicPropertiesType));
+			RequireNonPublicPropertiesWithInherited (typeof (NonPublicPropertiesWithInheritedType));
 			RequireAllProperties (typeof (AllPropertiesType));
 			RequirePublicEvents (typeof (PublicEventsType));
 			RequireNonPublicEvents (typeof (NonPublicEventsType));
+			RequireNonPublicEventsWithInherited (typeof (NonPublicEventsWithInheritedType));
 			RequireAllEvents (typeof (AllEventsType));
 			RequireInterfaces (typeof (InterfacesType));
 			RequireAll (typeof (AllType));
@@ -164,6 +172,45 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
+		private static void RequirePublicConstructorsWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.PublicConstructorsWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class PublicConstructorsWithInheritedBaseType
+		{
+			[Kept]
+			public PublicConstructorsWithInheritedBaseType () { }
+
+			[Kept]
+			public PublicConstructorsWithInheritedBaseType (int i) { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (PublicConstructorsWithInheritedBaseType))]
+		class PublicConstructorsWithInheritedType : PublicConstructorsWithInheritedBaseType
+		{
+			private PublicConstructorsWithInheritedType () { }
+
+			[Kept]
+			public PublicConstructorsWithInheritedType (int i) { }
+
+			private PublicConstructorsWithInheritedType (int i, int j) { }
+
+			// Not implied by the DynamicallyAccessedMemberTypes logic, but
+			// explicit cctors would be kept by ILLink.
+			// [Kept]
+			// static PublicConstructorsType () { }
+
+			public void Method1 () { }
+			public bool Property1 { get; set; }
+			public bool Field1;
+		}
+
+		[Kept]
 		class PublicConstructorsBeforeFieldInitType
 		{
 			static int i = 10;
@@ -211,6 +258,45 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// Kept by the DynamicallyAccessedMembers logic
 			[Kept]
 			static NonPublicConstructorsType () { }
+
+			public void Method1 () { }
+			public bool Property1 { get; set; }
+			public bool Field1;
+		}
+
+		[Kept]
+		private static void RequireNonPublicConstructorsWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.NonPublicConstructorsWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class NonPublicConstructorsWithInheritedBaseType
+		{
+			[Kept]
+			protected NonPublicConstructorsWithInheritedBaseType () { }
+
+			[Kept]
+			protected NonPublicConstructorsWithInheritedBaseType (int i) { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (NonPublicConstructorsWithInheritedBaseType))]
+		class NonPublicConstructorsWithInheritedType : NonPublicConstructorsWithInheritedBaseType
+		{
+			[Kept]
+			private NonPublicConstructorsWithInheritedType () { }
+
+			public NonPublicConstructorsWithInheritedType (int i) { }
+
+			[Kept]
+			private NonPublicConstructorsWithInheritedType (int i, int j) { }
+
+			// Kept by the DynamicallyAccessedMembers logic
+			[Kept]
+			static NonPublicConstructorsWithInheritedType () { }
 
 			public void Method1 () { }
 			public bool Property1 { get; set; }
@@ -543,6 +629,146 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public bool Field1;
 		}
 
+		[Kept]
+		private static void RequireNonPublicMethodsWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.NonPublicMethodsWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class NonPublicMethodsWithInheritedBaseType
+		{
+			public void PublicBaseMethod () { }
+			[Kept]
+			private void PrivateBaseMethod () { }
+			[Kept]
+			protected void ProtectedBaseMethod () { }
+			public void HideMethod () { }
+
+			public bool PublicPropertyOnBase { get; set; }
+			[Kept]
+			protected bool ProtectedPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			[Kept]
+			private bool PrivatePropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			public bool HideProperty { get; set; }
+
+			public event EventHandler<EventArgs> PublicEventOnBase;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			protected event EventHandler<EventArgs> ProtectedEventOnBase;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			private event EventHandler<EventArgs> PrivateEventOnBase;
+			public event EventHandler<EventArgs> HideEvent;
+
+			public static void PublicStaticBaseMethod () { }
+			[Kept]
+			private static void PrivateStaticBaseMethod () { }
+			[Kept]
+			protected static void ProtectedStaticBaseMethod () { }
+			public static void HideStaticMethod () { }
+
+			static public bool PublicStaticPropertyOnBase { get; set; }
+			[Kept]
+			[KeptBackingField]
+			static protected bool ProtectedStaticPropertyOnBase { [Kept] get; [Kept] set; }
+			[Kept]
+			[KeptBackingField]
+			static private bool PrivateStaticPropertyOnBase { [Kept] get; [Kept] set; }
+			static public bool HideStaticProperty { get; set; }
+
+			public static event EventHandler<EventArgs> PublicStaticEventOnBase;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			protected static event EventHandler<EventArgs> ProtectedStaticEventOnBase;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			private static event EventHandler<EventArgs> PrivateStaticEventOnBase;
+			public static event EventHandler<EventArgs> HideStaticEvent;
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (NonPublicMethodsWithInheritedBaseType))]
+		class NonPublicMethodsWithInheritedType : NonPublicMethodsWithInheritedBaseType
+		{
+			private NonPublicMethodsWithInheritedType () { }
+
+			public void PublicMethod1 () { }
+			public bool PublicMethod2 (int i) { return false; }
+
+			[Kept]
+			internal void InternalMethod () { }
+			[Kept]
+			protected void ProtectedMethod () { }
+			[Kept]
+			private void PrivateMethod () { }
+			public void HideMethod () { }
+
+			public bool PublicProperty { get; set; }
+			[Kept]
+			protected bool ProtectedProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			[Kept]
+			private bool PrivateProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			public bool HideProperty { get; set; }
+
+			public event EventHandler<EventArgs> PublicEvent;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			protected event EventHandler<EventArgs> ProtectedEvent;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			private event EventHandler<EventArgs> PrivateEvent;
+			public event EventHandler<EventArgs> HideEvent;
+
+			public static void PublicStaticMethod () { }
+			[Kept]
+			private static void PrivateStaticMethod () { }
+			[Kept]
+			protected static void ProtectedStaticMethod () { }
+			public static void HideStaticMethod () { }
+
+			static public bool PublicStaticProperty { get; set; }
+			[Kept]
+			[KeptBackingField]
+			static protected bool ProtectedStaticProperty { [Kept] get; [Kept] set; }
+			[Kept]
+			[KeptBackingField]
+			static private bool PrivateStaticProperty { [Kept] get; [Kept] set; }
+			static public bool HideStaticProperty { get; set; }
+
+			public static event EventHandler<EventArgs> PublicStaticEvent;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			protected static event EventHandler<EventArgs> ProtectedStaticEvent;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			private static event EventHandler<EventArgs> PrivateStaticEvent;
+			public static event EventHandler<EventArgs> HideStaticEvent;
+
+			public bool Field1;
+		}
 
 		[Kept]
 		private static void RequireAllMethods (
@@ -922,6 +1148,124 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public static event EventHandler<EventArgs> HideStaticEvent;
 		}
 
+		[Kept]
+		private static void RequireNonPublicFieldsWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.NonPublicFieldsWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class NonPublicFieldsWithInheritedBaseType
+		{
+			public bool PublicBaseField;
+			[Kept]
+			protected bool ProtectedBaseField;
+			[Kept]
+			private bool PrivateBaseField;
+			public bool HideField;
+
+			// Backing fields are always private, so they will be kept even if the property itself is public
+			[KeptBackingField]
+			public bool PublicPropertyOnBase { get; set; }
+			[KeptBackingField]
+			protected bool ProtectedPropertyOnBase { get; set; }
+			[KeptBackingField]
+			private bool PrivatePropertyOnBase { get; set; }
+
+			[KeptBackingField]
+			public event EventHandler<EventArgs> PublicEventOnBase;
+			[KeptBackingField]
+			protected event EventHandler<EventArgs> ProtectedEventOnBase;
+			[KeptBackingField]
+			private event EventHandler<EventArgs> PrivateEventOnBase;
+
+			static public bool StaticPublicBaseField;
+			[Kept]
+			static protected bool StaticProtectedBaseField;
+			[Kept]
+			static private bool StaticPrivateBaseField;
+			static public bool HideStaticField;
+
+			[KeptBackingField]
+			static public bool PublicStaticPropertyOnBase { get; set; }
+			[KeptBackingField]
+			static protected bool ProtectedStaticPropertyOnBase { get; set; }
+			[KeptBackingField]
+			static private bool PrivateStaticPropertyOnBase { get; set; }
+			[KeptBackingField]
+			static public bool HideStaticProperty { get; set; }
+
+			[KeptBackingField]
+			public static event EventHandler<EventArgs> PublicStaticEventOnBase;
+			[KeptBackingField]
+			protected static event EventHandler<EventArgs> ProtectedStaticEventOnBase;
+			[KeptBackingField]
+			private static event EventHandler<EventArgs> PrivateStaticEventOnBase;
+			[KeptBackingField]
+			public static event EventHandler<EventArgs> HideStaticEvent;
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (NonPublicFieldsWithInheritedBaseType))]
+		class NonPublicFieldsWithInheritedType : NonPublicFieldsWithInheritedBaseType
+		{
+			public bool PublicField;
+			public string PublicStringField;
+			[Kept]
+			internal bool InternalField;
+			[Kept]
+			protected bool ProtectedField;
+			[Kept]
+			private bool PrivateField;
+			public bool HideField;
+
+			// Backing fields are always private, so they will be kept even if the property itself is public
+			[KeptBackingField]
+			public bool PublicProperty { get; set; }
+			[KeptBackingField]
+			protected bool ProtectedProperty { get; set; }
+			[KeptBackingField]
+			private bool PrivateProperty { get; set; }
+			[KeptBackingField]
+			public bool HideProperty { get; set; }
+
+			[KeptBackingField]
+			public event EventHandler<EventArgs> PublicEvent;
+			[KeptBackingField]
+			protected event EventHandler<EventArgs> ProtectedEvent;
+			[KeptBackingField]
+			private event EventHandler<EventArgs> PrivateEvent;
+			[KeptBackingField]
+			public event EventHandler<EventArgs> HideEvent;
+
+			static public bool StaticPublicField;
+			static public string StaticPublicStringField;
+			[Kept]
+			static protected bool StaticProtectedField;
+			[Kept]
+			static private bool StaticPrivateField;
+			static public bool HideStaticField;
+
+			[KeptBackingField]
+			static public bool PublicStaticProperty { get; set; }
+			[KeptBackingField]
+			static protected bool ProtectedStaticProperty { get; set; }
+			[KeptBackingField]
+			static private bool PrivateStaticProperty { get; set; }
+			[KeptBackingField]
+			static public bool HideStaticProperty { get; set; }
+
+			[KeptBackingField]
+			public static event EventHandler<EventArgs> PublicStaticEvent;
+			[KeptBackingField]
+			protected static event EventHandler<EventArgs> ProtectedStaticEvent;
+			[KeptBackingField]
+			private static event EventHandler<EventArgs> PrivateStaticEvent;
+			[KeptBackingField]
+			public static event EventHandler<EventArgs> HideStaticEvent;
+		}
 
 		[Kept]
 		private static void RequireAllFields (
@@ -1080,6 +1424,58 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			private delegate int PrivateDelegate ();
 		}
 
+		[Kept]
+		private static void RequirePublicNestedTypesWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.PublicNestedTypesWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class PublicNestedTypesWithInheritedBaseType
+		{
+			[Kept]
+			[KeptMember (".ctor()")]
+			public class PublicBaseNestedType { }
+			protected class ProtectedBaseNestedType { }
+			private class PrivateBaseNestedType { }
+			[Kept]
+			[KeptMember (".ctor()")]
+			public class HideBaseNestedType { }
+			[Kept]
+			[KeptBaseType (typeof (MulticastDelegate))]
+			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
+			[KeptMember ("Invoke()")]
+			public delegate int PublicDelegate ();
+			private delegate int PrivateDelegate ();
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (PublicNestedTypesWithInheritedBaseType))]
+		class PublicNestedTypesWithInheritedType : PublicNestedTypesWithInheritedBaseType
+		{
+			[Kept]
+			[KeptMember (".ctor()")]
+			public class PublicNestedType { }
+			protected class ProtectedNestedType { }
+			private class PrivateNestedType { }
+			[Kept]
+			[KeptMember (".ctor()")]
+			public class HideNestedType { }
+
+			[Kept]
+			[KeptBaseType (typeof (MulticastDelegate))]
+			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
+			[KeptMember ("Invoke()")]
+			public delegate int PublicDelegate ();
+
+			private delegate int PrivateDelegate ();
+		}
 
 		[Kept]
 		private static void RequireNonPublicNestedTypes (
@@ -1125,6 +1521,58 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			private delegate int PrivateDelegate ();
 		}
 
+		[Kept]
+		private static void RequireNonPublicNestedTypesWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.NonPublicNestedTypesWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class NonPublicNestedTypesWithInheritedBaseType
+		{
+			public class PublicBaseNestedType { }
+			[Kept]
+			[KeptMember (".ctor()")]
+			protected class ProtectedBaseNestedType { }
+			[Kept]
+			[KeptMember (".ctor()")]
+			private class PrivateBaseNestedType { }
+			public class HideBaseNestedType { }
+			public delegate int PublicDelegate ();
+			[Kept]
+			[KeptBaseType (typeof (MulticastDelegate))]
+			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
+			[KeptMember ("Invoke()")]
+			private delegate int PrivateDelegate ();
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (NonPublicNestedTypesWithInheritedBaseType))]
+		class NonPublicNestedTypesWithInheritedType : NonPublicNestedTypesWithInheritedBaseType
+		{
+			public class PublicNestedType { }
+			[Kept]
+			[KeptMember (".ctor()")]
+			protected class ProtectedNestedType { }
+			[Kept]
+			[KeptMember (".ctor()")]
+			private class PrivateNestedType { }
+			public class HideNestedType { }
+
+			public delegate int PublicDelegate ();
+
+			[Kept]
+			[KeptBaseType (typeof (MulticastDelegate))]
+			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
+			[KeptMember ("Invoke()")]
+			private delegate int PrivateDelegate ();
+		}
 
 		[Kept]
 		private static void RequireAllNestedTypes (
@@ -1279,6 +1727,63 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[Kept]
 		[KeptBaseType (typeof (NonPublicPropertiesBaseType))]
 		class NonPublicPropertiesType : NonPublicPropertiesBaseType
+		{
+			public bool PublicProperty { get; set; }
+			public bool PublicPropertyGetter { get { return false; } private set { } }
+			public bool PublicPropertySetter { private get { return false; } set { } }
+			public bool PublicPropertyOnlyGetter { get { return false; } }
+			public bool PublicPropertyOnlySetter { set { } }
+			[Kept]
+			protected bool ProtectedProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			[Kept]
+			private bool PrivateProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			public bool HideProperty { get; set; }
+
+			static public bool PublicStaticProperty { get; set; }
+			[Kept]
+			[KeptBackingField]
+			static protected bool ProtectedStaticProperty { [Kept] get; [Kept] set; }
+			[Kept]
+			[KeptBackingField]
+			static private bool PrivateStaticProperty { [Kept] get; [Kept] set; }
+			static public bool HideStaticProperty { get; set; }
+		}
+
+		[Kept]
+		private static void RequireNonPublicPropertiesWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.NonPublicPropertiesWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class NonPublicPropertiesWithInheritedBaseType
+		{
+			public bool PublicPropertyOnBase { get; set; }
+			public bool PublicPropertyGetterOnBase { get { return false; } private set { } }
+			public bool PublicPropertySetterOnBase { private get { return false; } set { } }
+			public bool PublicPropertyOnlyGetterOnBase { get { return false; } }
+			public bool PublicPropertyOnlySetterOnBase { set { } }
+			[Kept]
+			protected bool ProtectedPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			[Kept]
+			private bool PrivatePropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
+			public bool HideProperty { get; set; }
+
+			static public bool PublicStaticPropertyOnBase { get; set; }
+			[Kept]
+			[KeptBackingField]
+			static protected bool ProtectedStaticPropertyOnBase { [Kept] get; [Kept] set; }
+			[Kept]
+			[KeptBackingField]
+			static private bool PrivateStaticPropertyOnBase { [Kept] get; [Kept] set; }
+			static public bool HideStaticProperty { get; set; }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (NonPublicPropertiesWithInheritedBaseType))]
+		class NonPublicPropertiesWithInheritedType : NonPublicPropertiesWithInheritedBaseType
 		{
 			public bool PublicProperty { get; set; }
 			public bool PublicPropertyGetter { get { return false; } private set { } }
@@ -1484,6 +1989,79 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[Kept]
 		[KeptBaseType (typeof (NonPublicEventsBaseType))]
 		class NonPublicEventsType : NonPublicEventsBaseType
+		{
+			public event EventHandler<EventArgs> PublicEvent;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			protected event EventHandler<EventArgs> ProtectedEvent;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			private event EventHandler<EventArgs> PrivateEvent;
+			public event EventHandler<EventArgs> HideEvent;
+
+			static public event EventHandler<EventArgs> PublicStaticEvent;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			static protected event EventHandler<EventArgs> ProtectedStaticEvent;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			static private event EventHandler<EventArgs> PrivateStaticEvent;
+			static public event EventHandler<EventArgs> HideStaticEvent;
+		}
+
+		[Kept]
+		private static void RequireNonPublicEventsWithInherited (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypesEx.NonPublicEventsWithInherited)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class NonPublicEventsWithInheritedBaseType
+		{
+			public event EventHandler<EventArgs> PublicEventOnBase;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			protected event EventHandler<EventArgs> ProtectedEventOnBase;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
+			private event EventHandler<EventArgs> PrivateEventOnBase;
+			public event EventHandler<EventArgs> HideEvent;
+
+			static public event EventHandler<EventArgs> PublicStaticEventOnBase;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			static protected event EventHandler<EventArgs> ProtectedStaticEventOnBase;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			static private event EventHandler<EventArgs> PrivateStaticEventOnBase;
+			static public event EventHandler<EventArgs> HideStaticEvent;
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (NonPublicEventsWithInheritedBaseType))]
+		class NonPublicEventsWithInheritedType : NonPublicEventsWithInheritedBaseType
 		{
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesRelationships.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesRelationships.cs
@@ -227,17 +227,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			type.RequiresNone ();
 			type.RequiresPublicParameterlessConstructor ();
 			type.RequiresPublicConstructors ();
+			type.RequiresPublicConstructorsWithInherited ();
 			type.RequiresNonPublicConstructors ();
+			type.RequiresNonPublicConstructorsWithInherited ();
 			type.RequiresPublicMethods ();
 			type.RequiresNonPublicMethods ();
+			type.RequiresNonPublicMethodsWithInherited ();
 			type.RequiresPublicFields ();
 			type.RequiresNonPublicFields ();
+			type.RequiresNonPublicFieldsWithInherited ();
 			type.RequiresPublicNestedTypes ();
+			type.RequiresPublicNestedTypesWithInherited ();
 			type.RequiresNonPublicNestedTypes ();
+			type.RequiresNonPublicNestedTypesWithInherited ();
 			type.RequiresPublicProperties ();
 			type.RequiresNonPublicProperties ();
+			type.RequiresNonPublicPropertiesWithInherited ();
 			type.RequiresPublicEvents ();
 			type.RequiresNonPublicEvents ();
+			type.RequiresNonPublicEventsWithInherited ();
 			type.RequiresInterfaces ();
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
@@ -21,19 +21,27 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			AllPropagatedWithDerivedClass.Test ();
 
 			TestPublicConstructorsAreNotPropagated (typeof (TestType));
+			TestPublicConstructorsWithInheritedArePropagated (typeof (TestType));
 			TestPublicEventsPropagated (typeof (TestType));
 			TestPublicFieldsPropagated (typeof (TestType));
 			TestPublicMethodsPropagated (typeof (TestType));
 			TestPublicNestedTypesAreNotPropagated (typeof (TestType));
+			TestPublicNestedTypesWithInheritedArePropagated (typeof (TestType));
 			TestPublicParameterlessConstructorIsNotPropagated (typeof (TestType));
 			TestPublicPropertiesPropagated (typeof (TestType));
 
 			TestNonPublicConstructorsAreNotPropagated (typeof (TestType));
+			TestNonPublicConstructorsWithInheritedArePropagated (typeof (TestType));
 			TestNonPublicEventsAreNotPropagated (typeof (TestType));
+			TestNonPublicEventsWithInheritedArePropagated (typeof (TestType));
 			TestNonPublicFieldsAreNotPropagated (typeof (TestType));
+			TestNonPublicFieldsWithInheritedArePropagated (typeof (TestType));
 			TestNonPublicMethodsAreNotPropagated (typeof (TestType));
+			TestNonPublicMethodsWithInheritedArePropagated (typeof (TestType));
 			TestNonPublicNestedTypesAreNotPropagated (typeof (TestType));
+			TestNonPublicNestedTypesWithInheritedArePropagated (typeof (TestType));
 			TestNonPublicPropertiesAreNotPropagated (typeof (TestType));
+			TestNonPublicPropertiesWithInheritedArePropagated (typeof (TestType));
 
 			TestInterfacesPropagated (typeof (TestType));
 
@@ -74,9 +82,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicConstructors))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicConstructorsWithInherited))]
 		static void TestPublicConstructorsAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresPublicConstructors ();
+			derivedType.BaseType.RequiresPublicConstructorsWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicConstructors))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicConstructorsWithInherited))]
+		static void TestPublicConstructorsWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.PublicConstructorsWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresPublicConstructors ();
+			derivedType.BaseType.RequiresPublicConstructorsWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresNonPublicConstructors ();
+
+			// Should warn
+			derivedType.BaseType.RequiresNonPublicConstructorsWithInherited ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
@@ -119,9 +143,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicNestedTypes))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicNestedTypesWithInherited))]
 		static void TestPublicNestedTypesAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresPublicNestedTypes ();
+			derivedType.BaseType.RequiresPublicNestedTypesWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicNestedTypes))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicNestedTypesWithInherited))]
+		static void TestPublicNestedTypesWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.PublicNestedTypesWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresPublicNestedTypes ();
+			derivedType.BaseType.RequiresPublicNestedTypesWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresNonPublicNestedTypes ();
+
+			// Should warn
+			derivedType.BaseType.RequiresNonPublicNestedTypesWithInherited ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicParameterlessConstructor))]
@@ -144,39 +184,119 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicConstructors))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicConstructorsWithInherited))]
 		static void TestNonPublicConstructorsAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresNonPublicConstructors ();
+			derivedType.BaseType.RequiresNonPublicConstructorsWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicConstructors))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicConstructorsWithInherited))]
+		static void TestNonPublicConstructorsWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicConstructorsWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresNonPublicConstructors ();
+			derivedType.BaseType.RequiresNonPublicConstructorsWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicConstructors ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicConstructorsWithInherited ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicEvents))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicEventsWithInherited))]
 		static void TestNonPublicEventsAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicEvents)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresNonPublicEvents ();
+			derivedType.BaseType.RequiresNonPublicEventsWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicEvents))]
+		static void TestNonPublicEventsWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicEventsWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresNonPublicEvents ();
+			derivedType.BaseType.RequiresNonPublicEventsWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicEvents ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicFields))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicFieldsWithInherited))]
 		static void TestNonPublicFieldsAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicFields)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresNonPublicFields ();
+			derivedType.BaseType.RequiresNonPublicFieldsWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+		static void TestNonPublicFieldsWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicFieldsWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresNonPublicFields ();
+			derivedType.BaseType.RequiresNonPublicFieldsWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicFields ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicMethods))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicMethodsWithInherited))]
 		static void TestNonPublicMethodsAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresNonPublicMethods ();
+			derivedType.BaseType.RequiresNonPublicMethodsWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestNonPublicMethodsWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicMethodsWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresNonPublicMethods ();
+			derivedType.BaseType.RequiresNonPublicMethodsWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicMethods ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicNestedTypes))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicNestedTypesWithInherited))]
 		static void TestNonPublicNestedTypesAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresNonPublicNestedTypes ();
+			derivedType.BaseType.RequiresNonPublicNestedTypesWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicNestedTypes))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicNestedTypesWithInherited))]
+		static void TestNonPublicNestedTypesWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicNestedTypesWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresNonPublicNestedTypes ();
+			derivedType.BaseType.RequiresNonPublicNestedTypesWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicNestedTypes ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicNestedTypesWithInherited ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicProperties))]
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresNonPublicPropertiesWithInherited))]
 		static void TestNonPublicPropertiesAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresNonPublicProperties ();
+			derivedType.BaseType.RequiresNonPublicPropertiesWithInherited ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicProperties))]
+		static void TestNonPublicPropertiesWithInheritedArePropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypesEx.NonPublicPropertiesWithInherited)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresNonPublicProperties ();
+			derivedType.BaseType.RequiresNonPublicPropertiesWithInherited ();
+
+			// Should warn
+			derivedType.BaseType.RequiresPublicProperties ();
 		}
 
 		static void TestInterfacesPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] Type derivedType)

--- a/src/tools/illink/test/Mono.Linker.Tests/Tests/TestFrameworkRulesAndConventions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/Tests/TestFrameworkRulesAndConventions.cs
@@ -76,6 +76,10 @@ namespace Mono.Linker.Tests.Tests
 			if (IsAttributeType (type))
 				return true;
 
+			// Extension types extending public enums
+			if (type.Name.EndsWith ("Ex") && type.IsAbstract && type.IsSealed)
+				return true;
+
 			// Anything else is not OK and should probably be defined in Mono.Linker.Tests.Cases and use SandboxDependency in order to be included
 			// with the tests that need it
 			return false;


### PR DESCRIPTION
Fixes #88512.

Add support for NonPublicConstructorsWithInherited et al in the shape that was approved by API review.

We want a bit for each of these new inherited options because e.g. if I want a combination of non-public fields (including inherited) and public constructors (but not inherited), this shouldn't mean to inherit all constructors. So we need an extra bit for each "inherited" possibility.

We also set the existing bit just for convenience so that bit operations still work nicely (i.e. it would be sufficient to do `NonPublicConstructorsWithInherited = 0x4000`, but `NonPublicConstructorsWithInherited = NonPublicConstructors | 0x4000` makes working with the enums easier because there's still the subset relationship and we can bit test without special casing.

The original proposal had two bits less (just "inherit constructors" and "inherit nested types") but the API review extended it to the more granular "inherit public constructors" and "inherit private constructors". Solely because the problem with .All is that it's too broad and we could have the same problem with "inherit constructors" being too broad in the future.

Cc @dotnet/illink @dotnet/ilc-contrib @eerhardt 