### PR TITLE
Fix obtaining type handles of IDynamicInterfaceCastableImplementation

### DIFF
--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Diagnostics.CodeAnalysis;

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -60,6 +60,7 @@ public class Interfaces
         TestDefaultDynamicStaticNonGeneric.Run();
         TestDefaultDynamicStaticGeneric.Run();
         TestDynamicStaticGenericVirtualMethods.Run();
+        TestRuntime109496Regression.Run();
 
         return Pass;
     }
@@ -1888,6 +1889,59 @@ public class Interfaces
             Console.WriteLine(s_entry.Enter1<SimpleCallClass>("One"));
             //Console.WriteLine(s_entry.Enter1<SimpleCallGenericClass<object>>("One"));
             Console.WriteLine(s_entry.Enter1<SimpleCallStruct<object>>("One"));
+        }
+    }
+
+    class TestRuntime109496Regression
+    {
+        class CastableThing : IDynamicInterfaceCastable
+        {
+            RuntimeTypeHandle IDynamicInterfaceCastable.GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
+                => Type.GetTypeFromHandle(interfaceType).GetCustomAttribute<TypeAttribute>().TheType.TypeHandle;
+            bool IDynamicInterfaceCastable.IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
+                => Type.GetTypeFromHandle(interfaceType).IsDefined(typeof(TypeAttribute));
+        }
+
+        [Type(typeof(IMyInterfaceImpl))]
+        interface IMyInterface
+        {
+            int Method();
+        }
+
+        [DynamicInterfaceCastableImplementation]
+        interface IMyInterfaceImpl : IMyInterface
+        {
+            int IMyInterface.Method() => 42;
+        }
+
+        [Type(typeof(IMyGenericInterfaceImpl<int>))]
+        interface IMyGenericInterface
+        {
+            int Method();
+        }
+
+        [DynamicInterfaceCastableImplementation]
+        interface IMyGenericInterfaceImpl<T> : IMyGenericInterface
+        {
+            int IMyGenericInterface.Method() => typeof(T).Name.Length;
+        }
+
+        class TypeAttribute : Attribute
+        {
+            public Type TheType { get; }
+
+            public TypeAttribute(Type t) => TheType = t;
+        }
+
+        public static void Run()
+        {
+            object o = new CastableThing();
+
+            if (((IMyInterface)o).Method() != 42)
+                throw new Exception();
+
+            if (((IMyGenericInterface)o).Method() != 5)
+                throw new Exception();
         }
     }
 }


### PR DESCRIPTION
Fixes #109496.

We try to optimize away type handles (MethodTables) of types that are only needed due to metadata. Trying to grab type handle of such type throws. This fixes it by unconditionally generating type handles of IDynamicInterfaceCastableImplementation.

Cc @dotnet/ilc-contrib 