### PR TITLE
macOS does not define IOV_MAX, it uses UIO_MAXIOV instead

### DIFF
--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1954,15 +1954,22 @@ static int GetAllowedVectorCount(int32_t vectorCount)
 {
     int allowedCount = (int)vectorCount;
 
+    // We need to respect the limit of items that can be passed in iov.
+    // In case of writes, the managed code is responsible for handling incomplete writes.
+    // In case of reads, we simply returns the number of bytes read and it's up to the users.
 #if defined(IOV_MAX)
     if (IOV_MAX < allowedCount)
     {
-        // We need to respect the limit of items that can be passed in iov.
-        // In case of writes, the managed code is reponsible for handling incomplete writes.
-        // In case of reads, we simply returns the number of bytes read and it's up to the users.
         allowedCount = IOV_MAX;
     }
+#elif defined(UIO_MAXIOV) // macOS and iOS
+    if (UIO_MAXIOV < allowedCount)
+    {
+        allowedCount = UIO_MAXIOV;
+    }
 #endif
+
+
     return allowedCount;
 }
 #endif // (HAVE_PREADV || HAVE_PWRITEV) && !defined(TARGET_WASM)


### PR DESCRIPTION
```log
Console log: 'System.IO.FileSystem.Tests' from job e1129958-3e30-4571-975b-814437ded6ef workitem 62d43513-46a3-49d0-aa6c-d64b6c93c90d (osx.1200.arm64.open) executed on machine dci-macm1-build-089.local running macOS-12.7.2
+ ./RunTests.sh --runtime-path /tmp/helix/working/97EF08C9/p
----- start Wed Nov 13 05:30:18 PST 2024 =============== To repro directly: =====================================================
pushd .
/tmp/helix/working/97EF08C9/p/dotnet exec --runtimeconfig System.IO.FileSystem.Tests.runtimeconfig.json --depsfile System.IO.FileSystem.Tests.deps.json xunit.console.dll System.IO.FileSystem.Tests.dll -xml testResults.xml -nologo -nocolor -trait category=OuterLoop -notrait category=IgnoreForCI -notrait category=failing 
popd
===========================================================================================================
/private/tmp/helix/working/97EF08C9/w/A24C0940/e /private/tmp/helix/working/97EF08C9/w/A24C0940/e
  Discovering: System.IO.FileSystem.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.IO.FileSystem.Tests (found 48 of 4132 test cases)
  Starting:    System.IO.FileSystem.Tests (parallel test collections = on, max threads = 8)
    System.IO.Tests.PathDirectory_Exists.PathWithReservedDeviceNameAsPath_ReturnsFalse [SKIP]
      Condition(s) not met: "ReservedDeviceNamesAreBlocked"
    System.IO.Tests.Directory_Exists.PathWithReservedDeviceNameAsPath_ReturnsFalse [SKIP]
      Condition(s) not met: "ReservedDeviceNamesAreBlocked"
    System.IO.Tests.File_Exists.PathWithReservedDeviceNameAsPath_ReturnsFalse [SKIP]
      Condition(s) not met: "ReservedDeviceNamesAreBlocked"
    System.IO.Tests.PathFile_Exists.PathWithReservedDeviceNameAsPath_ReturnsFalse [SKIP]
      Condition(s) not met: "ReservedDeviceNamesAreBlocked"
    System.IO.Tests.RandomAccess_WriteGatherAsync.NoInt32OverflowForLargeInputs(asyncFile: False, asyncMethod: False) [FAIL]
      System.IO.IOException : Invalid argument : '/tmp/helix/working/97EF08C9/t/#RandomAccess_WriteGatherAsync_rlmszfxh.5lp/NoInt32OverflowForLargeInputs_153_u9oqsjfv'
      Stack Trace:
        /_/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Unix.cs(205,0): at System.IO.RandomAccess.WriteGatherAtOffset(SafeFileHandle handle, IReadOnlyList`1 buffers, Int64 fileOffset)
        /_/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs(194,0): at System.IO.RandomAccess.Write(SafeFileHandle handle, IReadOnlyList`1 buffers, Int64 fileOffset)
        /_/src/libraries/System.IO.FileSystem/tests/RandomAccess/WriteGatherAsync.cs(193,0): at System.IO.Tests.RandomAccess_WriteGatherAsync.NoInt32OverflowForLargeInputs(Boolean asyncFile, Boolean asyncMethod)
        --- End of stack trace from previous location ---
```