### PR TITLE
[cdac] Fix calculation of `MethodDesc` optional slot addresses

### DIFF
--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -342,6 +342,10 @@ CDAC_TYPE_FIELD(MethodDescChunk, /*uint8*/, Count, cdac_data<MethodDescChunk>::C
 CDAC_TYPE_FIELD(MethodDescChunk, /*uint16*/, FlagsAndTokenRange, cdac_data<MethodDescChunk>::FlagsAndTokenRange)
 CDAC_TYPE_END(MethodDescChunk)
 
+CDAC_TYPE_BEGIN(MethodImpl)
+CDAC_TYPE_SIZE(sizeof(MethodImpl))
+CDAC_TYPE_END(MethodImpl)
+
 CDAC_TYPE_BEGIN(InstantiatedMethodDesc)
 CDAC_TYPE_SIZE(sizeof(InstantiatedMethodDesc))
 CDAC_TYPE_FIELD(InstantiatedMethodDesc, /*pointer*/, PerInstInfo, cdac_data<InstantiatedMethodDesc>::PerInstInfo)

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -342,9 +342,17 @@ CDAC_TYPE_FIELD(MethodDescChunk, /*uint8*/, Count, cdac_data<MethodDescChunk>::C
 CDAC_TYPE_FIELD(MethodDescChunk, /*uint16*/, FlagsAndTokenRange, cdac_data<MethodDescChunk>::FlagsAndTokenRange)
 CDAC_TYPE_END(MethodDescChunk)
 
+CDAC_TYPE_BEGIN(NonVtableSlot)
+CDAC_TYPE_SIZE(sizeof(MethodDesc::NonVtableSlot))
+CDAC_TYPE_END(NonVtableSlot)
+
 CDAC_TYPE_BEGIN(MethodImpl)
 CDAC_TYPE_SIZE(sizeof(MethodImpl))
 CDAC_TYPE_END(MethodImpl)
+
+CDAC_TYPE_BEGIN(NativeCodeSlot)
+CDAC_TYPE_SIZE(sizeof(MethodDesc::NativeCodeSlot))
+CDAC_TYPE_END(NativeCodeSlot)
 
 CDAC_TYPE_BEGIN(InstantiatedMethodDesc)
 CDAC_TYPE_SIZE(sizeof(InstantiatedMethodDesc))

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1853,10 +1853,8 @@ public:
     //
     // Optional MethodDesc slots appear after the end of base MethodDesc in this order:
     //
-
-    // class MethodImpl;                            // Present if HasMethodImplSlot() is true
-
     typedef PCODE NonVtableSlot;   // Present if HasNonVtableSlot() is true
+    // class MethodImpl;           // Present if HasMethodImplSlot() is true
     typedef PCODE NativeCodeSlot;  // Present if HasNativeCodeSlot() is true
 
 // Stub Dispatch code

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
@@ -73,4 +73,5 @@ public enum DataType
     HashMap,
     Bucket,
     UnwindInfo,
+    MethodImpl,
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
@@ -73,5 +73,7 @@ public enum DataType
     HashMap,
     Bucket,
     UnwindInfo,
+    NonVtableSlot,
     MethodImpl,
+    NativeCodeSlot,
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1003,11 +1003,11 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         offset += md.NativeCodeSlotOffset;
         return methodDesc.Address + offset;
     }
-    private TargetPointer GetAddressOfNonVtableSlot(TargetPointer methodDescPointer, MethodDesc md)
+    private TargetPointer GetAddressOfNonVtableSlot(MethodDesc md)
     {
         uint offset = MethodDescAdditionalPointersOffset(md);
         offset += md.NonVtableSlotOffset;
-        return methodDescPointer.Value + offset;
+        return md.Address + offset;
     }
 
     TargetCodePointer IRuntimeTypeSystem.GetNativeCode(MethodDescHandle methodDescHandle)
@@ -1027,22 +1027,22 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         if (!md.HasStableEntryPoint || md.HasPrecode)
             return TargetCodePointer.Null;
 
-        return GetStableEntryPoint(methodDescHandle.Address, md);
+        return GetStableEntryPoint(md);
     }
 
-    private TargetCodePointer GetStableEntryPoint(TargetPointer methodDescAddress, MethodDesc md)
+    private TargetCodePointer GetStableEntryPoint(MethodDesc md)
     {
-        // TODO(cdac): _ASSERTE(HasStableEntryPoint());
         // TODO(cdac): _ASSERTE(!IsVersionableWithVtableSlotBackpatch());
+        Debug.Assert(md.HasStableEntryPoint);
 
-        return GetMethodEntryPointIfExists(methodDescAddress, md);
+        return GetMethodEntryPointIfExists(md);
     }
 
