### PR TITLE
[tests] Fix recently added mono test

### DIFF
--- a/src/tests/Loader/classloader/SequentialLayout/ManagedSequential/LargeStructSize_Mono.cs
+++ b/src/tests/Loader/classloader/SequentialLayout/ManagedSequential/LargeStructSize_Mono.cs
@@ -55,7 +55,7 @@ public unsafe class LargeStructSize
     {
     }
 
-    [StructLayout(LayoutKind.Sequential, Size = int.MaxValue - 16 - 1)]
+    [StructLayout(LayoutKind.Sequential, Size = int.MaxValue - 16 + 1)]
     struct BigArray_64_2
     {
     }
@@ -65,9 +65,27 @@ public unsafe class LargeStructSize
     {
     }
 
-    [StructLayout(LayoutKind.Sequential, Size = int.MaxValue - 8 - 1)]
+    [StructLayout(LayoutKind.Sequential, Size = int.MaxValue - 8 + 1)]
     struct BigArray_32_2
     {
+    }
+
+    public static void Test64Bit ()
+    {
+            Assert.Equal(int.MaxValue - (IntPtr.Size * 2), sizeof(BigArray_64_1));
+            Assert.Throws<TypeLoadException>(() => sizeof(BigArray_64_2));
+            Assert.Throws<TypeLoadException>(() => sizeof(X_64));
+            Assert.Throws<TypeLoadException>(() => sizeof(X_explicit_64));
+            Assert.Throws<TypeLoadException>(() => sizeof(Y_64));
+    }
+
+    public static void Test32Bit ()
+    {
+            Assert.Equal(int.MaxValue - (IntPtr.Size * 2), sizeof(BigArray_32_1));
+            Assert.Throws<TypeLoadException>(() => sizeof(BigArray_32_2));
+            Assert.Throws<TypeLoadException>(() => sizeof(X_32));
+            Assert.Throws<TypeLoadException>(() => sizeof(X_explicit_32));
+            Assert.Throws<TypeLoadException>(() => sizeof(Y_32));
     }
 
     [Fact]
@@ -75,19 +93,11 @@ public unsafe class LargeStructSize
     {
         if (Environment.Is64BitProcess)
         {
-            Assert.Equal(int.MaxValue - (IntPtr.Size * 2), sizeof(BigArray_64_1));
-            Assert.Throws<TypeLoadException>(() => sizeof(BigArray_64_2));
-            Assert.Throws<TypeLoadException>(() => sizeof(X_64));
-            Assert.Throws<TypeLoadException>(() => sizeof(X_explicit_64));
-            Assert.Throws<TypeLoadException>(() => sizeof(Y_64));
+            Test64Bit ();
         }
         else
         {
-            Assert.Equal(int.MaxValue - (IntPtr.Size * 2), sizeof(BigArray_32_1));
-            Assert.Throws<TypeLoadException>(() => sizeof(BigArray_32_2));
-            Assert.Throws<TypeLoadException>(() => sizeof(X_32));
-            Assert.Throws<TypeLoadException>(() => sizeof(X_explicit_32));
-            Assert.Throws<TypeLoadException>(() => sizeof(Y_32));
+            Test32Bit ();
         }
     }
 }


### PR DESCRIPTION
There are two issues with the test. Firstly, the `BigArray_x_2` structs were expected to throw type load exception in the test, due to size limit, but their size was decremented by one instead of incremented. Secondly, inlining of `Environment.Is64BitProcess` fails due to class initialization not yet being performed. This means that we would end up initializing both 32bit and 64bit types in the test.

This test has been failing on mono ever since it was added in https://github.com/dotnet/runtime/pull/104393. It seems to have gone undercover because it is not being run as apart of normal desktop runtime tests due to incorrect configuration where it is removed in `Loader.csproj`. This hack was apparently done because disabling the test on coreclr hits a separate issue https://github.com/dotnet/runtime/issues/105964.

Test was consistently failing on mobile where we use a different mechanism for running runtime tests.