### PR TITLE
Allow optimizing mask conversions on x64 as well

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -26786,7 +26786,55 @@ bool GenTree::OperIsHWIntrinsic(NamedIntrinsic intrinsicId) const
 {
     if (OperIsHWIntrinsic())
     {
-        return AsHWIntrinsic()->GetHWIntrinsicId() == intrinsicId;
+        return AsHWIntrinsic()->OperIsHWIntrinsic(intrinsicId);
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------
+// OperIsConvertMaskToVector: Is this a ConvertMaskToVector hwintrinsic
+//
+// Return Value:
+//    true if the node is a ConvertMaskToVector hwintrinsic
+//    otherwise; false
+//
+bool GenTree::OperIsConvertMaskToVector() const
+{
+    if (OperIsHWIntrinsic())
+    {
+        return AsHWIntrinsic()->OperIsConvertMaskToVector();
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------
+// OperIsConvertVectorToMask: Is this a ConvertVectorToMask hwintrinsic
+//
+// Return Value:
+//    true if the node is a ConvertVectorToMask hwintrinsic
+//    otherwise; false
+//
+bool GenTree::OperIsConvertVectorToMask() const
+{
+    if (OperIsHWIntrinsic())
+    {
+        return AsHWIntrinsic()->OperIsConvertVectorToMask();
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------
+// OperIsVectorConditionalSelect: Is this a vector ConditionalSelect hwintrinsic
+//
+// Return Value:
+//    true if the node is a vector ConditionalSelect hwintrinsic
+//    otherwise; false
+//
+bool GenTree::OperIsVectorConditionalSelect() const
+{
+    if (OperIsHWIntrinsic())
+    {
+        return AsHWIntrinsic()->OperIsVectorConditionalSelect();
     }
     return false;
 }
@@ -30669,8 +30717,6 @@ bool GenTree::CanDivOrModPossiblyOverflow(Compiler* comp) const
 #if defined(FEATURE_HW_INTRINSICS)
 GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
 {
-    assert(tree->OperIsHWIntrinsic());
-
     if (!opts.Tier0OptimizationEnabled())
     {
         return tree;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6590,8 +6590,8 @@ struct GenTreeHWIntrinsic : public GenTreeJitIntrinsic
     bool OperIsVectorConditionalSelect() const
     {
 #if defined(TARGET_XARCH)
-        return OperIsHWIntrinsic(NI_Vector128_ConditionalSelect) ||
-               OperIsHWIntrinsic(NI_Vector256_ConditionalSelect) || OperIsHWIntrinsic(NI_Vector512_ConditionalSelect);
+        return OperIsHWIntrinsic(NI_Vector128_ConditionalSelect) || OperIsHWIntrinsic(NI_Vector256_ConditionalSelect) ||
+               OperIsHWIntrinsic(NI_Vector512_ConditionalSelect);
 #elif defined(TARGET_ARM64)
         return OperIsHWIntrinsic(NI_AdvSimd_BitwiseSelect) || OperIsHWIntrinsic(NI_Sve_ConditionalSelect);
 #else

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1665,32 +1665,9 @@ public:
     }
 
     bool OperIsHWIntrinsic(NamedIntrinsic intrinsicId) const;
-
-    bool OperIsConvertMaskToVector() const
-    {
-#if defined(FEATURE_HW_INTRINSICS)
-#if defined(TARGET_XARCH)
-        return OperIsHWIntrinsic(NI_EVEX_ConvertMaskToVector);
-#elif defined(TARGET_ARM64)
-        return OperIsHWIntrinsic(NI_Sve_ConvertMaskToVector);
-#endif // !TARGET_XARCH && !TARGET_ARM64
-#else
-        return false;
-#endif // FEATURE_HW_INTRINSICS
-    }
-
-    bool OperIsConvertVectorToMask() const
-    {
-#if defined(FEATURE_HW_INTRINSICS)
-#if defined(TARGET_XARCH)
-        return OperIsHWIntrinsic(NI_EVEX_ConvertVectorToMask);
-#elif defined(TARGET_ARM64)
-        return OperIsHWIntrinsic(NI_Sve_ConvertVectorToMask);
-#endif // !TARGET_XARCH && !TARGET_ARM64
-#else
-        return false;
-#endif // FEATURE_HW_INTRINSICS
-    }
+    bool OperIsConvertMaskToVector() const;
+    bool OperIsConvertVectorToMask() const;
+    bool OperIsVectorConditionalSelect() const;
 
     // This is here for cleaner GT_LONG #ifdefs.
     static bool OperIsLong(genTreeOps gtOper)
@@ -6582,6 +6559,45 @@ struct GenTreeHWIntrinsic : public GenTreeJitIntrinsic
     bool OperIsCreateScalarUnsafe() const;
     bool OperIsBitwiseHWIntrinsic() const;
     bool OperIsEmbRoundingEnabled() const;
+
+    bool OperIsHWIntrinsic(NamedIntrinsic intrinsicId) const
+    {
+        return GetHWIntrinsicId() == intrinsicId;
+    }
+
+    bool OperIsConvertMaskToVector() const
+    {
+#if defined(TARGET_XARCH)
+        return OperIsHWIntrinsic(NI_EVEX_ConvertMaskToVector);
+#elif defined(TARGET_ARM64)
+        return OperIsHWIntrinsic(NI_Sve_ConvertMaskToVector);
+#else
+        return false;
+#endif
+    }
+
+    bool OperIsConvertVectorToMask() const
+    {
+#if defined(TARGET_XARCH)
+        return OperIsHWIntrinsic(NI_EVEX_ConvertVectorToMask);
+#elif defined(TARGET_ARM64)
+        return OperIsHWIntrinsic(NI_Sve_ConvertVectorToMask);
+#else
+        return false;
+#endif
+    }
+
+    bool OperIsVectorConditionalSelect() const
+    {
+#if defined(TARGET_XARCH)
+        return OperIsHWIntrinsic(NI_Vector128_ConditionalSelect) ||
+               OperIsHWIntrinsic(NI_Vector256_ConditionalSelect) || OperIsHWIntrinsic(NI_Vector512_ConditionalSelect);
+#elif defined(TARGET_ARM64)
+        return OperIsHWIntrinsic(NI_AdvSimd_BitwiseSelect) || OperIsHWIntrinsic(NI_Sve_ConditionalSelect);
+#else
+        return false;
+#endif
+    }
 
     bool OperRequiresAsgFlag() const;
     bool OperRequiresCallFlag() const;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2766,12 +2766,12 @@ void LinearScan::buildIntervals()
                     {
                         calleeSaveCount = CNT_CALLEE_ENREG;
                     }
-#if (defined(TARGET_XARCH) || defined(TARGET_ARM64)) && defined(FEATURE_SIMD)
+#if defined(FEATURE_MASKED_HW_INTRINSICS)
                     else if (varTypeUsesMaskReg(interval->registerType))
                     {
                         calleeSaveCount = CNT_CALLEE_SAVED_MASK;
                     }
-#endif // (TARGET_XARCH || TARGET_ARM64) && FEATURE_SIMD
+#endif // FEATURE_MASKED_HW_INTRINSICS
                     else
                     {
                         assert(varTypeUsesFloatReg(interval->registerType));

--- a/src/coreclr/jit/optimizemaskconversions.cpp
+++ b/src/coreclr/jit/optimizemaskconversions.cpp
@@ -259,6 +259,12 @@ public:
 
     Compiler::fgWalkResult PostOrderVisit(GenTree** use, GenTree* user)
     {
+#if defined(TARGET_ARM64)
+        static constexpr const int ConvertVectorToMaskValueOp = 2;
+#else
+        static constexpr const int ConvertVectorToMaskValueOp = 1;
+#endif
+
         GenTreeLclVarCommon* lclOp            = nullptr;
         bool                 isLocalStore     = false;
         bool                 isLocalUse       = false;
@@ -281,11 +287,12 @@ public:
             isLocalStore  = true;
             addConversion = true;
         }
-        else if ((*use)->OperIsConvertVectorToMask() && (*use)->AsHWIntrinsic()->Op(2)->OperIs(GT_LCL_VAR))
+        else if ((*use)->OperIsConvertVectorToMask() &&
+                 (*use)->AsHWIntrinsic()->Op(ConvertVectorToMaskValueOp)->OperIs(GT_LCL_VAR))
         {
             // Found
             //      user(use:ConvertVectorToMask(LCL_VAR(x)))
-            lclOp            = (*use)->AsHWIntrinsic()->Op(2)->AsLclVarCommon();
+            lclOp            = (*use)->AsHWIntrinsic()->Op(ConvertVectorToMaskValueOp)->AsLclVarCommon();
             isLocalUse       = true;
             removeConversion = true;
         }


### PR DESCRIPTION
This mostly just extends the mask conversion optimization to light-up on x64 as well. In order to achieve that it mostly just adds in the minor different handling for the conversion cost and ensuring the right operand is accessed.

It additionally adds support for one more important scenario, which is recognizing that `ConditionalSelect` despite taking a vector in IR has special support to be lowered/contained such that the mask can be consumed directly. -- The same is technically also possible for the various bitwise operations, but those are less important to handle initially.