### PR TITLE
Help finding Brotli headers when doing VMR build under FreeBSD

### DIFF
--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -18,6 +18,9 @@ if (NOT CLR_CMAKE_TARGET_BROWSER AND NOT CLR_CMAKE_TARGET_WASI)
 
     if (CLR_CMAKE_USE_SYSTEM_BROTLI)
         add_definitions(-DFEATURE_USE_SYSTEM_BROTLI)
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(BROTLI REQUIRED libbrotlicommon)
+        include_directories(${BROTLI_INCLUDE_DIRS})
     else ()
         include(${CLR_SRC_NATIVE_DIR}/external/brotli.cmake)
 

--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT CLR_CMAKE_TARGET_BROWSER AND NOT CLR_CMAKE_TARGET_WASI)
 
     if (CLR_CMAKE_USE_SYSTEM_BROTLI)
         add_definitions(-DFEATURE_USE_SYSTEM_BROTLI)
-        if (CLR_CMAKE_TARGET_FREEBSD)
+        if (CLR_CMAKE_HOST_FREEBSD)
             set(CMAKE_REQUIRED_INCLUDES ${CROSS_ROOTFS}/usr/local/include)
         endif()
     else ()

--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -18,9 +18,9 @@ if (NOT CLR_CMAKE_TARGET_BROWSER AND NOT CLR_CMAKE_TARGET_WASI)
 
     if (CLR_CMAKE_USE_SYSTEM_BROTLI)
         add_definitions(-DFEATURE_USE_SYSTEM_BROTLI)
-        find_package(PkgConfig REQUIRED)
-        pkg_check_modules(BROTLI REQUIRED libbrotlicommon)
-        include_directories(${BROTLI_INCLUDE_DIRS})
+        if (CLR_CMAKE_TARGET_FREEBSD)
+            set(CMAKE_REQUIRED_INCLUDES ${CROSS_ROOTFS}/usr/local/include)
+        endif()
     else ()
         include(${CLR_SRC_NATIVE_DIR}/external/brotli.cmake)
 


### PR DESCRIPTION
Small change to make VMR build complete under FreeBSD. It's the only patch we use right now, to build v9. fyi @arrowd @Thefrank 