### PR TITLE
JIT: Mark some intrinsics as must-expand for NAOT due to ILScanner dependencies

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3992,11 +3992,6 @@ void Compiler::compSetOptimizationLevel()
             "IL Code Size,Instr %4d,%4d, Basic Block count %3d, Local Variable Num,Ref count %3d,%3d for method %s\n",
             info.compILCodeSize, opts.instrCount, fgBBcount, lvaCount, opts.lvRefCount, info.compFullName));
 
-    if (IsTargetAbi(CORINFO_NATIVEAOT_ABI))
-    {
-        theMinOptsValue = true;
-    }
-
 _SetMinOpts:
 
     // Set the MinOpts value

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3992,6 +3992,11 @@ void Compiler::compSetOptimizationLevel()
             "IL Code Size,Instr %4d,%4d, Basic Block count %3d, Local Variable Num,Ref count %3d,%3d for method %s\n",
             info.compILCodeSize, opts.instrCount, fgBBcount, lvaCount, opts.lvRefCount, info.compFullName));
 
+    if (IsTargetAbi(CORINFO_NATIVEAOT_ABI))
+    {
+        theMinOptsValue = true;
+    }
+
 _SetMinOpts:
 
     // Set the MinOpts value

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3384,17 +3384,24 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
 
     if (IsTargetAbi(CORINFO_NATIVEAOT_ABI))
     {
-        // Intrinsics that we should make every effort to expand for NativeAOT.
-        // If the intrinsic cannot possibly be expanded, it's fine, but
-        // if it can be, it should expand.
         switch (ni)
         {
+            // Intrinsics that we should make every effort to expand for NativeAOT.
+            // If the intrinsic cannot possibly be expanded, it's fine, but
+            // if it can be, it should expand.
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_CreateSpan:
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray:
             case NI_Internal_Runtime_MethodTable_Of:
             case NI_System_Activator_AllocatorOf:
             case NI_System_Activator_DefaultConstructorOf:
                 betterToExpand = true;
+                break;
+
+            // Intrinsics that we should always expand for NativeAOT. These are
+            // required to be scanned due to ILScanner assumptions.
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences:
+            case NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference:
+                mustExpand = true;
                 break;
 
             default:

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3391,14 +3391,14 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             // if it can be, it should expand.
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_CreateSpan:
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray:
-            case NI_Internal_Runtime_MethodTable_Of:
-            case NI_System_Activator_AllocatorOf:
-            case NI_System_Activator_DefaultConstructorOf:
                 betterToExpand = true;
                 break;
 
             // Intrinsics that we should always expand for NativeAOT. These are
             // required to be expanded due to ILScanner assumptions.
+            case NI_Internal_Runtime_MethodTable_Of:
+            case NI_System_Activator_AllocatorOf:
+            case NI_System_Activator_DefaultConstructorOf:
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences:
                 mustExpand = true;
                 break;

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3398,7 +3398,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                 break;
 
             // Intrinsics that we should always expand for NativeAOT. These are
-            // required to be scanned due to ILScanner assumptions.
+            // required to be expanded due to ILScanner assumptions.
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences:
             case NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference:
                 mustExpand = true;

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3400,8 +3400,11 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             // Intrinsics that we should always expand for NativeAOT. These are
             // required to be expanded due to ILScanner assumptions.
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences:
-            case NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference:
                 mustExpand = true;
+                break;
+
+            case NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference:
+                mustExpand |= sig->sigInst.methInstCount == 1;
                 break;
 
             default:


### PR DESCRIPTION
These two intrinsics are treated specially by ILScanner, and thus must always be expanded for NAOT, even in MinOpts.

Context: https://github.com/dotnet/runtime/pull/103950#issuecomment-2458788247