### PR TITLE
[dac] Make `GetObjectStringData` return the needed buffer element count instead of byte count

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1576,7 +1576,7 @@ ClrDataAccess::GetObjectStringData(CLRDATA_ADDRESS obj, unsigned int count, _Ino
 
             if (SUCCEEDED(hr))
             {
-                _ASSERTE(bytesRead == count * sizeof(WCHAR));
+                needed = bytesRead / sizeof(WCHAR);
                 stringData[count - 1] = W('\0');
             }
             else

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1571,12 +1571,18 @@ ClrDataAccess::GetObjectStringData(CLRDATA_ADDRESS obj, unsigned int count, _Ino
                 count = needed;
 
             TADDR pszStr = TO_TADDR(obj)+offsetof(StringObject, m_FirstChar);
-            hr = m_pTarget->ReadVirtual(pszStr, (PBYTE)stringData, count * sizeof(WCHAR), &needed);
+            ULONG32 bytesRead;
+            hr = m_pTarget->ReadVirtual(pszStr, (PBYTE)stringData, count * sizeof(WCHAR), &bytesRead);
 
             if (SUCCEEDED(hr))
+            {
+                _ASSERTE(bytesRead == count * sizeof(WCHAR));
                 stringData[count - 1] = W('\0');
+            }
             else
+            {
                 stringData[0] = W('\0');
+            }
         }
         else
         {

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1573,10 +1573,10 @@ ClrDataAccess::GetObjectStringData(CLRDATA_ADDRESS obj, unsigned int count, _Ino
             TADDR pszStr = TO_TADDR(obj)+offsetof(StringObject, m_FirstChar);
             ULONG32 bytesRead;
             hr = m_pTarget->ReadVirtual(pszStr, (PBYTE)stringData, count * sizeof(WCHAR), &bytesRead);
+            needed = bytesRead / sizeof(WCHAR);
 
             if (SUCCEEDED(hr))
             {
-                needed = bytesRead / sizeof(WCHAR);
                 stringData[count - 1] = W('\0');
             }
             else

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1577,7 +1577,7 @@ ClrDataAccess::GetObjectStringData(CLRDATA_ADDRESS obj, unsigned int count, _Ino
 
             if (SUCCEEDED(hr))
             {
-                stringData[count - 1] = W('\0');
+                stringData[needed - 1] = W('\0');
             }
             else
             {


### PR DESCRIPTION
`GetObjectStringData` is returning the byte count instead of the buffer element count. This is inconsistent with all the other APIs that (optionally) return a needed count which return the buffer element count, not the byte count - for example, for strings specifically: `GetAssemblyName`, `GetMethodDescName`, `GetObjectClassName`, `GetMethodTableName`, `GetFrameName`, `GetPEFileName`.

The only place I found using it (that is, not passing in `NULL`) is:
https://github.com/dotnet/diagnostics/blob/d1077f536993e79a013c6f97593af84cfbbf0134/src/SOS/Strike/clrma/managedanalysis.cpp#L673-L679
which just treats it as the buffer element count (so creates a larger buffer than necessary)

@mikem8361 / @dotnet/dotnet-diag From what I can tell, this was not actually intended. Is this okay for us to change?