### PR TITLE
Remove and readd .deb, .rpm, and .pkg as FileExtensionSignInfos

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -26,6 +26,14 @@
     <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
 
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
+
+    <!-- 
+      Removal is temporarily needed as we integrate support for these extensions into SignTool.
+      Should be cleaned up after https://github.com/dotnet/arcade/issues/14432,
+      https://github.com/dotnet/arcade/issues/14433, and 
+      https://github.com/dotnet/arcade/issues/14435 are completed.
+     -->
+    <FileExtensionSignInfo Remove=".deb;.rpm;.pkg" />
     <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />
     <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
   </ItemGroup>


### PR DESCRIPTION
See https://github.com/dotnet/arcade/pull/15216#discussion_r1833155044 for context on why this is needed.

In short, we're integrating these extensions into arcade's SignTool in order to support signing of the VMR. The removal and readdition of these extensions in runtime's `Signing.Props` is needed so that SignTool doesn't break and complain about duplicate `FileExtensionSignInfo`s when signing runtime's artifacts.