### PR TITLE
NamedPipeClientStream Connect with SafePipeHandle

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateNamedPipeClient.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateNamedPipeClient.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial SafePipeHandle CreateNamedPipeClient(
-            string? lpFileName,
+            string lpFileName,
             int dwDesiredAccess,
             System.IO.FileShare dwShareMode,
             ref SECURITY_ATTRIBUTES secAttrs,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitNamedPipe.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitNamedPipe.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Kernel32, EntryPoint = "WaitNamedPipeW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool WaitNamedPipe(string? name, int timeout);
+        internal static partial bool WaitNamedPipe(string name, int timeout);
     }
 }

--- a/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.cs
+++ b/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.cs
@@ -42,7 +42,9 @@ namespace System.IO.Pipes
     }
     public sealed partial class NamedPipeClientStream : System.IO.Pipes.PipeStream
     {
-        public NamedPipeClientStream(System.IO.Pipes.PipeDirection direction, bool isAsync, bool isConnected, Microsoft.Win32.SafeHandles.SafePipeHandle safePipeHandle) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
+        [System.Obsolete]
+        public NamedPipeClientStream(System.IO.Pipes.PipeDirection direction, bool isAsync, bool isConnected, Microsoft.Win32.SafeHandles.SafePipeHandle safePipeHandle) : this (default(System.IO.Pipes.PipeDirection), default(bool), default(Microsoft.Win32.SafeHandles.SafePipeHandle)) { }
+        public NamedPipeClientStream(System.IO.Pipes.PipeDirection direction, bool isAsync, Microsoft.Win32.SafeHandles.SafePipeHandle safePipeHandle) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
         public NamedPipeClientStream(string pipeName) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
         public NamedPipeClientStream(string serverName, string pipeName) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -110,7 +110,7 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
-            SafePipeHandle handle = CreateNamedPipeClient(_normalizedPipePath, ref secAttrs, _pipeFlags, _accessRights);
+            SafePipeHandle handle = CreateNamedPipeClient(_normalizedPipePath!, ref secAttrs, _pipeFlags, _accessRights);
 
             if (handle.IsInvalid)
             {
@@ -133,7 +133,7 @@ namespace System.IO.Pipes
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
 
-                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
+                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath!, timeout))
                 {
                     errorCode = Marshal.GetLastPInvokeError();
 
@@ -147,7 +147,7 @@ namespace System.IO.Pipes
                 }
 
                 // Pipe server should be free. Let's try to connect to it.
-                handle = CreateNamedPipeClient(_normalizedPipePath, ref secAttrs, _pipeFlags, _accessRights);
+                handle = CreateNamedPipeClient(_normalizedPipePath!, ref secAttrs, _pipeFlags, _accessRights);
 
                 if (handle.IsInvalid)
                 {
@@ -173,7 +173,7 @@ namespace System.IO.Pipes
             ValidateRemotePipeUser();
             return true;
 
-            static SafePipeHandle CreateNamedPipeClient(string? path, ref Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs, int pipeFlags, int access)
+            static SafePipeHandle CreateNamedPipeClient(string path, ref Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs, int pipeFlags, int access)
                 => Interop.Kernel32.CreateNamedPipeClient(path, access, FileShare.None, ref secAttrs, FileMode.Open, pipeFlags, hTemplateFile: IntPtr.Zero);
         }
 

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -92,6 +92,11 @@ namespace System.IO.Pipes
         public NamedPipeClientStream(PipeDirection direction, bool isAsync, bool isConnected, SafePipeHandle safePipeHandle)
             : base(direction, 0)
         {
+            if (!isConnected)
+            {
+                throw new ArgumentOutOfRangeException(nameof(isConnected));
+            }
+
             ArgumentNullException.ThrowIfNull(safePipeHandle);
 
             if (safePipeHandle.IsInvalid)
@@ -101,10 +106,7 @@ namespace System.IO.Pipes
             ValidateHandleIsPipe(safePipeHandle);
 
             InitializeHandle(safePipeHandle, true, isAsync);
-            if (isConnected)
-            {
-                State = PipeState.Connected;
-            }
+            State = PipeState.Connected;
         }
 
         ~NamedPipeClientStream()

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -89,14 +89,20 @@ namespace System.IO.Pipes
         }
 
         // Create a NamedPipeClientStream from an existing server pipe handle.
+        [Obsolete]
         public NamedPipeClientStream(PipeDirection direction, bool isAsync, bool isConnected, SafePipeHandle safePipeHandle)
-            : base(direction, 0)
+            : this(direction, isAsync, safePipeHandle)
         {
             if (!isConnected)
             {
                 throw new ArgumentOutOfRangeException(nameof(isConnected));
             }
+        }
 
