### PR TITLE
Fix a comment to match the function signature

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1792,8 +1792,6 @@ static void OsAttachThread(void* thread)
 // It fails fast if some other thread value was attached to the current fiber.
 // Parameters:
 //  thread        - thread to detach
-// Return:
-//  true if the thread was detached, false if there was no attached thread
 void OsDetachThread(void* thread)
 {
     ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);


### PR DESCRIPTION
Trivial change. A follow up to https://github.com/dotnet/runtime/pull/110589

Re: https://github.com/dotnet/runtime/pull/110629#discussion_r1881030647

The comment on a function was not adjusted when the function was changed to return void.

