### PR TITLE
[cdac] Simplify usage of TestPlaceholderTarget in tests

### DIFF
--- a/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
+++ b/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
@@ -242,12 +243,12 @@ public class CodeVersionsTests
         IRuntimeTypeSystem mockRuntimeTypeSystem = new MockRuntimeTypeSystem(target, methodDescs ?? [], methodTables ?? []);
         ILoader loader = new MockLoader(modules ?? []);
         IContractFactory<ICodeVersions> cvfactory = new CodeVersionsFactory();
-        target.SetContracts(new TestPlaceholderTarget.TestRegistry() {
-            CodeVersionsContract = new (() => cvfactory.CreateContract(target, 1)),
-            ExecutionManagerContract = new (() => mockExecutionManager),
-            RuntimeTypeSystemContract = new (() => mockRuntimeTypeSystem),
-            LoaderContract = new (() => loader),
-        });
+        ContractRegistry reg = Mock.Of<ContractRegistry>(
+            c => c.CodeVersions == cvfactory.CreateContract(target, 1)
+                && c.ExecutionManager == mockExecutionManager
+                && c.RuntimeTypeSystem == mockRuntimeTypeSystem
+                && c.Loader == loader);
+        target.SetContracts(reg);
         return target;
     }
 

--- a/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
+++ b/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
@@ -241,13 +241,11 @@ public class CodeVersionsTests
                             IReadOnlyCollection<MockModule>? modules = null,
                             ReadFromTargetDelegate reader = null,
                             Dictionary<DataType, TypeInfo>? typeInfoCache = null)
-            : base(arch, reader)
+            : base(arch, reader, typeInfoCache ?? [])
         {
             IExecutionManager mockExecutionManager = new MockExecutionManager(codeBlocks ?? []);
             IRuntimeTypeSystem mockRuntimeTypeSystem = new MockRuntimeTypeSystem(this, methodDescs ?? [], methodTables ?? []);
             ILoader loader = new MockLoader(modules ?? []);
-            if (typeInfoCache != null)
-                SetTypeInfoCache(typeInfoCache);
             IContractFactory<ICodeVersions> cvfactory = new CodeVersionsFactory();
             SetContracts(new TestRegistry() {
                 CodeVersionsContract = new (() => cvfactory.CreateContract(this, 1)),

--- a/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
+++ b/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
@@ -234,16 +234,9 @@ public class CodeVersionsTests
         IReadOnlyCollection<MockModule> modules = null,
         MockCodeVersions builder = null)
     {
-        TestPlaceholderTarget target;
-        if (builder != null)
-        {
-            builder.MarkCreated();
-            target = new TestPlaceholderTarget(arch, builder.Builder.GetReadContext().ReadFromTarget, builder.Types);
-        }
-        else
-        {
-            target = new TestPlaceholderTarget(arch, null);
-        }
+        TestPlaceholderTarget target = builder != null
+            ? new TestPlaceholderTarget(arch, builder.Builder.GetReadContext().ReadFromTarget, builder.Types)
+            : new TestPlaceholderTarget(arch, null);
 
         IExecutionManager mockExecutionManager = new MockExecutionManager(codeBlocks ?? []);
         IRuntimeTypeSystem mockRuntimeTypeSystem = new MockRuntimeTypeSystem(target, methodDescs ?? [], methodTables ?? []);

--- a/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
+++ b/src/native/managed/cdacreader/tests/CodeVersionsTests.cs
@@ -241,7 +241,7 @@ public class CodeVersionsTests
                             IReadOnlyCollection<MockModule>? modules = null,
                             ReadFromTargetDelegate reader = null,
                             Dictionary<DataType, TypeInfo>? typeInfoCache = null)
-            : base(arch, reader, typeInfoCache ?? [])
+            : base(arch, reader, typeInfoCache)
         {
             IExecutionManager mockExecutionManager = new MockExecutionManager(codeBlocks ?? []);
             IRuntimeTypeSystem mockRuntimeTypeSystem = new MockRuntimeTypeSystem(this, methodDescs ?? [], methodTables ?? []);

--- a/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTestBuilder.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTestBuilder.cs
@@ -161,10 +161,6 @@ internal class ExecutionManagerTestBuilder
                 cur = new TargetCodePointer(cur.Value + (ulong)BytesAtLastLevel); // FIXME: round ?
             } while (cur.Value < end);
         }
-        public void MarkCreated()
-        {
-            _builder.MarkCreated();
-        }
 
         public MockMemorySpace.ReadContext GetReadContext()
         {
@@ -480,6 +476,4 @@ internal class ExecutionManagerTestBuilder
 
         return r2rModule.Address;
     }
-
-    public void MarkCreated() => Builder.MarkCreated();
 }

--- a/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTestBuilder.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTestBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
 using InteriorMapValue = Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers.RangeSectionMap.InteriorMapValue;
