### PR TITLE
[browser][MT] fix EventPipe demo after running mono on deputy

### DIFF
--- a/docs/design/mono/jiterpreter.md
+++ b/docs/design/mono/jiterpreter.md
@@ -21,6 +21,13 @@ To set runtime options when using the .NET runtime directly, use the `withRuntim
     const runtime = await dotnet
         .withRuntimeOptions(["--jiterpreter-stats-enabled"])
 ```
+
+Or disable jiterp with
+
+```javascript
+    const runtime = await dotnet
+        .withRuntimeOptions(["--no-jiterpreter-traces-enabled"])
+```
 When using Blazor, you can use the Msbuild property `BlazorWebAssemblyJiterpreter` as a convenient shorthand to configure whether the Jiterpreter is enabled. You can also use `BlazorWebAssemblyRuntimeOptions` to set specific options directly. At present, the Jiterpreter only functions in Blazor applications that have been published. When running with debugging enabled, it will be inactive.
 
 ## Trace lifecycle

--- a/src/mono/browser/runtime/diagnostics/browser/controller.ts
+++ b/src/mono/browser/runtime/diagnostics/browser/controller.ts
@@ -4,7 +4,7 @@
 import WasmEnableThreads from "consts:wasmEnableThreads";
 
 import { threads_c_functions as cwraps } from "../../cwraps";
-import { INTERNAL, mono_assert } from "../../globals";
+import { INTERNAL, mono_assert, loaderHelpers } from "../../globals";
 import { mono_log_info, mono_log_debug, mono_log_warn } from "../../logging";
 import { withStackAlloc, getI32 } from "../../memory";
 import { waitForThread } from "../../pthreads";
