### PR TITLE
Enable more ILLink test cases with native AOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
@@ -638,17 +638,31 @@ namespace ILLink.Shared.TrimAnalysis
             return false;
         }
 
-#pragma warning disable IDE0060
         private partial bool TryResolveTypeNameForCreateInstanceAndMark(in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType)
         {
-            // TODO: niche APIs that we probably shouldn't even have added
-            // We have to issue a warning, otherwise we could break the app without a warning.
-            // This is not the ideal warning, but it's good enough for now.
-            _diagnosticContext.AddDiagnostic(DiagnosticId.UnrecognizedParameterInMethodCreateInstance, calledMethod.GetParameter((ParameterIndex)(1 + (calledMethod.HasImplicitThis() ? 1 : 0))).GetDisplayName(), calledMethod.GetDisplayName());
-            resolvedType = default;
-            return false;
+            if (!System.Reflection.Metadata.AssemblyNameInfo.TryParse(assemblyName, out var an)
+                || _callingMethod.Context.ResolveAssembly(an) is not ModuleDesc resolvedAssembly)
+            {
+                _diagnosticContext.AddDiagnostic(DiagnosticId.UnresolvedAssemblyInCreateInstance,
+                    assemblyName,
+                    calledMethod.GetDisplayName());
+                resolvedType = default;
+                return false;
+            }
+
+            if (!_reflectionMarker.TryResolveTypeNameAndMark(resolvedAssembly, typeName, _diagnosticContext, "Reflection", out TypeDesc? foundType))
+            {
+                // It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
+                // Note that we did find the assembly, so it's not a ILLink config problem, it's either intentional, or wrong versions of assemblies
+                // but ILLink can't know that. In case a user tries to create an array using System.Activator we should simply ignore it, the user
+                // might expect an exception to be thrown.
+                resolvedType = default;
+                return false;
+            }
+
+            resolvedType = new TypeProxy(foundType);
+            return true;
         }
-#pragma warning restore IDE0060
 
         private partial void MarkStaticConstructor(TypeProxy type)
             => _reflectionMarker.MarkStaticConstructor(_diagnosticContext.Origin, type.Type, _reason);

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
@@ -69,17 +69,17 @@ namespace Mono.Linker.Tests.TestCases
 		[MemberData (nameof (TestDatabase.Reflection), MemberType = typeof (TestDatabase))]
 		public void Reflection (string t)
 		{
-			switch (t) {
-			case "TypeHierarchyReflectionWarnings":
-			case "ParametersUsedViaReflection":
-			case "UnsafeAccessor":
-			case "TypeUsedViaReflection":
-			case "RunClassConstructor":
-			case "NestedTypeUsedViaReflection":
-				Run (t);
+			switch (t)
+			{
+			case "ObjectGetType":
+				// Skip for now
+				break;
+			case "ObjectGetTypeLibraryMode":
+                	case "TypeHierarchyLibraryModeSuppressions":
+				// No Library mode
 				break;
 			default:
-				// Skip the rest for now
+				Run (t);
 				break;
 			}
 		}

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
@@ -75,7 +75,7 @@ namespace Mono.Linker.Tests.TestCases
 				// Skip for now
 				break;
 			case "ObjectGetTypeLibraryMode":
-                	case "TypeHierarchyLibraryModeSuppressions":
+			case "TypeHierarchyLibraryModeSuppressions":
 				// No Library mode
 				break;
 			default:

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -142,7 +142,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		// doesn't work on arrays, but the current implementation will preserve it anyway due to how it processes
 		// string -> Type resolution. This will only impact code which would have failed at runtime, so very unlikely to
 		// actually occur in real apps (and even if it does happen, it just increases size, doesn't break behavior).
-		[Kept (By = Tool.Trimmer)] // NativeAOT doesn't preserve array element types just due to the usage of the array type
+		[Kept (By = Tool.Trimmer | Tool.NativeAot)]
 		class ArrayCreateInstanceByNameElement
 		{
 			public ArrayCreateInstanceByNameElement ()
@@ -151,7 +151,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		[ExpectedWarning ("IL2032", Tool.NativeAot, "https://github.com/dotnet/runtime/issues/82447")]
 		static void TestArrayCreateInstanceByName ()
 		{
 			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayCreateInstanceByNameElement[]");

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -171,7 +171,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		// Small formatting difference
-		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance) + "(Type, Object[])", Tool.Trimmer, "")]
+		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance) + "(Type, Object[])", Tool.Trimmer | Tool.NativeAot, "")]
 		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance) + "(Type, params Object[])", Tool.Analyzer, "")]
 		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance), nameof (CultureInfo))]
 		[Kept]
@@ -197,7 +197,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance) + "(Type)")]
 		// Small formatting difference
-		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance) + "(Type, Object[])", Tool.Trimmer, "")]
+		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance) + "(Type, Object[])", Tool.Trimmer | Tool.NativeAot, "")]
 		[ExpectedWarning ("IL2067", nameof (Activator) + "." + nameof (Activator.CreateInstance) + "(Type, params Object[])", Tool.Analyzer, "")]
 		[Kept]
 		private static void FromParameterWithNonPublicConstructors (
@@ -552,6 +552,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		class TestCreateInstanceOfTWithNoConstraintType
 		{
+			[Kept(By = Tool.NativeAot /* native AOT intrinsically expands CreateInstance<T> and would keep this method, albeit not reflection-visible */)]
 			public TestCreateInstanceOfTWithNoConstraintType ()
 			{
 			}
@@ -680,7 +681,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 			[Kept]
 			[KeptBaseType (typeof (AnnotatedBase))]
-			[KeptMember (".ctor()")]
+			[KeptMember (".ctor()", By = Tool.Trimmer /* This type is never allocated so there's no reason to keep ctor due to a GetType call */)]
 			class Derived : AnnotatedBase
 			{
 				[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
@@ -83,10 +83,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[ExpectedWarning ("IL2026", nameof (StaticPropertyExpressionAccess), Tool.Trimmer, "https://github.com/dotnet/linker/issues/2669")]
+			[ExpectedWarning ("IL2026", nameof (StaticPropertyExpressionAccess), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/2669")]
 			[ExpectedWarning ("IL2026", nameof (StaticPropertyViaReflection))]
 			[ExpectedWarning ("IL2026", nameof (StaticPropertyViaRuntimeMethod))]
-			[ExpectedWarning ("IL2026", nameof (InstancePropertyExpressionAccess), Tool.Trimmer, "https://github.com/dotnet/linker/issues/2669")]
+			[ExpectedWarning ("IL2026", nameof (InstancePropertyExpressionAccess), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/2669")]
 			[ExpectedWarning ("IL2026", nameof (InstancePropertyViaReflection))]
 			public static void Test ()
 			{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
@@ -337,7 +337,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[ExpectedWarning ("IL2026", Tool.Trimmer, "https://github.com/dotnet/linker/issues/2638")]
+			[ExpectedWarning ("IL2026", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/2638")]
 			public static void Test ()
 			{
 				BindingFlags left = BindingFlags.Instance | BindingFlags.Static;


### PR DESCRIPTION
When I was working on the `DAMT.All*`, I noticed we don't run many Reflection tests, this is progress towards that.

Also fixes rare `CreateInstance` overloads - these were never worth the effort to implement honestly, but more code sharing made implementing them a breeze.

Contributes to #82447.

Cc @dotnet/ilc-contrib 