### PR TITLE
Small clean up in assertionprop for relops

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4290,7 +4290,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         }
 #endif
 
-        newTree = curAssertion->assertionKind == OAK_EQUAL ? gtNewIconNode(1) : gtNewIconNode(0);
+        newTree = curAssertion->assertionKind == OAK_EQUAL ? gtNewIconNode(0) : gtNewIconNode(1);
         newTree = gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT);
         newTree = fgMorphTree(newTree);
         DISPTREE(newTree);


### PR DESCRIPTION
This PR:
1) Simplifies `optVNConstantPropOnJTrue`
2) Enables constant folding for relops with side-effects
3) `optAssertionProp_RangeProperties` now for `array[idx] = 42;` tells that `array.Length` is never negative and never zero.
