### PR TITLE
[Tests] Add more logging for runtime test timeouts

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -787,14 +787,18 @@ namespace CoreclrTestLib
                         outputWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}{2}{3}, start: {4}, end: {5})",
                                 executable, timeout, (environmentVar != null) ? " from variable " : "", (environmentVar != null) ? TIMEOUT_ENVIRONMENT_VAR : "",
                                 startTime.ToString(), endTime.ToString());
+                        outputWriter.Flush();
                         errorWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}{2}{3}, start: {4}, end: {5})",
                                 executable, timeout, (environmentVar != null) ? " from variable " : "", (environmentVar != null) ? TIMEOUT_ENVIRONMENT_VAR : "",
                                 startTime.ToString(), endTime.ToString());
+                        errorWriter.Flush();
 
-                        Console.WriteLine("Timed Out with Active Processes:");
-                        foreach (var process in Process.GetProcesses())
+                        Console.WriteLine("Collecting diagnostic information...");
+                        Console.WriteLine("Snapshot of processes currently running:");
+                        Console.WriteLine($"\t{"ID",-6} ProcessName");
+                        foreach (var activeProcess in Process.GetProcesses())
                         {
-                            Console.WriteLine($"{process.ProcessName} (ID: {process.Id})");
+                            Console.WriteLine($"\t{activeProcess.Id,-6} {activeProcess.ProcessName}");
                         }
 
                         if (collectCrashDumps)

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -642,6 +642,8 @@ namespace CoreclrTestLib
         // The children are sorted in the order they should be dumped
         static unsafe IEnumerable<Process> FindChildProcessesByName(Process process, string childName)
         {
+            Console.WriteLine($"Finding all child processes of '{process.ProcessName}' (ID: {process.Id}) with name '{childName}'");
+
             var children = new Stack<Process>();
             Queue<Process> childrenToCheck = new Queue<Process>();
             HashSet<int> seen = new HashSet<int>();
@@ -656,6 +658,7 @@ namespace CoreclrTestLib
                 if (seen.Contains(child.Id))
                     continue;
 
+                Console.WriteLine($"Checking child process: '{child.ProcessName}' (ID: {child.Id})");
                 seen.Add(child.Id);
 
                 foreach (var grandchild in child.GetChildren())
@@ -787,6 +790,12 @@ namespace CoreclrTestLib
                         errorWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}{2}{3}, start: {4}, end: {5})",
                                 executable, timeout, (environmentVar != null) ? " from variable " : "", (environmentVar != null) ? TIMEOUT_ENVIRONMENT_VAR : "",
                                 startTime.ToString(), endTime.ToString());
+
+                        Console.WriteLine("Timed Out with Active Processes:");
+                        foreach (var process in Process.GetProcesses())
+                        {
+                            Console.WriteLine($"{process.ProcessName} (ID: {process.Id})");
+                        }
 
                         if (collectCrashDumps)
                         {

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.cs
@@ -189,7 +189,8 @@ namespace BinderTracingTests
 
         private static bool RunTestInSeparateProcess(MethodInfo method)
         {
-            var startInfo = new ProcessStartInfo(Process.GetCurrentProcess().MainModule.FileName, new[] { Assembly.GetExecutingAssembly().Location, method.Name })
+            string subprocessName = Process.GetCurrentProcess().MainModule.FileName;
+            var startInfo = new ProcessStartInfo(subprocessName, new[] { Assembly.GetExecutingAssembly().Location, method.Name })
             {
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
@@ -199,7 +200,7 @@ namespace BinderTracingTests
             Console.WriteLine($"[{DateTime.Now:T}] Launching process for {method.Name}...");
             using (Process p = Process.Start(startInfo))
             {
-                Console.WriteLine($"Started subprocess {p.Id} for {method.Name}...");
+                Console.WriteLine($"Started subprocess '{subprocessName}' with PID {p.Id} for {method.Name}...");
                 p.OutputDataReceived += (_, args) => Console.WriteLine(args.Data);
                 p.BeginOutputReadLine();
 

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Threading;
 
 using Xunit;
 
@@ -185,7 +184,6 @@ namespace BinderTracingTests
             }
 
             Console.WriteLine($"Test {method.Name} finished.");
-            Thread.Sleep(60000);
             return true;
         }
 

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Threading;
 
 using Xunit;
 
@@ -184,6 +185,7 @@ namespace BinderTracingTests
             }
 
             Console.WriteLine($"Test {method.Name} finished.");
+            Thread.Sleep(60000);
             return true;
         }
 


### PR DESCRIPTION
The runtime testing infrastructure collects dumps of the test process and all of its `corerun` child processes whenever the runtime test times out.
https://github.com/dotnet/runtime/blob/e3b3aaaf21b88b7992cd8a42321e01cf1aa704a2/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs#L795-L807

However, there have been instances where a runtime test times out due to waiting for a subprocess to finish, yet there are logs indicating that the subprocess has finished. See https://github.com/dotnet/runtime/issues/104670#issuecomment-2486232941. Its not clear whether 1) the subprocess is indeed hanging (yet no crashdump is collected) or 2) the subprocess completed yet failed to signal back to the parent process (no crashdump to collect).

This PR aims to clarify, if the Id of the subprocess that the main test process is waiting for is known, whether that Id is part of the list of active processes at timeout.