### PR TITLE
JIT: fix inliner profile consistency computation

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12949,15 +12949,14 @@ bool Compiler::fgMorphBlockStmt(BasicBlock*     block,
         // We should not convert it to a ThrowBB.
         if ((block != fgFirstBB) || !fgFirstBB->HasFlag(BBF_INTERNAL))
         {
-            if (!block->KindIs(BBJ_THROW))
-            {
-                // Convert block to a throw bb
-                fgConvertBBToThrowBB(block);
+            // Convert block to a throw bb, or make it rarely run if already a throw.
+            //
+            const bool isThrow = block->KindIs(BBJ_THROW);
+            fgConvertBBToThrowBB(block);
 
-                if (invalidateDFSTreeOnFGChange)
-                {
-                    fgInvalidateDfsTree();
-                }
+            if (!isThrow && invalidateDFSTreeOnFGChange)
+            {
+                fgInvalidateDfsTree();
             }
         }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12949,12 +12949,15 @@ bool Compiler::fgMorphBlockStmt(BasicBlock*     block,
         // We should not convert it to a ThrowBB.
         if ((block != fgFirstBB) || !fgFirstBB->HasFlag(BBF_INTERNAL))
         {
-            // Convert block to a throw bb
-            fgConvertBBToThrowBB(block);
-
-            if (invalidateDFSTreeOnFGChange)
+            if (!block->KindIs(BBJ_THROW))
             {
-                fgInvalidateDfsTree();
+                // Convert block to a throw bb
+                fgConvertBBToThrowBB(block);
+
+                if (invalidateDFSTreeOnFGChange)
+                {
+                    fgInvalidateDfsTree();
+                }
             }
         }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10806,6 +10806,9 @@ PhaseStatus Compiler::fgValueNumber()
         }
     }
 
+    assert(m_dfsTree != nullptr);
+    assert(m_loops != nullptr);
+
     m_blockToLoop = BlockToNaturalLoopMap::Build(m_loops);
     // Compute the side effects of loops.
     optComputeLoopSideEffects();


### PR DESCRIPTION
It's possible for the JIT to inline a profiled inlinee into an unprofiled context, and then have a subsequent inline fold a profiled branch. If so we may see a case where the folded edges don't have profile information.

Tolerate this.

Fixes #109657

Re-morphing of a statement during early-prop may mistakenly believe it has altered the flow graph and so invalidates DFS. Value numbering is not set up to handle this and crashes. Since this seems like a rare occurrence, have morph detect if it has really changed the flowgraph and avoid invalidating the DFS when it hasn't.

Fixes #109730 