### PR TITLE
Add support for DOTNET_DiagnosticPortDefaultPrefix

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -716,6 +716,7 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCGenAnalysisDump, W("GCGenAnalysisDump"), 0, 
 //
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_DOTNET_DefaultDiagnosticPortSuspend, W("DefaultDiagnosticPortSuspend"), 0, "This sets the deafult diagnostic port to suspend causing the runtime to pause during startup before major subsystems are started.  Resume using the Diagnostics IPC ResumeStartup command on the default diagnostic port.");
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_DOTNET_DiagnosticPorts, W("DiagnosticPorts"), "A semicolon delimited list of additional Diagnostic Ports, where a Diagnostic Port is a NamedPipe path without '\\\\.\\pipe\\' on Windows or the full path of Unix Domain Socket on Linux/Unix followed by optional tags, e.g., '<path>,connect,nosuspend;<path>'");
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_DOTNET_DiagnosticPortDefaultPrefix, W("DiagnosticPortDefaultPrefix"), "The default prefix for the diagnostic port name. The default is `dotnet-diagnostic`.");
 
 //
 // LTTng

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -168,6 +168,20 @@ ds_rt_config_value_get_default_port_suspend (void)
     return 0;
 }
 
+static
+inline
+ep_char8_t *
+ds_rt_config_value_get_port_default_prefix (void)
+{
+    STATIC_CONTRACT_NOTHROW;
+
+    char* value;
+    if (RhConfig::Environment::TryGetStringValue("DiagnosticPortDefaultPrefix", &value))
+        return (ep_char8_t*)value;
+
+    return nullptr;
+}
+
 /*
 * DiagnosticsDump.
 */

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -178,6 +178,18 @@ ds_rt_config_value_get_default_port_suspend (void)
 	return static_cast<uint32_t>(CLRConfig::GetConfigValue (CLRConfig::EXTERNAL_DOTNET_DefaultDiagnosticPortSuspend));
 }
 
+
+static
+inline
+ep_char8_t *
+ds_rt_config_value_get_port_default_prefix (void)
+{
+    STATIC_CONTRACT_NOTHROW;
+
+	CLRConfigStringHolder value(CLRConfig::GetConfigValue (CLRConfig::EXTERNAL_DOTNET_DiagnosticPortDefaultPrefix));
+	return ep_rt_utf16_to_utf8_string (reinterpret_cast<ep_char16_t *>(value.GetValue ()));
+}
+
 /*
 * DiagnosticsDump.
 */

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -149,6 +149,14 @@ ds_rt_config_value_get_default_port_suspend (void)
 	return value_uint32_t;
 }
 
+static
+inline
+ep_char8_t *
+ds_rt_config_value_get_port_default_prefix (void)
+{
+	return g_getenv ("DOTNET_DiagnosticPortDefaultPrefix");
+}
+
 /*
 * DiagnosticsDump.
 */

--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.c
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.c
@@ -117,7 +117,9 @@ DiagnosticsIpc *
 ds_ipc_alloc (
 	const ep_char8_t *ipc_name,
 	DiagnosticsIpcConnectionMode mode,
-	ds_ipc_error_callback_func callback)
+	ds_ipc_error_callback_func callback,
+    const ep_char8_t *ipc_default_prefix)
+
 {
 	int32_t characters_written = -1;
 
@@ -144,7 +146,8 @@ ds_ipc_alloc (
 		characters_written = sprintf_s (
 			(char *)&instance->pipe_name,
 			(size_t)DS_IPC_WIN32_MAX_NAMED_PIPE_LEN,
-			(const char *)"\\\\.\\pipe\\dotnet-diagnostic-%d",
+			(const char *)"\\\\.\\pipe\\%s-%d",
+            ipc_default_prefix,
 			GetCurrentProcessId ());
 	}
 

--- a/src/native/eventpipe/ds-ipc-pal.h
+++ b/src/native/eventpipe/ds-ipc-pal.h
@@ -30,7 +30,8 @@ DiagnosticsIpc *
 ds_ipc_alloc (
 	const ep_char8_t *ipc_name,
 	DiagnosticsIpcConnectionMode mode,
-	ds_ipc_error_callback_func callback);
+	ds_ipc_error_callback_func callback,
+    const ep_char8_t *ipc_default_prefix);
 
 void
 ds_ipc_free (DiagnosticsIpc *ipc);

