### PR TITLE
[cdac] Remove GetMethodDescData fallback to legacy DAC

### DIFF
--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -264,7 +264,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
         if ((addressLowBits != TypeHandleBits.MethodTable) && (addressLowBits != TypeHandleBits.TypeDesc))
         {
-            throw new InvalidOperationException("Invalid type handle pointer");
+            throw new ArgumentException("Invalid type handle pointer", nameof(typeHandlePointer));
         }
 
         // if we already validated this address, return a handle
@@ -303,7 +303,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         // Otherwse, get ready to validate
         if (!_typeValidation.TryValidateMethodTablePointer(methodTablePointer))
         {
-            throw new InvalidOperationException("Invalid method table pointer");
+            throw new ArgumentException("Invalid method table pointer", nameof(typeHandlePointer));
         }
         // ok, we validated it, cache the data and add the MethodTable_1 struct to the dictionary
         Data.MethodTable trustedMethodTableData = _target.ProcessedData.GetOrAdd<Data.MethodTable>(methodTablePointer);
@@ -633,7 +633,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
         if (!_methodValidation.ValidateMethodDescPointer(methodDescPointer, out TargetPointer methodDescChunkPointer))
         {
-            throw new InvalidOperationException("Invalid method desc pointer");
+            throw new ArgumentException("Invalid method desc pointer", nameof(methodDescPointer));
         }
 
         // ok, we validated it, cache the data and add the MethodDesc struct to the dictionary

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -195,7 +195,6 @@ internal sealed unsafe partial class SOSDacImpl
             return HResults.E_INVALIDARG;
         }
 
