### PR TITLE
JIT: tail merge returns with multiple statements

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -6486,6 +6486,22 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
 
         if (block->KindIs(BBJ_RETURN) && !block->isEmpty() && (block != genReturnBB))
         {
+
+#if !FEATURE_TAILCALL_OPT_SHARED_RETURN
+            // Avoid spitting a return away from a possible tail call
+            //
+            if (!block->hasSingleStmt())
+            {
+                Statement* const lastStmt = block->lastStmt();
+                Statement* const prevStmt = lastStmt->GetPrevStmt();
+                GenTree* const   prevTree = prevStmt->GetRootNode();
+                if (prevTree->IsCall() && prevTree->AsCall()->CanTailCall())
+                {
+                    continue;
+                }
+            }
+#endif
+
             retBlocks.Push(block);
         }
     }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -6484,9 +6484,7 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
     {
         iterateTailMerge(block);
 
-        // TODO: consider removing hasSingleStmt(), it should find more opportunities
-        // (with size and TP regressions)
-        if (block->KindIs(BBJ_RETURN) && block->hasSingleStmt() && (block != genReturnBB))
+        if (block->KindIs(BBJ_RETURN) && !block->isEmpty() && (block != genReturnBB))
         {
             retBlocks.Push(block);
         }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -6486,8 +6486,6 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
 
         if (block->KindIs(BBJ_RETURN) && !block->isEmpty() && (block != genReturnBB))
         {
-
-#if !FEATURE_TAILCALL_OPT_SHARED_RETURN
             // Avoid spitting a return away from a possible tail call
             //
             if (!block->hasSingleStmt())
@@ -6500,7 +6498,6 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
                     continue;
                 }
             }
-#endif
 
             retBlocks.Push(block);
         }


### PR DESCRIPTION
Remove the restriction that a mergeable return have one statement.