+        // Create a NamedPipeClientStream from an existing server pipe handle.
+        public NamedPipeClientStream(PipeDirection direction, bool isAsync, SafePipeHandle safePipeHandle)
+            : base(direction, 0)
+        {
             ArgumentNullException.ThrowIfNull(safePipeHandle);
 
             if (safePipeHandle.IsInvalid)

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
@@ -97,6 +97,15 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.In)]
         [InlineData(PipeDirection.InOut)]
         [InlineData(PipeDirection.Out)]
+        public static void NotConnected_Throws_ArgumentOutOfRangeException(PipeDirection direction)
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("isConnected", () => new NamedPipeClientStream(direction, false, false, null));
+        }
+
+        [Theory]
+        [InlineData(PipeDirection.In)]
+        [InlineData(PipeDirection.InOut)]
+        [InlineData(PipeDirection.Out)]
         public static void NullHandle_Throws_ArgumentNullException(PipeDirection direction)
         {
             AssertExtensions.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeClientStream(direction, false, true, null));

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
@@ -97,18 +97,9 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.In)]
         [InlineData(PipeDirection.InOut)]
         [InlineData(PipeDirection.Out)]
-        public static void NotConnected_Throws_ArgumentOutOfRangeException(PipeDirection direction)
-        {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("isConnected", () => new NamedPipeClientStream(direction, false, false, null));
-        }
-
-        [Theory]
-        [InlineData(PipeDirection.In)]
-        [InlineData(PipeDirection.InOut)]
-        [InlineData(PipeDirection.Out)]
         public static void NullHandle_Throws_ArgumentNullException(PipeDirection direction)
         {
-            AssertExtensions.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeClientStream(direction, false, true, null));
+            AssertExtensions.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeClientStream(direction, false, null));
         }
 
         [Theory]
@@ -118,7 +109,7 @@ namespace System.IO.Pipes.Tests
         public static void InvalidHandle_Throws_ArgumentException(PipeDirection direction)
         {
             using SafePipeHandle pipeHandle = new SafePipeHandle(new IntPtr(-1), true);
-            AssertExtensions.Throws<ArgumentException>("safePipeHandle", () => new NamedPipeClientStream(direction, false, true, pipeHandle));
+            AssertExtensions.Throws<ArgumentException>("safePipeHandle", () => new NamedPipeClientStream(direction, false, pipeHandle));
         }
 
         [Theory]
@@ -138,7 +129,7 @@ namespace System.IO.Pipes.Tests
                     IntPtr handle = safeHandle.DangerousGetHandle();
 
                     SafePipeHandle fakePipeHandle = new SafePipeHandle(handle, ownsHandle: false);
-                    Assert.Throws<IOException>(() => new NamedPipeClientStream(direction, false, true, fakePipeHandle));
+                    Assert.Throws<IOException>(() => new NamedPipeClientStream(direction, false, fakePipeHandle));
                 }
                 finally
                 {

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
@@ -35,7 +35,7 @@ namespace System.IO.Pipes.Tests
 
             void ChildFunc(string handle)
             {
-                using (var childClient = new NamedPipeClientStream(PipeDirection.Out, isAsync: false, isConnected: true, new SafePipeHandle((IntPtr)long.Parse(handle, CultureInfo.InvariantCulture), ownsHandle: true)))
+                using (var childClient = new NamedPipeClientStream(PipeDirection.Out, isAsync: false, new SafePipeHandle((IntPtr)long.Parse(handle, CultureInfo.InvariantCulture), ownsHandle: true)))
                 {
                     for (int i = 0; i < 5; i++)
                     {

--- a/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
@@ -171,7 +171,7 @@ namespace System.IO.Pipes.Tests
 
             if (writeable is NamedPipeServerStream server)
             {
-                using (NamedPipeClientStream client = new NamedPipeClientStream(PipeDirection.In, false, true, ((NamedPipeClientStream)readable).SafePipeHandle))
+                using (NamedPipeClientStream client = new NamedPipeClientStream(PipeDirection.In, false, ((NamedPipeClientStream)readable).SafePipeHandle))
                 {
                     if (OperatingSystem.IsWindows())
                     {
@@ -186,7 +186,7 @@ namespace System.IO.Pipes.Tests
             }
             else
             {
-                using (NamedPipeClientStream client = new NamedPipeClientStream(PipeDirection.Out, false, true, ((NamedPipeClientStream)writeable).SafePipeHandle))
+                using (NamedPipeClientStream client = new NamedPipeClientStream(PipeDirection.Out, false, ((NamedPipeClientStream)writeable).SafePipeHandle))
                 {
                     Task clientTask = client.WriteAsync(msg1, 0, msg1.Length);
                     int receivedLength = readable.Read(received1, 0, msg1.Length);


### PR DESCRIPTION
* Checked that isConnected in the NamedPipeClientStream constructor is always true.
* Created a new constructor without the argument.
* Marked the old constructor as obsolete.
* Corrected the nullability in the interop declarations.

I am aware that I did slightly more than in the original issue. Therefore I created a base commit and two additional commits that can be easily removed from this PR if desired.

Fixes #32760