### PR TITLE
Add `TimeSpan.FromMilliseconds(long)` overload

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -15,7 +15,7 @@ namespace System
     // to 100 nanoseconds. While this maps well into units of time such as hours
     // and days, any periods longer than that aren't representable in a nice fashion.
     // For instance, a month can be between 28 and 31 days, while a year
-    // can contain 365 or 366 days.  A decade can have between 1 and 3 leapyears,
+    // can contain 365 or 366 days.  A decade can have between 1 and 3 leap-years,
     // depending on when you map the TimeSpan into the calendar.  This is why
     // we do not provide Years() or Months().
     //
@@ -587,6 +587,18 @@ namespace System
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// milliseconds.
+        /// </summary>
+        /// <param name="milliseconds">Number of milliseconds.</param>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of milliseconds.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameter specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
+        public static TimeSpan FromMilliseconds(long milliseconds)
+            => FromUnits(milliseconds, TicksPerMillisecond, MinMilliseconds, MaxMilliseconds);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
         /// milliseconds, and microseconds.
         /// </summary>
         /// <param name="milliseconds">Number of milliseconds.</param>
@@ -595,7 +607,7 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
-        public static TimeSpan FromMilliseconds(long milliseconds, long microseconds = 0)
+        public static TimeSpan FromMilliseconds(long milliseconds, long microseconds)
         {
             Int128 totalMicroseconds = Math.BigMul(milliseconds, MicrosecondsPerMillisecond)
                                      + microseconds;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6014,7 +6014,8 @@ namespace System
         public static System.TimeSpan FromMicroseconds(double value) { throw null; }
         public static System.TimeSpan FromMicroseconds(long microseconds) { throw null; }
         public static System.TimeSpan FromMilliseconds(double value) { throw null; }
-        public static System.TimeSpan FromMilliseconds(long milliseconds, long microseconds = (long)0) { throw null; }
+        public static System.TimeSpan FromMilliseconds(long milliseconds) { throw null; }
+        public static System.TimeSpan FromMilliseconds(long milliseconds, long microseconds) { throw null; }
         public static System.TimeSpan FromMinutes(double value) { throw null; }
         public static System.TimeSpan FromMinutes(long minutes) { throw null; }
         public static System.TimeSpan FromMinutes(long minutes, long seconds = (long)0, long milliseconds = (long)0, long microseconds = (long)0) { throw null; }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq.Expressions;
 using System.Text;
 using Xunit;
 
@@ -631,7 +632,7 @@ namespace System.Tests
         [InlineData(0, -(maxSeconds + 1), 0, 0)]
         [InlineData(0, 0, maxMilliseconds + 1, 0)]
         [InlineData(0, 0, -(maxMilliseconds + 1), 0)]
-        [InlineData(0, 0, 0, maxMicroseconds + 1)]        
+        [InlineData(0, 0, 0, maxMicroseconds + 1)]
         [InlineData(0, 0, 0, -(maxMicroseconds + 1))]
         public static void FromMinutes_Int_ShouldOverflow(long minutes, long seconds, long milliseconds, long microseconds)
         {
@@ -713,7 +714,16 @@ namespace System.Tests
             long ticksFromMicroseconds = microseconds * TimeSpan.TicksPerMicrosecond;
             var expected = TimeSpan.FromTicks(ticksFromMilliseconds + ticksFromMicroseconds);
             Assert.Equal(expected, TimeSpan.FromMilliseconds(milliseconds, microseconds));
+
+            expected = TimeSpan.FromTicks(ticksFromMilliseconds);
+            Assert.Equal(expected, TimeSpan.FromMilliseconds(milliseconds));
+
+            // The following exist to ensure compilation of the expressions
+            Expression<Action> a = () => TimeSpan.FromMilliseconds(milliseconds);
+            Expression<Action> b = () => TimeSpan.FromMilliseconds(milliseconds, microseconds);
+            Expression<Action> c = () => TimeSpan.FromMilliseconds((double)milliseconds);
         }
+
         [Theory]
         [InlineData(maxMilliseconds + 1, 0)]
         [InlineData(-(maxMilliseconds + 1), 0)]
@@ -730,6 +740,11 @@ namespace System.Tests
         public static void FromMilliseconds_Int_ShouldOverflow(long milliseconds, long microseconds)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMilliseconds(milliseconds, microseconds));
+
+            if (microseconds == 0)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMilliseconds(milliseconds));
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/109833

Related issue https://github.com/dotnet/runtime/issues/93890#issuecomment-1777761585