### PR TITLE
Fix failing test on NativeAOT

### DIFF
--- a/src/tests/tracing/eventpipe/randomizedallocationsampling/allocationsampling.cs
+++ b/src/tests/tracing/eventpipe/randomizedallocationsampling/allocationsampling.cs
@@ -69,7 +69,10 @@ namespace Tracing.Tests
                     AllocationSampledData payload = new AllocationSampledData(eventData, source.PointerSize);
                     // uncomment to see the allocation events payload
                     //Logger.logger.Log($"{payload.AllocationKind} | ({payload.ObjectSize}) {payload.TypeName}  = 0x{payload.Address}");
-                    if (payload.TypeName == "Tracing.Tests.Object128")
+                    if (payload.TypeName == "Tracing.Tests.Object128" ||
+                        (payload.TypeName == "NULL" && payload.ObjectSize >= 128))  // NativeAOT doesn't report type names but we can use the size as a good proxy
+                                                                                    // A real profiler would resolve the TypeID from PDBs but replicating that would
+                                                                                    // make the test more complicated
                     {
                         Object128Count++;
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/109828
This test hadn't been updated to account for NativeAOT's lack of type names in the new randomized sampling allocation events.