### PR TITLE
Define a DllMain for native AOT shared libraries

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Bootstrap/CMakeLists.txt
@@ -18,3 +18,7 @@ endfunction()
 
 add_subdirectory(base)
 add_subdirectory(dll)
+
+if (CLR_CMAKE_TARGET_WIN32)
+  add_subdirectory(dllmain)
+endif()

--- a/src/coreclr/nativeaot/Bootstrap/dllmain/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Bootstrap/dllmain/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(dllmain)
+
+set(SOURCES
+    dllmain.cpp
+)
+
+add_library(dllmain STATIC ${SOURCES})
+
+install_bootstrapper_object(dllmain aotsdk)
+
+add_library(dllmain.GuardCF STATIC ${SOURCES})
+install_bootstrapper_object(dllmain.GuardCF aotsdk)
+set_target_properties(dllmain.GuardCF PROPERTIES CLR_CONTROL_FLOW_GUARD ON)

--- a/src/coreclr/nativeaot/Bootstrap/dllmain/dllmain.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/dllmain/dllmain.cpp
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <windows.h>
+
+// No-op DllMain. The purpose is to reserve DllMain for our purposes.
+//
+// Some users also try to define a DllMain in managed code using an UnmanagedCallersOnly
+// attribute. This will not work correctly because the entire runtime initialization would run
+// as part of such DllMain, before the first line of users DllMain executes. We don't support
+// initializing the runtime under loader lock.
+//
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    return TRUE;
+}

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -40,6 +40,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
 
     <ItemGroup>
+      <NativeLibrary Condition="'$(NativeLib)' != ''" Include="$(IlcSdkPath)dllmain$(ObjectSuffix)" />
       <NativeLibrary Include="$(IlcSdkPath)$(BootstrapperName)$(ObjectSuffix)" />
       <NativeLibrary Include="$(IlcSdkPath)$(FullRuntimeName)$(LibrarySuffix)" />
       <NativeLibrary Include="$(IlcSdkPath)$(EventPipeName)$(LibrarySuffix)" />


### PR DESCRIPTION
In theory a breaking change since any other `DllMain` would cause a symbol conflict during linking.

Closes #109543