### PR TITLE
Fix Configuration to throw with ErrorOnUnknownConfiguration option

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -465,9 +465,14 @@ namespace Microsoft.Extensions.Configuration
             }
             else
             {
-                if (isParentCollection && bindingPoint.Value is null && string.IsNullOrEmpty(configValue))
+                // Reaching this point indicates that the configuration section is a leaf node with a string value.
+                // Typically, configValue will be an empty string if the value in the configuration is empty or null.
+                // While configValue could be any other string, we already know it cannot be converted to the required type, as TryConvertValue has already failed.
+                if (isParentCollection && bindingPoint.Value is null && (string.IsNullOrEmpty(configValue) || options.ErrorOnUnknownConfiguration))
                 {
-                    // If we don't have an instance, try to create one
+                    // If configValue is an empty string, we attempt to create a default instance of the required type.
+                    // If configValue is not an empty string and options.ErrorOnUnknownConfiguration is true,
+                    // we continue processing the configuration and throw an exception at the appropriate point.
                     bindingPoint.TrySetValue(CreateInstance(type, config, options, out _));
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -478,11 +478,8 @@ namespace Microsoft.Extensions.Configuration
                         Debug.Assert(section is not null);
                         throw new InvalidOperationException(SR.Format(SR.Error_FailedBinding, section.Path, type));
                     }
-
-                    return;
                 }
-
-                if (isParentCollection && bindingPoint.Value is null)
+                else if (isParentCollection && bindingPoint.Value is null)
                 {
                     // Try to create the default instance of the type
                     bindingPoint.TrySetValue(CreateInstance(type, config, options, out _));

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -468,11 +468,23 @@ namespace Microsoft.Extensions.Configuration
                 // Reaching this point indicates that the configuration section is a leaf node with a string value.
                 // Typically, configValue will be an empty string if the value in the configuration is empty or null.
                 // While configValue could be any other string, we already know it cannot be converted to the required type, as TryConvertValue has already failed.
-                if (isParentCollection && bindingPoint.Value is null && (string.IsNullOrEmpty(configValue) || options.ErrorOnUnknownConfiguration))
+
+                if (!string.IsNullOrEmpty(configValue))
                 {
-                    // If configValue is an empty string, we attempt to create a default instance of the required type.
-                    // If configValue is not an empty string and options.ErrorOnUnknownConfiguration is true,
-                    // we continue processing the configuration and throw an exception at the appropriate point.
+                    // If we have a value, but no children, we can't bind it to anything
+                    // We already tried calling TryConvertValue and couldn't convert the configuration value to the required type.
+                    if (options.ErrorOnUnknownConfiguration)
+                    {
+                        Debug.Assert(section is not null);
+                        throw new InvalidOperationException(SR.Format(SR.Error_FailedBinding, section.Path, type));
+                    }
+
+                    return;
+                }
+
+                if (isParentCollection && bindingPoint.Value is null)
+                {
+                    // Try to create the default instance of the type
                     bindingPoint.TrySetValue(CreateInstance(type, config, options, out _));
                 }
             }
@@ -503,8 +515,6 @@ namespace Microsoft.Extensions.Configuration
             BinderOptions options,
             out ParameterInfo[]? constructorParameters)
         {
-            Debug.Assert(!type.IsArray);
-
             constructorParameters = null;
 
             if (type.IsInterface || type.IsAbstract)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2815,5 +2815,16 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.True(result.Enabled);
             Assert.Equal(new [] { "new", "class", "rosebud"}, result.Keywords);
         }
+
+#if !BUILDING_SOURCE_GENERATOR_TESTS
+        [Fact]
+        public void EnsureThrowingWithCollectionAndErrorOnUnknownConfigurationOption()
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Values:Monday"] = "not-an-array-of-string" }).Build();
+            Assert.Throws<InvalidOperationException>(() => configuration.Get<TestSettings>(options => options.ErrorOnUnknownConfiguration = true));
+        }
+
+        internal class TestSettings { public Dictionary<DayOfWeek, string[]> Values { get; init; } = []; }
+#endif
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2822,6 +2822,12 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Values:Monday"] = "not-an-array-of-string" }).Build();
             Assert.Throws<InvalidOperationException>(() => configuration.Get<TestSettings>(options => options.ErrorOnUnknownConfiguration = true));
+
+            configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Values:Monday"] = "" }).Build();
+            Assert.Throws<InvalidOperationException>(() => configuration.Get<TestSettings>(options => options.ErrorOnUnknownConfiguration = true));
+
+            configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Values:Monday"] = null }).Build();
+            Assert.Throws<InvalidOperationException>(() => configuration.Get<TestSettings>(options => options.ErrorOnUnknownConfiguration = true));
         }
 
         internal class TestSettings { public Dictionary<DayOfWeek, string[]> Values { get; init; } = []; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/110147

This change addresses a regression introduced in `Microsoft.Extensions.Configuration.Binder` version 9.0.0. The issue occurs when binding a configuration with `ErrorOnUnknownConfiguration` set to `true`, where an `InvalidOperationException` should be thrown. The regression specifically affects scenarios involving collections, where binding collection values to invalid configuration values does not behave as expected.

The original change caused the regression is https://github.com/dotnet/runtime/pull/97777

The change is ensuring back to the .NET 8.0 behavior, but we should look at fixing the source generator in general with `ErrorOnUnknownConfiguration`.