### PR TITLE
Add readonly Capacity property to PriorityQueue<TElement, TPriority>

### DIFF
--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -287,6 +287,7 @@ namespace System.Collections.Generic
         public PriorityQueue(int initialCapacity, System.Collections.Generic.IComparer<TPriority>? comparer) { }
         public System.Collections.Generic.IComparer<TPriority> Comparer { get { throw null; } }
         public int Count { get { throw null; } }
+        public int Capacity { get { throw null; } }
         public System.Collections.Generic.PriorityQueue<TElement, TPriority>.UnorderedItemsCollection UnorderedItems { get { throw null; } }
         public void Clear() { }
         public TElement Dequeue() { throw null; }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -172,6 +172,11 @@ namespace System.Collections.Generic
         public int Count => _size;
 
         /// <summary>
+        ///  Gets the total numbers of elements the internal data structure can hold without resizing.
+        /// </summary>
+        public int Capacity => _nodes.Length;
+
+        /// <summary>
         ///  Gets the priority comparer used by the <see cref="PriorityQueue{TElement, TPriority}"/>.
         /// </summary>
         public IComparer<TPriority> Comparer => _comparer ?? Comparer<TPriority>.Default;

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -172,7 +172,7 @@ namespace System.Collections.Generic
         public int Count => _size;
 
         /// <summary>
-        ///  Gets the total numbers of elements the internal data structure can hold without resizing.
+        ///  Gets the total numbers of elements the queue's backing storage can hold without resizing.
         /// </summary>
         public int Capacity => _nodes.Length;
 

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
@@ -34,6 +34,15 @@ namespace System.Collections.Tests
             return queue;
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(100)]
+        public void CreateWithCapacity_EqualsCapacityProperty(int capacity)
+        {
+            var queue = new PriorityQueue<TElement, TPriority>(capacity);
+            Assert.Equal(capacity, queue.Capacity);
+        }
+
         #endregion
 
         #region Constructors

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
@@ -43,7 +43,7 @@ namespace System.Collections.Tests
             Assert.Equal(capacity, queue.Capacity);
         }
 
-        [Theory]
+        [Fact]
         public void PriorityQueue_EnsureCapacityThenTrimExcess_CapacityUpdates()
         {
             var queue = new PriorityQueue<TElement, TPriority>(2);

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
@@ -43,6 +43,19 @@ namespace System.Collections.Tests
             Assert.Equal(capacity, queue.Capacity);
         }
 
+        [Theory]
+        public void PriorityQueue_EnsureCapacityThenTrimExcess_CapacityUpdates(int capacity)
+        {
+            var queue = new PriorityQueue<TElement, TPriority>(2);
+            Assert.Equal(2, queue.Capacity);
+
+            queue.EnsureCapacity(12);
+            Assert.True(queue.Capacity >= 12, "capacity should be at least 12 after ensuring capacity");
+
+            queue.TrimExcess();
+            Assert.Equal(0, queue.Capacity);
+        }
+
         #endregion
 
         #region Constructors

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
@@ -50,7 +50,7 @@ namespace System.Collections.Tests
             Assert.Equal(2, queue.Capacity);
 
             queue.EnsureCapacity(12);
-            Assert.True(queue.Capacity >= 12, "capacity should be at least 12 after ensuring capacity");
+            Assert.InRange(queue.Capacity, 12, int.MaxValue);
 
             queue.TrimExcess();
             Assert.Equal(0, queue.Capacity);

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
@@ -44,7 +44,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        public void PriorityQueue_EnsureCapacityThenTrimExcess_CapacityUpdates(int capacity)
+        public void PriorityQueue_EnsureCapacityThenTrimExcess_CapacityUpdates()
         {
             var queue = new PriorityQueue<TElement, TPriority>(2);
             Assert.Equal(2, queue.Capacity);


### PR DESCRIPTION
This was asked in https://github.com/dotnet/runtime/issues/66426#issuecomment-1536878286 but the PR that closed that issue didn't actually add it.

PriorityQueue has TrimExcess and EnsureCapacity, so adding Capacity property aligns the APIs with the other collections.

Fixes #110728