### PR TITLE
Remove unsafe code from IPAddress

### DIFF
--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -674,7 +674,7 @@ namespace System.Net
             if (IsIPv6)
             {
                 // For IPv6 addresses, we must compare the full 128-bit representation and the scope IDs.
-                return _numbers.AsSpan(0, 16).SequenceEqual(comparand._numbers.AsSpan(0, 16)) &&
+                return _numbers.AsSpan(0, 8).SequenceEqual(comparand._numbers.AsSpan(0, 8)) &&
                     PrivateScopeId == comparand.PrivateScopeId;
             }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -10,6 +10,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
+#pragma warning disable SA1648 // TODO: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3595
+
 namespace System.Net
 {
     /// <devdoc>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/94941

The safer patterns seem to show better codegen in fact + removed an allocation from `MapToIPv6`