-        int hr = HResults.E_NOTIMPL;
         try
         {
             Contracts.IRuntimeTypeSystem rtsContract = _target.Contracts.RuntimeTypeSystem;
@@ -366,80 +365,73 @@ internal sealed unsafe partial class SOSDacImpl
             // and would require accessing CorLib bound managed fields which the cDAC does not
             // currently support. However, it must remain in the return type for compatibility.
             data->managedDynamicMethodObject = 0;
-
-            hr = HResults.S_OK;
         }
         catch (global::System.Exception ex)
         {
-            hr = ex.HResult;
+            return ex.HResult;
         }
 
 #if DEBUG
         if (_legacyImpl is not null)
         {
-            if (hr == HResults.S_OK) {
-                DacpMethodDescData dataLocal = default;
-                DacpReJitData[]? rgRevertedRejitDataLocal = null;
-                if (rgRevertedRejitData != null)
-                {
-                    rgRevertedRejitDataLocal = new DacpReJitData[cRevertedRejitVersions];
-                }
-                uint cNeededRevertedRejitDataLocal = 0;
-                uint* pcNeededRevertedRejitDataLocal = null;
-                if (pcNeededRevertedRejitData != null)
-                {
-                    pcNeededRevertedRejitDataLocal = &cNeededRevertedRejitDataLocal;
-                }
-                int hrLocal;
-                fixed (DacpReJitData* rgRevertedRejitDataLocalPtr = rgRevertedRejitDataLocal)
-                {
-                    hrLocal = _legacyImpl.GetMethodDescData(methodDesc, ip, &dataLocal, cRevertedRejitVersions, rgRevertedRejitDataLocalPtr, pcNeededRevertedRejitDataLocal);
-                }
-                Debug.Assert(hrLocal == hr);
-                Debug.Assert(data->bHasNativeCode == dataLocal.bHasNativeCode);
-                Debug.Assert(data->bIsDynamic == dataLocal.bIsDynamic);
-                Debug.Assert(data->wSlotNumber == dataLocal.wSlotNumber);
-                Debug.Assert(data->NativeCodeAddr == dataLocal.NativeCodeAddr);
-                Debug.Assert(data->AddressOfNativeCodeSlot == dataLocal.AddressOfNativeCodeSlot);
-                Debug.Assert(data->MethodDescPtr == dataLocal.MethodDescPtr);
-                Debug.Assert(data->MethodTablePtr == dataLocal.MethodTablePtr);
-                Debug.Assert(data->ModulePtr == dataLocal.ModulePtr);
-                Debug.Assert(data->MDToken == dataLocal.MDToken);
-                Debug.Assert(data->GCInfo == dataLocal.GCInfo);
-                Debug.Assert(data->GCStressCodeCopy == dataLocal.GCStressCodeCopy);
-                // managedDynamicMethodObject is not currently populated by the cDAC API and may differ from legacyImpl.
-                Debug.Assert(data->managedDynamicMethodObject == 0);
-                Debug.Assert(data->requestedIP == dataLocal.requestedIP);
-                Debug.Assert(data->cJittedRejitVersions == dataLocal.cJittedRejitVersions);
+            DacpMethodDescData dataLocal = default;
+            DacpReJitData[]? rgRevertedRejitDataLocal = null;
+            if (rgRevertedRejitData != null)
+            {
+                rgRevertedRejitDataLocal = new DacpReJitData[cRevertedRejitVersions];
+            }
+            uint cNeededRevertedRejitDataLocal = 0;
+            uint* pcNeededRevertedRejitDataLocal = null;
+            if (pcNeededRevertedRejitData != null)
+            {
+                pcNeededRevertedRejitDataLocal = &cNeededRevertedRejitDataLocal;
+            }
+            int hrLocal;
+            fixed (DacpReJitData* rgRevertedRejitDataLocalPtr = rgRevertedRejitDataLocal)
+            {
+                hrLocal = _legacyImpl.GetMethodDescData(methodDesc, ip, &dataLocal, cRevertedRejitVersions, rgRevertedRejitDataLocalPtr, pcNeededRevertedRejitDataLocal);
+            }
+            Debug.Assert(hrLocal == HResults.S_OK);
+            Debug.Assert(data->bHasNativeCode == dataLocal.bHasNativeCode);
+            Debug.Assert(data->bIsDynamic == dataLocal.bIsDynamic);
+            Debug.Assert(data->wSlotNumber == dataLocal.wSlotNumber);
+            Debug.Assert(data->NativeCodeAddr == dataLocal.NativeCodeAddr);
+            Debug.Assert(data->AddressOfNativeCodeSlot == dataLocal.AddressOfNativeCodeSlot);
+            Debug.Assert(data->MethodDescPtr == dataLocal.MethodDescPtr);
+            Debug.Assert(data->MethodTablePtr == dataLocal.MethodTablePtr);
+            Debug.Assert(data->ModulePtr == dataLocal.ModulePtr);
+            Debug.Assert(data->MDToken == dataLocal.MDToken);
+            Debug.Assert(data->GCInfo == dataLocal.GCInfo);
+            Debug.Assert(data->GCStressCodeCopy == dataLocal.GCStressCodeCopy);
+            // managedDynamicMethodObject is not currently populated by the cDAC API and may differ from legacyImpl.
+            Debug.Assert(data->managedDynamicMethodObject == 0);
+            Debug.Assert(data->requestedIP == dataLocal.requestedIP);
+            Debug.Assert(data->cJittedRejitVersions == dataLocal.cJittedRejitVersions);
 
-                // rejitDataCurrent
-                Debug.Assert(data->rejitDataCurrent.rejitID == dataLocal.rejitDataCurrent.rejitID);
-                Debug.Assert(data->rejitDataCurrent.NativeCodeAddr == dataLocal.rejitDataCurrent.NativeCodeAddr);
-                Debug.Assert(data->rejitDataCurrent.flags == dataLocal.rejitDataCurrent.flags);
+            // rejitDataCurrent
+            Debug.Assert(data->rejitDataCurrent.rejitID == dataLocal.rejitDataCurrent.rejitID);
+            Debug.Assert(data->rejitDataCurrent.NativeCodeAddr == dataLocal.rejitDataCurrent.NativeCodeAddr);
+            Debug.Assert(data->rejitDataCurrent.flags == dataLocal.rejitDataCurrent.flags);
 
-                // rejitDataRequested
-                Debug.Assert(data->rejitDataRequested.rejitID == dataLocal.rejitDataRequested.rejitID);
-                Debug.Assert(data->rejitDataRequested.NativeCodeAddr == dataLocal.rejitDataRequested.NativeCodeAddr);
-                Debug.Assert(data->rejitDataRequested.flags == dataLocal.rejitDataRequested.flags);
+            // rejitDataRequested
+            Debug.Assert(data->rejitDataRequested.rejitID == dataLocal.rejitDataRequested.rejitID);
+            Debug.Assert(data->rejitDataRequested.NativeCodeAddr == dataLocal.rejitDataRequested.NativeCodeAddr);
+            Debug.Assert(data->rejitDataRequested.flags == dataLocal.rejitDataRequested.flags);
 
-                // rgRevertedRejitData
-                if (rgRevertedRejitData != null && rgRevertedRejitDataLocal != null)
+            // rgRevertedRejitData
+            if (rgRevertedRejitData != null && rgRevertedRejitDataLocal != null)
+            {
+                Debug.Assert(cNeededRevertedRejitDataLocal == *pcNeededRevertedRejitData);
+                for (ulong i = 0; i < cNeededRevertedRejitDataLocal; i++)
                 {
-                    Debug.Assert(cNeededRevertedRejitDataLocal == *pcNeededRevertedRejitData);
-                    for (ulong i = 0; i < cNeededRevertedRejitDataLocal; i++)
-                    {
-                        Debug.Assert(rgRevertedRejitData[i].rejitID == rgRevertedRejitDataLocal[i].rejitID);
-                        Debug.Assert(rgRevertedRejitData[i].NativeCodeAddr == rgRevertedRejitDataLocal[i].NativeCodeAddr);
-                        Debug.Assert(rgRevertedRejitData[i].flags == rgRevertedRejitDataLocal[i].flags);
-                    }
+                    Debug.Assert(rgRevertedRejitData[i].rejitID == rgRevertedRejitDataLocal[i].rejitID);
+                    Debug.Assert(rgRevertedRejitData[i].NativeCodeAddr == rgRevertedRejitDataLocal[i].NativeCodeAddr);
+                    Debug.Assert(rgRevertedRejitData[i].flags == rgRevertedRejitDataLocal[i].flags);
                 }
-            } else {
-                // TODO[cdac]: stop delegating to the legacy DAC
-                hr = _legacyImpl.GetMethodDescData(methodDesc, ip, data, cRevertedRejitVersions, rgRevertedRejitData, pcNeededRevertedRejitData);
             }
         }
 #endif
-        return hr;
+        return HResults.S_OK;
     }
 
     private void CopyNativeCodeVersionToReJitData(

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -195,6 +195,7 @@ internal sealed unsafe partial class SOSDacImpl
             return HResults.E_INVALIDARG;
         }
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IRuntimeTypeSystem rtsContract = _target.Contracts.RuntimeTypeSystem;
@@ -368,7 +369,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (global::System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -391,47 +392,50 @@ internal sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetMethodDescData(methodDesc, ip, &dataLocal, cRevertedRejitVersions, rgRevertedRejitDataLocalPtr, pcNeededRevertedRejitDataLocal);
             }
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(data->bHasNativeCode == dataLocal.bHasNativeCode);
-            Debug.Assert(data->bIsDynamic == dataLocal.bIsDynamic);
-            Debug.Assert(data->wSlotNumber == dataLocal.wSlotNumber);
-            Debug.Assert(data->NativeCodeAddr == dataLocal.NativeCodeAddr);
-            Debug.Assert(data->AddressOfNativeCodeSlot == dataLocal.AddressOfNativeCodeSlot);
-            Debug.Assert(data->MethodDescPtr == dataLocal.MethodDescPtr);
-            Debug.Assert(data->MethodTablePtr == dataLocal.MethodTablePtr);
-            Debug.Assert(data->ModulePtr == dataLocal.ModulePtr);
-            Debug.Assert(data->MDToken == dataLocal.MDToken);
-            Debug.Assert(data->GCInfo == dataLocal.GCInfo);
-            Debug.Assert(data->GCStressCodeCopy == dataLocal.GCStressCodeCopy);
-            // managedDynamicMethodObject is not currently populated by the cDAC API and may differ from legacyImpl.
-            Debug.Assert(data->managedDynamicMethodObject == 0);
-            Debug.Assert(data->requestedIP == dataLocal.requestedIP);
-            Debug.Assert(data->cJittedRejitVersions == dataLocal.cJittedRejitVersions);
-
-            // rejitDataCurrent
-            Debug.Assert(data->rejitDataCurrent.rejitID == dataLocal.rejitDataCurrent.rejitID);
-            Debug.Assert(data->rejitDataCurrent.NativeCodeAddr == dataLocal.rejitDataCurrent.NativeCodeAddr);
-            Debug.Assert(data->rejitDataCurrent.flags == dataLocal.rejitDataCurrent.flags);
-
-            // rejitDataRequested
-            Debug.Assert(data->rejitDataRequested.rejitID == dataLocal.rejitDataRequested.rejitID);
-            Debug.Assert(data->rejitDataRequested.NativeCodeAddr == dataLocal.rejitDataRequested.NativeCodeAddr);
-            Debug.Assert(data->rejitDataRequested.flags == dataLocal.rejitDataRequested.flags);
-
-            // rgRevertedRejitData
-            if (rgRevertedRejitData != null && rgRevertedRejitDataLocal != null)
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
             {
-                Debug.Assert(cNeededRevertedRejitDataLocal == *pcNeededRevertedRejitData);
-                for (ulong i = 0; i < cNeededRevertedRejitDataLocal; i++)
+                Debug.Assert(data->bHasNativeCode == dataLocal.bHasNativeCode);
+                Debug.Assert(data->bIsDynamic == dataLocal.bIsDynamic);
+                Debug.Assert(data->wSlotNumber == dataLocal.wSlotNumber);
+                Debug.Assert(data->NativeCodeAddr == dataLocal.NativeCodeAddr);
+                Debug.Assert(data->AddressOfNativeCodeSlot == dataLocal.AddressOfNativeCodeSlot);
+                Debug.Assert(data->MethodDescPtr == dataLocal.MethodDescPtr);
+                Debug.Assert(data->MethodTablePtr == dataLocal.MethodTablePtr);
+                Debug.Assert(data->ModulePtr == dataLocal.ModulePtr);
+                Debug.Assert(data->MDToken == dataLocal.MDToken);
+                Debug.Assert(data->GCInfo == dataLocal.GCInfo);
+                Debug.Assert(data->GCStressCodeCopy == dataLocal.GCStressCodeCopy);
+                // managedDynamicMethodObject is not currently populated by the cDAC API and may differ from legacyImpl.
+                Debug.Assert(data->managedDynamicMethodObject == 0);
+                Debug.Assert(data->requestedIP == dataLocal.requestedIP);
+                Debug.Assert(data->cJittedRejitVersions == dataLocal.cJittedRejitVersions);
+
+                // rejitDataCurrent
+                Debug.Assert(data->rejitDataCurrent.rejitID == dataLocal.rejitDataCurrent.rejitID);
+                Debug.Assert(data->rejitDataCurrent.NativeCodeAddr == dataLocal.rejitDataCurrent.NativeCodeAddr);
+                Debug.Assert(data->rejitDataCurrent.flags == dataLocal.rejitDataCurrent.flags);
+
+                // rejitDataRequested
+                Debug.Assert(data->rejitDataRequested.rejitID == dataLocal.rejitDataRequested.rejitID);
+                Debug.Assert(data->rejitDataRequested.NativeCodeAddr == dataLocal.rejitDataRequested.NativeCodeAddr);
+                Debug.Assert(data->rejitDataRequested.flags == dataLocal.rejitDataRequested.flags);
+
+                // rgRevertedRejitData
+                if (rgRevertedRejitData != null && rgRevertedRejitDataLocal != null)
                 {
-                    Debug.Assert(rgRevertedRejitData[i].rejitID == rgRevertedRejitDataLocal[i].rejitID);
-                    Debug.Assert(rgRevertedRejitData[i].NativeCodeAddr == rgRevertedRejitDataLocal[i].NativeCodeAddr);
-                    Debug.Assert(rgRevertedRejitData[i].flags == rgRevertedRejitDataLocal[i].flags);
+                    Debug.Assert(cNeededRevertedRejitDataLocal == *pcNeededRevertedRejitData);
+                    for (ulong i = 0; i < cNeededRevertedRejitDataLocal; i++)
+                    {
+                        Debug.Assert(rgRevertedRejitData[i].rejitID == rgRevertedRejitDataLocal[i].rejitID);
+                        Debug.Assert(rgRevertedRejitData[i].NativeCodeAddr == rgRevertedRejitDataLocal[i].NativeCodeAddr);
+                        Debug.Assert(rgRevertedRejitData[i].flags == rgRevertedRejitDataLocal[i].flags);
+                    }
                 }
             }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     private void CopyNativeCodeVersionToReJitData(
@@ -540,7 +544,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -553,9 +557,12 @@ internal sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetMethodDescName(methodDesc, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
-            Debug.Assert(name == null || new ReadOnlySpan<char>(nameLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(name)));
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
+                Debug.Assert(name == null || new ReadOnlySpan<char>(nameLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(name)));
+            }
         }
 #endif
         return hr;
