### PR TITLE
threads.h: Fix up grammar/spelling in vm/threads.h

### DIFF
--- a/docs/design/coreclr/botr/readytorun-overview.md
+++ b/docs/design/coreclr/botr/readytorun-overview.md
@@ -117,7 +117,7 @@ To allow changes in the runtime, we simply require that the new runtime handle a
 
 ### Restrictions on Runtime Evolution
 
-As mentioned previously, when designing for version compatibility we have the choice of either simply disallowing a change (by changing the breaking change rules), or insuring that the format is sufficiently flexible to allow evolution. For example, for managed code we have opted to disallow changes to value type (struct) layout so that codegen for structs can be efficient. In addition, the design also includes a small number of restrictions that affect the flexibility of evolving the runtime itself. They are:
+As mentioned previously, when designing for version compatibility we have the choice of either simply disallowing a change (by changing the breaking change rules), or ensuring that the format is sufficiently flexible to allow evolution. For example, for managed code we have opted to disallow changes to value type (struct) layout so that codegen for structs can be efficient. In addition, the design also includes a small number of restrictions that affect the flexibility of evolving the runtime itself. They are:
 
 - The field layout of `System.Object` cannot change. (First, there is a pointer sized field for type information and then the other fields.)
 - The field layout of arrays cannot change. (First, there is a pointer sized field for type information, and then a pointer sized field for the length. After these fields is the array data, packed using existing alignment rules.)

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -610,7 +610,7 @@ void DebuggerRCThread::ThreadProc(void)
     // This message actually serves a purpose (which is why it is always run)
     // The Stress log is run during hijacking, when other threads can be suspended
     // at arbitrary locations (including when holding a lock that NT uses to serialize
