### PR TITLE
[cDAC] Set RejitFlags to use a known underlying type

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7284,11 +7284,11 @@ HRESULT DacDbiInterfaceImpl::GetActiveRejitILCodeVersionNode(VMPTR_Module vmModu
     // Be careful, there are two different definitions of 'active' being used here
     // For the CodeVersionManager, the active IL version is whatever one should be used in the next invocation of the method
     // 'rejit active' narrows that to only include rejit IL bodies where the profiler has already provided the definition
-    // for the new IL (ilCodeVersion.GetRejitState()==ILCodeVersion::RejitFlags::kStateActive). It is possible that the code version
+    // for the new IL (ilCodeVersion.GetRejitState()==RejitFlags::kStateActive). It is possible that the code version
     // manager's active IL version hasn't yet asked the profiler for the IL body to use, in which case we want to filter it
     //  out from the return in this method.
     ILCodeVersion activeILVersion = pCodeVersionManager->GetActiveILCodeVersion(pModule, methodTk);
-    if (activeILVersion.IsNull() || activeILVersion.IsDefaultVersion() || activeILVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive)
+    if (activeILVersion.IsNull() || activeILVersion.IsDefaultVersion() || activeILVersion.GetRejitState() != RejitFlags::kStateActive)
     {
         pVmILCodeVersionNode->SetDacTargetPtr(0);
     }

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7284,11 +7284,11 @@ HRESULT DacDbiInterfaceImpl::GetActiveRejitILCodeVersionNode(VMPTR_Module vmModu
     // Be careful, there are two different definitions of 'active' being used here
     // For the CodeVersionManager, the active IL version is whatever one should be used in the next invocation of the method
     // 'rejit active' narrows that to only include rejit IL bodies where the profiler has already provided the definition
-    // for the new IL (ilCodeVersion.GetRejitState()==ILCodeVersion::kStateActive). It is possible that the code version
+    // for the new IL (ilCodeVersion.GetRejitState()==ILCodeVersion::RejitFlags::kStateActive). It is possible that the code version
     // manager's active IL version hasn't yet asked the profiler for the IL body to use, in which case we want to filter it
     //  out from the return in this method.
     ILCodeVersion activeILVersion = pCodeVersionManager->GetActiveILCodeVersion(pModule, methodTk);
-    if (activeILVersion.IsNull() || activeILVersion.IsDefaultVersion() || activeILVersion.GetRejitState() != ILCodeVersion::kStateActive)
+    if (activeILVersion.IsNull() || activeILVersion.IsDefaultVersion() || activeILVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive)
     {
         pVmILCodeVersionNode->SetDacTargetPtr(0);
     }
@@ -7390,7 +7390,7 @@ HRESULT DacDbiInterfaceImpl::GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode vm
     DD_ENTER_MAY_THROW;
 #ifdef FEATURE_REJIT
     ILCodeVersion ilCode(vmILCodeVersionNode.GetDacPtr());
-    pData->m_state = ilCode.GetRejitState();
+    pData->m_state = static_cast<DWORD>(ilCode.GetRejitState());
     pData->m_pbIL = PTR_TO_CORDB_ADDRESS(dac_cast<TADDR>(ilCode.GetIL()));
     pData->m_dwCodegenFlags = ilCode.GetJitFlags();
     const InstrumentedILOffsetMapping* pMapping = ilCode.GetInstrumentedILMap();

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -921,11 +921,11 @@ void CopyNativeCodeVersionToReJitData(NativeCodeVersion nativeCodeVersion, Nativ
             pReJitData->flags = DacpReJitData::kUnknown;
             break;
 
-        case ILCodeVersion::kStateRequested:
+        case ILCodeVersion::RejitFlags::kStateRequested:
             pReJitData->flags = DacpReJitData::kRequested;
             break;
 
-        case ILCodeVersion::kStateActive:
+        case ILCodeVersion::RejitFlags::kStateActive:
             pReJitData->flags = DacpReJitData::kActive;
             break;
         }
@@ -4618,7 +4618,7 @@ HRESULT ClrDataAccess::GetPendingReJITID(CLRDATA_ADDRESS methodDesc, int *pRejit
     {
         hr = E_INVALIDARG;
     }
-    else if (ilVersion.GetRejitState() == ILCodeVersion::kStateRequested)
+    else if (ilVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateRequested)
     {
         *pRejitId = (int)ilVersion.GetVersionId();
     }
@@ -4661,11 +4661,11 @@ HRESULT ClrDataAccess::GetReJITInformation(CLRDATA_ADDRESS methodDesc, int rejit
             pReJitData->flags = DacpReJitData2::kUnknown;
             break;
 
-        case ILCodeVersion::kStateRequested:
+        case ILCodeVersion::RejitFlags::kStateRequested:
             pReJitData->flags = DacpReJitData2::kRequested;
             break;
 
-        case ILCodeVersion::kStateActive:
+        case ILCodeVersion::RejitFlags::kStateActive:
             pReJitData->flags = DacpReJitData2::kActive;
             break;
         }
@@ -4698,7 +4698,7 @@ HRESULT ClrDataAccess::GetProfilerModifiedILInformation(CLRDATA_ADDRESS methodDe
     CodeVersionManager* pCodeVersionManager = pMD->GetCodeVersionManager();
     CodeVersionManager::LockHolder codeVersioningLockHolder;
     ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pMD);
-    if (ilVersion.GetRejitState() != ILCodeVersion::kStateActive || !ilVersion.HasDefaultIL())
+    if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
     {
         pILData->type = DacpProfilerILData::ReJITModified;
         pILData->rejitID = static_cast<ULONG>(pCodeVersionManager->GetActiveILCodeVersion(pMD).GetVersionId());
@@ -4748,7 +4748,7 @@ HRESULT ClrDataAccess::GetMethodsWithProfilerModifiedIL(CLRDATA_ADDRESS mod, CLR
 
                 TADDR pDynamicIL = pModule->GetDynamicIL(pMD->GetMemberDef());
                 ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pMD);
-                if (ilVersion.GetRejitState() != ILCodeVersion::kStateActive || !ilVersion.HasDefaultIL() || pDynamicIL != (TADDR)NULL)
+                if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL() || pDynamicIL != (TADDR)NULL)
                 {
                     methodDescs[*pcMethodDescs] = PTR_CDADDR(pMD);
                     ++(*pcMethodDescs);

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -921,11 +921,11 @@ void CopyNativeCodeVersionToReJitData(NativeCodeVersion nativeCodeVersion, Nativ
             pReJitData->flags = DacpReJitData::kUnknown;
             break;
 
-        case ILCodeVersion::RejitFlags::kStateRequested:
+        case RejitFlags::kStateRequested:
             pReJitData->flags = DacpReJitData::kRequested;
             break;
 
-        case ILCodeVersion::RejitFlags::kStateActive:
+        case RejitFlags::kStateActive:
             pReJitData->flags = DacpReJitData::kActive;
             break;
         }
@@ -4618,7 +4618,7 @@ HRESULT ClrDataAccess::GetPendingReJITID(CLRDATA_ADDRESS methodDesc, int *pRejit
     {
         hr = E_INVALIDARG;
     }
-    else if (ilVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateRequested)
+    else if (ilVersion.GetRejitState() == RejitFlags::kStateRequested)
     {
         *pRejitId = (int)ilVersion.GetVersionId();
     }
@@ -4661,11 +4661,11 @@ HRESULT ClrDataAccess::GetReJITInformation(CLRDATA_ADDRESS methodDesc, int rejit
             pReJitData->flags = DacpReJitData2::kUnknown;
             break;
 
-        case ILCodeVersion::RejitFlags::kStateRequested:
+        case RejitFlags::kStateRequested:
             pReJitData->flags = DacpReJitData2::kRequested;
             break;
 
-        case ILCodeVersion::RejitFlags::kStateActive:
+        case RejitFlags::kStateActive:
             pReJitData->flags = DacpReJitData2::kActive;
             break;
         }
@@ -4698,7 +4698,7 @@ HRESULT ClrDataAccess::GetProfilerModifiedILInformation(CLRDATA_ADDRESS methodDe
     CodeVersionManager* pCodeVersionManager = pMD->GetCodeVersionManager();
     CodeVersionManager::LockHolder codeVersioningLockHolder;
     ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pMD);
-    if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
+    if (ilVersion.GetRejitState() != RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
     {
         pILData->type = DacpProfilerILData::ReJITModified;
         pILData->rejitID = static_cast<ULONG>(pCodeVersionManager->GetActiveILCodeVersion(pMD).GetVersionId());
@@ -4748,7 +4748,7 @@ HRESULT ClrDataAccess::GetMethodsWithProfilerModifiedIL(CLRDATA_ADDRESS mod, CLR
 
                 TADDR pDynamicIL = pModule->GetDynamicIL(pMD->GetMemberDef());
                 ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pMD);
-                if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL() || pDynamicIL != (TADDR)NULL)
+                if (ilVersion.GetRejitState() != RejitFlags::kStateActive || !ilVersion.HasDefaultIL() || pDynamicIL != (TADDR)NULL)
                 {
                     methodDescs[*pcMethodDescs] = PTR_CDADDR(pMD);
                     ++(*pcMethodDescs);

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12251,7 +12251,7 @@ HRESULT Debugger::DeoptimizeMethodHelper(Module* pModule, mdMethodDef methodDef)
         // call back in to anything so set it all here to match the original IL and debug codegen flags
         ilCodeVersion.SetIL(ILCodeVersion(pModule, methodDef).GetIL());
         ilCodeVersion.SetJitFlags(COR_PRF_CODEGEN_DISABLE_ALL_OPTIMIZATIONS | COR_PRF_CODEGEN_DEBUG_INFO);
-        ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateActive);
+        ilCodeVersion.SetRejitState(RejitFlags::kStateActive);
         ilCodeVersion.SetEnableReJITCallback(false);
     }
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12251,7 +12251,7 @@ HRESULT Debugger::DeoptimizeMethodHelper(Module* pModule, mdMethodDef methodDef)
         // call back in to anything so set it all here to match the original IL and debug codegen flags
         ilCodeVersion.SetIL(ILCodeVersion(pModule, methodDef).GetIL());
         ilCodeVersion.SetJitFlags(COR_PRF_CODEGEN_DISABLE_ALL_OPTIMIZATIONS | COR_PRF_CODEGEN_DEBUG_INFO);
-        ilCodeVersion.SetRejitState(ILCodeVersion::kStateActive);
+        ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateActive);
         ilCodeVersion.SetEnableReJITCallback(false);
     }
 

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1058,7 +1058,7 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
     {
         // Did the current rejit provide a map?
         const InstrumentedILOffsetMapping *pReJitMap = NULL;
-        if (ilVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive)
+        if (ilVersion.GetRejitState() == RejitFlags::kStateActive)
         {
             pReJitMap = ilVersion.GetInstrumentedILMap();
         }

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1058,7 +1058,7 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
     {
         // Did the current rejit provide a map?
         const InstrumentedILOffsetMapping *pReJitMap = NULL;
-        if (ilVersion.GetRejitState() == ILCodeVersion::kStateActive)
+        if (ilVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive)
         {
             pReJitMap = ilVersion.GetInstrumentedILMap();
         }

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -549,7 +549,7 @@ ILCodeVersionNode::ILCodeVersionNode() :
     m_methodDef(0),
     m_rejitId(0),
     m_pNextILVersionNode(dac_cast<PTR_ILCodeVersionNode>(nullptr)),
-    m_rejitState(ILCodeVersion::RejitFlags::kStateRequested),
+    m_rejitState(RejitFlags::kStateRequested),
     m_pIL(),
     m_jitFlags(0),
     m_deoptimized(FALSE)
@@ -563,7 +563,7 @@ ILCodeVersionNode::ILCodeVersionNode(Module* pModule, mdMethodDef methodDef, ReJ
     m_methodDef(methodDef),
     m_rejitId(id),
     m_pNextILVersionNode(dac_cast<PTR_ILCodeVersionNode>(nullptr)),
-    m_rejitState(ILCodeVersion::RejitFlags::kStateRequested),
+    m_rejitState(RejitFlags::kStateRequested),
     m_pIL(nullptr),
     m_jitFlags(0),
     m_deoptimized(isDeoptimized)
@@ -588,17 +588,17 @@ ReJITID ILCodeVersionNode::GetVersionId() const
     return m_rejitId;
 }
 
-ILCodeVersion::RejitFlags ILCodeVersionNode::GetRejitState() const
+RejitFlags ILCodeVersionNode::GetRejitState() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
-    return m_rejitState.Load() & ILCodeVersion::RejitFlags::kStateMask;
+    return m_rejitState.Load() & RejitFlags::kStateMask;
 }
 
 BOOL ILCodeVersionNode::GetEnableReJITCallback() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    return (m_rejitState.Load() & ILCodeVersion::RejitFlags::kSuppressParams) == ILCodeVersion::RejitFlags::kSuppressParams;
+    return (m_rejitState.Load() & RejitFlags::kSuppressParams) == RejitFlags::kSuppressParams;
 }
 
 PTR_COR_ILMETHOD ILCodeVersionNode::GetIL() const
@@ -632,14 +632,14 @@ BOOL ILCodeVersionNode::IsDeoptimized() const
 }
 
 #ifndef DACCESS_COMPILE
-void ILCodeVersionNode::SetRejitState(ILCodeVersion::RejitFlags newState)
+void ILCodeVersionNode::SetRejitState(RejitFlags newState)
 {
     LIMITED_METHOD_CONTRACT;
     // We're doing a non thread safe modification to m_rejitState
     _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
 
-    ILCodeVersion::RejitFlags oldNonMaskFlags = m_rejitState.Load() & ~ILCodeVersion::RejitFlags::kStateMask;
-    m_rejitState.Store(static_cast<ILCodeVersion::RejitFlags>(newState | oldNonMaskFlags));
+    RejitFlags oldNonMaskFlags = m_rejitState.Load() & ~RejitFlags::kStateMask;
+    m_rejitState.Store(static_cast<RejitFlags>(newState | oldNonMaskFlags));
 }
 
 void ILCodeVersionNode::SetEnableReJITCallback(BOOL state)
@@ -648,14 +648,14 @@ void ILCodeVersionNode::SetEnableReJITCallback(BOOL state)
     // We're doing a non thread safe modification to m_rejitState
     _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
 
-    ILCodeVersion::RejitFlags oldFlags = m_rejitState.Load();
+    RejitFlags oldFlags = m_rejitState.Load();
     if (state)
     {
-        m_rejitState.Store(oldFlags | ILCodeVersion::RejitFlags::kSuppressParams);
+        m_rejitState.Store(oldFlags | RejitFlags::kSuppressParams);
     }
     else
     {
-        m_rejitState.Store(oldFlags & ~ILCodeVersion::RejitFlags::kSuppressParams);
+        m_rejitState.Store(oldFlags & ~RejitFlags::kSuppressParams);
     }
 }
 
@@ -849,7 +849,7 @@ bool ILCodeVersion::HasAnyOptimizedNativeCodeVersion(NativeCodeVersion tier0Nati
 }
 #endif
 
-ILCodeVersion::RejitFlags ILCodeVersion::GetRejitState() const
+RejitFlags ILCodeVersion::GetRejitState() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
     if (m_storageKind == StorageKind::Explicit)
@@ -858,7 +858,7 @@ ILCodeVersion::RejitFlags ILCodeVersion::GetRejitState() const
     }
     else
     {
-        return ILCodeVersion::RejitFlags::kStateActive;
+        return RejitFlags::kStateActive;
     }
 }
 

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -184,7 +184,7 @@ public:
     HRESULT SetActiveNativeCodeVersion(NativeCodeVersion activeNativeCodeVersion);
 #endif //DACCESS_COMPILE
 
