### PR TITLE
Use explicit full-path for loading MsQuic.dll on Windows

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -89,8 +89,23 @@ internal sealed unsafe partial class MsQuicApi
 
         if (OperatingSystem.IsWindows())
         {
-            // Windows ships msquic in the assembly directory.
-            loaded = NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
+#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
+            // Windows ships msquic in the assembly directory next to System.Net.Quic, so load that.
+            // For single-file deployments, the assembly location is an empty string so we fall back
+            // to AppContext.BaseDirectory which is the directory containing the single-file executable.
+            string path = typeof(MsQuicApi).Assembly.Location is string assemblyLocation && !string.IsNullOrEmpty(assemblyLocation)
+                ? System.IO.Path.GetDirectoryName(assemblyLocation)!
+                : AppContext.BaseDirectory;
+#pragma warning restore IL3000
+
+            path = System.IO.Path.Combine(path, Interop.Libraries.MsQuic);
+
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(null, $"Attempting to load MsQuic from {path}");
+            }
+
+            loaded = NativeLibrary.TryLoad(path, typeof(MsQuicApi).Assembly, DllImportSearchPath.LegacyBehavior, out msQuicHandle);
         }
         else
         {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -70,6 +70,8 @@ internal sealed unsafe partial class MsQuicApi
     internal static bool Tls13ClientMayBeDisabled { get; }
 
 #pragma warning disable CA1810 // Initialize all static fields in 'MsQuicApi' when those fields are declared and remove the explicit static constructor
+    [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
+        Justification = "The code handles the Assembly.Location being null/empty by falling back to AppContext.BaseDirectory")]
     static MsQuicApi()
     {
         bool loaded = false;


### PR DESCRIPTION
This PR explicitly composes the path from which MsQuic.dll is attempted to be loaded. It also logs the path to enable better diagnostics.