### PR TITLE
Expression.Compile: empty the evaluation stack before evaluating second expression in OrElse and AndAlso

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -275,8 +275,6 @@ namespace System.Linq.Expressions.Compiler
 
         private void EmitMethodAndAlso(BinaryExpression b, CompilationFlags flags)
         {
-            Debug.Assert(b.Method!.IsStatic);
-
             Label labEnd = _ilg.DefineLabel();
             EmitExpression(b.Left);
             _ilg.Emit(OpCodes.Dup);
@@ -285,13 +283,25 @@ namespace System.Linq.Expressions.Compiler
             _ilg.Emit(OpCodes.Call, opFalse);
             _ilg.Emit(OpCodes.Brtrue, labEnd);
 
+            //store the value of the left value before emitting b.Right to empty the evaluation stack
+            LocalBuilder locLeft = GetLocal(b.Left.Type);
+            _ilg.Emit(OpCodes.Stloc, locLeft);
+
             EmitExpression(b.Right);
+            //store the right value to local
+            LocalBuilder locRight = GetLocal(b.Right.Type);
+            _ilg.Emit(OpCodes.Stloc, locRight);
+
+            Debug.Assert(b.Method.IsStatic);
+            _ilg.Emit(OpCodes.Ldloc, locLeft);
+            _ilg.Emit(OpCodes.Ldloc, locRight);
             if ((flags & CompilationFlags.EmitAsTailCallMask) == CompilationFlags.EmitAsTail)
             {
                 _ilg.Emit(OpCodes.Tailcall);
             }
-
             _ilg.Emit(OpCodes.Call, b.Method);
+            FreeLocal(locLeft);
+            FreeLocal(locRight);
             _ilg.MarkLabel(labEnd);
         }
 
