### PR TITLE
Install zlib in the IlcFrameworkNative folder instead of alongside the runtime

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -29,7 +29,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
 
     <PropertyGroup>
-      <UseSystemZlib Condition="'$(UseSystemZlib)' == '' and !Exists('$(IlcSdkPath)libz.a')">true</UseSystemZlib>
+      <UseSystemZlib Condition="'$(UseSystemZlib)' == '' and !Exists('$(IlcFrameworkNativePath)libz.a')">true</UseSystemZlib>
       <FullRuntimeName>libRuntime.WorkstationGC</FullRuntimeName>
       <FullRuntimeName Condition="'$(ServerGarbageCollection)' == 'true' or '$(IlcLinkServerGC)' == 'true'">libRuntime.ServerGC</FullRuntimeName>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -166,7 +166,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup>
       <!-- zlib must be added after System.IO.Compression.Native, order matters. -->
-      <NativeLibrary Condition="'$(UseSystemZlib)' != 'true'" Include="$(IlcSdkPath)libz.a" />
+      <NativeLibrary Condition="'$(UseSystemZlib)' != 'true'" Include="$(IlcFrameworkNativePath)libz.a" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(StaticICULinking)' == 'true' and '$(NativeLib)' != 'Static' and '$(InvariantGlobalization)' != 'true'">

