### PR TITLE
Add support for emitting Source Link data

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -87,6 +87,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
+      <LinkerArg Condition="$(EnableSourceLink) == 'true'" Include="/SOURCELINK:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).sourcelink" />
       <LinkerArg Condition="'$(NativeLib)' == 'Shared'" Include="/DLL" />
       <LinkerArg Include="@(NativeLibrary->'&quot;%(Identity)&quot;')" />
       <LinkerArg Include="@(SdkNativeLibrary->'&quot;%(Identity)&quot;')" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -87,7 +87,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <LinkerArg Condition="$(EnableSourceLink) == 'true'" Include="/SOURCELINK:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).sourcelink" />
+      <LinkerArg Condition="$(IlcMultiModule) != 'true' and $(EnableSourceLink) == 'true'" Include="/SOURCELINK:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).sourcelink" />
       <LinkerArg Condition="'$(NativeLib)' == 'Shared'" Include="/DLL" />
       <LinkerArg Include="@(NativeLibrary->'&quot;%(Identity)&quot;')" />
       <LinkerArg Include="@(SdkNativeLibrary->'&quot;%(Identity)&quot;')" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -237,6 +237,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcGenerateMstatFile) == 'true'" Include="--mstat:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).mstat" />
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--dgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).codegen.dgml.xml" />
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--scandgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).scan.dgml.xml" />
+      <IlcArg Condition="$(EnableSourceLink) == 'true' and $(_targetOS) == 'win'" Include="--sourcelink:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).sourcelink" />
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(FullPath)')" />
       <IlcArg Include="@(TrimmerRootDescriptor->'--descriptor:%(FullPath)')" />
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -237,7 +237,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcGenerateMstatFile) == 'true'" Include="--mstat:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).mstat" />
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--dgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).codegen.dgml.xml" />
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--scandgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).scan.dgml.xml" />
-      <IlcArg Condition="$(EnableSourceLink) == 'true' and $(_targetOS) == 'win'" Include="--sourcelink:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).sourcelink" />
+      <IlcArg Condition="$(IlcMultiModule) != 'true' and $(EnableSourceLink) == 'true' and $(_targetOS) == 'win'" Include="--sourcelink:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).sourcelink" />
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(FullPath)')" />
       <IlcArg Include="@(TrimmerRootDescriptor->'--descriptor:%(FullPath)')" />
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />

