### PR TITLE
JIT: Remove `fgFirstColdBlock` checks in frontend phases

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -424,7 +424,7 @@ bool BasicBlock::IsFirstColdBlock(Compiler* compiler) const
 bool BasicBlock::CanRemoveJumpToNext(Compiler* compiler) const
 {
     assert(KindIs(BBJ_ALWAYS));
-    return JumpsToNext() && (bbNext != compiler->fgFirstColdBlock);
+    return JumpsToNext() && !IsLastHotBlock(compiler);
 }
 
 //------------------------------------------------------------------------
@@ -441,7 +441,7 @@ bool BasicBlock::CanRemoveJumpToTarget(BasicBlock* target, Compiler* compiler) c
 {
     assert(KindIs(BBJ_COND));
     assert(TrueTargetIs(target) || FalseTargetIs(target));
-    return NextIs(target) && !compiler->fgInDifferentRegions(this, target);
+    return NextIs(target) && !IsLastHotBlock(compiler);
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
Part of #107749. Now that hot/cold splitting runs after layout in the backend, where the flowgraph is expected to never change, we shouldn't need to check for the presence of a cold code section in the frontend.