### PR TITLE
[mono] Chain `SIGSEGV` native crashes to the default `SIGSEGV` handler

### DIFF
--- a/src/mono/mono/mini/mini-posix.c
+++ b/src/mono/mono/mini/mini-posix.c
@@ -218,7 +218,7 @@ MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
  * sigaction.sa_handler == SIG_DFL. This is used to propagate the crash to the OS.
  */
 void
-mono_chain_signal_to_default_sigsegv_handler ()
+mono_chain_signal_to_default_sigsegv_handler (void)
 {
 	struct sigaction *saved_handler = (struct sigaction *)get_saved_signal_handler (SIGSEGV);
 

--- a/src/mono/mono/mini/mini-posix.c
+++ b/src/mono/mono/mini/mini-posix.c
@@ -188,7 +188,7 @@ save_old_signal_handler (int signo, struct sigaction *old_action)
  *
  *   Call the original signal handler for the signal given by the arguments, which
  * should be the same as for a signal handler. Returns TRUE if the original handler
- * was called, false otherwise.
+ * was called, false otherwise. NOTE: sigaction.sa_handler == SIG_DFL handlers are not considered.
  */
 gboolean
 MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
@@ -196,6 +196,7 @@ MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 	int signal = MONO_SIG_HANDLER_GET_SIGNO ();
 	struct sigaction *saved_handler = (struct sigaction *)get_saved_signal_handler (signal);
 
+	// Ignores chaining to default signal handlers i.e. when saved_handler->sa_handler == SIG_DFL
 	if (saved_handler && saved_handler->sa_handler) {
 		if (!(saved_handler->sa_flags & SA_SIGINFO)) {
 			saved_handler->sa_handler (signal);
@@ -208,6 +209,27 @@ MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 	}
 	return FALSE;
 }
+
+
+/*
+ * mono_chain_signal_to_default_sigsegv_handler:
+ *
+ *   Call the original SIGSEGV signal handler in cases when the original handler is
+ * sigaction.sa_handler == SIG_DFL. This is used to propagate the crash to the OS.
+ */
+void
+mono_chain_signal_to_default_sigsegv_handler ()
+{
+	struct sigaction *saved_handler = (struct sigaction *)get_saved_signal_handler (SIGSEGV);
+
+	if (saved_handler && saved_handler->sa_handler == SIG_DFL) {
+		sigaction (SIGSEGV, saved_handler, NULL);
+		raise (SIGSEGV);
+	} else {
+		g_async_safe_printf ("\nFailed to chain SIGSEGV signal to the default handler.\n");
+	}
+}
+
 
 MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 {
@@ -348,8 +370,14 @@ add_signal_handler (int signo, MonoSignalHandler handler, int flags)
 
 	/* if there was already a handler in place for this signal, store it */
 	if (! (previous_sa.sa_flags & SA_SIGINFO) &&
-			(SIG_DFL == previous_sa.sa_handler)) {
-		/* it there is no sa_sigaction function and the sa_handler is default, we can safely ignore this */
+			(SIG_DFL == previous_sa.sa_handler) && signo != SIGSEGV) {
+		/* 
+		 * If there is no sa_sigaction function and the sa_handler is default, 
+		 * it means the currently registered handler for this signal is the default one.
+		 * For signal chaining, we need to store the default SIGSEGV handler so that the crash 
+		 * is properly propagated, while default handlers for other signals are ignored and 
+		 * are not considered.
+		 */
 	} else {
 		if (mono_do_signal_chaining)
 			save_old_signal_handler (signo, &previous_sa);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3908,7 +3908,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 		mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
 
 		if (mono_do_crash_chaining) {
-			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+			if (!mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
+				mono_chain_signal_to_default_sigsegv_handler ();
 			return;
 		}
 	}
@@ -3918,7 +3919,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	} else {
 		mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
 		if (mono_do_crash_chaining) {
-			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+			if (!mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
+				mono_chain_signal_to_default_sigsegv_handler ();
 			return;
 		}
 	}

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -678,6 +678,7 @@ void MONO_SIG_HANDLER_SIGNATURE (mono_sigsegv_signal_handler);
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigint_signal_handler) ;
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigterm_signal_handler) ;
 gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
+void mono_chain_signal_to_default_sigsegv_handler ();
 
 #if defined (HOST_WASM)
 

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -678,7 +678,7 @@ void MONO_SIG_HANDLER_SIGNATURE (mono_sigsegv_signal_handler);
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigint_signal_handler) ;
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigterm_signal_handler) ;
 gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
