### PR TITLE
Fix aka.ms URL in host's missing framework error

### DIFF
--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -450,18 +450,22 @@ pal::string_t get_download_url(const pal::char_t* framework_name, const pal::cha
         url.append(_X("missing_runtime=true"));
     }
 
+#if defined(TARGET_WINDOWS)
+#define TARGET_OS "win"
+#elif defined(TARGET_OSX)
+#define TARGET_OS "osx"
+#elif defined(TARGET_LINUX) || defined(TARGET_ANDROID)
+#define TARGET_OS "linux"
+#else
+// others are community supported platforms
+#define TARGET_OS "community"
+#endif
+
     const pal::char_t* arch = get_current_arch_name();
     url.append(_X("&arch="));
     url.append(arch);
     url.append(_X("&rid="));
-    url.append(get_runtime_id());
-
-    pal::string_t os = pal::get_current_os_rid_platform();
-    if (os.empty())
-        os = pal::get_current_os_fallback_rid();
-
-    url.append(_X("&os="));
-    url.append(os);
+    url.append(_STRINGIFY(TARGET_OS) _X("-") _STRINGIFY(CURRENT_ARCH_NAME));
 
     return url;
 }


### PR DESCRIPTION
When running app targeting a missing framework, text after `To install missing framework, download:` currently looks like:

* fedora non-portable build: `https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=9.0.0&arch=arm64&rid=fedora.41-arm64&os=fedora.41`
  * redirects to `https://dotnet.microsoft.com/en-us/download/dotnet/9.0/runtime?cid=getdotnetcore&arch=arm64` because `rid=fedora...` is unknown on akams side.
* alpine portable build: `https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=9.0.0&arch=arm64&rid=linux-musl-arm64&os=alpine.3.20`
  * redirects to `https://dotnet.microsoft.com/en-us/download/dotnet/9.0/runtime?cid=getdotnetcore&os=linux&arch=arm64` because `rid=linux-musl..` starts with `linux`.
* alpine non-portable build `https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=9.0.0&arch=arm64&rid=alpine.3.21-arm64&os=alpine`
  * redirects to `https://dotnet.microsoft.com/en-us/download/dotnet/9.0/runtime?cid=getdotnetcore&arch=arm64` same as fedora non-portable (`rid=alpine..` doesn't match anything on akams side)
* osx `https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=9.0.0&arch=arm64&rid=osx-arm64&os=osx.15`
  * redirects to `https://dotnet.microsoft.com/en-us/download/dotnet/9.0/runtime?cid=getdotnetcore&os=macos&arch=arm64` because `rid=osx..` starts with osx and maps to macos in akams system.

This PR fixes these disparities by always using non-portable RID in `rid=` and removes `os=` parameter because it is simply ignored.