### PR TITLE
Fix potential NRE in GenericSpecializationPartCreationInfo

### DIFF
--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericSpecializationPartCreationInfo.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericSpecializationPartCreationInfo.cs
@@ -581,8 +581,8 @@ namespace System.ComponentModel.Composition.ReflectionModel
             {
                 if (!GenericServices.CanSpecialize(
                     specialization[i],
-                    (genericParameterConstraints![i] as Type[]).CreateTypeSpecializations(specialization),
-                    genericParameterAttributes![i]))
+                    (genericParameterConstraints[i] as Type[]).CreateTypeSpecializations(specialization),
+                    genericParameterAttributes[i]))
                 {
                     return false;
                 }

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericSpecializationPartCreationInfo.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericSpecializationPartCreationInfo.cs
@@ -562,12 +562,17 @@ namespace System.ComponentModel.Composition.ReflectionModel
                 return true;
             }
 
-            if ((genericParameterConstraints != null) && (genericParameterConstraints.Length != partArity))
+            if ((genericParameterConstraints == null) || (genericParameterAttributes == null))
             {
                 return false;
             }
 
-            if ((genericParameterAttributes != null) && (genericParameterAttributes.Length != partArity))
+            if (genericParameterConstraints.Length != partArity)
+            {
+                return false;
+            }
+
+            if (genericParameterAttributes.Length != partArity)
             {
                 return false;
             }


### PR DESCRIPTION
Method GenericSpecializationPartCreationInfo.CanSpecialize checks that arrays genericParameterConstraints and genericParameterAttributes are both null or have expected lengths only. But it doesn't check that one of genericParameterConstraints and genericParameterAttributes is null, but other is not null and have expected length. In this case it will be NullReferenceException.

Now these arrays are either saved to metadata together or not saved together: 

```
internal static IDictionary<string, object?> GetPartMetadataForType(this Type type, CreationPolicy creationPolicy)
{
...
                if (hasConstraints)
                {
                    dictionary.Add(CompositionConstants.GenericParameterConstraintsMetadataName, genericParameterConstraints);
                    dictionary.Add(CompositionConstants.GenericParameterAttributesMetadataName, genericParameterAttributes);
                }
...
}
```

So in case when one if it is null and other is not null, we can return false instead of NullReferenceException.

Found by Linux Verification Center (linuxtesting.org) with SVACE.