### PR TITLE
Allow AltJit for matched VM to also use otherwise unsupported ISAs

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6042,8 +6042,13 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
     // Note that it might be better to do this immediately when setting the JIT flags in CILJit::compileMethod()
     // (when JitFlags::SetFromFlags() is called), but this is close enough. (To move this logic to
     // CILJit::compileMethod() would require moving the info.compMatchedVM computation there as well.)
+    //
+    // We additionally want to do this for AltJit so that we can validate ISAs that the underlying CPU may
+    // not support directly. Doing this check later, after opts.altJit has been initialized might be better
+    // but it requires moving the whole set of logic down into compCompileHelper after compInitOptions has
+    // run and we're going to end up exiting early if JIT_FLAG_ALT_JIT and opts.altJit don't match anyways
 
-    if (!info.compMatchedVM)
+    if (!info.compMatchedVM || compileFlags->IsSet(JitFlags::JIT_FLAG_ALT_JIT))
     {
         CORINFO_InstructionSetFlags instructionSetFlags;
 


### PR DESCRIPTION
This allows easier local validation of new ISAs including for the platform you're running on. Previously additional hoops had to be jumped through in order to validate codegen for an unsupported ISA on the same platform you're running against.