### PR TITLE
JIT: Fix reporting of tier name metadata

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4053,6 +4053,11 @@ _SetMinOpts:
         {
             codeGen->SetAlignLoops(JitConfig.JitAlignLoops() == 1);
         }
+
+#ifdef DEBUG
+        const char* tieringName = compGetTieringName(true);
+        JitMetadata::report(this, JitMetadata::TieringName, tieringName, strlen(tieringName));
+#endif
     }
 
     fgCanRelocateEHRegions = true;
@@ -7151,13 +7156,6 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE classPtr,
         // Disable JitDisasm for non-optimized code.
         opts.disAsm = false;
     }
-
-#ifdef DEBUG
-    {
-        const char* tieringName = compGetTieringName(true);
-        JitMetadata::report(this, JitMetadata::TieringName, tieringName, strlen(tieringName));
-    }
-#endif
 
 #if COUNT_BASIC_BLOCKS
     bbCntTable.record(fgBBcount);

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -157,12 +157,12 @@ static void PrintDiffsCsvRow(
     bool hasDiff)
 {
     fw.Printf("%d,%u,", context, contextSize);
-    fw.PrintQuotedCsvField(baseRes.CompileResults->MethodFullName == nullptr ? "" : baseRes.CompileResults->MethodFullName);
+    fw.PrintQuotedCsvField(diffRes.CompileResults->MethodFullName == nullptr ? "" : diffRes.CompileResults->MethodFullName);
     fw.Printf(
         ",%s,%s,%s,%s,%s,%lld,%lld",
-        baseRes.CompileResults->TieringName == nullptr ? "" : baseRes.CompileResults->TieringName,
+        diffRes.CompileResults->TieringName == nullptr ? "" : diffRes.CompileResults->TieringName,
         ResultToString(baseRes.Result), ResultToString(diffRes.Result),
-        baseRes.IsMinOpts ? "True" : "False",
+        diffRes.IsMinOpts ? "True" : "False",
         hasDiff ? "True" : "False",
         baseRes.NumExecutedInstructions, diffRes.NumExecutedInstructions);
 


### PR DESCRIPTION
The tier name was reported for both the root and the inlinees. On the SPMI side this would result in using the last tier name reported, which usually would be from an inlinee. The inlinee tier does not always match the root tier, for example when OSR is enabled.