@@ -311,20 +321,17 @@ namespace System.Linq.Expressions.Compiler
         {
             BinaryExpression b = (BinaryExpression)expr;
 
-            if (b.Method != null)
+            if (b.Method != null && !b.IsLiftedLogical)
             {
-                if (b.IsLiftedLogical)
-                {
-                    EmitExpression(b.ReduceUserdefinedLifted());
-                }
-                else
-                {
-                    EmitMethodAndAlso(b, flags);
-                }
+                EmitMethodAndAlso(b, flags);
             }
             else if (b.Left.Type == typeof(bool?))
             {
                 EmitLiftedAndAlso(b);
+            }
+            else if (b.IsLiftedLogical)
+            {
+                EmitExpression(b.ReduceUserdefinedLifted());
             }
             else
             {
@@ -381,23 +388,33 @@ namespace System.Linq.Expressions.Compiler
 
         private void EmitMethodOrElse(BinaryExpression b, CompilationFlags flags)
         {
-            Debug.Assert(b.Method!.IsStatic);
-
             Label labEnd = _ilg.DefineLabel();
             EmitExpression(b.Left);
             _ilg.Emit(OpCodes.Dup);
             MethodInfo? opTrue = TypeUtils.GetBooleanOperator(b.Method.DeclaringType!, "op_True");
             Debug.Assert(opTrue != null, "factory should check that the method exists");
-
             _ilg.Emit(OpCodes.Call, opTrue);
             _ilg.Emit(OpCodes.Brtrue, labEnd);
+
+            //store the value of the left value before emitting b.Right to empty the evaluation stack
+            LocalBuilder locLeft = GetLocal(b.Left.Type);
+            _ilg.Emit(OpCodes.Stloc, locLeft);
+
             EmitExpression(b.Right);
+            //store the right value to local
+            LocalBuilder locRight = GetLocal(b.Right.Type);
+            _ilg.Emit(OpCodes.Stloc, locRight);
+
+            Debug.Assert(b.Method.IsStatic);
+            _ilg.Emit(OpCodes.Ldloc, locLeft);
+            _ilg.Emit(OpCodes.Ldloc, locRight);
             if ((flags & CompilationFlags.EmitAsTailCallMask) == CompilationFlags.EmitAsTail)
             {
                 _ilg.Emit(OpCodes.Tailcall);
             }
-
             _ilg.Emit(OpCodes.Call, b.Method);
+            FreeLocal(locLeft);
+            FreeLocal(locRight);
             _ilg.MarkLabel(labEnd);
         }
 
@@ -405,20 +422,17 @@ namespace System.Linq.Expressions.Compiler
         {
             BinaryExpression b = (BinaryExpression)expr;
 
-            if (b.Method != null)
+            if (b.Method != null && !b.IsLiftedLogical)
             {
-                if (b.IsLiftedLogical)
-                {
-                    EmitExpression(b.ReduceUserdefinedLifted());
-                }
-                else
-                {
-                    EmitMethodOrElse(b, flags);
-                }
+                EmitMethodOrElse(b, flags);
             }
             else if (b.Left.Type == typeof(bool?))
             {
                 EmitLiftedOrElse(b);
+            }
+            else if (b.IsLiftedLogical)
+            {
+                EmitExpression(b.ReduceUserdefinedLifted());
             }
             else
             {
@@ -455,35 +469,36 @@ namespace System.Linq.Expressions.Compiler
         /// </remarks>
         private void EmitExpressionAndBranch(bool branchValue, Expression node, Label label)
         {
-            Debug.Assert(node.Type == typeof(bool));
             CompilationFlags startEmitted = EmitExpressionStart(node);
-            switch (node.NodeType)
+            try
             {
-                case ExpressionType.Not:
-                    EmitBranchNot(branchValue, (UnaryExpression)node, label);
-                    break;
-
-                case ExpressionType.AndAlso:
-                case ExpressionType.OrElse:
-                    EmitBranchLogical(branchValue, (BinaryExpression)node, label);
-                    break;
-
-                case ExpressionType.Block:
-                    EmitBranchBlock(branchValue, (BlockExpression)node, label);
-                    break;
-
-                case ExpressionType.Equal:
-                case ExpressionType.NotEqual:
-                    EmitBranchComparison(branchValue, (BinaryExpression)node, label);
-                    break;
-
-                default:
-                    EmitExpression(node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitNoExpressionStart);
-                    EmitBranchOp(branchValue, label);
-                    break;
+                if (node.Type == typeof(bool))
+                {
+                    switch (node.NodeType)
+                    {
+                        case ExpressionType.Not:
+                            EmitBranchNot(branchValue, (UnaryExpression)node, label);
+                            return;
+                        case ExpressionType.AndAlso:
+                        case ExpressionType.OrElse:
+                            EmitBranchLogical(branchValue, (BinaryExpression)node, label);
+                            return;
+                        case ExpressionType.Block:
+                            EmitBranchBlock(branchValue, (BlockExpression)node, label);
+                            return;
+                        case ExpressionType.Equal:
+                        case ExpressionType.NotEqual:
+                            EmitBranchComparison(branchValue, (BinaryExpression)node, label);
+                            return;
+                    }
+                }
+                EmitExpression(node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitNoExpressionStart);
+                EmitBranchOp(branchValue, label);
             }
-
-            EmitExpressionEnd(startEmitted);
+            finally
+            {
+                EmitExpressionEnd(startEmitted);
+            }
         }
 
         private void EmitBranchOp(bool branch, Label label)
@@ -499,7 +514,6 @@ namespace System.Linq.Expressions.Compiler
                 EmitBranchOp(branch, label);
                 return;
             }
-
             EmitExpressionAndBranch(!branch, node.Operand, label);
         }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -278,7 +278,7 @@ namespace System.Linq.Expressions.Compiler
             Label labEnd = _ilg.DefineLabel();
             EmitExpression(b.Left);
             _ilg.Emit(OpCodes.Dup);
-            MethodInfo? opFalse = TypeUtils.GetBooleanOperator(b.Method.DeclaringType!, "op_False");
+            MethodInfo? opFalse = TypeUtils.GetBooleanOperator(b.Method!.DeclaringType!, "op_False");
             Debug.Assert(opFalse != null, "factory should check that the method exists");
             _ilg.Emit(OpCodes.Call, opFalse);
             _ilg.Emit(OpCodes.Brtrue, labEnd);
@@ -391,7 +391,7 @@ namespace System.Linq.Expressions.Compiler
             Label labEnd = _ilg.DefineLabel();
             EmitExpression(b.Left);
             _ilg.Emit(OpCodes.Dup);
-            MethodInfo? opTrue = TypeUtils.GetBooleanOperator(b.Method.DeclaringType!, "op_True");
+            MethodInfo? opTrue = TypeUtils.GetBooleanOperator(b.Method!.DeclaringType!, "op_True");
             Debug.Assert(opTrue != null, "factory should check that the method exists");
             _ilg.Emit(OpCodes.Call, opTrue);
             _ilg.Emit(OpCodes.Brtrue, labEnd);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1361,10 +1361,29 @@ namespace System.Linq.Expressions.Interpreter
             _instructions.EmitCall(opTrue);
             _instructions.EmitBranchTrue(labEnd);
 
+            // Store the left value to a local to empty the evaluation stack before
+            // compiling the right expression. The right expression may contain a
+            // TryCatch (or anything that does not tolerate non-empty evaluation
+            // stack on entry), so we must not leave the dup'd left value on the
+            // stack while the right expression executes.
+            LocalDefinition leftTemp = _locals.DefineLocal(Expression.Parameter(expr.Left.Type), _instructions.Count);
+            _instructions.EmitStoreLocal(leftTemp.Index);
+
             Compile(expr.Right);
+
+            // Store the right value, then reload both left and right before calling
+            // the user-defined operator method.
+            LocalDefinition rightTemp = _locals.DefineLocal(Expression.Parameter(expr.Right.Type), _instructions.Count);
+            _instructions.EmitStoreLocal(rightTemp.Index);
+
+            _instructions.EmitLoadLocal(leftTemp.Index);
+            _instructions.EmitLoadLocal(rightTemp.Index);
 
             Debug.Assert(expr.Method.IsStatic);
             _instructions.EmitCall(expr.Method);
+
+            _locals.UndefineLocal(leftTemp, _instructions.Count);
+            _locals.UndefineLocal(rightTemp, _instructions.Count);
 
             _instructions.MarkLabel(labEnd);
         }

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -7,6 +7,7 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Linq.Expressions.Tests
 {
@@ -1589,6 +1590,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void TryCatchInOrElse(bool useInterpreter)
         {
+            MethodInfo orMethod = typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
+                "op_BitwiseOr",
+                new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) })
+                ?? typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
+                    "Or",
+                    new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) });
+
             var expr = Expression.Lambda<Func<System.Data.SqlTypes.SqlBoolean>>(
                 Expression.OrElse(
                     Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
@@ -1596,7 +1604,8 @@ namespace System.Linq.Expressions.Tests
                         Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
                         Expression.Catch(
                             typeof(System.Data.SqlTypes.SqlTypeException),
-                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False)))));
+                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False))),
+                    orMethod));   // <-- pass the method explicitly
             var func = expr.Compile(preferInterpretation: useInterpreter);
             Assert.Equal(System.Data.SqlTypes.SqlBoolean.True, func());
         }
