### PR TITLE
[mono][sgen] Add separate card mark function to be used with debug

### DIFF
--- a/src/mono/mono/sgen/sgen-cardtable.h
+++ b/src/mono/mono/sgen/sgen-cardtable.h
@@ -30,7 +30,7 @@ void sgen_card_table_preclean_mod_union (guint8 *cards, guint8 *cards_preclean, 
 guint8* sgen_get_card_table_configuration (int *shift_bits, gpointer *mask);
 guint8* sgen_get_target_card_table_configuration (int *shift_bits, target_mgreg_t *mask);
 
-void sgen_card_table_init (SgenRememberedSet *remset);
+void sgen_card_table_init (SgenRememberedSet *remset, gboolean consistency_checks);
 
 /*How many bytes a single card covers*/
 #define CARD_BITS 9

--- a/src/mono/mono/sgen/sgen-gc.c
+++ b/src/mono/mono/sgen/sgen-gc.c
@@ -3909,7 +3909,7 @@ sgen_gc_init (void)
 
 	memset (&remset, 0, sizeof (remset));
 
-	sgen_card_table_init (&remset);
+	sgen_card_table_init (&remset, remset_consistency_checks);
 
 	sgen_register_root (NULL, 0, sgen_make_user_root_descriptor (sgen_mark_normal_gc_handles), ROOT_TYPE_NORMAL, MONO_ROOT_SOURCE_GC_HANDLE, GINT_TO_POINTER (ROOT_TYPE_NORMAL), "GC Handles (SGen, Normal)");
 


### PR DESCRIPTION
When marking cards for a non-array object or a an element vt in an object, it is enough to mark a card for any address within that object/vt because they are always fully scanned. Cardtable consistency checks are not accounting for this detail and it is difficult to have it implemented. Instead, when having such debug flags enabled, we use an explicit approach where every single card is being marked.