### PR TITLE
Specify a security descriptor when using global Mutex

### DIFF
--- a/src/libraries/Common/src/System/Diagnostics/NetFrameworkUtils.cs
+++ b/src/libraries/Common/src/System/Diagnostics/NetFrameworkUtils.cs
@@ -4,6 +4,8 @@
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using Microsoft.Win32;
@@ -21,6 +23,13 @@ namespace System.Diagnostics
         internal static void EnterMutexWithoutGlobal(string mutexName, ref Mutex mutex)
         {
             Mutex tmpMutex = new Mutex(false, mutexName, out _);
+
+            // Specify a SID in case the mutex has not yet been created; this prevents it from using the SID from the current thread.
+            // This SID (AuthenticatedUserSid) is the same one used by .NET Framework.
+            MutexSecurity sec = new MutexSecurity();
+            SecurityIdentifier everyoneSid = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
+            sec.AddAccessRule(new MutexAccessRule(everyoneSid, MutexRights.Synchronize | MutexRights.Modify, AccessControlType.Allow));
+            tmpMutex.SetAccessControl(sec);
 
             SafeWaitForMutex(tmpMutex, ref mutex);
         }

--- a/src/libraries/Common/src/System/Diagnostics/NetFrameworkUtils.cs
+++ b/src/libraries/Common/src/System/Diagnostics/NetFrameworkUtils.cs
@@ -27,8 +27,8 @@ namespace System.Diagnostics
             // Specify a SID in case the mutex has not yet been created; this prevents it from using the SID from the current thread.
             // This SID (AuthenticatedUserSid) is the same one used by .NET Framework.
             MutexSecurity sec = new MutexSecurity();
-            SecurityIdentifier everyoneSid = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
-            sec.AddAccessRule(new MutexAccessRule(everyoneSid, MutexRights.Synchronize | MutexRights.Modify, AccessControlType.Allow));
+            SecurityIdentifier authenticatedUserSid = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
+            sec.AddAccessRule(new MutexAccessRule(authenticatedUserSid, MutexRights.Synchronize | MutexRights.Modify, AccessControlType.Allow));
             tmpMutex.SetAccessControl(sec);
 
             SafeWaitForMutex(tmpMutex, ref mutex);

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -222,6 +222,7 @@
       Microsoft.Extensions.Primitives;
       System.Diagnostics.EventLog;
       System.Security.Cryptography.Xml;
+      System.Threading.AccessControl;
       System.Threading.RateLimiting;
     </AspNetCoreAppLibrary>
     <WindowsDesktopCoreAppLibrary>

--- a/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
@@ -137,6 +137,7 @@ System.Diagnostics.EventLog</PackageDescription>
                       ReferenceOutputAssembly="false"
                       OutputItemType="TfmRuntimeSpecificPackageFile"
                       PrivateAssets="true" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Threading.AccessControl\src\System.Threading.AccessControl.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
@@ -139,6 +139,7 @@ System.Diagnostics.PerformanceCounter</PackageDescription>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Configuration.ConfigurationManager\src\System.Configuration.ConfigurationManager.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Threading.AccessControl\src\System.Threading.AccessControl.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/MutexTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/MutexTests.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Threading;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public static class MutextTests
+    {
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't create global objects in appcontainer
+        public static void VerifySecurityIdentifier()
+        {
+            string mutexName = $"{Guid.NewGuid():N}";
+
+            Mutex mutex = null;
+
+            // We can't test with the same global mutex used by performance counters, since the mutex was likely already
+            // initialized elsewhere and perhaps with with different ACLs, so we use a Guid to create a new mutex and
+            // then simulate the behavior by calling into EnterMutex() like the performance monitor code does.
+#pragma warning disable CS0436 // Type conflicts with imported type
+            NetFrameworkUtils.EnterMutex(mutexName, ref mutex);
+#pragma warning restore CS0436
+
+            try
+            {
+                // This is the SID that is added by EnterMutex().
+                SecurityIdentifier allUsersSid = new(WellKnownSidType.AuthenticatedUserSid, null);
+
+                MutexSecurity security = mutex.GetAccessControl();
+                AuthorizationRuleCollection rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
+                Assert.Equal(1, rules.Count);
+                MutexAccessRule accessRule = (MutexAccessRule)rules[0];
+                SecurityIdentifier sid = (SecurityIdentifier)accessRule.IdentityReference;
+                Assert.Equal(allUsersSid, sid);
+            }
+            finally
+            {
+                if (mutex != null)
+                {
+                    mutex.ReleaseMutex();
+                    mutex.Close();
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/MutexTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/MutexTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
-    public static class MutextTests
+    public static class MutexTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't create global objects in appcontainer
         public static void VerifySecurityIdentifier()
@@ -27,14 +27,14 @@ namespace System.Diagnostics.Tests
             try
             {
                 // This is the SID that is added by EnterMutex().
-                SecurityIdentifier allUsersSid = new(WellKnownSidType.AuthenticatedUserSid, null);
+                SecurityIdentifier authenticatedUserSid = new(WellKnownSidType.AuthenticatedUserSid, null);
 
                 MutexSecurity security = mutex.GetAccessControl();
                 AuthorizationRuleCollection rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
                 Assert.Equal(1, rules.Count);
                 MutexAccessRule accessRule = (MutexAccessRule)rules[0];
                 SecurityIdentifier sid = (SecurityIdentifier)accessRule.IdentityReference;
-                Assert.Equal(allUsersSid, sid);
+                Assert.Equal(authenticatedUserSid, sid);
             }
             finally
             {

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/System.Diagnostics.PerformanceCounter.Tests.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/System.Diagnostics.PerformanceCounter.Tests.csproj
@@ -1,20 +1,22 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="PerformanceCounterTests.cs" />
-    <Compile Include="PerformanceCounterCategoryTests.cs" />
-    <Compile Include="ValidationTests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
-    <Compile Include="CounterSampleTests.cs" />
-    <Compile Include="CounterSampleCalculatorTests.cs" />
-    <Compile Include="CounterCreationDataTests.cs" />
     <Compile Include="CounterCreationDataCollectionTests.cs" />
-    <Compile Include="InstanceDataTests.cs" />
-    <Compile Include="Helpers.cs" />
-    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs" Link="Common\System\ShouldNotBeInvokedException.cs" />
+    <Compile Include="CounterCreationDataTests.cs" />
+    <Compile Include="CounterSampleCalculatorTests.cs" />
+    <Compile Include="CounterSampleTests.cs" />
+    <Compile Include="PerformanceCounterCategoryTests.cs" />
+    <Compile Include="PerformanceCounterTests.cs" />
     <Compile Include="PerformanceDataTests.cs" />
+    <Compile Include="Helpers.cs" />
+    <Compile Include="InstanceDataTests.cs" />
+    <Compile Include="MutexTests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Compile Include="ValidationTests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Compile Include="$(CommonPath)System\Diagnostics\NetFrameworkUtils.cs" Link="Common\System\Diagnostics\NetFrameworkUtils.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs" Link="Common\System\ShouldNotBeInvokedException.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="provider.man" CopyToOutputDirectory="Always" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/110399

Adds the same security descriptor [as .NET Framework](https://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/SharedUtils.cs,119).

This also affects EventLog; the test added here was only added to PerformanceCounter since EventLog shares the same code.

Note the S.D.PerformanceCounter and S.D.EventLog packages get a new package dependency to `System.Security.AccessControl` since that is where the extension methods are defined that are used to set the security descriptor.