### PR TITLE
[release/8.0-staging] Fix stubs for `HybridGlobalization`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
@@ -1,7 +1,10 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
     <type fullname="System.Globalization.GlobalizationMode">
-      <method signature="System.Boolean get_Hybrid()" body="stub" value="true" feature="System.Globalization.Hybrid" featurevalue="false" />
+      <method signature="System.Boolean get_Hybrid()" body="stub" value="false" feature="System.Globalization.Hybrid" featurevalue="false" />
+    </type>
+    <type fullname="System.Globalization.GlobalizationMode">
+      <method signature="System.Boolean get_Hybrid()" body="stub" value="true" feature="System.Globalization.Hybrid" featurevalue="true" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
Partial backport of #93473 to release/8.0
Fixes https://github.com/dotnet/runtime/issues/109951

## Customer Impact

Customers that don’t use HybridGlobalization but use hashing methods from System.Globalization started having problems with publishing their apps. In publish we run trimming by default and this stub was activating HybridGlobalization way of processing for hashing, which means: throwing PNSE. In non-hybrid mode it’s not expected and it broke their publish pipe.

- [x] Customer reported
- [ ] Found internally

## Regression

- [x] Yes
- [ ] No

Regression from https://github.com/dotnet/runtime/pull/85254.

## Testing

Tested manually.

## Risk

Medium, the change corrects a logical error / typo of stubbing a value with `true` when its value is `false`.