### PR TITLE
[wasm] Fix rebuild of browser-bench with startup apps

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -43,13 +43,15 @@
     <WasmExtraFilesToDeploy Include="style.css" />
     <Compile Remove="Console/Console.cs" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" />
-    <ArtifactsDotnetLatestSdks Include="$(ArtifactsDir)bin/dotnet-latest/sdk/*/*" />
   </ItemGroup>
 
   <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
   <UsingTask TaskName="GetNugetConfigTask" AssemblyFile="$(OutputPath)Wasm.Browser.Bench.Sample.dll" />
 
-  <Target Name="SetWBTSdksPath">
+  <Target Name="SetWBTSdksPath" DependsOnTargets="BuildWBT">
+    <ItemGroup>
+      <ArtifactsDotnetLatestSdks Include="$(ArtifactsDir)bin/dotnet-latest/sdk/*/*" />
+    </ItemGroup>
     <PropertyGroup>
       <WBTSdksPath>%(ArtifactsDotnetLatestSdks.RootDir)%(ArtifactsDotnetLatestSdks.Directory)Sdks</WBTSdksPath>
     </PropertyGroup>
@@ -68,7 +70,7 @@
     <NugetPackagesPath>$(MSBuildThisFileDirectory)nugetPackages</NugetPackagesPath>
   </PropertyGroup>
 
-  <Target Name="BuildWBT">
+  <Target Name="BuildWBT" Condition="!Exists('$(ArtifactsDir)bin/dotnet-latest')">
     <PropertyGroup>
       <_ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</_ScriptExt>
       <_ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</_ScriptExt>


### PR DESCRIPTION
This fixes 2 issues

 * clean build of browser-bench with startup apps failed, because WBT's dotnet-latest wasn't available when setting the sdk spath
 * problem with rebuilding WBT, where WBT fails with

```
runtime/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets(201,5): error MSB4018: The "InstallWorkloadFromArtifacts" task failed unexpectedly. [runtime/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj] [runtime/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj]
runtime/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets(201,5): error MSB4018: System.IO.IOException: Directory not empty : 'runtime/artifacts/bin/dotnet-latest/host/fxr/10.0.0-alpha.1.24610.2' [runtime/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj] [runtime/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj]
runtime/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets(201,5): error MSB4018: at System.IO.FileSystem.RemoveDirectoryRecursive(String fullPath) [runtime/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj] [runtime/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj]
runtime/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets(201,5): error MSB4018: at Microsoft.Workload.Build.Tasks.InstallWorkloadFromArtifacts.Execute() [runtime/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj] [runtime/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj]
runtime/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets(201,5): error MSB4018: at Microsoft.Build.BackEnd.TaskExecutionHost.Execute() [runtime/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj] [runtime/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj]
runtime/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets(201,5): error MSB4018: at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [runtime/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj] [runtime/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj]
      0 Warning(s)
      1 Error(s)

```