### PR TITLE
JIT: Add global search option to 3-opt layout

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6235,8 +6235,9 @@ public:
         void ConsiderEdge(FlowEdge* edge);
         void AddNonFallthroughSuccs(unsigned blockPos);
         void AddNonFallthroughPreds(unsigned blockPos);
-        bool RunGreedyThreeOptPass(unsigned startPos, unsigned endPos);
 
+        bool RunGreedyThreeOptPass(unsigned startPos, unsigned endPos);
+        bool RunGlobalThreeOptPass(unsigned startPos, unsigned endPos);
         bool RunThreeOptPass(BasicBlock* startBlock, BasicBlock* endBlock);
 
     public:

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5494,9 +5494,11 @@ bool Compiler::ThreeOptLayout::RunGlobalThreeOptPass(unsigned startPos, unsigned
                 }
             }
         }
+    // Keep searching for cut points until the cost model converges
     } while (foundPartition);
 
-    if (modified)
+    // Update ordinals, but only if we reordered anything, and if we will do another pass
+    if (modified && (currEHRegion != 0))
     {
         for (unsigned i = startPos; i <= endPos; i++)
         {

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5465,6 +5465,7 @@ bool Compiler::ThreeOptLayout::RunGlobalThreeOptPass(unsigned startPos, unsigned
         foundPartition = false;
         for (unsigned s2Start = startPos + 1; !foundPartition && (s2Start < endPos); s2Start++)
         {
+            // Don't partition between call-finally pairs
             BasicBlock* const s2Block = blockOrder[s2Start];
             if (s2Block->isBBCallFinallyPairTail())
             {
@@ -5473,6 +5474,7 @@ bool Compiler::ThreeOptLayout::RunGlobalThreeOptPass(unsigned startPos, unsigned
 
             for (unsigned s3Start = s2Start + 1; s3Start <= endPos; s3Start++)
             {
+                // Don't partition between call-finally pairs
                 BasicBlock* const s3Block = blockOrder[s3Start];
                 if (s3Block->isBBCallFinallyPairTail())
                 {
@@ -5528,7 +5530,8 @@ bool Compiler::ThreeOptLayout::RunThreeOptPass(BasicBlock* startBlock, BasicBloc
     }
 
     JITDUMP("Initial layout cost: %f\n", GetLayoutCost(startPos, endPos));
-    const bool modified = RunGlobalThreeOptPass(startPos, endPos);
+    const bool modified = JitConfig.JitDoGlobalThreeOpt() ? RunGlobalThreeOptPass(startPos, endPos)
+                                                          : RunGreedyThreeOptPass(startPos, endPos);
 
     // Write back to 'tempOrder' so changes to this region aren't lost next time we swap 'tempOrder' and 'blockOrder'
     if (modified)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5494,7 +5494,7 @@ bool Compiler::ThreeOptLayout::RunGlobalThreeOptPass(unsigned startPos, unsigned
                 }
             }
         }
-    // Keep searching for cut points until the cost model converges
+        // Keep searching for cut points until the cost model converges
     } while (foundPartition);
 
     // Update ordinals, but only if we reordered anything, and if we will do another pass

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5480,7 +5480,7 @@ bool Compiler::ThreeOptLayout::RunGlobalThreeOptPass(unsigned startPos, unsigned
                 continue;
             }
 
-            for (unsigned s3Start = s2Start + 1; s3Start <= endPos; s3Start++)
+            for (unsigned s3Start = s2Start + 1; !foundPartition && (s3Start <= endPos); s3Start++)
             {
                 BasicBlock* const s3Block = blockOrder[s3Start];
                 if (!isValidCutPoint(s3Block))
@@ -5488,11 +5488,26 @@ bool Compiler::ThreeOptLayout::RunGlobalThreeOptPass(unsigned startPos, unsigned
                     continue;
                 }
 
-                if (TrySwappingPartitions(startPos, s2Start, s3Start, endPos, endPos))
+                for (unsigned s3End = s3Start; s3End < endPos; s3End++)
+                {
+                    BasicBlock* const s4Block = blockOrder[s3End + 1];
+                    if (!isValidCutPoint(s4Block))
+                    {
+                        continue;
+                    }
+
+                    if (TrySwappingPartitions(startPos, s2Start, s3Start, s3End, endPos))
+                    {
+                        foundPartition = true;
+                        modified       = true;
+                        break;
+                    }
+                }
+
+                if (!foundPartition && TrySwappingPartitions(startPos, s2Start, s3Start, endPos, endPos))
                 {
                     foundPartition = true;
                     modified       = true;
-                    break;
                 }
             }
         }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5288,6 +5288,8 @@ void Compiler::ThreeOptLayout::Run()
             }
         }
     }
+
+    INDEBUG(compiler->Metrics.BasicBlockLayoutCost = GetLayoutCost(0, numCandidateBlocks - 1));
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -781,7 +781,7 @@ RELEASE_CONFIG_INTEGER(JitEnablePhysicalPromotion, "JitEnablePhysicalPromotion",
 // Enable cross-block local assertion prop
 RELEASE_CONFIG_INTEGER(JitEnableCrossBlockLocalAssertionProp, "JitEnableCrossBlockLocalAssertionProp", 1)
 
-// Do greedy RPO-based layout in Compiler::fgReorderBlocks.
+// Do greedy RPO-based block layout.
 RELEASE_CONFIG_INTEGER(JitDoReversePostOrderLayout, "JitDoReversePostOrderLayout", 1);
 
 // Globally search for cut points in 3-opt layout instead of using the greedy strategy.

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -784,6 +784,9 @@ RELEASE_CONFIG_INTEGER(JitEnableCrossBlockLocalAssertionProp, "JitEnableCrossBlo
 // Do greedy RPO-based layout in Compiler::fgReorderBlocks.
 RELEASE_CONFIG_INTEGER(JitDoReversePostOrderLayout, "JitDoReversePostOrderLayout", 1);
 
+// Globally search for cut points in 3-opt layout instead of using the greedy strategy.
+CONFIG_INTEGER(JitDoGlobalThreeOpt, "JitDoGlobalThreeOpt", 1);
+
 // Enable strength reduction
 RELEASE_CONFIG_INTEGER(JitEnableStrengthReduction, "JitEnableStrengthReduction", 1)
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -785,7 +785,7 @@ RELEASE_CONFIG_INTEGER(JitEnableCrossBlockLocalAssertionProp, "JitEnableCrossBlo
 RELEASE_CONFIG_INTEGER(JitDoReversePostOrderLayout, "JitDoReversePostOrderLayout", 1);
 
 // Globally search for cut points in 3-opt layout instead of using the greedy strategy.
-RELEASE_CONFIG_INTEGER(JitDoGlobalThreeOpt, "JitDoGlobalThreeOpt", 0);
+RELEASE_CONFIG_INTEGER(JitDoGlobalThreeOpt, "JitDoGlobalThreeOpt", 1);
 
 // Enable strength reduction
 RELEASE_CONFIG_INTEGER(JitEnableStrengthReduction, "JitEnableStrengthReduction", 1)

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -785,7 +785,7 @@ RELEASE_CONFIG_INTEGER(JitEnableCrossBlockLocalAssertionProp, "JitEnableCrossBlo
 RELEASE_CONFIG_INTEGER(JitDoReversePostOrderLayout, "JitDoReversePostOrderLayout", 1);
 
 // Globally search for cut points in 3-opt layout instead of using the greedy strategy.
-RELEASE_CONFIG_INTEGER(JitDoGlobalThreeOpt, "JitDoGlobalThreeOpt", 1);
+RELEASE_CONFIG_INTEGER(JitDoGlobalThreeOpt, "JitDoGlobalThreeOpt", 0);
 
 // Enable strength reduction
 RELEASE_CONFIG_INTEGER(JitEnableStrengthReduction, "JitEnableStrengthReduction", 1)

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -785,7 +785,7 @@ RELEASE_CONFIG_INTEGER(JitEnableCrossBlockLocalAssertionProp, "JitEnableCrossBlo
 RELEASE_CONFIG_INTEGER(JitDoReversePostOrderLayout, "JitDoReversePostOrderLayout", 1);
 
 // Globally search for cut points in 3-opt layout instead of using the greedy strategy.
-CONFIG_INTEGER(JitDoGlobalThreeOpt, "JitDoGlobalThreeOpt", 1);
+RELEASE_CONFIG_INTEGER(JitDoGlobalThreeOpt, "JitDoGlobalThreeOpt", 1);
 
 // Enable strength reduction
 RELEASE_CONFIG_INTEGER(JitEnableStrengthReduction, "JitEnableStrengthReduction", 1)

--- a/src/coreclr/jit/jitmetadatalist.h
+++ b/src/coreclr/jit/jitmetadatalist.h
@@ -50,6 +50,7 @@ JITMETADATAMETRIC(RedundantBranchesEliminated,           int,              JIT_M
 JITMETADATAMETRIC(JumpThreadingsPerformed,               int,              JIT_METADATA_HIGHER_IS_BETTER)
 JITMETADATAMETRIC(CseCount,                              int,              0)
 JITMETADATAMETRIC(BasicBlocksAtCodegen,                  int,              0)
+JITMETADATAMETRIC(BasicBlockLayoutCost,                  double,           JIT_METADATA_LOWER_IS_BETTER)
 JITMETADATAMETRIC(PerfScore,                             double,           JIT_METADATA_LOWER_IS_BETTER)
 JITMETADATAMETRIC(BytesAllocated,                        int64_t,          JIT_METADATA_LOWER_IS_BETTER)
 JITMETADATAMETRIC(ImporterBranchFold,                    int,              0)


### PR DESCRIPTION
Follow-up to #103450, part of #107749. This is enabled for now just to get a CI run in; I intend to disable this by default since it's prohibitively expensive to run for most cases. In a follow-up, we can explore turning this on for sufficiently small regions, and/or when we think the current block layout is close to optimal.