### PR TITLE
Check loaded in dac values to avoid SIGSEGV on null pointers

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -361,9 +361,25 @@ BOOL MethodTable::ValidateWithPossibleAV()
     // for that. We need to do more sanity checking to
     // make sure that our pointer here is in fact a valid object.
     PTR_EEClass pEEClass = this->GetClassWithPossibleAV();
-    return ((pEEClass && (this == pEEClass->GetMethodTableWithPossibleAV())) ||
-        ((HasInstantiation() || IsArray()) &&
-        (pEEClass && (pEEClass->GetMethodTableWithPossibleAV()->GetClassWithPossibleAV() == pEEClass))));
+    if (pEEClass == NULL)
+    {
+        return FALSE;
+    }
+
+    PTR_MethodTable pEEClassFromMethodTable = pEEClass->GetMethodTableWithPossibleAV();
+    if (pEEClassFromMethodTable == NULL)
+    {
+        return FALSE;
+    }
+
+    // non-generic check
+    if (this == pEEClassFromMethodTable)
+    {
+        return TRUE;
+    }
+
+    // generic instantiation check
+    return (HasInstantiation() || IsArray()) && (pEEClassFromMethodTable->GetClassWithPossibleAV() == pEEClass);
 }
 
 

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -162,7 +162,13 @@ BOOL Object::ValidateObjectWithPossibleAV()
     CANNOT_HAVE_CONTRACT;
     SUPPORTS_DAC;
 
-    return GetGCSafeMethodTable()->ValidateWithPossibleAV();
+    PTR_MethodTable table = GetGCSafeMethodTable();
+    if (table == NULL)
+    {
+        return FALSE;
+    }
+
+    return table->ValidateWithPossibleAV();
 }
 
 


### PR DESCRIPTION
Hey, folks!
I've encountered a debugger crash on mac os arm with the attached stack trace. 
Looks like we tried to access some field on a null instance.
I went through the code path and added null checks for objects we marshal from the left side.
My change is similar to https://github.com/dotnet/runtime/pull/104128, but I tried to fix it for the whole ```Object::ValidateObjectWithPossibleAV``` method

```
Code Type: ARM-64 (Native)
OS Version: macOS 14.5 (23F79)

Exception Type: EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x0000000000000028
Exception Codes: 0x0000000000000001, 0x0000000000000028

Termination Reason: Namespace SIGNAL, Code 11 Segmentation fault: 11
Terminating Process: exc handler [90060]

External Modification Warnings: Process used task_for_pid().

Thread 10 Crashed: 
0   libmscordaccore.dylib                   0x121352b9c MethodTable:: ValidateWithPossibleAV() + 20
1   libmscordaccore.dylib                   0x121381574 DacDbiInterfaceImpl:: FastSanityCheckObject(__DPtr<Object>) + 84
2   libmscordaccore.dylib                   0x121381df0 DacDbiInterfaceImpl:: GetBasicObjectInfo(unsigned long long, CorElementType, VMPTR_Base<AppDomain, __VPtr<AppDomain>>, DebuggerIPCE_ObjectData*) + 104
3   libmscordbi.dylib                       0x120f3a020 CordbReferenceValue:: InitRef(MemoryRange) + 476
4   libmscordbi.dylib                       0x120f3a368 CordbReferenceValue::Dereference(ICorDebugValue**) + 368
```