### PR TITLE
Fix transformer handling of boolean schemas in JsonSchemaExporter.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -26,8 +26,8 @@ namespace System.Text.Json.Schema
         internal const string MinLengthPropertyName = "minLength";
         internal const string MaxLengthPropertyName = "maxLength";
 
-        public static JsonSchema False => new(false);
-        public static JsonSchema True => new(true);
+        public static JsonSchema CreateFalseSchema() => new(false);
+        public static JsonSchema CreateTrueSchema() => new(true);
 
         public JsonSchema() { }
         private JsonSchema(bool trueOrFalse) { _trueOrFalse = trueOrFalse; }
@@ -279,7 +279,7 @@ namespace System.Text.Json.Schema
             switch (schema._trueOrFalse)
             {
                 case false:
-                    schema = new JsonSchema { Not = True };
+                    schema = new JsonSchema { Not = CreateTrueSchema() };
                     break;
                 case true:
                     schema = new JsonSchema();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -26,8 +26,8 @@ namespace System.Text.Json.Schema
         internal const string MinLengthPropertyName = "minLength";
         internal const string MaxLengthPropertyName = "maxLength";
 
-        public static JsonSchema False { get; } = new(false);
-        public static JsonSchema True { get; } = new(true);
+        public static JsonSchema False => new(false);
+        public static JsonSchema True => new(true);
 
         public JsonSchema() { }
         private JsonSchema(bool trueOrFalse) { _trueOrFalse = trueOrFalse; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -211,7 +211,7 @@ namespace System.Text.Json.Schema
                     JsonUnmappedMemberHandling effectiveUnmappedMemberHandling = typeInfo.UnmappedMemberHandling ?? typeInfo.Options.UnmappedMemberHandling;
                     if (effectiveUnmappedMemberHandling is JsonUnmappedMemberHandling.Disallow)
                     {
-                        additionalProperties = JsonSchema.False;
+                        additionalProperties = JsonSchema.CreateFalseSchema();
                     }
 
                     if (typeDiscriminator is { } typeDiscriminatorPair)
@@ -350,7 +350,7 @@ namespace System.Text.Json.Schema
                 default:
                     Debug.Assert(typeInfo.Kind is JsonTypeInfoKind.None);
                     // Return a `true` schema for types with user-defined converters.
-                    return CompleteSchema(ref state, JsonSchema.True);
+                    return CompleteSchema(ref state, JsonSchema.CreateTrueSchema());
             }
 
             JsonSchema CompleteSchema(ref GenerationState state, JsonSchema schema)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
@@ -80,6 +80,6 @@ namespace System.Text.Json.Serialization.Converters
             return node;
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchema();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
@@ -31,6 +31,6 @@ namespace System.Text.Json.Serialization.Converters
             return JsonValue.CreateFromElement(ref element, options.GetNodeOptions());
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchema();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -147,6 +147,6 @@ namespace System.Text.Json.Serialization.Converters
             return true;
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchema();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonDocumentConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonDocumentConverter.cs
@@ -26,6 +26,6 @@ namespace System.Text.Json.Serialization.Converters
             value.WriteTo(writer);
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchema();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonElementConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonElementConverter.cs
@@ -18,6 +18,6 @@ namespace System.Text.Json.Serialization.Converters
             value.WriteTo(writer);
         }
 
-        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.True;
+        internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchema();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverter.cs
@@ -21,6 +21,6 @@ namespace System.Text.Json.Serialization.Converters
             throw new NotSupportedException(ErrorMessage);
 
         internal override JsonSchema? GetSchema(JsonNumberHandling _) =>
-            new JsonSchema { Comment = "Unsupported .NET type", Not = JsonSchema.True };
+            new JsonSchema { Comment = "Unsupported .NET type", Not = JsonSchema.CreateTrueSchema() };
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
@@ -110,6 +110,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ClassWithComponentModelAttributes))]
         [JsonSerializable(typeof(ClassWithJsonPointerEscapablePropertyNames))]
         [JsonSerializable(typeof(ClassWithOptionalObjectParameter))]
+        [JsonSerializable(typeof(ClassWithPropertiesUsingCustomConverters))]
         // Collection types
         [JsonSerializable(typeof(int[]))]
         [JsonSerializable(typeof(List<bool>))]


### PR DESCRIPTION
The `JsonSchemaExporter` implementation uses singletons to represent boolean schema nodes, however this approach does not account for the possibility of a transformer context registering itself to the singleton. Should be backported to 9.

Fix #109868.