### PR TITLE
Fix ambiguous call build break in Fuzzing project

### DIFF
--- a/src/libraries/Fuzzing/DotnetFuzzing/Assert.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Assert.cs
@@ -29,9 +29,6 @@ internal static class Assert
             throw new Exception("Value is  null");
     }
 
-    public static void SequenceEqual<T>(Span<T> expected, Span<T> actual) =>
-        SequenceEqual((ReadOnlySpan<T>)expected, (ReadOnlySpan<T>)actual);
-
     public static void SequenceEqual<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual)
     {
         if (!expected.SequenceEqual(actual))


### PR DESCRIPTION
Compiler isn't happy about
> The call is ambiguous between the following methods or properties: 'Assert.SequenceEqual<T>(Span<T>, Span<T>)' and 'Assert.SequenceEqual<T>(ReadOnlySpan<T>, ReadOnlySpan<T>)'

here
https://github.com/dotnet/runtime/blob/144dcae3497f73366ec7d076e6e7ea4ff856ce7d/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/Base64Fuzzer.cs#L142
where the args are `Span<byte>` and `byte[]`.