--- a/src/coreclr/tools/Common/Microsoft/SourceLink/Tools/SourceLinkMap.cs
+++ b/src/coreclr/tools/Common/Microsoft/SourceLink/Tools/SourceLinkMap.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Microsoft.SourceLink.Tools
+{
+    /// <summary>
+    /// Source Link URL map. Maps file paths matching Source Link patterns to URLs.
+    /// </summary>
+    internal readonly struct SourceLinkMap
+    {
+        private readonly ReadOnlyCollection<Entry> _entries;
+
+        private SourceLinkMap(ReadOnlyCollection<Entry> mappings)
+        {
+            _entries = mappings;
+        }
+
+        public readonly struct Entry(FilePathPattern filePath, UriPattern uri)
+        {
+            public readonly FilePathPattern FilePath = filePath;
+            public readonly UriPattern Uri = uri;
+
+            public void Deconstruct(out FilePathPattern filePath, out UriPattern uri)
+            {
+                filePath = FilePath;
+                uri = Uri;
+            }
+        }
+
+        public readonly struct FilePathPattern(string path, bool isPrefix)
+        {
+            public readonly string Path = path;
+            public readonly bool IsPrefix = isPrefix;
+        }
+
+        public readonly struct UriPattern(string prefix, string suffix)
+        {
+            public readonly string Prefix = prefix;
+            public readonly string Suffix = suffix;
+        }
+
+        public IReadOnlyList<Entry> Entries => _entries;
+
+        /// <summary>
+        /// Parses Source Link JSON string.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="json"/> is null.</exception>
+        /// <exception cref="InvalidDataException">The JSON does not follow Source Link specification.</exception>
+        /// <exception cref="JsonException"><paramref name="json"/> is not valid JSON string.</exception>
+        public static SourceLinkMap Parse(string json)
+        {
+            ArgumentNullException.ThrowIfNull(json);
+
+            var list = new List<Entry>();
+
+            var root = JsonDocument.Parse(json, new JsonDocumentOptions() { AllowTrailingCommas = true }).RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidDataException();
+            }
+
+            foreach (var rootEntry in root.EnumerateObject())
+            {
+                if (!rootEntry.NameEquals("documents"))
+                {
+                    // potential future extensibility
+                    continue;
+                }
+
+                if (rootEntry.Value.ValueKind != JsonValueKind.Object)
+                {
+                    throw new InvalidDataException();
+                }
+
+                foreach (var documentsEntry in rootEntry.Value.EnumerateObject())
+                {
+                    if (documentsEntry.Value.ValueKind != JsonValueKind.String ||
+                        !TryParseEntry(documentsEntry.Name, documentsEntry.Value.GetString()!, out var entry))
+                    {
+                        throw new InvalidDataException();
+                    }
+
+                    list.Add(entry);
+                }
+            }
+
+            // Sort the map by decreasing file path length. This ensures that the most specific paths will checked before the least specific
+            // and that absolute paths will be checked before a wildcard path with a matching base
+            list.Sort((left, right) => -left.FilePath.Path.Length.CompareTo(right.FilePath.Path.Length));
+
+            return new SourceLinkMap(new ReadOnlyCollection<Entry>(list));
+        }
+
+        private static bool TryParseEntry(string key, string value, out Entry entry)
+        {
+            entry = default;
+
+            // VALIDATION RULES
+            // 1. The only acceptable wildcard is one and only one '*', which if present will be replaced by a relative path
+            // 2. If the filepath does not contain a *, the uri cannot contain a * and if the filepath contains a * the uri must contain a *
+            // 3. If the filepath contains a *, it must be the final character
+            // 4. If the uri contains a *, it may be anywhere in the uri
+            if (key.Length == 0)
+            {
+                return false;
+            }
+
+            var filePathStar = key.IndexOf('*');
+            if (filePathStar == key.Length - 1)
+            {
+                key = key[..filePathStar];
+            }
+            else if (filePathStar >= 0)
+            {
+                return false;
+            }
+
+            string uriPrefix, uriSuffix;
+            var uriStar = value.IndexOf('*');
+            if (uriStar >= 0)
+            {
+                if (filePathStar < 0)
+                {
+                    return false;
+                }
+
+                uriPrefix = value[..uriStar];
+                uriSuffix = value[(uriStar + 1)..];
+
+                if (uriSuffix.Contains('*'))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                uriPrefix = value;
+                uriSuffix = "";
+            }
+
+            entry = new Entry(
+                new FilePathPattern(key, isPrefix: filePathStar >= 0),
+                new UriPattern(uriPrefix, uriSuffix));
+
+            return true;
+        }
+
+        /// <summary>
+        /// Maps specified <paramref name="path"/> to the corresponding URL.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
+        public bool TryGetUri(
+            string path,
+            out string uri)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+
+            if (path.Contains('*'))
+            {
+                uri = null;
+                return false;
+            }
+
+            // Note: the mapping function is case-insensitive.
+
+            foreach (var (file, mappedUri) in _entries)
+            {
+                if (file.IsPrefix)
+                {
+                    if (path.StartsWith(file.Path, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var escapedPath = string.Join("/", path[file.Path.Length..].Split(['/', '\\']).Select(Uri.EscapeDataString));
+                        uri = mappedUri.Prefix + escapedPath + mappedUri.Suffix;
+                        return true;
+                    }
+                }
+                else if (string.Equals(path, file.Path, StringComparison.OrdinalIgnoreCase))
+                {
+                    Debug.Assert(mappedUri.Suffix.Length == 0);
+                    uri = mappedUri.Prefix;
+                    return true;
+                }
+            }
+
+            uri = null;
+            return false;
+        }
+    }
+}

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PdbSymbolReader.cs
@@ -17,5 +17,6 @@ namespace Internal.TypeSystem.Ecma
         public abstract IEnumerable<ILLocalVariable> GetLocalVariableNamesForMethod(int methodToken);
         public abstract int GetStateMachineKickoffMethod(int methodToken);
         public abstract void Dispose();
