### PR TITLE
Change assembler to clang in android MonoAOT

### DIFF
--- a/src/mono/msbuild/android/build/AndroidBuild.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.targets
@@ -149,13 +149,6 @@
       <AndroidLibraryMinApiLevel Condition="'$(AndroidLibraryMinApiLevel)' == ''">21</AndroidLibraryMinApiLevel>
     </PropertyGroup>
 
-    <NdkToolFinderTask
-      Condition="'$(AOTWithLibraryFiles)' == 'true' or '$(_IsLibraryMode)' == 'true'"
-      Architecture="$(TargetArchitecture)"
-      HostOS="$(_HostOS)"
-      MinApiLevel="$(AndroidLibraryMinApiLevel)">
-    </NdkToolFinderTask>
-
     <PropertyGroup Condition="'$(AOTWithLibraryFiles)' == 'true' or '$(_IsLibraryMode)' == 'true'">
       <_AsPrefixPath>$([MSBuild]::EnsureTrailingSlash('$(_AsPrefixPath)'))</_AsPrefixPath>
       <_ToolPrefixPath>$([MSBuild]::EnsureTrailingSlash('$(_ToolPrefixPath)'))</_ToolPrefixPath>

--- a/src/mono/msbuild/android/build/AndroidBuild.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.targets
@@ -112,12 +112,20 @@
       <_AotOutputType>ObjectFile</_AotOutputType>
     </PropertyGroup>
 
-    <ItemGroup>
-      <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm'" Include="mtriple=armv7-linux-gnueabi" />
-      <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64'" Include="mtriple=aarch64-linux-android" />
-      <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x86'" Include="mtriple=i686-linux-android" />
-      <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x64'" Include="mtriple=x86_64-linux-android" />
+    <PropertyGroup>
+      <_Triple Condition="'$(TargetArchitecture)' == 'arm'">armv7-linux-gnueabi</_Triple>
+      <_Triple Condition="'$(TargetArchitecture)' == 'arm64'">aarch64-linux-android</_Triple>
+      <_Triple Condition="'$(TargetArchitecture)' == 'x86'">i686-linux-android</_Triple>
+      <_Triple Condition="'$(TargetArchitecture)' == 'x64'">x86_64-linux-android</_Triple>
+    </PropertyGroup>
 
+    <PropertyGroup>
+      <_LdName>clang</_LdName>
+      <_LdOptions>-fuse-ld=lld</_LdOptions>
+      <_AsName>clang</_AsName>
+    </PropertyGroup>
+
+    <ItemGroup>
       <MonoAOTCompilerDefaultAotArguments Include="static" />
       <MonoAOTCompilerDefaultAotArguments Include="dwarfdebug" />
       <MonoAOTCompilerDefaultAotArguments Condition="'$(_IsLibraryMode)' == 'true'" Include="direct-icalls" />
@@ -146,12 +154,6 @@
       Architecture="$(TargetArchitecture)"
       HostOS="$(_HostOS)"
       MinApiLevel="$(AndroidLibraryMinApiLevel)">
-      <Output TaskParameter="AsPrefixPath" PropertyName="_AsPrefixPath" />
-      <Output TaskParameter="ToolPrefixPath" PropertyName="_ToolPrefixPath" />
-      <Output TaskParameter="Triple" PropertyName="_Triple" />
-      <Output TaskParameter="LdName" PropertyName="_LdName" />
-      <Output TaskParameter="LdPath" PropertyName="_LdPath" />
-      <Output TaskParameter="ClangPath" PropertyName="_ClangPath" />
     </NdkToolFinderTask>
 
     <PropertyGroup Condition="'$(AOTWithLibraryFiles)' == 'true' or '$(_IsLibraryMode)' == 'true'">
@@ -221,20 +223,23 @@
 
     <MonoAOTCompiler
         AotModulesTablePath="$(_AotModuleTablePath)"
-        AsPrefix="$(_AsPrefixPath)"
+        AsName="$(_AsName)"
+        AsOptions="-target $(_Triple) -c -x assembler"
         Assemblies="@(_AotInputAssemblies)"
         CompilerBinaryPath="$(_CompilerBinaryPath)"
         DirectPInvokes="@(DirectPInvokes)"
         DirectPInvokeLists="@(DirectPInvokeLists)"
         EnableUnmanagedCallersOnlyMethodsExport="$(_EnableUnmanagedCallersOnlyMethodsExport)"
         IntermediateOutputPath="$(_MobileIntermediateOutputPath)"
