### PR TITLE
Update TagName docs to include behavior if tag is not found

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/TagList.netcore.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/TagList.netcore.cs
@@ -266,6 +266,7 @@ namespace System.Diagnostics
         /// Searches for the specified tag and returns the zero-based index of the first occurrence within the entire <see cref="T:System.Diagnostics.TagList" />.
         /// </summary>
         /// <param name="item">The tag to locate in the <see cref="T:System.Diagnostics.TagList" />.</param>
+        /// <returns>The zero-based index of the first occurrence within the <see cref="T:System.Diagnostics.TagList" />, or -1 if there is no such tag.</returns>
         public readonly int IndexOf(KeyValuePair<string, object?> item)
         {
             ReadOnlySpan<KeyValuePair<string, object?>> tags =

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/TagList.netfx.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/TagList.netfx.cs
@@ -416,6 +416,7 @@ namespace System.Diagnostics
         /// Searches for the specified tag and returns the zero-based index of the first occurrence within the entire <see cref="T:System.Diagnostics.TagList" />.
         /// </summary>
         /// <param name="item">The tag to locate in the <see cref="T:System.Diagnostics.TagList" />.</param>
+        /// <returns>The zero-based index of the first occurrence within the <see cref="T:System.Diagnostics.TagList" />, or -1 if there is no such tag.</returns>
         public readonly int IndexOf(KeyValuePair<string, object?> item)
         {
             if (_overflowTags is not null)


### PR DESCRIPTION
Adds detail to the documentation of `TagName.IndexOf` to clarify that the method will return -1 if the specified tag was not found.

(No behavior change; this is a documentation change only.)