### PR TITLE
[release/9.0-staging] Suppress IL3050 warnings in ILLink tests

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -10,6 +10,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	[Reference ("System.Core.dll")]
 	[ExpectedNoWarnings]
 	[KeptPrivateImplementationDetails ("ThrowSwitchExpressionException")]
+	[KeptAttributeAttribute(typeof(UnconditionalSuppressMessageAttribute))]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	public class ExpressionCallString
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallStringAndLocals.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallStringAndLocals.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -7,6 +8,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[Reference ("System.Core.dll")]
 	[ExpectedNoWarnings]
+	[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	public class ExpressionCallStringAndLocals
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 	[SetupLinkAttributesFile ("AddSuppressionsBeforeAttributeRemoval.xml")]
 
 	[ExpectedNoWarnings]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	public class AddSuppressionsBeforeAttributeRemoval
 	{
 		[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsFeatureSubstitutions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsFeatureSubstitutions.cs
@@ -13,6 +13,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 	[SetupLinkerArgument ("--feature", "Feature", "false")]
 	[ExpectedNoWarnings]
 	[SkipKeptItemsValidation]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	public class DetectRedundantSuppressionsFeatureSubstitutions
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypes.cs
@@ -10,6 +10,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 	[ExpectedNoWarnings]
 	[SkipKeptItemsValidation]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	public class DetectRedundantSuppressionsInMembersAndTypes
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
@@ -23,6 +23,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 	[ExpectedNoWarnings]
 	[SkipKeptItemsValidation]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	class DetectRedundantSuppressionsTrimmedMembersTarget
 	{
 		[ExpectedWarning ("IL2072")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 #endif
 	[SkipKeptItemsValidation]
 	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	public class SuppressWarningsInMembersAndTypesUsingTarget
 	{
 		/// <summary>
@@ -83,6 +84,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 	}
 
 	[ExpectedNoWarnings]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	public class WarningsInMembers
 	{
 		public void Method ()


### PR DESCRIPTION
The ILLink Roslyn analyzer tests have been broken in release/9.0-staging since https://github.com/dotnet/runtime/pull/108482.

This was fixed in main with https://github.com/dotnet/runtime/pull/108757/commits/f94b11251ac64b8f4706c5f9fa9ed113430ca93c, so backporting that fix to .NET 9 (this is a test-only change). https://github.com/dotnet/runtime/pull/108757#issuecomment-2409968867 has context on why this was failing.