### PR TITLE
Disable GFNI tests for NAOT

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_r.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <AssemblyName>X86_Gfni_r</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Would have to translate Illegal instruction to PNSE -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_r.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Would have to translate Illegal instruction to PNSE -->
+    <!-- https://github.com/dotnet/runtime/issues/110293 -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_ro.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Would have to translate Illegal instruction to PNSE -->
+    <!-- https://github.com/dotnet/runtime/issues/110293 -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Gfni/Gfni_ro.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <AssemblyName>X86_Gfni_ro</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Would have to translate Illegal instruction to PNSE -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>


### PR DESCRIPTION
Fixes #110240 

GFNI is enabled opportunistically, and the HWIntrinsics tests check that the methods throw PNSE when not supported.  On NAOT, instead of throwing, the instructions are emitted, so they result in illegal instruction instead.