### PR TITLE
Support building the repo with clang 20

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -645,6 +645,13 @@ if (CLR_CMAKE_HOST_UNIX)
     endif()
   endif()
 
+  if (CMAKE_CXX_COMPILER_ID)
+    check_cxx_compiler_flag(-Wno-nontrivial-memaccess COMPILER_SUPPORTS_FNO_NONTRIVIAL_MEMACCESS)
+    if (COMPILER_SUPPORTS_FNO_NONTRIVIAL_MEMACCESS)
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nontrivial-memaccess>)
+    endif()
+  endif()
+
   # Some architectures (e.g., ARM) assume char type is unsigned while CoreCLR assumes char is signed
   # as x64 does. It has been causing issues in ARM (https://github.com/dotnet/runtime/issues/5778)
   add_compile_options(-fsigned-char)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -622,12 +622,7 @@ if (CLR_CMAKE_HOST_UNIX)
     add_compile_options(-Wno-switch-default)
 
     # clang 20 suppressions
-    if (CMAKE_CXX_COMPILER_ID)
-      check_cxx_compiler_flag(-Wnontrivial-memaccess COMPILER_SUPPORTS_W_NONTRIVIAL_MEMACCESS)
-      if (COMPILER_SUPPORTS_W_NONTRIVIAL_MEMACCESS)
-        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nontrivial-memaccess>)
-      endif()
-    endif()
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nontrivial-memaccess>)
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -620,6 +620,14 @@ if (CLR_CMAKE_HOST_UNIX)
 
     # clang 18.1 supressions
     add_compile_options(-Wno-switch-default)
+
+    # clang 20 suppressions
+    if (CMAKE_CXX_COMPILER_ID)
+      check_cxx_compiler_flag(-Wnontrivial-memaccess COMPILER_SUPPORTS_W_NONTRIVIAL_MEMACCESS)
+      if (COMPILER_SUPPORTS_W_NONTRIVIAL_MEMACCESS)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nontrivial-memaccess>)
+      endif()
+    endif()
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)
@@ -642,13 +650,6 @@ if (CLR_CMAKE_HOST_UNIX)
       if (COMPILER_SUPPORTS_F_ALIGNED_NEW)
         add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-faligned-new>)
       endif()
-    endif()
-  endif()
-
-  if (CMAKE_CXX_COMPILER_ID)
-    check_cxx_compiler_flag(-Wno-nontrivial-memaccess COMPILER_SUPPORTS_FNO_NONTRIVIAL_MEMACCESS)
-    if (COMPILER_SUPPORTS_FNO_NONTRIVIAL_MEMACCESS)
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nontrivial-memaccess>)
     endif()
   endif()
 

--- a/src/coreclr/debug/ee/stdafx.h
+++ b/src/coreclr/debug/ee/stdafx.h
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <algorithm>
 #include <cmath>
+#include <common.h>
 
 #include <windows.h>
 

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -73,6 +73,10 @@
 
 #include <olectl.h>
 
+#ifdef HOST_AMD64
+#include <xmmintrin.h>
+#endif
+
 using std::max;
 using std::min;
 


### PR DESCRIPTION
Fix errors from building with clang-20.

The issues were:

- Using memcpy with non-trivial structs became warn-as-error.
- our "safe to return" pattern breaks in constexpr in C++11 mode and clang-20 updated their intrinsics headers to make intrinsics constexpr. Include the intrinsics headers before we ever include debugreturn.h