-    enum RejitFlags
+    enum class RejitFlags : uint32_t
     {
         // The profiler has requested a ReJit, so we've allocated stuff, but we haven't
         // called back to the profiler to get any info or indicate that the ReJit has
@@ -208,7 +208,9 @@ public:
         // Indicates that the method being ReJITted is an inliner of the actual
         // ReJIT request and we should not issue the GetReJITParameters for this
         // method.
-        kSuppressParams = 0x80000000
+        kSuppressParams = 0x80000000,
+
+        support_use_as_flags // Enable the template functions in enum_class_flags.h
     };
 
     RejitFlags GetRejitState() const;

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -145,7 +145,34 @@ private:
 
 #ifdef FEATURE_CODE_VERSIONING
 
+enum class RejitFlags : uint32_t
+{
+    // The profiler has requested a ReJit, so we've allocated stuff, but we haven't
+    // called back to the profiler to get any info or indicate that the ReJit has
+    // started. (This Info can be 'reused' for a new ReJit if the
+    // profiler calls RequestRejit again before we transition to the next state.)
+    kStateRequested = 0x00000000,
 
+    // The CLR has initiated the call to the profiler's GetReJITParameters() callback
+    // but it hasn't completed yet. At this point we have to assume the profiler has
+    // committed to a specific IL body, even if the CLR doesn't know what it is yet.
+    // If the profiler calls RequestRejit we need to allocate a new ILCodeVersion
+    // and call GetReJITParameters() again.
+    kStateGettingReJITParameters = 0x00000001,
+
+    // We have asked the profiler about this method via ICorProfilerFunctionControl,
+    // and have thus stored the IL and codegen flags the profiler specified.
+    kStateActive = 0x00000002,
+
+    kStateMask = 0x0000000F,
+
+    // Indicates that the method being ReJITted is an inliner of the actual
+    // ReJIT request and we should not issue the GetReJITParameters for this
+    // method.
+    kSuppressParams = 0x80000000,
+
+    support_use_as_flags // Enable the template functions in enum_class_flags.h
+};
 
 class ILCodeVersion
 {
@@ -183,35 +210,6 @@ public:
     HRESULT GetOrCreateActiveNativeCodeVersion(MethodDesc* pClosedMethodDesc, NativeCodeVersion* pNativeCodeVersion);
     HRESULT SetActiveNativeCodeVersion(NativeCodeVersion activeNativeCodeVersion);
 #endif //DACCESS_COMPILE
-
-    enum class RejitFlags : uint32_t
-    {
-        // The profiler has requested a ReJit, so we've allocated stuff, but we haven't
-        // called back to the profiler to get any info or indicate that the ReJit has
-        // started. (This Info can be 'reused' for a new ReJit if the
-        // profiler calls RequestRejit again before we transition to the next state.)
-        kStateRequested = 0x00000000,
-
-        // The CLR has initiated the call to the profiler's GetReJITParameters() callback
-        // but it hasn't completed yet. At this point we have to assume the profiler has
-        // committed to a specific IL body, even if the CLR doesn't know what it is yet.
-        // If the profiler calls RequestRejit we need to allocate a new ILCodeVersion
-        // and call GetReJITParameters() again.
-        kStateGettingReJITParameters = 0x00000001,
-
-        // We have asked the profiler about this method via ICorProfilerFunctionControl,
-        // and have thus stored the IL and codegen flags the profiler specified.
-        kStateActive = 0x00000002,
-
-        kStateMask = 0x0000000F,
-
-        // Indicates that the method being ReJITted is an inliner of the actual
-        // ReJIT request and we should not issue the GetReJITParameters for this
-        // method.
-        kSuppressParams = 0x80000000,
-
-        support_use_as_flags // Enable the template functions in enum_class_flags.h
-    };
 
     RejitFlags GetRejitState() const;
     BOOL GetEnableReJITCallback() const;
@@ -390,7 +388,7 @@ public:
     PTR_COR_ILMETHOD GetIL() const;
     DWORD GetJitFlags() const;
     const InstrumentedILOffsetMapping* GetInstrumentedILMap() const;
-    ILCodeVersion::RejitFlags GetRejitState() const;
+    RejitFlags GetRejitState() const;
     BOOL GetEnableReJITCallback() const;
     PTR_ILCodeVersionNode GetNextILVersionNode() const;
     BOOL IsDeoptimized() const;
@@ -398,7 +396,7 @@ public:
     void SetIL(COR_ILMETHOD* pIL);
     void SetJitFlags(DWORD flags);
     void SetInstrumentedILMap(SIZE_T cMap, COR_IL_MAP * rgMap);
-    void SetRejitState(ILCodeVersion::RejitFlags newState);
+    void SetRejitState(RejitFlags newState);
     void SetEnableReJITCallback(BOOL state);
     void SetNextILVersionNode(ILCodeVersionNode* pNextVersionNode);
 #endif
@@ -408,7 +406,7 @@ private:
     const mdMethodDef m_methodDef;
     const ReJITID m_rejitId;
     PTR_ILCodeVersionNode m_pNextILVersionNode; // Never modified after being added to the linked list
-    Volatile<ILCodeVersion::RejitFlags> m_rejitState;
+    Volatile<RejitFlags> m_rejitState;
     VolatilePtr<COR_ILMETHOD, PTR_COR_ILMETHOD> m_pIL;
     Volatile<DWORD> m_jitFlags;
     InstrumentedILOffsetMapping m_instrumentedILMap;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7928,7 +7928,7 @@ CorInfoInline CEEInfo::canInline (CORINFO_METHOD_HANDLE hCaller,
             CodeVersionManager* pCodeVersionManager = pCallee->GetCodeVersionManager();
             CodeVersionManager::LockHolder codeVersioningLockHolder;
             ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pCallee);
-            if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
+            if (ilVersion.GetRejitState() != RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
             {
                 result = INLINE_FAIL;
                 szFailReason = "ReJIT methods cannot be inlined.";
@@ -8131,7 +8131,7 @@ void CEEInfo::reportInliningDecision (CORINFO_METHOD_HANDLE inlinerHnd,
                 CodeVersionManager* pCodeVersionManager = pCallee->GetCodeVersionManager();
                 CodeVersionManager::LockHolder codeVersioningLockHolder;
                 ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pCallee);
-                if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
+                if (ilVersion.GetRejitState() != RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
                 {
                     shouldCallReJIT = TRUE;
                     modId = reinterpret_cast<ModuleID>(pCaller->GetModule());

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7928,7 +7928,7 @@ CorInfoInline CEEInfo::canInline (CORINFO_METHOD_HANDLE hCaller,
             CodeVersionManager* pCodeVersionManager = pCallee->GetCodeVersionManager();
             CodeVersionManager::LockHolder codeVersioningLockHolder;
             ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pCallee);
-            if (ilVersion.GetRejitState() != ILCodeVersion::kStateActive || !ilVersion.HasDefaultIL())
+            if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
             {
                 result = INLINE_FAIL;
                 szFailReason = "ReJIT methods cannot be inlined.";
@@ -8131,7 +8131,7 @@ void CEEInfo::reportInliningDecision (CORINFO_METHOD_HANDLE inlinerHnd,
                 CodeVersionManager* pCodeVersionManager = pCallee->GetCodeVersionManager();
                 CodeVersionManager::LockHolder codeVersioningLockHolder;
                 ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(pCallee);
-                if (ilVersion.GetRejitState() != ILCodeVersion::kStateActive || !ilVersion.HasDefaultIL())
+                if (ilVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive || !ilVersion.HasDefaultIL())
                 {
                     shouldCallReJIT = TRUE;
                     modId = reinterpret_cast<ModuleID>(pCaller->GetModule());

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2113,11 +2113,11 @@ HRESULT VersionedPrepareCodeConfig::FinishConfiguration()
     // Any code build stages that do just in time configuration should
     // be configured now
 #ifdef FEATURE_REJIT
-    if (m_ilCodeVersion.GetRejitState() != ILCodeVersion::kStateActive)
+    if (m_ilCodeVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive)
     {
         ReJitManager::ConfigureILCodeVersion(m_ilCodeVersion);
     }
-    _ASSERTE(m_ilCodeVersion.GetRejitState() == ILCodeVersion::kStateActive);
+    _ASSERTE(m_ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive);
 #endif
 
     return S_OK;

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2113,11 +2113,11 @@ HRESULT VersionedPrepareCodeConfig::FinishConfiguration()
     // Any code build stages that do just in time configuration should
     // be configured now
 #ifdef FEATURE_REJIT
-    if (m_ilCodeVersion.GetRejitState() != ILCodeVersion::RejitFlags::kStateActive)
+    if (m_ilCodeVersion.GetRejitState() != RejitFlags::kStateActive)
     {
         ReJitManager::ConfigureILCodeVersion(m_ilCodeVersion);
     }
-    _ASSERTE(m_ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive);
+    _ASSERTE(m_ilCodeVersion.GetRejitState() == RejitFlags::kStateActive);
 #endif
 
     return S_OK;

--- a/src/coreclr/vm/rejit.cpp
+++ b/src/coreclr/vm/rejit.cpp
@@ -874,7 +874,7 @@ HRESULT ReJitManager::BindILVersion(
     ILCodeVersion ilCodeVersion = pCodeVersionManager->GetActiveILCodeVersion(pModule, methodDef);
     BOOL fDoCallback = (flags & COR_PRF_REJIT_INLINING_CALLBACKS) == COR_PRF_REJIT_INLINING_CALLBACKS;
 
-    if (ilCodeVersion.GetRejitState() == ILCodeVersion::kStateRequested)
+    if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateRequested)
     {
         // We can 'reuse' this instance because the profiler doesn't know about
         // it yet. (This likely happened because a profiler called RequestReJIT
@@ -965,12 +965,12 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
         CodeVersionManager::LockHolder codeVersioningLockHolder;
         switch (ilCodeVersion.GetRejitState())
         {
-        case ILCodeVersion::kStateRequested:
-            ilCodeVersion.SetRejitState(ILCodeVersion::kStateGettingReJITParameters);
+        case ILCodeVersion::RejitFlags::kStateRequested:
+            ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateGettingReJITParameters);
             fNeedsParameters = TRUE;
             break;
 
-        case ILCodeVersion::kStateGettingReJITParameters:
+        case ILCodeVersion::RejitFlags::kStateGettingReJITParameters:
             fWaitForParameters = TRUE;
             break;
 
@@ -1026,9 +1026,9 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
                 // This code path also happens if the GetReJITParameters callback was suppressed due to
                 // the method being ReJITted as an inliner by the runtime (instead of by the user).
                 CodeVersionManager::LockHolder codeVersioningLockHolder;
-                if (ilCodeVersion.GetRejitState() == ILCodeVersion::kStateGettingReJITParameters)
+                if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateGettingReJITParameters)
                 {
-                    ilCodeVersion.SetRejitState(ILCodeVersion::kStateActive);
+                    ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateActive);
                     ilCodeVersion.SetIL(ILCodeVersion(pModule, methodDef).GetIL());
                 }
             }
@@ -1045,7 +1045,7 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
             _ASSERTE(pFuncControl != NULL);
 
             CodeVersionManager::LockHolder codeVersioningLockHolder;
-            if (ilCodeVersion.GetRejitState() == ILCodeVersion::kStateGettingReJITParameters)
+            if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateGettingReJITParameters)
             {
                 // Inside the above call to ICorProfilerCallback4::GetReJITParameters, the profiler
                 // will have used the specified pFuncControl to provide its IL and codegen flags.
@@ -1055,7 +1055,7 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
                 // ilCodeVersion is now the owner of the memory for the IL buffer
                 ilCodeVersion.SetInstrumentedILMap(pFuncControl->GetInstrumentedMapEntryCount(),
                     pFuncControl->GetInstrumentedMapEntries());
-                ilCodeVersion.SetRejitState(ILCodeVersion::kStateActive);
+                ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateActive);
             }
         }
     }
@@ -1086,7 +1086,7 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
         {
             {
                 CodeVersionManager::LockHolder codeVersioningLockHolder;
-                if (ilCodeVersion.GetRejitState() == ILCodeVersion::kStateActive)
+                if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive)
                 {
                     break; // the other thread got the parameters successfully, go race to rejit
                 }
@@ -1188,7 +1188,7 @@ HRESULT ReJitManager::GetReJITIDs(PTR_MethodDesc pMD, ULONG cReJitIds, ULONG * p
     {
         ILCodeVersion curILVersion = *iter;
 
-        if (curILVersion.GetRejitState() == ILCodeVersion::kStateActive)
+        if (curILVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive)
         {
             if (cnt < cReJitIds)
             {

--- a/src/coreclr/vm/rejit.cpp
+++ b/src/coreclr/vm/rejit.cpp
@@ -874,7 +874,7 @@ HRESULT ReJitManager::BindILVersion(
     ILCodeVersion ilCodeVersion = pCodeVersionManager->GetActiveILCodeVersion(pModule, methodDef);
     BOOL fDoCallback = (flags & COR_PRF_REJIT_INLINING_CALLBACKS) == COR_PRF_REJIT_INLINING_CALLBACKS;
 
-    if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateRequested)
+    if (ilCodeVersion.GetRejitState() == RejitFlags::kStateRequested)
     {
         // We can 'reuse' this instance because the profiler doesn't know about
         // it yet. (This likely happened because a profiler called RequestReJIT
@@ -965,12 +965,12 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
         CodeVersionManager::LockHolder codeVersioningLockHolder;
         switch (ilCodeVersion.GetRejitState())
         {
-        case ILCodeVersion::RejitFlags::kStateRequested:
-            ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateGettingReJITParameters);
+        case RejitFlags::kStateRequested:
+            ilCodeVersion.SetRejitState(RejitFlags::kStateGettingReJITParameters);
             fNeedsParameters = TRUE;
             break;
 
-        case ILCodeVersion::RejitFlags::kStateGettingReJITParameters:
+        case RejitFlags::kStateGettingReJITParameters:
             fWaitForParameters = TRUE;
             break;
 
@@ -1026,9 +1026,9 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
                 // This code path also happens if the GetReJITParameters callback was suppressed due to
                 // the method being ReJITted as an inliner by the runtime (instead of by the user).
                 CodeVersionManager::LockHolder codeVersioningLockHolder;
-                if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateGettingReJITParameters)
+                if (ilCodeVersion.GetRejitState() == RejitFlags::kStateGettingReJITParameters)
                 {
-                    ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateActive);
+                    ilCodeVersion.SetRejitState(RejitFlags::kStateActive);
                     ilCodeVersion.SetIL(ILCodeVersion(pModule, methodDef).GetIL());
                 }
             }
@@ -1045,7 +1045,7 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
             _ASSERTE(pFuncControl != NULL);
 
             CodeVersionManager::LockHolder codeVersioningLockHolder;
-            if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateGettingReJITParameters)
+            if (ilCodeVersion.GetRejitState() == RejitFlags::kStateGettingReJITParameters)
             {
                 // Inside the above call to ICorProfilerCallback4::GetReJITParameters, the profiler
                 // will have used the specified pFuncControl to provide its IL and codegen flags.
@@ -1055,7 +1055,7 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
                 // ilCodeVersion is now the owner of the memory for the IL buffer
                 ilCodeVersion.SetInstrumentedILMap(pFuncControl->GetInstrumentedMapEntryCount(),
                     pFuncControl->GetInstrumentedMapEntries());
-                ilCodeVersion.SetRejitState(ILCodeVersion::RejitFlags::kStateActive);
+                ilCodeVersion.SetRejitState(RejitFlags::kStateActive);
             }
         }
     }
@@ -1086,7 +1086,7 @@ HRESULT ReJitManager::ConfigureILCodeVersion(ILCodeVersion ilCodeVersion)
         {
             {
                 CodeVersionManager::LockHolder codeVersioningLockHolder;
-                if (ilCodeVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive)
+                if (ilCodeVersion.GetRejitState() == RejitFlags::kStateActive)
                 {
                     break; // the other thread got the parameters successfully, go race to rejit
                 }
@@ -1188,7 +1188,7 @@ HRESULT ReJitManager::GetReJITIDs(PTR_MethodDesc pMD, ULONG cReJitIds, ULONG * p
     {
         ILCodeVersion curILVersion = *iter;
 
-        if (curILVersion.GetRejitState() == ILCodeVersion::RejitFlags::kStateActive)
+        if (curILVersion.GetRejitState() == RejitFlags::kStateActive)
         {
             if (cnt < cReJitIds)
             {


### PR DESCRIPTION
The previous implementation using an `enum` should be the size of a `uint32_t` but it isn't explicitly defined. To make the size of `RejitFlags` more clear, changing it to an `enum class` with an explicit `uint32_t` backing.

Will be used #109936 by the cDAC `GetMethodDescData` to fetch `ReJIT` information. 
