### PR TITLE
Respect `ClassInterfaceAttribute` during COM server activation

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -596,7 +596,6 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
 
             public static IntPtr GetObjectAsInterface(object obj, ValidatedInterfaceType interfaceType)
             {
-                // If the requested "interface type" is type object then return as IUnknown
                 if (interfaceType.Kind is ValidatedInterfaceKind.IUnknown)
                 {
                     Debug.Assert(interfaceType.ManagedType is null);

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -564,11 +564,14 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 }
                 else if (riid == Marshal.IID_IDispatch)
                 {
-                    // If unspecified, default is ClassInterfaceType.AutoDispatch.
+                    ClassInterfaceAttribute? attr =
+                        classType.GetCustomAttribute<ClassInterfaceAttribute>()
+                        ?? classType.Assembly.GetCustomAttribute<ClassInterfaceAttribute>(); // If there is no attribute on the Type, check the Assembly.
+
+                    // If the attribute is unspecified, the default is ClassInterfaceType.AutoDispatch.
                     // See DEFAULT_CLASS_INTERFACE_TYPE in native.
-                    ClassInterfaceAttribute? attr = classType.GetCustomAttribute<ClassInterfaceAttribute>();
                     if (attr is null
-                        || attr.Value is ClassInterfaceType.AutoDual or ClassInterfaceType.AutoDispatch)
+                        || attr.Value is ClassInterfaceType.AutoDispatch or ClassInterfaceType.AutoDual)
                     {
                         return new ValidatedInterfaceType() { Kind = ValidatedInterfaceKind.IDispatch, ManagedType = null };
                     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -22,6 +22,11 @@ namespace System.Runtime.InteropServices
         /// IUnknown is {00000000-0000-0000-C000-000000000046}
         /// </summary>
         internal static readonly Guid IID_IUnknown = new Guid(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+
+        /// <summary>
+        /// IDispatch is {00020400-0000-0000-C000-000000000046}
+        /// </summary>
+        internal static readonly Guid IID_IDispatch = new Guid(0x00020400, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
 #endif //FEATURE_COMINTEROP
 
         internal static int SizeOfHelper(RuntimeType t, [MarshalAs(UnmanagedType.Bool)] bool throwIfNotMarshalable)

--- a/src/tests/Interop/COM/NETServer/ClassInterfaceTesting.cs
+++ b/src/tests/Interop/COM/NETServer/ClassInterfaceTesting.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 618 // Must test deprecated features
+
+[ComVisible(true)]
+[Guid(Server.Contract.Guids.ClassInterfaceNotSetTesting)]
+public class ClassInterfaceNotSetTesting
+{
+}
+
+[ComVisible(true)]
+[Guid(Server.Contract.Guids.ClassInterfaceNoneTesting)]
+[ClassInterface(ClassInterfaceType.None)]
+public class ClassInterfaceNoneTesting
+{
+}
+
+[ComVisible(true)]
+[Guid(Server.Contract.Guids.ClassInterfaceAutoDispatchTesting)]
+[ClassInterface(ClassInterfaceType.AutoDispatch)]
+public class ClassInterfaceAutoDispatchTesting
+{
+}
+
+[ComVisible(true)]
+[Guid(Server.Contract.Guids.ClassInterfaceAutoDualTesting)]
+[ClassInterface(ClassInterfaceType.AutoDual)]
+public class ClassInterfaceAutoDualTesting
+{
+}
+
+#pragma warning restore 618 // Must test deprecated features

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/CoreShim.X.manifest
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/CoreShim.X.manifest
@@ -11,6 +11,22 @@
   <comClass
     clsid="{CCFF894B-A27C-45E0-9B30-6C88D722E843}"
     threadingModel="Both" />
+  <!-- ClassInterfaceNotSetTesting -->
+  <comClass
+    clsid="{B8314D5A-DE70-435B-AD97-8F88820D1F3C}"
+    threadingModel="Both" />
+  <!-- ClassInterfaceNoneTesting -->
+  <comClass
+    clsid="{ED4D9C70-1C9F-406B-B51F-87DD977AF3B2}"
+    threadingModel="Both" />
+  <!-- ClassInterfaceAutoDispatchTesting -->
+  <comClass
+    clsid="{C1A0AE72-791B-4380-946E-B7BABDEA1701}"
+    threadingModel="Both" />
+  <!-- ClassInterfaceAutoDualTesting -->
+  <comClass
+    clsid="{95696E2C-742F-4639-A9D4-5D36EE021C49}"
+    threadingModel="Both" />
 </file>
 
 </assembly>

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
@@ -35,6 +35,7 @@ struct ComInit
 using ComMTA = ComInit<COINIT_MULTITHREADED>;
 void ValidationTests();
 void ValidationByRefTests();
+void ValidationClassInterfaceTests();
 
 int __cdecl main()
 {
@@ -52,6 +53,16 @@ int __cdecl main()
         CoreShimComActivation csact{ W("NETServer"), W("MiscTypesTesting") };
         ValidationTests();
         ValidationByRefTests();
+    }
+    catch (HRESULT hr)
+    {
+        ::printf("Test Failure: 0x%08x\n", hr);
+        return 101;
+    }
+
+    try
+    {
+        ValidationClassInterfaceTests();
     }
     catch (HRESULT hr)
     {
@@ -84,7 +95,7 @@ void ValidationTests()
 
     HRESULT hr;
 
-    IMiscTypesTesting *miscTypesTesting;
+    ComSmartPtr<IMiscTypesTesting> miscTypesTesting;
     THROW_IF_FAILED(::CoCreateInstance(CLSID_MiscTypesTesting, nullptr, CLSCTX_INPROC, IID_IMiscTypesTesting, (void**)&miscTypesTesting));
 
     ::printf("-- Primitives <=> VARIANT...\n");
@@ -328,7 +339,7 @@ void ValidationByRefTests()
 
     HRESULT hr;
 
-    IMiscTypesTesting *miscTypesTesting;
+    ComSmartPtr<IMiscTypesTesting> miscTypesTesting;
     THROW_IF_FAILED(::CoCreateInstance(CLSID_MiscTypesTesting, nullptr, CLSCTX_INPROC, IID_IMiscTypesTesting, (void**)&miscTypesTesting));
 
     ::printf("-- Primitives <=> BYREF VARIANT...\n");
@@ -365,7 +376,7 @@ void ValidationByRefTests()
         THROW_FAIL_IF_FALSE(CompareStringOrdinal(expected, -1, value, -1, FALSE) == CSTR_EQUAL);
         ::SysFreeString(expected);
     }
-    
+
     ::printf("-- System.Guid <=> BYREF VARIANT...\n");
     {
         /* 8EFAD956-B33D-46CB-90F4-45F55BA68A96 */
@@ -378,7 +389,7 @@ void ValidationByRefTests()
         THROW_FAIL_IF_FALSE(memcmp(V_RECORD(&guidVar.Input), &expected, sizeof(expected)) == 0);
         THROW_IF_FAILED(miscTypesTesting->Marshal_Instance_Variant(W("{00000000-0000-0000-0000-000000000000}"), &guidVar.Result));
         THROW_FAIL_IF_FALSE(V_VT(&guidVar.Result) == VT_RECORD);
-        
+
         // Use the Guid as input.
         VariantMarshalTest args{};
         THROW_IF_FAILED(::VariantCopy(&args.Input, &guidVar.Input));
@@ -397,5 +408,49 @@ void ValidationByRefTests()
         V_VT(&args.Result) = VT_BYREF|VT_I4;
         V_I4REF(&args.Result) = &value;
         THROW_FAIL_IF_FALSE(miscTypesTesting->Marshal_ByRefVariant(&args.Result, args.Input) == 0x80004002); // COR_E_INVALIDCAST
+    }
+}
+
+void ValidationClassInterfaceTests()
+{
+    ::printf(__FUNCTION__ "() through CoCreateInstance...\n");
+
+    HRESULT hr;
+
+    {
+        CoreShimComActivation csact{ W("NETServer"), W("ClassInterfaceNotSetTesting") };
+        ::printf("-- ClassInterfaceType not set ...\n");
+
+        ComSmartPtr<IUnknown> pUnk;
+        THROW_IF_FAILED(::CoCreateInstance(CLSID_ClassInterfaceNotSetTesting, nullptr, CLSCTX_INPROC, IID_IUnknown, (void**)&pUnk));
+        ComSmartPtr<IDispatch> pDisp;
+        THROW_IF_FAILED(::CoCreateInstance(CLSID_ClassInterfaceNotSetTesting, nullptr, CLSCTX_INPROC, IID_IDispatch, (void**)&pDisp));
+    }
+    {
+        CoreShimComActivation csact{ W("NETServer"), W("ClassInterfaceNoneTesting") };
+        ::printf("-- ClassInterfaceType.None ...\n");
+
+        ComSmartPtr<IUnknown> pUnk;
+        THROW_IF_FAILED(::CoCreateInstance(CLSID_ClassInterfaceNoneTesting, nullptr, CLSCTX_INPROC, IID_IUnknown, (void**)&pUnk));
+        ComSmartPtr<IDispatch> pDisp;
+        THROW_FAIL_IF_FALSE(E_NOINTERFACE == ::CoCreateInstance(CLSID_ClassInterfaceNoneTesting, nullptr, CLSCTX_INPROC, IID_IDispatch, (void**)&pDisp));
+    }
+    {
+        CoreShimComActivation csact{ W("NETServer"), W("ClassInterfaceAutoDispatchTesting") };
+        ::printf("-- ClassInterfaceType.AutoDispatch ...\n");
+
+        ComSmartPtr<IUnknown> pUnk;
+        THROW_IF_FAILED(::CoCreateInstance(CLSID_ClassInterfaceAutoDispatchTesting, nullptr, CLSCTX_INPROC, IID_IUnknown, (void**)&pUnk));
+        ComSmartPtr<IDispatch> pDisp;
+        THROW_IF_FAILED(::CoCreateInstance(CLSID_ClassInterfaceAutoDispatchTesting, nullptr, CLSCTX_INPROC, IID_IDispatch, (void**)&pDisp));
+    }
+    {
+        CoreShimComActivation csact{ W("NETServer"), W("ClassInterfaceAutoDualTesting") };
+        ::printf("-- ClassInterfaceType.AutoDual ...\n");
+
+        ComSmartPtr<IUnknown> pUnk;
+        THROW_IF_FAILED(::CoCreateInstance(CLSID_ClassInterfaceAutoDualTesting, nullptr, CLSCTX_INPROC, IID_IUnknown, (void**)&pUnk));
+        ComSmartPtr<IDispatch> pDisp;
+        THROW_IF_FAILED(::CoCreateInstance(CLSID_ClassInterfaceAutoDualTesting, nullptr, CLSCTX_INPROC, IID_IDispatch, (void**)&pDisp));
     }
 }

--- a/src/tests/Interop/COM/NativeServer/Servers.h
+++ b/src/tests/Interop/COM/NativeServer/Servers.h
@@ -23,6 +23,10 @@ class DECLSPEC_UUID("66DB7882-E2B0-471D-92C7-B2B52A0EA535") LicenseTesting;
 class DECLSPEC_UUID("FAEF42AE-C1A4-419F-A912-B768AC2679EA") DefaultInterfaceTesting;
 class DECLSPEC_UUID("CE137261-6F19-44F5-A449-EF963B3F987E") InspectableTesting;
 class DECLSPEC_UUID("4F54231D-9E11-4C0B-8E0B-2EBD8B0E5811") TrackMyLifetimeTesting;
+class DECLSPEC_UUID("B8314D5A-DE70-435B-AD97-8F88820D1F3C") ClassInterfaceNotSetTesting;
+class DECLSPEC_UUID("ED4D9C70-1C9F-406B-B51F-87DD977AF3B2") ClassInterfaceNoneTesting;
+class DECLSPEC_UUID("C1A0AE72-791B-4380-946E-B7BABDEA1701") ClassInterfaceAutoDispatchTesting;
+class DECLSPEC_UUID("95696E2C-742F-4639-A9D4-5D36EE021C49") ClassInterfaceAutoDualTesting;
 
 #define CLSID_NumericTesting __uuidof(NumericTesting)
 #define CLSID_ArrayTesting __uuidof(ArrayTesting)
@@ -38,6 +42,10 @@ class DECLSPEC_UUID("4F54231D-9E11-4C0B-8E0B-2EBD8B0E5811") TrackMyLifetimeTesti
 #define CLSID_DefaultInterfaceTesting __uuidof(DefaultInterfaceTesting)
 #define CLSID_InspectableTesting __uuidof(InspectableTesting)
 #define CLSID_TrackMyLifetimeTesting __uuidof(TrackMyLifetimeTesting)
+#define CLSID_ClassInterfaceNotSetTesting __uuidof(ClassInterfaceNotSetTesting)
+#define CLSID_ClassInterfaceNoneTesting __uuidof(ClassInterfaceNoneTesting)
+#define CLSID_ClassInterfaceAutoDispatchTesting __uuidof(ClassInterfaceAutoDispatchTesting)
+#define CLSID_ClassInterfaceAutoDualTesting  __uuidof(ClassInterfaceAutoDualTesting)
 
 #define IID_INumericTesting __uuidof(INumericTesting)
 #define IID_IArrayTesting __uuidof(IArrayTesting)

--- a/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
+++ b/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
@@ -23,5 +23,9 @@ namespace Server.Contract
         public const string ConsumeNETServerTesting = "DE4ACF53-5957-4D31-8BE2-EA6C80683246";
         public const string InspectableTesting = "CE137261-6F19-44F5-A449-EF963B3F987E";
         public const string TrackMyLifetimeTesting = "4F54231D-9E11-4C0B-8E0B-2EBD8B0E5811";
+        public const string ClassInterfaceNotSetTesting = "B8314D5A-DE70-435B-AD97-8F88820D1F3C";
+        public const string ClassInterfaceNoneTesting = "ED4D9C70-1C9F-406B-B51F-87DD977AF3B2";
+        public const string ClassInterfaceAutoDispatchTesting = "C1A0AE72-791B-4380-946E-B7BABDEA1701";
+        public const string ClassInterfaceAutoDualTesting = "95696E2C-742F-4639-A9D4-5D36EE021C49";
     }
 }


### PR DESCRIPTION
Managed COM servers can define the `ClassInterfaceAttribute` to indicate if `IDispatch` is supported.
Add tests for these activation scenarios.