### PR TITLE
Fix AOT warning in System.Linq.Expressions

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteOpsReflectionCache.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteOpsReflectionCache.cs
@@ -7,6 +7,8 @@ using System.Linq.Expressions;
 using System.Reflection;
 
 namespace System.Runtime.CompilerServices;
+
+[RequiresDynamicCode(Expression.NewArrayRequiresDynamicCode)]
 internal static class CallSiteOpsReflectionCache<T> where T : class
 {
     [Obsolete("CallSiteOps has been deprecated and is not supported.", error: false), EditorBrowsable(EditorBrowsableState.Never)]
@@ -31,7 +33,5 @@ internal static class CallSiteOpsReflectionCache<T> where T : class
     public static readonly MethodInfo MoveRule = ((Delegate)CallSiteOps.MoveRule<T>).GetMethodInfo();
 
     [Obsolete("CallSiteOps has been deprecated and is not supported.", error: false), EditorBrowsable(EditorBrowsableState.Never)]
-    [UnconditionalSuppressMessage("DynamicCode", "IL3050",
-        Justification = "CallSiteOps is obsolete and CallSite has RUC. Propagating warnings through fields isn't worth it.")]
     public static readonly MethodInfo Bind = ((Delegate)CallSiteOps.Bind<T>).GetMethodInfo();
 }


### PR DESCRIPTION
The UnconditionalSuppressMessage didn't work correctly because it wasn't targeting the static constructor. We don't need to suppress this warning - we can just bubble it up because it looks like all references to CallSiteOpsReflectionCache<T> are already annotated with RequiresDynamicCode.