### PR TITLE
Fix CMP0173 policy warning with cmake 3.31

### DIFF
--- a/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
@@ -186,7 +186,6 @@ if(FEATURE_MERGE_JIT_AND_ENGINE)
 endif(FEATURE_MERGE_JIT_AND_ENGINE)
 
 if (CLR_CMAKE_TARGET_OSX)
-    include(CMakeFindFrameworks)
     find_library(FOUNDATION Foundation REQUIRED)
 endif()
 

--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -140,7 +140,6 @@ include_directories("../Common")
 
 if (GEN_SHARED_LIB)
     if (CLR_CMAKE_TARGET_APPLE)
-        include(CMakeFindFrameworks)
         find_library(FOUNDATION Foundation REQUIRED)
     endif()
 

--- a/src/native/libs/System.Native/extra_libs.cmake
+++ b/src/native/libs/System.Native/extra_libs.cmake
@@ -13,7 +13,6 @@ macro(append_extra_system_libs NativeLibsExtra)
     endif ()
 
     if (CLR_CMAKE_TARGET_APPLE)
-        include(CMakeFindFrameworks)
         find_library(FOUNDATION Foundation REQUIRED)
         list(APPEND ${NativeLibsExtra} ${FOUNDATION})
     endif ()

--- a/src/tests/Interop/ObjectiveC/AutoReleaseTest/CMakeLists.txt
+++ b/src/tests/Interop/ObjectiveC/AutoReleaseTest/CMakeLists.txt
@@ -15,7 +15,6 @@ set(SOURCES
 
 set_source_files_properties(autorelease.m PROPERTIES COMPILE_FLAGS -fno-objc-arc)
 
-include(CMakeFindFrameworks)
 find_library(FOUNDATION Foundation REQUIRED)
 
 add_library(ObjectiveC SHARED ${SOURCES})


### PR DESCRIPTION
In some places, where we use `find_library(FOUNDATION`, we don't `include(CMakeFindFrameworks)` while in other places we do.  These look like added "just in case". CMake 3.31 has deprecated `include(CMakeFindFrameworks)`:

```
-- Performing Test LINKER_SUPPORTS_UNDEFINED_VERSION - Failed
CMake Warning (dev) at dlls/mscoree/coreclr/CMakeLists.txt:189 (include):
  Policy CMP0173 is not set: The CMakeFindFrameworks module is removed.  Run
  "cmake --help-policy CMP0173" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /opt/homebrew/share/cmake/Modules/CMakeFindFrameworks.cmake:29 (message):
  CMakeFindFrameworks.cmake is not maintained and lacks support for more
  recent framework handling.  It will be removed in a future version of
  CMake.  Update the code to use find_library() instead.
Call Stack (most recent call first):
  dlls/mscoree/coreclr/CMakeLists.txt:189 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done (57.5s)
```

Lets see if it works warning-free in the CI without the include before resorting to policy oriented fix.