### PR TITLE
Add WriteLine() to the Debug/DebugProvider

### DIFF
--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
@@ -31,6 +31,7 @@ namespace System.Diagnostics
         public virtual void Write(string? message) { }
         public static void WriteCore(string message) { }
         public virtual void WriteLine(string? message) { }
+        public virtual void WriteLine() { }
     }
     public static partial class Debug
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
@@ -134,6 +134,10 @@ namespace System.Diagnostics
             s_provider.Fail(message, detailMessage);
 
         [Conditional("DEBUG")]
+        public static void WriteLine() =>
+            s_provider.WriteLine();
+
+        [Conditional("DEBUG")]
         public static void WriteLine(string? message) =>
             s_provider.WriteLine(message);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.cs
@@ -63,6 +63,11 @@ namespace System.Diagnostics
             }
         }
 
+        public virtual void WriteLine()
+        {
+            Write(Environment.NewLineConst);
+        }
+
         public virtual void WriteLine(string? message)
         {
             Write(message + Environment.NewLineConst);


### PR DESCRIPTION
Add functionality to the `Debug/DebugProvider` classes so that calling `Debug.WriteLine()` with no arguments writes an empty line to the debug output, mirroring the behavior of `Console.WriteLine()`.

**Implementation**: Ensure that `Debug.WriteLine()` writes an empty line to the output when called with no arguments, just like `Console.WriteLine()`.