### PR TITLE
Reapply "Fold "X relop 0" in assertprop" (#110129)

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/Directory.Build.targets
+++ b/src/libraries/System.Runtime.InteropServices/tests/Directory.Build.targets
@@ -3,7 +3,7 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
   </PropertyGroup>
-  <!-- Expose unmanaged entry points from NativeExports  -->
+  <!-- Expose unmanaged entry points from NativeExports -->
   <ItemGroup Condition="'$(ReferencesNativeExports)' == 'true'">
     <UnmanagedEntryPointsAssembly Include="Microsoft.Interop.Tests.NativeExports" />
     <DirectPInvoke Include="Microsoft.Interop.Tests.NativeExportsNE" />


### PR DESCRIPTION
This reverts commit da9381e707c8196dd853388cdde1d2596feb49ef.


The bug was in `optAssertionProp_RangeProperties`, when we check `First, analyze possible X ==/!= CNS assertions.` assertions we need to make sure it's `O1K_LCLVAR` assertion, not e.g. `O1K_ARR_BND`