-    // all memory allocations).  By sending a message now, we insure that the stress
+    // all memory allocations).  By sending a message now, we ensure that the stress
     // log will not allocate memory at these critical times an avoid deadlock.
     {
         SUPPRESS_ALLOCATION_ASSERTS_IN_THIS_SCOPE;

--- a/src/coreclr/dlls/mscorpe/pewriter.cpp
+++ b/src/coreclr/dlls/mscorpe/pewriter.cpp
@@ -1185,7 +1185,7 @@ HRESULT PEWriter::link() {
     // NOTE:
     // link() can be called more than once!  This is because at least one compiler
     // (the prejitter) needs to know the base addresses of some segments before it
-    // builds others. It's up to the caller to insure the layout remains the same
+    // builds others. It's up to the caller to ensure the layout remains the same
     // after changes are made, though.
     //
 

--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -328,7 +328,7 @@ BOOL Assembler::AddMethod(Method *pMethod)
     unsigned codeSize = m_CurPC;
     unsigned codeSizeAligned = codeSize;
     if (moreSections)
-        codeSizeAligned = (codeSizeAligned + 3) & ~3;    // to insure EH section aligned
+        codeSizeAligned = (codeSizeAligned + 3) & ~3;    // to ensure EH section aligned
 
     unsigned headerSize = COR_ILMETHOD::Size(&fatHeader, moreSections);
     unsigned ehSize     = COR_ILMETHOD_SECT_EH::Size(pMethod->m_dwNumExceptions, pMethod->m_ExceptionList);

--- a/src/coreclr/inc/ceegen.h
+++ b/src/coreclr/inc/ceegen.h
@@ -275,7 +275,7 @@ class CCeeGen : public ICeeGenInternal {
     // Write the metadata in "emitter" to the default metadata section is "section" is 0
     // If 'section != 0, it will put the data in 'buffer'.  This
     // buffer is assumed to be in 'section' at 'offset' and of size 'buffLen'
-    // (should use GetSaveSize to insure that buffer is big enough
+    // (should use GetSaveSize to ensure that buffer is big enough
     virtual HRESULT emitMetaData(IMetaDataEmit *emitter,
                         CeeSection* section=0, DWORD offset=0, BYTE* buffer=0, unsigned buffLen=0);
     virtual HRESULT getMethodRVA(ULONG codeOffset, ULONG *codeRVA);

--- a/src/coreclr/inc/cordebug.idl
+++ b/src/coreclr/inc/cordebug.idl
@@ -5180,7 +5180,7 @@ interface ICorDebugNativeFrame : ICorDebugFrame
      * coherent state.  (Note that even if the frame is in a valid
      * state as far as the runtime is concerned, there still may be
      * problems - e.g. uninitialized local variables, etc.  The caller
-     * (or perhaps the user) is responsible for insuring coherency of
+     * (or perhaps the user) is responsible for ensuring coherency of
      * the running program.)
      *
      * Calling SetIP immediately invalidates all frames and chains for the

--- a/src/coreclr/inc/iceefilegen.h
+++ b/src/coreclr/inc/iceefilegen.h
@@ -149,7 +149,7 @@ class ICeeFileGen {
     // Emit the metadata from "emitter".
     // If 'section != 0, it will put the data in 'buffer'.  This
     // buffer is assumed to be in 'section' at 'offset' and of size 'buffLen'
-    // (should use GetSaveSize to insure that buffer is big enough
+    // (should use GetSaveSize to ensure that buffer is big enough
     virtual HRESULT EmitMetaDataAt (HCEEFILE ceeFile, IMetaDataEmit *emitter,
                                     HCEESECTION section, DWORD offset,
                                     BYTE* buffer, unsigned buffLen);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4963,7 +4963,7 @@ void CodeGen::genFinalizeFrame()
 
     // We currently only expect to push/pop consecutive FP registers
     // and these have to be double-sized registers as well.
-    // Here we will insure that maskPushRegsFloat obeys these requirements.
+    // Here we will ensure that maskPushRegsFloat obeys these requirements.
     //
     if (maskPushRegsFloat != RBM_NONE)
     {

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -750,7 +750,7 @@ void CodeGen::inst_RV_SH(
 #elif defined(TARGET_XARCH)
 
 #ifdef TARGET_AMD64
-    // X64 JB BE insures only encodable values make it here.
+    // X64 JB BE ensures only encodable values make it here.
     // x86 can encode 8 bits, though it masks down to 5 or 6
     // depending on 32-bit or 64-bit registers are used.
     // Here we will allow anything that is encodable.

--- a/src/coreclr/pal/tests/palsuite/common/palsuite.cpp
+++ b/src/coreclr/pal/tests/palsuite/common/palsuite.cpp
@@ -154,7 +154,7 @@ mkAbsoluteFilenameW (
     sizeFN = wcslen( fileName );
     sizeAPN = (sizeDN + 1 + sizeFN + 1);
 
-    /* insure ((dirName + DELIM + fileName + \0) =< _MAX_PATH ) */
+    /* ensure ((dirName + DELIM + fileName + \0) =< _MAX_PATH ) */
     if ( sizeAPN > _MAX_PATH )
     {
 	return ( 0 );
@@ -195,7 +195,7 @@ mkAbsoluteFilenameA (
     sizeFN = strlen( fileName );
     sizeAPN = (sizeDN + 1 + sizeFN + 1);
     
-    /* insure ((dirName + DELIM + fileName + \0) =< _MAX_PATH ) */
+    /* ensure ((dirName + DELIM + fileName + \0) =< _MAX_PATH ) */
     if ( sizeAPN > _MAX_PATH )
     {
         return ( 0 );

--- a/src/coreclr/pal/tests/palsuite/threading/CreateSemaphoreW_ReleaseSemaphore/test3/createsemaphore.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/CreateSemaphoreW_ReleaseSemaphore/test3/createsemaphore.cpp
@@ -6,7 +6,7 @@
 ** Source: createsemaphorew_releasesemaphore/test3/createsemaphore.c
 **
 ** Purpose: Test attributes of CreateSemaphoreExW and ReleaseSemaphore.
-** Insure for CreateSemaphore that lInitialCount and lMaximumCount
+** Ensure for CreateSemaphore that lInitialCount and lMaximumCount
 ** constraints are respected.  Validate that CreateSemaphore rejects
 ** conditions where initial count and / or maximum count are negative
 ** and conditions where the initial count is greater than the maximum

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -389,9 +389,9 @@ void StressLog::Terminate(BOOL fProcessDetach) {
         lockh.Acquire(); lockh.Release();       // The Enter() Leave() forces a memory barrier on weak memory model systems
                                 // we want all the other threads to notice that facilitiesToLog is now zero
 
-                // This is not strictly threadsafe, since there is no way of insuring when all the
+                // This is not strictly threadsafe, since there is no way of ensuring when all the
                 // threads are out of logMsg.  In practice, since they can no longer enter logMsg
-                // and there are no blocking operations in logMsg, simply sleeping will insure
+                // and there are no blocking operations in logMsg, simply sleeping will ensure
                 // that everyone gets out.
         ClrSleepEx(2, FALSE);
         lockh.Acquire();

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -253,7 +253,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
 
         ULONG size = (ULONG) ((rangeEnd - rangeStart) / 128) + 1;
 
-        // To insure the test the growing logic in debug code make the size much smaller.
+        // To ensure the test the growing logic in debug code make the size much smaller.
         INDEBUG(size = size / 4 + 1);
         unwindInfo = (PTR_UnwindInfoTable)new UnwindInfoTable(rangeStart, rangeEnd, size);
         unwindInfo->Register();
@@ -433,7 +433,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
 {
     STANDARD_VM_CONTRACT;
     {
-        // CodeHeapIterator holds the m_CodeHeapCritSec, which insures code heaps don't get deallocated while being walked
+        // CodeHeapIterator holds the m_CodeHeapCritSec, which ensures code heaps don't get deallocated while being walked
         EEJitManager::CodeHeapIterator heapIterator(NULL);
 
         // Currently m_CodeHeapCritSec is given the CRST_UNSAFE_ANYMODE flag which allows it to be taken in a GC_NOTRIGGER
@@ -4957,7 +4957,7 @@ void ExecutionManager::Unload(LoaderAllocator *pLoaderAllocator)
 // (This is also true on ARM64, but it not true for x86)
 //
 // For these architectures, in JITed code and in the prestub, we encode direct calls
-// using the preferred call instruction and we also try to insure that the Jitted
+// using the preferred call instruction and we also try to ensure that the Jitted
 // code is within the 32-bit pc-rel range of clr.dll to allow direct JIT helper calls.
 //
 // When the call target is too far away to encode using the preferred call instruction.

--- a/src/coreclr/vm/comdynamic.cpp
+++ b/src/coreclr/vm/comdynamic.cpp
@@ -347,7 +347,7 @@ extern "C" void QCALLTYPE TypeBuilder_SetMethodIL(QCall::ModuleHandle pModule,
 
     unsigned codeSizeAligned     = fatHeader.GetCodeSize();
     if (moreSections)
-        codeSizeAligned = AlignUp(codeSizeAligned, 4); // to insure EH section aligned
+        codeSizeAligned = AlignUp(codeSizeAligned, 4); // to ensure EH section aligned
     unsigned headerSize          = COR_ILMETHOD::Size(&fatHeader, numExceptions != 0);
 
     //Create the exception handlers.

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2696,7 +2696,7 @@ extern "C"
         } CONTRACTL_END;
 
         // Mark that we are the special ETWRundown thread.  Currently all this does
-        // is insure that AVs thrown in this thread are treated as normal exceptions.
+        // is ensure that AVs thrown in this thread are treated as normal exceptions.
         // This allows us to catch and swallow them.   We can do this because we have
         // a reasonably strong belief that doing ETW Rundown does not change runtime state
         // and thus if an AV happens it is better to simply give up logging ETW and

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -12,11 +12,11 @@
 
 // It is illegal to cause a GC or EH to happen in an FCALL before setting
 // up a frame.  To prevent accidentally violating this rule, FCALLs turn
-// on BEGINGCFORBID, which insures that these things can't happen in a
+// on BEGINGCFORBID, which ensures that these things can't happen in a
 // checked build without causing an ASSERTE.  Once you set up a frame,
 // this state is turned off as long as the frame is active, and then is
 // turned on again when the frame is torn down.   This mechanism should
-// be sufficient to insure that the rules are followed.
+// be sufficient to ensure that the rules are followed.
 
 // In general you set up a frame by using the following macros
 
@@ -596,7 +596,7 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
             /* gcpoll; */
 
 // The while(__helperframe.RestoreState() needs a bit of explanation.
-// The issue is insuring that the same machine state (which registers saved)
+// The issue is ensuring that the same machine state (which registers saved)
 // exists when the machine state is probed (when the frame is created, and
 // when it is actually used (when the frame is popped.  We do this by creating
 // a flow of control from use to def.  Note that 'RestoreState' always returns false
@@ -910,7 +910,7 @@ void HCallAssert(void*& cache, void* target);
 // the helper routine to the end of the FCALL using trivial heurisitics.   The easiest (and only supported)
 // way of doing this is to place your helper right before a return (eg at the end of the method).  Generally
 // this is not a problem at all, since the FCALL itself will pick off some common case and then tail-call to
-// the helper for everything else.  You must use the code:FC_INNER_RETURN macros to do the call, to insure
+// the helper for everything else.  You must use the code:FC_INNER_RETURN macros to do the call, to ensure
 // that the C++ compiler does not tail-call optimize the call to the inner function and mess up the stack
 // depth.
 //

--- a/src/coreclr/vm/gccover.cpp
+++ b/src/coreclr/vm/gccover.cpp
@@ -697,7 +697,7 @@ void DoGcStress (PCONTEXT regs, NativeCodeVersion nativeCodeVersion)
             }
             else {
                 // We have been in this routine before.  Give up on epilog checking because
-                // it is hard to insure that the saved caller register state is correct
+                // it is hard to ensure that the saved caller register state is correct
                 // This also has the effect of only doing the checking once per routine
                 // (Even if there are multiple epilogs)
                 gcCover->doingEpilogChecks = false;

--- a/src/coreclr/vm/i386/gmsx86.cpp
+++ b/src/coreclr/vm/i386/gmsx86.cpp
@@ -26,10 +26,10 @@
 
       if (machState.setMachState != 0) return;
 
-   setMachState is guarnenteed to return 0 (so the return
+   setMachState is guaranteed to return 0 (so the return
    statement will never be executed), but the expression above
-   insures insures that there is a 'quick' path to epilog
-   of the function.  This insures that setMachState will only
+   ensures that there is a 'quick' path to epilog
+   of the function.  This ensures that setMachState will only
    have to parse a limited number of X86 instructions.   */
 
 
@@ -47,7 +47,7 @@
 #if !defined(DACCESS_COMPILE)
 
 #ifdef _MSC_VER
-#pragma optimize("gsy", on )        // optimize to insure that code generation does not have junk in it
+#pragma optimize("gsy", on )        // optimize to ensure that code generation does not have junk in it
 #endif // _MSC_VER
 #pragma warning(disable:4717)
 

--- a/src/coreclr/vm/i386/jitinterfacex86.cpp
+++ b/src/coreclr/vm/i386/jitinterfacex86.cpp
@@ -44,7 +44,7 @@ public:
         MP_ALLOCATOR = 0x1,
         SIZE_IN_EAX  = 0x2,
         OBJ_ARRAY    = 0x4,
-        ALIGN8       = 0x8,     // insert a dummy object to insure 8 byte alignment (until the next GC)
+        ALIGN8       = 0x8,     // insert a dummy object to ensure 8 byte alignment (until the next GC)
         ALIGN8OBJ    = 0x10,
     };
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12920,7 +12920,7 @@ BOOL g_fAllowRel32 = TRUE;
 // The reason that this is named UnsafeJitFunction is that this helper
 // method is not thread safe!  When multiple threads get in here for
 // the same pMD, ALL of them MUST return the SAME value.
-// To insure that this happens you must call MakeJitWorker.
+// To ensure that this happens you must call MakeJitWorker.
 // It creates a DeadlockAware list of methods being jitted and prevents us
 // from trying to jit the same method more that once.
 //

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -134,7 +134,7 @@ class MethodDataCache
     UINT32 m_iLastTouched;
 
 #ifdef HOST_64BIT
-    UINT32 pad;      // insures that we are a multiple of 8-bytes
+    UINT32 pad;      // ensures that we are a multiple of 8-bytes
 #endif
 };  // class MethodDataCache
 

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -1101,7 +1101,7 @@ FORCEINLINE DWORD MethodTable::GetOffsetOfOptionalMember(OptionalMemberId id)
     if (id == OptionalMember_##NAME) { \
         return offset; \
     } \
-    C_ASSERT(sizeof(TYPE) % sizeof(UINT_PTR) == 0); /* To insure proper alignment */ \
+    C_ASSERT(sizeof(TYPE) % sizeof(UINT_PTR) == 0); /* To ensure proper alignment */ \
     if (Has##NAME()) { \
         offset += sizeof(TYPE); \
     }

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -1547,7 +1547,7 @@ uint32_t StackTraceArray::CopyDataFrom(StackTraceArray const & src)
 
 #ifdef _DEBUG
 //===============================================================================
-// Code that insures that our unmanaged version of Nullable is consistant with
+// Code that ensures that our unmanaged version of Nullable is consistant with
 // the managed version Nullable<T> for all T.
 
 void Nullable::CheckFieldOffsets(TypeHandle nullableType)
@@ -1564,7 +1564,7 @@ void Nullable::CheckFieldOffsets(TypeHandle nullableType)
 
     MethodTable* nullableMT = nullableType.GetMethodTable();
 
-        // insure that the managed version of the table is the same as the
+        // ensure that the managed version of the table is the same as the
         // unmanaged.  Note that we can't do this in corelib.h because this
         // class is generic and field layout depends on the instantiation.
 

--- a/src/coreclr/vm/stackingallocator.h
+++ b/src/coreclr/vm/stackingallocator.h
@@ -38,7 +38,7 @@
     {
         StackBlock     *m_Next;         // Next oldest block in list
         DWORD_PTR   m_Length;       // Length of block excluding header  (needs to be pointer-sized for alignment on IA64)
-        INDEBUG(Sentinel*   m_Sentinel;)    // insure that we don't fall of the end of the buffer
+        INDEBUG(Sentinel*   m_Sentinel;)    // ensure that we don't fall of the end of the buffer
         INDEBUG(void**      m_Pad;)    		// keep the size a multiple of 8
         char *GetData() { return (char *)(this + 1);}
     };

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1529,7 +1529,7 @@ void Thread::InitThread()
         // This message actually serves a purpose (which is why it is always run)
         // The Stress log is run during hijacking, when other threads can be suspended
         // at arbitrary locations (including when holding a lock that NT uses to serialize
-        // all memory allocations).  By sending a message now, we insure that the stress
+        // all memory allocations).  By sending a message now, we ensure that the stress
         // log will not allocate memory at these critical times an avoid deadlock.
     STRESS_LOG2(LF_ALWAYS, LL_ALWAYS, "SetupThread  managed Thread %p Thread Id = %x\n", this, GetThreadId());
 
@@ -5998,7 +5998,7 @@ BOOL Thread::UniqueStack(void* stackStart)
     size_t stackTrace[UniqueStackDepth+1] = {0};
 
         // stackTraceHash represents a hash of entire stack at the time we make the call,
-        // We insure at least GC per unique stackTrace.  What information is contained in
+        // We ensure at least GC per unique stackTrace.  What information is contained in
         // 'stackTrace' is somewhat arbitrary.  We choose it to mean all functions live
         // on the stack up to the first jitted function.
 
@@ -6017,7 +6017,7 @@ BOOL Thread::UniqueStack(void* stackStart)
         if (pFrame == 0 || pFrame == (Frame*) -1)
             break;
 
-        pFrame->GetFunction();      // This insures that helper frames are inited
+        pFrame->GetFunction();      // This ensures that helper frames are inited
 
         if (pFrame->GetReturnAddress() != 0)
         {

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -22,16 +22,16 @@
 // in the GC heap, causing data corruption. This is a 'GC Hole', and is very bad. We have special modes (see
 // code:EEConfig.GetGCStressLevel) called GCStress to help find such issues.
 //
-// In order to find all GC references on the stacks we need insure that no thread is manipulating a GC
-// reference at the time of the scan. This is the job of code:Thread.SuspendRuntime. Logically it suspends
-// every thread in the process. Unfortunately it can not literally simply call the OS SuspendThread API on
-// all threads. The reason is that the other threads MIGHT hold important locks (for example there is a lock
-// that is taken when unmanaged heap memory is requested, or when a DLL is loaded). In general process
+// In order to find all GC references on the stacks, we need to ensure that no thread is manipulating a GC
+// reference at the time of the scan. This is the job of code:Thread.SuspendRuntime. Logically, it suspends
+// every thread in the process. Unfortunately, it can not literally simply call the OS SuspendThread API on
+// all threads. The reason is that the other threads MIGHT hold important locks (for example, there is a lock
+// that is taken when unmanaged heap memory is requested, or when a DLL is loaded). In general, process
 // global structures in the OS will be protected by locks, and if you suspend a thread it might hold that
-// lock. If you happen to need that OS service (eg you might need to allocated unmanaged memory), then
+// lock. If you happen to need that OS service (eg you might need to allocate unmanaged memory), then
 // deadlock will occur (as you wait on the suspended thread, that never wakes up).
 //
-// Luckily, we don't need to actually suspend the threads, we just need to insure that all GC references on
+// Luckily, we don't need to actually suspend the threads, we just need to ensure that all GC references on
 // the stack are stable. This is where the concept of cooperative mode and preemptive mode (a bad name) come
 // from.
 //
@@ -40,14 +40,14 @@
 // The runtime keeps a table of all threads that have ever run managed code in the code:ThreadStore table.
 // The ThreadStore table holds a list of Thread objects (see code:#ThreadClass). This object holds all
 // information about managed threads. Cooperative mode is defined as the mode the thread is in when the field
-// code:Thread.m_fPreemptiveGCDisabled is non-zero. When this field is zero the thread is said to be in
+// code:Thread.m_fPreemptiveGCDisabled is non-zero. When this field is zero, the thread is said to be in
 // Preemptive mode (named because if you preempt the thread in this mode, it is guaranteed to be in a place
 // where a GC can occur).
 //
 // When a thread is in cooperative mode, it is basically saying that it is potentially modifying GC
 // references, and so the runtime must Cooperate with it to get to a 'GC Safe' location where the GC
 // references can be enumerated. This is the mode that a thread is in MOST times when it is running managed
-// code (in fact if the EIP is in JIT compiled code, there is only one place where you are NOT in cooperative
+// code (in fact, if the EIP is in JIT compiled code, there is only one place where you are NOT in cooperative
 // mode (Inlined PINVOKE transition code)). Conversely, any time non-runtime unmanaged code is running, the
 // thread MUST NOT be in cooperative mode (you risk deadlock otherwise). Only code in mscorwks.dll might be
 // running in either cooperative or preemptive mode.
@@ -55,7 +55,7 @@
 // It is easier to describe the invariant associated with being in Preemptive mode. When the thread is in
 // preemptive mode (when code:Thread.m_fPreemptiveGCDisabled is zero), the thread guarantees two things
 //
-//     * That it not currently running code that manipulates GC references.
+//     * That it is not currently running code that manipulates GC references.
 //     * That it has set the code:Thread.m_pFrame pointer in the code:Thread to be a subclass of the class
 //         code:Frame which marks the location on the stack where the last managed method frame is. This
 //         allows the GC to start crawling the stack from there (essentially skip over the unmanaged frames).
@@ -70,8 +70,8 @@
 // the deadlock problem mentioned earlier, because threads that are running unmanaged code are allowed to
 // run. Enumeration of GC references starts at the first managed frame (pointed at by code:Thread.m_pFrame).
 //
-// When a thread is in cooperative mode, it means that GC references might be being manipulated. There are
-// two important possibilities
+// When a thread is in cooperative mode, it means that GC references might be in the process of being
+// manipulated. There are two important possibilities
 //
 //     * The CPU is running JIT compiled code
 //     * The CPU is running code elsewhere (which should only be in mscorwks.dll, because everywhere else a
@@ -87,23 +87,23 @@
 // what is called FullyInterruptible, then we have information for any possible instruction pointer in the
 // method and we can simply stop the thread (however we have to do this carefully TODO explain).
 //
-// However for most methods, we only keep GC information for paticular EIP's, in particular we keep track of
-// GC reference liveness only at call sites. Thus not every location is 'GC Safe' (that is we can enumerate
+// However for most methods, we only keep GC information for particular EIPs, in particular we keep track of
+// GC reference liveness only at call sites. Thus, not every location is 'GC Safe' (that is, we can enumerate
 // all references, but must be 'driven' to a GC safe location).
 //
 // We drive threads to GC safe locations by hijacking. This is a term for updating the return address on the
 // stack so that we gain control when a method returns. If we find that we are in JITTed code but NOT at a GC
-// safe location, then we find the return address for the method and modfiy it to cause the runtime to stop.
+// safe location, then we find the return address for the method and modify it to cause the runtime to stop.
 // We then let the method run. Hopefully the method quickly returns, and hits our hijack, and we are now at a
-// GC-safe location (all call sites are GC-safe). If not we repeat the procedure (possibly moving the
-// hijack). At some point a method returns, and we get control. For methods that have loops that don't make
-// calls, we are forced to make the method FullyInterruptible, so we can be sure to stop the mehod.
+// GC-safe location (all call sites are GC-safe). If not, we repeat the procedure (possibly moving the
+// hijack). At some point, a method returns, and we get control. For methods that have loops that don't make
+// calls, we are forced to make the method FullyInterruptible, so we can be sure to stop the method.
 //
 // This leaves only the case where we are in cooperative modes, but not in JIT compiled code (we should be in
-// clr.dll). In this case we simply let the thread run. The idea is that code in clr.dll makes the
+// clr.dll). In this case, we simply let the thread run. The idea is that code in clr.dll makes the
 // promise that it will not do ANYTHING that will block (which includes taking a lock), while in cooperative
-// mode, or do anything that might take a long time without polling to see if a GC is needed. Thus this code
-// 'cooperates' to insure that GCs can happen in a timely fashion.
+// mode, or do anything that might take a long time without polling to see if a GC is needed. Thus, this code
+// 'cooperates' to ensure that GCs can happen in a timely fashion.
 //
 // If you need to switch the GC mode of the current thread, look for the GCX_COOP() and GCX_PREEMP() macros.
 //

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -3188,7 +3188,7 @@ public:
 #endif // HOST_64BIT
 
         // For debugging, you may want to make this number very large, (8K)
-        // should basically insure that no collisions happen
+        // should basically ensure that no collisions happen
 #define OBJREF_TABSIZE              256
         DWORD_PTR dangerousObjRefs[OBJREF_TABSIZE];      // Really objectRefs with lower bit stolen
         // m_allObjRefEntriesBad is TRUE iff dangerousObjRefs are all marked as GC happened

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
@@ -273,7 +273,7 @@ Typical Baggage usage includes adding a few baggage properties and enumeration t
 `TimeSpan Duration { get; private set; }` - Represents Activity duration if activity was stopped, TimeSpan.Zero otherwise.
 
 ### Id
-`string Id { get; private set; }` - Represents particular activity identifier. Filtering to a particular Id insures that you get only log records related to specific request within the operation. It is generated when the activity is started.
+`string Id { get; private set; }` - Represents particular activity identifier. Filtering to a particular Id ensures that you get only log records related to specific request within the operation. It is generated when the activity is started.
 Id is passed to external dependencies and considered as [ParentId](#parentid) for new external activity.
 
 ### ParentId

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -217,7 +217,7 @@ namespace System.Diagnostics
 
         /// <summary>
         /// This is an ID that is specific to a particular request.   Filtering
-        /// to a particular ID insures that you get only one request that matches.
+        /// to a particular ID ensures that you get only one request that matches.
         /// Id has a hierarchical structure: '|root-id.id1_id2.id3_' Id is generated when
         /// <see cref="Start"/> is called by appending suffix to Parent.Id
         /// or ParentId; Activity has no Id until it started

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -455,7 +455,7 @@ namespace System.Diagnostics.Tests
                     }
                     Assert.Equal(0, eventSourceListener.EventCount);        // No Event should be fired.
 
-                    // Disable all the listener and insure that no more events come through.
+                    // Disable all the listener and ensure that no more events come through.
                     eventSourceListener.Disable();
 
                     diagnosticSourceListener.Write("TestEvent1", null);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1067,7 +1067,7 @@ namespace System.IO.Compression
             // try to read it, even if the 32-bit size values aren't masked. thus, we should always put the
             // correct size information in there. note that order of uncomp/comp is switched, and these are
             // 64-bit values
-            // also, note that in order for this to be correct, we have to insure that the zip64 extra field
+            // also, note that in order for this to be correct, we have to ensure that the zip64 extra field
             // is always the first extra field that is written
             if (zip64HeaderUsed)
             {

--- a/src/libraries/System.Management/src/System/Management/ManagementObject.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementObject.cs
@@ -1629,7 +1629,7 @@ namespace System.Management
                     new InternalObjectPutEventHandler(this.HandleObjectPut);
 
                 SecurityHandler securityHandler = null;
-                // Assign to error initially to insure internal event handler cleanup
+                // Assign to error initially to ensure internal event handler cleanup
                 // on non-management exception.
                 int status = (int)ManagementStatus.Failed;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Hashtable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Hashtable.cs
@@ -378,8 +378,8 @@ namespace System.Collections
         //
         // 1) The only ?correctness? requirement is that the ?increment? used to probe
         //    a. Be non-zero
-        //    b. Be relatively prime to the table size ?hashSize?. (This is needed to insure you probe all entries in the table before you ?wrap? and visit entries already probed)
-        // 2) Because we choose table sizes to be primes, we just need to insure that the increment is 0 < incr < hashSize
+        //    b. Be relatively prime to the table size ?hashSize?. (This is needed to ensure you probe all entries in the table before you ?wrap? and visit entries already probed)
+        // 2) Because we choose table sizes to be primes, we just need to ensure that the increment is 0 < incr < hashSize
         //
         // Thus this function would work: Incr = 1 + (seed % (hashSize-1))
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -144,7 +144,7 @@ namespace System.Diagnostics.Tracing
                 ActivityInfo? currentActivity = m_current.Value;
                 ActivityInfo? newCurrentActivity = null;               // if we have seen any live activities (orphans), at he first one we have seen.
 
-                // Search to find the activity to stop in one pass.   This insures that we don't let one mistake
+                // Search to find the activity to stop in one pass.   This ensures that we don't let one mistake
                 // (stopping something that was not started) cause all active starts to be stopped
                 // By first finding the target start to stop we are more robust.
                 ActivityInfo? activityToStop = FindActiveActivity(fullActivityName, currentActivity);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -7,7 +7,7 @@
 /* DESIGN NOTES DESIGN NOTES DESIGN NOTES DESIGN NOTES */
 // DESIGN NOTES
 // Over the years EventSource has become more complex and so it is important to understand
-// the basic structure of the code to insure that it does not grow more complex.
+// the basic structure of the code to ensure that it does not grow more complex.
 //
 // Basic Model
 //

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics.Tracing
         : ConcurrentSetItem<KeyValuePair<string, EventTags>, NameInfo>
     {
         /// <summary>
-        /// Insure that eventIds strictly less than 'eventId' will not be
+        /// Ensure that eventIds strictly less than 'eventId' will not be
         /// used by the SelfDescribing events.
         /// </summary>
         internal static void ReserveEventIDsBelow(int eventId)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -1792,7 +1792,7 @@ namespace System.Threading.Tasks
         {
             //
             // WARNING: The Task/Task<TResult>/TaskCompletionSource classes
-            // have all been carefully crafted to insure that GetExceptions()
+            // have all been carefully crafted to ensure that GetExceptions()
             // is never called while AddException() is being called.  There
             // are locks taken on m_contingentProperties in several places:
             //
@@ -1804,7 +1804,7 @@ namespace System.Threading.Tasks
             //    is allowed to complete its operation before Task.Exception_get()
             //    can access GetExceptions().
             //
-            // -- Task.ThrowIfExceptional(): The lock insures that Wait() will
+            // -- Task.ThrowIfExceptional(): The lock ensures that Wait() will
             //    not attempt to call GetExceptions() while Task<TResult>.TrySetException()
             //    is in the process of calling AddException().
             //

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
@@ -16,7 +16,7 @@ namespace System.Threading.Tasks.Tests
             Action[] actions = new Action[256];
 
             // The thinking here is that we'll put enough "filler" into this array to
-            // insure that "natural" chunk size is greater than 2.  Without the
+            // ensure that "natural" chunk size is greater than 2.  Without the
             // NoBuffering option, the Parallel.ForEach below is certain to deadlock.
             // Somewhere a Signal() is going to be after a Wait() in the same chunk, and
             // the loop will deadlock.

--- a/src/mono/mono/mini/mini-ppc.c
+++ b/src/mono/mono/mini/mini-ppc.c
@@ -816,7 +816,7 @@ mono_arch_flush_icache (guint8 *code, gint size)
 	}
 #else
 	/* For POWER5/6 with ICACHE_SNOOPing only one icbi in the range is required.
-	 * The sync is required to insure that the store queue is completely empty.
+	 * The sync is required to ensure that the store queue is completely empty.
 	 * While the icbi performs no cache operations, icbi/isync is required to
 	 * kill local prefetch.
 	 */

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16892/GitHub_16892.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16892/GitHub_16892.cs
@@ -59,8 +59,8 @@ public class Program
         Item[] arr = itemArray;
         int result = 0;
 
-        // Insure that we have to generate fully interruptible GC information
-        // Form a possible infinte loop that the JIT believes could execute
+        // Ensure that we have to generate fully interruptible GC information
+        // Form a possible infinite loop that the JIT believes could execute
         // without encountering a GC safe point.
         //
         do {

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -75,7 +75,7 @@ namespace Tracing.Tests.Common
     }
 
     // This event source is used by the test infra to
-    // to insure that providers have finished being enabled
+    // to ensure that providers have finished being enabled
     // for the session being observed. Since the client API
     // returns the pipe for reading _before_ it finishes
     // enabling the providers to write to that session,


### PR DESCRIPTION
Studying some internal CLR native NT thread handling related to https://github.com/DataDog/dd-trace-dotnet/issues/6172 and came across this `threads.h` code comment that needed some grammar/spelling fix ups.

Thanks,  
Brian