### PR TITLE
Allow nibblemap deletes to be no-op

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4149,9 +4149,9 @@ void EEJitManager::NibbleMapDeleteUnlocked(HeapList* pHp, TADDR pCode)
 
     PTR_DWORD pMap = pHp->pHdrMap;
 
-    // assert that the nibble is not empty and the DWORD is not a pointer
+    // assert that the DWORD is not a pointer
     pMap += index;
-    _ASSERTE(((*pMap) & ~mask) && !IsPointer(*pMap));
+    _ASSERTE(!IsPointer(*pMap));
 
     // delete the relevant nibble
     VolatileStore<DWORD>(pMap, (*pMap) & mask);

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4149,7 +4149,9 @@ void EEJitManager::NibbleMapDeleteUnlocked(HeapList* pHp, TADDR pCode)
 
     PTR_DWORD pMap = pHp->pHdrMap;
 
-    // assert that the DWORD is not a pointer
+    // Assert that the DWORD is not a pointer. Deleting a portion of a pointer
+    // would cause the state of the map to be invalid. Deleting empty nibbles,
+    // a no-op, is allowed and can occur when removing JIT data.
     pMap += index;
     _ASSERTE(!IsPointer(*pMap));
 


### PR DESCRIPTION
Fixes #109970 

#108939 changed nibblemap delete function to assert that the delete operation occurred on a valid nibble. Testing with the AltJit triggered the revert path (`BackoutJitData`) which attempts to delete the nibblemap entry which is never set.

In other paths the nibblemap entry has already been set, therefore I am modifying the assert to allow no-op deletes. This should be the same behavior as before #108939.