### PR TITLE
[cdac] Always re-read global pointers in `GetUsefulGlobals`

### DIFF
--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -32,7 +32,8 @@ internal sealed unsafe partial class SOSDacImpl
     private readonly Target _target;
 
     // When this class is created, the runtime may not have loaded the string and object method tables and set the global pointers.
-    // They should be set when actually requested via a DAC API, so we lazily read the global pointers.
+    // This is also the case for the GetUsefulGlobals API, which can be called as part of load notifications before runtime start.
+    // They should be set when actually requested via other DAC APIs, so we lazily read the global pointers.
     private readonly Lazy<TargetPointer> _stringMethodTable;
     private readonly Lazy<TargetPointer> _objectMethodTable;
 
@@ -1241,8 +1242,10 @@ internal sealed unsafe partial class SOSDacImpl
         {
             data->ArrayMethodTable = _target.ReadPointer(
                 _target.ReadGlobalPointer(Constants.Globals.ObjectArrayMethodTable));
-            data->StringMethodTable = _stringMethodTable.Value;
-            data->ObjectMethodTable = _objectMethodTable.Value;
+            data->StringMethodTable = _target.ReadPointer(
+                _target.ReadGlobalPointer(Constants.Globals.StringMethodTable));
+            data->ObjectMethodTable = _target.ReadPointer(
+                _target.ReadGlobalPointer(Constants.Globals.ObjectMethodTable));
             data->ExceptionMethodTable = _target.ReadPointer(
                 _target.ReadGlobalPointer(Constants.Globals.ExceptionMethodTable));
             data->FreeMethodTable = _target.ReadPointer(


### PR DESCRIPTION
`GetUsefulGlobals` can be called before the runtime is actually initialized, so we need to re-read the global pointers instead of storing any of them.

Contributes to https://github.com/dotnet/runtime/issues/99302