### PR TITLE
JIT: Remove lexical dependencies in switch recognition

### DIFF
--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -329,7 +329,6 @@ bool Compiler::optSwitchConvert(
         assert(rootNode->OperIs(GT_JTRUE));
 
         // We only support reversed tests (GT_NE) in the last block of the chain.
-        // TODO: Remove this restriction.
         assert(rootNode->gtGetOp1()->OperIs(GT_EQ));
         lastBlock = lastBlock->GetFalseTarget();
     }
@@ -368,7 +367,6 @@ bool Compiler::optSwitchConvert(
     for (int i = 0; i < (testsCount - 1); i++)
     {
         // We always follow the false target because reversed tests are only supported for the last block.
-        // TODO: Lift this restriction, and follow the true target if the test is reversed.
         assert(blockToRemove->KindIs(BBJ_COND));
         BasicBlock* const nextBlockToRemove = blockToRemove->GetFalseTarget();
         fgRemoveBlock(blockToRemove, true);

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -51,8 +51,8 @@ PhaseStatus Compiler::optSwitchRecognition()
 // Arguments:
 //    block            - The block to check
 //    allowSideEffects - is variableNode allowed to have side-effects (COMMA)?
-//    trueEdge         - [out] The successor edge taken if X == CNS
-//    falseEdge        - [out] The successor edge taken if X != CNS
+//    trueTarget       - [out] The successor visited if X == CNS
+//    falseTarget      - [out] The successor visited if X != CNS
 //    isReversed       - [out] True if the condition is reversed (GT_NE)
 //    variableNode     - [out] The variable node (X in the example above)
 //    cns              - [out] The constant value (CNS in the example above)
@@ -176,13 +176,12 @@ bool Compiler::optSwitchDetectAndConvert(BasicBlock* firstBlock)
         weight_t          falseLikelihood = firstBlock->GetFalseEdge()->getLikelihood();
         const BasicBlock* prevBlock       = firstBlock;
 
-        // Now walk the next blocks and see if they are basically the same type of test
-        for (const BasicBlock* currBb = firstBlock->Next(); currBb != nullptr; currBb = currBb->Next())
+        // Now walk the chain of test blocks, and see if they are basically the same type of test
+        for (BasicBlock *currBb = falseTarget, *currFalseTarget; currBb != nullptr; currBb = currFalseTarget)
         {
             GenTree*    currVariableNode = nullptr;
             ssize_t     currCns          = 0;
             BasicBlock* currTrueTarget   = nullptr;
-            BasicBlock* currFalseTarget  = nullptr;
 
             if (!currBb->hasSingleStmt())
             {
@@ -366,7 +365,6 @@ bool Compiler::optSwitchConvert(
     // Unlink and remove the whole chain of conditional blocks
     fgRemoveRefPred(falseEdge);
     BasicBlock* blockToRemove = falseEdge->getDestinationBlock();
-    assert(firstBlock->NextIs(blockToRemove));
     for (int i = 0; i < (testsCount - 1); i++)
     {
         // We always follow the false target because reversed tests are only supported for the last block.


### PR DESCRIPTION
Fixes #107076. Part of #107749. Instead of relying on the "not equal" target of each test block being the next block, explicitly follow the chain of "not equal" targets.