### PR TITLE
Explicitly set UnsupportedTargetFrameworkVersion for VS support

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,6 +41,7 @@
       unconditionally in Microsoft.NETCoreSdk.BundledVersions.props.
     -->
     <NETCoreAppMaximumVersion>$(NetCoreAppCurrentVersion)</NETCoreAppMaximumVersion>
+    <UnsupportedTargetFrameworkVersion>$([MSBuild]::Add('$(NETCoreAppMaximumVersion.Split('.')[0])', '1')).0</UnsupportedTargetFrameworkVersion>
     <!-- SDK sets product to assembly but we want it to be our product name -->
     <Product>Microsoft%AE .NET</Product>
     <!-- Use the .NET product branding version for informational version description -->


### PR DESCRIPTION
Filed https://github.com/dotnet/sdk/issues/44839 to discuss whether `UnsupportedTargetFrameworkVersion` should be auto-calculated.

This is needed to avoid this error inside VS:
```
11>------ Build started: Project: System.IO.Pipelines (src\System.IO.Pipelines), Configuration: Debug Any CPU ------
10>C:\Program Files\dotnet\sdk\9.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(171,5): error NETSDK1209: The current Visual Studio version does not support targeting .NET 10.0.  Either target .NET 10.0 or lower, or use Visual Studio version 17.16 or higher
10>Done building project "System.Text.Json.csproj" -- FAILED.
```