### PR TITLE
[EventTrace] AddEventPipe filter data parsing

### DIFF
--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -137,7 +137,7 @@ void ParseFilterDataClientSequenceNumber(
             size_t value_len = strnlen(value, buffer_end - buffer);
             buffer += value_len + 1;
 
-            if (buffer >= buffer_end)
+            if (buffer > buffer_end)
                 break;
 
             if (strcmp(key, "GCSeqNumber") != 0)

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -127,13 +127,15 @@ void ParseFilterDataClientSequenceNumber(
         while (buffer < buffer_end)
         {
             const char* key = buffer;
-            buffer += strlen(key) + 1;
+            size_t key_len = strnlen(key, buffer_end - buffer);
+            buffer += key_len + 1;
 
             if (buffer >= buffer_end)
                 break;
 
             const char* value = buffer;
-            buffer += strlen(value) + 1;
+            size_t value_len = strnlen(value, buffer_end - buffer);
+            buffer += value_len + 1;
 
             if (buffer >= buffer_end)
                 break;

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2363,13 +2363,15 @@ VOID ParseFilterDataClientSequenceNumber(
         while (buffer < buffer_end)
         {
             const char* key = buffer;
-            buffer += strlen(key) + 1;
+            size_t key_len = strnlen(key, buffer_end - buffer);
+            buffer += key_len + 1;
 
             if (buffer >= buffer_end)
                 break;
 
             const char* value = buffer;
-            buffer += strlen(value) + 1;
+            size_t value_len = strnlen(value, buffer_end - buffer);
+            buffer += value_len + 1;
 
             if (buffer >= buffer_end)
                 break;

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2373,7 +2373,7 @@ VOID ParseFilterDataClientSequenceNumber(
             size_t value_len = strnlen(value, buffer_end - buffer);
             buffer += value_len + 1;
 
-            if (buffer >= buffer_end)
+            if (buffer > buffer_end)
                 break;
 
             if (strcmp(key, "GCSeqNumber") != 0)

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2328,6 +2328,7 @@ enum CallbackProviderIndex
     DotNETRuntimePrivate = 3
 };
 
+#if !defined(HOST_UNIX)
 // EventFilterType identifies the filter type used by the PEVENT_FILTER_DESCRIPTOR
 enum EventFilterType
 {
@@ -2347,7 +2348,6 @@ VOID ParseFilterDataClientSequenceNumber(
 {
     LIMITED_METHOD_CONTRACT;
 
-#if !defined(HOST_UNIX)
     if (FilterData == NULL)
         return;
 
@@ -2388,8 +2388,8 @@ VOID ParseFilterDataClientSequenceNumber(
             }
         }
     }
-#endif // !defined(HOST_UNIX)
 }
+#endif // !defined(HOST_UNIX)
 
 // Common handler for all ETW or EventPipe event notifications. Based on the provider that
 // was enabled/disabled, this implementation forwards the event state change onto GCHeapUtilities
@@ -2474,7 +2474,9 @@ VOID EtwCallbackCommon(
         // Profilers may (optionally) specify extra data in the filter parameter
         // to log with the GCStart event.
         LONGLONG l64ClientSequenceNumber = 0;
+#if !defined(HOST_UNIX)
         ParseFilterDataClientSequenceNumber((PEVENT_FILTER_DESCRIPTOR)pFilterData, &l64ClientSequenceNumber);
+#endif // !defined(HOST_UNIX)
         ETW::GCLog::ForceGC(l64ClientSequenceNumber);
     }
     // TypeSystemLog needs a notification when certain keywords are modified, so

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2331,22 +2331,14 @@ enum CallbackProviderIndex
 // EventFilterType identifies the filter type used by the PEVENT_FILTER_DESCRIPTOR
 enum EventFilterType
 {
-    None = 0x0,
-    ClientSequenceNumber = 0x1,
-    EventPipePayload = 0x2,
-    // Schematized = 0x80000000,
-    // SystemFlags = 0x80000001,
-    // TraceHandle = 0x80000002,
-    // PID = 0x80000004,
-    // ExecutableName = 0x80000008,
-    // PackageID = 0x80000010,
-    // PackageAppID = 0x80000020,
-    // Payload = 0x80000100,
-    // EventID = 0x80000200,
-    // EventName = 0x80000400,
-    // Stackwalk = 0x80001000,
-    // StackwalkName = 0x80002000,
-    // StackwalkLevelKW = 0x80004000,
+    // data should be pairs of UTF8 null terminated strings all concatenated together.
+    // The first element of the pair is the key and the 2nd is the value. We expect one of the
+    // keys to be the string "GCSeqNumber" and the value to be a number encoded as text.
+    // This is the standard way EventPipe encodes filter values
+    StringKeyValueEncoding = 0,
+    // data should be an 8 byte binary LONGLONG value
+    // this is the historic encoding defined by .NET Framework for use with ETW
+    LongBinaryClientSequenceNumber = 1
 };
 
 VOID ParseFilterDataClientSequenceNumber(
@@ -2359,11 +2351,11 @@ VOID ParseFilterDataClientSequenceNumber(
     if (FilterData == NULL)
         return;
 
-    if (FilterData->Type == ClientSequenceNumber && FilterData->Size == sizeof(LONGLONG))
+    if (FilterData->Type == LongBinaryClientSequenceNumber && FilterData->Size == sizeof(LONGLONG))
     {
         *pClientSequenceNumber = *(LONGLONG *) (FilterData->Ptr);
     }
-    else if (FilterData->Type == EventPipePayload)
+    else if (FilterData->Type == StringKeyValueEncoding)
     {
         const char* buffer = reinterpret_cast<const char*>(FilterData->Ptr);
         const char* buffer_end = buffer + FilterData->Size;
@@ -2378,6 +2370,9 @@ VOID ParseFilterDataClientSequenceNumber(
 
             const char* value = buffer;
             buffer += strlen(value) + 1;
+
+            if (buffer >= buffer_end)
+                break;
 
             if (strcmp(key, "GCSeqNumber") != 0)
                 continue;

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -421,7 +421,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 		if (j < filter_data_len)
 			buffer_size = j + 1;
 
-		ep_event_filter_desc_init (&event_filter_desc, (uint64_t)buffer, buffer_size, /* EventFilterType.EventPipePayload */ 2);
+		ep_event_filter_desc_init (&event_filter_desc, (uint64_t)buffer, buffer_size, /* EventFilterType.StringKeyValueEncoding */ 0);
 		is_event_filter_desc_init = true;
 	}
 

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -421,7 +421,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 		if (j < filter_data_len)
 			buffer_size = j + 1;
 
-		ep_event_filter_desc_init (&event_filter_desc, (uint64_t)buffer, buffer_size, 0);
+		ep_event_filter_desc_init (&event_filter_desc, (uint64_t)buffer, buffer_size, /* EventFilterType.EventPipePayload */ 2);
 		is_event_filter_desc_init = true;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/102572

This PR follows-up on https://github.com/dotnet/runtime/pull/102612#discussion_r1649499591 and https://github.com/dotnet/runtime/pull/102612#discussion_r1651605026 by extending the FilterData parsing to cover EventPipe scenarios.

## Testing

Checked the value of  [l64ClientSequenceNumber](https://github.com/dotnet/runtime/blob/6d23ef4d68bbcdb38fdc22218d1073c5083ac6a1/src/coreclr/vm/eventtrace.cpp#L2423) after enabling an EventPipe session with ` dotnet trace collect -n sampleapp --providers "Microsoft-Windows-DotNETRuntime:800000:5:mihw=whim;GCSeqNumber=2024"` and saw `0x7e8`.