### PR TITLE
Fix calling convention mismatch in GC callouts

### DIFF
--- a/src/coreclr/nativeaot/Runtime/RestrictedCallouts.h
+++ b/src/coreclr/nativeaot/Runtime/RestrictedCallouts.h
@@ -97,6 +97,6 @@ private:
     static CrstStatic s_sLock;
 
     // Prototypes for the callouts.
-    typedef void (F_CALL_CONV * GcRestrictedCallbackFunction)(uint32_t uiCondemnedGeneration);
+    typedef void (* GcRestrictedCallbackFunction)(uint32_t uiCondemnedGeneration);
     typedef CLR_BOOL (* HandleTableRestrictedCallbackFunction)(Object * pObject);
 };

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -137,9 +137,9 @@ namespace System.Runtime.InteropServices
 
         public static unsafe void RegisterGCCallbacks()
         {
-            delegate* unmanaged<int, void> gcStartCallback = &GCStartCollection;
-            delegate* unmanaged<int, void> gcStopCallback = &GCStopCollection;
-            delegate* unmanaged<int, void> gcAfterMarkCallback = &GCAfterMarkPhase;
+            delegate* unmanaged[Fastcall]<int, void> gcStartCallback = &GCStartCollection;
+            delegate* unmanaged[Fastcall]<int, void> gcStopCallback = &GCStopCollection;
+            delegate* unmanaged[Fastcall]<int, void> gcAfterMarkCallback = &GCAfterMarkPhase;
 
             if (!RuntimeImports.RhRegisterGcCallout(RuntimeImports.GcRestrictedCalloutKind.StartCollection, (IntPtr)gcStartCallback) ||
                 !RuntimeImports.RhRegisterGcCallout(RuntimeImports.GcRestrictedCalloutKind.EndCollection, (IntPtr)gcStopCallback) ||
@@ -155,7 +155,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Used during GC callback
-        [UnmanagedCallersOnly]
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvFastcall)])]
         private static void GCStartCollection(int condemnedGeneration)
         {
             if (condemnedGeneration >= 2)
@@ -167,7 +167,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Used during GC callback
-        [UnmanagedCallersOnly]
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvFastcall)])]
         private static void GCStopCollection(int condemnedGeneration)
         {
             if (condemnedGeneration >= 2)
@@ -177,7 +177,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Used during GC callback
-        [UnmanagedCallersOnly]
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvFastcall)])]
         private static void GCAfterMarkPhase(int condemnedGeneration)
         {
             DetachNonPromotedObjects();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -137,9 +137,9 @@ namespace System.Runtime.InteropServices
 
         public static unsafe void RegisterGCCallbacks()
         {
-            delegate* unmanaged[Fastcall]<int, void> gcStartCallback = &GCStartCollection;
-            delegate* unmanaged[Fastcall]<int, void> gcStopCallback = &GCStopCollection;
-            delegate* unmanaged[Fastcall]<int, void> gcAfterMarkCallback = &GCAfterMarkPhase;
+            delegate* unmanaged<int, void> gcStartCallback = &GCStartCollection;
+            delegate* unmanaged<int, void> gcStopCallback = &GCStopCollection;
+            delegate* unmanaged<int, void> gcAfterMarkCallback = &GCAfterMarkPhase;
 
             if (!RuntimeImports.RhRegisterGcCallout(RuntimeImports.GcRestrictedCalloutKind.StartCollection, (IntPtr)gcStartCallback) ||
                 !RuntimeImports.RhRegisterGcCallout(RuntimeImports.GcRestrictedCalloutKind.EndCollection, (IntPtr)gcStopCallback) ||
@@ -155,7 +155,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Used during GC callback
-        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvFastcall)])]
+        [UnmanagedCallersOnly]
         private static void GCStartCollection(int condemnedGeneration)
         {
             if (condemnedGeneration >= 2)
@@ -167,7 +167,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Used during GC callback
-        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvFastcall)])]
+        [UnmanagedCallersOnly]
         private static void GCStopCollection(int condemnedGeneration)
         {
             if (condemnedGeneration >= 2)
@@ -177,7 +177,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Used during GC callback
-        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvFastcall)])]
+        [UnmanagedCallersOnly]
         private static void GCAfterMarkPhase(int condemnedGeneration)
         {
             DetachNonPromotedObjects();


### PR DESCRIPTION
Fixes #110607.

The native side expected fastcall, managed side wasn't fastcall.

Filed #110684 on the test hole. We would have caught it during native AOT x86 bringup if this had any tests since this is a guaranteed stack corruption and crash.

Cc @dotnet/interop-contrib 