### PR TITLE
Reference ILVerification projects from ILLink solutions

### DIFF
--- a/src/tools/illink/illink.sln
+++ b/src/tools/illink/illink.sln
@@ -37,6 +37,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ILLink.Shared", "src\ILLink
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILLink.RoslynAnalyzer.Tests.Generator", "test\ILLink.RoslynAnalyzer.Tests.Generator\ILLink.RoslynAnalyzer.Tests.Generator.csproj", "{3DDE7064-4B68-4979-8843-FDF4CE5A5140}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILVerification", "..\..\coreclr\tools\ILVerification\ILVerification.csproj", "{D8D5B259-911F-4A74-B6E0-722A7ACE9361}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -203,6 +205,18 @@ Global
 		{3DDE7064-4B68-4979-8843-FDF4CE5A5140}.Release|x64.Build.0 = Release|Any CPU
 		{3DDE7064-4B68-4979-8843-FDF4CE5A5140}.Release|x86.ActiveCfg = Release|Any CPU
 		{3DDE7064-4B68-4979-8843-FDF4CE5A5140}.Release|x86.Build.0 = Release|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Release|x64.Build.0 = Release|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -218,6 +232,7 @@ Global
 		{8DA71B3B-5809-44E5-A018-5DE5C6FF6C2A} = {03EB085F-3E2E-4A68-A7DF-951ADF59A0CC}
 		{6D20F334-B7E4-4585-854B-8A0E2B29B4AA} = {AA0569FB-73E9-4B42-9A19-714BB1229DAE}
 		{3DDE7064-4B68-4979-8843-FDF4CE5A5140} = {C2969923-7BAA-4FE4-853C-F670B0D3C6C8}
+		{D8D5B259-911F-4A74-B6E0-722A7ACE9361} = {C2969923-7BAA-4FE4-853C-F670B0D3C6C8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E43A3901-42B0-48CA-BB36-5CD40A99A6EE}

--- a/src/tools/illink/trimming.sln
+++ b/src/tools/illink/trimming.sln
@@ -57,6 +57,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ilc", "ilc", "{BC94A262-6D8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.Trimming.Tests", "..\..\coreclr\tools\aot\ILCompiler.Trimming.Tests\ILCompiler.Trimming.Tests.csproj", "{4604F088-6A78-4D8F-96AC-EE8F8301BA33}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILVerification", "..\..\coreclr\tools\ILVerification\ILVerification.csproj", "{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Checked|Any CPU = Checked|Any CPU
@@ -412,6 +414,24 @@ Global
 		{4604F088-6A78-4D8F-96AC-EE8F8301BA33}.Release|x64.Build.0 = Release|x64
 		{4604F088-6A78-4D8F-96AC-EE8F8301BA33}.Release|x86.ActiveCfg = Release|x86
 		{4604F088-6A78-4D8F-96AC-EE8F8301BA33}.Release|x86.Build.0 = Release|x86
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Checked|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Checked|Any CPU.Build.0 = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Checked|x64.ActiveCfg = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Checked|x64.Build.0 = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Checked|x86.ActiveCfg = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Checked|x86.Build.0 = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Debug|x64.Build.0 = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Debug|x86.Build.0 = Debug|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Release|x64.ActiveCfg = Release|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Release|x64.Build.0 = Release|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Release|x86.ActiveCfg = Release|Any CPU
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -438,6 +458,7 @@ Global
 		{FB237949-3F88-4E16-A770-8D13E48B84AF} = {C2969923-7BAA-4FE4-853C-F670B0D3C6C8}
 		{BC94A262-6D89-4432-AC11-22FE75FBC91F} = {C2969923-7BAA-4FE4-853C-F670B0D3C6C8}
 		{4604F088-6A78-4D8F-96AC-EE8F8301BA33} = {BC94A262-6D89-4432-AC11-22FE75FBC91F}
+		{4FCE2738-74C4-4E55-BF7C-4161DBFFF11D} = {C2969923-7BAA-4FE4-853C-F670B0D3C6C8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E43A3901-42B0-48CA-BB36-5CD40A99A6EE}


### PR DESCRIPTION
I wasn't able to run ILLink unit tests in VS without doing this. My steps:

* build.cmd tools.illink+tools.illinktests
* open src\tools\illink.sln in VS
* right click Mono.Linker.Tests project and choose Run tests
* CS0006	Metadata file 'D:\git\runtime2\artifacts\bin\ILVerification\Debug\ILVerification.dll' could not be found	Mono.Linker.Tests	D:\git\runtime2\src\tools\illink\test\Mono.Linker.Tests\CSC	1
* Add ILVerification project to the SLN
* Try running tests again
* MSB3030	Could not copy the file "D:\git\runtime2\artifacts\obj\coreclr\cdac-build-tool\Debug\apphost.exe" because it was not found.	Mono.Linker.Tests	C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets	5321
* Exclude cdac-build-tool from building unless we need the CoreCLR VM (in separate PR #109719)
* Try running tests again
* Success

Cc @dotnet/illink 