+        LdName="$(_LdName)"
+        LdOptions="$(_LdOptions)"
         LibraryFormat="$(_AotLibraryFormat)"
         LLVMPath="$(_MonoLLVMPath)"
         MibcProfilePath="@(ProfiledAOTProfilePaths)"
         Mode="$(_AOTMode)"
         OutputDir="$(_MobileIntermediateOutputPath)"
         OutputType="$(_AotOutputType)"
-        ToolPrefix="$(_ToolPrefixPath)"
+        Triple="$(_Triple)"
         UseAotDataFile="$(_UseAotDataFile)"
         UseLLVM="$(MonoEnableLLVM)">
         <Output TaskParameter="CompiledAssemblies" ItemName="_AssembliesToBundleInternal" />

--- a/src/mono/msbuild/android/build/AndroidBuild.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.targets
@@ -120,6 +120,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
+      <_AsOptions>-target $(_Triple) -c -x assembler</_AsOptions>
       <_LdName>clang</_LdName>
       <_LdOptions>-fuse-ld=lld</_LdOptions>
       <_AsName>clang</_AsName>
@@ -217,7 +218,7 @@
     <MonoAOTCompiler
         AotModulesTablePath="$(_AotModuleTablePath)"
         AsName="$(_AsName)"
-        AsOptions="-target $(_Triple) -c -x assembler"
+        AsOptions="$(_AsOptions)"
         Assemblies="@(_AotInputAssemblies)"
         CompilerBinaryPath="$(_CompilerBinaryPath)"
         DirectPInvokes="@(DirectPInvokes)"

--- a/src/mono/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/sample/Android/AndroidSampleApp.csproj
@@ -82,6 +82,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
+      <_AsOptions>-target $(_Triple) -c -x assembler</_AsOptions>
       <_LdName>clang</_LdName>
       <_LdOptions>-fuse-ld=lld</_LdOptions>
       <_AsName>clang</_AsName>
@@ -90,7 +91,7 @@
     <MonoAOTCompiler Condition="'$(ForceAOT)' == 'true'"
         AotModulesTablePath="$(_AotModulesTablePath)"
         AsName="$(_AsName)"
-        AsOptions="-target $(_Triple) -c -x assembler"
+        AsOptions="$(_AsOptions)"
         Assemblies="@(AotInputAssemblies)"
         CompilerBinaryPath="@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','$(TargetOS)-$(TargetArchitecture.ToLowerInvariant())'))"
         IntermediateOutputPath="$(IntermediateOutputPath)"

--- a/src/mono/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/sample/Android/AndroidSampleApp.csproj
@@ -69,36 +69,39 @@
       <AndroidLibraryMinApiLevel Condition="'$(AndroidLibraryMinApiLevel)' == ''">21</AndroidLibraryMinApiLevel>
     </PropertyGroup>
 
-    <NdkToolFinderTask
-      Condition="'$(AOTWithLibraryFiles)' == 'true'"
-      Architecture="$(TargetArchitecture)"
-      HostOS="$(_HostOS)"
-      MinApiLevel="$(AndroidLibraryMinApiLevel)">
-      <Output TaskParameter="AsPrefixPath" PropertyName="_AsPrefixPath" />
-      <Output TaskParameter="ToolPrefixPath" PropertyName="_ToolPrefixPath" />
-      <Output TaskParameter="Triple" PropertyName="_Triple" />
-      <Output TaskParameter="LdName" PropertyName="_LdName" />
-      <Output TaskParameter="LdPath" PropertyName="_LdPath" />
-      <Output TaskParameter="ClangPath" PropertyName="_ClangPath" />
-    </NdkToolFinderTask>
-
     <PropertyGroup Condition="'$(AOTWithLibraryFiles)' == 'true'">
       <_AsPrefixPath>$([MSBuild]::EnsureTrailingSlash('$(_AsPrefixPath)'))</_AsPrefixPath>
       <_ToolPrefixPath>$([MSBuild]::EnsureTrailingSlash('$(_ToolPrefixPath)'))</_ToolPrefixPath>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <_Triple Condition="'$(TargetArchitecture)' == 'arm'">armv7-linux-gnueabi</_Triple>
