### PR TITLE
Remove 4244 suppression around conversions

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,7 +20,6 @@ endif()
 if (CLR_CMAKE_HOST_WIN32)
     # 4100 - unreferenced formal parameter
     # 4242 - conversion from 'type1' to 'type2', possible loss of data
-    # 4244 - conversion from 'type1' to 'type2', possible loss of data
     # 4514 - unreferenced inline function has been removed
     # 4625 - copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
     # 4626 - assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
@@ -33,7 +32,7 @@ if (CLR_CMAKE_HOST_WIN32)
     # 5026 - move constructor was implicitly defined as deleted
     # 5027 - move assignment operator was implicitly defined as deleted
     # 5039 - pointer or reference to potentially throwing function passed to extern C function under -EHc. Undefined behavior may occur if this function throws an exception.
-    add_compile_options(-wd4100 -wd4242 -wd4244 -wd4514 -wd4625 -wd4626 -wd4668 -wd4710 -wd4711 -wd4774 -wd4820 -wd5025 -wd5026 -wd5027 -wd5039)
+    add_compile_options(-wd4100 -wd4242 -wd4514 -wd4625 -wd4626 -wd4668 -wd4710 -wd4711 -wd4774 -wd4820 -wd5025 -wd5026 -wd5027 -wd5039)
 
     set_property(DIRECTORY PROPERTY CLR_EH_OPTION /EHa) # enable C++ EH (w/ SEH exceptions)
 endif()


### PR DESCRIPTION
This conversion can be suspicious and therefore this warning is important. Found with binskim.