### PR TITLE
JIT: Don't run `fgComputeBlockWeights` in MinOpts

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4769,12 +4769,12 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_GS_COOKIE, &Compiler::gsPhase);
 
-    // Compute the block weights
-    //
-    DoPhase(this, PHASE_COMPUTE_BLOCK_WEIGHTS, &Compiler::fgComputeBlockWeights);
-
     if (opts.OptimizationEnabled())
     {
+        // Compute the block weights
+        //
+        DoPhase(this, PHASE_COMPUTE_BLOCK_WEIGHTS, &Compiler::fgComputeBlockWeights);
+
         // Invert loops
         //
         DoPhase(this, PHASE_INVERT_LOOPS, &Compiler::optInvertLoops);


### PR DESCRIPTION
Block weights don't seem particularly useful in MinOpts. Skipping `fgComputeBlockWeights` when we aren't optimizing had few diffs locally, so this looks like an opportunity to save some TP.

(As an aside, I suspect we can soon replace `fgComputeBlockWeights` and `optSetBlockWeights` with profile synthesis. After the existing flow opt and unreachable block removal passes, I think we ought to compute the loop data structures, run profile synthesis, and then run loop opts. Since earlier phases don't seem too dependent on profile fidelity, but loop inversion/cloning/etc. stand to benefit from it, this is a natural checkpoint for running synthesis.)