### PR TITLE
Avoid a list/array allocation in Task.WhenAll(enumerable)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ValueListBuilder.cs
@@ -13,11 +13,14 @@ namespace System.Collections.Generic
         private T[]? _arrayFromPool;
         private int _pos;
 
-        public ValueListBuilder(Span<T> initialSpan)
+        public ValueListBuilder(Span<T?> scratchBuffer)
         {
-            _span = initialSpan;
-            _arrayFromPool = null;
-            _pos = 0;
+            _span = scratchBuffer!;
+        }
+
+        public ValueListBuilder(int capacity)
+        {
+            Grow(capacity);
         }
 
         public int Length

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -97,7 +97,7 @@ namespace System.Text.RegularExpressions
         [InlineArray(4)]
         private struct FourStackStrings // used to do the equivalent of: Span<string> strings = stackalloc string[4];
         {
-            private string _item1;
+            private string? _item1;
         }
 
         /// <summary>


### PR DESCRIPTION
When the incoming enumerable isn't a `Task[]` or `List<Task>`, we end up allocating either a `Task[]` or a `List<T>` (which then may incur one or more array allocations under the covers). We can avoid that by using an internal builder.

Closes https://github.com/dotnet/runtime/issues/110530