### PR TITLE
Fix regression in constructor parameter binding logic.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -1209,7 +1209,8 @@ namespace System.Text.Json.Serialization.Metadata
                     continue;
                 }
 
-                ParameterLookupKey paramKey = new(propertyInfo.PropertyType, propertyInfo.Name);
+                string propertyName = propertyInfo.MemberName ?? propertyInfo.Name;
+                ParameterLookupKey paramKey = new(propertyInfo.PropertyType, propertyName);
                 if (!parameterIndex.TryAdd(paramKey, parameterInfo))
                 {
                     // Multiple object properties cannot bind to the same constructor parameter.

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1668,5 +1668,32 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(2, result.Y);
             Assert.Equal(3, result.Z);
         }
+
+        [Fact]
+        public async Task ClassWithConflictingCaseInsensitiveProperties_Succeeds_When_CaseSensitive()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/109768
+
+            string json = """{"a": "lower", "A": "upper"}""";
+            ClassWithConflictingCaseInsensitiveProperties result = await Serializer.DeserializeWrapper<ClassWithConflictingCaseInsensitiveProperties>(json);
+            Assert.Equal("lower", result.From);
+            Assert.Equal("upper", result.To);
+        }
+
+        public class ClassWithConflictingCaseInsensitiveProperties
+        {
+            [JsonPropertyName("a")]
+            public string From { get; set; }
+
+            [JsonPropertyName("A")]
+            public string To { get; set; }
+
+            [JsonConstructor]
+            public ClassWithConflictingCaseInsensitiveProperties(string from, string to)
+            {
+                From = from;
+                To = to;
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
@@ -154,6 +154,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(TypeWithEnumParameters))]
         [JsonSerializable(typeof(ClassWithIgnoredPropertyDefaultParam))]
         [JsonSerializable(typeof(ClassWithCustomConverterOnCtorParameter))]
+        [JsonSerializable(typeof(ClassWithConflictingCaseInsensitiveProperties))]
         internal sealed partial class ConstructorTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -303,6 +304,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(TypeWithEnumParameters))]
         [JsonSerializable(typeof(ClassWithIgnoredPropertyDefaultParam))]
         [JsonSerializable(typeof(ClassWithCustomConverterOnCtorParameter))]
+        [JsonSerializable(typeof(ClassWithConflictingCaseInsensitiveProperties))]
         internal sealed partial class ConstructorTestsContext_Default : JsonSerializerContext
         {
         }


### PR DESCRIPTION
A refactoring introduced in https://github.com/dotnet/runtime/commit/455f54003d0b8391cfee670688d285b9a50b5a1c regressed the way in which [conflicting parameters are being resolved](https://github.com/dotnet/runtime/commit/455f54003d0b8391cfee670688d285b9a50b5a1c#diff-8d841bf86f2a9da83758276bd17f55d002ee5b55f58b72da658df351a7c22bc0L1138). This PR reinstates the original logic.

Fix #109768. Should be backported to .NET 9.