### PR TITLE
[HTTP] WinHttpHandler - Increase the default drain size

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -87,7 +87,7 @@ namespace System.Net.Http
         private bool _tcpKeepAliveEnabled;
 
         private int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
-        private int _maxResponseDrainSize = 64 * 1024;
+        private int _maxResponseDrainSize = HttpHandlerDefaults.DefaultMaxResponseDrainSize;
         private IDictionary<string, object>? _properties; // Only create dictionary when required.
         private volatile bool _operationStarted;
         private volatile bool _disposed;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -65,7 +65,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.Equal(TimeSpan.FromSeconds(1), handler.TcpKeepAliveInterval);
 
             Assert.Equal(64, handler.MaxResponseHeadersLength);
-            Assert.Equal(64 * 1024, handler.MaxResponseDrainSize);
+            Assert.Equal(1024 * 1024, handler.MaxResponseDrainSize);
             Assert.NotNull(handler.Properties);
         }
 


### PR DESCRIPTION
For some reason, the default [`MaxResponseDrainSize`](https://learn.microsoft.com/dotnet/api/system.net.http.winhttphandler.maxresponsedrainsize) has been 64 KB. But SocketsHandler has the default as 1MB: https://github.com/dotnet/runtime/blob/386669e7bb97ce977c4a0629eed8d6955e72298c/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs#L39

Also, WinHTTP native default is 1MB: https://learn.microsoft.com/en-us/windows/win32/winhttp/option-flags#winhttp_option_max_response_drain_size

**Opening this PR to discuss the change to unify it to 1MB.**

There might be some historical reason why it is like that. Please leave a comment if you have more insights into this.

Also, I don't think this is a breaking change as it is more permisible, but I might be wrong.

@dotnet/ncl @MihaZupan @antonfirsov @stephentoub 