@@ -13,6 +14,7 @@ internal class ExecutionManagerTestBuilder
 {
     public const ulong ExecutionManagerCodeRangeMapAddress = 0x000a_fff0;
 
+    const bool UseFunclets = true;
     const int RealCodeHeaderSize = 0x08; // must be big enough for the offsets of RealCodeHeader size in ExecutionManagerTestTarget, below
 
     public struct AllocationRange
@@ -259,6 +261,7 @@ internal class ExecutionManagerTestBuilder
 
     internal MockMemorySpace.Builder Builder { get; }
     internal Dictionary<DataType, Target.TypeInfo> Types { get; }
+    internal (string Name, ulong Value)[] Globals { get; }
 
     private readonly RangeSectionMapTestBuilder _rsmBuilder;
 
@@ -287,11 +290,19 @@ internal class ExecutionManagerTestBuilder
                 CodeHeapListNodeFields,
                 RealCodeHeaderFields,
                 RuntimeFunctionFields,
-                MockDescriptors.HashMap.HashMapFields,
-                MockDescriptors.HashMap.BucketFields(Builder.TargetTestHelpers),
                 ReadyToRunInfoFields(Builder.TargetTestHelpers),
                 MockDescriptors.ModuleFields,
-            ]);
+            ]).Concat(MockDescriptors.HashMap.GetTypes(Builder.TargetTestHelpers))
+            .ToDictionary();
+        Globals =
+        [
+            (nameof(Constants.Globals.ExecutionManagerCodeRangeMapAddress), ExecutionManagerCodeRangeMapAddress),
+            (nameof(Constants.Globals.StubCodeBlockLast), 0x0Fu),
+            (nameof(Constants.Globals.FeatureEHFunclets), UseFunclets ? 1 : 0),
+        ];
+        Globals = Globals
+            .Concat(MockDescriptors.HashMap.GetGlobals(Builder.TargetTestHelpers))
+            .ToArray();
     }
 
     internal NibbleMapTestBuilderBase CreateNibbleMap(ulong codeRangeStart, uint codeRangeSize)

--- a/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
@@ -25,10 +25,9 @@ public class ExecutionManagerTests
         }
 
         public ExecutionManagerTestTarget(int version, MockTarget.Architecture arch, ReadFromTargetDelegate dataReader, TargetPointer topRangeSectionMap, Dictionary<DataType, TypeInfo> typeInfoCache)
