### PR TITLE
exclude obj/cmake from codeql. 

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -10,4 +10,4 @@ path_classifiers:
     - src/libraries/**/ref/*
     # exclude artifacts/obj/**/CMakeFiles/* since CMake generates random
     # directory names causing creation of duplicate issues
-    - artifacts/obj/**/CMakeFiles/*
+    - artifacts/obj/**/CMakeFiles/**/CheckFunctionExists.c

--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -8,3 +8,6 @@ path_classifiers:
     # be excluded from analysis. If there is a problem at the API layer, the analysis
     # engine will detect the problem in the src/ implementations anyway.
     - src/libraries/**/ref/*
+    # exclude artifacts/obj/**/CMakeFiles/* since CMake generates random
+    # directory names causing creation of duplicate issues
+    - artifacts/obj/**/CMakeFiles/*

--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -8,6 +8,8 @@ path_classifiers:
     # be excluded from analysis. If there is a problem at the API layer, the analysis
     # engine will detect the problem in the src/ implementations anyway.
     - src/libraries/**/ref/*
-    # exclude artifacts/obj/**/CMakeFiles/* since CMake generates random
-    # directory names causing creation of duplicate issues
+    # exclude artifacts/obj/**/CMakeFiles/**/CheckFunctionExists.c since CMake 
+    # generates random directory names causing creation of duplicate issues 
+    # related to obsolete encryption algorithm used. Note that CheckFuntionExists 
+    # is build time only and shouldnt affect the product binares. 
     - artifacts/obj/**/CMakeFiles/**/CheckFunctionExists.c

--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -11,5 +11,6 @@ path_classifiers:
     # exclude artifacts/obj/**/CMakeFiles/**/CheckFunctionExists.c since CMake 
     # generates random directory names causing creation of duplicate issues 
     # related to obsolete encryption algorithm used. Note that CheckFuntionExists 
-    # is build time only and shouldnt affect the product binares. 
+    # files are generated as part of build-time checks in CMake and are not compiled
+    # or linked into any product binaries.
     - artifacts/obj/**/CMakeFiles/**/CheckFunctionExists.c


### PR DESCRIPTION
There are duplicate issues being created due to random directory names generated by cmake in obj/cmake