--- a/src/mono/browser/runtime/CMakeLists.txt
+++ b/src/mono/browser/runtime/CMakeLists.txt
@@ -29,11 +29,11 @@ target_link_libraries(dotnet.native
     ${MONO_ARTIFACTS_DIR}/libmono-profiler-aot.a
     ${MONO_ARTIFACTS_DIR}/libmono-profiler-browser.a
     ${MONO_ARTIFACTS_DIR}/libmono-profiler-log.a
-    ${MONO_ARTIFACTS_DIR}/libz.a
     ${NATIVE_BIN_DIR}/wasm-bundled-timezones.a
     ${NATIVE_BIN_DIR}/libSystem.Native.a
     ${NATIVE_BIN_DIR}/libSystem.Globalization.Native.a
-    ${NATIVE_BIN_DIR}/libSystem.IO.Compression.Native.a)
+    ${NATIVE_BIN_DIR}/libSystem.IO.Compression.Native.a
+    ${NATIVE_BIN_DIR}/libz.a)
 
 set_target_properties(dotnet.native PROPERTIES
     LINK_DEPENDS "${NATIVE_BIN_DIR}/src/emcc-default.rsp;${NATIVE_BIN_DIR}/src/es6/dotnet.es6.pre.js;${NATIVE_BIN_DIR}/src/es6/dotnet.es6.lib.js;${NATIVE_BIN_DIR}/src/es6/dotnet.es6.extpost.js;"

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -273,7 +273,7 @@ JS_ENGINES = [NODE_JS]
     </PropertyGroup>
 
     <RemoveDir Directories="$(EMSDK_PATH)" />
-    
+
     <ItemGroup>
       <EmsdkFiles   Condition="'%(PackageReference.Identity)' != 'runtime.$(_portableHostOS)-$(BuildArchitecture).Microsoft.NETCore.Runtime.Wasm.Node.Transport' and '%(PackageReference.Identity)' != 'Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Python.win-$(BuildArchitecture)'"
                     Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\**" />
@@ -295,7 +295,7 @@ JS_ENGINES = [NODE_JS]
     <ReadLinesFromFile File="$(EMSDK_PATH)emsdk_env$(ScriptExt)">
       <Output TaskParameter="Lines" PropertyName="_EmsdkEnvFileText" />
     </ReadLinesFromFile>
-    <WriteLinesToFile File="$(EMSDK_PATH)emsdk_env$(ScriptExt)" 
+    <WriteLinesToFile File="$(EMSDK_PATH)emsdk_env$(ScriptExt)"
                       Overwrite="true"
                       Lines="$(_EmsdkPaths);$(_EmsdkEnvFileText)" />
     <WriteLinesToFile File="$(EMSDK_PATH)emscripten/.emscripten"
@@ -313,7 +313,7 @@ JS_ENGINES = [NODE_JS]
 
     <PropertyGroup>
       <ShouldProvisionEmscripten>false</ShouldProvisionEmscripten>
-    </PropertyGroup>    
+    </PropertyGroup>
   </Target>
 
   <!-- Sets up WASI SDK if you don't have the WASI_SDK_PATH env variable set -->
@@ -365,8 +365,8 @@ JS_ENGINES = [NODE_JS]
     See https://github.com/llvm/llvm-project/pull/98373
     See https://github.com/dotnet/runtime/issues/104773
     -->
-    <Exec Command="wasm-opt --version" IgnoreExitCode="true" 
-      IgnoreStandardErrorWarningFormat="true" 
+    <Exec Command="wasm-opt --version" IgnoreExitCode="true"
+      IgnoreStandardErrorWarningFormat="true"
       StandardErrorImportance="low"
       StandardOutputImportance="Low" >
       <Output TaskParameter="ExitCode" PropertyName="_WasmOptExitCode"/>
@@ -1207,9 +1207,6 @@ JS_ENGINES = [NODE_JS]
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="('$(TargetsBrowser)' == 'true'  or '$(TargetsWasi)' == 'true') and '$(BuildMonoAOTCrossCompilerOnly)' != 'true'" Include="$(MonoObjDir)out\lib\libmono-wasm-nosimd.a">
         <Destination>$(RuntimeBinDir)libmono-wasm-nosimd.a</Destination>
-      </_MonoRuntimeArtifacts>
-      <_MonoRuntimeArtifacts Condition="('$(TargetsBrowser)' == 'true'  or '$(TargetsWasi)' == 'true') and '$(BuildMonoAOTCrossCompilerOnly)' != 'true'" Include="$(MonoObjDir)_deps\fetchzlibng-build\libz.a">
-        <Destination>$(RuntimeBinDir)libz.a</Destination>
       </_MonoRuntimeArtifacts>
     </ItemGroup>
 

--- a/src/mono/wasi/runtime/CMakeLists.txt
+++ b/src/mono/wasi/runtime/CMakeLists.txt
@@ -27,11 +27,11 @@ target_link_libraries(dotnet
     ${MONO_ARTIFACTS_DIR}/libmonosgen-2.0.a
     ${MONO_ARTIFACTS_DIR}/libmono-icall-table.a
     ${MONO_ARTIFACTS_DIR}/libmono-wasm-${CONFIGURATION_INTERPSIMDTABLES_LIB}.a
-    ${MONO_ARTIFACTS_DIR}/libz.a
     ${NATIVE_BIN_DIR}/wasm-bundled-timezones.a
     ${NATIVE_BIN_DIR}/libSystem.Native.a
     ${NATIVE_BIN_DIR}/libSystem.Globalization.Native.a
     ${NATIVE_BIN_DIR}/libSystem.IO.Compression.Native.a
+    ${NATIVE_BIN_DIR}/libz.a
 )
 
 set_target_properties(dotnet PROPERTIES

--- a/src/native/external/zlib-ng.cmake
+++ b/src/native/external/zlib-ng.cmake
@@ -1,4 +1,4 @@
- # IMPORTANT: do not use add_compile_options(), add_definitions() or similar functions here since it will leak to the including projects 
+ # IMPORTANT: do not use add_compile_options(), add_definitions() or similar functions here since it will leak to the including projects
 
 include(FetchContent)
 
@@ -16,9 +16,15 @@ set(WITH_RVV OFF)
 # We don't support ARMv6 and the check works incorrectly when compiling for ARMv7 w/ Thumb instruction set
 set(WITH_ARMV6 OFF)
 
-# 'aligned_alloc' is not available in browser/wasi, yet it is set by zlib-ng/CMakeLists.txt.
 if (CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
+  # 'aligned_alloc' is not available in browser/wasi, yet it is set by zlib-ng/CMakeLists.txt.
   set(HAVE_ALIGNED_ALLOC FALSE CACHE BOOL "have aligned_alloc" FORCE)
+
+  # zlib-ng uses atomics, so we need to enable threads when requested for browser/wasi, otherwise the wasm target won't have thread support.
+  if (CMAKE_USE_PTHREADS)
+      add_compile_options(-pthread)
+      add_linker_flag(-pthread)
+  endif()
 endif()
 
 set(BUILD_SHARED_LIBS OFF) # Shared libraries aren't supported in wasm

--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -91,6 +91,8 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
     endif()
 
     set_target_properties(System.IO.Compression.Native-Static PROPERTIES OUTPUT_NAME System.IO.Compression.Native CLEAN_DIRECT_OUTPUT 1)
+
+    install (TARGETS zlib DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
 else ()
     if (GEN_SHARED_LIB)
         include (GenerateExportHeader)
@@ -163,12 +165,11 @@ else ()
     if(STATIC_LIBS_ONLY)
         install_static_library(System.IO.Compression.Native.Aot aotsdk nativeaot)
         install_static_library(System.IO.Compression.Native.Aot.GuardCF aotsdk nativeaot)
+        if (NOT CLR_CMAKE_USE_SYSTEM_ZLIB)
+            install_static_library(zlib aotsdk nativeaot)
+        endif()
     endif()
 
 endif ()
-
-if((NOT CLR_CMAKE_USE_SYSTEM_ZLIB) AND STATIC_LIBS_ONLY)
-    install_static_library(zlib aotsdk nativeaot)
-endif()
 
 install (TARGETS System.IO.Compression.Native-Static DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)

--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -92,7 +92,9 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
 
     set_target_properties(System.IO.Compression.Native-Static PROPERTIES OUTPUT_NAME System.IO.Compression.Native CLEAN_DIRECT_OUTPUT 1)
 
-    install (TARGETS zlib DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
+    if (NOT CLR_CMAKE_USE_SYSTEM_ZLIB)
+        install (TARGETS zlib DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
+    endif()
 else ()
     if (GEN_SHARED_LIB)
         include (GenerateExportHeader)


### PR DESCRIPTION
As the NativeAOT runtime doesn't use zlib, it makes more sense for NativeAOT for zlib to be shipped alongside the Compression.Native library. We don't have any shipping scenarios with Mono where we use the non-system zlib outside of wasm (which seems to be working well), so we should be able to figure something out for dev-innerloop-only scenarios if needed.