-    private TargetCodePointer GetMethodEntryPointIfExists(TargetPointer methodDescAddress, MethodDesc md)
+    private TargetCodePointer GetMethodEntryPointIfExists(MethodDesc md)
     {
         if (md.HasNonVtableSlot)
         {
-            TargetPointer pSlot = GetAddressOfNonVtableSlot(methodDescAddress, md);
+            TargetPointer pSlot = GetAddressOfNonVtableSlot(md);
             return _target.ReadCodePointer(pSlot);
         }
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescFlags_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescFlags_1.cs
@@ -10,14 +10,12 @@ internal static class MethodDescFlags_1
     internal enum MethodDescFlags : ushort
     {
         ClassificationMask = 0x7,
-        #region Additional pointers
-        // The below flags each imply that there's an extra pointer-sized piece of data after the MethodDesc in the MethodDescChunk
+        #region Optional slots
+        // The below flags each imply that there's an extra pointer-size-aligned piece of data after the MethodDesc in the MethodDescChunk
         HasNonVtableSlot = 0x0008,
         HasMethodImpl = 0x0010,
         HasNativeCodeSlot = 0x0020,
-        // Mask for the above flags
-        MethodDescAdditionalPointersMask = 0x0038,
-        #endregion Additional pointers
+        #endregion Optional slots
     }
 
     [Flags]
@@ -35,5 +33,4 @@ internal static class MethodDescFlags_1
     {
         TemporaryEntryPointAssigned = 0x04,
     }
-
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescOptionalSlots.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescOptionalSlots.cs
@@ -82,7 +82,7 @@ internal static class MethodDescOptionalSlots
 
         uint offset = 0;
         if (HasNonVtableSlot(flags))
-            offset += (uint)target.PointerSize;
+            offset += target.GetTypeInfo(DataType.NonVtableSlot).Size!.Value;
 
         if (HasMethodImpl(flags))
             offset += target.GetTypeInfo(DataType.MethodImpl).Size!.Value;

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescOptionalSlots.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescOptionalSlots.cs
@@ -17,8 +17,49 @@ internal static class MethodDescOptionalSlots
     internal static bool HasNativeCodeSlot(ushort flags)
         => (flags & (ushort)MethodDescFlags_1.MethodDescFlags.HasNativeCodeSlot) != 0;
 
-    // Offsets are from the start of optional slots data (so right after the MethodDesc)
-    internal static uint NonVtableSlotOffset(ushort flags)
+    internal static TargetPointer GetAddressOfNonVtableSlot(TargetPointer methodDesc, MethodClassification classification, ushort flags, Target target)
+    {
+        uint offset = StartOffset(classification, target);
+        offset += NonVtableSlotOffset(flags);
+        return methodDesc + offset;
+    }
+
+    internal static TargetPointer GetAddressOfNativeCodeSlot(TargetPointer methodDesc, MethodClassification classification, ushort flags, Target target)
+    {
+        uint offset = StartOffset(classification, target);
+        offset += NativeCodeSlotOffset(flags, target);
+        return methodDesc + offset;
+    }
+
+    // Offset from the MethodDesc address to the start of its optional slots
+    private static uint StartOffset(MethodClassification classification, Target target)
+    {
+        // See MethodDesc::GetBaseSize and s_ClassificationSizeTable
+        // sizeof(MethodDesc),                 mcIL
+        // sizeof(FCallMethodDesc),            mcFCall
+        // sizeof(NDirectMethodDesc),          mcPInvoke
+        // sizeof(EEImplMethodDesc),           mcEEImpl
+        // sizeof(ArrayMethodDesc),            mcArray
+        // sizeof(InstantiatedMethodDesc),     mcInstantiated
+        // sizeof(CLRToCOMCallMethodDesc),     mcComInterOp
+        // sizeof(DynamicMethodDesc)           mcDynamic
+        DataType type = classification switch
+        {
+            MethodClassification.IL => DataType.MethodDesc,
+            MethodClassification.FCall => throw new NotImplementedException(), //TODO[cdac]:
+            MethodClassification.PInvoke => throw new NotImplementedException(), //TODO[cdac]:
+            MethodClassification.EEImpl => throw new NotImplementedException(), //TODO[cdac]:
+            MethodClassification.Array => throw new NotImplementedException(), //TODO[cdac]:
+            MethodClassification.Instantiated => DataType.InstantiatedMethodDesc,
+            MethodClassification.ComInterop => throw new NotImplementedException(), //TODO[cdac]:
+            MethodClassification.Dynamic => DataType.DynamicMethodDesc,
+            _ => throw new InvalidOperationException($"Unexpected method classification 0x{classification:x2} for MethodDesc")
+        };
+        return target.GetTypeInfo(type).Size ?? throw new InvalidOperationException($"size of MethodDesc not known");
+    }
+
+    // Offsets are from the start of optional slots data (so right after the MethodDesc), obtained via StartOffset
+    private static uint NonVtableSlotOffset(ushort flags)
     {
         if (!HasNonVtableSlot(flags))
             throw new InvalidOperationException("no non-vtable slot");
@@ -26,7 +67,7 @@ internal static class MethodDescOptionalSlots
         return 0u;
     }
 
-    internal static uint MethodImplOffset(ushort flags, Target target)
+    private static uint MethodImplOffset(ushort flags, Target target)
     {
         if (!HasMethodImpl(flags))
             throw new InvalidOperationException("no method impl slot");
@@ -34,7 +75,7 @@ internal static class MethodDescOptionalSlots
         return HasNonVtableSlot(flags) ? (uint)target.PointerSize : 0;
     }
 
-    internal static uint NativeCodeSlotOffset(ushort flags, Target target)
+    private static uint NativeCodeSlotOffset(ushort flags, Target target)
     {
         if (!HasNativeCodeSlot(flags))
             throw new InvalidOperationException("no native code slot");

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescOptionalSlots.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodDescOptionalSlots.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
+
+// Non-vtable slot, native code slot, and MethodImpl slots are stored after the MethodDesc itself, packed tightly
+// in the order: [non-vtable; method impl; native code].
+internal static class MethodDescOptionalSlots
+{
+    internal static bool HasNonVtableSlot(ushort flags)
+        => (flags & (ushort)MethodDescFlags_1.MethodDescFlags.HasNonVtableSlot) != 0;
+
+    internal static bool HasMethodImpl(ushort flags)
+        => (flags & (ushort)MethodDescFlags_1.MethodDescFlags.HasMethodImpl) != 0;
+
+    internal static bool HasNativeCodeSlot(ushort flags)
+        => (flags & (ushort)MethodDescFlags_1.MethodDescFlags.HasNativeCodeSlot) != 0;
+
+    // Offsets are from the start of optional slots data (so right after the MethodDesc)
+    internal static uint NonVtableSlotOffset(ushort flags)
+    {
+        if (!HasNonVtableSlot(flags))
+            throw new InvalidOperationException("no non-vtable slot");
+
+        return 0u;
+    }
+
+    internal static uint MethodImplOffset(ushort flags, Target target)
+    {
+        if (!HasMethodImpl(flags))
+            throw new InvalidOperationException("no method impl slot");
+
+        return HasNonVtableSlot(flags) ? (uint)target.PointerSize : 0;
+    }
+
+    internal static uint NativeCodeSlotOffset(ushort flags, Target target)
+    {
+        if (!HasNativeCodeSlot(flags))
+            throw new InvalidOperationException("no native code slot");
+
+        uint offset = 0;
+        if (HasNonVtableSlot(flags))
+            offset += (uint)target.PointerSize;
+
+        if (HasMethodImpl(flags))
+            offset += target.GetTypeInfo(DataType.MethodImpl).Size!.Value;
+
+        return offset;
+    }
+}

--- a/src/native/managed/cdacreader/tests/MethodDescTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodDescTests.cs
@@ -106,13 +106,13 @@ public class MethodDescTests
 
         uint methodDescSize = methodDescBuilder.Types[DataType.MethodDesc].Size.Value;
         if (flags.HasFlag(MethodDescFlags_1.MethodDescFlags.HasNonVtableSlot))
-            methodDescSize += (uint)helpers.PointerSize;
+            methodDescSize += methodDescBuilder.Types[DataType.NonVtableSlot].Size!.Value;
 
         if (flags.HasFlag(MethodDescFlags_1.MethodDescFlags.HasMethodImpl))
             methodDescSize += methodDescBuilder.Types[DataType.MethodImpl].Size!.Value;
 
         if (flags.HasFlag(MethodDescFlags_1.MethodDescFlags.HasNativeCodeSlot))
-            methodDescSize += (uint)helpers.PointerSize;
+            methodDescSize += methodDescBuilder.Types[DataType.NativeCodeSlot].Size!.Value;
 
         byte chunkSize = (byte)(methodDescSize / methodDescBuilder.MethodDescAlignment);
         TargetPointer chunk = methodDescBuilder.AddMethodDescChunk(methodTable, string.Empty, count: 1, chunkSize, tokenRange: 0);

--- a/src/native/managed/cdacreader/tests/MethodDescTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodDescTests.cs
@@ -34,6 +34,7 @@ public class MethodDescTests
 
         const int MethodDefToken = 0x06 << 24;
         const ushort expectedRidRangeStart = 0x2000; // arbitrary (larger than  1<< TokenRemainderBitCount)
+        Assert.True(expectedRidRangeStart > (1 << MockDescriptors.MethodDescriptors.TokenRemainderBitCount));
         const ushort expectedRidRemainder = 0x10; // arbitrary
         const uint expectedRid = expectedRidRangeStart | expectedRidRemainder; // arbitrary
         uint expectedToken = MethodDefToken | expectedRid;

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
@@ -79,7 +79,9 @@ internal partial class MockDescriptors
                     MethodDescFields,
                     MethodDescChunkFields,
                 ]);
