### PR TITLE
Add a null pointer check to CCeeGen::GetString

### DIFF
--- a/src/coreclr/md/ceefilegen/cceegen.cpp
+++ b/src/coreclr/md/ceefilegen/cceegen.cpp
@@ -120,7 +120,7 @@ STDMETHODIMP CCeeGen::GetString(ULONG RVA, __inout LPWSTR *lpString)
 
 
 ErrExit:
-    if (*lpString)
+    if (lpString != NULL && *lpString != 0)
         return S_OK;
     return hr;
 }


### PR DESCRIPTION
Add a null pointer check to CCeeGen::GetString
If lpString is NULL, there will be a null pointer access violation.

Found by Linux Verification Center (linuxtesting.org) using SVACE.