### PR TITLE
JIT: Relax cost improvement assert in 3-opt layout

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5375,9 +5375,10 @@ bool Compiler::ThreeOptLayout::RunThreeOptPass(BasicBlock* startBlock, BasicBloc
         }
 
 #ifdef DEBUG
-        // Ensure the swap improved the overall layout
+        // Ensure the swap improved the overall layout. Tolerate some imprecision.
         const weight_t newLayoutCost = GetLayoutCost(startPos, endPos);
-        assert(newLayoutCost < currLayoutCost);
+        assert((newLayoutCost < currLayoutCost) ||
+               Compiler::fgProfileWeightsEqual(newLayoutCost, currLayoutCost, 0.001));
         currLayoutCost = newLayoutCost;
 #endif // DEBUG
     }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5375,10 +5375,9 @@ bool Compiler::ThreeOptLayout::RunThreeOptPass(BasicBlock* startBlock, BasicBloc
         }
 
 #ifdef DEBUG
-        // Ensure the swap improved the overall layout, or at least didn't regress it
-        // (rounding errors might cause nearly-tied scores to be equal)
+        // Ensure the swap improved the overall layout
         const weight_t newLayoutCost = GetLayoutCost(startPos, endPos);
-        assert(newLayoutCost <= currLayoutCost);
+        assert(newLayoutCost < currLayoutCost);
         currLayoutCost = newLayoutCost;
 #endif // DEBUG
     }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4950,12 +4950,16 @@ weight_t Compiler::ThreeOptLayout::GetCost(BasicBlock* block, BasicBlock* next)
 
     const weight_t  maxCost         = block->bbWeight;
     const FlowEdge* fallthroughEdge = compiler->fgGetPredForBlock(next, block);
+    assert(maxCost >= BB_ZERO_WEIGHT);
 
     if (fallthroughEdge != nullptr)
     {
         // The edge's weight should never exceed its source block's weight,
         // but handle negative results from rounding errors in getLikelyWeight(), just in case
-        return max(0.0, maxCost - fallthroughEdge->getLikelyWeight());
+        const weight_t edgeWeight = fallthroughEdge->getLikelyWeight();
+        assert(edgeWeight >= BB_ZERO_WEIGHT);
+        assert(edgeWeight <= maxCost);
+        return maxCost - edgeWeight;
     }
 
     return maxCost;

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5375,9 +5375,10 @@ bool Compiler::ThreeOptLayout::RunThreeOptPass(BasicBlock* startBlock, BasicBloc
         }
 
 #ifdef DEBUG
-        // Ensure the swap improved the overall layout
+        // Ensure the swap improved the overall layout, or at least didn't regress it
+        // (rounding errors might cause nearly-tied scores to be equal)
         const weight_t newLayoutCost = GetLayoutCost(startPos, endPos);
-        assert(newLayoutCost < currLayoutCost);
+        assert(newLayoutCost <= currLayoutCost);
         currLayoutCost = newLayoutCost;
 #endif // DEBUG
     }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4950,16 +4950,12 @@ weight_t Compiler::ThreeOptLayout::GetCost(BasicBlock* block, BasicBlock* next)
 
     const weight_t  maxCost         = block->bbWeight;
     const FlowEdge* fallthroughEdge = compiler->fgGetPredForBlock(next, block);
-    assert(maxCost >= BB_ZERO_WEIGHT);
 
     if (fallthroughEdge != nullptr)
     {
         // The edge's weight should never exceed its source block's weight,
         // but handle negative results from rounding errors in getLikelyWeight(), just in case
-        const weight_t edgeWeight = fallthroughEdge->getLikelyWeight();
-        assert(edgeWeight >= BB_ZERO_WEIGHT);
-        assert(edgeWeight <= maxCost);
-        return maxCost - edgeWeight;
+        return max(0.0, maxCost - fallthroughEdge->getLikelyWeight());
     }
 
     return maxCost;


### PR DESCRIPTION
Follow-up to #109741. Fixes #109831. Fixes #109905. Fixes #109903.

Tolerate some floating point imprecision when comparing the cost of a new layout produced by 3-opt to the previous layout's cost. The JitStress failures I looked all stressed JitOptRepeat, which can produce absurdly large loop block weights by rerunning `optSetBlockWeights`. Manually inspecting the layout decisions made for these methods shows 3-opt making reasonable transformations, but the assertion `newLayoutCost < currLayoutCost` fails due to imprecision from summing large block weights. Having a backup check that the layout costs are within some epsilon seems like a reasonable fix.