+            types[DataType.NonVtableSlot] = new Target.TypeInfo() { Size = (uint)TargetTestHelpers.PointerSize };
             types[DataType.MethodImpl] = new Target.TypeInfo() { Size = (uint)TargetTestHelpers.PointerSize * 2 };
+            types[DataType.NativeCodeSlot] = new Target.TypeInfo() { Size = (uint)TargetTestHelpers.PointerSize };
             types = types
                 .Concat(RTSBuilder.Types)
                 .Concat(LoaderBuilder.Types)

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
@@ -40,22 +40,30 @@ internal partial class MockDescriptors
             ]
         };
 
+        private const ulong DefaultAllocationRangeStart = 0x2000_2000;
+        private const ulong DefaultAllocationRangeEnd = 0x2000_3000;
+
         internal readonly RuntimeTypeSystem RTSBuilder;
         internal readonly Loader LoaderBuilder;
 
         internal Dictionary<DataType, Target.TypeInfo> Types { get; }
         internal (string Name, ulong Value)[] Globals { get; }
 
-        internal MockMemorySpace.BumpAllocator MethodDescChunkAllocator { get; set; }
+        private readonly MockMemorySpace.BumpAllocator _allocator;
 
         internal TargetTestHelpers TargetTestHelpers => RTSBuilder.Builder.TargetTestHelpers;
         internal MockMemorySpace.Builder Builder => RTSBuilder.Builder;
         internal uint MethodDescAlignment => RuntimeTypeSystem.GetMethodDescAlignment(TargetTestHelpers);
 
         internal MethodDescriptors(RuntimeTypeSystem rtsBuilder, Loader loaderBuilder)
