### PR TITLE
Add AggressiveInlining to type checks in SearchValues<string>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/SingleStringSearchValuesThreeChars.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/SingleStringSearchValuesThreeChars.cs
@@ -35,9 +35,13 @@ namespace System.Buffers
         // With case-sensitive comparisons, we've therefore already confirmed the match.
         // With case-insensitive comparisons, we've applied the CaseConversionMask to the input, so while the anchors likely matched, we can't be sure.
         // An exception to that is if we know the value is composed of only ASCII letters, in which case masking the input can't produce false positives.
-        private static bool CanSkipAnchorMatchVerification =>
-            !TValueLength.AtLeast4Chars &&
-            (typeof(TCaseSensitivity) == typeof(CaseSensitive) || typeof(TCaseSensitivity) == typeof(CaseInsensitiveAsciiLetters));
+        private static bool CanSkipAnchorMatchVerification
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get =>
+                !TValueLength.AtLeast4Chars &&
+                (typeof(TCaseSensitivity) == typeof(CaseSensitive) || typeof(TCaseSensitivity) == typeof(CaseInsensitiveAsciiLetters));
+        }
 
         public SingleStringSearchValuesThreeChars(HashSet<string>? uniqueValues, string value) : base(uniqueValues)
         {


### PR DESCRIPTION
Fixes #109735 (regression from #108368)

This check should completely disappear at runtime when the type is specialized, but looks like the JIT isn't inlining it right now, generating a bunch of extra dead code in the callers.

```c#
public partial class RegexRegression
{
    private static readonly SearchValues<string> s_values = SearchValues.Create(["abc"], StringComparison.Ordinal);

    [Benchmark]
    public int Test() => "abc".AsSpan().IndexOfAny(s_values);
}
```

Where `before` is before #108368, `pr1` is with that change, `pr2` is with this PR.

| Method | Toolchain         | Mean     | Error     | Ratio | Code Size |
|------- |------------------ |---------:|----------:|------:|----------:|
| Test   | \before\corerun.exe | 1.619 ns | 0.0357 ns |  1.00 |     532 B |
| Test   | \pr1\corerun.exe  | 2.410 ns | 0.0760 ns |  1.49 |   1,096 B |
| Test   | \pr2\corerun.exe  | 1.637 ns | 0.0386 ns |  1.01 |     532 B |