### PR TITLE
Don't wait for finalizers in 'IReferenceTrackerHost::ReleaseDisconnectedReferenceSources'

### DIFF
--- a/src/coreclr/interop/trackerobjectmanager.cpp
+++ b/src/coreclr/interop/trackerobjectmanager.cpp
@@ -84,7 +84,10 @@ namespace
 
     STDMETHODIMP HostServices::ReleaseDisconnectedReferenceSources()
     {
-        return InteropLibImports::WaitForRuntimeFinalizerForExternal();
+        // This could lead to deadlock if finalizer thread is trying to get back to this thread, because we are
+        // not pumping anymore. Disable this for now. See: https://github.com/dotnet/runtime/issues/109538.
+        // return InteropLibImports::WaitForRuntimeFinalizerForExternal();
+        return S_OK;
     }
 
     STDMETHODIMP HostServices::NotifyEndOfReferenceTrackingOnThread()

--- a/src/coreclr/interop/trackerobjectmanager.cpp
+++ b/src/coreclr/interop/trackerobjectmanager.cpp
@@ -84,9 +84,9 @@ namespace
 
     STDMETHODIMP HostServices::ReleaseDisconnectedReferenceSources()
     {
-        // This could lead to deadlock if finalizer thread is trying to get back to this thread, because we are
+        // We'd like to call InteropLibImports::WaitForRuntimeFinalizerForExternal() here, but this could
+        // lead to deadlock if the finalizer thread is trying to get back to this thread, because we are
         // not pumping anymore. Disable this for now. See: https://github.com/dotnet/runtime/issues/109538.
-        // return InteropLibImports::WaitForRuntimeFinalizerForExternal();
         return S_OK;
     }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -1420,7 +1420,9 @@ namespace System.Runtime.InteropServices
         {
             try
             {
-                GC.WaitForPendingFinalizers();
+                // This could lead to deadlock if finalizer thread is trying to get back to this thread, because we are
+                // not pumping anymore. Disable this for now. See: https://github.com/dotnet/runtime/issues/109538.
+                // GC.WaitForPendingFinalizers();
                 return HResults.S_OK;
             }
             catch (Exception e)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -1418,17 +1418,10 @@ namespace System.Runtime.InteropServices
         [UnmanagedCallersOnly]
         internal static unsafe int IReferenceTrackerHost_ReleaseDisconnectedReferenceSources(IntPtr pThis)
         {
-            try
-            {
-                // We'd like to call GC.WaitForPendingFinalizers() here, but this could lead to deadlock
-                // if the finalizer thread is trying to get back to this thread, because we are not pumping
-                // anymore. Disable this for now. See: https://github.com/dotnet/runtime/issues/109538.
-                return HResults.S_OK;
-            }
-            catch (Exception e)
-            {
-                return Marshal.GetHRForException(e);
-            }
+            // We'd like to call GC.WaitForPendingFinalizers() here, but this could lead to deadlock
+            // if the finalizer thread is trying to get back to this thread, because we are not pumping
+            // anymore. Disable this for now. See: https://github.com/dotnet/runtime/issues/109538.
+            return HResults.S_OK;
         }
 
         [UnmanagedCallersOnly]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -1420,9 +1420,9 @@ namespace System.Runtime.InteropServices
         {
             try
             {
-                // This could lead to deadlock if finalizer thread is trying to get back to this thread, because we are
-                // not pumping anymore. Disable this for now. See: https://github.com/dotnet/runtime/issues/109538.
-                // GC.WaitForPendingFinalizers();
+                // We'd like to call GC.WaitForPendingFinalizers() here, but this could lead to deadlock
+                // if the finalizer thread is trying to get back to this thread, because we are not pumping
+                // anymore. Disable this for now. See: https://github.com/dotnet/runtime/issues/109538.
                 return HResults.S_OK;
             }
             catch (Exception e)


### PR DESCRIPTION
### Contributes to #109538

This PR updates the `IReferenceTrackerHost::ReleaseDisconnectedReferenceSources` implementation for CoreCLR and NativeAOT to match what .NET Native was doing, and not wait for finalizers, to avoid deadlocks in ASTA scenarios (UWP). Finalizers will just continue running normally, and if the process is suspended (which can only happen on UWP anyway), they'll resume when the process is resumed later on. Worst case scenario this would only cause a non-optimal memory use cleanup before suspension (which is better than a deadlock anyway). Can be revisited and improved for .NET 10 if needed.