### PR TITLE
Handle not truncating root folder in `CorUnix::InternalCanonicalizeRealPath` for all architectures instead of only amd64

### DIFF
--- a/src/coreclr/pal/src/file/file.cpp
+++ b/src/coreclr/pal/src/file/file.cpp
@@ -334,7 +334,6 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, PathCharString& lpBuffe
     }
     else
     {
-#if defined(HOST_AMD64)
         bool fSetFilename = true;
         // Since realpath implementation cannot handle inexistent filenames,
         // check if we are going to truncate the "/" corresponding to the
@@ -358,8 +357,9 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, PathCharString& lpBuffe
             fSetFilename = false;
         }
         else
-#endif // defined(HOST_AMD64)
+        {
             *pchSeparator = '\0';
+        }
 
         if (!RealPathHelper(lpExistingPath, lpBuffer))
         {
@@ -368,16 +368,12 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, PathCharString& lpBuffe
             goto LExit;
         }
 
-#if defined(HOST_AMD64)
         if (fSetFilename == true)
-#endif // defined(HOST_AMD64)
             lpFilename = pchSeparator + 1;
     }
 
-#if defined(HOST_AMD64)
     if (lpFilename == NULL)
         goto LExit;
-#endif // HOST_AMD64
 
     if (!lpBuffer.Append("/",1) || !lpBuffer.Append(lpFilename, strlen(lpFilename)))
     {


### PR DESCRIPTION
We had this handling (of not truncating if the path is right in the root folder `/`) ifdef-ed under `HOST_AMD64` for some reason. As a result, on other architectures we determine that the path doesn't exist and fail to load any assemblies from the root. This change simply removes the ifdef such that we have this handling on all architectures.

Fixes https://github.com/dotnet/runtime/issues/109593. Manually validated in a linux arm64 container.