### PR TITLE
Add a test to validate hostfxr C API

### DIFF
--- a/src/native/corehost/hostfxr.h
+++ b/src/native/corehost/hostfxr.h
@@ -1,11 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#ifndef __HOSTFXR_H__
-#define __HOSTFXR_H__
+#ifndef HAVE_HOSTFXR_H
+#define HAVE_HOSTFXR_H
 
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
 
 #if defined(_WIN32)
     #define HOSTFXR_CALLTYPE __cdecl
@@ -296,10 +301,6 @@ struct hostfxr_dotnet_environment_sdk_info
     const char_t* path;
 };
 
-typedef void(HOSTFXR_CALLTYPE* hostfxr_get_dotnet_environment_info_result_fn)(
-    const struct hostfxr_dotnet_environment_info* info,
-    void* result_context);
-
 struct hostfxr_dotnet_environment_framework_info
 {
     size_t size;
@@ -321,6 +322,10 @@ struct hostfxr_dotnet_environment_info
     size_t framework_count;
     const struct hostfxr_dotnet_environment_framework_info* frameworks;
 };
+
+typedef void(HOSTFXR_CALLTYPE* hostfxr_get_dotnet_environment_info_result_fn)(
+    const struct hostfxr_dotnet_environment_info* info,
+    void* result_context);
 
 //
 // Returns available SDKs and frameworks.
@@ -415,4 +420,8 @@ typedef int32_t(HOSTFXR_CALLTYPE* hostfxr_resolve_frameworks_for_runtime_config_
     /*opt*/ hostfxr_resolve_frameworks_result_fn callback,
     /*opt*/ void* result_context);
 
-#endif //__HOSTFXR_H__
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // HAVE_HOSTFXR_H

--- a/src/native/corehost/test/mockhostfxr/CMakeLists.txt
+++ b/src/native/corehost/test/mockhostfxr/CMakeLists.txt
@@ -1,8 +1,10 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
-add_library(mockhostfxr_2_2 SHARED mockhostfxr.cpp)
-add_library(mockhostfxr_5_0 SHARED mockhostfxr.cpp)
+set(MOCKHOSTFXR_SRC mockhostfxr.cpp test_c_api.c)
+
+add_library(mockhostfxr_2_2 SHARED ${MOCKHOSTFXR_SRC})
+add_library(mockhostfxr_5_0 SHARED ${MOCKHOSTFXR_SRC})
 
 target_link_libraries(mockhostfxr_2_2 PRIVATE libhostcommon)
 target_link_libraries(mockhostfxr_5_0 PRIVATE libhostcommon)

--- a/src/native/corehost/test/mockhostfxr/mockhostfxr.cpp
+++ b/src/native/corehost/test/mockhostfxr/mockhostfxr.cpp
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #include "error_codes.h"
 #include "hostfxr.h"
 #include "host_startup_info.h"

--- a/src/native/corehost/test/mockhostfxr/test_c_api.c
+++ b/src/native/corehost/test/mockhostfxr/test_c_api.c
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// hostfxr.h is a public API. When included in .c files, it may fail to compile
+// if C++-specific syntax is used within the extern "C" block. Since all usage of
+// this API in runtime repo is within C++ code, such breakages are not encountered
+// during normal development or testing.
+#include "hostfxr.h"


### PR DESCRIPTION
Add a test for https://github.com/dotnet/runtime/pull/109763 and align the style as headers in `src/native/minipal/*.h`.