### PR TITLE
Include correct `HResult` in `IOException` during preallocation when the disk is full

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Win32.SafeHandles
                     throw new IOException(SR.Format(errorCode == Interop.Errors.ERROR_DISK_FULL
                                                         ? SR.IO_DiskFull_Path_AllocationSize
                                                         : SR.IO_FileTooLarge_Path_AllocationSize,
-                                            fullPath, preallocationSize));
+                                            fullPath, preallocationSize), Win32Marshal.MakeHRFromErrorCode(errorCode));
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -136,6 +136,8 @@ namespace Microsoft.Win32.SafeHandles
                 int errorCode = Marshal.GetLastPInvokeError();
 
                 // Only throw for errors that indicate there is not enough space.
+                // SetFileInformationByHandle fails with ERROR_DISK_FULL in certain cases when the size is disallowed by filesystem,
+                // such as >4GB on FAT32 volume. We cannot distinguish them currently.
                 if (errorCode is Interop.Errors.ERROR_DISK_FULL or
                     Interop.Errors.ERROR_FILE_TOO_LARGE or
                     Interop.Errors.ERROR_INVALID_PARAMETER)
@@ -149,9 +151,6 @@ namespace Microsoft.Win32.SafeHandles
                                                         ? SR.IO_DiskFull_Path_AllocationSize
                                                         : SR.IO_FileTooLarge_Path_AllocationSize,
                                             fullPath, preallocationSize), Win32Marshal.MakeHRFromErrorCode(errorCode));
-
-                    // SetFileInformationByHandle fails with ERROR_DISK_FULL in certain cases where the size is disallowed by filesystem
-                    // such as >4GB on FAT32 volume. We cannot distinguish them currently.
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -149,6 +149,9 @@ namespace Microsoft.Win32.SafeHandles
                                                         ? SR.IO_DiskFull_Path_AllocationSize
                                                         : SR.IO_FileTooLarge_Path_AllocationSize,
                                             fullPath, preallocationSize), Win32Marshal.MakeHRFromErrorCode(errorCode));
+
+                    // SetFileInformationByHandle fails with ERROR_DISK_FULL in certain cases where the size is disallowed by filesystem
+                    // such as >4GB on FAT32 volume. We cannot distinguish them currently.
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -136,8 +136,9 @@ namespace Microsoft.Win32.SafeHandles
                 int errorCode = Marshal.GetLastPInvokeError();
 
                 // Only throw for errors that indicate there is not enough space.
-                if (errorCode == Interop.Errors.ERROR_DISK_FULL ||
-                    errorCode == Interop.Errors.ERROR_FILE_TOO_LARGE)
+                if (errorCode is Interop.Errors.ERROR_DISK_FULL or
+                    Interop.Errors.ERROR_FILE_TOO_LARGE or
+                    Interop.Errors.ERROR_INVALID_PARAMETER)
                 {
                     fileHandle.Dispose();
 

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
@@ -119,6 +119,7 @@ namespace System.IO.Tests
             try
             {
                 using (File.OpenHandle(path, mode: FileMode.Create, access: FileAccess.ReadWrite, preallocationSize: VeryLargeFileSize)) { }
+                Assert.Fail("The test should fail due to failure to preallocate a very large file.");
             }
             catch (IOException ex)
             {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
@@ -98,7 +98,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void PreallocateLargeFileAndFail()
+        public void PreallocationSizeVeryLargeThrowsCorrectHResult()
         {
             const long VeryLargeFileSize = (long)128 * 1024 * 1024 * 1024 * 1024; // 128TB, large but still allowed by NTFS
             const int ERROR_DISK_FULL = unchecked((int)0x80070070);

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
@@ -125,7 +125,7 @@ namespace System.IO.Tests
             try
             {
                 using (File.OpenHandle(path, mode: FileMode.Create, access: FileAccess.ReadWrite, preallocationSize: VeryLargeFileSize)) { }
-                Assert.Fail("The test should fail due to failure to preallocate a very large file.");
+                Assert.Fail("File.OpenHandle should throw due to failure to preallocate a very large file.");
             }
             catch (IOException ex)
             {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/OpenHandle.cs
@@ -100,7 +100,13 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void PreallocationSizeVeryLargeThrowsCorrectHResult()
         {
-            const long VeryLargeFileSize = (long)128 * 1024 * 1024 * 1024 * 1024; // 128TB, large but still allowed by NTFS
+            const long VeryLargeFileSize = (long)128 * 1024 * 1024 * 1024 * 1024; // 128TB
+
+            // The largest file size depends on cluster size.
+            // See https://learn.microsoft.com/en-us/windows-server/storage/file-server/ntfs-overview#support-for-large-volumes
+
+
+            const int ERROR_INVALID_PARAMETER = unchecked((int)0x80070057);
             const int ERROR_DISK_FULL = unchecked((int)0x80070070);
 
             string path = GetTestFilePath();
@@ -123,7 +129,8 @@ namespace System.IO.Tests
             }
             catch (IOException ex)
             {
-                Assert.Equal(ERROR_DISK_FULL, ex.HResult);
+                // Accept both results since we cannot assume the cluster size of testing volume
+                Assert.True(ex.HResult is ERROR_INVALID_PARAMETER or ERROR_DISK_FULL);
             }
         }
     }


### PR DESCRIPTION
Close #100457 