### PR TITLE
SPMI: Avoid duplicate example diffs in diffs summary

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2733,8 +2733,8 @@ class SuperPMIReplayAsmDiffs:
 
                 return 1
 
-            by_small_then_improvement = sorted(by_diff_size_pct, key=is_small_diff)
-            by_small_then_regression = sorted(reversed(by_diff_size_pct), key=is_small_diff)
+            by_improvement_then_small = sorted(by_diff_size_pct, key=is_small_diff)
+            by_regression_then_small = sorted(reversed(by_diff_size_pct), key=is_small_diff)
 
             def pick_examples(diffs, picked_contexts):
                 seen = set()
@@ -2754,10 +2754,10 @@ class SuperPMIReplayAsmDiffs:
 
                 return result
 
-            example_improvements = pick_examples(by_small_then_improvement, set())
+            example_improvements = pick_examples(by_improvement_then_small, set())
 
             example_improvement_contexts = set(row["Context"] for row in example_improvements)
-            example_regressions = pick_examples(by_small_then_regression, example_improvement_contexts)
+            example_regressions = pick_examples(by_regression_then_small, example_improvement_contexts)
 
             contexts = smallest_contexts + top_improvements + top_regressions + top_improvements_pct + top_regressions_pct + smallest_zero_size_contexts + example_improvements + example_regressions
             examples = example_improvements + example_regressions

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1954,7 +1954,7 @@ def aggregate_diff_metrics(details_file):
     # Project out these fields for the saved diffs, to use for further
     # processing. Saving everything into memory is costly on memory when there
     # are a large number of diffs.
-    diffs_fields = ["Context", "Context size", "Base ActualCodeBytes", "Diff ActualCodeBytes", "Base PerfScore", "Diff PerfScore"]
+    diffs_fields = ["Context", "Method full name", "Context size", "Base ActualCodeBytes", "Diff ActualCodeBytes", "Base PerfScore", "Diff PerfScore"]
     diffs = []
 
     for row in read_csv(details_file):
@@ -2725,12 +2725,40 @@ class SuperPMIReplayAsmDiffs:
 
             display_subset("Smallest {} zero sized diffs:", smallest_zero_size_contexts)
 
-            by_diff_size_pct_examples = [diff for diff in by_diff_size_pct if abs(int(diff['Diff ActualCodeBytes']) - int(diff['Base ActualCodeBytes'])) < 50]
-            if len(by_diff_size_pct_examples) == 0:
-                by_diff_size_pct_examples = by_diff_size_pct
+            # Prefer to show small diffs over large percentage wise diffs; sort by this additionally.
+            # sorted is stable, so for multiple small diffs this will keep them in order of percentage wise improvement/regression.
+            def is_small_diff(row):
+                if abs(int(row['Diff ActualCodeBytes']) - int(row['Base ActualCodeBytes'])) < 50:
+                    return 0
 
-            example_improvements = by_diff_size_pct_examples[:3]
-            example_regressions = by_diff_size_pct_examples[3:][-3:]
+                return 1
+
+            by_small_then_improvement = sorted(by_diff_size_pct, key=is_small_diff)
+            by_small_then_regression = sorted(reversed(by_diff_size_pct), key=is_small_diff)
+
+            def pick_examples(diffs, picked_contexts):
+                seen = set()
+                def try_add_seen(row):
+                    len_before = len(seen)
+                    seen.add(row["Method full name"])
+                    return len_before < len(seen)
+
+                result = []
+                for row in diffs:
+                    if not try_add_seen(row) or row["Context"] in picked_contexts:
+                        continue
+
+                    result.append(row)
+                    if len(result) >= 3:
+                        break
+
+                return result
+
+            example_improvements = pick_examples(by_small_then_improvement, set())
+
+            example_improvement_contexts = set(row["Context"] for row in example_improvements)
+            example_regressions = pick_examples(by_small_then_regression, example_improvement_contexts)
+
             contexts = smallest_contexts + top_improvements + top_regressions + top_improvements_pct + top_regressions_pct + smallest_zero_size_contexts + example_improvements + example_regressions
             examples = example_improvements + example_regressions
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2745,7 +2745,7 @@ class SuperPMIReplayAsmDiffs:
 
                 result = []
                 for row in diffs:
-                    if not try_add_seen(row) or row["Context"] in picked_contexts:
+                    if row["Context"] in picked_contexts or not try_add_seen(row):
                         continue
 
                     result.append(row)

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2733,8 +2733,8 @@ class SuperPMIReplayAsmDiffs:
 
                 return 1
 
-            by_improvement_then_small = sorted(by_diff_size_pct, key=is_small_diff)
-            by_regression_then_small = sorted(reversed(by_diff_size_pct), key=is_small_diff)
+            by_small_then_improvement = sorted(by_diff_size_pct, key=is_small_diff)
+            by_small_then_regression = sorted(reversed(by_diff_size_pct), key=is_small_diff)
 
             def pick_examples(diffs, picked_contexts):
                 seen = set()
@@ -2754,10 +2754,10 @@ class SuperPMIReplayAsmDiffs:
 
                 return result
 
-            example_improvements = pick_examples(by_improvement_then_small, set())
+            example_improvements = pick_examples(by_small_then_improvement, set())
 
             example_improvement_contexts = set(row["Context"] for row in example_improvements)
-            example_regressions = pick_examples(by_regression_then_small, example_improvement_contexts)
+            example_regressions = pick_examples(by_small_then_regression, example_improvement_contexts)
 
             contexts = smallest_contexts + top_improvements + top_regressions + top_improvements_pct + top_regressions_pct + smallest_zero_size_contexts + example_improvements + example_regressions
             examples = example_improvements + example_regressions


### PR DESCRIPTION
We frequently see examples like this in the diffs report produced:
![image](https://github.com/user-attachments/assets/583ce306-7ebb-4d25-9a56-dcd81363aa42)

This PR deduplicates the contexts picked by method name, ensuring that we only get one of each name. I've also improved the logic to pick example regressions to show. After:
![image](https://github.com/user-attachments/assets/1dff33fc-7774-49e3-9054-641255db9cb1)

cc @dotnet/jit-contrib 