### PR TITLE
Skip ENOSYS filter in numa init

### DIFF
--- a/src/coreclr/gc/unix/numasupport.cpp
+++ b/src/coreclr/gc/unix/numasupport.cpp
@@ -54,7 +54,7 @@ static int GetNodeNum(const char* path, bool firstOnly)
 void NUMASupportInitialize()
 {
 #ifdef TARGET_LINUX
-    if (syscall(__NR_get_mempolicy, NULL, NULL, 0, 0, 0) < 0 && (errno == ENOSYS || errno == EPERM))
+    if (syscall(__NR_get_mempolicy, NULL, NULL, 0, 0, 0) < 0)
         return;
 
     int highestNumaNode = GetNodeNum("/sys/devices/system/node", false);

--- a/src/coreclr/gc/unix/numasupport.cpp
+++ b/src/coreclr/gc/unix/numasupport.cpp
@@ -54,7 +54,7 @@ static int GetNodeNum(const char* path, bool firstOnly)
 void NUMASupportInitialize()
 {
 #ifdef TARGET_LINUX
-    if (syscall(__NR_get_mempolicy, NULL, NULL, 0, 0, 0) < 0 && errno == ENOSYS)
+    if (syscall(__NR_get_mempolicy, NULL, NULL, 0, 0, 0) < 0 && (errno == ENOSYS || errno == EPERM))
         return;
 
     int highestNumaNode = GetNodeNum("/sys/devices/system/node", false);


### PR DESCRIPTION
The usage of `get_mempolicy` is restricted by secomp profile in docker. I couldn't figure out way to repro it with SELinux (class labels are confusing), but docker approach is fine.

It was fixed in libnuma a few days ago https://github.com/numactl/numactl/commit/0efea0eb1980964c3264c901ec4e8934c4c05541 so it's not a huge issue.

Fix https://github.com/dotnet/runtime/issues/110074