### PR TITLE
Use the managed signer to remove the code signature from singlefile bundles

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -153,7 +153,7 @@ namespace Microsoft.NET.HostModel.AppHost
                                     MachObjectFile machObjectFile = MachObjectFile.Create(memoryMappedViewAccessor);
                                     appHostLength = machObjectFile.CreateAdHocSignature(memoryMappedViewAccessor, fileName);
                                 }
-                                else if (MachObjectFile.TryRemoveCodesign(memoryMappedViewAccessor, out long? length))
+                                else if (MachObjectFile.RemoveCodeSignatureIfPresent(memoryMappedViewAccessor, out long? length))
                                 {
                                     appHostLength = length.Value;
                                 }

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -287,7 +287,7 @@ namespace Microsoft.NET.HostModel.Bundle
             {
                 if (_target.IsOSX)
                 {
-                    MachObjectFile.TryRemoveCodesign(bundle);
+                    MachObjectFile.RemoveCodesign(bundle);
                 }
                 bundle.Position = bundle.Length;
                 foreach (var fileSpec in fileSpecs)

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.CoreSetup;
 using Microsoft.NET.HostModel.AppHost;
+using Microsoft.NET.HostModel.MachO;
 
 namespace Microsoft.NET.HostModel.Bundle
 {
@@ -92,7 +94,7 @@ namespace Microsoft.NET.HostModel.Bundle
         /// startOffset: offset of the start 'file' within 'bundle'
         /// compressedSize: size of the compressed data, if entry was compressed, otherwise 0
         /// </returns>
-        private (long startOffset, long compressedSize) AddToBundle(Stream bundle, FileStream file, FileType type)
+        private (long startOffset, long compressedSize) AddToBundle(FileStream bundle, FileStream file, FileType type)
         {
             long startOffset = bundle.Position;
             if (ShouldCompress(type))
@@ -273,20 +275,23 @@ namespace Microsoft.NET.HostModel.Bundle
 
             BinaryUtils.CopyFile(hostSource, bundlePath);
 
-            if (_target.IsOSX && RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && Codesign.IsAvailable)
-            {
-                Codesign.Run("--remove-signature", bundlePath);
-            }
-
             // Note: We're comparing file paths both on the OS we're running on as well as on the target OS for the app
             // We can't really make assumptions about the file systems (even on Linux there can be case insensitive file systems
             // and vice versa for Windows). So it's safer to do case sensitive comparison everywhere.
             var relativePathToSpec = new Dictionary<string, FileSpec>(StringComparer.Ordinal);
 
             long headerOffset = 0;
-            using (BinaryWriter writer = new BinaryWriter(File.OpenWrite(bundlePath)))
+            using (FileStream bundle = File.Open(bundlePath, FileMode.Open, FileAccess.ReadWrite))
+            using (BinaryWriter writer = new BinaryWriter(bundle))
             {
-                Stream bundle = writer.BaseStream;
+                long? newLength;
+                using (MemoryMappedFile mmap = MemoryMappedFile.CreateFromFile(bundle, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
+                using (MemoryMappedViewAccessor accessor = mmap.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite))
+                {
+                    MachObjectFile.TryRemoveCodesign(accessor, out newLength);
+                }
+                newLength ??= new FileInfo(bundlePath).Length;
+                bundle.SetLength(newLength.Value);
                 bundle.Position = bundle.Length;
 
                 foreach (var fileSpec in fileSpecs)

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -287,7 +287,7 @@ namespace Microsoft.NET.HostModel.Bundle
             {
                 if (_target.IsOSX)
                 {
-                    MachObjectFile.RemoveCodesign(bundle);
+                    MachObjectFile.RemoveCodeSignatureIfPresent(bundle);
                 }
                 bundle.Position = bundle.Length;
                 foreach (var fileSpec in fileSpecs)

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -285,14 +285,9 @@ namespace Microsoft.NET.HostModel.Bundle
             using (FileStream bundle = File.Open(bundlePath, FileMode.Open, FileAccess.ReadWrite))
             using (BinaryWriter writer = new BinaryWriter(bundle, Encoding.Default, leaveOpen: true))
             {
-                long? newLength;
-                using (MemoryMappedFile mmap = MemoryMappedFile.CreateFromFile(bundle, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
-                using (MemoryMappedViewAccessor accessor = mmap.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite))
+                if (_target.IsOSX)
                 {
-                    if(MachObjectFile.TryRemoveCodesign(accessor, out newLength))
-                    {
-                        bundle.SetLength(newLength.Value);
-                    }
+                    MachObjectFile.TryRemoveCodesign(bundle);
                 }
                 bundle.Position = bundle.Length;
                 foreach (var fileSpec in fileSpecs)

--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
@@ -143,7 +143,7 @@ internal unsafe partial class MachObjectFile
     /// <param name="memoryMappedViewAccessor">The file to remove the signature from.</param>
     /// <param name="newLength">The new length of the file if the signature is remove and the method returns true</param>
     /// <returns>True if a signature was present and removed, false otherwise</returns>
-    public static bool TryRemoveCodesign(MemoryMappedViewAccessor memoryMappedViewAccessor, out long? newLength)
+    public static bool RemoveCodeSignatureIfPresent(MemoryMappedViewAccessor memoryMappedViewAccessor, out long? newLength)
     {
         newLength = null;
         if (!IsMachOImage(memoryMappedViewAccessor))
@@ -168,9 +168,8 @@ internal unsafe partial class MachObjectFile
 
     /// <summary>
     /// Removes the code signature load command and signature, and resizes the file if necessary.
-    /// Returns true if the signature was removed, false otherwise.
     /// </summary>
-    public static void RemoveCodesign(FileStream bundle)
+    public static void RemoveCodeSignatureIfPresent(FileStream bundle)
     {
         long? newLength;
         bool resized;
@@ -178,7 +177,7 @@ internal unsafe partial class MachObjectFile
         using (MemoryMappedFile mmap = MemoryMappedFile.CreateFromFile(bundle, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
         using (MemoryMappedViewAccessor accessor = mmap.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite))
         {
-            resized = TryRemoveCodesign(accessor, out newLength);
+            resized = RemoveCodeSignatureIfPresent(accessor, out newLength);
         }
         if (resized)
         {

--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
@@ -170,7 +170,7 @@ internal unsafe partial class MachObjectFile
     /// Removes the code signature load command and signature, and resizes the file if necessary.
     /// Returns true if the signature was removed, false otherwise.
     /// </summary>
-    public static bool TryRemoveCodesign(FileStream bundle)
+    public static void RemoveCodesign(FileStream bundle)
     {
         long? newLength;
         bool resized;
@@ -184,7 +184,6 @@ internal unsafe partial class MachObjectFile
         {
             bundle.SetLength(newLength.Value);
         }
-        return resized;
     }
 
     /// <summary>

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
@@ -485,12 +485,23 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
             }
         }
 
-        private static readonly byte[] s_placeholderData = AppBinaryPathPlaceholderSearchValue.Concat(DotNetSearchPlaceholderValue).ToArray();
+        private static readonly byte[] s_apphostPlaceholderData = AppBinaryPathPlaceholderSearchValue.Concat(DotNetSearchPlaceholderValue).ToArray();
+        private static readonly byte[] s_singleFileApphostPlaceholderData = {
+            // 8 bytes represent the bundle header-offset
+            // Zero for non-bundle apphosts (default).
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // 32 bytes represent the bundle signature: SHA-256 for ".net core bundle"
+            0x8b, 0x12, 0x02, 0xb9, 0x6a, 0x61, 0x20, 0x38,
+            0x72, 0x7b, 0x93, 0x02, 0x14, 0xd7, 0xa0, 0x32,
+            0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
+            0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
+        };
+
         /// <summary>
         /// Prepares a mock executable file with the AppHost placeholder embedded in it.
         /// This file will not run, but can be used to test HostWriter and signing process.
         /// </summary>
-        public static string PrepareMockMachAppHostFile(string directory)
+        public static string PrepareMockMachAppHostFile(string directory, bool singleFile = false)
         {
             string fileName = "MockAppHost.mach.o";
             string outputFilePath = Path.Combine(directory, fileName);
@@ -501,7 +512,7 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
                 // Add the placeholder - it just needs to exist somewhere in the image
                 // We'll put it at 4096 bytes into the file - this should be in the middle of the __TEXT segment
                 managedSignFile.Position = 4096;
-                managedSignFile.Write(s_placeholderData);
+                managedSignFile.Write(singleFile ? s_singleFileApphostPlaceholderData : s_apphostPlaceholderData);
             }
             return outputFilePath;
         }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
@@ -334,6 +334,7 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 SigningTests.IsSigned(bundledApp).Should().BeFalse();
+                return;
             }
 
             // Check if the file is signed

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
         }
 
         private static string BundlerHostName = Binaries.GetExeName(SharedTestState.AppName);
-        private Bundler CreateBundlerInstance(BundleOptions bundleOptions = BundleOptions.None, Version version = null, bool macosCodesign = true)
-            => new Bundler(BundlerHostName, sharedTestState.App.GetUniqueSubdirectory("bundle"), bundleOptions, targetFrameworkVersion: version, macosCodesign: macosCodesign);
+        private Bundler CreateBundlerInstance(BundleOptions bundleOptions = BundleOptions.None, Version version = null, bool macosCodesign = true, OSPlatform? targetOS = null)
+            => new Bundler(BundlerHostName, sharedTestState.App.GetUniqueSubdirectory("bundle"), bundleOptions, targetFrameworkVersion: version, macosCodesign: macosCodesign, targetOS: targetOS);
 
         [Fact]
         public void EnableCompression_Before60_Fails()
@@ -328,7 +328,7 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
                 new FileSpec(app.RuntimeConfigJson, Path.GetRelativePath(app.Location, app.RuntimeConfigJson)),
             };
 
-            Bundler bundler = CreateBundlerInstance(macosCodesign: shouldCodesign);
+            Bundler bundler = CreateBundlerInstance(targetOS: OSPlatform.OSX, macosCodesign: shouldCodesign);
             string bundledApp = bundler.GenerateBundle(fileSpecs);
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
@@ -333,6 +333,7 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
+                // SingleFile is still only signed on MacOS with codesign
                 SigningTests.IsSigned(bundledApp).Should().BeFalse();
                 return;
             }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
@@ -228,13 +228,7 @@ namespace Microsoft.NET.HostModel.MachO.CodeSign.Tests
                 var destinationFileName = Path.GetFileName(removedSignaturePath);
                 var appHostSignedLength = appHostLength + MachObjectFile.GetSignatureSizeEstimate((uint)appHostLength, destinationFileName);
 
-                using (MemoryMappedFile memoryMappedFile = MemoryMappedFile.CreateFromFile(appHostDestinationStream, null, appHostSignedLength, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
-                using (MemoryMappedViewAccessor memoryMappedViewAccessor = memoryMappedFile.CreateViewAccessor(0, appHostSignedLength, MemoryMappedFileAccess.ReadWrite))
-                {
-                    if (MachObjectFile.TryRemoveCodesign(memoryMappedViewAccessor, out long? newLength))
-                        appHostLength = newLength.Value;
-                }
-                appHostDestinationStream.SetLength(appHostLength);
+                MachObjectFile.RemoveCodeSignatureIfPresent(appHostDestinationStream);
             }
         }
     }


### PR DESCRIPTION
When working on [using the managed Mac signer in the SDK](https://github.com/dotnet/sdk/pull/45019) on non-mac hosts, I found that since the bundler uses codesign to remove the signature, we end up with an invalid signature for single file osx executables. This PR updates the bundler to use the managed signer to remove the signature.

Signing bundles requires a little more thought and effort since the headers/load commands need to be updated to include the bundle data in the file. This will be done in a separate PR.

Part of https://github.com/dotnet/runtime/issues/110055.