### PR TITLE
Mark inited static readonly loads as non-faulting.

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4175,7 +4175,7 @@ GenTree* Compiler::impImportStaticFieldAddress(CORINFO_RESOLVED_TOKEN* pResolved
             }
             if (isStaticReadOnlyInitedRef)
             {
-                indirFlags |= (GTF_IND_INVARIANT | GTF_IND_NONNULL);
+                indirFlags |= (GTF_IND_NONFAULTING | GTF_IND_INVARIANT | GTF_IND_NONNULL);
             }
             break;
         }


### PR DESCRIPTION
Extracted from #108579.