@@ -572,6 +579,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (mt == 0 || data == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IRuntimeTypeSystem contract = _target.Contracts.RuntimeTypeSystem;
@@ -610,7 +618,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -618,22 +626,25 @@ internal sealed unsafe partial class SOSDacImpl
         {
             DacpMethodTableData dataLocal;
             int hrLocal = _legacyImpl.GetMethodTableData(mt, &dataLocal);
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(data->module == dataLocal.module);
-            Debug.Assert(data->klass == dataLocal.klass);
-            Debug.Assert(data->parentMethodTable == dataLocal.parentMethodTable);
-            Debug.Assert(data->wNumInterfaces == dataLocal.wNumInterfaces);
-            Debug.Assert(data->wNumMethods == dataLocal.wNumMethods);
-            Debug.Assert(data->wNumVtableSlots == dataLocal.wNumVtableSlots);
-            Debug.Assert(data->wNumVirtuals == dataLocal.wNumVirtuals);
-            Debug.Assert(data->cl == dataLocal.cl);
-            Debug.Assert(data->dwAttrClass == dataLocal.dwAttrClass);
-            Debug.Assert(data->bContainsGCPointers == dataLocal.bContainsGCPointers);
-            Debug.Assert(data->bIsShared == dataLocal.bIsShared);
-            Debug.Assert(data->bIsDynamic == dataLocal.bIsDynamic);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(data->module == dataLocal.module);
+                Debug.Assert(data->klass == dataLocal.klass);
+                Debug.Assert(data->parentMethodTable == dataLocal.parentMethodTable);
+                Debug.Assert(data->wNumInterfaces == dataLocal.wNumInterfaces);
+                Debug.Assert(data->wNumMethods == dataLocal.wNumMethods);
+                Debug.Assert(data->wNumVtableSlots == dataLocal.wNumVtableSlots);
+                Debug.Assert(data->wNumVirtuals == dataLocal.wNumVirtuals);
+                Debug.Assert(data->cl == dataLocal.cl);
+                Debug.Assert(data->dwAttrClass == dataLocal.dwAttrClass);
+                Debug.Assert(data->bContainsGCPointers == dataLocal.bContainsGCPointers);
+                Debug.Assert(data->bIsShared == dataLocal.bIsShared);
+                Debug.Assert(data->bIsDynamic == dataLocal.bIsDynamic);
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
     int ISOSDacInterface.GetMethodTableFieldData(ulong mt, void* data)
         => _legacyImpl is not null ? _legacyImpl.GetMethodTableFieldData(mt, data) : HResults.E_NOTIMPL;
@@ -642,6 +653,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (eeClassReallyCanonMT == 0 || value == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IRuntimeTypeSystem contract = _target.Contracts.RuntimeTypeSystem;
@@ -650,7 +662,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (global::System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -658,11 +670,12 @@ internal sealed unsafe partial class SOSDacImpl
         {
             ulong valueLocal;
             int hrLocal = _legacyImpl.GetMethodTableForEEClass(eeClassReallyCanonMT, &valueLocal);
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(*value == valueLocal);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+                Debug.Assert(*value == valueLocal);
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetMethodTableName(ulong mt, uint count, char* mtName, uint* pNeeded)
@@ -670,6 +683,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (mt == 0)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IRuntimeTypeSystem typeSystemContract = _target.Contracts.RuntimeTypeSystem;
@@ -706,7 +720,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (global::System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -719,12 +733,15 @@ internal sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetMethodTableName(mt, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
-            Debug.Assert(mtName == null || new ReadOnlySpan<char>(mtNameLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(mtName)));
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
+                Debug.Assert(mtName == null || new ReadOnlySpan<char>(mtNameLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(mtName)));
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetMethodTableSlot(ulong mt, uint slot, ulong* value)
@@ -752,6 +769,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (moduleAddr == 0 || data == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.ILoader contract = _target.Contracts.Loader;
@@ -793,7 +811,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (global::System.Exception e)
         {
-            return e.HResult;
+            hr = e.HResult;
         }
 
 #if DEBUG
@@ -801,30 +819,33 @@ internal sealed unsafe partial class SOSDacImpl
         {
             DacpModuleData dataLocal;
             int hrLocal = _legacyImpl.GetModuleData(moduleAddr, &dataLocal);
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(data->Address == dataLocal.Address);
-            Debug.Assert(data->PEAssembly == dataLocal.PEAssembly);
-            Debug.Assert(data->Assembly == dataLocal.Assembly);
-            Debug.Assert(data->isReflection == dataLocal.isReflection);
-            Debug.Assert(data->isPEFile == dataLocal.isPEFile);
-            Debug.Assert(data->dwTransientFlags == dataLocal.dwTransientFlags);
-            Debug.Assert(data->ilBase == dataLocal.ilBase);
-            Debug.Assert(data->metadataStart == dataLocal.metadataStart);
-            Debug.Assert(data->metadataSize == dataLocal.metadataSize);
-            Debug.Assert(data->LoaderAllocator == dataLocal.LoaderAllocator);
-            Debug.Assert(data->ThunkHeap == dataLocal.ThunkHeap);
-            Debug.Assert(data->FieldDefToDescMap == dataLocal.FieldDefToDescMap);
-            Debug.Assert(data->ManifestModuleReferencesMap == dataLocal.ManifestModuleReferencesMap);
-            Debug.Assert(data->MemberRefToDescMap == dataLocal.MemberRefToDescMap);
-            Debug.Assert(data->MethodDefToDescMap == dataLocal.MethodDefToDescMap);
-            Debug.Assert(data->TypeDefToMethodTableMap == dataLocal.TypeDefToMethodTableMap);
-            Debug.Assert(data->TypeRefToMethodTableMap == dataLocal.TypeRefToMethodTableMap);
-            Debug.Assert(data->dwModuleID == dataLocal.dwModuleID);
-            Debug.Assert(data->dwBaseClassIndex == dataLocal.dwBaseClassIndex);
-            Debug.Assert(data->dwModuleIndex == dataLocal.dwModuleIndex);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(data->Address == dataLocal.Address);
+                Debug.Assert(data->PEAssembly == dataLocal.PEAssembly);
+                Debug.Assert(data->Assembly == dataLocal.Assembly);
+                Debug.Assert(data->isReflection == dataLocal.isReflection);
+                Debug.Assert(data->isPEFile == dataLocal.isPEFile);
+                Debug.Assert(data->dwTransientFlags == dataLocal.dwTransientFlags);
+                Debug.Assert(data->ilBase == dataLocal.ilBase);
+                Debug.Assert(data->metadataStart == dataLocal.metadataStart);
+                Debug.Assert(data->metadataSize == dataLocal.metadataSize);
+                Debug.Assert(data->LoaderAllocator == dataLocal.LoaderAllocator);
+                Debug.Assert(data->ThunkHeap == dataLocal.ThunkHeap);
+                Debug.Assert(data->FieldDefToDescMap == dataLocal.FieldDefToDescMap);
+                Debug.Assert(data->ManifestModuleReferencesMap == dataLocal.ManifestModuleReferencesMap);
+                Debug.Assert(data->MemberRefToDescMap == dataLocal.MemberRefToDescMap);
+                Debug.Assert(data->MethodDefToDescMap == dataLocal.MethodDefToDescMap);
+                Debug.Assert(data->TypeDefToMethodTableMap == dataLocal.TypeDefToMethodTableMap);
+                Debug.Assert(data->TypeRefToMethodTableMap == dataLocal.TypeRefToMethodTableMap);
+                Debug.Assert(data->dwModuleID == dataLocal.dwModuleID);
+                Debug.Assert(data->dwBaseClassIndex == dataLocal.dwBaseClassIndex);
+                Debug.Assert(data->dwModuleIndex == dataLocal.dwModuleIndex);
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetNestedExceptionData(ulong exception, ulong* exceptionObject, ulong* nextNestedException)
@@ -832,6 +853,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (exception == 0 || exceptionObject == null || nextNestedException == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IException contract = _target.Contracts.Exception;
@@ -841,7 +863,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (global::System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -850,12 +872,15 @@ internal sealed unsafe partial class SOSDacImpl
             ulong exceptionObjectLocal;
             ulong nextNestedExceptionLocal;
             int hrLocal = _legacyImpl.GetNestedExceptionData(exception, &exceptionObjectLocal, &nextNestedExceptionLocal);
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(*exceptionObject == exceptionObjectLocal);
-            Debug.Assert(*nextNestedException == nextNestedExceptionLocal);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(*exceptionObject == exceptionObjectLocal);
+                Debug.Assert(*nextNestedException == nextNestedExceptionLocal);
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetObjectClassName(ulong obj, uint count, char* className, uint* pNeeded)
@@ -866,6 +891,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (objAddr == 0 || data == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IObject objectContract = _target.Contracts.Object;
@@ -940,7 +966,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -948,23 +974,26 @@ internal sealed unsafe partial class SOSDacImpl
         {
             DacpObjectData dataLocal;
             int hrLocal = _legacyImpl.GetObjectData(objAddr, &dataLocal);
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(data->MethodTable == dataLocal.MethodTable);
-            Debug.Assert(data->ObjectType == dataLocal.ObjectType);
-            Debug.Assert(data->Size == dataLocal.Size);
-            Debug.Assert(data->ElementTypeHandle == dataLocal.ElementTypeHandle);
-            Debug.Assert(data->ElementType == dataLocal.ElementType);
-            Debug.Assert(data->dwRank == dataLocal.dwRank);
-            Debug.Assert(data->dwNumComponents == dataLocal.dwNumComponents);
-            Debug.Assert(data->dwComponentSize == dataLocal.dwComponentSize);
-            Debug.Assert(data->ArrayDataPtr == dataLocal.ArrayDataPtr);
-            Debug.Assert(data->ArrayBoundsPtr == dataLocal.ArrayBoundsPtr);
-            Debug.Assert(data->ArrayLowerBoundsPtr == dataLocal.ArrayLowerBoundsPtr);
-            Debug.Assert(data->RCW == dataLocal.RCW);
-            Debug.Assert(data->CCW == dataLocal.CCW);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(data->MethodTable == dataLocal.MethodTable);
+                Debug.Assert(data->ObjectType == dataLocal.ObjectType);
+                Debug.Assert(data->Size == dataLocal.Size);
+                Debug.Assert(data->ElementTypeHandle == dataLocal.ElementTypeHandle);
+                Debug.Assert(data->ElementType == dataLocal.ElementType);
+                Debug.Assert(data->dwRank == dataLocal.dwRank);
+                Debug.Assert(data->dwNumComponents == dataLocal.dwNumComponents);
+                Debug.Assert(data->dwComponentSize == dataLocal.dwComponentSize);
+                Debug.Assert(data->ArrayDataPtr == dataLocal.ArrayDataPtr);
+                Debug.Assert(data->ArrayBoundsPtr == dataLocal.ArrayBoundsPtr);
+                Debug.Assert(data->ArrayLowerBoundsPtr == dataLocal.ArrayLowerBoundsPtr);
+                Debug.Assert(data->RCW == dataLocal.RCW);
+                Debug.Assert(data->CCW == dataLocal.CCW);
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetObjectStringData(ulong obj, uint count, char* stringData, uint* pNeeded)
@@ -972,6 +1001,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (obj == 0 || (stringData == null && pNeeded == null) || (stringData is not null && count <= 0))
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IObject contract = _target.Contracts.Object;
@@ -980,7 +1010,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -993,13 +1023,16 @@ internal sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetObjectStringData(obj, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
-            Debug.Assert(stringData == null || new ReadOnlySpan<char>(stringDataLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(stringData)));
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
+                Debug.Assert(stringData == null || new ReadOnlySpan<char>(stringDataLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(stringData)));
+            }
         }
 #endif
 
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetOOMData(ulong oomAddr, void* data)
@@ -1012,6 +1045,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (addr == 0 || peBase == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.ILoader contract = _target.Contracts.Loader;
@@ -1029,7 +1063,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -1037,11 +1071,12 @@ internal sealed unsafe partial class SOSDacImpl
         {
             ulong peBaseLocal;
             int hrLocal = _legacyImpl.GetPEFileBase(addr, &peBaseLocal);
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(*peBase == peBaseLocal);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+                Debug.Assert(*peBase == peBaseLocal);
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetPEFileName(ulong addr, uint count, char* fileName, uint* pNeeded)
@@ -1049,6 +1084,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (addr == 0 || (fileName == null && pNeeded == null) || (fileName is not null && count <= 0))
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.ILoader contract = _target.Contracts.Loader;
@@ -1069,7 +1105,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -1082,12 +1118,15 @@ internal sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetPEFileName(addr, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == HResults.S_OK);
-            Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
-            Debug.Assert(fileName == null || new ReadOnlySpan<char>(fileNameLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(fileName)));
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
+                Debug.Assert(fileName == null || new ReadOnlySpan<char>(fileNameLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(fileName)));
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetPrivateBinPaths(ulong appDomain, int count, char* paths, uint* pNeeded)
@@ -1116,6 +1155,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (thread == 0 || data == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IThread contract = _target.Contracts.Thread;
@@ -1142,7 +1182,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (global::System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -1150,25 +1190,28 @@ internal sealed unsafe partial class SOSDacImpl
         {
             DacpThreadData dataLocal;
             int hrLocal = _legacyImpl.GetThreadData(thread, &dataLocal);
-            Debug.Assert(hrLocal >= 0);
-            Debug.Assert(data->corThreadId == dataLocal.corThreadId);
-            Debug.Assert(data->osThreadId == dataLocal.osThreadId);
-            Debug.Assert(data->state == dataLocal.state);
-            Debug.Assert(data->preemptiveGCDisabled == dataLocal.preemptiveGCDisabled);
-            Debug.Assert(data->allocContextPtr == dataLocal.allocContextPtr);
-            Debug.Assert(data->allocContextLimit == dataLocal.allocContextLimit);
-            Debug.Assert(data->fiberData == dataLocal.fiberData);
-            Debug.Assert(data->context == dataLocal.context);
-            Debug.Assert(data->domain == dataLocal.domain);
-            Debug.Assert(data->lockCount == dataLocal.lockCount);
-            Debug.Assert(data->pFrame == dataLocal.pFrame);
-            Debug.Assert(data->firstNestedException == dataLocal.firstNestedException);
-            Debug.Assert(data->teb == dataLocal.teb);
-            Debug.Assert(data->lastThrownObjectHandle == dataLocal.lastThrownObjectHandle);
-            Debug.Assert(data->nextThread == dataLocal.nextThread);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(data->corThreadId == dataLocal.corThreadId);
+                Debug.Assert(data->osThreadId == dataLocal.osThreadId);
+                Debug.Assert(data->state == dataLocal.state);
+                Debug.Assert(data->preemptiveGCDisabled == dataLocal.preemptiveGCDisabled);
+                Debug.Assert(data->allocContextPtr == dataLocal.allocContextPtr);
+                Debug.Assert(data->allocContextLimit == dataLocal.allocContextLimit);
+                Debug.Assert(data->fiberData == dataLocal.fiberData);
+                Debug.Assert(data->context == dataLocal.context);
+                Debug.Assert(data->domain == dataLocal.domain);
+                Debug.Assert(data->lockCount == dataLocal.lockCount);
+                Debug.Assert(data->pFrame == dataLocal.pFrame);
+                Debug.Assert(data->firstNestedException == dataLocal.firstNestedException);
+                Debug.Assert(data->teb == dataLocal.teb);
+                Debug.Assert(data->lastThrownObjectHandle == dataLocal.lastThrownObjectHandle);
+                Debug.Assert(data->nextThread == dataLocal.nextThread);
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
     int ISOSDacInterface.GetThreadFromThinlockID(uint thinLockId, ulong* pThread)
         => _legacyImpl is not null ? _legacyImpl.GetThreadFromThinlockID(thinLockId, pThread) : HResults.E_NOTIMPL;
@@ -1182,6 +1225,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (data == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             Contracts.IThread thread = _target.Contracts.Thread;
@@ -1201,7 +1245,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (global::System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -1209,19 +1253,22 @@ internal sealed unsafe partial class SOSDacImpl
         {
             DacpThreadStoreData dataLocal;
             int hrLocal = _legacyImpl.GetThreadStoreData(&dataLocal);
-            Debug.Assert(hrLocal >= 0);
-            Debug.Assert(data->threadCount == dataLocal.threadCount);
-            Debug.Assert(data->firstThread == dataLocal.firstThread);
-            Debug.Assert(data->finalizerThread == dataLocal.finalizerThread);
-            Debug.Assert(data->gcThread == dataLocal.gcThread);
-            Debug.Assert(data->unstartedThreadCount == dataLocal.unstartedThreadCount);
-            Debug.Assert(data->backgroundThreadCount == dataLocal.backgroundThreadCount);
-            Debug.Assert(data->pendingThreadCount == dataLocal.pendingThreadCount);
-            Debug.Assert(data->deadThreadCount == dataLocal.deadThreadCount);
-            Debug.Assert(data->fHostConfig == dataLocal.fHostConfig);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(data->threadCount == dataLocal.threadCount);
+                Debug.Assert(data->firstThread == dataLocal.firstThread);
+                Debug.Assert(data->finalizerThread == dataLocal.finalizerThread);
+                Debug.Assert(data->gcThread == dataLocal.gcThread);
+                Debug.Assert(data->unstartedThreadCount == dataLocal.unstartedThreadCount);
+                Debug.Assert(data->backgroundThreadCount == dataLocal.backgroundThreadCount);
+                Debug.Assert(data->pendingThreadCount == dataLocal.pendingThreadCount);
+                Debug.Assert(data->deadThreadCount == dataLocal.deadThreadCount);
+                Debug.Assert(data->fHostConfig == dataLocal.fHostConfig);
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetTLSIndex(uint* pIndex)
@@ -1232,6 +1279,7 @@ internal sealed unsafe partial class SOSDacImpl
         if (data == null)
             return HResults.E_INVALIDARG;
 
+        int hr = HResults.S_OK;
         try
         {
             data->ArrayMethodTable = _target.ReadPointer(
@@ -1247,7 +1295,7 @@ internal sealed unsafe partial class SOSDacImpl
         }
         catch (System.Exception ex)
         {
-            return ex.HResult;
+            hr = ex.HResult;
         }
 
 #if DEBUG
@@ -1255,15 +1303,18 @@ internal sealed unsafe partial class SOSDacImpl
         {
             DacpUsefulGlobalsData dataLocal;
             int hrLocal = _legacyImpl.GetUsefulGlobals(&dataLocal);
-            Debug.Assert(hrLocal >= 0);
-            Debug.Assert(data->ArrayMethodTable == dataLocal.ArrayMethodTable);
-            Debug.Assert(data->StringMethodTable == dataLocal.StringMethodTable);
-            Debug.Assert(data->ObjectMethodTable == dataLocal.ObjectMethodTable);
-            Debug.Assert(data->ExceptionMethodTable == dataLocal.ExceptionMethodTable);
-            Debug.Assert(data->FreeMethodTable == dataLocal.FreeMethodTable);
+            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(data->ArrayMethodTable == dataLocal.ArrayMethodTable);
+                Debug.Assert(data->StringMethodTable == dataLocal.StringMethodTable);
+                Debug.Assert(data->ObjectMethodTable == dataLocal.ObjectMethodTable);
+                Debug.Assert(data->ExceptionMethodTable == dataLocal.ExceptionMethodTable);
+                Debug.Assert(data->FreeMethodTable == dataLocal.FreeMethodTable);
+            }
         }
 #endif
-        return HResults.S_OK;
+        return hr;
     }
 
     int ISOSDacInterface.GetWorkRequestData(ulong addrWorkRequest, void* data)

--- a/src/native/managed/cdacreader/tests/MethodTableTests.cs
+++ b/src/native/managed/cdacreader/tests/MethodTableTests.cs
@@ -134,7 +134,7 @@ public class MethodTableTests
         {
             Contracts.IRuntimeTypeSystem metadataContract = target.Contracts.RuntimeTypeSystem;
             Assert.NotNull(metadataContract);
-            Assert.Throws<InvalidOperationException>(() => metadataContract.GetTypeHandle(badMethodTablePtr));
+            Assert.Throws<ArgumentException>(() => metadataContract.GetTypeHandle(badMethodTablePtr));
         });
     }
 


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/110322 goes in, the cDAC `GetMethodDescData` implementation should be done, so we can stop delegating to the legacy DAC as a fallback.

Contributes to https://github.com/dotnet/runtime/issues/109426.