### PR TITLE
Fix workload id for mobile-librarybuilder in 9.0 WorkloadManifest.json.in

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net9.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net9.Manifest/WorkloadManifest.json.in
@@ -35,7 +35,7 @@
       "extends": [ "microsoft-net-runtime-mono-tooling-net9" ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "linux-musl-x64", "linux-musl-arm64", "osx-x64", "osx-arm64" ]
     },
-    "mobile-librarybuilder-net9.0": {
+    "mobile-librarybuilder-net9": {
       "description": "Mobile SDK for building a self-contained .NET native library in net9.0",
       "packs": [
         "Microsoft.NET.Runtime.LibraryBuilder.Sdk.net9"


### PR DESCRIPTION
It shouldn't have the .0 suffix to match the other workloads.