### PR TITLE
Fold "X relop 0" in assertprop

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4272,7 +4272,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
     GenTree* op1     = tree->AsOp()->gtOp1;
     GenTree* op2     = tree->AsOp()->gtOp2;
 
-    // Can we can fold "X relop 0" based on assertions?
+    // Can we fold "X relop 0" based on assertions?
     if (op2->IsIntegralConst(0) && tree->OperIsCmpCompare())
     {
         bool isNonZero, isNeverNegative;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4280,35 +4280,33 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
 
         if (tree->OperIs(GT_GE, GT_LT) && isNeverNegative)
         {
-            // X is never negative:
+            // Assertions: X >= 0
             //
-            //   X >= 0 --> true
-            //   X < 0  --> false
-            //
+            // X >= 0 --> true
+            // X < 0  --> false
             newTree = tree->OperIs(GT_GE) ? gtNewTrue() : gtNewFalse();
         }
         else if (tree->OperIs(GT_GT, GT_LE) && isNeverNegative && isNonZero)
         {
-            // X is never negative and is never zero:
+            // Assertions: X > 0
             //
-            //   X > 0 --> true
-            //   X <= 0 --> false
-            //
-            newTree = tree->OperIs(GT_GT) ? gtNewIconNode(1) : gtNewFalse();
+            // X > 0  --> true
+            // X <= 0 --> false
+            newTree = tree->OperIs(GT_GT) ? gtNewTrue() : gtNewFalse();
         }
         else if (tree->OperIs(GT_EQ, GT_NE) && isNonZero)
         {
-            // X is never zero:
+            // Assertions: X != 0
             //
-            //   X == 0 --> false
-            //   X != 0 --> true
-            //
-            newTree = tree->OperIs(GT_EQ) ? gtNewFalse() : gtNewTrue();
+            // X != 0 --> true
+            // X == 0 --> false
+            newTree = tree->OperIs(GT_NE) ? gtNewTrue() : gtNewFalse();
         }
 
         if (newTree != tree)
         {
-            return optAssertionProp_Update(gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT), tree, stmt);
+            newTree = gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT);
+            return optAssertionProp_Update(newTree, tree, stmt);
         }
     }
 


### PR DESCRIPTION
Use `optAssertionProp_RangeProperties` to fold various "X relop 0" patterns in global assertion prop.

This, technically, repeats what RBO does, but with help of assertions. There should be more diffs if we generalize it.