### PR TITLE
NamedPipeClientStream Connect with SafePipeHandle

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateNamedPipeClient.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateNamedPipeClient.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial SafePipeHandle CreateNamedPipeClient(
-            string? lpFileName,
+            string lpFileName,
             int dwDesiredAccess,
             System.IO.FileShare dwShareMode,
             ref SECURITY_ATTRIBUTES secAttrs,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitNamedPipe.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitNamedPipe.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Kernel32, EntryPoint = "WaitNamedPipeW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool WaitNamedPipe(string? name, int timeout);
+        internal static partial bool WaitNamedPipe(string name, int timeout);
     }
 }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -39,7 +40,8 @@ namespace System.IO.Pipes
             SafePipeHandle? clientHandle = null;
             try
             {
-                socket.Connect(new UnixDomainSocketEndPoint(_normalizedPipePath!));
+                Debug.Assert(_normalizedPipePath != null);
+                socket.Connect(new UnixDomainSocketEndPoint(_normalizedPipePath));
                 clientHandle = new SafePipeHandle(socket);
                 ConfigureSocket(socket, clientHandle, _direction, 0, 0, _inheritability);
             }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -110,7 +111,8 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
-            SafePipeHandle handle = CreateNamedPipeClient(_normalizedPipePath!, ref secAttrs, _pipeFlags, _accessRights);
+            Debug.Assert(_normalizedPipePath != null);
+            SafePipeHandle handle = CreateNamedPipeClient(_normalizedPipePath, ref secAttrs, _pipeFlags, _accessRights);
 
             if (handle.IsInvalid)
             {
@@ -133,7 +135,7 @@ namespace System.IO.Pipes
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
 
-                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath!, timeout))
+                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
                 {
                     errorCode = Marshal.GetLastPInvokeError();
 
@@ -147,7 +149,7 @@ namespace System.IO.Pipes
                 }
 
                 // Pipe server should be free. Let's try to connect to it.
-                handle = CreateNamedPipeClient(_normalizedPipePath!, ref secAttrs, _pipeFlags, _accessRights);
+                handle = CreateNamedPipeClient(_normalizedPipePath, ref secAttrs, _pipeFlags, _accessRights);
 
                 if (handle.IsInvalid)
                 {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -110,7 +110,7 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
-            SafePipeHandle handle = CreateNamedPipeClient(_normalizedPipePath, ref secAttrs, _pipeFlags, _accessRights);
+            SafePipeHandle handle = CreateNamedPipeClient(_normalizedPipePath!, ref secAttrs, _pipeFlags, _accessRights);
 
             if (handle.IsInvalid)
             {
@@ -133,7 +133,7 @@ namespace System.IO.Pipes
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
 
-                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
+                if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath!, timeout))
                 {
                     errorCode = Marshal.GetLastPInvokeError();
 
@@ -147,7 +147,7 @@ namespace System.IO.Pipes
                 }
 
                 // Pipe server should be free. Let's try to connect to it.
-                handle = CreateNamedPipeClient(_normalizedPipePath, ref secAttrs, _pipeFlags, _accessRights);
+                handle = CreateNamedPipeClient(_normalizedPipePath!, ref secAttrs, _pipeFlags, _accessRights);
 
                 if (handle.IsInvalid)
                 {
@@ -173,7 +173,7 @@ namespace System.IO.Pipes
             ValidateRemotePipeUser();
             return true;
 
-            static SafePipeHandle CreateNamedPipeClient(string? path, ref Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs, int pipeFlags, int access)
+            static SafePipeHandle CreateNamedPipeClient(string path, ref Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs, int pipeFlags, int access)
                 => Interop.Kernel32.CreateNamedPipeClient(path, access, FileShare.None, ref secAttrs, FileMode.Open, pipeFlags, hTemplateFile: IntPtr.Zero);
         }
 

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -92,6 +92,11 @@ namespace System.IO.Pipes
         public NamedPipeClientStream(PipeDirection direction, bool isAsync, bool isConnected, SafePipeHandle safePipeHandle)
             : base(direction, 0)
         {
+            if (!isConnected)
+            {
+                throw new ArgumentOutOfRangeException(nameof(isConnected));
+            }
+
             ArgumentNullException.ThrowIfNull(safePipeHandle);
 
             if (safePipeHandle.IsInvalid)
@@ -101,10 +106,7 @@ namespace System.IO.Pipes
             ValidateHandleIsPipe(safePipeHandle);
 
             InitializeHandle(safePipeHandle, true, isAsync);
-            if (isConnected)
-            {
-                State = PipeState.Connected;
-            }
+            State = PipeState.Connected;
         }
 
         ~NamedPipeClientStream()

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
@@ -97,6 +97,15 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.In)]
         [InlineData(PipeDirection.InOut)]
         [InlineData(PipeDirection.Out)]
+        public static void NotConnected_Throws_ArgumentOutOfRangeException(PipeDirection direction)
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("isConnected", () => new NamedPipeClientStream(direction, false, false, null));
+        }
+
+        [Theory]
+        [InlineData(PipeDirection.In)]
+        [InlineData(PipeDirection.InOut)]
+        [InlineData(PipeDirection.Out)]
         public static void NullHandle_Throws_ArgumentNullException(PipeDirection direction)
         {
             AssertExtensions.Throws<ArgumentNullException>("safePipeHandle", () => new NamedPipeClientStream(direction, false, true, null));


### PR DESCRIPTION
This is a copy of #110075 without the change to the public API.

* Checked that isConnected in the NamedPipeClientStream constructor is always true.
* Corrected the nullability in the interop declarations.

Fixes #32760