### PR TITLE
[cdac] Handle hot/cold map lookup in `ExecutionManager.ReadyToRunJitManager.GetMethodInfo`

### DIFF
--- a/docs/design/datacontracts/ExecutionManager.md
+++ b/docs/design/datacontracts/ExecutionManager.md
@@ -56,15 +56,20 @@ Data descriptors used:
 | `Module` | `ReadyToRunInfo` | Pointer to the `ReadyToRunInfo` for the module |
 | `ReadyToRunInfo` | `CompositeInfo` | Pointer to composite R2R info - or itself for non-composite |
 | `ReadyToRunInfo` | `NumRuntimeFunctions` | Number of `RuntimeFunctions` |
-| `ReadyToRunInfo` | `RuntimeFunctions` | Pointer to an array of `RuntimeFunctions` |
+| `ReadyToRunInfo` | `RuntimeFunctions` | Pointer to an array of `RuntimeFunctions` - [see R2R format](../coreclr/botr/readytorun-format.md#readytorunsectiontyperuntimefunctions)|
+| `ReadyToRunInfo` | `NumHotColdMap` | Number of entries in the `HotColdMap` |
+| `ReadyToRunInfo` | `HotColdMap` | Pointer to an array of 32-bit integers - [see R2R format](../coreclr/botr/readytorun-format.md#readytorunsectiontypehotcoldmap-v80) |
 | `ReadyToRunInfo` | `DelayLoadMethodCallThunks` | Pointer to an `ImageDataDirectory` for the delay load method call thunks |
 | `ReadyToRunInfo` | `EntryPointToMethodDescMap` | `HashMap` of entry point addresses to `MethodDesc` pointers |
 | `ImageDataDirectory` | `VirtualAddress` | Virtual address of the image data directory |
 | `ImageDataDirectory` | `Size` | Size of the data |
 | `RuntimeFunction` | `BeginAddress` | Begin address of the function |
+| `RuntimeFunction` | `EndAddress` | End address of the function. Only exists on some platforms |
+| `RuntimeFunction` | `UnwindData` | Pointer to the unwind info for the function |
 | `HashMap` | `Buckets` | Pointer to the buckets of a `HashMap` |
 | `Bucket` | `Keys` | Array of keys of `HashMapSlotsPerBucket` length |
 | `Bucket` | `Values` | Array of values of `HashMapSlotsPerBucket` length |
+| `UnwindInfo` | `FunctionLength` | Length of the associated function in bytes. Only exists on some platforms |
 
 Global variables used:
 | Global Name | Type | Purpose |
@@ -80,67 +85,52 @@ Contracts used:
 | --- |
 | `PlatformMetadata` |
 
-The bulk of the work is done by the `GetCodeBlockHandle` API that maps a code pointer to information about the containing jitted method.
+The bulk of the work is done by the `GetCodeBlockHandle` API that maps a code pointer to information about the containing jitted method. This relies the [range section lookup](#rangesectionmap).
 
 ```csharp
     private CodeBlock? GetCodeBlock(TargetCodePointer jittedCodeAddress)
     {
-        RangeSection range = RangeSection.Find(_topRangeSectionMap, jittedCodeAddress);
-        if (range.Data == null)
-        {
+        TargetPointer rangeSection = // find range section corresponding to jittedCodeAddress - see RangeSectionMap below
+        if (/* no corresponding range section */)
             return null;
-        }
+
         JitManager jitManager = GetJitManager(range.Data);
-        if (jitManager.GetMethodInfo(range, jittedCodeAddress, out CodeBlock? info))
-        {
+        if (/* JIT manager corresponding to rangeSection */.GetMethodInfo(range, jittedCodeAddress, out CodeBlock? info))
             return info;
-        }
-        else
-        {
-            return null;
-        }
+        return null;
     }
     CodeBlockHandle? IExecutionManager.GetCodeBlockHandle(TargetCodePointer ip)
     {
-        TargetPointer key = ip.AsTargetPointer;
-        if (/*cache*/.ContainsKey(key))
-        {
-            return new CodeBlockHandle(key);
-        }
         CodeBlock? info = GetCodeBlock(ip);
-        if (info == null || !info.Valid)
-        {
+        if (info == null)
             return null;
-        }
-        /*cache*/.TryAdd(key, info);
-        return new CodeBlockHandle(key);
+        return new CodeBlockHandle(ip.AsTargetPointer);
     }
 ```
 
-Here `RangeSection.Find` implements the range section lookup, summarized below.
-
-There are two `JitManager`s: the "EE JitManager" for jitted code and "R2R JitManager" for ReadyToRun code.
+There are two JIT managers: the "EE JitManager" for jitted code and "R2R JitManager" for ReadyToRun code.
 
 The EE JitManager `GetMethodInfo` implements the nibble map lookup, summarized below, followed by returning the `RealCodeHeader` data:
 
 ```csharp
-bool GetMethodInfo(RangeSection rangeSection, TargetCodePointer jittedCodeAddress, [NotNullWhen(true)] out CodeBlock? info)
+bool GetMethodInfo(TargetPointer rangeSection, TargetCodePointer jittedCodeAddress, [NotNullWhen(true)] out CodeBlock? info)
 {
-    TargetPointer start = FindMethodCode(rangeSection, jittedCodeAddress); // nibble map lookup
+    info = default;
+    TargetPointer start = // look up jittedCodeAddress in nibble map for rangeSection - see NibbleMap below
     if (start == TargetPointer.Null)
-    {
         return false;
-    }
+
     TargetNUInt relativeOffset = jittedCodeAddress - start;
     int codeHeaderOffset = Target.PointerSize;
     TargetPointer codeHeaderIndirect = start - codeHeaderOffset;
-    if (RangeSection.IsStubCodeBlock(Target, codeHeaderIndirect))
-    {
+
+    // Check if address is in a stub code block
+    if (codeHeaderIndirect < Target.ReadGlobal<byte>("StubCodeBlockLast"))
         return false;
-    }
+
     TargetPointer codeHeaderAddress = Target.ReadPointer(codeHeaderIndirect);
-    Data.RealCodeHeader realCodeHeader = Target.ProcessedData.GetOrAdd<Data.RealCodeHeader>(codeHeaderAddress);
-    info = new CodeBlock(jittedCodeAddress, realCodeHeader.MethodDesc, relativeOffset, rangeSection.Data!.JitManager);
+    TargetPointer methodDesc = Target.ReadPointer(codeHeaderAddress + /* RealCodeHeader::MethodDesc offset */);
+    info = new CodeBlock(jittedCodeAddress, realCodeHeader.MethodDesc, relativeOffset);
     return true;
 }
 ```
@@ -148,35 +138,31 @@ bool GetMethodInfo(RangeSection rangeSection, TargetCodePointer jittedCodeAddres
 The R2R JitManager `GetMethodInfo` finds the runtime function corresponding to an address and maps its entry point pack to a method:
 
 ```csharp
-bool GetMethodInfo(RangeSection rangeSection, TargetCodePointer jittedCodeAddress, [NotNullWhen(true)] out CodeBlock? info)
+bool GetMethodInfo(TargetPointer rangeSection, TargetCodePointer jittedCodeAddress, [NotNullWhen(true)] out CodeBlock? info)
 {
-    if (rangeSection.Data == null)
-        throw new ArgumentException(nameof(rangeSection));
-
     info = default;
 
     TargetPointer r2rModule = Target.ReadPointer(/* range section address + RangeSection::R2RModule offset */);
     TargetPointer r2rInfo = Target.ReadPointer(r2rModule + /* Module::ReadyToRunInfo offset */);
 
     // Check if address is in a thunk
-    if (IsStubCodeBlockThunk(rangeSection.Data, r2rInfo, jittedCodeAddress))
+    if (/* jittedCodeAddress is in ReadyToRunInfo::DelayLoadMethodCallThunks */)
         return false;
 
     // Find the relative address that we are looking for
-    TargetCodePointer code = /* code pointer from jittedCodeAddress using PlatformMetadata.GetCodePointerFlags */
+    TargetCodePointer addr = /* code pointer from jittedCodeAddress using PlatformMetadata.GetCodePointerFlags */
     TargetPointer imageBase = Target.ReadPointer(/* range section address + RangeSection::RangeBegin offset */);
-    TargetPointer relativeAddr = code - imageBase;
+    TargetPointer relativeAddr = addr - imageBase;
 
     TargetPointer runtimeFunctions = Target.ReadPointer(r2rInfo + /* ReadyToRunInfo::RuntimeFunctions offset */);
     int index = // Iterate through runtimeFunctions and find index of function with relativeAddress
     if (index < 0)
         return false;
 
-    bool featureEHFunclets = Target.ReadGlobal<byte>(Constants.Globals.FeatureEHFunclets) != 0;
+    bool featureEHFunclets = Target.ReadGlobal<byte>("FeatureEHFunclets") != 0;
     if (featureEHFunclets)
     {
-        // TODO: [cdac] Look up in hot/cold mapping lookup table and if the method is in the cold block,
-        // get the index of the associated hot block.
+        index = // look up hot part index in the hot/cold map
     }
 
     TargetPointer function = runtimeFunctions + (ulong)(index * /* size of RuntimeFunction */);
@@ -186,11 +172,22 @@ bool GetMethodInfo(RangeSection rangeSection, TargetCodePointer jittedCodeAddres
 
     TargetPointer mapAddress = r2rInfo + /* ReadyToRunInfo::EntryPointToMethodDescMap offset */;
     TargetPointer methodDesc = /* look up entryPoint in HashMap at mapAddress */;
+    while (featureEHFunclets && methodDesc == TargetPointer.Null)
+    {
+        index--;
+        methodDesc = /* re-compute entryPoint based on updated index and look up in HashMap at mapAddress */
+    }
 
-    // TODO: [cdac] Handle method with cold code when computing relative offset
     TargetNUInt relativeOffset = new TargetNUInt(code - startAddress);
+    if (/* function has cold part and addr is in the cold part*/)
+    {
+        uint coldIndex = // look up cold part in hot/cold map
+        TargetPointer coldFunction = runtimeFunctions + (ulong)(coldIndex * /* size of RuntimeFunction */);
+        TargetPointer coldStart = imageBase + Target.Read<uint>(function + /* RuntimeFunction::BeginAddress offset */);
+        relativeOffset = /* function length of hot part */ + addr - coldStart;
+    }
 
-    info = new CodeBlock(startAddress.Value, methodDesc, relativeOffset, rangeSection.Data!.JitManager);
+    info = new CodeBlock(startAddress.Value, methodDesc, relativeOffset);
     return true;
 }
 ```
@@ -204,19 +201,16 @@ class CodeBlock
 
     public TargetCodePointer StartAddress { get; }
     public TargetPointer MethodDesc { get; }
-    public TargetPointer JitManagerAddress { get; }
     public TargetNUInt RelativeOffset { get; }
 
-    public CodeBlock(TargetCodePointer startAddress, TargetPointer methodDesc, TargetNUInt relativeOffset, TargetPointer jitManagerAddress)
+    public CodeBlock(TargetCodePointer startAddress, TargetPointer methodDesc, TargetNUInt relativeOffset)
     {
         StartAddress = startAddress;
         MethodDesc = methodDesc;
         RelativeOffset = relativeOffset;
-        JitManagerAddress = jitManagerAddress;
     }
 
     public TargetPointer MethodDescAddress => _codeHeaderData.MethodDesc;
-    public bool Valid => JitManagerAddress != TargetPointer.Null;
 }
 ```
 

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -418,6 +418,8 @@ CDAC_TYPE_INDETERMINATE(ReadyToRunInfo)
 CDAC_TYPE_FIELD(ReadyToRunInfo, /*pointer*/, CompositeInfo, cdac_data<ReadyToRunInfo>::CompositeInfo)
 CDAC_TYPE_FIELD(ReadyToRunInfo, /*uint32*/, NumRuntimeFunctions, cdac_data<ReadyToRunInfo>::NumRuntimeFunctions)
 CDAC_TYPE_FIELD(ReadyToRunInfo, /*pointer*/, RuntimeFunctions, cdac_data<ReadyToRunInfo>::RuntimeFunctions)
+CDAC_TYPE_FIELD(ReadyToRunInfo, /*uint32*/, NumHotColdMap, cdac_data<ReadyToRunInfo>::NumHotColdMap)
+CDAC_TYPE_FIELD(ReadyToRunInfo, /*pointer*/, HotColdMap, cdac_data<ReadyToRunInfo>::HotColdMap)
 CDAC_TYPE_FIELD(ReadyToRunInfo, /*pointer*/, DelayLoadMethodCallThunks, cdac_data<ReadyToRunInfo>::DelayLoadMethodCallThunks)
 CDAC_TYPE_FIELD(ReadyToRunInfo, /*HashMap*/, EntryPointToMethodDescMap, cdac_data<ReadyToRunInfo>::EntryPointToMethodDescMap)
 CDAC_TYPE_END(ReadyToRunInfo)
@@ -431,7 +433,18 @@ CDAC_TYPE_END(ImageDataDirectory)
 CDAC_TYPE_BEGIN(RuntimeFunction)
 CDAC_TYPE_SIZE(sizeof(RUNTIME_FUNCTION))
 CDAC_TYPE_FIELD(RuntimeFunction, /*uint32*/, BeginAddress, offsetof(RUNTIME_FUNCTION, BeginAddress))
+#ifdef TARGET_AMD64
+CDAC_TYPE_FIELD(RuntimeFunction, /*uint32*/, EndAddress, offsetof(RUNTIME_FUNCTION, EndAddress))
+#endif
+CDAC_TYPE_FIELD(RuntimeFunction, /*uint32*/, UnwindData, offsetof(RUNTIME_FUNCTION, UnwindData))
 CDAC_TYPE_END(RuntimeFunction)
+
+CDAC_TYPE_BEGIN(UnwindInfo)
+CDAC_TYPE_INDETERMINATE(UnwindInfo)
+#ifdef TARGET_X86
+CDAC_TYPE_FIELD(UnwindInfo, /*uint32*/, FunctionLength, offsetof(UNWIND_INFO, FunctionLength))
+#endif
+CDAC_TYPE_END(UnwindInfo)
 
 CDAC_TYPE_BEGIN(HashMap)
 CDAC_TYPE_INDETERMINATE(HashMap)

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -347,6 +347,8 @@ struct cdac_data<ReadyToRunInfo>
     static constexpr size_t CompositeInfo = offsetof(ReadyToRunInfo, m_pCompositeInfo);
     static constexpr size_t NumRuntimeFunctions = offsetof(ReadyToRunInfo, m_nRuntimeFunctions);
     static constexpr size_t RuntimeFunctions = offsetof(ReadyToRunInfo, m_pRuntimeFunctions);
+    static constexpr size_t NumHotColdMap = offsetof(ReadyToRunInfo, m_nHotColdMap);
+    static constexpr size_t HotColdMap = offsetof(ReadyToRunInfo, m_pHotColdMap);
     static constexpr size_t DelayLoadMethodCallThunks = offsetof(ReadyToRunInfo, m_pSectionDelayLoadMethodCallThunks);
     static constexpr size_t EntryPointToMethodDescMap = offsetof(ReadyToRunInfo, m_entryPointToMethodDescMap);
 };

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
@@ -17,7 +17,6 @@ internal interface IExecutionManager : IContract
     CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => throw new NotImplementedException();
     TargetPointer GetMethodDesc(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
     TargetCodePointer GetStartAddress(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
-
 }
 
 internal readonly struct ExecutionManager : IExecutionManager

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
@@ -72,4 +72,5 @@ public enum DataType
     RuntimeFunction,
     HashMap,
     Bucket,
+    UnwindInfo,
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerBase.ReadyToRunJitManager.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerBase.ReadyToRunJitManager.cs
@@ -43,37 +43,70 @@ internal partial class ExecutionManagerBase<T> : IExecutionManager
             TargetPointer imageBase = rangeSection.Data.RangeBegin;
             TargetPointer relativeAddr = addr - imageBase;
 
-            int index = GetRuntimeFunctionIndexForAddress(r2rInfo, relativeAddr);
-            if (index < 0)
+            uint index;
+            if (!TryGetRuntimeFunctionIndexForAddress(r2rInfo, relativeAddr, out index))
                 return false;
 
             bool featureEHFunclets = Target.ReadGlobal<byte>(Constants.Globals.FeatureEHFunclets) != 0;
             if (featureEHFunclets)
             {
-                // TODO: [cdac] Look up in hot/cold mapping lookup table and if the method is in the cold block,
-                // get the index of the associated hot block.
-                //   HotColdMappingLookupTable::LookupMappingForMethod
-                //
-                // while GetMethodDescForEntryPoint for the begin address of function at index is null
-                //   index--
+                // Look up index in hot/cold map - if the function is in the cold part, get the index of the hot part.
+                index = GetHotFunctionIndex(r2rInfo, index);
             }
 
-            TargetPointer functionEntry = r2rInfo.RuntimeFunctions + (ulong)(index * _runtimeFunctionSize);
-            Data.RuntimeFunction function = Target.ProcessedData.GetOrAdd<Data.RuntimeFunction>(functionEntry);
+            TargetPointer methodDesc = GetMethodDescForRuntimeFunction(r2rInfo, imageBase, index);
+            while (featureEHFunclets && methodDesc == TargetPointer.Null)
+            {
+                index--;
+                methodDesc = GetMethodDescForRuntimeFunction(r2rInfo, imageBase, index);
+            }
 
-            // ReadyToRunInfo::GetMethodDescForEntryPointInNativeImage
-            TargetCodePointer startAddress = imageBase + function.BeginAddress;
-            TargetPointer entryPoint = CodePointerUtils.AddressFromCodePointer(startAddress, Target);
-
-            TargetPointer methodDesc = _lookup.GetValue(r2rInfo.EntryPointToMethodDescMap, entryPoint);
             Debug.Assert(methodDesc != TargetPointer.Null);
+            Data.RuntimeFunction function = GetRuntimeFunction(r2rInfo, index);
 
-            // TODO: [cdac] Handle method with cold code when computing relative offset
-            // ReadyToRunJitManager::JitTokenToMethodRegionInfo
+            TargetCodePointer startAddress = imageBase + function.BeginAddress;
             TargetNUInt relativeOffset = new TargetNUInt(addr - startAddress);
+
+            // Take any cold code into account for the relative offset
+            if (TryGetColdFunctionIndex(r2rInfo, index, out uint hotColdMapIndex, out uint coldFunctionIndex))
+            {
+                // ReadyToRunJitManager::JitTokenToMethodRegionInfo
+                Data.RuntimeFunction coldFunction = GetRuntimeFunction(r2rInfo, coldFunctionIndex);
+                TargetPointer coldStart = imageBase + coldFunction.BeginAddress;
+                if (addr >= coldStart)
+                {
+                    uint nextColdFunctionIndex = hotColdMapIndex == r2rInfo.NumHotColdMap - 2
+                        ? r2rInfo.NumRuntimeFunctions - 1
+                        : Target.Read<uint>(r2rInfo.HotColdMap + (hotColdMapIndex + 2) * sizeof(uint)) - 1;
+                    Data.RuntimeFunction nextColdFunction = GetRuntimeFunction(r2rInfo, nextColdFunctionIndex);
+                    uint coldSize = nextColdFunction.BeginAddress + GetFunctionLength(nextColdFunction) - coldFunction.BeginAddress;
+                    if (coldSize > 0)
+                    {
+                        uint hotSize = GetFunctionLength(function);
+                        relativeOffset = new TargetNUInt(hotSize + addr - coldStart);
+                    }
+                }
+            }
 
             info = new CodeBlock(startAddress.Value, methodDesc, relativeOffset, rangeSection.Data!.JitManager);
             return true;
+        }
+
+        private uint GetFunctionLength(Data.RuntimeFunction function)
+        {
+            if (function.EndAddress.HasValue)
+                return function.EndAddress.Value - function.BeginAddress;
+
+            Data.UnwindInfo  unwindInfo = Target.ProcessedData.GetOrAdd<Data.UnwindInfo>(function.UnwindData);
+            if (unwindInfo.FunctionLength.HasValue)
+                return unwindInfo.FunctionLength.Value;
+
+            Debug.Assert(unwindInfo.Header.HasValue);
+
+            // First 18 bits are function length / (pointer size / 2).
+            // See UnwindFragmentInfo::Finalize
+            uint funcLengthInHeader = unwindInfo.Header.Value & ((1 << 18) - 1);
+            return (uint)(funcLengthInHeader * (Target.PointerSize / 2));
         }
 
         private bool IsStubCodeBlockThunk(Data.RangeSection rangeSection, Data.ReadyToRunInfo r2rInfo, TargetCodePointer jittedCodeAddress)
@@ -87,7 +120,7 @@ internal partial class ExecutionManagerBase<T> : IExecutionManager
             return thunksData.VirtualAddress <= rva && rva < thunksData.VirtualAddress + thunksData.Size;
         }
 
-        private int GetRuntimeFunctionIndexForAddress(Data.ReadyToRunInfo r2rInfo, TargetPointer relativeAddress)
+        private bool TryGetRuntimeFunctionIndexForAddress(Data.ReadyToRunInfo r2rInfo, TargetPointer relativeAddress, out uint index)
         {
             // NativeUnwindInfoLookupTable::LookupUnwindInfoForMethod
             uint start = 0;
@@ -121,10 +154,14 @@ internal partial class ExecutionManagerBase<T> : IExecutionManager
 
                 Data.RuntimeFunction func = GetRuntimeFunction(r2rInfo, i);
                 if (relativeAddress >= func.BeginAddress)
-                    return (int)i;
+                {
+                    index = i;
+                    return true;
+                }
             }
 
-            return -1;
+            index = ~0u;
+            return false;
         }
 
         private Data.RuntimeFunction GetRuntimeFunction(Data.ReadyToRunInfo r2rInfo, uint index)
@@ -132,6 +169,133 @@ internal partial class ExecutionManagerBase<T> : IExecutionManager
             TargetPointer first = r2rInfo.RuntimeFunctions;
             TargetPointer addr = first + (ulong)(index * _runtimeFunctionSize);
             return Target.ProcessedData.GetOrAdd<Data.RuntimeFunction>(addr);
+        }
+
+        private TargetPointer GetMethodDescForRuntimeFunction(Data.ReadyToRunInfo r2rInfo, TargetPointer imageBase, uint runtimeFunctionIndex)
+        {
+            Data.RuntimeFunction function = GetRuntimeFunction(r2rInfo, runtimeFunctionIndex);
+
+            // ReadyToRunInfo::GetMethodDescForEntryPointInNativeImage
+            TargetCodePointer startAddress = imageBase + function.BeginAddress;
+            TargetPointer entryPoint = CodePointerUtils.AddressFromCodePointer(startAddress, Target);
+
+            TargetPointer methodDesc = _lookup.GetValue(r2rInfo.EntryPointToMethodDescMap, entryPoint);
+            if (methodDesc == (ulong)HashMapLookup.SpecialKeys.InvalidEntry)
+                return TargetPointer.Null;
+
+            return methodDesc;
+        }
+
+        private uint GetHotFunctionIndex(Data.ReadyToRunInfo r2rInfo, uint runtimeFunctionIndex)
+        {
+            int lookupIndex = LookupHotColdMappingForMethod(r2rInfo, runtimeFunctionIndex);
+
+            // If runtime function is in the cold part, get the associated hot part
+            if (lookupIndex != -1 && (lookupIndex & 1) == 1)
+                runtimeFunctionIndex = Target.Read<uint>(r2rInfo.HotColdMap + (ulong)lookupIndex * sizeof(uint));
+
+            return runtimeFunctionIndex;
+        }
+
+        private bool IsColdCode(Data.ReadyToRunInfo r2rInfo, uint runtimeFunctionIndex)
+        {
+            if (r2rInfo.NumHotColdMap == 0)
+                return false;
+
+            // Determine if the method index represents a hot or cold part by comparing against the first
+            // cold part index (hot < cold).
+            uint firstColdRuntimeFunctionIndex = Target.Read<uint>(r2rInfo.HotColdMap);
+            return runtimeFunctionIndex >= firstColdRuntimeFunctionIndex;
+        }
+
+        private bool TryGetColdFunctionIndex(Data.ReadyToRunInfo r2rInfo, uint runtimeFunctionIndex, out uint lookupIndex, out uint coldFunctionIndex)
+        {
+            Debug.Assert(!IsColdCode(r2rInfo, runtimeFunctionIndex));
+
+            lookupIndex = ~0u;
+            coldFunctionIndex = ~0u;
+            int lookupIndexLocal = LookupHotColdMappingForMethod(r2rInfo, runtimeFunctionIndex);
+
+            // Runtime function has no cold part
+            if (lookupIndexLocal == -1)
+                return false;
+
+            Debug.Assert((lookupIndexLocal & 1) == 0);
+            lookupIndex = (uint)lookupIndexLocal;
+            coldFunctionIndex = Target.Read<uint>(r2rInfo.HotColdMap + (ulong)lookupIndexLocal * sizeof(uint));
+            return true;
+        }
+
+        // Look up a runtime function index in the hot/cold map
+        // If the runtime function index is:
+        //  - cold and in the map, returns the index of the hot part in the hot/cold map
+        //  - hot and in the map, returns the index of the cold part in the hot/cold map
+        //  - not in the map, returns -1
+        private int LookupHotColdMappingForMethod(Data.ReadyToRunInfo r2rInfo, uint runtimeFunctionIndex)
+        {
+            // HotColdMappingLookupTable::LookupMappingForMethod
+            if (r2rInfo.NumHotColdMap == 0)
+                return -1;
+
+            // Hot/cold lookup table should contain a subset of indices in the runtime functions
+            Debug.Assert(r2rInfo.NumHotColdMap <= r2rInfo.NumRuntimeFunctions);
+
+            // Each method is represented by a pair of unsigned 32-bit integers. First is the runtime
+            // function index of the cold part, second is the runtime function index of the hot part.
+            // HotColdMap is these pairs as an array, so the logical size is half the array size.
+            uint start = 0;
+            uint end = (r2rInfo.NumHotColdMap - 1) / 2;
+
+            bool isColdCode = IsColdCode(r2rInfo, runtimeFunctionIndex);
+            int indexCorrection = isColdCode ? 0 : 1;
+
+            // Entries are sorted by the hot part runtime function indices. This also means they are sorted
+            // by the cold part indices, as the cold part is emitted in the same order as hot parts.
+            // Binary search until we get to 10 or fewer items.
+            while (end - start > 10)
+            {
+                uint middle = start + (end - start) / 2;
+                long index = middle * 2 + indexCorrection;
+
+                if (runtimeFunctionIndex < Target.Read<uint>(r2rInfo.HotColdMap + (ulong)(index * sizeof(uint))))
+                {
+                    end = middle - 1;
+                }
+                else
+                {
+                    start = middle;
+                }
+            }
+
+            // Find the hot/cold map index corresponding to the cold/hot runtime function index
+            for (uint i = start; i <= end; ++i)
+            {
+                uint index = i * 2;
+
+                uint value = Target.Read<uint>(r2rInfo.HotColdMap + (ulong)(index + indexCorrection) * sizeof(uint));
+                if (value == runtimeFunctionIndex)
+                {
+                    return isColdCode
+                        ? (int)index + 1
+                        : (int)index;
+                }
+                else if (isColdCode && runtimeFunctionIndex > Target.Read<uint>(r2rInfo.HotColdMap + (ulong)index * sizeof(uint)))
+                {
+                    // If function index is a cold funclet from a cold block, the above check for equality will fail.
+                    // To get its corresponding hot block, find the cold block containing the funclet,
+                    // then use the lookup table.
+                    // The cold funclet's function index will be greater than its cold block's function index,
+                    // but less than the next cold block's function index in the lookup table.
+                    bool isFuncletIndex = index + 2 == r2rInfo.NumHotColdMap
+                        || runtimeFunctionIndex < Target.Read<uint>(r2rInfo.HotColdMap + (ulong)(index + 2) * sizeof(uint));
+                    if (isFuncletIndex)
+                    {
+                        return (int)index + 1;
+                    }
+                }
+            }
+
+            return -1;
         }
     }
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/BinaryThenLinearSearch.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/BinaryThenLinearSearch.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
-internal static class BinaryThenLinearSeach
+internal static class BinaryThenLinearSearch
 {
     private const uint BinarySearchCountThreshold = 10;
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/BinaryThenLinearSearch.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/BinaryThenLinearSearch.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
+
+internal static class BinaryThenLinearSeach
+{
+    private const uint BinarySearchCountThreshold = 10;
+
+    public static bool Search(
+        uint start,
+        uint end,
+        Func<uint, bool> compare,
+        Func<uint, bool> match,
+        out uint index)
+    {
+        // Binary search until we get to a fewer than the threshold number of items.
+        while (end - start > BinarySearchCountThreshold)
+        {
+            uint middle = start + (end - start) / 2;
+            if (compare(middle))
+            {
+                end = middle - 1;
+            }
+            else
+            {
+                start = middle;
+            }
+        }
+
+        // Linear search over the remaining items
+        for (uint i = start; i <= end; ++i)
+        {
+            if (!match(i))
+                continue;
+
+            index = i;
+            return true;
+        }
+
+        index = ~0u;
+        return false;
+    }
+}

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
@@ -27,7 +27,7 @@ internal sealed class HotColdLookup
             return runtimeFunctionIndex;
 
         // If runtime function is in the cold part, get the associated hot part
-        Debug.Assert((hotIndex & 1) == 1);
+        Debug.Assert(hotIndex % 2 != 0, "Hot part index should be an odd number");
         return _target.Read<uint>(hotColdMap + (ulong)hotIndex * sizeof(uint));
     }
 
@@ -39,6 +39,7 @@ internal sealed class HotColdLookup
         if (!TryLookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex, out uint _, out coldIndex))
             return false;
 
+        Debug.Assert(coldIndex % 2 == 0, "Cold part index should be an even number");
         functionIndex = _target.Read<uint>(hotColdMap + (ulong)coldIndex * sizeof(uint));
         return true;
     }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
@@ -83,7 +83,7 @@ internal sealed class HotColdLookup
 
         // Index used for the search is the logical index of hot/cold pairs. We double it to index
         // into the HotColdMap array.
-        if (BinaryThenLinearSeach.Search(start, end, Compare, Match, out uint index))
+        if (BinaryThenLinearSearch.Search(start, end, Compare, Match, out uint index))
         {
             hotIndex = index * 2 + 1;
             coldIndex = index * 2;

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
@@ -31,17 +31,15 @@ internal sealed class HotColdLookup
         return _target.Read<uint>(hotColdMap + (ulong)hotIndex * sizeof(uint));
     }
 
-    public bool TryGetColdFunctionIndex(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex, out uint lookupIndex, out uint functionIndex)
+    public bool TryGetColdFunctionIndex(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex, out uint functionIndex)
     {
-        lookupIndex = ~0u;
         functionIndex = ~0u;
 
         uint coldIndex;
         if (!TryLookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex, out uint _, out coldIndex))
             return false;
 
-        lookupIndex = coldIndex;
-        functionIndex = _target.Read<uint>(hotColdMap + (ulong)lookupIndex * sizeof(uint));
+        functionIndex = _target.Read<uint>(hotColdMap + (ulong)coldIndex * sizeof(uint));
         return true;
     }
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
+
+internal sealed class HotColdLookup
+{
+    public static HotColdLookup Create(Target target)
+        => new HotColdLookup(target);
+
+    private readonly Target _target;
+
+    private HotColdLookup(Target target)
+    {
+        _target = target;
+    }
+
+    public uint GetHotFunctionIndex(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex)
+    {
+        int lookupIndex = LookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex);
+
+        // If runtime function is in the cold part, get the associated hot part
+        if (lookupIndex != -1 && (lookupIndex & 1) == 1)
+            runtimeFunctionIndex = _target.Read<uint>(hotColdMap + (ulong)lookupIndex * sizeof(uint));
+
+        return runtimeFunctionIndex;
+    }
+
+    private bool IsColdCode(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex)
+    {
+        if (numHotColdMap == 0)
+            return false;
+
+        // Determine if the method index represents a hot or cold part by comparing against the first
+        // cold part index (hot < cold).
+        uint firstColdRuntimeFunctionIndex = _target.Read<uint>(hotColdMap);
+        return runtimeFunctionIndex >= firstColdRuntimeFunctionIndex;
+    }
+
+    public bool TryGetColdFunctionIndex(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex, out uint lookupIndex, out uint coldFunctionIndex)
+    {
+        Debug.Assert(!IsColdCode(numHotColdMap, hotColdMap, runtimeFunctionIndex));
+
+        lookupIndex = ~0u;
+        coldFunctionIndex = ~0u;
+        int lookupIndexLocal = LookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex);
+
+        // Runtime function has no cold part
+        if (lookupIndexLocal == -1)
+            return false;
+
+        Debug.Assert((lookupIndexLocal & 1) == 0);
+        lookupIndex = (uint)lookupIndexLocal;
+        coldFunctionIndex = _target.Read<uint>(hotColdMap + (ulong)lookupIndexLocal * sizeof(uint));
+        return true;
+    }
+
+    // Look up a runtime function index in the hot/cold map
+    // If the runtime function index is:
+    //  - cold and in the map, returns the index of the hot part in the hot/cold map
+    //  - hot and in the map, returns the index of the cold part in the hot/cold map
+    //  - not in the map, returns -1
+    private int LookupHotColdMappingForMethod(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex)
+    {
+        // HotColdMappingLookupTable::LookupMappingForMethod
+        if (numHotColdMap == 0)
+            return -1;
+
+        // Each method is represented by a pair of unsigned 32-bit integers. First is the runtime
+        // function index of the cold part, second is the runtime function index of the hot part.
+        // HotColdMap is these pairs as an array, so the logical size is half the array size.
+        uint start = 0;
+        uint end = (numHotColdMap - 1) / 2;
+
+        bool isColdCode = IsColdCode(numHotColdMap, hotColdMap, runtimeFunctionIndex);
+        int indexCorrection = isColdCode ? 0 : 1;
+
+        // Entries are sorted by the hot part runtime function indices. This also means they are sorted
+        // by the cold part indices, as the cold part is emitted in the same order as hot parts.
+        // Binary search until we get to 10 or fewer items.
+        while (end - start > 10)
+        {
+            uint middle = start + (end - start) / 2;
+            long index = middle * 2 + indexCorrection;
+
+            if (runtimeFunctionIndex < _target.Read<uint>(hotColdMap + (ulong)(index * sizeof(uint))))
+            {
+                end = middle - 1;
+            }
+            else
+            {
+                start = middle;
+            }
+        }
+
+        // Find the hot/cold map index corresponding to the cold/hot runtime function index
+        for (uint i = start; i <= end; ++i)
+        {
+            uint index = i * 2;
+
+            uint value = _target.Read<uint>(hotColdMap + (ulong)(index + indexCorrection) * sizeof(uint));
+            if (value == runtimeFunctionIndex)
+            {
+                return isColdCode
+                    ? (int)index + 1
+                    : (int)index;
+            }
+            else if (isColdCode && runtimeFunctionIndex > _target.Read<uint>(hotColdMap + (ulong)index * sizeof(uint)))
+            {
+                // If function index is a cold funclet from a cold block, the above check for equality will fail.
+                // To get its corresponding hot block, find the cold block containing the funclet,
+                // then use the lookup table.
+                // The cold funclet's function index will be greater than its cold block's function index,
+                // but less than the next cold block's function index in the lookup table.
+                bool isFuncletIndex = index + 2 == numHotColdMap
+                    || runtimeFunctionIndex < _target.Read<uint>(hotColdMap + (ulong)(index + 2) * sizeof(uint));
+                if (isFuncletIndex)
+                {
+                    return (int)index + 1;
+                }
+            }
+        }
+
+        return -1;
+    }
+}

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/HotColdLookup.cs
@@ -19,13 +19,30 @@ internal sealed class HotColdLookup
 
     public uint GetHotFunctionIndex(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex)
     {
-        int lookupIndex = LookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex);
+        if (!IsColdCode(numHotColdMap, hotColdMap, runtimeFunctionIndex))
+            return runtimeFunctionIndex;
+
+        uint hotIndex;
+        if (!TryLookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex, out hotIndex, out _))
+            return runtimeFunctionIndex;
 
         // If runtime function is in the cold part, get the associated hot part
-        if (lookupIndex != -1 && (lookupIndex & 1) == 1)
-            runtimeFunctionIndex = _target.Read<uint>(hotColdMap + (ulong)lookupIndex * sizeof(uint));
+        Debug.Assert((hotIndex & 1) == 1);
+        return _target.Read<uint>(hotColdMap + (ulong)hotIndex * sizeof(uint));
+    }
 
-        return runtimeFunctionIndex;
+    public bool TryGetColdFunctionIndex(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex, out uint lookupIndex, out uint functionIndex)
+    {
+        lookupIndex = ~0u;
+        functionIndex = ~0u;
+
+        uint coldIndex;
+        if (!TryLookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex, out uint _, out coldIndex))
+            return false;
+
+        lookupIndex = coldIndex;
+        functionIndex = _target.Read<uint>(hotColdMap + (ulong)lookupIndex * sizeof(uint));
+        return true;
     }
 
     private bool IsColdCode(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex)
@@ -39,34 +56,22 @@ internal sealed class HotColdLookup
         return runtimeFunctionIndex >= firstColdRuntimeFunctionIndex;
     }
 
-    public bool TryGetColdFunctionIndex(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex, out uint lookupIndex, out uint coldFunctionIndex)
+    // Look up a runtime function index in the hot/cold map. If the function is in the
+    // hot/cold map, return whether the function corresponds to cold code and the hot
+    // and cold lookup indexes for the function.
+    private bool TryLookupHotColdMappingForMethod(
+        uint numHotColdMap,
+        TargetPointer hotColdMap,
+        uint runtimeFunctionIndex,
+        out uint hotIndex,
+        out uint coldIndex)
     {
-        Debug.Assert(!IsColdCode(numHotColdMap, hotColdMap, runtimeFunctionIndex));
+        hotIndex = ~0u;
+        coldIndex = ~0u;
 
-        lookupIndex = ~0u;
-        coldFunctionIndex = ~0u;
-        int lookupIndexLocal = LookupHotColdMappingForMethod(numHotColdMap, hotColdMap, runtimeFunctionIndex);
-
-        // Runtime function has no cold part
-        if (lookupIndexLocal == -1)
-            return false;
-
-        Debug.Assert((lookupIndexLocal & 1) == 0);
-        lookupIndex = (uint)lookupIndexLocal;
-        coldFunctionIndex = _target.Read<uint>(hotColdMap + (ulong)lookupIndexLocal * sizeof(uint));
-        return true;
-    }
-
-    // Look up a runtime function index in the hot/cold map
-    // If the runtime function index is:
-    //  - cold and in the map, returns the index of the hot part in the hot/cold map
-    //  - hot and in the map, returns the index of the cold part in the hot/cold map
-    //  - not in the map, returns -1
-    private int LookupHotColdMappingForMethod(uint numHotColdMap, TargetPointer hotColdMap, uint runtimeFunctionIndex)
-    {
         // HotColdMappingLookupTable::LookupMappingForMethod
         if (numHotColdMap == 0)
-            return -1;
+            return false;
 
         // Each method is represented by a pair of unsigned 32-bit integers. First is the runtime
         // function index of the cold part, second is the runtime function index of the hot part.
@@ -103,26 +108,29 @@ internal sealed class HotColdLookup
             uint value = _target.Read<uint>(hotColdMap + (ulong)(index + indexCorrection) * sizeof(uint));
             if (value == runtimeFunctionIndex)
             {
-                return isColdCode
-                    ? (int)index + 1
-                    : (int)index;
+                hotIndex = index + 1;
+                coldIndex = index;
+                return true;
             }
-            else if (isColdCode && runtimeFunctionIndex > _target.Read<uint>(hotColdMap + (ulong)index * sizeof(uint)))
+
+            // If function index is a cold funclet from a cold block, the above check for equality will fail.
+            // To get its corresponding hot block, find the cold block containing the funclet,
+            // then use the lookup table.
+            // The cold funclet's function index will be greater than its cold block's function index,
+            // but less than the next cold block's function index in the lookup table.
+            if (isColdCode && runtimeFunctionIndex > _target.Read<uint>(hotColdMap + (ulong)index * sizeof(uint)))
             {
-                // If function index is a cold funclet from a cold block, the above check for equality will fail.
-                // To get its corresponding hot block, find the cold block containing the funclet,
-                // then use the lookup table.
-                // The cold funclet's function index will be greater than its cold block's function index,
-                // but less than the next cold block's function index in the lookup table.
                 bool isFuncletIndex = index + 2 == numHotColdMap
                     || runtimeFunctionIndex < _target.Read<uint>(hotColdMap + (ulong)(index + 2) * sizeof(uint));
                 if (isFuncletIndex)
                 {
-                    return (int)index + 1;
+                    hotIndex = index + 1;
+                    coldIndex = index;
+                    return true;
                 }
             }
         }
 
-        return -1;
+        return false;
     }
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/RuntimeFunctionLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/RuntimeFunctionLookup.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
+
+internal sealed class RuntimeFunctionLookup
+{
+    public static RuntimeFunctionLookup Create(Target target)
+        => new RuntimeFunctionLookup(target);
+
+    private readonly uint _runtimeFunctionSize;
+    private readonly Target _target;
+
+    private RuntimeFunctionLookup(Target target)
+    {
+        _target = target;
+        _runtimeFunctionSize = target.GetTypeInfo(DataType.RuntimeFunction).Size!.Value;
+    }
+
+    public uint GetFunctionLength(Data.RuntimeFunction function)
+    {
+        if (function.EndAddress.HasValue)
+            return function.EndAddress.Value - function.BeginAddress;
+
+        Data.UnwindInfo unwindInfo = _target.ProcessedData.GetOrAdd<Data.UnwindInfo>(function.UnwindData);
+        if (unwindInfo.FunctionLength.HasValue)
+            return unwindInfo.FunctionLength.Value;
+
+        Debug.Assert(unwindInfo.Header.HasValue);
+
+        // First 18 bits are function length / (pointer size / 2).
+        // See UnwindFragmentInfo::Finalize
+        uint funcLengthInHeader = unwindInfo.Header.Value & ((1 << 18) - 1);
+        return (uint)(funcLengthInHeader * (_target.PointerSize / 2));
+    }
+
+    public bool TryGetRuntimeFunctionIndexForAddress(TargetPointer runtimeFunctions, uint numRuntimeFunctions, TargetPointer relativeAddress, out uint index)
+    {
+        // NativeUnwindInfoLookupTable::LookupUnwindInfoForMethod
+        uint start = 0;
+        uint end = numRuntimeFunctions - 1;
+        relativeAddress = CodePointerUtils.CodePointerFromAddress(relativeAddress, _target).AsTargetPointer;
+
+        // Entries are sorted. Binary search until we get to 10 or fewer items.
+        while (end - start > 10)
+        {
+            uint middle = start + (end - start) / 2;
+            Data.RuntimeFunction func = GetRuntimeFunction(runtimeFunctions, middle);
+            if (relativeAddress < func.BeginAddress)
+            {
+                end = middle - 1;
+            }
+            else
+            {
+                start = middle;
+            }
+        }
+
+        // Find the runtime function that contains the address of interest
+        for (uint i = start; i <= end; ++i)
+        {
+            // Entries are terminated by a sentinel value of -1, so we can index one past the end safely.
+            // Read as a runtime function, its begin address is 0xffffffff (always > relative address).
+            // See RuntimeFunctionsTableNode.GetData in RuntimeFunctionsTableNode.cs
+            Data.RuntimeFunction nextFunc = GetRuntimeFunction(runtimeFunctions, i + 1);
+            if (relativeAddress >= nextFunc.BeginAddress)
+                continue;
+
+            Data.RuntimeFunction func = GetRuntimeFunction(runtimeFunctions, i);
+            if (relativeAddress >= func.BeginAddress)
+            {
+                index = i;
+                return true;
+            }
+        }
+
+        index = ~0u;
+        return false;
+    }
+
+    public Data.RuntimeFunction GetRuntimeFunction(TargetPointer runtimeFunctions, uint index)
+    {
+        TargetPointer addr = runtimeFunctions + (ulong)(index * _runtimeFunctionSize);
+        return _target.ProcessedData.GetOrAdd<Data.RuntimeFunction>(addr);
+    }
+}

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/RuntimeFunctionLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/RuntimeFunctionLookup.cs
@@ -44,7 +44,7 @@ internal sealed class RuntimeFunctionLookup
         relativeAddress = CodePointerUtils.CodePointerFromAddress(relativeAddress, _target).AsTargetPointer;
 
         // Entries are sorted.
-        return BinaryThenLinearSeach.Search(start, end, Compare, Match, out index);
+        return BinaryThenLinearSearch.Search(start, end, Compare, Match, out index);
 
         bool Compare(uint index)
         {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunInfo.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunInfo.cs
@@ -18,7 +18,14 @@ internal sealed class ReadyToRunInfo : IData<ReadyToRunInfo>
         CompositeInfo = target.ReadPointer(address + (ulong)type.Fields[nameof(CompositeInfo)].Offset);
 
         NumRuntimeFunctions = target.Read<uint>(address + (ulong)type.Fields[nameof(NumRuntimeFunctions)].Offset);
-        RuntimeFunctions = target.ReadPointer(address + (ulong)type.Fields[nameof(RuntimeFunctions)].Offset);
+        RuntimeFunctions = NumRuntimeFunctions > 0
+            ? target.ReadPointer(address + (ulong)type.Fields[nameof(RuntimeFunctions)].Offset)
+            : TargetPointer.Null;
+
+        NumHotColdMap = target.Read<uint>(address + (ulong)type.Fields[nameof(NumHotColdMap)].Offset);
+        HotColdMap = NumHotColdMap > 0
+            ? target.ReadPointer(address + (ulong)type.Fields[nameof(HotColdMap)].Offset)
+            : TargetPointer.Null;
 
         DelayLoadMethodCallThunks = target.ReadPointer(address + (ulong)type.Fields[nameof(DelayLoadMethodCallThunks)].Offset);
 
@@ -30,6 +37,9 @@ internal sealed class ReadyToRunInfo : IData<ReadyToRunInfo>
 
     public uint NumRuntimeFunctions { get; }
     public TargetPointer RuntimeFunctions { get; }
+
+    public uint NumHotColdMap { get; }
+    public TargetPointer HotColdMap { get; }
 
     public TargetPointer DelayLoadMethodCallThunks { get; }
     public TargetPointer EntryPointToMethodDescMap { get; }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunInfo.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunInfo.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 internal sealed class ReadyToRunInfo : IData<ReadyToRunInfo>
@@ -23,6 +25,7 @@ internal sealed class ReadyToRunInfo : IData<ReadyToRunInfo>
             : TargetPointer.Null;
 
         NumHotColdMap = target.Read<uint>(address + (ulong)type.Fields[nameof(NumHotColdMap)].Offset);
+        Debug.Assert(NumHotColdMap % 2 == 0, "Hot/cold map should have an even number of entries (pairs of hot/cold runtime function indexes)");
         HotColdMap = NumHotColdMap > 0
             ? target.ReadPointer(address + (ulong)type.Fields[nameof(HotColdMap)].Offset)
             : TargetPointer.Null;

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RuntimeFunction.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RuntimeFunction.cs
@@ -13,7 +13,15 @@ internal sealed class RuntimeFunction : IData<RuntimeFunction>
         Target.TypeInfo type = target.GetTypeInfo(DataType.RuntimeFunction);
 
         BeginAddress = target.Read<uint>(address + (ulong)type.Fields[nameof(BeginAddress)].Offset);
+
+        // Not all platforms define EndAddress
+        if (type.Fields.ContainsKey(nameof(EndAddress)))
+            EndAddress = target.Read<uint>(address + (ulong)type.Fields[nameof(EndAddress)].Offset);
+
+        UnwindData = target.Read<uint>(address + (ulong)type.Fields[nameof(UnwindData)].Offset);
      }
 
     public uint BeginAddress { get; }
+    public uint? EndAddress { get; }
+    public uint UnwindData { get; }
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/UnwindInfo.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/UnwindInfo.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal sealed class UnwindInfo : IData<UnwindInfo>
+{
+    static UnwindInfo IData<UnwindInfo>.Create(Target target, TargetPointer address)
+        => new UnwindInfo(target, address);
+
+    public UnwindInfo(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.UnwindInfo);
+
+        if (type.Fields.ContainsKey(nameof(FunctionLength)))
+        {
+            // The unwind info contains the function length on some platforms (x86)
+            FunctionLength = target.Read<uint>(address + (ulong)type.Fields[nameof(FunctionLength)].Offset);
+        }
+        else
+        {
+            // Otherwise, it starts with a bitfield header
+            Header = target.Read<uint>(address);
+        }
+     }
+
+    public uint? FunctionLength { get; }
+    public uint? Header { get; }
+}

--- a/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/ExecutionManagerTests.cs
@@ -147,7 +147,7 @@ public class ExecutionManagerTests
 
         uint runtimeFunction = 0x100;
 
-        TargetPointer r2rInfo = emBuilder.AddReadyToRunInfo([runtimeFunction]);
+        TargetPointer r2rInfo = emBuilder.AddReadyToRunInfo([runtimeFunction], []);
         MockDescriptors.HashMap hashMapBuilder = new(emBuilder.Builder);
         hashMapBuilder.PopulatePtrMap(
             r2rInfo + (uint)emBuilder.Types[DataType.ReadyToRunInfo].Fields[nameof(Data.ReadyToRunInfo.EntryPointToMethodDescMap)].Offset,
@@ -182,7 +182,7 @@ public class ExecutionManagerTests
 
         uint expectedRuntimeFunction = 0x100;
 
-        TargetPointer r2rInfo = emBuilder.AddReadyToRunInfo([expectedRuntimeFunction]);
+        TargetPointer r2rInfo = emBuilder.AddReadyToRunInfo([expectedRuntimeFunction], []);
         MockDescriptors.HashMap hashMapBuilder = new(emBuilder.Builder);
         hashMapBuilder.PopulatePtrMap(
             r2rInfo + (uint)emBuilder.Types[DataType.ReadyToRunInfo].Fields[nameof(Data.ReadyToRunInfo.EntryPointToMethodDescMap)].Offset,
@@ -228,7 +228,7 @@ public class ExecutionManagerTests
 
         uint[] runtimeFunctions = [ 0x100, 0xc00 ];
 
-        TargetPointer r2rInfo = emBuilder.AddReadyToRunInfo(runtimeFunctions);
+        TargetPointer r2rInfo = emBuilder.AddReadyToRunInfo(runtimeFunctions, []);
         MockDescriptors.HashMap hashMapBuilder = new(emBuilder.Builder);
         hashMapBuilder.PopulatePtrMap(
             r2rInfo + (uint)emBuilder.Types[DataType.ReadyToRunInfo].Fields[nameof(Data.ReadyToRunInfo.EntryPointToMethodDescMap)].Offset,

--- a/src/native/managed/cdacreader/tests/ExecutionManager/HotColdLookupTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/HotColdLookupTests.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Moq;
+using Xunit;
+
+using System;
+using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests.ExecutionManager;
+
+public class HotColdLookupTests
+{
+    private static readonly TargetPointer HotColdMapAddr = 0x1000; // arbitrary
+
+    private static Target CreateMockTarget((uint Cold, uint Hot)[] entries)
+    {
+        Mock<Target> target = new();
+        target.Setup(t => t.Read<uint>(It.IsAny<ulong>()))
+            .Returns((ulong addr) =>
+            {
+                for (uint i = 0; i < entries.Length; i++)
+                {
+                    if (addr == HotColdMapAddr + (i * 2) * sizeof(uint))
+                        return entries[i].Cold;
+
+                    if (addr == HotColdMapAddr + (i * 2 + 1) * sizeof(uint))
+                        return entries[i].Hot;
+                }
+
+                throw new NotImplementedException();
+            });
+
+        return target.Object;
+    }
+
+    [Fact]
+    public void GetHotFunctionIndex()
+    {
+        (uint Cold, uint Hot)[] entries =
+        [
+            (0x100, 0x10),
+            (0x200, 0x20),
+            (0x300, 0x30),
+            (0x400, 0x40),
+        ];
+
+        uint numHotColdMap = (uint)entries.Length * 2;
+        Target target = CreateMockTarget(entries);
+
+        var lookup = HotColdLookup.Create(target);
+        foreach (var entry in entries)
+        {
+            // Hot part as input
+            uint hotIndex = lookup.GetHotFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Hot);
+            Assert.Equal(entry.Hot, hotIndex);
+
+            // Cold part as input
+            hotIndex = lookup.GetHotFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Cold);
+            Assert.Equal(entry.Hot, hotIndex);
+        }
+    }
+
+    [Fact]
+    public void GetHotFunctionIndex_ColdFunclet()
+    {
+        (uint Cold, uint Hot)[] entries =
+        [
+            (0x100, 0x10),
+            (0x200, 0x20),
+        ];
+
+        uint numHotColdMap = (uint)entries.Length * 2;
+        Target target = CreateMockTarget(entries);
+
+        var lookup = HotColdLookup.Create(target);
+
+        // Cold funclet - between two cold blocks' indexes
+        uint functionIndex = 0x110;
+        uint hotIndex = lookup.GetHotFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex);
+        Assert.Equal(entries[0].Hot, hotIndex);
+    }
+
+    [Fact]
+    public void GetHotFunctionIndex_EmptyMap()
+    {
+        Target target = CreateMockTarget([]);
+
+        var lookup = HotColdLookup.Create(target);
+
+        // Function must be hot if there is no map
+        uint functionIndex = 0x110;
+        uint hotIndex = lookup.GetHotFunctionIndex(0, HotColdMapAddr, functionIndex);
+        Assert.Equal(functionIndex, hotIndex);
+    }
+
+    [Fact]
+    public void GetHotFunctionIndex_NoEntryInMap()
+    {
+        (uint Cold, uint Hot)[] entries =
+        [
+            (0x100, 0x10),
+            (0x200, 0x20),
+        ];
+
+        uint numHotColdMap = (uint)entries.Length * 2;
+        Target target = CreateMockTarget(entries);
+
+        var lookup = HotColdLookup.Create(target);
+
+        // Function must be hot if it is not in the map
+        uint functionIndex = 0x30;
+        uint hotIndex = lookup.GetHotFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex);
+        Assert.Equal(functionIndex, hotIndex);
+    }
+
+    [Fact]
+    public void TryGetColdFunctionIndex()
+    {
+        (uint Cold, uint Hot)[] entries =
+        [
+            (0x100, 0x10),
+            (0x200, 0x20),
+            (0x300, 0x30),
+            (0x400, 0x40),
+        ];
+
+        uint numHotColdMap = (uint)entries.Length * 2;
+        Target target = CreateMockTarget(entries);
+
+        var lookup = HotColdLookup.Create(target);
+        for (uint i = 0; i < entries.Length; i++)
+        {
+            var entry = entries[i];
+
+            // Hot part as input
+            bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Hot, out uint lookupIndex, out uint coldFunctionIndex);
+            Assert.True(res);
+            Assert.Equal(i * 2, lookupIndex);
+            Assert.Equal(entry.Cold, coldFunctionIndex);
+
+            // Cold part as input
+            res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Cold, out lookupIndex, out coldFunctionIndex);
+            Assert.True(res);
+            Assert.Equal(i * 2, lookupIndex);
+            Assert.Equal(entry.Cold, coldFunctionIndex);
+        }
+    }
+
+    [Fact]
+    public void TryGetColdFunctionIndex_ColdFunclet()
+    {
+        (uint Cold, uint Hot)[] entries =
+        [
+            (0x100, 0x10),
+            (0x200, 0x20),
+        ];
+
+        uint numHotColdMap = (uint)entries.Length * 2;
+        Target target = CreateMockTarget(entries);
+
+        var lookup = HotColdLookup.Create(target);
+
+        // Cold funclet - between two cold blocks' indexes
+        uint functionIndex = 0x110;
+        bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex, out uint lookupIndex, out uint coldFunctionIndex);
+        Assert.True(res);
+        Assert.Equal(0u, lookupIndex);
+        Assert.Equal(entries[0].Cold, coldFunctionIndex);
+    }
+
+    [Fact]
+    public void TryGetColdFunctionIndex_EmptyMap()
+    {
+        Target target = CreateMockTarget([]);
+
+        var lookup = HotColdLookup.Create(target);
+
+        // Function has no cold part if map is empty
+        uint functionIndex = 0x110;
+        bool res = lookup.TryGetColdFunctionIndex(0, HotColdMapAddr, functionIndex, out _, out _);
+        Assert.False(res);
+    }
+
+    [Fact]
+    public void TryGetColdFunctionIndex_NoEntryInMap()
+    {
+        (uint Cold, uint Hot)[] entries =
+        [
+            (0x100, 0x10),
+            (0x200, 0x20),
+        ];
+
+        uint numHotColdMap = (uint)entries.Length * 2;
+        Target target = CreateMockTarget(entries);
+
+        var lookup = HotColdLookup.Create(target);
+
+        // Function has no cold part if it is not in the map
+        uint functionIndex = 0x30;
+        bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex, out _, out _);
+        Assert.False(res);
+    }
+}

--- a/src/native/managed/cdacreader/tests/ExecutionManager/HotColdLookupTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/HotColdLookupTests.cs
@@ -129,20 +129,16 @@ public class HotColdLookupTests
         Target target = CreateMockTarget(entries);
 
         var lookup = HotColdLookup.Create(target);
-        for (uint i = 0; i < entries.Length; i++)
+        foreach (var entry in entries)
         {
-            var entry = entries[i];
-
             // Hot part as input
-            bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Hot, out uint lookupIndex, out uint coldFunctionIndex);
+            bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Hot, out uint coldFunctionIndex);
             Assert.True(res);
-            Assert.Equal(i * 2, lookupIndex);
             Assert.Equal(entry.Cold, coldFunctionIndex);
 
             // Cold part as input
-            res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Cold, out lookupIndex, out coldFunctionIndex);
+            res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, entry.Cold, out coldFunctionIndex);
             Assert.True(res);
-            Assert.Equal(i * 2, lookupIndex);
             Assert.Equal(entry.Cold, coldFunctionIndex);
         }
     }
@@ -163,9 +159,8 @@ public class HotColdLookupTests
 
         // Cold funclet - between two cold blocks' indexes
         uint functionIndex = 0x110;
-        bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex, out uint lookupIndex, out uint coldFunctionIndex);
+        bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex, out uint coldFunctionIndex);
         Assert.True(res);
-        Assert.Equal(0u, lookupIndex);
         Assert.Equal(entries[0].Cold, coldFunctionIndex);
     }
 
@@ -178,7 +173,7 @@ public class HotColdLookupTests
 
         // Function has no cold part if map is empty
         uint functionIndex = 0x110;
-        bool res = lookup.TryGetColdFunctionIndex(0, HotColdMapAddr, functionIndex, out _, out _);
+        bool res = lookup.TryGetColdFunctionIndex(0, HotColdMapAddr, functionIndex, out _);
         Assert.False(res);
     }
 
@@ -198,7 +193,7 @@ public class HotColdLookupTests
 
         // Function has no cold part if it is not in the map
         uint functionIndex = 0x30;
-        bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex, out _, out _);
+        bool res = lookup.TryGetColdFunctionIndex(numHotColdMap, HotColdMapAddr, functionIndex, out _);
         Assert.False(res);
     }
 }

--- a/src/native/managed/cdacreader/tests/ExecutionManager/RuntimeFunctionTests.cs
+++ b/src/native/managed/cdacreader/tests/ExecutionManager/RuntimeFunctionTests.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
+using System.Collections.Generic;
+using System;
+using Moq;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests.ExecutionManager;
+
+public class RuntimeFunctionTests
+{
+    public static IEnumerable<object[]> StdArchFunctionLengthData()
+    {
+        foreach (object[] arr in new MockTarget.StdArch())
+        {
+            MockTarget.Architecture arch = (MockTarget.Architecture)arr[0];
+            yield return new object[] { arch, true /*includeEndAddress*/, false /*unwindInfoIsFunctionLength*/};
+            yield return new object[] { arch, true /*includeEndAddress*/, true /*unwindInfoIsFunctionLength*/};
+            yield return new object[] { arch, false /*includeEndAddress*/, false /*unwindInfoIsFunctionLength*/};
+            yield return new object[] { arch, false /*includeEndAddress*/, true /*unwindInfoIsFunctionLength*/};
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(StdArchFunctionLengthData))]
+    public void GetFunctionLength(MockTarget.Architecture arch, bool includeEndAddress, bool unwindInfoIsFunctionLength)
+    {
+        MockMemorySpace.Builder builder = new(new TargetTestHelpers(arch));
+        MockDescriptors.RuntimeFunctions runtimeFunctions = new(builder, includeEndAddress, unwindInfoIsFunctionLength);
+
+        uint[] entries = [0x100, 0x1f0, 0x1000, 0x2000, 0xa000];
+        TargetPointer addr = runtimeFunctions.AddRuntimeFunctions(entries);
+
+        Target target = new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, runtimeFunctions.Types);
+        RuntimeFunctionLookup lookup = RuntimeFunctionLookup.Create(target);
+
+        for (uint i = 0; i < entries.Length; i++)
+        {
+            uint expectedFunctionLength = i < entries.Length - 1
+                ? Math.Min(entries[i + 1] - entries[i], MockDescriptors.RuntimeFunctions.DefaultFunctionLength)
+                : MockDescriptors.RuntimeFunctions.DefaultFunctionLength;
+
+            Data.RuntimeFunction function = lookup.GetRuntimeFunction(addr, i);
+            uint functionLength = lookup.GetFunctionLength(function);
+            Assert.Equal(expectedFunctionLength, functionLength);
+        }
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void TryGetRuntimeFunctionIndexForAddress(MockTarget.Architecture arch)
+    {
+        MockMemorySpace.Builder builder = new(new TargetTestHelpers(arch));
+        MockDescriptors.RuntimeFunctions runtimeFunctions = new(builder);
+
+        uint[] entries = [0x100, 0x1f0, 0x1000, 0x2000, 0xa000];
+        TargetPointer addr = runtimeFunctions.AddRuntimeFunctions(entries);
+
+        TestPlaceholderTarget target = new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, runtimeFunctions.Types);
+        ContractRegistry reg = Mock.Of<ContractRegistry>(
+            c => c.PlatformMetadata == new Mock<Contracts.IPlatformMetadata>().Object);
+        target.SetContracts(reg);
+        RuntimeFunctionLookup lookup = RuntimeFunctionLookup.Create(target);
+
+        for (uint i = 0; i < entries.Length; i++)
+        {
+            TargetPointer relativeAddress = (TargetPointer)entries[i];
+            bool res = lookup.TryGetRuntimeFunctionIndexForAddress(addr, (uint)entries.Length, relativeAddress, out uint index);
+            Assert.True(res);
+            Assert.Equal(i, index);
+        }
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void TryGetRuntimeFunctionIndexForAddress_NoMatch(MockTarget.Architecture arch)
+    {
+        MockMemorySpace.Builder builder = new(new TargetTestHelpers(arch));
+        MockDescriptors.RuntimeFunctions runtimeFunctions = new(builder);
+
+        uint[] entries = [0x100, 0x1f0];
+        TargetPointer addr = runtimeFunctions.AddRuntimeFunctions(entries);
+
+        TestPlaceholderTarget target = new TestPlaceholderTarget(builder.TargetTestHelpers.Arch, builder.GetReadContext().ReadFromTarget, runtimeFunctions.Types);
+        ContractRegistry reg = Mock.Of<ContractRegistry>(
+            c => c.PlatformMetadata == new Mock<Contracts.IPlatformMetadata>().Object);
+        target.SetContracts(reg);
+        RuntimeFunctionLookup lookup = RuntimeFunctionLookup.Create(target);
+
+        TargetPointer relativeAddress = 0x0ff;
+        bool res = lookup.TryGetRuntimeFunctionIndexForAddress(addr, (uint)entries.Length, relativeAddress, out _);
+        Assert.False(res);
+    }
+}

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.RuntimeFunctions.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.RuntimeFunctions.cs
@@ -41,6 +41,8 @@ internal partial class MockDescriptors
         private const ulong DefaultAllocationRangeStart = 0x0004_0000;
         private const ulong DefaultAllocationRangeEnd = 0x0005_0000;
 
+        internal const uint DefaultFunctionLength = 0x100;
+
         private readonly MockMemorySpace.BumpAllocator _allocator;
 
         public RuntimeFunctions(MockMemorySpace.Builder builder, bool includeEndAddress = true, bool unwindInfoIsFunctionLength = false)
@@ -75,10 +77,10 @@ internal partial class MockDescriptors
                 Span<byte> func = Builder.BorrowAddressRange(runtimeFunctionsFragment.Address + i * runtimeFunctionSize, (int)runtimeFunctionSize);
                 helpers.Write(func.Slice(runtimeFunctionType.Fields[nameof(Data.RuntimeFunction.BeginAddress)].Offset, sizeof(uint)), runtimeFunctions[i]);
 
-                // Set the function length at halfway to the start of the next function (or 0x100 for the last function)
+                // Set the function length to the default function length or up to the next function start
                 uint functionLength = i < numRuntimeFunctions - 1
-                    ? (runtimeFunctions[i + 1] - runtimeFunctions[i]) / 2
-                    : 0x100;
+                    ? Math.Min(runtimeFunctions[i + 1] - runtimeFunctions[i], DefaultFunctionLength)
+                    : DefaultFunctionLength;
                 if (runtimeFunctionType.Fields.ContainsKey(nameof(Data.RuntimeFunction.EndAddress)))
                     helpers.Write(func.Slice(runtimeFunctionType.Fields[nameof(Data.RuntimeFunction.EndAddress)].Offset, sizeof(uint)), runtimeFunctions[i] + functionLength);
 

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.RuntimeFunctions.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.RuntimeFunctions.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+internal partial class MockDescriptors
+{
+    internal class RuntimeFunctions
+    {
+        private static TypeFields RuntimeFunctionFields(bool includeEndAddress)
+        {
+            TargetTestHelpers.Field[] fields = [
+                new(nameof(Data.RuntimeFunction.BeginAddress), DataType.uint32),
+                new(nameof(Data.RuntimeFunction.UnwindData), DataType.uint32),
+            ];
+            if (includeEndAddress)
+                fields = fields.Append(new(nameof(Data.RuntimeFunction.EndAddress), DataType.uint32)).ToArray();
+
+            return new()
+            {
+                DataType = DataType.RuntimeFunction,
+                Fields = fields
+            };
+        }
+
+        private static TypeFields UnwindInfoFields(bool isFunctionLength) => new()
+        {
+            DataType = DataType.UnwindInfo,
+            Fields = isFunctionLength
+                ? [new(nameof(Data.UnwindInfo.FunctionLength), DataType.uint32)]
+                : [new(nameof(Data.UnwindInfo.Header), DataType.uint32)]
+        };
+
+        internal MockMemorySpace.Builder Builder { get; }
+        internal Dictionary<DataType, Target.TypeInfo> Types { get; }
+
+        private const ulong DefaultAllocationRangeStart = 0x0004_0000;
+        private const ulong DefaultAllocationRangeEnd = 0x0005_0000;
+
+        private readonly MockMemorySpace.BumpAllocator _allocator;
+
+        public RuntimeFunctions(MockMemorySpace.Builder builder, bool includeEndAddress = true, bool unwindInfoIsFunctionLength = false)
+            : this(builder, (DefaultAllocationRangeStart, DefaultAllocationRangeEnd), includeEndAddress, unwindInfoIsFunctionLength)
+        { }
+
+        public RuntimeFunctions(MockMemorySpace.Builder builder, (ulong Start, ulong End) allocationRange, bool includeEndAddress, bool unwindInfoIsFunctionLength)
+        {
+            Builder = builder;
+            _allocator = Builder.CreateAllocator(allocationRange.Start, allocationRange.End);
+            Types = GetTypesForTypeFields(
+                Builder.TargetTestHelpers,
+                [
+                    RuntimeFunctionFields(includeEndAddress),
+                    UnwindInfoFields(unwindInfoIsFunctionLength)
+                ]);
+        }
+
+        public TargetPointer AddRuntimeFunctions(uint[] runtimeFunctions)
+        {
+            TargetTestHelpers helpers = Builder.TargetTestHelpers;
+
+            // Add the array of runtime functions
+            uint numRuntimeFunctions = (uint)runtimeFunctions.Length;
+            Target.TypeInfo runtimeFunctionType = Types[DataType.RuntimeFunction];
+            uint runtimeFunctionSize = runtimeFunctionType.Size.Value;
+            Target.TypeInfo unwindInfoType = Types[DataType.UnwindInfo];
+            MockMemorySpace.HeapFragment runtimeFunctionsFragment = _allocator.Allocate((numRuntimeFunctions + 1) * runtimeFunctionSize, $"RuntimeFunctions[{numRuntimeFunctions}]");
+            Builder.AddHeapFragment(runtimeFunctionsFragment);
+            for (uint i = 0; i < numRuntimeFunctions; i++)
+            {
+                Span<byte> func = Builder.BorrowAddressRange(runtimeFunctionsFragment.Address + i * runtimeFunctionSize, (int)runtimeFunctionSize);
+                helpers.Write(func.Slice(runtimeFunctionType.Fields[nameof(Data.RuntimeFunction.BeginAddress)].Offset, sizeof(uint)), runtimeFunctions[i]);
+
+                // Set the function length at halfway to the start of the next function (or 0x100 for the last function)
+                uint functionLength = i < numRuntimeFunctions - 1
+                    ? (runtimeFunctions[i + 1] - runtimeFunctions[i]) / 2
+                    : 0x100;
+                if (runtimeFunctionType.Fields.ContainsKey(nameof(Data.RuntimeFunction.EndAddress)))
+                    helpers.Write(func.Slice(runtimeFunctionType.Fields[nameof(Data.RuntimeFunction.EndAddress)].Offset, sizeof(uint)), runtimeFunctions[i] + functionLength);
+
+                // Add the unwindInfo
+                MockMemorySpace.HeapFragment unwindInfoFragment = _allocator.Allocate(unwindInfoType.Size.Value, $"UnwindInfo for RuntimeFunction {runtimeFunctions[i]}");
+                Builder.AddHeapFragment(unwindInfoFragment);
+                Span<byte> unwindInfo = unwindInfoFragment.Data.AsSpan();
+                if (Types[DataType.UnwindInfo].Fields.ContainsKey(nameof(Data.UnwindInfo.FunctionLength)))
+                {
+                    helpers.Write(unwindInfo.Slice(unwindInfoType.Fields[nameof(Data.UnwindInfo.FunctionLength)].Offset, sizeof(uint)), functionLength);
+                }
+                else
+                {
+                    // First 18 bits of the header are function length / (pointer size / 2) 
+                    uint headerBits = (uint)(functionLength / (helpers.PointerSize / 2));
+                    if (headerBits > 1 << 18 - 1)
+                        throw new InvalidOperationException("Function length is too long ");
+
+                    helpers.Write(unwindInfo.Slice(unwindInfoType.Fields[nameof(Data.UnwindInfo.Header)].Offset, sizeof(uint)), headerBits);
+                }
+
+                helpers.Write(func.Slice(runtimeFunctionType.Fields[nameof(Data.RuntimeFunction.UnwindData)].Offset, sizeof(uint)), (uint)unwindInfoFragment.Address);
+            }
+
+            // Runtime function entries are terminated by a sentinel value of -1
+            Span<byte> sentinel = Builder.BorrowAddressRange(runtimeFunctionsFragment.Address + numRuntimeFunctions * runtimeFunctionSize, (int)runtimeFunctionSize);
+            helpers.Write(sentinel.Slice(runtimeFunctionType.Fields[nameof(Data.RuntimeFunction.BeginAddress)].Offset, sizeof(uint)), ~0u);
+
+            return runtimeFunctionsFragment.Address;
+        }
+    }
+}


### PR DESCRIPTION
Implement the hot/cold lookup logic for `ExecutionManager.ReadyToRunJitManager.GetMethodInfo`. Basic logic is now:
1. Check if the address is in a thunk for READYTORUN_HELPER_DelayLoad_MethodCall
2. Find the runtime function entry corresponding to the address
    - _If the runtime function entry is cold code, find the runtime function entry for the corresponding hot part_
3. Look up the MethodDesc for the entry point using the ReadyToRunInfo's hash map
4. Compute the relative offset based the function's start address
    - _If the runtime function has a cold part and the address is in the cold part, compute the relative offset based on the size of the hot part and the offset from the start of the cold part_ 

_Sub-bullets of 2 and 4_ are the parts added by this change.

Add tests for `ExecutionManager` for getting code blocks and method desc in R2R with hot/cold splitting, runtime functions lookup functionality, and hot/cold map lookup logic.
- Pull out helper for RuntimeFunctions mock memory
- `ExecutionManagerTests` just uses one specific runtime function / unwind info layout
  - The `RuntimeFunctionsTests` handle testing the matrix of different layouts

The `RuntimeFunction` and `UnwindInfo` structures are different depending on the platform. This matters for calculating the function length. To facilitate testing, I pulled out the runtime functions lookup into a helper class. This change puts reading the hot/cold map in a helper class `HotColdLookup`. Having separate helpers (similarly, HashMapLookup and NibbleMap) should let us mock them out for testing if we want - there'd still be some work for how they are created (for example, tests need to be able to provide some instance instead of the contract directly creating the class), but it puts us in a reasonable position.

Manually validated with `!ip2md` (temporarily commented out throwing not implemented for rejit ID requests) for an app published with R2R `--hot-cold-splitting` that we correctly map addresses in cold/hot blocks to hot/cold parts, determine their start addresses and sizes, and return the correct method desc.

Contributes to https://github.com/dotnet/runtime/issues/99302, https://github.com/dotnet/runtime/issues/109426