### PR TITLE
JIT: Update profile data for continuation block of removed call-finally

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -575,6 +575,12 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
         fgPrepareCallFinallyRetForRemoval(leave);
         fgRemoveBlock(leave, /* unreachable */ true);
 
+        // Remove profile weight into the continuation block
+        if (continuation->hasProfileWeight())
+        {
+            continuation->setBBProfileWeight(max(0.0, continuation->bbWeight - leave->bbWeight));
+        }
+
         // (3) Convert the callfinally to a normal jump to the handler
         assert(callFinally->HasInitializedTarget());
         callFinally->SetKind(BBJ_ALWAYS);
@@ -614,6 +620,12 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
                     fgRemoveStmt(block, finallyRet);
                     FlowEdge* const newEdge = fgAddRefPred(continuation, block);
                     block->SetKindAndTargetEdge(BBJ_ALWAYS, newEdge);
+
+                    // Propagate profile weight into the continuation block
+                    if (continuation->hasProfileWeight())
+                    {
+                        continuation->setBBProfileWeight(continuation->bbWeight + block->bbWeight);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #110317. Follow-up to #109792. When removing a call-finally pair associated with an empty try region, decrement any flow from the pair into the continuation block, and add any flow from the now-inlined finally region's exit(s) into the continuation block.