### PR TITLE
[testing] Lower default r2r NativeHashtable fill factor to improve runtime lookup performance

### DIFF
--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
@@ -1996,7 +1996,7 @@ namespace Internal.NativeFormat
         // Current size of index entry
         private int _entryIndexSize; // 0 - uint8, 1 - uint16, 2 - uint32
 
-        public const int DefaultFillFactor = 13;
+        public const int DefaultFillFactor = 5;
 
         public VertexHashtable(int fillFactor = DefaultFillFactor)
         {


### PR DESCRIPTION
In some startup measurements we spend a lot of time looking up r2r entry points. One potential remedy for this is to lower the fill factor for the hashtable used to perform these lookups, so that each bucket contains fewer methods and we have fewer methods to check as a result. This will raise the size of r2r images by Some Amount, and it's possible that changing it could break something, so I'm opening this draft PR to do an outerloop run and see if anything falls over.