### PR TITLE
[RISC-V] JIT: Fix emitInsMayWriteToGCReg

### DIFF
--- a/src/coreclr/jit/instrsriscv64.h
+++ b/src/coreclr/jit/instrsriscv64.h
@@ -80,11 +80,6 @@ INST(csrrci,        "csrrci",         0,    0x00007073)
 
 INST(ecall,         "ecall",          0,    0x00000073)
 INST(ebreak,        "ebreak",         0,    0x00100073)
-INST(uret,          "uret",           0,    0x00200073)
-INST(sret,          "sret",           0,    0x10200073)
-INST(mret,          "mret",           0,    0x30200073)
-INST(wfi,           "wfi",            0,    0x10500073)
-INST(sfence_vma,    "sfence.vma",     0,    0x12000073)
 
 //// R_R_I
 INST(lb,            "lb",             LD,   0x00000003)


### PR DESCRIPTION
emitter::emitInsMayWriteToGCReg didn't account for some instructions which broke GC info.

This fixes an intermittent segfault (~3 fails out of 6400 runs) with GCStress=0x3 in Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case7. The direct cause was the GC ref register loaded in Interlocked.Exchange being reported too late, e.g. here:
https://github.com/dotnet/runtime/blob/949c3ec60bc6914aa2763c24deb7adad9d90841c/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs#L51
with Dispose() inlined from here:
https://github.com/dotnet/runtime/blob/949c3ec60bc6914aa2763c24deb7adad9d90841c/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryAccessor.cs#L103-L104
The asm diff with GC info:
```diff
@@ -300,30 +300,31 @@ G_M43658_IG03:        ; bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref
                              ; byrRegs +[a1]
 00007C      mv             a2, zero
 000080      amoswap.d.aqrl s1, a2, (a1)
+                             ; gcrRegs +[s1]
 000084      beqz           s1, G_M43658_IG04
 000088      ld             a1, 0(s1)
                              ; byrRegs -[a1]
 00008C      lui            ra, 520356
 000090      addiw          ra, ra, -1628
 000094      slli           ra, ra, 7
 000098      addi           ra, ra, 40
 00009C      bne            a1, ra, G_M43658_IG07
 0000A0      mv             a0, s1
 0000A4      addi           a1, zero, 1
 0000A8      lui            a2, 520356
 0000AC      addiw          a2, a2, -1627
 0000B0      slli           a2, a2, 7
 0000B4      addi           a2, a2, 72
 0000B8      ld             a2, 0(a2)
 0000BC      jalr           ra, 0(a2)           // System.IO.MemoryMappedFiles.MemoryMappedViewAccessor:Dispose(ubyte):this
-                             ; gcrRegs -[a0] +[s1]
+                             ; gcrRegs -[a0]
                              ; gcr arg pop 0
 0000C0      mv             a0, s1
                              ; gcrRegs +[a0]
 0000C4      lui            a1, 262177
 0000C8      addiw          a1, a1, -346
 0000CC      slli           a1, a1, 8
 0000D0      addi           a1, a1, 116
 0000D4      jalr           ra, 0(a1)           // System.GC:_SuppressFinalize(System.Object)
                              ; gcrRegs -[s1-a0]
                              ; gcr arg pop 0
```

Part of #84834, cc @dotnet/samsung