### PR TITLE
Dispose instance of XmlNodeReader in LoadInnerXml

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXPathTransform.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXPathTransform.cs
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.Xml
                     if (elem.LocalName == "XPath")
                     {
                         _xpathexpr = elem.InnerXml.Trim(null);
-                        XmlNodeReader nr = new XmlNodeReader(elem);
+                        using XmlNodeReader nr = new XmlNodeReader(elem);
                         XmlNameTable nt = nr.NameTable;
                         _nsm = new XmlNamespaceManager(nt);
                         if (!Utils.VerifyAttributes(elem, (string?)null))


### PR DESCRIPTION
Add missing Dispose call of XmlNodeReader

Found by Linux Verification Center (linuxtesting.org) with SVACE.