### PR TITLE
Fix build with -DCLR_CMAKE_USE_SYSTEM_BROTLI=true

### DIFF
--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -7,6 +7,10 @@ if (NOT CLR_CMAKE_USE_SYSTEM_ZLIB)
 endif()
 
 if (CLR_CMAKE_USE_SYSTEM_BROTLI)
+    find_library(BROTLIDEC brotlidec REQUIRED)
+    find_library(BROTLIENC brotlienc REQUIRED)
+    list(APPEND ${BROTLI_LIBRARIES} ${BROTLIDEC} ${BROTLIENC})
+
     if (CLR_CMAKE_HOST_FREEBSD)
         set(CMAKE_REQUIRED_INCLUDES ${CROSS_ROOTFS}/usr/local/include)
     endif()

--- a/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
+++ b/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
@@ -19,4 +19,11 @@ macro(append_extra_compression_libs NativeLibsExtra)
     list(APPEND ZLIB_LIBRARIES $<IF:$<BOOL:${CLR_CMAKE_USE_SYSTEM_ZLIB}>,z,zlib>)
   endif ()
   list(APPEND ${NativeLibsExtra} ${ZLIB_LIBRARIES})
+
+  if (CLR_CMAKE_USE_SYSTEM_BROTLI)
+    find_library(BROTLIDEC brotlidec REQUIRED)
+    find_library(BROTLIENC brotlienc REQUIRED)
+
+    list(APPEND ${NativeLibsExtra} ${BROTLIDEC} ${BROTLIENC})
+  endif ()
 endmacro()


### PR DESCRIPTION
Currently, this fails on Fedora 41:

    $ ./build.sh  --cmakeargs  -DCLR_CMAKE_USE_SYSTEM_BROTLI=true /p:FullAssemblySigningSupported=false
    ...
    [100%] Linking CXX executable singlefilehost
    ld.lld: error: undefined symbol: BrotliDecoderCreateInstance
    >>> referenced by entrypoints.c
    >>> entrypoints.c.o:(s_compressionNative) in archive ../libs-native/System.IO.Compression.Native/libSystem.IO.Compression.Native.a

This seems to be a regression introduced when this bit was accidentally dropped:
https://github.com/dotnet/runtime/pull/109707/files#diff-7a160e52815fdd808d9415ada41dd5b1748826b27c78277e14f4adcf1ce61511

Fix the build by re-introducing it.

Fixes: https://github.com/dotnet/runtime/issues/110751