### PR TITLE
Fix upload conflict Microsoft.NETCore.App.Ref in official build

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -285,6 +285,12 @@ extends:
             nameSuffix: NativeAOT
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             postBuildSteps:
+              # delete Microsoft.NETCore.App.Ref package to prevent upload conflict
+              - task: DeleteFiles@1
+                displayName: 'Delete Microsoft.NETCore.App.Ref package'
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
+                  Contents: 'Microsoft.NETCore.App.Ref.*.nupkg'
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
                   name: NativeAOTRuntimePacks
@@ -329,6 +335,12 @@ extends:
             nameSuffix: Mono
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             postBuildSteps:
+              # delete Microsoft.NETCore.App.Ref package to prevent upload conflict
+              - task: DeleteFiles@1
+                displayName: 'Delete Microsoft.NETCore.App.Ref package'
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
+                  Contents: 'Microsoft.NETCore.App.Ref.*.nupkg'
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
                   name: MonoRuntimePacks
@@ -347,6 +359,12 @@ extends:
             nameSuffix: Mono
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             postBuildSteps:
+              # delete Microsoft.NETCore.App.Ref package to prevent upload conflict
+              - task: DeleteFiles@1
+                displayName: 'Delete Microsoft.NETCore.App.Ref package'
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
+                  Contents: 'Microsoft.NETCore.App.Ref.*.nupkg'
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
                   name: MonoRuntimePacks
@@ -365,6 +383,12 @@ extends:
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             runtimeVariant: multithread
             postBuildSteps:
+              # delete Microsoft.NETCore.App.Ref package to prevent upload conflict
+              - task: DeleteFiles@1
+                displayName: 'Delete Microsoft.NETCore.App.Ref package'
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
+                  Contents: 'Microsoft.NETCore.App.Ref.*.nupkg'
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
                   name: MonoRuntimePacks


### PR DESCRIPTION
We're occasionally seeing errors on the official build during artifacts upload (https://github.com/dotnet/dnceng/issues/1916)
This is because multiple jobs are trying to push the Microsoft.NETCore.App.Ref nuget package to the same AzDO build artifacts container, causing conflicts.

Since we'll be using the VMR in the near future and it is using a different asset selection the quick fix is to just delete the package on the jobs where it's not supposed to be uploaded rather than trying to introduce a complicated condition in msbuild.