### PR TITLE
Fix race condition when cancelling pending HTTP connection attempts

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http1.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http1.cs
@@ -259,8 +259,7 @@ namespace System.Net.Http
             HttpConnection? connection = null;
             Exception? connectionException = null;
 
-            CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource();
-            waiter.ConnectionCancellationTokenSource = cts;
+            CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource(waiter);
             try
             {
                 connection = await CreateHttp11ConnectionAsync(queueItem.Request, true, cts.Token).ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
@@ -181,8 +181,7 @@ namespace System.Net.Http
             Exception? connectionException = null;
             HttpConnectionWaiter<Http2Connection?> waiter = queueItem.Waiter;
 
-            CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource();
-            waiter.ConnectionCancellationTokenSource = cts;
+            CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource(waiter);
             try
             {
                 (Stream stream, TransportContext? transportContext, Activity? activity, IPEndPoint? remoteEndPoint) = await ConnectAsync(queueItem.Request, true, cts.Token).ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -75,52 +75,60 @@ namespace System.Net.Http
             // Loop in case we get a 421 and need to send the request to a different authority.
             while (true)
             {
-                if (!TryGetHttp3Authority(request, out HttpAuthority? authority, out Exception? reasonException))
+                HttpConnectionWaiter<Http3Connection?>? http3ConnectionWaiter = null;
+                try
                 {
-                    if (reasonException is null)
+                    if (!TryGetHttp3Authority(request, out HttpAuthority? authority, out Exception? reasonException))
+                    {
+                        if (reasonException is null)
+                        {
+                            return null;
+                        }
+                        ThrowGetVersionException(request, 3, reasonException);
+                    }
+
+                    long queueStartingTimestamp = HttpTelemetry.Log.IsEnabled() || Settings._metrics!.RequestsQueueDuration.Enabled ? Stopwatch.GetTimestamp() : 0;
+                    Activity? waitForConnectionActivity = ConnectionSetupDistributedTracing.StartWaitForConnectionActivity(authority);
+
+                    if (!TryGetPooledHttp3Connection(request, out Http3Connection? connection, out http3ConnectionWaiter))
+                    {
+                        try
+                        {
+                            connection = await http3ConnectionWaiter.WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            ConnectionSetupDistributedTracing.ReportError(waitForConnectionActivity, ex);
+                            waitForConnectionActivity?.Stop();
+                            throw;
+                        }
+                    }
+
+                    // Request cannot be sent over H/3 connection, try downgrade or report failure.
+                    // Note that if there's an H/3 suitable origin authority but is unavailable or blocked via Alt-Svc, exception is thrown instead.
+                    if (connection is null)
                     {
                         return null;
                     }
-                    ThrowGetVersionException(request, 3, reasonException);
-                }
 
-                long queueStartingTimestamp = HttpTelemetry.Log.IsEnabled() || Settings._metrics!.RequestsQueueDuration.Enabled ? Stopwatch.GetTimestamp() : 0;
-                Activity? waitForConnectionActivity = ConnectionSetupDistributedTracing.StartWaitForConnectionActivity(authority);
+                    HttpResponseMessage response = await connection.SendAsync(request, queueStartingTimestamp, waitForConnectionActivity, cancellationToken).ConfigureAwait(false);
 
-                if (!TryGetPooledHttp3Connection(request, out Http3Connection? connection, out HttpConnectionWaiter<Http3Connection?>? http3ConnectionWaiter))
-                {
-                    try
+                    // If an Alt-Svc authority returns 421, it means it can't actually handle the request.
+                    // An authority is supposed to be able to handle ALL requests to the origin, so this is a server bug.
+                    // In this case, we blocklist the authority and retry the request at the origin.
+                    if (response.StatusCode == HttpStatusCode.MisdirectedRequest && connection.Authority != _originAuthority)
                     {
-                        connection = await http3ConnectionWaiter.WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
+                        response.Dispose();
+                        BlocklistAuthority(connection.Authority);
+                        continue;
                     }
-                    catch (Exception ex)
-                    {
-                        ConnectionSetupDistributedTracing.ReportError(waitForConnectionActivity, ex);
-                        waitForConnectionActivity?.Stop();
-                        throw;
-                    }
-                }
 
-                // Request cannot be sent over H/3 connection, try downgrade or report failure.
-                // Note that if there's an H/3 suitable origin authority but is unavailable or blocked via Alt-Svc, exception is thrown instead.
-                if (connection is null)
+                    return response;
+                }
+                finally
                 {
-                    return null;
+                    http3ConnectionWaiter?.CancelIfNecessary(this, cancellationToken.IsCancellationRequested);
                 }
-
-                HttpResponseMessage response = await connection.SendAsync(request, queueStartingTimestamp, waitForConnectionActivity, cancellationToken).ConfigureAwait(false);
-
-                // If an Alt-Svc authority returns 421, it means it can't actually handle the request.
-                // An authority is supposed to be able to handle ALL requests to the origin, so this is a server bug.
-                // In this case, we blocklist the authority and retry the request at the origin.
-                if (response.StatusCode == HttpStatusCode.MisdirectedRequest && connection.Authority != _originAuthority)
-                {
-                    response.Dispose();
-                    BlocklistAuthority(connection.Authority);
-                    continue;
-                }
-
-                return response;
             }
         }
 
@@ -253,8 +261,7 @@ namespace System.Net.Http
             HttpAuthority? authority = null;
             HttpConnectionWaiter<Http3Connection?> waiter = queueItem.Waiter;
 
-            CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource();
-            waiter.ConnectionCancellationTokenSource = cts;
+            CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource(waiter);
             Activity? connectionSetupActivity = null;
             try
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -127,7 +127,7 @@ namespace System.Net.Http
                 }
                 finally
                 {
-                    http3ConnectionWaiter?.CancelIfNecessary(this, cancellationToken.IsCancellationRequested);
+                    http3ConnectionWaiter?.SetTimeoutToPendingConnectionAttempt(this, cancellationToken.IsCancellationRequested);
                 }
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionWaiter.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionWaiter.cs
@@ -75,7 +75,7 @@ namespace System.Net.Http
             }
         }
 
-        public void CancelIfNecessary(HttpConnectionPool pool, bool requestCancelled)
+        public void SetTimeoutToPendingConnectionAttempt(HttpConnectionPool pool, bool requestCancelled)
         {
             int timeout = GlobalHttpSettings.SocketsHttpHandler.PendingConnectionTimeoutOnRequestCompletion;
             if (ConnectionCancellationTokenSource is null ||


### PR DESCRIPTION
Fixes #110598

There's a race condition here where if the initiating request completes right away, before we're able to set the `CTS` in `InjectNewHttp11ConnectionAsync`, we'll never set the timeout.
https://github.com/dotnet/runtime/blob/c969265440b74e95429fb513e6d940d6c9bc2fd3/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionWaiter.cs#L78-L93
https://github.com/dotnet/runtime/blob/c969265440b74e95429fb513e6d940d6c9bc2fd3/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http1.cs#L256-L263
It's easy to reproduce if you add a delay between the `Yield` and assigning the `cts`, while failing the request.
The test I added was 100% deterministic if I added the delay, or increased the `Parallel` count from 100 to 1000, but that takes too long to run for CI.

The HTTP/3 change is just adding a try/finally to signal the waiter, looks like we missed that in #101531.
[Diff without whitespace changes](https://github.com/dotnet/runtime/pull/110744/files?diff=split&w=1)