+        public abstract ReadOnlySpan<byte> GetSourceLinkData();
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
@@ -205,6 +206,22 @@ namespace Internal.TypeSystem.Ecma
                 ProbeScopeForLocals(variables, localScopeHandle);
             }
             return variables;
+        }
+
+        public override unsafe ReadOnlySpan<byte> GetSourceLinkData()
+        {
+            // {CC110556-A091-4D38-9FEC-25AB9A351A6A}
+            Guid sourceLinkDataGuid = new Guid(0xCC110556, 0xA091, 0x4D38, 0x9F, 0xEC, 0x25, 0xAB, 0x9A, 0x35, 0x1A, 0x6A);
+            foreach (CustomDebugInformationHandle cdiHandle in _reader.GetCustomDebugInformation(Handle.ModuleDefinition))
+            {
+                CustomDebugInformation cdi = _reader.GetCustomDebugInformation(cdiHandle);
+                if (_reader.GetGuid(cdi.Kind) == sourceLinkDataGuid)
+                {
+                    BlobReader br = _reader.GetBlobReader(cdi.Value);
+                    return new ReadOnlySpan<byte>(br.StartPointer, br.Length);
+                }
+            }
+            return ReadOnlySpan<byte>.Empty;
         }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
@@ -1361,6 +1361,11 @@ namespace Internal.TypeSystem.Ecma
         {
             return 0;
         }
