### PR TITLE
[release/8.0] Suppress IL3000 in MsQuicApi constructor

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -65,6 +65,8 @@ internal sealed unsafe partial class MsQuicApi
     internal static bool Tls13ClientMayBeDisabled { get; }
 
 #pragma warning disable CA1810 // Initialize all static fields in 'MsQuicApi' when those fields are declared and remove the explicit static constructor
+    [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
+        Justification = "The code handles the Assembly.Location being null/empty by falling back to AppContext.BaseDirectory")]
     static MsQuicApi()
     {
         bool loaded = false;


### PR DESCRIPTION
A call to `Assembly.Location` was added in a recent fix. It has `IL30000` suppressed via `#pragma warning disable`, but that only applies to the compilation of the library itself. Consumers will hit it when doing something like publishing their app as NativeAOT.

This change adds an `[UnconditionalSuppressMessage]` to the `MsQuicApi` static constructor such that `IL30000` should also be suppressed for apps consuming the runtime.

## Customer Impact

Customers are seeing a warning when NativeAoT compiling applications relying on HttpClient. Many customers also use option to treat warning as errors and thus are unable to build their applications without suppressing the warning.

Available workarounds are either
- revert to previous release
- suppress the warning (and remember to unsuppress it once fix is released)
- update to .NET 9.0 (may not be possible, some customers need to stay on LTS release versions)

## Regression

- [x] Yes
- [ ] No

Regression against previous release. The same issue has discovered for 9.0 GA release and fixed before final build was created. However, the fix was not backported to 8.0.

## Testing

The same change is present as part of 9.0 builds where the regression does not reproduce.

## Risk

Low, no functional change, the issue pointed to by the warning is already correctly handled at runtime.