### PR TITLE
Added check of RequiresValidationContext before calling IsValid

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -33,6 +33,8 @@ namespace System.ComponentModel.DataAnnotations
             Justification = "The ctor is marked with RequiresUnreferencedCode informing the caller to preserve the other property.")]
         protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
+            ArgumentNullException.ThrowIfNull(validationContext);
+            
             var otherPropertyInfo = validationContext.ObjectType.GetRuntimeProperty(OtherProperty);
             if (otherPropertyInfo == null)
             {

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -34,7 +34,7 @@ namespace System.ComponentModel.DataAnnotations
         protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             ArgumentNullException.ThrowIfNull(validationContext);
-            
+
             var otherPropertyInfo = validationContext.ObjectType.GetRuntimeProperty(OtherProperty);
             if (otherPropertyInfo == null)
             {

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -361,7 +361,7 @@ namespace System.ComponentModel.DataAnnotations
             // The IsValid method without a validationContext predates the one accepting the context.
             // This is theoretically unreachable through normal use cases.
             // Instead, the overload using validationContext should be called.
-            return !RequiresValidationContext && IsValid(value, null!) == ValidationResult.Success;
+            return IsValid(value, null!) == ValidationResult.Success;
         }
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -361,7 +361,7 @@ namespace System.ComponentModel.DataAnnotations
             // The IsValid method without a validationContext predates the one accepting the context.
             // This is theoretically unreachable through normal use cases.
             // Instead, the overload using validationContext should be called.
-            return IsValid(value, null!) == ValidationResult.Success;
+            return !RequiresValidationContext && IsValid(value, null!) == ValidationResult.Success;
         }
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/CompareAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/CompareAttributeTests.cs
@@ -99,6 +99,15 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Contains("CustomDisplayName", newErrorMessage);
         }
 
+        [Fact]
+        public static void IsValid_ValidationContextNull_ThrowsArgumentNullException()
+        {
+            var attribute = new CompareAttribute(nameof(CompareObject.ComparePropertyWithDisplayName));
+            var compareObject = new CompareObject("test");
+
+            Assert.Throws<ArgumentNullException>(() => attribute.IsValid(compareObject.CompareProperty));
+        }
+
         private class DerivedCompareAttribute : CompareAttribute
         {
             public DerivedCompareAttribute(string otherProperty) : base(otherProperty) { }


### PR DESCRIPTION
The fix is done to avoid NRE when CompareAttribute's implementation of IsValid(object? value, ValidationContext validationContext) is called with validationContext == null.

Fix #42490

Found by Linux Verification Center (linuxtesting.org) with SVACE.