@@ -1604,6 +1613,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void TryCatchInAndAlso(bool useInterpreter)
         {
+            MethodInfo andMethod = typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
+                "op_BitwiseAnd",
+                new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) })
+                ?? typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
+                    "And",
+                    new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) });
+
             var expr = Expression.Lambda<Func<System.Data.SqlTypes.SqlBoolean>>(
                 Expression.AndAlso(
                     Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
@@ -1611,7 +1627,8 @@ namespace System.Linq.Expressions.Tests
                         Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
                         Expression.Catch(
                             typeof(System.Data.SqlTypes.SqlTypeException),
-                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False)))));
+                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False))),
+                    andMethod));
             var func = expr.Compile(preferInterpretation: useInterpreter);
             Assert.Equal(System.Data.SqlTypes.SqlBoolean.True, func());
         }

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -7,7 +7,6 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace System.Linq.Expressions.Tests
 {
@@ -1587,50 +1586,57 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("catch (Exception ex) { ... }", e7.ToString());
         }
 
+        // A user-defined boolean type with op_True/op_False and bitwise operators, used to
+        // exercise the conditional logical operators (OrElse/AndAlso). Defined locally so the
+        // required operators are not trimmed away (e.g. under NativeAOT), which would otherwise
+        // make the runtime lookup of op_True/op_False fail.
+        public sealed class UserBool
+        {
+            public bool Value { get; }
+
+            public UserBool(bool value) => Value = value;
+
+            public static readonly UserBool True = new UserBool(true);
+            public static readonly UserBool False = new UserBool(false);
+
+            public static bool operator true(UserBool b) => b.Value;
+            public static bool operator false(UserBool b) => !b.Value;
+
+            public static UserBool operator &(UserBool x, UserBool y) => new UserBool(x.Value && y.Value);
+            public static UserBool operator |(UserBool x, UserBool y) => new UserBool(x.Value || y.Value);
+
+            public override bool Equals(object obj) => obj is UserBool other && other.Value == Value;
+            public override int GetHashCode() => Value.GetHashCode();
+        }
+
         [Theory, ClassData(typeof(CompilationTypes))]
         public void TryCatchInOrElse(bool useInterpreter)
         {
-            MethodInfo orMethod = typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
-                "op_BitwiseOr",
-                new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) })
-                ?? typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
-                    "Or",
-                    new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) });
-
-            var expr = Expression.Lambda<Func<System.Data.SqlTypes.SqlBoolean>>(
+            var expr = Expression.Lambda<Func<UserBool>>(
                 Expression.OrElse(
-                    Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                    Expression.Constant(UserBool.True),
                     Expression.TryCatch(
-                        Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                        Expression.Constant(UserBool.True),
                         Expression.Catch(
-                            typeof(System.Data.SqlTypes.SqlTypeException),
-                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False))),
-                    orMethod));   // <-- pass the method explicitly
-            var func = expr.Compile(preferInterpretation: useInterpreter);
-            Assert.Equal(System.Data.SqlTypes.SqlBoolean.True, func());
+                            typeof(TestException),
+                            Expression.Constant(UserBool.False)))));
+            var func = expr.Compile(useInterpreter);
+            Assert.Equal(UserBool.True, func());
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void TryCatchInAndAlso(bool useInterpreter)
         {
-            MethodInfo andMethod = typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
-                "op_BitwiseAnd",
-                new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) })
-                ?? typeof(System.Data.SqlTypes.SqlBoolean).GetMethod(
-                    "And",
-                    new[] { typeof(System.Data.SqlTypes.SqlBoolean), typeof(System.Data.SqlTypes.SqlBoolean) });
-
-            var expr = Expression.Lambda<Func<System.Data.SqlTypes.SqlBoolean>>(
+            var expr = Expression.Lambda<Func<UserBool>>(
                 Expression.AndAlso(
-                    Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                    Expression.Constant(UserBool.True),
                     Expression.TryCatch(
-                        Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                        Expression.Constant(UserBool.True),
                         Expression.Catch(
-                            typeof(System.Data.SqlTypes.SqlTypeException),
-                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False))),
-                    andMethod));
-            var func = expr.Compile(preferInterpretation: useInterpreter);
-            Assert.Equal(System.Data.SqlTypes.SqlBoolean.True, func());
+                            typeof(TestException),
+                            Expression.Constant(UserBool.False)))));
+            var func = expr.Compile(useInterpreter);
+            Assert.Equal(UserBool.True, func());
         }
     }
 }

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -1585,5 +1585,35 @@ namespace System.Linq.Expressions.Tests
             CatchBlock e7 = Expression.Catch(Expression.Parameter(typeof(Exception), "ex"), Expression.Empty(), Expression.Constant(true));
             Assert.Equal("catch (Exception ex) { ... }", e7.ToString());
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void TryCatchInOrElse(bool useInterpreter)
+        {
+            var expr = Expression.Lambda<Func<System.Data.SqlTypes.SqlBoolean>>(
+                Expression.OrElse(
+                    Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                    Expression.TryCatch(
+                        Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                        Expression.Catch(
+                            typeof(System.Data.SqlTypes.SqlTypeException),
+                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False)))));
+            var func = expr.Compile(preferInterpretation: useInterpreter);
+            Assert.Equal(System.Data.SqlTypes.SqlBoolean.True, func());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void TryCatchInAndAlso(bool useInterpreter)
+        {
+            var expr = Expression.Lambda<Func<System.Data.SqlTypes.SqlBoolean>>(
+                Expression.AndAlso(
+                    Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                    Expression.TryCatch(
+                        Expression.Constant(System.Data.SqlTypes.SqlBoolean.True),
+                        Expression.Catch(
+                            typeof(System.Data.SqlTypes.SqlTypeException),
+                            Expression.Constant(System.Data.SqlTypes.SqlBoolean.False)))));
+            var func = expr.Compile(preferInterpretation: useInterpreter);
+            Assert.Equal(System.Data.SqlTypes.SqlBoolean.True, func());
+        }
     }
 }


### PR DESCRIPTION
Fixes #103197 
Reverts commit https://github.com/dotnet/runtime/commit/2ecfbbdc3ca2ff7d8c2cd1ad696947e698f42eee