### PR TITLE
Change assertion in IPGlobalProperties_DomainName_ReturnsEmptyStringWhenNotSet

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -214,7 +214,7 @@ namespace System.Net.NetworkInformation.Tests
             IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
 
             // [ActiveIssue("https://github.com/dotnet/runtime/issues/109280")]
-            string expectedDomainName = PlatformDetection.IsLinuxBionic || PlatformDetection.IsAndroid ? "localdomain" : string.Empty;
+            string expectedDomainName = PlatformDetection.IsAndroid ? "localdomain" : string.Empty;
             Assert.Equal(expectedDomainName, gp.DomainName);
         }
     }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -212,7 +212,10 @@ namespace System.Net.NetworkInformation.Tests
         public void IPGlobalProperties_DomainName_ReturnsEmptyStringWhenNotSet()
         {
             IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
-            Assert.Equal(string.Empty, gp.DomainName);
+
+            // https://github.com/dotnet/runtime/issues/109280
+            string expectedDomainName = PlatformDetection.IsLinuxBionic || PlatformDetection.IsAndroid ? "localdomain" : string.Empty;
+            Assert.Equal(expectedDomainName, gp.DomainName);
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -213,7 +213,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
 
-            // https://github.com/dotnet/runtime/issues/109280
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/109280")]
             string expectedDomainName = PlatformDetection.IsLinuxBionic || PlatformDetection.IsAndroid ? "localdomain" : string.Empty;
             Assert.Equal(expectedDomainName, gp.DomainName);
         }


### PR DESCRIPTION
Contributes to #109280. Given that we don't seem to understand the reason the value is `localdomain`, this change feels like a test hack instead of an actual fix, thus the `ActiveIssue` link. If we don't care that much, I'm happy to delete the comment and close the issue.