@@ -56,6 +56,7 @@ export function getController (): ServerController {
 
 export async function startDiagnosticServer (websocket_url: string): Promise<ServerController | null> {
     mono_assert(WasmEnableThreads, "The diagnostic server requires threads to be enabled during build time.");
+    mono_assert(!loaderHelpers.is_exited(), "runtime is exited");
     const sizeOfPthreadT = 4;
     mono_log_info(`starting the diagnostic server url: ${websocket_url}`);
     const result: PThreadPtr | undefined = withStackAlloc(sizeOfPthreadT, (pthreadIdPtr) => {

--- a/src/mono/browser/runtime/diagnostics/mock/index.ts
+++ b/src/mono/browser/runtime/diagnostics/mock/index.ts
@@ -6,6 +6,7 @@ import monoDiagnosticsMock from "consts:monoDiagnosticsMock";
 import { createMockEnvironment } from "./environment";
 import type { MockEnvironment, MockScriptConnection } from "./export-types";
 import { assertNever } from "../../types/internal";
+import { loaderHelpers, mono_assert } from "../../globals";
 import { mono_log_debug, mono_log_warn } from "../../logging";
 
 export interface MockRemoteSocket extends EventTarget {
@@ -27,6 +28,7 @@ export type MockScript = (env: MockEnvironment) => MockConnectionScript[];
 let MockImplConstructor: new (script: MockScript) => Mock;
 export function mock (script: MockScript): Mock {
     if (monoDiagnosticsMock) {
+        mono_assert(!loaderHelpers.is_exited(), "runtime is exited");
         if (!MockImplConstructor) {
             class MockScriptEngineSocketImpl implements MockRemoteSocket {
                 constructor (private readonly engine: MockScriptEngineImpl) { }

--- a/src/mono/browser/runtime/diagnostics/server_pthread/index.ts
+++ b/src/mono/browser/runtime/diagnostics/server_pthread/index.ts
@@ -5,6 +5,7 @@
 import WasmEnableThreads from "consts:wasmEnableThreads";
 import monoDiagnosticsMock from "consts:monoDiagnosticsMock";
 
+import { loaderHelpers } from "../../globals";
 import { PromiseAndController, assertNever } from "../../types/internal";
 import { pthread_self } from "../../pthreads";
 import { createPromiseController, mono_assert } from "../../globals";
@@ -90,6 +91,7 @@ class DiagnosticServerImpl implements DiagnosticServer {
     private attachToRuntimeController = createPromiseController<void>().promise_control;
 
     start (): void {
+        mono_assert(!loaderHelpers.is_exited(), "runtime is exited");
         mono_log_info(`starting diagnostic server with url: ${this.websocketUrl}`);
         this.startRequestedController.resolve();
     }

--- a/src/mono/browser/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
+++ b/src/mono/browser/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
@@ -74,7 +74,7 @@ const Parser = {
         }
         const size = (buf[j + 3] << 24) | (buf[j + 2] << 16) | (buf[j + 1] << 8) | buf[j];
         advancePos(pos, 4);
-        return size;
+        return size >>> 0;
     },
     tryParseUint64 (buf: Uint8Array, pos: { pos: number }): [number, number] | undefined {
         const lo = Parser.tryParseUint32(buf, pos);

--- a/src/mono/browser/runtime/diagnostics/server_pthread/protocol-socket.ts
+++ b/src/mono/browser/runtime/diagnostics/server_pthread/protocol-socket.ts
@@ -10,6 +10,7 @@ import {
 import Magic from "./ipc-protocol/magic";
 import Parser from "./ipc-protocol/base-parser";
 import { assertNever } from "../../types/internal";
+import { loaderHelpers, mono_assert } from "../../globals";
 import { mono_log_debug, mono_log_warn } from "../../logging";
 
 export const dotnetDiagnosticsServerProtocolCommandEvent = "dotnet:diagnostics:protocolCommand" as const;
@@ -177,6 +178,7 @@ class ProtocolSocketImpl implements ProtocolSocket {
 
     onMessage (this: ProtocolSocketImpl, ev: MessageEvent<ArrayBuffer | Blob | string>): void {
         const data = ev.data;
+        mono_assert(!loaderHelpers.is_exited(), "runtime is exited");
         mono_log_debug(() => `protocol socket received message ${ev.data}`);
         if (typeof data === "object" && data instanceof ArrayBuffer) {
             this.onArrayBuffer(data);

--- a/src/mono/browser/runtime/diagnostics/server_pthread/socket-connection.ts
+++ b/src/mono/browser/runtime/diagnostics/server_pthread/socket-connection.ts
@@ -4,6 +4,7 @@
 import { assertNever } from "../../types/internal";
 import { VoidPtr } from "../../types/emscripten";
 import type { CommonSocket } from "./common-socket";
+import { loaderHelpers, mono_assert } from "../../globals";
 import { mono_log_debug, mono_log_warn } from "../../logging";
 import { localHeapViewU8 } from "../../memory";
 enum ListenerState {
@@ -34,6 +35,7 @@ export class EventPipeSocketConnection {
     private _state: ListenerState;
     readonly stream: SocketGuts;
     constructor (socket: CommonSocket) {
+        mono_assert(!loaderHelpers.is_exited(), "runtime is exited");
         this._state = ListenerState.Sending;
         this.stream = new SocketGuts(socket);
     }

--- a/src/mono/browser/runtime/startup.ts
+++ b/src/mono/browser/runtime/startup.ts
@@ -294,6 +294,9 @@ async function onRuntimeInitializedAsync (userOnRuntimeInitialized: (module:Emsc
             update_thread_info();
             runtimeHelpers.managedThreadTID = tcwraps.mono_wasm_create_deputy_thread();
 
+            // this is not mono-attached thread, so we can start it earlier
+            await mono_wasm_init_diagnostics();
+
             // await mono started on deputy thread
             await runtimeHelpers.afterMonoStarted.promise;
             runtimeHelpers.ioThreadTID = tcwraps.mono_wasm_create_io_thread();
@@ -546,11 +549,6 @@ export async function start_runtime () {
 
         if (runtimeHelpers.config.logProfilerOptions)
             mono_wasm_init_log_profiler(runtimeHelpers.config.logProfilerOptions);
-
-        if (WasmEnableThreads) {
-            // this is not mono-attached thread, so we can start it earlier
-            await mono_wasm_init_diagnostics();
-        }
 
         mono_wasm_load_runtime();
 

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -540,6 +540,7 @@ export const enum WorkerToMainMessageType {
     deputyFailed = "deputyFailed",
     deputyStarted = "monoStarted",
     deputyReady = "deputyReady",
+    diagnosticServerInit = "diagnosticServerInit",
     ioStarted = "ioStarted",
     preload = "preload",
 }

--- a/src/mono/mono/component/diagnostics_server.c
+++ b/src/mono/mono/component/diagnostics_server.c
@@ -67,7 +67,7 @@ mono_wasm_diagnostic_server_resume_runtime_startup (void);
 static bool
 ds_server_wasm_init (void)
 {
-	/* called on the main thread when the runtime is sufficiently initialized */
+	/* called on the deputy thread when the runtime is sufficiently initialized */
 	mono_coop_sem_init (&wasm_ds_options.suspend_resume, 0);
 	mono_wasm_diagnostic_server_on_runtime_server_init(&wasm_ds_options);
 	return true;

--- a/src/mono/mono/component/diagnostics_server.c
+++ b/src/mono/mono/component/diagnostics_server.c
@@ -86,20 +86,6 @@ ds_server_wasm_pause_for_diagnostics_monitor (void)
 {
 	/* wait until the DS receives a resume */
 	if (wasm_ds_options.suspend) {
-		/* WISH: it would be better if we split mono_runtime_init_checked() (and runtime
-		 * initialization in general) into two separate functions that we could call from
-		 * JS, and wait for the resume event in JS.  That would allow the browser to remain
-		 * responsive.
-		 *
-		 * (We can't pause earlier because we need to start up enough of the runtime that DS
-		 * can call ep_enable_2() and get session IDs back.  Which seems to require
-		 * mono_jit_init_version() to be called. )
-		 *
-		 * With the current setup we block the browser UI.  Emscripten still processes its
-		 * queued work in futex_wait_busy, so at least other pthreads aren't waiting for us.
-		 * But the user can't interact with the browser tab at all. Even the JS console is
-		 * not displayed.
-		 */
 		int res = mono_coop_sem_wait(&wasm_ds_options.suspend_resume, MONO_SEM_FLAGS_NONE);
 		g_assert (res == 0);
 	}

--- a/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
+++ b/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
@@ -3,7 +3,11 @@
     <WasmBuildNative>true</WasmBuildNative>
     <FeatureWasmPerfTracing>true</FeatureWasmPerfTracing>
     <WasmEnableThreads>true</WasmEnableThreads>
+    <WasmEnableWebcil>false</WasmEnableWebcil>
     <WasmEnablePerfTracing>true</WasmEnablePerfTracing>
+    <HybridGlobalization>false</HybridGlobalization>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <DebugType>portable</DebugType>
     <NoWarn>$(NoWarn);CA2007</NoWarn> <!-- consider ConfigureAwait() -->
     <MonoDiagnosticsMock Condition="('$(MonoDiagnosticsMock)' == '') and ('$(Configuration)' == 'Debug' or '$(ArchiveTests)' == 'true')">true</MonoDiagnosticsMock>
   </PropertyGroup>
@@ -26,7 +30,7 @@
 {
   "MONO_LOG_LEVEL": "warning",
   "MONO_LOG_MASK": "all",
-  "DOTNET_DiagnosticPorts": "mock:./mock.js,suspend",
+  "DOTNET_DiagnosticPorts": "mock:../mock.js,suspend",
   "CI_TEST": "$(ArchiveTests)"
 }' />
   </ItemGroup>

--- a/src/mono/sample/wasm/browser-eventpipe/index.html
+++ b/src/mono/sample/wasm/browser-eventpipe/index.html
@@ -14,7 +14,7 @@
   <h3 id="header">Wasm Browser EventPipe profiling Sample</h3>
   <div>
     <button id="startWork">Start Work</button>
-    <label for="inputN">N:</label> <input type="number" id="inputN" value="10"/>
+    <label for="inputN">N:</label> <input type="number" id="inputN" value="25"/>
   </div>
   <div>Computing Fib(N) repeatedly: <span id="out"></span>
 </body>

--- a/src/mono/sample/wasm/browser-eventpipe/main.js
+++ b/src/mono/sample/wasm/browser-eventpipe/main.js
@@ -54,6 +54,8 @@ async function main() {
         .withElementOnExit()
         .withExitCodeLogging()
         .withDiagnosticTracing(false)
+        //.withEnvironmentVariable("MONO_DIAGNOSTICS", "--diagnostic-mono-profiler=enable")// --diagnostic-ports=mock:../mock.js,suspend
+        //.withEnvironmentVariable("DOTNET_DiagnosticPorts", "mock:../mock.js,suspend")
         .withConfig({
             pthreadPoolInitialSize: 7,
         })

--- a/src/mono/sample/wasm/browser-eventpipe/main.js
+++ b/src/mono/sample/wasm/browser-eventpipe/main.js
@@ -21,10 +21,10 @@ async function doWork(startWork, stopWork, getIterationsDone) {
     document.getElementById("startWork").innerText = "Stopping";
     document.getElementById("out").innerHTML = '... ...';
 
-    stopWork();
+    await stopWork();
 
     const ret = await workPromise; // get the answer
-    const iterations = getIterationsDone(); // get how many times the loop ran
+    const iterations = await getIterationsDone(); // get how many times the loop ran
 
     INTERNAL.diagnosticServerThread.postMessageToWorker({
         type: "diagnostic_server_mock",
@@ -54,6 +54,12 @@ async function main() {
         .withElementOnExit()
         .withExitCodeLogging()
         .withDiagnosticTracing(false)
+        .withConfig({
+            pthreadPoolInitialSize: 7,
+        })
+        .withRuntimeOptions([
+            "--no-jiterpreter-traces-enabled"
+        ])
         .create();
 
     globalThis.__Module = Module;
@@ -96,6 +102,8 @@ async function main() {
             document.body.removeChild(link);
         }
     });
+
+    INTERNAL.diagnosticServerThread.port.start();
 
     const config = getConfig();
     if (isTest(config)) {

--- a/src/mono/sample/wasm/browser-eventpipe/mock.js
+++ b/src/mono/sample/wasm/browser-eventpipe/mock.js
@@ -4,11 +4,11 @@
 /// @ts-check
 
 /**
- * @typedef { import("../../../wasm/runtime/diagnostics-mock").MockEnvironment } MockEnvironment
- * @typedef { import("../../../wasm/runtime/diagnostics-mock").MockScriptConnection } MockScriptConnection
- * @typedef { import("../../../wasm/runtime/diagnostics-mock").PromiseAndController } PromiseAndController
- * @typedef { import("../../../wasm/runtime/diagnostics-mock").PromiseAndController<number> } PromiseAndControllerNumber
- * @typedef { import("../../../wasm/runtime/diagnostics-mock").PromiseAndController<void> } PromiseAndControllerVoid
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").MockEnvironment } MockEnvironment
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").MockScriptConnection } MockScriptConnection
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").PromiseAndController } PromiseAndController
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").PromiseAndController<number> } PromiseAndControllerNumber
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").PromiseAndController<void> } PromiseAndControllerVoid
  */
 
 /**
@@ -62,7 +62,7 @@ function script(env) {
                     ]
                 }));
                 let sessionID = undefined;
-                const buffer = new SharedArrayBuffer(2_000_000);
+                const buffer = new SharedArrayBuffer(20_000_000);
                 const view = new Uint8Array(buffer);
                 let length = 0;
                 await conn.processSend((bytes) => {

--- a/src/mono/sample/wasm/browser-eventpipe/mock2.js
+++ b/src/mono/sample/wasm/browser-eventpipe/mock2.js
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/// @ts-check
+
+/**
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").MockEnvironment } MockEnvironment
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").MockScriptConnection } MockScriptConnection
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").PromiseAndController } PromiseAndController
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").PromiseAndController<number> } PromiseAndControllerNumber
+ * @typedef { import("../../../browser/runtime/diagnostics-mock").PromiseAndController<void> } PromiseAndControllerVoid
+ */
+
+// "Microsoft-Windows-DotNETRuntime"
+const DotNETRuntimeKeywords = {
+    GC_KEYWORD: 0x1n,
+    GC_HANDLE_KEYWORD: 0x2n,
+    LOADER_KEYWORD: 0x8n,
+    JIT_KEYWORD: 0x10n,
+    APP_DOMAIN_RESOURCE_MANAGEMENT_KEYWORD: 0x800n,
+    CONTENTION_KEYWORD: 0x4000n,
+    EXCEPTION_KEYWORD: 0x8000n,
+    THREADING_KEYWORD: 0x10000n,
+    TYPE_KEYWORD: 0x80000n,
+    GC_HEAP_DUMP_KEYWORD: 0x100000n,
+    GC_ALLOCATION_KEYWORD: 0x200000n,
+    GC_MOVES_KEYWORD: 0x400000n,
+    GC_HEAP_COLLECT_KEYWORD: 0x800000n,
+    GC_HEAP_AND_TYPE_NAMES_KEYWORD: 0x1000000n,
+    GC_FINALIZATION_KEYWORD: 0x1000000n,
+    GC_RESIZE_KEYWORD: 0x2000000n,
+    GC_ROOT_KEYWORD: 0x4000000n,
+    GC_HEAP_DUMP_VTABLE_CLASS_REF_KEYWORD: 0x8000000n,
+    METHOD_TRACING_KEYWORD: 0x20000000n,
+    TYPE_DIAGNOSTIC_KEYWORD: 0x8000000000n,
+    TYPE_LOADING_KEYWORD: 0x8000000000n,
+    MONITOR_KEYWORD: 0x10000000000n,
+    METHOD_INSTRUMENTATION_KEYWORD: 0x40000000000n,
+}
+
+/**
+ * @returns {[number,number]}
+ * */
+function lo_hi(value) {
+    return [Number(value & 0xFFFFFFFFn), Number(value >> 32n)]
+}
+
+/**
+ * @param {MockEnvironment} env
+ * @returns {((conn: MockScriptConnection) => Promise<void>)[]}
+ * */
+function script(env) {
+    /** @type { PromiseAndControllerNumber } */
+    const sessionStarted = env.createPromiseController();
+    /** @type { PromiseAndControllerVoid } */
+    const runtimeResumed = env.createPromiseController();
+    /** @type { PromiseAndControllerVoid } */
+    const waitForever = env.createPromiseController();
+
+    /** @type { PromiseAndControllerVoid } */
+    const fibonacciDone = env.createPromiseController();
+    env.addEventListenerFromBrowser("fibonacci-done", (event) => {
+        fibonacciDone.promise_control.resolve();
+    });
+
+    return [
+        async (conn) => {
+            await Promise.all([conn.waitForSend(env.expectAdvertise)]);
+            console.warn("resuming runtime");
+            conn.reply(env.command.makeProcessResumeRuntime());
+            runtimeResumed.promise_control.resolve();
+        },
+        async (conn) => {
+            try {
+                await conn.waitForSend(env.expectAdvertise);
+                await runtimeResumed.promise;
+                console.warn("session start");
+                conn.reply(env.command.makeEventPipeCollectTracing2({
+                    circularBufferMB: 256,
+                    format: 1,
+                    requestRundown: false,
+                    providers: [
+                        {
+                            keywords: [0xFFFFFFFF, 0xFFFFFFFF],
+                            logLevel: 4,
+                            provider_name: "Microsoft-Windows-DotNETRuntime",
+                            filter_data: null
+                        },
+                        {
+                            keywords: [0xFFFFFFFF, 0xFFFFFFFF],
+                            logLevel: 4,
+                            provider_name: "Microsoft-Windows-DotNETRuntimePrivate",
+                            filter_data: null
+                        }
+                    ]
+                }));
+                let sessionID = undefined;
+                const buffer = new SharedArrayBuffer(20_000_000);
+                const view = new Uint8Array(buffer);
+                let length = 0;
+                await conn.processSend((bytes) => {
+                    if (sessionID === undefined) {
+                        // first block is just a session handshake
+                        if (!env.reply.expectOk(4)) {
+                            throw new Error("bad data");
+                        }
+                        sessionID = env.reply.extractOkSessionID(bytes)
+                        sessionStarted.promise_control.resolve(sessionID);
+                        env.postMessageToBrowser({ cmd: "collecting" });
+                    }
+                    else {
+                        const bytesView = new Uint8Array(bytes)
+                        view.set(bytesView, length);
+                        length += bytesView.byteLength;
+                    }
+                });
+                console.warn("final totalBytesStreamed " + length);
+                env.postMessageToBrowser({ cmd: "collected", buffer, length });
+            }
+            catch (err) {
+                console.error(err)
+            }
+        },
+        async (conn) => {
+            await Promise.all([conn.waitForSend(env.expectAdvertise), runtimeResumed.promise, sessionStarted.promise, fibonacciDone.promise]);
+            const sessionID = await sessionStarted.promise;
+            console.warn("delaying 5 seconds before stopping tracing");
+            await env.delay(5000);
+            console.warn("delaying done, stopping tracing");
+            conn.reply(env.command.makeEventPipeStopTracing({ sessionID }));
+        },
+        async (conn) => {
+            await conn.waitForSend(env.expectAdvertise);
+            await waitForever.promise;
+        }
+    ];
+};
+
+export default script;


### PR DESCRIPTION
- start diagnostics server from UI thread
- pass diagnosticServerInit message to UI thread to run postServerAttachToRuntime there
- fix loaderHelpers in runtime/diagnostics TS folder
- fix EP sample
- document how to disable jiterpreter in JS