### PR TITLE
[cDAC] SOSDacImpl::GetMethodDescData DynamicMethodObject

### DIFF
--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -360,10 +360,10 @@ internal sealed unsafe partial class SOSDacImpl
             }
 #endif
 
-            // Since the cDAC does not currently support fetching CorLib bound managed fields,
-            // this API does not populate the data->managedDynamicMethodObject field as in the
-            // legacy implementation. While the field is unused, it must remain in the return
-            // type for compatibility.
+            // Unlike the legacy implementation, the cDAC does not currently populate
+            // data->managedDynamicMethodObject. This field is unused in both SOS and CLRMD
+            // and would require accessing CorLib bound managed fields which the cDAC does not
+            // currently support. However, it must remain in the return type for compatibility.
 
             hr = HResults.S_OK;
         }

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -362,8 +362,8 @@ internal sealed unsafe partial class SOSDacImpl
 
             // Since the cDAC does not currently support fetching CorLib bound managed fields,
             // this API does not populate the data->managedDynamicMethodObject field as in the
-            // original implementation. While the field is unused, it must remain in the
-            // return type for compatibility.
+            // legacy implementation. While the field is unused, it must remain in the return
+            // type for compatibility.
 
             hr = HResults.S_OK;
         }

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -360,10 +360,10 @@ internal sealed unsafe partial class SOSDacImpl
             }
 #endif
 
-            if (data->bIsDynamic != 0)
-            {
-                throw new NotImplementedException(); // TODO[cdac]: get the dynamic method managed object
-            }
+            // Since the cDAC does not currently support fetching CorLib bound managed fields,
+            // this API does not populate the data->managedDynamicMethodObject field as in the
+            // original implementation. While this field appears to be unused, it must remain
+            // in the return type for compatibility.
 
             hr = HResults.S_OK;
         }
@@ -405,7 +405,8 @@ internal sealed unsafe partial class SOSDacImpl
                 Debug.Assert(data->MDToken == dataLocal.MDToken);
                 Debug.Assert(data->GCInfo == dataLocal.GCInfo);
                 Debug.Assert(data->GCStressCodeCopy == dataLocal.GCStressCodeCopy);
-                Debug.Assert(data->managedDynamicMethodObject == dataLocal.managedDynamicMethodObject);
+                // managedDynamicMethodObject is not currently populated by the cDAC API.
+                // Debug.Assert(data->managedDynamicMethodObject == dataLocal.managedDynamicMethodObject);
                 Debug.Assert(data->requestedIP == dataLocal.requestedIP);
                 Debug.Assert(data->cJittedRejitVersions == dataLocal.cJittedRejitVersions);
 

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -364,6 +364,7 @@ internal sealed unsafe partial class SOSDacImpl
             // data->managedDynamicMethodObject. This field is unused in both SOS and CLRMD
             // and would require accessing CorLib bound managed fields which the cDAC does not
             // currently support. However, it must remain in the return type for compatibility.
+            data->managedDynamicMethodObject = 0;
 
             hr = HResults.S_OK;
         }

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -407,7 +407,7 @@ internal sealed unsafe partial class SOSDacImpl
                 Debug.Assert(data->GCInfo == dataLocal.GCInfo);
                 Debug.Assert(data->GCStressCodeCopy == dataLocal.GCStressCodeCopy);
                 // managedDynamicMethodObject is not currently populated by the cDAC API and may differ from legacyImpl.
-                // Debug.Assert(data->managedDynamicMethodObject == dataLocal.managedDynamicMethodObject);
+                Debug.Assert(data->managedDynamicMethodObject == 0);
                 Debug.Assert(data->requestedIP == dataLocal.requestedIP);
                 Debug.Assert(data->cJittedRejitVersions == dataLocal.cJittedRejitVersions);
 

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -362,8 +362,8 @@ internal sealed unsafe partial class SOSDacImpl
 
             // Since the cDAC does not currently support fetching CorLib bound managed fields,
             // this API does not populate the data->managedDynamicMethodObject field as in the
-            // original implementation. While this field appears to be unused, it must remain
-            // in the return type for compatibility.
+            // original implementation. While the field is unused, it must remain in the
+            // return type for compatibility.
 
             hr = HResults.S_OK;
         }
@@ -405,7 +405,7 @@ internal sealed unsafe partial class SOSDacImpl
                 Debug.Assert(data->MDToken == dataLocal.MDToken);
                 Debug.Assert(data->GCInfo == dataLocal.GCInfo);
                 Debug.Assert(data->GCStressCodeCopy == dataLocal.GCStressCodeCopy);
-                // managedDynamicMethodObject is not currently populated by the cDAC API.
+                // managedDynamicMethodObject is not currently populated by the cDAC API and may differ from legacyImpl.
                 // Debug.Assert(data->managedDynamicMethodObject == dataLocal.managedDynamicMethodObject);
                 Debug.Assert(data->requestedIP == dataLocal.requestedIP);
                 Debug.Assert(data->cJittedRejitVersions == dataLocal.cJittedRejitVersions);


### PR DESCRIPTION
Contributes to #109426

Previously the cDAC version of `GetMethodDescData` would throw if a method is dynamic because fetching the `managedDynamicMethodObject` was not supported. The `managedDynamicMethodObject` is a small portion of the returned information for dynamic methods and is unused in both [SOS](https://github.com/search?q=repo%3Adotnet%2Fdiagnostics+managedDynamicMethodObject&type=code) and [CLRMD](https://github.com/search?q=repo%3Amicrosoft%2Fclrmd%20manageddynamicmethodobject&type=code).

Since it is a relatively large lift to access this field (on a CorLib bound managed object) I believe it is reasonable to leave this field blank for now. Due to compatibility with the legacy implementation we need to keep the return object the same so the field is zero'd out.