### PR TITLE
Fix message when no DAM members match

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DynamicDependencyAttributesOnEntityNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DynamicDependencyAttributesOnEntityNode.cs
@@ -204,7 +204,7 @@ namespace ILCompiler.DependencyAnalysis
                     metadataManager.Logger.LogWarning(
                         new MessageOrigin(entity),
                         DiagnosticId.NoMembersResolvedForMemberSignatureOrType,
-                        memberTypesFromAttribute.ToString(),
+                        ((DynamicallyAccessedMemberTypes)memberTypesFromAttribute).ToString(),
                         targetType.GetDisplayName());
                     return;
                 }


### PR DESCRIPTION
`memberTypesFromAttribute` is typed as `int` so the `ToString` gives us a number instead of enum name. Noticed by accident.

Cc @dotnet/ilc-contrib 