+            : this(rtsBuilder, loaderBuilder, (DefaultAllocationRangeStart, DefaultAllocationRangeEnd))
+        { }
+
+        internal MethodDescriptors(RuntimeTypeSystem rtsBuilder, Loader loaderBuilder, (ulong Start, ulong End) allocationRange)
         {
             RTSBuilder = rtsBuilder;
             LoaderBuilder = loaderBuilder;
+            _allocator = Builder.CreateAllocator(allocationRange.Start, allocationRange.End);
             Types = GetTypes();
             Globals = rtsBuilder.Globals.Concat(
             [
@@ -71,6 +79,7 @@ internal partial class MockDescriptors
                     MethodDescFields,
                     MethodDescChunkFields,
                 ]);
+            types[DataType.MethodImpl] = new Target.TypeInfo() { Size = (uint)TargetTestHelpers.PointerSize * 2 };
             types = types
                 .Concat(RTSBuilder.Types)
                 .Concat(LoaderBuilder.Types)
@@ -83,7 +92,7 @@ internal partial class MockDescriptors
             uint totalAllocSize = Types[DataType.MethodDescChunk].Size.Value;
             totalAllocSize += (uint)(size * MethodDescAlignment);
 
-            MockMemorySpace.HeapFragment methodDescChunk = MethodDescChunkAllocator.Allocate(totalAllocSize, $"MethodDescChunk {name}");
+            MockMemorySpace.HeapFragment methodDescChunk = _allocator.Allocate(totalAllocSize, $"MethodDescChunk {name}");
             Span<byte> dest = methodDescChunk.Data;
             TargetTestHelpers.WritePointer(dest.Slice(Types[DataType.MethodDescChunk].Fields[nameof(Data.MethodDescChunk.MethodTable)].Offset), methodTable);
             TargetTestHelpers.Write(dest.Slice(Types[DataType.MethodDescChunk].Fields[nameof(Data.MethodDescChunk.Size)].Offset), size);
@@ -93,25 +102,22 @@ internal partial class MockDescriptors
             return methodDescChunk.Address;
         }
 
