### PR TITLE
Allow hiding `UnmanagedCallersOnly` exports

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -102,7 +102,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   </PropertyGroup>
 
   <ItemGroup Condition="$(IlcSystemModule) == ''">
-    <UnmanagedEntryPointsAssembly Include="System.Private.CoreLib" />
+    <UnmanagedEntryPointsAssembly Include="System.Private.CoreLib,HIDDEN" />
     <AutoInitializedAssemblies Include="System.Private.CoreLib" />
     <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" Condition="$(StackTraceSupport) != 'false'" />
     <AutoInitializedAssemblies Include="System.Private.TypeLoader" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1423,12 +1423,16 @@ namespace ILCompiler.DependencyAnalysis
         /// Returns alternative symbol name that object writer should produce for given symbols
         /// in addition to the regular one.
         /// </summary>
-        public string GetSymbolAlternateName(ISymbolNode node)
+        public string GetSymbolAlternateName(ISymbolNode node, out bool isHidden)
         {
-            string value;
-            if (!NodeAliases.TryGetValue(node, out value))
+            if (!NodeAliases.TryGetValue(node, out var value))
+            {
+                isHidden = false;
                 return null;
-            return value;
+            }
+
+            isHidden = value.Hidden;
+            return value.Name;
         }
 
         public ArrayOfEmbeddedPointersNode<GCStaticsNode> GCStaticsRegion = new ArrayOfEmbeddedPointersNode<GCStaticsNode>(
@@ -1451,7 +1455,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public ReadyToRunHeaderNode ReadyToRunHeader;
 
-        public Dictionary<ISymbolNode, string> NodeAliases = new Dictionary<ISymbolNode, string>();
+        public Dictionary<ISymbolNode, (string Name, bool Hidden)> NodeAliases = new Dictionary<ISymbolNode, (string, bool)>();
 
         protected internal TypeManagerIndirectionNode TypeManagerIndirection = new TypeManagerIndirectionNode();
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExpectedIsaFeaturesRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExpectedIsaFeaturesRootProvider.cs
@@ -24,7 +24,7 @@ namespace ILCompiler
             {
                 int isaFlags = HardwareIntrinsicHelpers.GetRuntimeRequiredIsaFlags(_isaSupport);
                 byte[] bytes = BitConverter.GetBytes(isaFlags);
-                rootProvider.RootReadOnlyDataBlob(bytes, 4, "ISA support flags", "g_requiredCpuFeatures");
+                rootProvider.RootReadOnlyDataBlob(bytes, 4, "ISA support flags", "g_requiredCpuFeatures", exportHidden: true);
             }
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
@@ -26,7 +26,7 @@ namespace ILCompiler
         }
 
         public void AddExportedMethods(IEnumerable<EcmaMethod> methods)
-            => _methods.AddRange(methods.Where(m => m.Module != _context.SystemModule));
+            => _methods.AddRange(methods);
 
         public void EmitExportedMethods()
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
@@ -10,7 +10,7 @@ namespace ILCompiler
     /// </summary>
     public interface IRootingServiceProvider
     {
-        void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
+        void AddCompilationRoot(MethodDesc method, string reason, string exportName = null, bool exportHidden = false);
         void AddCompilationRoot(TypeDesc type, string reason);
         void AddReflectionRoot(TypeDesc type, string reason);
         void AddReflectionRoot(MethodDesc method, string reason);
@@ -19,7 +19,7 @@ namespace ILCompiler
         void RootGCStaticBaseForType(TypeDesc type, string reason);
         void RootNonGCStaticBaseForType(TypeDesc type, string reason);
         void RootModuleMetadata(ModuleDesc module, string reason);
-        void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName);
+        void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName, bool exportHidden);
         void RootDelegateMarshallingData(DefType type, string reason);
         void RootStructMarshallingData(DefType type, string reason);
         void AddCompilationRoot(object o, string reason);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
