### PR TITLE
JIT: Repair profile after tail-merging

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4657,11 +4657,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_CLONE_FINALLY, &Compiler::fgCloneFinally);
 
-    // Drop back to just checking profile likelihoods.
-    //
-    activePhaseChecks &= ~PhaseChecks::CHECK_PROFILE;
-    activePhaseChecks |= PhaseChecks::CHECK_LIKELIHOODS;
-
     // Do some flow-related optimizations
     //
     if (opts.OptimizationEnabled())
@@ -4672,6 +4667,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             return fgHeadTailMerge(true);
         });
 
+        // Drop back to just checking profile likelihoods.
+        //
+        activePhaseChecks &= ~PhaseChecks::CHECK_PROFILE;
+        activePhaseChecks |= PhaseChecks::CHECK_LIKELIHOODS;
+
         // Merge common throw blocks
         //
         DoPhase(this, PHASE_MERGE_THROWS, &Compiler::fgTailMergeThrows);
@@ -4679,6 +4679,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // Run an early flow graph simplification pass
         //
         DoPhase(this, PHASE_EARLY_UPDATE_FLOW_GRAPH, &Compiler::fgUpdateFlowGraphPhase);
+    }
+    else
+    {
+        // Drop back to just checking profile likelihoods.
+        //
+        activePhaseChecks &= ~PhaseChecks::CHECK_PROFILE;
+        activePhaseChecks |= PhaseChecks::CHECK_LIKELIHOODS;
     }
 
     // Promote struct locals

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2438,17 +2438,16 @@ PhaseStatus Compiler::fgTailMergeThrows()
                 {
                     JITDUMP("*** " FMT_BB " now branching to " FMT_BB "\n", predBlock->bbNum, canonicalBlock->bbNum);
                     FlowEdge* prevEdge      = fgGetPredForBlock(nonCanonicalBlock, predBlock);
-                    weight_t  removedWeight = predBlock->bbWeight * prevEdge->getLikelihood();
+                    weight_t  removedWeight = prevEdge->getLikelyWeight();
                     fgReplaceJumpTarget(predBlock, nonCanonicalBlock, canonicalBlock);
 
                     // In practice, when we have true profile data, we can repair it locally here, since the no-return
                     // call means that there is no contribution from nonCanonicalBlock to any of its successors.
                     // Note that this might not be the case if we have profile data from e.g. synthesis, so this
                     // repair is best-effort only.
-                    canonicalBlock->bbWeight += removedWeight;
-                    if (canonicalBlock->bbWeight > BB_ZERO_WEIGHT)
+                    if (canonicalBlock->hasProfileWeight())
                     {
-                        canonicalBlock->RemoveFlags(BBF_RUN_RARELY);
+                        canonicalBlock->setBBProfileWeight(canonicalBlock->bbWeight + removedWeight);
                     }
                     updated = true;
                 }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -6576,6 +6576,14 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
                     FlowEdge* const newEdge = fgAddRefPred(crossJumpTarget, predBlock);
                     predBlock->SetKindAndTargetEdge(BBJ_ALWAYS, newEdge);
                 }
+
+                // For tail merge we have a common successor of predBlock and
+                // crossJumpTarget, so the profile update can be done locally.
+                crossJumpTarget->bbWeight += predBlock->bbWeight;
+                if (crossJumpTarget->bbWeight > BB_ZERO_WEIGHT)
+                {
+                    crossJumpTarget->RemoveFlags(BBF_RUN_RARELY);
+                }
             }
 
             // We changed things

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -6579,10 +6579,9 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
 
                 // For tail merge we have a common successor of predBlock and
                 // crossJumpTarget, so the profile update can be done locally.
-                crossJumpTarget->bbWeight += predBlock->bbWeight;
-                if (crossJumpTarget->bbWeight > BB_ZERO_WEIGHT)
+                if (crossJumpTarget->hasProfileWeight() && predBlock->hasProfileWeight())
                 {
-                    crossJumpTarget->RemoveFlags(BBF_RUN_RARELY);
+                    crossJumpTarget->setBBProfileWeight(crossJumpTarget->bbWeight + predBlock->bbWeight);
                 }
             }
 


### PR DESCRIPTION
We can locally repair PGO data after tail-merging, which should keep global flow preservation. Also, we can do a best-effort repair in the throw-merging phase, but this one is not generally possible to repair locally.

Motivated by a case I saw in diffs of #110404.

Before:
```scala
*************** Finishing PHASE Head and tail merge
Trees after Head and tail merge

---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight        IBC [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                           24533k 24533056 [000..002)-> BB05(1)                 (always)                     i IBC
BB02 [0001]  1       BB05                34933k 34932740 [002..048)-> BB04(0.1),BB03(0.9)     ( cond )                     i IBC bwd bwd-target
BB03 [0002]  1       BB02                31435k 31434760 [048..050)-> BB05(0.889),BB04(0.111) ( cond )                     i IBC bwd
BB04 [0003]  2       BB02,BB03            6994k  6993920 [050..???)-> BB07(1)                 (always)                     i IBC
BB07 [0007]  2       BB04,BB06            6994k  6993920 [058..058)                           (return)                     i IBC
BB05 [0004]  2       BB01,BB03           52472k 52471876 [058..068)-> BB02(0.666),BB06(0.334) ( cond )                     i IBC idxlen bwd bwd-src
BB06 [0005]  1       BB05                17539k 17539136 [068..072)-> BB07(1)                 (always)                     i IBC
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
(return weight does not match entry weight)
After:
```scala
*************** Finishing PHASE Head and tail merge
Trees after Head and tail merge

---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight        IBC [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                           24533k 24533056 [000..002)-> BB05(1)                 (always)                     i IBC
BB02 [0001]  1       BB05                34933k 34932740 [002..048)-> BB04(0.1),BB03(0.9)     ( cond )                     i IBC bwd bwd-target
BB03 [0002]  1       BB02                31435k 31434760 [048..050)-> BB05(0.889),BB04(0.111) ( cond )                     i IBC bwd
BB04 [0003]  2       BB02,BB03            6994k  6993920 [050..???)-> BB07(1)                 (always)                     i IBC
BB07 [0007]  2       BB04,BB06           24533k 24533056 [058..058)                           (return)                     i IBC
BB05 [0004]  2       BB01,BB03           52472k 52471876 [058..068)-> BB02(0.666),BB06(0.334) ( cond )                     i IBC idxlen bwd bwd-src
BB06 [0005]  1       BB05                17539k 17539136 [068..072)-> BB07(1)                 (always)                     i IBC
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```