### PR TITLE
[wasm] Run downlevel tests only on main

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
@@ -67,9 +67,13 @@ public class NonWasmTemplateBuildTests : TestMainJsTestBase
         )
         .MultiplyWithSingleArgs
         (
-            "net6.0",
-            s_previousTargetFramework,
-            s_latestTargetFramework
+            EnvironmentVariables.WorkloadsTestPreviousVersions
+                ? [
+                    "net6.0",
+                    s_previousTargetFramework,
+                    s_latestTargetFramework
+                ]
+                : [s_latestTargetFramework]
         )
         .UnwrapItemsAsArrays().ToList();
 


### PR DESCRIPTION
Based on https://github.com/dotnet/runtime/pull/103118. Apparently the one test slipped through, but it should have the same limitation to run only latest TFM test on non-main branches.

Fixes https://github.com/dotnet/runtime/issues/109653
Fixes https://github.com/dotnet/runtime/issues/109627

Forwardport of https://github.com/dotnet/runtime/pull/109723