### PR TITLE
Rename {CLR,DOTNET}_ICU/OPENSSL_VERSION_OVERRIDE

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_icushim.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim.c
@@ -302,13 +302,13 @@ static int OpenICULibraries(int majorVer, int minorVer, int subVer, const char* 
     return libicuuc != NULL;
 }
 
-// Select libraries using the version override specified by the CLR_ICU_VERSION_OVERRIDE
+// Select libraries using the version override specified by the DOTNET_ICU_VERSION_OVERRIDE
 // environment variable.
 // The format of the string in this variable is majorVer[.minorVer[.subVer]] (the brackets
 // indicate optional parts).
 static int FindLibUsingOverride(const char* versionPrefix, char* symbolName, char* symbolVersion)
 {
-    char* versionOverride = getenv("CLR_ICU_VERSION_OVERRIDE");
+    char* versionOverride = getenv("DOTNET_ICU_VERSION_OVERRIDE");
     if (versionOverride != NULL)
     {
         if (strcmp(versionOverride, "build") == 0)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -66,11 +66,11 @@ static void DlOpen(const char* libraryName)
 
 static void OpenLibraryOnce(void)
 {
-    // If there is an override of the version specified using the CLR_OPENSSL_VERSION_OVERRIDE
+    // If there is an override of the version specified using the DOTNET_OPENSSL_VERSION_OVERRIDE
     // env variable, try to load that first.
     // The format of the value in the env variable is expected to be the version numbers,
     // like 1.0.0, 1.0.2 etc.
-    char* versionOverride = getenv("CLR_OPENSSL_VERSION_OVERRIDE");
+    char* versionOverride = getenv("DOTNET_OPENSSL_VERSION_OVERRIDE");
 
     if ((versionOverride != NULL) && strnlen(versionOverride, MaxVersionStringLength + 1) <= MaxVersionStringLength)
     {


### PR DESCRIPTION
It's the only environment variable using `CLR_` prefix.