### PR TITLE
Avoid array allocation in Task.WhenAll?

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -6285,7 +6285,7 @@ namespace System.Threading.Tasks
 
             return taskList.Count == 0 ?
                 new Task<TResult[]>(false, Array.Empty<TResult>(), TaskCreationOptions.None, default) :
-                new WhenAllPromise<TResult>(taskList.ToArray());
+                new WhenAllPromise<TResult>(CollectionsMarshal.AsMemory(taskList)); // 
         }
 
         /// <summary>
@@ -6391,7 +6391,7 @@ namespace System.Threading.Tasks
             /// <summary>The number of tasks remaining to complete.</summary>
             private int m_count;
 
-            internal WhenAllPromise(Task<T>[] tasks)
+            internal WhenAllPromise(ReadOnlyMemory<Task<T>> tasks)
             {
                 Debug.Assert(tasks != null, "Expected a non-null task array");
                 Debug.Assert(tasks.Length > 0, "Expected a non-zero length task array");

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -6291,7 +6291,8 @@ namespace System.Threading.Tasks
             }
             while (enumerator.MoveNext());
 
-            return new WhenAllPromise<TResult>(taskList._items);
+            // Can this be done similar to CollectionsMarshal.AsSpan? There's no Memory-based counterpart
+            return new WhenAllPromise<TResult>(CollectionsMarshal.AsMemory(taskList));
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -6285,7 +6285,7 @@ namespace System.Threading.Tasks
 
             return taskList.Count == 0 ?
                 new Task<TResult[]>(false, Array.Empty<TResult>(), TaskCreationOptions.None, default) :
-                new WhenAllPromise<TResult>(CollectionsMarshal.AsMemory(taskList)); // 
+                new WhenAllPromise<TResult>(CollectionsMarshal.AsMemory(taskList)); // No such method, can this be done similar to CollectionsMarshal.AsSpan?
         }
 
         /// <summary>


### PR DESCRIPTION
Proposing possible improvements for `Task.WhenAll<TResult>(IEnumerable)`:

- `List<T>` allocation could be avoided if the source is empty.
- Array allocation could be avoided, the backing store of the newly created `List<T>` could be used directly.