-        internal TargetPointer GetMethodDescAddress(TargetPointer chunkAddress, byte index)
+        private TargetPointer GetMethodDescAddress(TargetPointer chunkAddress, byte index)
         {
             Target.TypeInfo methodDescChunkTypeInfo = Types[DataType.MethodDescChunk];
             return chunkAddress + methodDescChunkTypeInfo.Size.Value + index * MethodDescAlignment;
         }
-        internal Span<byte> BorrowMethodDesc(TargetPointer methodDescChunk, byte index)
-        {
-            TargetPointer methodDescAddress = GetMethodDescAddress(methodDescChunk, index);
-            Target.TypeInfo methodDescTypeInfo = Types[DataType.MethodDesc];
-            return Builder.BorrowAddressRange(methodDescAddress, (int)methodDescTypeInfo.Size.Value);
-        }
 
-        internal void SetMethodDesc(scoped Span<byte> dest, byte index, ushort slotNum, ushort tokenRemainder)
+        internal TargetPointer SetMethodDesc(TargetPointer methodDescChunk, byte index, ushort slotNum, ushort flags, ushort tokenRemainder)
         {
+            TargetPointer methodDesc = GetMethodDescAddress(methodDescChunk, index);
             Target.TypeInfo methodDescTypeInfo = Types[DataType.MethodDesc];
-            TargetTestHelpers.Write(dest.Slice(methodDescTypeInfo.Fields[nameof(Data.MethodDesc.ChunkIndex)].Offset), (byte)index);
-            TargetTestHelpers.Write(dest.Slice(methodDescTypeInfo.Fields[nameof(Data.MethodDesc.Flags3AndTokenRemainder)].Offset), tokenRemainder);
-            TargetTestHelpers.Write(dest.Slice(methodDescTypeInfo.Fields[nameof(Data.MethodDesc.Slot)].Offset), slotNum);
-            // TODO: write more fields
+            Span<byte> data = Builder.BorrowAddressRange(methodDesc, (int)methodDescTypeInfo.Size.Value);
+            TargetTestHelpers.Write(data.Slice(methodDescTypeInfo.Fields[nameof(Data.MethodDesc.ChunkIndex)].Offset), (byte)index);
+            TargetTestHelpers.Write(data.Slice(methodDescTypeInfo.Fields[nameof(Data.MethodDesc.Flags)].Offset), flags);
+            TargetTestHelpers.Write(data.Slice(methodDescTypeInfo.Fields[nameof(Data.MethodDesc.Flags3AndTokenRemainder)].Offset), tokenRemainder);
+            TargetTestHelpers.Write(data.Slice(methodDescTypeInfo.Fields[nameof(Data.MethodDesc.Slot)].Offset), slotNum);
+            return methodDesc;
         }
     }
 }

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
@@ -11,7 +11,7 @@ internal partial class MockDescriptors
 {
     public class MethodDescriptors
     {
-        internal const uint TokenRemainderBitCount = 12u; /* see METHOD_TOKEN_REMAINDER_BIT_COUNT*/
+        internal const byte TokenRemainderBitCount = 12; /* see METHOD_TOKEN_REMAINDER_BIT_COUNT*/
 
         private static readonly TypeFields MethodDescFields = new TypeFields()
         {


### PR DESCRIPTION
The cDAC was assuming that the additional data after a MethodDesc were each just pointers. That is only true for the non-vtable slot and native code slot, not method impl. This change includes the size of those additional slots in the data descriptor and uses them when computing the addresses those optional slots.

As part of this, I pulled out shared helpers around dealing with optional slots for use by `MethodValidation` and `RuntimeTypeSystem_1`.

Found this while trying to finish out `RuntimeTypeSystem_1.GetMethodClassificationDataType` for https://github.com/dotnet/runtime/issues/109426 when doing a `!dumpmt` for a method table with explicit interface implementations (or `!dumpmd` on a method that is an explicit interface implementation).

Contributes to https://github.com/dotnet/runtime/issues/99302, https://github.com/dotnet/runtime/issues/109426