### PR TITLE
Add dllmain to PlatformManifestEntry

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -153,6 +153,8 @@
     <PlatformManifestFileEntry Include="bootstrapper.GuardCF.obj" IsNative="true" />
     <PlatformManifestFileEntry Include="bootstrapperdll.obj" IsNative="true" />
     <PlatformManifestFileEntry Include="bootstrapperdll.GuardCF.obj" IsNative="true" />
+    <PlatformManifestFileEntry Include="dllmain.obj" IsNative="true" />
+    <PlatformManifestFileEntry Include="dllmain.GuardCF.obj" IsNative="true" />
     <PlatformManifestFileEntry Include="eventpipe-disabled.lib" IsNative="true" />
     <PlatformManifestFileEntry Include="eventpipe-disabled.GuardCF.lib" IsNative="true" />
     <PlatformManifestFileEntry Include="eventpipe-enabled.lib" IsNative="true" />


### PR DESCRIPTION
dllmain.obj and dllmain.GuardCF.obj were missing and causing the official build to fail