### PR TITLE
Fix test under JIT stress

### DIFF
--- a/src/libraries/Common/tests/System/Reflection/InvokeInterpretedTests.cs
+++ b/src/libraries/Common/tests/System/Reflection/InvokeInterpretedTests.cs
@@ -16,7 +16,6 @@ namespace System.Reflection.Tests
             Exception exInner = ex.InnerException;
 
             Assert.Contains("Here", exInner.ToString());
-            Assert.Contains("InterpretedInvoke_Method", exInner.ToString());
             Assert.DoesNotContain("InvokeStub_TestClassThatThrows", exInner.ToString());
         }
 
@@ -29,7 +28,6 @@ namespace System.Reflection.Tests
             Exception exInner = ex.InnerException;
 
             Assert.Contains("Here", exInner.ToString());
-            Assert.Contains("InterpretedInvoke_Constructor", exInner.ToString());
             Assert.DoesNotContain("InvokeStub_TestClassThatThrows", exInner.ToString());
         }
 


### PR DESCRIPTION
Fixes #110511 

The needed validation here is the appropriate exception message is present and the generated frame, `InvokeStub_TestClassThatThrows`, isn't present.

Under `DOTNET_JitStress=1`, the stacks are now different:

No `DOTNET_` variables set
```
BEGIN VerifyInvokeIsUsingInterpreter_Method
System.Exception: Here
   at System.Reflection.Tests.InvokeInterpretedTests.TestClassThatThrows.Throw() in E:\runtime\src\libraries\Common\tests\System\Reflection\InvokeInterpretedTests.cs:line 43
   at System.RuntimeMethodHandle.InvokeMethod(ObjectHandleOnStack target, Void** arguments, ObjectHandleOnStack sig, BOOL isConstructor, ObjectHandleOnStack result)
   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args) in E:\runtime\src\coreclr\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.CoreCLR.cs:line 36
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr) in E:\runtime\src\libraries\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.cs:line 57
END VerifyInvokeIsUsingInterpreter_Method

BEGIN VerifyInvokeIsUsingInterpreter_Constructor
System.Exception: Here
   at System.Reflection.Tests.InvokeInterpretedTests.TestClassThatThrows..ctor() in E:\runtime\src\libraries\Common\tests\System\Reflection\InvokeInterpretedTests.cs:line 40
   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Constructor(Object obj, IntPtr* args) in E:\runtime\src\coreclr\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.CoreCLR.cs:line 33
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr) in E:\runtime\src\libraries\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.cs:line 57
END VerifyInvokeIsUsingInterpreter_Constructor
```

Set `DOTNET_JitStress=1`
```
BEGIN VerifyInvokeIsUsingInterpreter_Method
System.Exception: Here
   at System.Reflection.Tests.InvokeInterpretedTests.TestClassThatThrows.Throw() in E:\runtime\src\libraries\Common\tests\System\Reflection\InvokeInterpretedTests.cs:line 43
   at System.RuntimeMethodHandle.InvokeMethod(ObjectHandleOnStack target, Void** arguments, ObjectHandleOnStack sig, BOOL isConstructor, ObjectHandleOnStack result)
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor) in E:\runtime\src\coreclr\System.Private.CoreLib\src\System\RuntimeHandles.cs:line 1094
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr) in E:\runtime\src\libraries\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.cs:line 57
END VerifyInvokeIsUsingInterpreter_Method

BEGIN VerifyInvokeIsUsingInterpreter_Constructor
System.Exception: Here
   at System.Reflection.Tests.InvokeInterpretedTests.TestClassThatThrows..ctor() in E:\runtime\src\libraries\Common\tests\System\Reflection\InvokeInterpretedTests.cs:line 40
   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Constructor(Object obj, IntPtr* args) in E:\runtime\src\coreclr\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.CoreCLR.cs:line 33
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr) in E:\runtime\src\libraries\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.cs:line 57
END VerifyInvokeIsUsingInterpreter_Constructor
```