### PR TITLE
Adds Linux CMake presets for coreclr

### DIFF
--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -275,6 +275,33 @@
         "Checked",
         "x64"
       ]
+    },
+    {
+      "name": "linux.arm64.Debug",
+      "displayName": "linux.arm64.Debug",
+      "inherits": [
+        "linux-base",
+        "Debug",
+        "ARM64"
+      ]
+    },
+    {
+      "name": "linux.arm64.Release",
+      "displayName": "linux.arm64.Release",
+      "inherits": [
+        "linux-base",
+        "Release",
+        "ARM64"
+      ]
+    },
+    {
+      "name": "linux.arm64.Checked",
+      "displayName": "linux.arm64.Checked",
+      "inherits": [
+        "linux-base",
+        "Checked",
+        "ARM64"
+      ]
     }
   ]
 }

--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -46,6 +46,21 @@
       }
     },
     {
+      "name": "linux-base",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CLR_CMAKE_TARGET_OS": "linux"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Linux"
+          ]
+        }
+      }
+    },
+    {
       "name": "Debug",
       "hidden": true,
       "cacheVariables": {
@@ -232,6 +247,33 @@
         "osx-base",
         "Checked",
         "ARM64"
+      ]
+    },
+    {
+      "name": "linux.x64.Debug",
+      "displayName": "linux.x64.Debug",
+      "inherits": [
+        "linux-base",
+        "Debug",
+        "x64"
+      ]
+    },
+    {
+      "name": "linux.x64.Release",
+      "displayName": "linux.x64.Release",
+      "inherits": [
+        "linux-base",
+        "Release",
+        "x64"
+      ]
+    },
+    {
+      "name": "linux.x64.Checked",
+      "displayName": "linux.x64.Checked",
+      "inherits": [
+        "linux-base",
+        "Checked",
+        "x64"
       ]
     }
   ]


### PR DESCRIPTION
I noticed when opening this project in CLion on Ubuntu that presets are supported for Windows and macOS but not Linux. As macOS support was added recently in #109061, I thought I'd raise this small PR to include Linux x64 as well.