+
+        public override ReadOnlySpan<byte> GetSourceLinkData()
+        {
+            return ReadOnlySpan<byte>.Empty;
+        }
     }
 #endif
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SourceLinkWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SourceLinkWriter.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.SourceLink.Tools;
+
+using ILCompiler.DependencyAnalysis;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
+
+namespace ILCompiler
+{
+    public class SourceLinkWriter : ObjectDumper
+    {
+        private readonly TextWriter _writer;
+        private readonly HashSet<string> _generatedSourceMappings;
+        private readonly Dictionary<EcmaModule, SourceLinkMap> _sourceLinkMaps;
+
+        public SourceLinkWriter(string sourceLinkFileName)
+        {
+            _writer = File.CreateText(sourceLinkFileName);
+            _generatedSourceMappings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _sourceLinkMaps = new Dictionary<EcmaModule, SourceLinkMap>();
+        }
+
+        internal override void Begin()
+        {
+            _writer.Write("{\"documents\":{");
+        }
+
+        protected override void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData)
+        {
+            if (node is not INodeWithDebugInfo debugInfoNode
+                || node is not IMethodBodyNode methodBodyNode
+                || methodBodyNode.Method.GetTypicalMethodDefinition() is not EcmaMethod ecmaMethod)
+            {
+                return;
+            }
+
+            if (!_sourceLinkMaps.TryGetValue(ecmaMethod.Module, out SourceLinkMap map))
+            {
+                ReadOnlySpan<byte> sourceLinkBytes = ecmaMethod.Module.PdbReader.GetSourceLinkData();
+                string sourceLinkData = sourceLinkBytes.IsEmpty
+                    ? "{\"documents\":{}}" : Encoding.UTF8.GetString(sourceLinkBytes);
+                _sourceLinkMaps.Add(ecmaMethod.Module, map = SourceLinkMap.Parse(sourceLinkData));
+            }
+
+            foreach (NativeSequencePoint sequencePoint in debugInfoNode.GetNativeSequencePoints())
+            {
+                if (_generatedSourceMappings.Contains(sequencePoint.FileName))
+                    continue;
+
+                if (!map.TryGetUri(sequencePoint.FileName, out string uri))
+                    continue;
+
+                if (_generatedSourceMappings.Count != 0)
+                    _writer.Write(", ");
+
+                _writer.Write($"\"{JsonEscape(sequencePoint.FileName)}\": \"{JsonEscape(uri)}\"");
+
+                _generatedSourceMappings.Add(sequencePoint.FileName);
+            }
+
+            static string JsonEscape(string str)
+                => str.Replace(@"\", @"\\").Replace("\"", "\\\"");
+        }
+
+        internal override void End()
+        {
+            _writer.WriteLine("}}");
+            _writer.Dispose();
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SourceLinkWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SourceLinkWriter.cs
@@ -45,10 +45,15 @@ namespace ILCompiler
 
             if (!_sourceLinkMaps.TryGetValue(ecmaMethod.Module, out SourceLinkMap map))
             {
-                ReadOnlySpan<byte> sourceLinkBytes = ecmaMethod.Module.PdbReader.GetSourceLinkData();
+                ReadOnlySpan<byte> sourceLinkBytes = ecmaMethod.Module.PdbReader is PdbSymbolReader reader ? reader.GetSourceLinkData() : default;
                 string sourceLinkData = sourceLinkBytes.IsEmpty
                     ? "{\"documents\":{}}" : Encoding.UTF8.GetString(sourceLinkBytes);
                 _sourceLinkMaps.Add(ecmaMethod.Module, map = SourceLinkMap.Parse(sourceLinkData));
+            }
+
+            if (map.Entries.Count == 0)
+            {
+                return;
             }
 
             foreach (NativeSequencePoint sequencePoint in debugInfoNode.GetNativeSequencePoints())

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" Link="Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.UpdateResourceDataModel.cs" Link="Compiler\Win32Resources\ResourceData.UpdateResourceDataModel.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.Win32Structs.cs" Link="Compiler\Win32Resources\ResourceData.Win32Structs.cs" />
+    <Compile Include="..\..\Common\Microsoft\SourceLink\Tools\SourceLinkMap.cs" Link="Common\SourceLinkMap.cs" />
     <Compile Include="..\..\Common\TypeSystem\IL\DelegateInfo.cs">
       <Link>IL\DelegateInfo.cs</Link>
     </Compile>
@@ -457,6 +458,7 @@
     <Compile Include="Compiler\ObjectDataInterner.cs" />
     <Compile Include="Compiler\ReachabilityInstrumentationFilter.cs" />
     <Compile Include="Compiler\ReachabilityInstrumentationProvider.cs" />
+    <Compile Include="Compiler\SourceLinkWriter.cs" />
     <Compile Include="Compiler\SubstitutedILProvider.cs" />
     <Compile Include="Compiler\SubstitutionProvider.cs" />
     <Compile Include="Compiler\GenericRootProvider.cs" />

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -75,6 +75,8 @@ namespace ILCompiler
             new("--map") { Description = "Generate a map file" };
         public CliOption<string> MstatFileName { get; } =
             new("--mstat") { Description = "Generate an mstat file" };
+        public CliOption<string> SourceLinkFileName { get; } =
+            new("--sourcelink") { Description = "Generate a SourceLink file" };
         public CliOption<string> MetadataLogFileName { get; } =
             new("--metadatalog") { Description = "Generate a metadata log file" };
         public CliOption<bool> CompleteTypesMetadata { get; } =
@@ -209,6 +211,7 @@ namespace ILCompiler
             Options.Add(SubstitutionFilePaths);
             Options.Add(MapFileName);
             Options.Add(MstatFileName);
+            Options.Add(SourceLinkFileName);
             Options.Add(MetadataLogFileName);
             Options.Add(CompleteTypesMetadata);
             Options.Add(ReflectionData);

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -606,6 +606,7 @@ namespace ILCompiler
 
             string mapFileName = Get(_command.MapFileName);
             string mstatFileName = Get(_command.MstatFileName);
+            string sourceLinkFileName = Get(_command.SourceLinkFileName);
 
             List<ObjectDumper> dumpers = new List<ObjectDumper>();
 
@@ -614,6 +615,9 @@ namespace ILCompiler
 
             if (mstatFileName != null)
                 dumpers.Add(new MstatObjectDumper(mstatFileName, typeSystemContext));
+
+            if (sourceLinkFileName != null)
+                dumpers.Add(new SourceLinkWriter(sourceLinkFileName));
 
             CompilationResults compilationResults = compilation.Compile(outputFilePath, ObjectDumper.Compose(dumpers));
             string exportsFile = Get(_command.ExportsFile);


### PR DESCRIPTION
Fixes #81415.

We read the source link data from the portable PDB, map file names to URLs, and emit into a JSON file. Then pass the JSON file to link.exe. We make no effort to make the source link data more compact. We could attempt to find common prefixes and emit as `*` but I left that as a future potential extension. The extra data in the expanded form is nothing compared to the size of native PDBs.

Cc @dotnet/ilc-contrib 