@@ -36,7 +36,7 @@ namespace ILCompiler
 
                 // Bodies that are visible from outside should not be folded because we don't know
                 // if they're address taken.
-                if (factory.GetSymbolAlternateName(body) != null)
+                if (factory.GetSymbolAlternateName(body, out _) != null)
                     continue;
 
                 var key = new MethodInternKey(body, factory);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
@@ -422,14 +422,14 @@ namespace ILCompiler.ObjectWriter
                         n == node ? currentSymbolName : GetMangledName(n),
                         n.Offset + thumbBit,
                         n.Offset == 0 && isMethod ? nodeContents.Data.Length : 0);
-                    if (_nodeFactory.GetSymbolAlternateName(n) is string alternateName)
+                    if (_nodeFactory.GetSymbolAlternateName(n, out bool isHidden) is string alternateName)
                     {
                         string alternateCName = ExternCName(alternateName);
                         sectionWriter.EmitSymbolDefinition(
                             alternateCName,
                             n.Offset + thumbBit,
                             n.Offset == 0 && isMethod ? nodeContents.Data.Length : 0,
-                            global: true);
+                            global: !isHidden);
 
                         if (n is IMethodNode)
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
@@ -23,7 +23,7 @@ namespace ILCompiler
             _rootAdder = rootAdder;
         }
 
-        public void AddCompilationRoot(MethodDesc method, string reason, string exportName = null)
+        public void AddCompilationRoot(MethodDesc method, string reason, string exportName = null, bool exportHidden = false)
         {
             MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             IMethodNode methodEntryPoint = _factory.MethodEntrypoint(canonMethod);
@@ -32,7 +32,7 @@ namespace ILCompiler
             if (exportName != null)
             {
                 exportName = _factory.NameMangler.NodeMangler.ExternMethod(exportName, method);
-                _factory.NodeAliases.Add(methodEntryPoint, exportName);
+                _factory.NodeAliases.Add(methodEntryPoint, (exportName, exportHidden));
             }
 
             if (canonMethod != method && method.HasInstantiation)
@@ -140,12 +140,12 @@ namespace ILCompiler
             }
         }
 
-        public void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName)
+        public void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName, bool exportHidden)
         {
             var blob = _factory.ReadOnlyDataBlob("__readonlydata_" + exportName, data, alignment);
             _rootAdder(blob, reason);
             exportName = _factory.NameMangler.NodeMangler.ExternVariable(exportName);
-            _factory.NodeAliases.Add(blob, exportName);
+            _factory.NodeAliases.Add(blob, (exportName, exportHidden));
         }
 
         public void RootDelegateMarshallingData(DefType type, string reason)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
