### PR TITLE
Fix conversion of `void*` to `OBJECTREF`

### DIFF
--- a/src/coreclr/vm/invokeutil.cpp
+++ b/src/coreclr/vm/invokeutil.cpp
@@ -554,7 +554,7 @@ OBJECTREF InvokeUtil::CreateObjectAfterInvoke(TypeHandle th, void * pValue) {
 
     case ELEMENT_TYPE_PTR:
     {
-        obj = CreatePointer(th, *(void **)pValue);
+        obj = CreatePointer(th, *(LPVOID*)pValue);
         break;
     }
 
@@ -564,7 +564,7 @@ OBJECTREF InvokeUtil::CreateObjectAfterInvoke(TypeHandle th, void * pValue) {
     case ELEMENT_TYPE_STRING:
     case ELEMENT_TYPE_OBJECT:
     case ELEMENT_TYPE_VAR:
-        obj = *(OBJECTREF *)pValue;
+        obj = ObjectToOBJECTREF(*(Object**)pValue);
         break;
 
     case ELEMENT_TYPE_FNPTR:


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/110394

The blind cast from a `void*` to an `OBJECTREF` can create "invalid" object refs. This is a limitation of the `OBJECTREF` validation system. In this case, using the proper helper function fixes the problem.