### PR TITLE
Update install-dependencies to support RedHat

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -27,7 +27,7 @@ case "$os" in
                 libssl-dev libkrb5-dev zlib1g-dev pigz cpio
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-        elif [ "$ID" = "fedora" ]; then
+        elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ]; then
             dnf install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel zlib-devel lttng-ust-devel pigz cpio
         elif [ "$ID" = "alpine" ]; then
             apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev zlib-dev openssl-dev pigz cpio


### PR DESCRIPTION
Adds the RHEL ID along with fedora since in our case the dependencies are the same.

Tested on RHEL 9.