### PR TITLE
Add cpio to Codespaces Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         clang \
         cmake \
+        cpio \
         build-essential \
         python3 \
         curl \

--- a/.devcontainer/android/Dockerfile
+++ b/.devcontainer/android/Dockerfile
@@ -4,14 +4,15 @@ FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 # Set up machine requirements to build the repo
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-        cmake \
-        llvm \
         clang \
+        cmake \
+        cpio \
         build-essential \
         python3 \
         curl \
         git \
         lldb \
+        llvm \
         liblldb-dev \
         libunwind8 \
         libunwind8-dev \
@@ -20,6 +21,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         liblttng-ust-dev \
         libssl-dev \
         libkrb5-dev \
+        zlib1g-dev \
+        ninja-build \
         zlib1g-dev \
         ninja-build \
         openjdk-17-jdk \

--- a/.devcontainer/wasm-multiThreaded/Dockerfile
+++ b/.devcontainer/wasm-multiThreaded/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         clang \
         cmake \
+        cpio \
         build-essential \
         python3 \
         curl \

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         clang \
         cmake \
+        cpio \
         build-essential \
         python3 \
         curl \


### PR DESCRIPTION
Right now it fails when building installers (we don't do that during prebuild so we didn't notice)