-void mono_chain_signal_to_default_sigsegv_handler ();
+void mono_chain_signal_to_default_sigsegv_handler (void);
 
 #if defined (HOST_WASM)
 

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -587,6 +587,12 @@ MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 	return FALSE;
 }
 
+void
+mono_chain_signal_to_default_sigsegv_handler ()
+{
+	g_error ("mono_chain_signal_to_default_sigsegv_handler not supported on WASM");
+}
+
 gboolean
 mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, void *sigctx)
 {

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -588,7 +588,7 @@ MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 }
 
 void
-mono_chain_signal_to_default_sigsegv_handler ()
+mono_chain_signal_to_default_sigsegv_handler (void)
 {
 	g_error ("mono_chain_signal_to_default_sigsegv_handler not supported on WASM");
 }

--- a/src/mono/mono/mini/mini-windows.c
+++ b/src/mono/mono/mini/mini-windows.c
@@ -253,7 +253,7 @@ MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 }
 
 void
-mono_chain_signal_to_default_sigsegv_handler ()
+mono_chain_signal_to_default_sigsegv_handler (void)
 {
 	g_error ("mono_chain_signal_to_default_sigsegv_handler not supported on Windows");
 }

--- a/src/mono/mono/mini/mini-windows.c
+++ b/src/mono/mono/mini/mini-windows.c
@@ -252,6 +252,12 @@ MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 	return TRUE;
 }
 
+void
+mono_chain_signal_to_default_sigsegv_handler ()
+{
+	g_error ("mono_chain_signal_to_default_sigsegv_handler not supported on Windows");
+}
+
 #if !HAVE_EXTERN_DEFINED_NATIVE_CRASH_HANDLER
 #ifndef MONO_CROSS_COMPILE
 void


### PR DESCRIPTION
## Description

### The problem

When `SIGSEGV` gets raised from native code Mono does not create crash reports on iOS-like platforms.
Instead our handler dumps native/managed stack traces and returns from the handler normally at:

https://github.com/dotnet/runtime/blob/c969265440b74e95429fb513e6d940d6c9bc2fd3/src/mono/mono/mini/mini-runtime.c#L3908-L3912

If it returns normally the code continues at the point the signal occurred, reexecuting the same instruction raising the signal again. This resulted in "double faults" in mono runtime, which we handled in such way that we exit from double faulting with `exit(-1)`:

https://github.com/dotnet/runtime/blob/c969265440b74e95429fb513e6d940d6c9bc2fd3/src/mono/mono/mini/mini-posix.c#L787-L792

preventing any crash log of being created. 

This is true even in .NET 7, stack trace of an app that crashes, but does not generate any crash report (full crash report: https://gist.github.com/ivanpovazan/798e5185f13dada2d80e9b023b179a18) :
```
...
0x109687394 - /Users/ivan/tmp/net7/MacCat7/bin/Debug/net7.0-maccatalyst/maccatalyst-arm64/MacCat7.app/Contents/MacOS/MacCat7 : xamarin_main
0x109ae3574 - /Users/ivan/tmp/net7/MacCat7/bin/Debug/net7.0-maccatalyst/maccatalyst-arm64/MacCat7.app/Contents/MacOS/MacCat7 : main
0x187bdc274 - /usr/lib/dyld : start

Exiting early due to double fault.
```

### Crash chaining

On mobile we enable crash chaining `mono_do_crash_chaining=true` and signal chaining `mono_do_signal_chaining=true` :
https://github.com/xamarin/xamarin-macios/blob/27e1882103ef4bc1c8db16c18533039ecc03ee3e/runtime/monovm-bridge.m#L83-L84
which means that after handling the native crash we chain the signal to any previous handlers defined for the signal. However, during registration of mono signal handlers, the default handler is being ignored:
https://github.com/dotnet/runtime/blob/c969265440b74e95429fb513e6d940d6c9bc2fd3/src/mono/mono/mini/mini-posix.c#L349-L356

For this reason there is no effect when `mono_chain_signal` is called in the basic setup (no user-defined handler).

## The fix

In this PR we are changing the logic of preserving original handlers by considering the default SIGSEGV handlers - when `sa.sa_handler == SIG_DFL` for signal chaining as well.
When the SIGSEGV native crash occurs and after we finish with our handler, we first try to chain the signal to any saved non-default handler - `sa.sa_handler != SIG_DFL`, if that fails, then we try chaining to the default one - `sa.sa_handler == SIG_DFL`. This way we avoid double faulting and properly propagate the SIGSEGV to the OS handler.

## Test

Tested on MAUI iOS and MacCatalyst apps where now crash reports are properly generated.
Android behaviour is left unchanged.

---
Fixes: https://github.com/dotnet/runtime/issues/106064