### PR TITLE
[cdac] Fix `ISOSDacInterface13.TraverseLoaderHeap` parameter type

### DIFF
--- a/src/native/managed/cdacreader/src/Legacy/ISOSDacInterface.cs
+++ b/src/native/managed/cdacreader/src/Legacy/ISOSDacInterface.cs
@@ -556,19 +556,12 @@ internal unsafe partial interface ISOSDacInterface12
     int GetGlobalAllocationContext(ulong* allocPtr, ulong* allocLimit);
 }
 
-internal struct VISITHEAP
-{
-    public ulong blockData;
-    public nuint blockSize;
-    public Interop.BOOL blockIsCurrentBlock;
-}
-
 [GeneratedComInterface]
 [Guid("3176a8ed-597b-4f54-a71f-83695c6a8c5e")]
 internal unsafe partial interface ISOSDacInterface13
 {
     [PreserveSig]
-    int TraverseLoaderHeap(ulong loaderHeapAddr, /*LoaderHeapKind*/ int kind, VISITHEAP pCallback);
+    int TraverseLoaderHeap(ulong loaderHeapAddr, /*LoaderHeapKind*/ int kind, /*VISITHEAP*/ delegate* unmanaged<ulong, nuint, Interop.BOOL> pCallback);
     [PreserveSig]
     int GetDomainLoaderAllocator(ulong domainAddress, ulong* pLoaderAllocator);
     [PreserveSig]

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -1412,7 +1412,7 @@ internal sealed unsafe partial class SOSDacImpl
     #endregion ISOSDacInterface12
 
     #region ISOSDacInterface13
-    int ISOSDacInterface13.TraverseLoaderHeap(ulong loaderHeapAddr, /*LoaderHeapKind*/ int kind, VISITHEAP pCallback)
+    int ISOSDacInterface13.TraverseLoaderHeap(ulong loaderHeapAddr, /*LoaderHeapKind*/ int kind, /*VISITHEAP*/ delegate* unmanaged<ulong, nuint, Interop.BOOL> pCallback)
         => _legacyImpl13 is not null ? _legacyImpl13.TraverseLoaderHeap(loaderHeapAddr, kind, pCallback) : HResults.E_NOTIMPL;
     int ISOSDacInterface13.GetDomainLoaderAllocator(ulong domainAddress, ulong* pLoaderAllocator)
         => _legacyImpl13 is not null ? _legacyImpl13.GetDomainLoaderAllocator(domainAddress, pLoaderAllocator) : HResults.E_NOTIMPL;


### PR DESCRIPTION
The `VISITHEAP` parameter is a function pointer, not a struct. I must have just completely failed at reading when I wrote that...

Found this while running the diagnostics repo SOS tests with the cDAC enabled and a debug cdacreader. I was trying to check that https://github.com/dotnet/runtime/pull/110602 should finish out what is needed for `GetMethodDescData`. There's still one more issue I'm investigating where we end up with <unknown> as a method name because our method desc validation (incorrectly) fails.

Contributes to https://github.com/dotnet/runtime/issues/99302