### PR TITLE
Fix C++/CLI applications which use __declspec(appdomain)

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -4317,7 +4317,10 @@ void MethodTable::DoFullyLoad(Generics::RecursionGraph * const pVisited,  const 
         ClassLoader::ValidateMethodsWithCovariantReturnTypes(this);
     }
 
-    if ((level == CLASS_LOADED) && CORDisableJITOptimizations(this->GetModule()->GetDebuggerInfoBits()) && !HasInstantiation())
+    if ((level == CLASS_LOADED) && 
+        CORDisableJITOptimizations(this->GetModule()->GetDebuggerInfoBits()) &&
+        !HasInstantiation() &&
+        !GetModule()->GetAssembly()->IsLoading()) // Do not do this during the vtable fixup stage of C++/CLI assembly loading. See https://github.com/dotnet/runtime/issues/110365
     {
         if (g_fEEStarted)
         {

--- a/src/tests/Interop/IJW/IjwNativeCallingManagedDll/IjwNativeCallingManagedDll.cpp
+++ b/src/tests/Interop/IJW/IjwNativeCallingManagedDll/IjwNativeCallingManagedDll.cpp
@@ -17,10 +17,22 @@ extern "C" DLL_EXPORT int __cdecl NativeEntryPoint()
 }
 
 #pragma managed
+
+// Needed to provide a regression case for https://github.com/dotnet/runtime/issues/110365
+[assembly:System::Diagnostics::DebuggableAttribute(true, true)];
+[module:System::Diagnostics::DebuggableAttribute(true, true)];
+
+public value struct ValueToReturnStorage
+{
+    ValueToReturnStorage() : valueToReturn(100) {}
+    int valueToReturn;
+};
+
+// store the value to return in an appdomain local static variable to allow this test to be a regression test for https://github.com/dotnet/runtime/issues/110365
+static __declspec(appdomain) ValueToReturnStorage s_valueToReturnStorage;
+
 public ref class TestClass
 {
-private:
-    static int s_valueToReturn = 100;
 public:
     int ManagedEntryPoint()
     {
@@ -29,12 +41,12 @@ public:
 
     static void ChangeReturnedValue(int i)
     {
-        s_valueToReturn = i;
+        s_valueToReturnStorage.valueToReturn = i;
     }
 
     static int GetReturnValue()
     {
-        return s_valueToReturn;
+        return s_valueToReturnStorage.valueToReturn;
     }
 };
 

--- a/src/tests/Interop/IJW/IjwNativeCallingManagedDll/IjwNativeCallingManagedDll.cpp
+++ b/src/tests/Interop/IJW/IjwNativeCallingManagedDll/IjwNativeCallingManagedDll.cpp
@@ -24,8 +24,8 @@ extern "C" DLL_EXPORT int __cdecl NativeEntryPoint()
 
 public value struct ValueToReturnStorage
 {
-    ValueToReturnStorage() : valueToReturn(100) {}
     int valueToReturn;
+    bool valueSet;
 };
 
 // store the value to return in an appdomain local static variable to allow this test to be a regression test for https://github.com/dotnet/runtime/issues/110365
@@ -42,11 +42,15 @@ public:
     static void ChangeReturnedValue(int i)
     {
         s_valueToReturnStorage.valueToReturn = i;
+        s_valueToReturnStorage.valueSet = true;
     }
 
     static int GetReturnValue()
     {
-        return s_valueToReturnStorage.valueToReturn;
+        if (s_valueToReturnStorage.valueSet)
+            return s_valueToReturnStorage.valueToReturn;
+        else
+            return 100;
     }
 };
 


### PR DESCRIPTION
Do not eagerly allocate static variable space while loading the assembly in use. This avoids possible recursive loading issues found in C++/CLI codebases. Repurpose the NativeCallingManaged test to subsume this particular regression test case.

Fix #110365