### PR TITLE
[WASI] Skip signal handler registration on WASI

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.netcoreapp.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.netcoreapp.cs
@@ -15,10 +15,13 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private partial void RegisterShutdownHandlers()
         {
-            Action<PosixSignalContext> handler = HandlePosixSignal;
-            _sigIntRegistration = PosixSignalRegistration.Create(PosixSignal.SIGINT, handler);
-            _sigQuitRegistration = PosixSignalRegistration.Create(PosixSignal.SIGQUIT, handler);
-            _sigTermRegistration = PosixSignalRegistration.Create(PosixSignal.SIGTERM, handler);
+            if (!OperatingSystem.IsWasi())
+            {
+                Action<PosixSignalContext> handler = HandlePosixSignal;
+                _sigIntRegistration = PosixSignalRegistration.Create(PosixSignal.SIGINT, handler);
+                _sigQuitRegistration = PosixSignalRegistration.Create(PosixSignal.SIGQUIT, handler);
+                _sigTermRegistration = PosixSignalRegistration.Create(PosixSignal.SIGTERM, handler);
+            }
         }
 
         private void HandlePosixSignal(PosixSignalContext context)


### PR DESCRIPTION
WASI does not support POSIX signals, but `Microsoft.Extensions.Hosting` works fine as long as we don't try to register or deregister signal handlers.