--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -175,7 +175,10 @@ ipc_stream_factory_build_and_add_port (
 
 	if (builder->type == DS_PORT_TYPE_LISTEN) {
 #ifndef DS_IPC_DISABLE_LISTEN_PORTS
-		ipc = ds_ipc_alloc (builder->path, DS_IPC_CONNECTION_MODE_LISTEN, callback);
+        ep_char8_t* ipc_default_prefix = ds_rt_config_value_get_port_default_prefix();
+        ipc_default_prefix = ipc_default_prefix != nullptr ? ipc_default_prefix : (ep_char8_t*)"dotnet-diagnostic";
+
+		ipc = ds_ipc_alloc (builder->path, DS_IPC_CONNECTION_MODE_LISTEN, callback, ipc_default_prefix);
 		ep_raise_error_if_nok (ipc != NULL);
 		ep_raise_error_if_nok (ds_ipc_listen (ipc, callback));
 		ep_raise_error_if_nok (dn_vector_ptr_push_back (_ds_port_array, (DiagnosticsPort *)ds_listen_port_alloc (ipc, builder)));
@@ -185,7 +188,10 @@ ipc_stream_factory_build_and_add_port (
 #endif
 	} else if (builder->type == DS_PORT_TYPE_CONNECT) {
 #ifndef DS_IPC_DISABLE_CONNECT_PORTS
-		ipc = ds_ipc_alloc (builder->path, DS_IPC_CONNECTION_MODE_CONNECT, callback);
+        ep_char8_t* ipc_default_prefix = ds_rt_config_value_get_port_default_prefix();
+        ipc_default_prefix = ipc_default_prefix != nullptr ? ipc_default_prefix : (ep_char8_t*)"dotnet-diagnostic";
+
+		ipc = ds_ipc_alloc (builder->path, DS_IPC_CONNECTION_MODE_CONNECT, callback, ipc_default_prefix);
 		ep_raise_error_if_nok (ipc != NULL);
 		ep_raise_error_if_nok (dn_vector_ptr_push_back (_ds_port_array, (DiagnosticsPort *)ds_connect_port_alloc (ipc, builder)));
 #else

--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -176,7 +176,7 @@ ipc_stream_factory_build_and_add_port (
 	if (builder->type == DS_PORT_TYPE_LISTEN) {
 #ifndef DS_IPC_DISABLE_LISTEN_PORTS
         ep_char8_t* ipc_default_prefix = ds_rt_config_value_get_port_default_prefix();
-        ipc_default_prefix = ipc_default_prefix != nullptr ? ipc_default_prefix : (ep_char8_t*)"dotnet-diagnostic";
+        ipc_default_prefix = ipc_default_prefix != NULL ? ipc_default_prefix : (ep_char8_t*)"dotnet-diagnostic";
 
 		ipc = ds_ipc_alloc (builder->path, DS_IPC_CONNECTION_MODE_LISTEN, callback, ipc_default_prefix);
 		ep_raise_error_if_nok (ipc != NULL);
@@ -189,7 +189,7 @@ ipc_stream_factory_build_and_add_port (
 	} else if (builder->type == DS_PORT_TYPE_CONNECT) {
 #ifndef DS_IPC_DISABLE_CONNECT_PORTS
         ep_char8_t* ipc_default_prefix = ds_rt_config_value_get_port_default_prefix();
-        ipc_default_prefix = ipc_default_prefix != nullptr ? ipc_default_prefix : (ep_char8_t*)"dotnet-diagnostic";
+        ipc_default_prefix = ipc_default_prefix != NULL ? ipc_default_prefix : (ep_char8_t*)"dotnet-diagnostic";
 
 		ipc = ds_ipc_alloc (builder->path, DS_IPC_CONNECTION_MODE_CONNECT, callback, ipc_default_prefix);
 		ep_raise_error_if_nok (ipc != NULL);

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -63,6 +63,10 @@ static
 uint32_t
 ds_rt_config_value_get_default_port_suspend (void);
 
+static
+ep_char8_t *
+ds_rt_config_value_get_port_default_prefix (void);
+
 /*
 * DiagnosticsDump.
 */


### PR DESCRIPTION
Fixes #110473

It is a try before #110473 is accepted, but wanted to check how difficult it would be to bring this.

This PR is missing tests and would require some docs in Diagnostic Port. Only compiled on Windows and MacOS. Not yet tested locally.