@@ -16,10 +16,13 @@ namespace ILCompiler
     {
         private EcmaModule _module;
 
-        public UnmanagedEntryPointsRootProvider(EcmaModule module)
+        public UnmanagedEntryPointsRootProvider(EcmaModule module, bool hidden = false)
         {
             _module = module;
+            Hidden = hidden;
         }
+
+        public bool Hidden { get; }
 
         public IEnumerable<EcmaMethod> ExportedMethods
         {
@@ -62,12 +65,12 @@ namespace ILCompiler
                 if (ecmaMethod.IsUnmanagedCallersOnly)
                 {
                     string unmanagedCallersOnlyExportName = ecmaMethod.GetUnmanagedCallersOnlyExportName();
-                    rootProvider.AddCompilationRoot((MethodDesc)ecmaMethod, "Native callable", unmanagedCallersOnlyExportName);
+                    rootProvider.AddCompilationRoot((MethodDesc)ecmaMethod, "Native callable", unmanagedCallersOnlyExportName, Hidden);
                 }
                 else
                 {
                     string runtimeExportName = ecmaMethod.GetRuntimeExportName();
-                    rootProvider.AddCompilationRoot((MethodDesc)ecmaMethod, "Runtime export", runtimeExportName);
+                    rootProvider.AddCompilationRoot((MethodDesc)ecmaMethod, "Runtime export", runtimeExportName, Hidden);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -281,15 +281,19 @@ namespace ILCompiler
                     compilationRoots.Add(new Win32ResourcesRootProvider(module));
                 }
 
-                foreach (var unmanagedEntryPointsAssembly in Get(_command.UnmanagedEntryPointsAssemblies))
+                foreach (var unmanagedEntryPointsAssemblyValue in Get(_command.UnmanagedEntryPointsAssemblies))
                 {
+                    const string hiddenSuffix = ",HIDDEN";
+                    bool hidden = unmanagedEntryPointsAssemblyValue.EndsWith(hiddenSuffix, StringComparison.Ordinal);
+                    string unmanagedEntryPointsAssembly = hidden ? unmanagedEntryPointsAssemblyValue.Remove(unmanagedEntryPointsAssemblyValue.Length - hiddenSuffix.Length) : unmanagedEntryPointsAssemblyValue;
+
                     if (typeSystemContext.InputFilePaths.ContainsKey(unmanagedEntryPointsAssembly))
                     {
                         // Skip adding UnmanagedEntryPointsRootProvider for modules that have been already registered as an input module
                         continue;
                     }
                     EcmaModule module = typeSystemContext.GetModuleForSimpleName(unmanagedEntryPointsAssembly);
-                    compilationRoots.Add(new UnmanagedEntryPointsRootProvider(module));
+                    compilationRoots.Add(new UnmanagedEntryPointsRootProvider(module, hidden));
                 }
 
                 foreach (var rdXmlFilePath in Get(_command.RdXmlFilePaths))
@@ -621,7 +625,7 @@ namespace ILCompiler
                 {
                     foreach (var compilationRoot in compilationRoots)
                     {
-                        if (compilationRoot is UnmanagedEntryPointsRootProvider provider)
+                        if (compilationRoot is UnmanagedEntryPointsRootProvider provider && !provider.Hidden)
                             defFileWriter.AddExportedMethods(provider.ExportedMethods);
                     }
                 }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -285,7 +285,7 @@ namespace ILCompiler
                 {
                     const string hiddenSuffix = ",HIDDEN";
                     bool hidden = unmanagedEntryPointsAssemblyValue.EndsWith(hiddenSuffix, StringComparison.Ordinal);
-                    string unmanagedEntryPointsAssembly = hidden ? unmanagedEntryPointsAssemblyValue.Remove(unmanagedEntryPointsAssemblyValue.Length - hiddenSuffix.Length) : unmanagedEntryPointsAssemblyValue;
+                    string unmanagedEntryPointsAssembly = hidden ? unmanagedEntryPointsAssemblyValue[..^hiddenSuffix.Length] : unmanagedEntryPointsAssemblyValue;
 
                     if (typeSystemContext.InputFilePaths.ContainsKey(unmanagedEntryPointsAssembly))
                     {

--- a/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
@@ -24,7 +24,7 @@
       <ReproResponseLines Include="-g" />
       <ReproResponseLines Include="-O" Condition="'$(Optimize)' == 'true'" />
       <ReproResponseLines Include="--dehydrate" />
-      <ReproResponseLines Include="--generateunmanagedentrypoints:System.Private.CoreLib" />
+      <ReproResponseLines Include="--generateunmanagedentrypoints:System.Private.CoreLib,HIDDEN" />
       <ReproResponseLines Include="--initassembly:System.Private.CoreLib" />
       <ReproResponseLines Include="--initassembly:System.Private.StackTraceMetadata" />
       <ReproResponseLines Include="--initassembly:System.Private.TypeLoader" />


### PR DESCRIPTION
Should fix #109341. We currently rely on the linkerscript not exporting these, make it a per-assembly compiler switch. As a side effect it removes a piece of policy that skipped CoreLib exports from the exports linkerscript. The policy is now in .targets.

Cc @dotnet/ilc-contrib 