### PR TITLE
[release/9.0-staging] Update ApiCompatNetCoreAppBaselineVersion to 9.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -121,8 +121,7 @@
     <NetFrameworkToolCurrent Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <NetFrameworkCurrent Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
 
-    <!-- Important: Set this to the GA version (or a close approximation) during servicing and adjust the TFM property below. -->
-    <ApiCompatNetCoreAppBaselineVersion>9.0.0-rtm.24516.5</ApiCompatNetCoreAppBaselineVersion>
+    <ApiCompatNetCoreAppBaselineVersion>9.0.0</ApiCompatNetCoreAppBaselineVersion>
     <ApiCompatNetCoreAppBaselineTFM>net9.0</ApiCompatNetCoreAppBaselineTFM>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/106598
Follow up of https://github.com/dotnet/runtime/pull/109316#discussion_r1820295635