### PR TITLE
Expression.Compile: avoid invoking lambda expression receiver when interpreting and calling method other than MulticastDelegate Invoke

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -970,6 +970,12 @@ namespace System.Dynamic.Utils
             return delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
         }
 
+        internal static bool IsDelegateInvoke(MethodInfo methodInfo)
+        {
+            return methodInfo is { IsStatic: false, Name: "Invoke", DeclaringType: { } declaringType } &&
+                IsDelegate(declaringType);
+        }
+
         internal static bool IsUnsigned(this Type type) => IsUnsigned(GetNonNullableType(type).GetTypeCode());
 
         internal static bool IsUnsigned(this TypeCode typeCode)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -239,6 +239,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class ActionCallInstruction<T0> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Action<T0> _target;
         public override int ProducedStack => 0;
         public override int ArgumentCount => 1;
@@ -246,6 +247,7 @@ namespace System.Linq.Expressions.Interpreter
         public ActionCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Action<T0>)target.CreateDelegate(typeof(Action<T0>));
         }
 
@@ -258,7 +260,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 InterpretLambdaInvoke(targetLambda, Array.Empty<object>());
@@ -278,6 +280,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class ActionCallInstruction<T0, T1> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Action<T0, T1> _target;
         public override int ProducedStack => 0;
         public override int ArgumentCount => 2;
@@ -285,6 +288,7 @@ namespace System.Linq.Expressions.Interpreter
         public ActionCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Action<T0, T1>)target.CreateDelegate(typeof(Action<T0, T1>));
         }
 
@@ -297,7 +301,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 InterpretLambdaInvoke(targetLambda, new object[] { frame.Data[frame.StackIndex - 1] });
@@ -317,6 +321,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class ActionCallInstruction<T0, T1, T2> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Action<T0, T1, T2> _target;
         public override int ProducedStack => 0;
         public override int ArgumentCount => 3;
@@ -324,6 +329,7 @@ namespace System.Linq.Expressions.Interpreter
         public ActionCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Action<T0, T1, T2>)target.CreateDelegate(typeof(Action<T0, T1, T2>));
         }
 
@@ -336,7 +342,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 InterpretLambdaInvoke(targetLambda, new object[] { frame.Data[frame.StackIndex - 2], frame.Data[frame.StackIndex - 1] });
@@ -356,6 +362,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class ActionCallInstruction<T0, T1, T2, T3> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Action<T0, T1, T2, T3> _target;
         public override int ProducedStack => 0;
         public override int ArgumentCount => 4;
@@ -363,6 +370,7 @@ namespace System.Linq.Expressions.Interpreter
         public ActionCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Action<T0, T1, T2, T3>)target.CreateDelegate(typeof(Action<T0, T1, T2, T3>));
         }
 
@@ -375,7 +383,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 InterpretLambdaInvoke(targetLambda, new object[] { frame.Data[frame.StackIndex - 3], frame.Data[frame.StackIndex - 2], frame.Data[frame.StackIndex - 1] });
@@ -416,6 +424,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class FuncCallInstruction<T0, TRet> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Func<T0, TRet> _target;
         public override int ProducedStack => 1;
         public override int ArgumentCount => 1;
@@ -423,6 +432,7 @@ namespace System.Linq.Expressions.Interpreter
         public FuncCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Func<T0, TRet>)target.CreateDelegate(typeof(Func<T0, TRet>));
         }
 
@@ -436,7 +446,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 result = InterpretLambdaInvoke(targetLambda, Array.Empty<object>());
@@ -457,6 +467,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class FuncCallInstruction<T0, T1, TRet> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Func<T0, T1, TRet> _target;
         public override int ProducedStack => 1;
         public override int ArgumentCount => 2;
@@ -464,6 +475,7 @@ namespace System.Linq.Expressions.Interpreter
         public FuncCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Func<T0, T1, TRet>)target.CreateDelegate(typeof(Func<T0, T1, TRet>));
         }
 
@@ -477,7 +489,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 result = InterpretLambdaInvoke(targetLambda, new object[] { frame.Data[frame.StackIndex - 1] });
@@ -498,6 +510,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class FuncCallInstruction<T0, T1, T2, TRet> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Func<T0, T1, T2, TRet> _target;
         public override int ProducedStack => 1;
         public override int ArgumentCount => 3;
@@ -505,6 +518,7 @@ namespace System.Linq.Expressions.Interpreter
         public FuncCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Func<T0, T1, T2, TRet>)target.CreateDelegate(typeof(Func<T0, T1, T2, TRet>));
         }
 
@@ -518,7 +532,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 result = InterpretLambdaInvoke(targetLambda, new object[] { frame.Data[frame.StackIndex - 2], frame.Data[frame.StackIndex - 1] });
@@ -539,6 +553,7 @@ namespace System.Linq.Expressions.Interpreter
     internal sealed class FuncCallInstruction<T0, T1, T2, T3, TRet> : CallInstruction
     {
         private readonly bool _isInstance;
+        private readonly bool _isDelegateInvoke;
         private readonly Func<T0, T1, T2, T3, TRet> _target;
         public override int ProducedStack => 1;
         public override int ArgumentCount => 4;
@@ -546,6 +561,7 @@ namespace System.Linq.Expressions.Interpreter
         public FuncCallInstruction(MethodInfo target)
         {
             _isInstance = !target.IsStatic;
+            _isDelegateInvoke = TypeUtils.IsDelegateInvoke(target);
             _target = (Func<T0, T1, T2, T3, TRet>)target.CreateDelegate(typeof(Func<T0, T1, T2, T3, TRet>));
         }
 
@@ -559,7 +575,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isInstance && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 result = InterpretLambdaInvoke(targetLambda, new object[] { frame.Data[frame.StackIndex - 3], frame.Data[frame.StackIndex - 2], frame.Data[frame.StackIndex - 1] });

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -446,7 +446,7 @@ namespace System.Linq.Expressions.Interpreter
                 NullCheck(firstArg);
             }
 
