### PR TITLE
Remove duplicate IsAscii check in string.IsNormalized

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -13,10 +12,10 @@ namespace System.Globalization
         {
             CheckNormalizationForm(normalizationForm);
 
-            // In Invariant mode we assume all characters are normalized.
-            if (GlobalizationMode.Invariant || source.IsEmpty || Ascii.IsValid(source))
+            // In Invariant mode we assume all characters are normalized because we don't support any linguistic operations on strings.
+            // If it's ASCII && one of the 4 main forms, then it's already normalized.
+            if (GlobalizationMode.Invariant || Ascii.IsValid(source))
             {
-                // This is because we don't support any linguistic operation on the strings
                 return true;
             }
 
@@ -29,10 +28,10 @@ namespace System.Globalization
         {
             CheckNormalizationForm(normalizationForm);
 
-            if (GlobalizationMode.Invariant)
+            // In Invariant mode we assume all characters are normalized because we don't support any linguistic operations on strings.
+            // If it's ASCII && one of the 4 main forms, then it's already normalized.
+            if (GlobalizationMode.Invariant || Ascii.IsValid(strInput))
             {
-                // In Invariant mode we assume all characters are normalized.
-                // This is because we don't support any linguistic operation on the strings
                 return strInput;
             }
 
@@ -45,17 +44,10 @@ namespace System.Globalization
         {
             CheckNormalizationForm(normalizationForm);
 
-            if (source.IsEmpty)
-            {
-                charsWritten = 0;
-                return true;
-            }
-
+            // In Invariant mode we assume all characters are normalized because we don't support any linguistic operations on strings.
+            // If it's ASCII && one of the 4 main forms, then it's already normalized.
             if (GlobalizationMode.Invariant || Ascii.IsValid(source))
             {
-                // In Invariant mode we assume all characters are normalized.
-                // This is because we don't support any linguistic operation on the strings
-
                 if (source.TryCopyTo(destination))
                 {
                     charsWritten = source.Length;
@@ -75,10 +67,10 @@ namespace System.Globalization
         {
             CheckNormalizationForm(normalizationForm);
 
-            if (GlobalizationMode.Invariant || source.IsEmpty || Ascii.IsValid(source))
+            // In Invariant mode we assume all characters are normalized because we don't support any linguistic operations on strings.
+            // If it's ASCII && one of the 4 main forms, then it's already normalized.
+            if (GlobalizationMode.Invariant || Ascii.IsValid(source))
             {
-                // In Invariant mode we assume all characters are normalized.
-                // This is because we don't support any linguistic operation on the strings
                 return source.Length;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Buffers.Text;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -709,15 +708,6 @@ namespace System
 
         public bool IsNormalized(NormalizationForm normalizationForm)
         {
-            if (Ascii.IsValid(this))
-            {
-                // If its ASCII && one of the 4 main forms, then its already normalized
-                if (normalizationForm == NormalizationForm.FormC ||
-                    normalizationForm == NormalizationForm.FormKC ||
-                    normalizationForm == NormalizationForm.FormD ||
-                    normalizationForm == NormalizationForm.FormKD)
-                    return true;
-            }
             return Normalization.IsNormalized(this, normalizationForm);
         }
 
@@ -728,15 +718,6 @@ namespace System
 
         public string Normalize(NormalizationForm normalizationForm)
         {
-            if (Ascii.IsValid(this))
-            {
-                // If its ASCII && one of the 4 main forms, then its already normalized
-                if (normalizationForm == NormalizationForm.FormC ||
-                    normalizationForm == NormalizationForm.FormKC ||
-                    normalizationForm == NormalizationForm.FormD ||
-                    normalizationForm == NormalizationForm.FormKD)
-                    return this;
-            }
             return Normalization.Normalize(this, normalizationForm);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/StringNormalizationExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/StringNormalizationExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text;
 
 namespace System
@@ -41,7 +42,7 @@ namespace System
         /// <returns><see langword="true"/> if the specified span of characters is in a normalized form; otherwise, <see langword="false"/>.</returns>
         /// <exception cref="ArgumentException">The specified character span contains an invalid code point or the normalization form is invalid.</exception>
         public static bool IsNormalized(this ReadOnlySpan<char> source, NormalizationForm normalizationForm = NormalizationForm.FormC) =>
-            System.Globalization.Normalization.IsNormalized(source, normalizationForm);
+            Normalization.IsNormalized(source, normalizationForm);
 
         /// <summary>
         /// Normalizes the specified string to the <see cref="NormalizationForm.FormC" />.
@@ -77,7 +78,7 @@ namespace System
         /// <returns><see langword="true"/> if the specified span of characters was successfully normalized; otherwise, <see langword="false"/>.</returns>
         /// <exception cref="ArgumentException">The specified character span contains an invalid code point or the normalization form is invalid.</exception>
         public static bool TryNormalize(this ReadOnlySpan<char> source, Span<char> destination, out int charsWritten, NormalizationForm normalizationForm = NormalizationForm.FormC) =>
-            System.Globalization.Normalization.TryNormalize(source, destination, out charsWritten, normalizationForm);
+            Normalization.TryNormalize(source, destination, out charsWritten, normalizationForm);
 
         /// <summary>
         /// Gets the estimated length of the normalized form of the specified string in the <see cref="NormalizationForm.FormC" />.
@@ -87,6 +88,6 @@ namespace System
         /// <returns>The estimated length of the normalized form of the specified string.</returns>
         /// <exception cref="ArgumentException">The specified character span contains an invalid code point or the normalization form is invalid.</exception>
         public static int GetNormalizedLength(this ReadOnlySpan<char> source, NormalizationForm normalizationForm = NormalizationForm.FormC) =>
-            System.Globalization.Normalization.GetNormalizedLength(source, normalizationForm);
+            Normalization.GetNormalizedLength(source, normalizationForm);
     }
 }


### PR DESCRIPTION
Introduced in #110465

`Normalization.IsNormalized` now does the ASCII check, so we can skip it in `string.IsNormalized` that just calls the former.
This also lets us skip the ascii check entirely on Invariant mode.