### PR TITLE
[release/8.0] [browser] Fix processing of satellite assemblies from referenced assembly during publish

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -207,7 +207,7 @@
     <!-- Use a unique property, so the already run wasm targets can also run -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="WasmNestedPublishApp"
-             Properties="_WasmInNestedPublish_UniqueProperty_XYZ=true;;WasmBuildingForNestedPublish=true;DeployOnBuild=;_IsPublishing=;_WasmIsPublishing=$(_IsPublishing)">
+             Properties="_WasmInNestedPublish_UniqueProperty_XYZ=true;;WasmBuildingForNestedPublish=true;DeployOnBuild=;_IsPublishing=;_WasmIsPublishing=$(_IsPublishing);ResolveAssemblyReferencesFindRelatedSatellites=true">
       <Output TaskParameter="TargetOutputs" ItemName="WasmNestedPublishAppResultItems" />
     </MSBuild>
 
@@ -503,6 +503,7 @@
   <Target Name="_AfterWasmBuildApp">
     <ItemGroup>
       <WasmAssembliesFinal Include="@(_WasmAssembliesInternal)" LlvmBitCodeFile="" />
+      <WasmAssembliesFinal Include="@(_WasmSatelliteAssemblies)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmBuildAssets.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmBuildAssets.cs
@@ -111,7 +111,12 @@ public class ComputeWasmBuildAssets : Task
                     assetCandidate.SetMetadata("AssetTraitName", "Culture");
                     assetCandidate.SetMetadata("AssetTraitValue", inferredCulture);
                     assetCandidate.SetMetadata("RelativePath", $"_framework/{inferredCulture}/{satelliteAssembly.GetMetadata("FileName")}{satelliteAssembly.GetMetadata("Extension")}");
-                    assetCandidate.SetMetadata("RelatedAsset", Path.GetFullPath(Path.Combine(OutputPath, "wwwroot", "_framework", Path.GetFileName(assetCandidate.GetMetadata("ResolvedFrom")))));
+
+                    var resolvedFrom = assetCandidate.GetMetadata("ResolvedFrom");
+                    if (resolvedFrom == "{RawFileName}") // Satellite assembly found from `<Reference />` element
+                        resolvedFrom = candidate.GetMetadata("OriginalItemSpec");
+
+                    assetCandidate.SetMetadata("RelatedAsset", Path.GetFullPath(Path.Combine(OutputPath, "wwwroot", "_framework", Path.GetFileName(resolvedFrom))));
 
                     assetCandidates.Add(assetCandidate);
                     continue;


### PR DESCRIPTION
Backport of #106696 to release/8.0
Fixes https://github.com/dotnet/runtime/issues/109604

## Customer Impact

- [x] Customer reported
- [ ] Found internally

This PR fixes publishing satellite assemblies in (Blazor) WebAssembly apps using .NET 9+ SDK.

## Regression

- [x] Yes
- [ ] No

Regression from https://github.com/dotnet/runtime/pull/90436. 

## Testing

This particular cross version scenario was tested manually, along with not affecting using the workload with .NET 8 SDK. Running automated tests for the cross version scenario is problematic because of how we version the runtime,  tracking in https://github.com/dotnet/runtime/issues/110049.

## Risk

Medium to low. Affected scenarios are covered with automatic tests. What we don't have covered with automatic tests is cross SDK and workload scenario.