### PR TITLE
[browser] Disable HybridGlobalization tests on WASM

### DIFF
--- a/eng/pipelines/coreclr/perf-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-wasm-jobs.yml
@@ -171,26 +171,3 @@ jobs:
         logicalmachine: 'perftiger'
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
         perfBranch: ${{ parameters.perfBranch }}
-
-- ${{if or(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), in(variables['Build.DefinitionName'], 'runtime-wasm-perf')) }}:
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
-        runKind: blazor_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-        #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
-        logicalmachine: 'perftiger'
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        hybridGlobalization: True
-        perfBranch: ${{ parameters.perfBranch }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -148,37 +148,6 @@ jobs:
       scenarios:
         - WasmTestOnWasmtime
 
-  # Hybrid Globalization tests
-  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-    parameters:
-      platforms:
-        - browser_wasm
-        - browser_wasm_win
-      nameSuffix: _HybridGlobalization
-      extraBuildArgs: /p:HybridGlobalization=true
-      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      alwaysRun: true
-      scenarios:
-        - WasmTestOnChrome
-        - WasmTestOnFirefox
-
-  # # Hybrid Globalization AOT tests
-  # # ActiveIssue: https://github.com/dotnet/runtime/issues/51746
-  # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-  #   parameters:
-  #     platforms:
-  #       - browser_wasm
-  #       - browser_wasm_win
-  #     nameSuffix: _HybridGlobalization_AOT
-  #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS) /p:HybridGlobalization=true
-  #     runAOT: true
-  #     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-  #     isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-  #     alwaysRun: true
-  #     scenarios:
-  #       - WasmTestOnChrome
-
 - ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeNonLibTests, true), ne(parameters.debuggerTestsOnly, true)) }}:
   # Builds only
   - template: /eng/pipelines/common/templates/wasm-build-only.yml

--- a/eng/testing/performance/blazor_perf.proj
+++ b/eng/testing/performance/blazor_perf.proj
@@ -9,14 +9,9 @@
     <Python>python3</Python>
     <HelixPreCommands Condition="'$(AGENT_OS)' != 'Windows_NT'">$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
 
-    <_MSBuildArgs>/p:_TrimmerDumpDependencies=true;/p:HybridGlobalization=$(hybridGlobalization);/warnaserror:NU1602,NU1604</_MSBuildArgs>
+    <_MSBuildArgs>/p:_TrimmerDumpDependencies=true;/warnaserror:NU1602,NU1604</_MSBuildArgs>
     <PublishArgs>--has-workload --readonly-dotnet --msbuild &quot;$(_MSBuildArgs)&quot; --msbuild-static AdditionalMonoLinkerOptions=%27&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;%27 --binlog $(LogDirectory)blazor_publish.binlog</PublishArgs>
     <PublishCommand>$(EnvVars) $(Python) pre.py publish $(PublishArgs)</PublishCommand>
-    <!-- For non-default configurations, add the configuration to the name of the test (in the matching format), otherwise didn't add anything.
-    This will ensure that PowerBI's using the test name rather than the run configuration for the data continue to work properly and defaults are connected -->
-    <HybridGlobalizationPath></HybridGlobalizationPath>
-    <HybridGlobalizationPath Condition="'$(hybridGlobalization)' == 'True'"> - HybridGlobalization</HybridGlobalizationPath>
-    <RunConfigsString>$(HybridGlobalizationPath)</RunConfigsString>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
@@ -51,48 +46,48 @@
   </ItemGroup>
 
   <ItemGroup>
-    <HelixWorkItem Condition="'$(hybridGlobalization)' != 'True'" Include="SOD - Minimum Blazor Template - Publish$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Minimum Blazor Template - Publish">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <!-- Specifying both illink dump msbuild properties in case illink version is not updated -->
       <Command>cd $(BlazorMinDirectory) &amp;&amp; $(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
-    <HelixWorkItem Condition="'$(hybridGlobalization)' != 'True'" Include="SOD - Minimum Blazor Template - Publish - AOT$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Minimum Blazor Template - Publish - AOT">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <!-- Specifying both illink dump msbuild properties in case illink version is not updated -->
       <Command>cd $(BlazorMinAOTDirectory) &amp;&amp; $(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
       <Timeout>00:30</Timeout>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - New Blazor Template - Publish$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - New Blazor Template - Publish">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <Command>cd $(BlazorDirectory) &amp;&amp; $(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - New Blazor Template - Publish - AOT$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - New Blazor Template - Publish - AOT">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <Command>cd $(BlazorAOTDirectory) &amp;&amp; $(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
         <Timeout>00:30</Timeout>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Pizza App - Publish$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Pizza App - Publish">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <!-- Specifying both illink dump msbuild properties in case illink version is not updated -->
       <Command>cd $(BlazorPizzaDirectory) &amp;&amp; $(PublishCommand) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation) $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Pizza App - Publish - AOT$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Pizza App - Publish - AOT">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <!-- Specifying both illink dump msbuild properties in case illink version is not updated -->
       <Command>cd $(BlazorPizzaAOTDirectory) &amp;&amp; $(PublishCommand) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation) $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
       <Timeout>1:00</Timeout>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Localized App - Publish$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Localized App - Publish">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation) $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
       <Timeout>1:00</Timeout>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Localized App - Publish - AOT$(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Localized App - Publish - AOT">
       <_PublishArgsWithAOT>--msbuild &quot;$(_MSBuildArgs);/p:RunAOTCompilation=true&quot;</_PublishArgsWithAOT>
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) $(_PublishArgsWithAOT) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation) $(ScenarioArgs)</Command>


### PR DESCRIPTION
Revert WASM-based part of https://github.com/dotnet/runtime/pull/89825.
Revert CI run from https://github.com/dotnet/runtime/pull/95324.

In an effort to keep focus on the core part of the runtime, we decided to discontinue the experiment of Web API-based Globalization support for WASM platform, called `HybridGlobalization`. This PR removes the optional tests from runtime CI and tests from performance CI. In parallel to this PR we will be working on removing code connected to this feature.

`HybridGlobalization` on iOS is still going to be supported and keeps being the default mode for that platform.