### PR TITLE
Reference net10.0 path for ILLink.Tasks assembly

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -18,7 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Older SDKs used this property as a sentinel instead, to control the import of this file
          (but not the targets, which were included with the SDK). -->
     <UsingILLinkTasksSdk>true</UsingILLinkTasksSdk>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net9.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net10.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
 
     <ILLinkAnalyzersPropsPath Condition="'$(ILLinkAnalyzersPropsPath)' == ''">$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.Analyzers.props</ILLinkAnalyzersPropsPath>


### PR DESCRIPTION
ILLink.Tasks targets the net10.0 TFM and it needs the assembly reference for the MSBuild props file to match that TFM.

Related to https://github.com/dotnet/sdk/pull/44685