-            : base(arch, dataReader)
+            : base(arch, dataReader, typeInfoCache)
         {
             _topRangeSectionMap = topRangeSectionMap;
-            SetTypeInfoCache(typeInfoCache);
             IContractFactory<IExecutionManager> emfactory = new ExecutionManagerFactory();
             SetContracts(new TestRegistry() {
                 ExecutionManagerContract = new (() => emfactory.CreateContract(this, version)),

--- a/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
@@ -17,10 +17,10 @@ public class ExecutionManagerTests
         TestPlaceholderTarget.ReadFromTargetDelegate reader = emBuilder.Builder.GetReadContext().ReadFromTarget;
         var target = new TestPlaceholderTarget(arch, reader, emBuilder.Types, emBuilder.Globals);
         IContractFactory<IExecutionManager> emfactory = new ExecutionManagerFactory();
-        target.SetContracts(new TestPlaceholderTarget.TestRegistry() {
-            ExecutionManagerContract = new (() => emfactory.CreateContract(target, emBuilder.Version)),
-            PlatformMetadataContract = new (() => new Mock<IPlatformMetadata>().Object)
-        });
+        ContractRegistry reg = Mock.Of<ContractRegistry>(
+            c => c.ExecutionManager == emfactory.CreateContract(target, emBuilder.Version)
+                && c.PlatformMetadata == new Mock<IPlatformMetadata>().Object);
+        target.SetContracts(reg);
         return target;
     }
 

--- a/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
@@ -13,7 +13,6 @@ public class ExecutionManagerTests
 {
     private static Target CreateTarget(ExecutionManagerTestBuilder emBuilder)
     {
-        emBuilder.MarkCreated();
         var arch = emBuilder.Builder.TargetTestHelpers.Arch;
         TestPlaceholderTarget.ReadFromTargetDelegate reader = emBuilder.Builder.GetReadContext().ReadFromTarget;
         var target = new TestPlaceholderTarget(arch, reader, emBuilder.Types, emBuilder.Globals);

--- a/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
@@ -11,24 +11,18 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests.ExecutionManager;
 
 public class ExecutionManagerTests
 {
-    internal class ExecutionManagerTestTarget : TestPlaceholderTarget
+    private static Target CreateTarget(ExecutionManagerTestBuilder emBuilder)
     {
-        public static ExecutionManagerTestTarget FromBuilder(ExecutionManagerTestBuilder emBuilder)
-        {
-            var arch = emBuilder.Builder.TargetTestHelpers.Arch;
-            ReadFromTargetDelegate reader = emBuilder.Builder.GetReadContext().ReadFromTarget;
-            return new ExecutionManagerTestTarget(emBuilder.Version, arch, reader, emBuilder.Types, emBuilder.Globals);
-        }
-
-        public ExecutionManagerTestTarget(int version, MockTarget.Architecture arch, ReadFromTargetDelegate dataReader, Dictionary<DataType, TypeInfo> typeInfoCache, (string Name, ulong Value)[] globals)
-            : base(arch, dataReader, typeInfoCache, globals)
-        {
-            IContractFactory<IExecutionManager> emfactory = new ExecutionManagerFactory();
-            SetContracts(new TestRegistry() {
-                ExecutionManagerContract = new (() => emfactory.CreateContract(this, version)),
-                PlatformMetadataContract = new (() => new Mock<IPlatformMetadata>().Object)
-            });
-        }
+        emBuilder.MarkCreated();
+        var arch = emBuilder.Builder.TargetTestHelpers.Arch;
+        TestPlaceholderTarget.ReadFromTargetDelegate reader = emBuilder.Builder.GetReadContext().ReadFromTarget;
+        var target = new TestPlaceholderTarget(arch, reader, emBuilder.Types, emBuilder.Globals);
+        IContractFactory<IExecutionManager> emfactory = new ExecutionManagerFactory();
+        target.SetContracts(new TestPlaceholderTarget.TestRegistry() {
+            ExecutionManagerContract = new (() => emfactory.CreateContract(target, emBuilder.Version)),
+            PlatformMetadataContract = new (() => new Mock<IPlatformMetadata>().Object)
+        });
+        return target;
     }
 
     [Theory]
@@ -36,8 +30,7 @@ public class ExecutionManagerTests
     public void GetCodeBlockHandle_Null(int version, MockTarget.Architecture arch)
     {
         ExecutionManagerTestBuilder emBuilder = new (version, arch, ExecutionManagerTestBuilder.DefaultAllocationRange);
-        emBuilder.MarkCreated();
-        var target = ExecutionManagerTestTarget.FromBuilder (emBuilder);
+        var target = CreateTarget(emBuilder);
 
         var em = target.Contracts.ExecutionManager;
         Assert.NotNull(em);
@@ -50,8 +43,7 @@ public class ExecutionManagerTests
     public void GetCodeBlockHandle_NoRangeSections(int version, MockTarget.Architecture arch)
     {
         ExecutionManagerTestBuilder emBuilder = new (version, arch, ExecutionManagerTestBuilder.DefaultAllocationRange);
-        emBuilder.MarkCreated();
-        var target = ExecutionManagerTestTarget.FromBuilder (emBuilder);
+        var target = CreateTarget(emBuilder);
 
         var em = target.Contracts.ExecutionManager;
         Assert.NotNull(em);
@@ -83,9 +75,7 @@ public class ExecutionManagerTests
         TargetPointer rangeSectionAddress = emBuilder.AddRangeSection(jittedCode, jitManagerAddress: jitManagerAddress, codeHeapListNodeAddress: codeHeapListNodeAddress);
         TargetPointer rangeSectionFragmentAddress = emBuilder.AddRangeSectionFragment(jittedCode, rangeSectionAddress);
 
-        emBuilder.MarkCreated();
-
-        var target = ExecutionManagerTestTarget.FromBuilder(emBuilder);
+        var target = CreateTarget(emBuilder);
 
         var em = target.Contracts.ExecutionManager;
         Assert.NotNull(em);
@@ -127,9 +117,7 @@ public class ExecutionManagerTests
         TargetPointer rangeSectionAddress = emBuilder.AddRangeSection(jittedCode, jitManagerAddress: jitManagerAddress, codeHeapListNodeAddress: codeHeapListNodeAddress);
         TargetPointer rangeSectionFragmentAddress = emBuilder.AddRangeSectionFragment(jittedCode, rangeSectionAddress);
 
-        emBuilder.MarkCreated();
-
-        var target = ExecutionManagerTestTarget.FromBuilder(emBuilder);
+        var target = CreateTarget(emBuilder);
 
         var em = target.Contracts.ExecutionManager;
         Assert.NotNull(em);
@@ -170,9 +158,7 @@ public class ExecutionManagerTests
         TargetPointer rangeSectionAddress = emBuilder.AddReadyToRunRangeSection(jittedCode, jitManagerAddress, r2rModule);
         _ = emBuilder.AddRangeSectionFragment(jittedCode, rangeSectionAddress);
 
-        emBuilder.MarkCreated();
-
-        Target target = ExecutionManagerTestTarget.FromBuilder(emBuilder);
+        Target target = CreateTarget(emBuilder);
 
         IExecutionManager em = target.Contracts.ExecutionManager;
         Assert.NotNull(em);
@@ -207,9 +193,7 @@ public class ExecutionManagerTests
         TargetPointer rangeSectionAddress = emBuilder.AddReadyToRunRangeSection(jittedCode, jitManagerAddress, r2rModule);
         _ = emBuilder.AddRangeSectionFragment(jittedCode, rangeSectionAddress);
 
-        emBuilder.MarkCreated();
-
-        Target target = ExecutionManagerTestTarget.FromBuilder(emBuilder);
+        Target target = CreateTarget(emBuilder);
 
         IExecutionManager em = target.Contracts.ExecutionManager;
         Assert.NotNull(em);
@@ -258,9 +242,7 @@ public class ExecutionManagerTests
         TargetPointer rangeSectionAddress = emBuilder.AddReadyToRunRangeSection(jittedCode, jitManagerAddress, r2rModule);
         _ = emBuilder.AddRangeSectionFragment(jittedCode, rangeSectionAddress);
 
-        emBuilder.MarkCreated();
-
-        Target target = ExecutionManagerTestTarget.FromBuilder(emBuilder);
+        Target target = CreateTarget(emBuilder);
 
         IExecutionManager em = target.Contracts.ExecutionManager;
         Assert.NotNull(em);

--- a/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
@@ -9,13 +9,6 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests.ExecutionManager;
 
 public class HashMapTests
 {
-    private static Target CreateTarget(MockDescriptors.HashMap hashMap)
-    {
-        MockMemorySpace.Builder builder = hashMap.Builder;
-        builder.MarkCreated();
-        return new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, hashMap.Types, hashMap.Globals);
-    }
-
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
     public void GetValue(MockTarget.Architecture arch)
@@ -32,7 +25,7 @@ public class HashMapTests
         TargetPointer mapAddress = hashMap.CreateMap(entries);
         TargetPointer ptrMapAddress = hashMap.CreatePtrMap(entries);
 
-        Target target = CreateTarget(hashMap);
+        Target target = new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, hashMap.Types, hashMap.Globals);
 
         var lookup = HashMapLookup.Create(target);
         var ptrLookup = PtrHashMapLookup.Create(target);
@@ -68,7 +61,7 @@ public class HashMapTests
         TargetPointer mapAddress = hashMap.CreateMap(entries);
         TargetPointer ptrMapAddress = hashMap.CreatePtrMap(entries);
 
-        Target target = CreateTarget(hashMap);
+        Target target = new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, hashMap.Types, hashMap.Globals);
 
         var lookup = HashMapLookup.Create(target);
         var ptrLookup = PtrHashMapLookup.Create(target);
@@ -93,7 +86,7 @@ public class HashMapTests
         TargetPointer mapAddress = hashMap.CreateMap(entries);
         TargetPointer ptrMapAddress = hashMap.CreatePtrMap(entries);
 
-        Target target = CreateTarget(hashMap);
+        Target target = new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, hashMap.Types, hashMap.Globals);
 
         {
             var lookup = HashMapLookup.Create(target);

--- a/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
@@ -14,10 +14,9 @@ public class HashMapTests
         private readonly (string Name, ulong Value, string? Type)[] _globals;
 
         public HashMapTestTarget(MockTarget.Architecture arch, MockMemorySpace.ReadContext readContext, MockDescriptors.HashMap hashMap)
-            : base (arch, readContext.ReadFromTarget)
+            : base (arch, readContext.ReadFromTarget, hashMap.Types)
         {
             _globals = hashMap.Globals;
-            SetTypeInfoCache(hashMap.Types);
         }
 
         public override T ReadGlobal<T>(string name)

--- a/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
@@ -11,24 +11,9 @@ public class HashMapTests
 {
     internal class HashMapTestTarget : TestPlaceholderTarget
     {
-        private readonly (string Name, ulong Value, string? Type)[] _globals;
-
         public HashMapTestTarget(MockTarget.Architecture arch, MockMemorySpace.ReadContext readContext, MockDescriptors.HashMap hashMap)
-            : base (arch, readContext.ReadFromTarget, hashMap.Types)
-        {
-            _globals = hashMap.Globals;
-        }
-
-        public override T ReadGlobal<T>(string name)
-        {
-            foreach (var global in _globals)
-            {
-                if (global.Name == name)
-                    return T.CreateChecked(global.Value);
-            }
-
-            return base.ReadGlobal<T>(name);
-        }
+            : base (arch, readContext.ReadFromTarget, hashMap.Types, hashMap.Globals)
+        { }
     }
 
     [Theory]

--- a/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/HashMapTests.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests.ExecutionManager;
 
 public class HashMapTests
 {
-    internal class HashMapTestTarget : TestPlaceholderTarget
+    private static Target CreateTarget(MockDescriptors.HashMap hashMap)
     {
-        public HashMapTestTarget(MockTarget.Architecture arch, MockMemorySpace.ReadContext readContext, MockDescriptors.HashMap hashMap)
-            : base (arch, readContext.ReadFromTarget, hashMap.Types, hashMap.Globals)
-        { }
+        MockMemorySpace.Builder builder = hashMap.Builder;
+        builder.MarkCreated();
+        return new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, hashMap.Types, hashMap.Globals);
     }
 
     [Theory]
@@ -31,9 +31,8 @@ public class HashMapTests
         ];
         TargetPointer mapAddress = hashMap.CreateMap(entries);
         TargetPointer ptrMapAddress = hashMap.CreatePtrMap(entries);
-        builder.MarkCreated();
 
-        Target target = new HashMapTestTarget(arch, builder.GetReadContext(), hashMap);
+        Target target = CreateTarget(hashMap);
 
         var lookup = HashMapLookup.Create(target);
         var ptrLookup = PtrHashMapLookup.Create(target);
@@ -68,9 +67,8 @@ public class HashMapTests
         ];
         TargetPointer mapAddress = hashMap.CreateMap(entries);
         TargetPointer ptrMapAddress = hashMap.CreatePtrMap(entries);
-        builder.MarkCreated();
 
-        Target target = new HashMapTestTarget(arch, builder.GetReadContext(), hashMap);
+        Target target = CreateTarget(hashMap);
 
         var lookup = HashMapLookup.Create(target);
         var ptrLookup = PtrHashMapLookup.Create(target);
@@ -94,9 +92,8 @@ public class HashMapTests
         (TargetPointer Key, TargetPointer Value)[] entries = [(0x100, 0x010)];
         TargetPointer mapAddress = hashMap.CreateMap(entries);
         TargetPointer ptrMapAddress = hashMap.CreatePtrMap(entries);
-        builder.MarkCreated();
 
-        Target target = new HashMapTestTarget(arch, builder.GetReadContext(), hashMap);
+        Target target = CreateTarget(hashMap);
 
         {
             var lookup = HashMapLookup.Create(target);

--- a/src/native/managed/cdacreader/tests/ExecutionManager/NibbleMapTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/NibbleMapTests.cs
@@ -9,19 +9,13 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests.ExecutionManager;
 
 public class NibbleMapTestsBase
 {
-    internal class NibbleMapTestTarget : TestPlaceholderTarget
+    internal static Target CreateTarget(NibbleMapTestBuilderBase nibbleMapTestBuilder)
     {
-        public NibbleMapTestTarget(MockTarget.Architecture arch, MockMemorySpace.ReadContext readContext)
-            : base(arch, readContext.ReadFromTarget)
+        MockMemorySpace.ReadContext readContext = new()
         {
-        }
-    }
-
-    internal static NibbleMapTestTarget CreateTarget(NibbleMapTestBuilderBase nibbleMapTestBuilder)
-    {
-        return new NibbleMapTestTarget(nibbleMapTestBuilder.Arch, new MockMemorySpace.ReadContext() {
             HeapFragments = new[] { nibbleMapTestBuilder.NibbleMapFragment }
-        });
+        };
+        return new TestPlaceholderTarget(nibbleMapTestBuilder.Arch, readContext.ReadFromTarget);
     }
 }
 
@@ -84,7 +78,7 @@ public class NibbleMapLinearLookupTests : NibbleMapTestsBase
         TargetCodePointer inputPC = new(mapBase + 0x0200u);
         uint codeSize = 0x80; // doesn't matter
         builder.AllocateCodeChunk (inputPC, codeSize);
-        NibbleMapTestTarget target = CreateTarget(builder);
+        Target target = CreateTarget(builder);
 
         // TESTCASE:
 
@@ -144,7 +138,7 @@ public class NibbleMapConstantLookupTests : NibbleMapTestsBase
         TargetCodePointer inputPC = new(mapBase + 0x0200u);
         uint codeSize = 0x400;
         builder.AllocateCodeChunk (inputPC, codeSize);
-        NibbleMapTestTarget target = CreateTarget(builder);
+        Target target = CreateTarget(builder);
 
         // TESTCASE:
 

--- a/src/native/managed/cdacreader/tests/ExecutionManager/RangeSectionMapTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/RangeSectionMapTests.cs
@@ -6,26 +6,17 @@ using Xunit;
 
 using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
-
 namespace Microsoft.Diagnostics.DataContractReader.UnitTests.ExecutionManager;
 
 public class RangeSectionMapTests
 {
-    internal class RSMTestTarget : TestPlaceholderTarget
-    {
-        public RSMTestTarget(MockTarget.Architecture arch, MockMemorySpace.ReadContext readContext)
-            : base (arch, readContext.ReadFromTarget)
-        {
-        }
-    }
-
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
     public void TestLookupFail(MockTarget.Architecture arch)
     {
         var builder = ExecutionManagerTestBuilder.CreateRangeSection(arch);
         builder.MarkCreated();
-        var target = new RSMTestTarget(arch, builder.GetReadContext());
+        var target = new TestPlaceholderTarget(arch, builder.GetReadContext().ReadFromTarget);
 
         var rsla = RangeSectionMap.Create(target);
 
@@ -44,7 +35,7 @@ public class RangeSectionMapTests
         var value = 0x0a0a_0a0au;
         builder.InsertAddressRange(inputPC, length, value);
         builder.MarkCreated();
-        var target = new RSMTestTarget(arch, builder.GetReadContext());
+        var target = new TestPlaceholderTarget(arch, builder.GetReadContext().ReadFromTarget);
 
         var rsla = RangeSectionMap.Create(target);
 
@@ -59,7 +50,7 @@ public class RangeSectionMapTests
     public void TestGetIndexForLevel(MockTarget.Architecture arch)
     {
         // Exhaustively test GetIndexForLevel for all possible values of the byte for each level
-        var target = new RSMTestTarget(arch, new MockMemorySpace.ReadContext());
+        var target = new TestPlaceholderTarget(arch, new MockMemorySpace.ReadContext().ReadFromTarget);
         var rsla = RangeSectionMap.Create(target);
         int numLevels = arch.Is64Bit ? 5 : 2;
         // the bits 0..effectiveRange - 1 are not handled the map and are irrelevant

--- a/src/native/managed/cdacreader/tests/ExecutionManager/RangeSectionMapTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/RangeSectionMapTests.cs
@@ -15,7 +15,6 @@ public class RangeSectionMapTests
     public void TestLookupFail(MockTarget.Architecture arch)
     {
         var builder = ExecutionManagerTestBuilder.CreateRangeSection(arch);
-        builder.MarkCreated();
         var target = new TestPlaceholderTarget(arch, builder.GetReadContext().ReadFromTarget);
 
         var rsla = RangeSectionMap.Create(target);
@@ -34,7 +33,6 @@ public class RangeSectionMapTests
         var length = 0x1000u;
         var value = 0x0a0a_0a0au;
         builder.InsertAddressRange(inputPC, length, value);
-        builder.MarkCreated();
         var target = new TestPlaceholderTarget(arch, builder.GetReadContext().ReadFromTarget);
 
         var rsla = RangeSectionMap.Create(target);

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.CodeVersions.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.CodeVersions.cs
@@ -90,8 +90,6 @@ internal partial class MockDescriptors
                 ]);
         }
 
-        public void MarkCreated() => Builder.MarkCreated();
-
         public TargetPointer AddMethodDescVersioningState(TargetPointer nativeCodeVersionNode, bool isDefaultVersionActive)
         {
             Target.TypeInfo info = Types[DataType.MethodDescVersioningState];

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.HashMap.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.HashMap.cs
@@ -35,13 +35,14 @@ internal partial class MockDescriptors
         internal Dictionary<DataType, Target.TypeInfo> Types { get; }
         internal (string Name, ulong Value)[] Globals { get; }
 
+        internal MockMemorySpace.Builder Builder { get; }
+
         private const ulong DefaultAllocationRangeStart = 0x0003_0000;
         private const ulong DefaultAllocationRangeEnd = 0x0004_0000;
 
         // See g_rgPrimes in hash.cpp
         private static readonly uint[] PossibleSizes = [5, 11, 17, 23, 29, 37];
 
-        private readonly MockMemorySpace.Builder _builder;
         private readonly MockMemorySpace.BumpAllocator _allocator;
 
         public HashMap(MockMemorySpace.Builder builder)
@@ -50,8 +51,8 @@ internal partial class MockDescriptors
 
         public HashMap(MockMemorySpace.Builder builder, (ulong Start, ulong End) allocationRange)
         {
-            _builder = builder;
-            _allocator = _builder.CreateAllocator(allocationRange.Start, allocationRange.End);
+            Builder = builder;
+            _allocator = Builder.CreateAllocator(allocationRange.Start, allocationRange.End);
             Types = GetTypes(builder.TargetTestHelpers);
             Globals = GetGlobals(builder.TargetTestHelpers);
         }
@@ -78,14 +79,14 @@ internal partial class MockDescriptors
         {
             Target.TypeInfo hashMapType = Types[DataType.HashMap];
             MockMemorySpace.HeapFragment map = _allocator.Allocate(hashMapType.Size!.Value, "HashMap");
-            _builder.AddHeapFragment(map);
+            Builder.AddHeapFragment(map);
             PopulateMap(map.Address, entries);
             return map.Address;
         }
 
         public void PopulateMap(TargetPointer mapAddress, (TargetPointer Key, TargetPointer Value)[] entries)
         {
-            TargetTestHelpers helpers = _builder.TargetTestHelpers;
+            TargetTestHelpers helpers = Builder.TargetTestHelpers;
 
             // HashMap::NewSize
             int requiredSlots = entries.Length * 3 / 2;
@@ -99,7 +100,7 @@ internal partial class MockDescriptors
             uint numBuckets = size + 1;
             uint totalBucketsSize = bucketSize * numBuckets;
             MockMemorySpace.HeapFragment buckets = _allocator.Allocate(totalBucketsSize, $"Buckets[{numBuckets}]");
-            _builder.AddHeapFragment(buckets);
+            Builder.AddHeapFragment(buckets);
             helpers.Write(buckets.Data.AsSpan().Slice(0, sizeof(uint)), size);
 
             const int maxRetry = 8;
@@ -124,7 +125,7 @@ internal partial class MockDescriptors
 
             // Update the map to point at the buckets
             Target.TypeInfo hashMapType = Types[DataType.HashMap];
-            Span<byte> map = _builder.BorrowAddressRange(mapAddress, (int)hashMapType.Size!.Value);
+            Span<byte> map = Builder.BorrowAddressRange(mapAddress, (int)hashMapType.Size!.Value);
             helpers.WritePointer(map.Slice(hashMapType.Fields[nameof(Data.HashMap.Buckets)].Offset, helpers.PointerSize), buckets.Address);
         }
 
@@ -148,7 +149,7 @@ internal partial class MockDescriptors
 
         private bool TryAddEntryToBucket(Span<byte> bucket, TargetPointer key, TargetPointer value)
         {
-            TargetTestHelpers helpers = _builder.TargetTestHelpers;
+            TargetTestHelpers helpers = Builder.TargetTestHelpers;
             Target.TypeInfo bucketType = Types[DataType.Bucket];
             for (int i = 0; i < HashMapSlotsPerBucket; i++)
             {

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.HashMap.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.HashMap.cs
@@ -71,7 +71,7 @@ internal partial class MockDescriptors
         {
             return [
                 (nameof(Constants.Globals.HashMapSlotsPerBucket), HashMapSlotsPerBucket),
-                (nameof(Constants.Globals.HashMapValueMask), helpers.PointerSize == 4 ? 0x7FFFFFFFu : 0x7FFFFFFFFFFFFFFFu),
+                (nameof(Constants.Globals.HashMapValueMask), helpers.MaxSignedTargetAddress),
             ];
         }
 

--- a/src/native/managed/cdacreader/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdacreader/tests/MockMemorySpace.cs
@@ -216,21 +216,12 @@ internal unsafe static partial class MockMemorySpace
             if (pointerData.Data.Length > 0)
                 AddHeapFragment(pointerData);
 
-            MarkCreated();
-            return descriptor.Address;
-        }
-
-        internal void MarkCreated()
-        {
-            if (_created)
-                throw new InvalidOperationException("Context already created");
             _created = true;
+            return descriptor.Address;
         }
 
         internal ReadContext GetReadContext()
         {
-            if (!_created)
-                throw new InvalidOperationException("Context not created");
             ReadContext context = new ReadContext
             {
                 HeapFragments = _heapFragments,

--- a/src/native/managed/cdacreader/tests/PrecodeStubsTests.cs
+++ b/src/native/managed/cdacreader/tests/PrecodeStubsTests.cs
@@ -290,10 +290,9 @@ public class PrecodeStubsTests
             return new PrecodeTestTarget(arch, reader, precodeBuilder.CodePointerFlags, precodeBuilder.MachineDescriptorAddress, typeInfo);
         }
         public PrecodeTestTarget(MockTarget.Architecture arch, ReadFromTargetDelegate reader, CodePointerFlags codePointerFlags, TargetPointer platformMetadataAddress, Dictionary<DataType, TypeInfo> typeInfoCache)
-            : base(arch, reader)
+            : base(arch, reader, typeInfoCache)
         {
             PrecodeMachineDescriptorAddress = platformMetadataAddress;
-            SetTypeInfoCache(typeInfoCache);
             IContractFactory<IPrecodeStubs> precodeFactory = new PrecodeStubsFactory();
 
             Mock<IPlatformMetadata> platformMetadata = new(MockBehavior.Strict);

--- a/src/native/managed/cdacreader/tests/PrecodeStubsTests.cs
+++ b/src/native/managed/cdacreader/tests/PrecodeStubsTests.cs
@@ -273,8 +273,6 @@ public class PrecodeStubsTests
             }
             return address;
         }
-
-        public void MarkCreated() => Builder.MarkCreated();
     }
 
     private static Target CreateTarget(PrecodeBuilder precodeBuilder)
@@ -283,7 +281,6 @@ public class PrecodeStubsTests
         TestPlaceholderTarget.ReadFromTargetDelegate reader = precodeBuilder.Builder.GetReadContext().ReadFromTarget;
         // hack for this test put the precode machine descriptor at the same address as the PlatformMetadata
         (string Name, ulong Value)[] globals = [(Constants.Globals.PlatformMetadata, precodeBuilder.MachineDescriptorAddress)];
-        precodeBuilder.MarkCreated();
         var target = new TestPlaceholderTarget(arch, reader, precodeBuilder.Types, globals);
 
         IContractFactory<IPrecodeStubs> precodeFactory = new PrecodeStubsFactory();

--- a/src/native/managed/cdacreader/tests/PrecodeStubsTests.cs
+++ b/src/native/managed/cdacreader/tests/PrecodeStubsTests.cs
@@ -180,7 +180,7 @@ public class PrecodeStubsTests
         public readonly MockMemorySpace.BumpAllocator PrecodeAllocator;
         public readonly MockMemorySpace.BumpAllocator StubDataPageAllocator;
 
-        internal Dictionary<DataType, Target.TypeInfo>? Types { get; }
+        internal Dictionary<DataType, Target.TypeInfo> Types { get; }
 
         public TargetPointer MachineDescriptorAddress;
         public CodePointerFlags CodePointerFlags {get; private set;}
@@ -190,16 +190,11 @@ public class PrecodeStubsTests
             Builder = builder;
             PrecodeAllocator = builder.CreateAllocator(allocationRange.PrecodeDescriptorStart, allocationRange.PrecodeDescriptorEnd);
             StubDataPageAllocator = builder.CreateAllocator(allocationRange.StubDataPageStart, allocationRange.StubDataPageEnd);
-            Types = typeInfoCache ?? CreateTypeInfoCache(Builder.TargetTestHelpers);
+            Types = typeInfoCache ?? GetTypes(Builder.TargetTestHelpers);
         }
 
-        public Dictionary<DataType, Target.TypeInfo> CreateTypeInfoCache(TargetTestHelpers targetTestHelpers) {
-            var typeInfo = new Dictionary<DataType, Target.TypeInfo>();
-            AddToTypeInfoCache(typeInfo, targetTestHelpers);
-            return typeInfo;
-        }
-
-        public void AddToTypeInfoCache(Dictionary<DataType, Target.TypeInfo> typeInfoCache, TargetTestHelpers targetTestHelpers) {
+        public Dictionary<DataType, Target.TypeInfo> GetTypes(TargetTestHelpers targetTestHelpers) {
+            Dictionary<DataType, Target.TypeInfo> types = new();
             var layout = targetTestHelpers.LayoutFields([
                 new(nameof(Data.PrecodeMachineDescriptor.StubCodePageSize), DataType.uint32),
                 new(nameof(Data.PrecodeMachineDescriptor.OffsetOfPrecodeType), DataType.uint8),
@@ -211,7 +206,7 @@ public class PrecodeStubsTests
                 new(nameof(Data.PrecodeMachineDescriptor.FixupPrecodeType), DataType.uint8),
                 new(nameof(Data.PrecodeMachineDescriptor.ThisPointerRetBufPrecodeType), DataType.uint8),
             ]);
-            typeInfoCache[DataType.PrecodeMachineDescriptor] = new Target.TypeInfo() {
+            types[DataType.PrecodeMachineDescriptor] = new Target.TypeInfo() {
                 Fields = layout.Fields,
                 Size = layout.Stride,
             };
@@ -219,10 +214,11 @@ public class PrecodeStubsTests
                 new(nameof(Data.StubPrecodeData.Type), DataType.uint8),
                 new(nameof(Data.StubPrecodeData.MethodDesc), DataType.pointer),
             ]);
-            typeInfoCache[DataType.StubPrecodeData] = new Target.TypeInfo() {
+            types[DataType.StubPrecodeData] = new Target.TypeInfo() {
                 Fields = layout.Fields,
                 Size = layout.Stride,
             };
+            return types;
         }
 
         private void SetCodePointerFlags(PrecodeTestDescriptor test)

--- a/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
+++ b/src/native/managed/cdacreader/tests/TargetTestHelpers.cs
@@ -19,6 +19,9 @@ internal unsafe class TargetTestHelpers
     }
 
     public int PointerSize => Arch.Is64Bit ? sizeof(ulong) : sizeof(uint);
+
+    public ulong MaxSignedTargetAddress => (ulong)(Arch.Is64Bit ? long.MaxValue : int.MaxValue);
+
     public int ContractDescriptorSize => ContractDescriptor.Size(Arch.Is64Bit);
 
 

--- a/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 /// </summary>
 internal class TestPlaceholderTarget : Target
 {
-    private protected ContractRegistry contractRegistry;
+    private ContractRegistry _contractRegistry;
     private readonly Target.IDataCache _dataCache;
     private readonly Dictionary<DataType, Target.TypeInfo> _typeInfoCache;
     private readonly (string Name, ulong Value)[] _globals;
@@ -28,7 +28,7 @@ internal class TestPlaceholderTarget : Target
     {
         IsLittleEndian = arch.IsLittleEndian;
         PointerSize = arch.Is64Bit ? 8 : 4;
-        contractRegistry = new TestRegistry();
+        _contractRegistry = new Mock<ContractRegistry>().Object;
         _dataCache = new DefaultDataCache(this);
         _typeInfoCache = types ?? [];
         _dataReader = reader;
@@ -37,7 +37,7 @@ internal class TestPlaceholderTarget : Target
 
     internal void SetContracts(ContractRegistry contracts)
     {
-        contractRegistry = contracts;
+        _contractRegistry = contracts;
     }
 
     public override int PointerSize { get; }
@@ -201,37 +201,7 @@ internal class TestPlaceholderTarget : Target
     }
 
     public override Target.IDataCache ProcessedData => _dataCache;
-    public override ContractRegistry Contracts => contractRegistry;
-
-    internal class TestRegistry : ContractRegistry
-    {
-        public TestRegistry() { }
-        internal Lazy<Contracts.IException>? ExceptionContract { get; set; }
-        internal Lazy<Contracts.ILoader>? LoaderContract { get; set; }
-        internal Lazy<Contracts.IEcmaMetadata>? EcmaMetadataContract { get; set; }
-        internal Lazy<Contracts.IObject>? ObjectContract { get; set; }
-        internal Lazy<Contracts.IThread>? ThreadContract { get; set; }
-        internal Lazy<Contracts.IRuntimeTypeSystem>? RuntimeTypeSystemContract { get; set; }
-        internal Lazy<Contracts.IDacStreams>? DacStreamsContract { get; set; }
-        internal Lazy<Contracts.IExecutionManager> ExecutionManagerContract { get; set; }
-        internal Lazy<Contracts.ICodeVersions>? CodeVersionsContract { get; set; }
-        internal Lazy<Contracts.IPlatformMetadata>? PlatformMetadataContract { get; set; }
-        internal Lazy<Contracts.IPrecodeStubs>? PrecodeStubsContract { get; set; }
-        internal Lazy<Contracts.IReJIT>? ReJITContract { get; set; }
-
-        public override Contracts.IException Exception => ExceptionContract.Value ?? throw new NotImplementedException();
-        public override Contracts.ILoader Loader => LoaderContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IEcmaMetadata EcmaMetadata => EcmaMetadataContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IObject Object => ObjectContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IThread Thread => ThreadContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IRuntimeTypeSystem RuntimeTypeSystem => RuntimeTypeSystemContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IDacStreams DacStreams => DacStreamsContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IExecutionManager ExecutionManager => ExecutionManagerContract.Value ?? throw new NotImplementedException();
-        public override Contracts.ICodeVersions CodeVersions => CodeVersionsContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IPlatformMetadata PlatformMetadata => PlatformMetadataContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IPrecodeStubs PrecodeStubs => PrecodeStubsContract.Value ?? throw new NotImplementedException();
-        public override Contracts.IReJIT ReJIT => ReJITContract.Value ?? throw new NotImplementedException();
-    }
+    public override ContractRegistry Contracts => _contractRegistry;
 
     // A data cache that stores data in a dictionary and calls IData.Create to construct the data.
     private class DefaultDataCache : Target.IDataCache

--- a/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
@@ -16,32 +16,31 @@ namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 internal class TestPlaceholderTarget : Target
 {
     private protected ContractRegistry contractRegistry;
-    private protected Target.IDataCache dataCache;
-    private protected Dictionary<DataType, Target.TypeInfo> typeInfoCache;
+    private readonly Target.IDataCache dataCache;
+    private readonly Dictionary<DataType, Target.TypeInfo> typeInfoCache;
 
     internal delegate int ReadFromTargetDelegate(ulong address, Span<byte> buffer);
 
-    protected ReadFromTargetDelegate _dataReader = (address, buffer) => throw new NotImplementedException();
+    private readonly ReadFromTargetDelegate _dataReader;
 
 #region Setup
     public TestPlaceholderTarget(MockTarget.Architecture arch, ReadFromTargetDelegate reader)
+        : this(arch, reader, [])
+    { }
+
+    public TestPlaceholderTarget(MockTarget.Architecture arch, ReadFromTargetDelegate reader, Dictionary<DataType, Target.TypeInfo> types)
     {
         IsLittleEndian = arch.IsLittleEndian;
         PointerSize = arch.Is64Bit ? 8 : 4;
         contractRegistry = new TestRegistry();
         dataCache = new DefaultDataCache(this);
-        typeInfoCache = null;
+        typeInfoCache = types;
         _dataReader = reader;
     }
 
     internal void SetContracts(ContractRegistry contracts)
     {
         contractRegistry = contracts;
-    }
-
-    internal void SetTypeInfoCache(Dictionary<DataType, Target.TypeInfo> cache)
-    {
-        typeInfoCache = cache;
     }
 
 #endregion Setup

--- a/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
@@ -24,7 +24,6 @@ internal class TestPlaceholderTarget : Target
 
     private readonly ReadFromTargetDelegate _dataReader;
 
-#region Setup
     public TestPlaceholderTarget(MockTarget.Architecture arch, ReadFromTargetDelegate reader, Dictionary<DataType, Target.TypeInfo> types = null, (string Name, ulong Value)[] globals = null)
     {
         IsLittleEndian = arch.IsLittleEndian;
@@ -40,8 +39,6 @@ internal class TestPlaceholderTarget : Target
     {
         contractRegistry = contracts;
     }
-
-#endregion Setup
 
     public override int PointerSize { get; }
     public override bool IsLittleEndian { get; }

--- a/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
@@ -11,7 +11,7 @@ using Moq;
 namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
 
 /// <summary>
-/// A base class implementation of Target that throws NotImplementedException for all methods.
+/// A mock implementation of Target that has basic implementations of getting types/globals and reading data
 /// </summary>
 internal class TestPlaceholderTarget : Target
 {


### PR DESCRIPTION
- Make `TestPlaceholderTarget` (mock target) constructor take type infos and global values
- Handle reading of global values in mock target implementation
- Use Moq for creating a `ContractRegistry` instead of our own explicit implementation
- Remove subclasses of `TestPlaceholderTarget`