### PR TITLE
ILC: Allow OOB reference to upgrade framework assembly

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -162,8 +162,15 @@ namespace Build.Tasks
                 {
                     if (GetFileVersion(itemSpec).CompareTo(GetFileVersion(frameworkItem.ItemSpec)) > 0)
                     {
-                        // Allow OOB references with higher version to take precedence over the framework assemblies.
-                        list.Add(taskItem);
+                        if (assemblyFileName == "System.Private.CoreLib.dll")
+                        {
+                            Log.LogError($"Overriding System.Private.CoreLib.dll with a newer version is not supported. Attempted to use {itemSpec} instead of {frameworkItem.ItemSpec}.");
+                        }
+                        else
+                        {
+                            // Allow OOB references with higher version to take precedence over the framework assemblies.
+                            list.Add(taskItem);
+                        }
                     }
 
                     assembliesToSkipPublish.Add(taskItem);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/109872, taking the approach @jkotas suggested in https://github.com/dotnet/runtime/issues/108909#issuecomment-2484728684.

Tested locally with the repro from https://github.com/dotnet/runtime/issues/109872, using `IlcBuildTasksPath` to point to a local build of the task.