### PR TITLE
Revert "Exclude shared libs from ilcframework in nupkg"

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -25,9 +25,6 @@
 
     <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
       <File Include="@(LibrariesRuntimeFiles)" TargetPath="framework" />
-      <!-- exclude shared libs as we only need static ones -->
-      <LibPackageExcludes Include="framework\%2A%2A\%2A$(LibSuffix)"/>
-
       <File Include="$(CoreCLRILCompilerDir)*" TargetPath="tools" />
       <File Include="$(CoreCLRAotSdkDir)*" TargetPath="sdk" />
       <File Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" TargetPath="mibc" />


### PR DESCRIPTION
Reverts dotnet/runtime#109253, see https://github.com/dotnet/runtime/pull/109253#discussion_r1835538968