### PR TITLE
Re-try loading ENGINE keys with a non-NULL UI_METHOD

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -53,6 +53,7 @@
 #if HAVE_OPENSSL_ENGINE
 // Some Linux distributions build without engine support.
 #include <openssl/engine.h>
+#include <openssl/ui.h> // We don't need the UI functions except in ENGINE scenarios.
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_1_1_1_RTM
@@ -699,6 +700,8 @@ extern bool g_libSslUses32BitTime;
     LIGHTUP_FUNCTION(SSL_verify_client_post_handshake) \
     LIGHTUP_FUNCTION(SSL_set_post_handshake_auth) \
     REQUIRED_FUNCTION(SSL_version) \
+    REQUIRED_FUNCTION(UI_create_method) \
+    REQUIRED_FUNCTION(UI_destroy_method) \
     FALLBACK_FUNCTION(X509_check_host) \
     REQUIRED_FUNCTION(X509_check_purpose) \
     REQUIRED_FUNCTION(X509_cmp_time) \
@@ -1249,6 +1252,8 @@ extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
 #define SSL_set_post_handshake_auth SSL_set_post_handshake_auth_ptr
 #define SSL_version SSL_version_ptr
 #define TLS_method TLS_method_ptr
+#define UI_create_method UI_create_method_ptr
+#define UI_destroy_method UI_destroy_method_ptr
 #define X509_check_host X509_check_host_ptr
 #define X509_check_purpose X509_check_purpose_ptr
 #define X509_cmp_time X509_cmp_time_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -32,6 +32,7 @@
 #include <openssl/sha.h>
 #include <openssl/ssl.h>
 #include <openssl/tls1.h>
+#include <openssl/ui.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
@@ -53,7 +54,6 @@
 #if HAVE_OPENSSL_ENGINE
 // Some Linux distributions build without engine support.
 #include <openssl/engine.h>
-#include <openssl/ui.h> // We don't need the UI functions except in ENGINE scenarios.
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_1_1_1_RTM


### PR DESCRIPTION
When loading a key from an OpenSSL engine, the `ENGINE_load_private_key` or `ENGINE_load_public_key` function is used, depending on the key. These functions accept a parameter called `ui_method` that an ENGINE can use if loading the key requires user interaction, such as a passphrase.

Currently, we pass `NULL` in to the `ui_method` parameter since we expect this functionality to be used from non-interactive scenarios.

OpenSSL also passes this parameter as-is to the engine. It does not do a NULL check.

Some engines, like tpm2tss, do not permit a `NULL` `UI_METHOD` and immediately error.

This change attempts to accommodate those engines by re-trying the key load with a UI_METHOD that does nothing. This is functionally equivalent to `UI_null()` from OpenSSL.

We do not try a non-NULL UI first to maintain as much compatibility as possible. .NET has always passed `NULL` to engines thus far, and an engine can do with that as they want - like falling back to their own UI, using OpenSSL's default, etc. If we unconditionally pass our UI_METHOD, that might break another engine that was happily doing the right thing with `NULL`.

Contributes to #109243 