-            if (_isDelegateInvoke && TryGetLightLambdaTarget(firstArg, out var targetLambda))
+            if (_isInstance/*Temporary:_isDelegateInvoke*/ && TryGetLightLambdaTarget(firstArg, out var targetLambda))
             {
                 // no need to Invoke, just interpret the lambda body
                 result = InterpretLambdaInvoke(targetLambda, Array.Empty<object>());

--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -1012,22 +1012,5 @@ namespace System.Linq.Expressions.Tests
             Func<bool> f = expr.Compile(preferInterpretation: useInterpreter);
             Assert.False(f());
         }
-
-        [Theory, ClassData(typeof(CompilationTypes))]
-        public void LambdaInstanceMethodReceiver_Action3(bool useInterpreter)
-        {
-            Expression<Action> expr = Expression.Lambda<Action>(
-                Expression.Call(
-                    Expression.Lambda<Action<int, int, int>>(
-                        Expression.Constant(1),
-                        Expression.Parameter(typeof(int)),
-                        Expression.Parameter(typeof(int)),
-                        Expression.Parameter(typeof(int))),
-                    typeof(Action<int, int, int>).GetMethod("GetObjectData", BindingFlags.Public | BindingFlags.Instance),
-                    Expression.Default(typeof(System.Runtime.Serialization.SerializationInfo)),
-                    Expression.Default(typeof(System.Runtime.Serialization.StreamingContext))));
-            Action a = expr.Compile(preferInterpretation: useInterpreter);
-            a();
-        }
     }
 }

--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -986,5 +986,48 @@ namespace System.Linq.Expressions.Tests
             Func<GenericStruct<string>, string> f = funcE.Compile();
             Assert.Equal("B", f(new GenericStruct<string>()));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void LambdaInstanceMethodReceiver_Func1(bool useInterpreter)
+        {
+            Expression<Func<string>> expr = Expression.Lambda<Func<string>>(
+                Expression.Call(
+                    Expression.Lambda<Func<int>>(
+                        Expression.Constant(1)),
+                    typeof(Func<int>).GetMethod("ToString", BindingFlags.Public | BindingFlags.Instance)));
+            Func<string> f = expr.Compile(preferInterpretation: useInterpreter);
+            Assert.Equal("System.Func`1[System.Int32]", f());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void LambdaInstanceMethodReceiver_Func2(bool useInterpreter)
+        {
+            Expression<Func<bool>> expr = Expression.Lambda<Func<bool>>(
+                Expression.Call(
+                    Expression.Lambda<Func<int, int>>(
+                        Expression.Constant(1),
+                        Expression.Parameter(typeof(int))),
+                    typeof(Func<int, int>).GetMethod("Equals", BindingFlags.Public | BindingFlags.Instance),
+                    Expression.Constant((object)null)));
+            Func<bool> f = expr.Compile(preferInterpretation: useInterpreter);
+            Assert.False(f());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void LambdaInstanceMethodReceiver_Action3(bool useInterpreter)
+        {
+            Expression<Action> expr = Expression.Lambda<Action>(
+                Expression.Call(
+                    Expression.Lambda<Action<int, int, int>>(
+                        Expression.Constant(1),
+                        Expression.Parameter(typeof(int)),
+                        Expression.Parameter(typeof(int)),
+                        Expression.Parameter(typeof(int))),
+                    typeof(Action<int, int, int>).GetMethod("GetObjectData", BindingFlags.Public | BindingFlags.Instance),
+                    Expression.Default(typeof(System.Runtime.Serialization.SerializationInfo)),
+                    Expression.Default(typeof(System.Runtime.Serialization.StreamingContext))));
+            Action a = expr.Compile(preferInterpretation: useInterpreter);
+            a();
+        }
     }
 }

--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -1012,5 +1012,35 @@ namespace System.Linq.Expressions.Tests
             Func<bool> f = expr.Compile(preferInterpretation: useInterpreter);
             Assert.False(f());
         }
+
+        private static void _CallWithFunc1(Func<int> f) { }
+
+        // TODO: Temporary
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void LambdaInstanceImplicitCast_Func1(bool useInterpreter)
+        {
+            Expression<Action> expr = Expression.Lambda<Action>(
+                Expression.Call(
+                    typeof(LambdaTests).GetMethod("_CallWithFunc1", BindingFlags.NonPublic | BindingFlags.Static),
+                    Expression.Lambda<Func<int>>(
+                        Expression.Constant(1))));
+            Action a = expr.Compile(preferInterpretation: useInterpreter);
+            a();
+        }
+
+        // TODO: Temporary
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void LambdaInstanceExplicitCast_Func1(bool useInterpreter)
+        {
+            Expression<Action> expr = Expression.Lambda<Action>(
+                Expression.Call(
+                    typeof(LambdaTests).GetMethod("_CallWithFunc1", BindingFlags.NonPublic | BindingFlags.Static),
+                    Expression.Convert(
+                        Expression.Lambda<Func<int>>(
+                            Expression.Constant(1)),
+                        typeof(Func<int>))));
+            Action a = expr.Compile(preferInterpretation: useInterpreter);
+            a();
+        }
     }
 }


### PR DESCRIPTION
Fixes #96385