+      <_Triple Condition="'$(TargetArchitecture)' == 'arm64'">aarch64-linux-android</_Triple>
+      <_Triple Condition="'$(TargetArchitecture)' == 'x86'">i686-linux-android</_Triple>
+      <_Triple Condition="'$(TargetArchitecture)' == 'x64'">x86_64-linux-android</_Triple>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_LdName>clang</_LdName>
+      <_LdOptions>-fuse-ld=lld</_LdOptions>
+      <_AsName>clang</_AsName>
+    </PropertyGroup>
+
     <MonoAOTCompiler Condition="'$(ForceAOT)' == 'true'"
         AotModulesTablePath="$(_AotModulesTablePath)"
-        AsPrefix="$(_AsPrefixPath)"
+        AsName="$(_AsName)"
+        AsOptions="-target $(_Triple) -c -x assembler"
         Assemblies="@(AotInputAssemblies)"
         CompilerBinaryPath="@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','$(TargetOS)-$(TargetArchitecture.ToLowerInvariant())'))"
         IntermediateOutputPath="$(IntermediateOutputPath)"
+        LdName="$(_LdName)"
+        LdOptions="$(_LdOptions)"
         LibraryFormat="$(_AotLibraryFormat)"
         LLVMPath="$(MonoAotCrossDir)"
         Mode="$(_AotMode)"
         OutputDir="$(_MobileIntermediateOutputPath)"
         OutputType="$(_AotOutputType)"
-        ToolPrefix="$(_ToolPrefixPath)"
+        Triple="$(_Triple)"
         UseAotDataFile="false"
         UseLLVM="$(UseLLVM)">
         <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -233,6 +233,16 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public string? ToolPrefix { get; set; }
 
     /// <summary>
+    /// Name of the assembler tool ran by the AOT compiler.
+    /// </summary>
+    public string? AsName { get; set; }
+
+    /// <summary>
+    /// Passes as-options to the AOT compiler
+    /// </summary>
+    public string? AsOptions { get; set; }
+
+    /// <summary>
     /// Prepends a prefix to the name of the assembler (as) tool ran by the AOT compiler.
     /// </summary>
     public string? AsPrefix { get; set; }
@@ -278,6 +288,11 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     /// Passes ld-flags to the AOT compiler, for use with UseLLVM=true
     /// </summary>
     public string? LdFlags { get; set; }
+
+    /// <summary>
+    /// Passes ld-options to the AOT compiler
+    /// </summary>
+    public string? LdOptions { get; set; }
 
     /// <summary>
     /// Specify WorkingDirectory for the AOT compiler
@@ -739,6 +754,16 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             aotArgs.Add($"tool-prefix={ToolPrefix}");
         }
 
+        if (!string.IsNullOrEmpty(AsName))
+        {
+            aotArgs.Add($"as-name={AsName}");
+        }
+
+        if (!string.IsNullOrEmpty(AsOptions))
+        {
+            aotArgs.Add($"as-options={AsOptions}");
+        }
+
         if (!string.IsNullOrEmpty(AsPrefix))
         {
             aotArgs.Add($"as-prefix={AsPrefix}");
@@ -952,6 +977,11 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         if (!string.IsNullOrEmpty(LdFlags))
         {
             aotArgs.Add($"ld-flags={LdFlags}");
+        }
+
+        if (!string.IsNullOrEmpty(LdOptions))
+        {
+            aotArgs.Add($"ld-options={LdOptions}");
         }
 
         // we need to quote the entire --aot arguments here to make sure it is parsed

--- a/src/tasks/MobileBuildTasks/Android/Ndk/NdkTools.cs
+++ b/src/tasks/MobileBuildTasks/Android/Ndk/NdkTools.cs
@@ -101,9 +101,9 @@ namespace Microsoft.Android.Build.Ndk
 
         private void ValidateRequiredProps(string hostOS)
         {
-            if (Ndk.NdkVersion.Main.Major != 23)
+            if (Ndk.NdkVersion.Main.Major != 27)
             {
-                throw new Exception($"NDK 23 is required. An unsupported NDK version was found ({Ndk.NdkVersion.Main.Major}).");
+                throw new Exception($"NDK 27 is required. An unsupported NDK version was found ({Ndk.NdkVersion.Main.Major}).");
             }
 
             try


### PR DESCRIPTION
Android NDK 27 does not ship with an assembler. The recommendation is to use clang. This PR makes MonoAOT compiler use clang assembler when building android. 

Related PR bumping version of NDK to 27: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1278

Changes were verified here: https://github.com/dotnet/runtime/pull/110196