### PR TITLE
Implement 'expectedType' null check

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -1115,6 +1115,11 @@ namespace System.Security.Cryptography.Xml
 
         private static bool IsKeyTheCorrectAlgorithm(AsymmetricAlgorithm key, Type expectedType)
         {
+            if (expectedType is null)
+            {
+                throw new ArgumentNullException(nameof(expectedType));
+            }
+
             Type actualType = key.GetType();
 
             if (actualType == expectedType)


### PR DESCRIPTION
Null check of 'expectedType' argument added to avoid potential NRE. 
Value ta, which may have null value in line 1034, is dereferenced in method call IsKeyTheCorrectAlgorithm().

Found by Linux Verification Center (linuxtesting.org) with SVACE.