### PR TITLE
JIT: Remove `fgRenumberBlocks` calls in loop opt phases

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5145,37 +5145,18 @@ BasicBlockVisit FlowGraphNaturalLoop::VisitLoopBlocks(TFunc func)
 template <typename TFunc>
 BasicBlockVisit FlowGraphNaturalLoop::VisitLoopBlocksLexical(TFunc func)
 {
-    BasicBlock* top           = m_header;
-    unsigned    numLoopBlocks = 0;
-    VisitLoopBlocks([&](BasicBlock* block) {
-        if (block->bbNum < top->bbNum)
-        {
-            top = block;
-        }
+    BasicBlock* const top    = GetLexicallyTopMostBlock();
+    BasicBlock* const bottom = GetLexicallyBottomMostBlock();
 
-        numLoopBlocks++;
-        return BasicBlockVisit::Continue;
-    });
-
-    INDEBUG(BasicBlock* prev = nullptr);
-    BasicBlock* cur = top;
-    while (numLoopBlocks > 0)
+    for (BasicBlock* const block : m_dfsTree->GetCompiler()->Blocks(top, bottom))
     {
-        // If we run out of blocks the blocks aren't sequential.
-        assert(cur != nullptr);
-
-        if (ContainsBlock(cur))
+        if (ContainsBlock(block))
         {
-            assert((prev == nullptr) || (prev->bbNum < cur->bbNum));
-
-            if (func(cur) == BasicBlockVisit::Abort)
+            if (func(block) == BasicBlockVisit::Abort)
+            {
                 return BasicBlockVisit::Abort;
-
-            INDEBUG(prev = cur);
-            numLoopBlocks--;
+            }
         }
-
-        cur = cur->Next();
     }
 
     return BasicBlockVisit::Continue;

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -3064,8 +3064,6 @@ PhaseStatus Compiler::optCloneLoops()
             m_dfsTree = fgComputeDfs();
             m_loops   = FlowGraphNaturalLoops::Find(m_dfsTree);
         }
-
-        fgRenumberBlocks();
     }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1303,7 +1303,6 @@ PhaseStatus Compiler::optUnrollLoops()
         }
 
         JITDUMP("A nested loop was unrolled. Doing another pass (pass %d)\n", passes + 1);
-        fgRenumberBlocks();
         fgInvalidateDfsTree();
         m_dfsTree = fgComputeDfs();
         m_loops   = FlowGraphNaturalLoops::Find(m_dfsTree);


### PR DESCRIPTION
Follow-up to #110026. This required a small refactor of `FlowGraphNaturalLoop::VisitLoopBlocksLexical` to remove its `bbNum` checks.