### PR TITLE
[release/9.0-staging] Fix wrong alias-to for tvos AOT packs in net8 workload manifest

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net8.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net8.Manifest/WorkloadManifest.json.in
@@ -277,7 +277,7 @@
       "kind": "framework",
       "version": "${PackageVersionNet8}",
       "alias-to": {
-        "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.osx-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.net8.osx-x64": {
@@ -312,8 +312,8 @@
       "kind": "Sdk",
       "version": "${PackageVersionNet8}",
       "alias-to": {
-        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-arm64.Cross.tvos-arm64",
-        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvos-arm64"
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvos-arm64",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-arm64.Cross.tvos-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net8.tvos-arm64" : {


### PR DESCRIPTION
## Customer Impact

- [ ] Customer reported
- [X] Found internally

While working on https://github.com/dotnet/runtime/pull/110477 I noticed that we made two mistakes when adding the net8 workload manifest.

1. Microsoft.NETCore.App.Runtime.AOT.Cross.net8.tvos-arm64 uses the wrong alias-to so on an arm64 macOS host you'd get the x64 package and vice versa
2. Microsoft.NETCore.App.Runtime.net8.osx-arm64 refers to the Mono runtime package instead of the CoreCLR one.

This will only show up if you target e.g. net8.0-tvos using a net9 sdk and as far as I know the SDK should fetch the correct package during build, it just won't be pre-downloaded to the sdk packs folder.

# Regression

- [ ] Yes
- [X] No

This was introduced in https://github.com/dotnet/runtime/commit/2d7fe94f837246e89c84a626f8f212094f364ab7 but it's only a regression in the sense that it happens when you use the net9 sdk to target net8.0-tvos

## Testing

Tested locally by modifying the WorkloadManifest.json and observing the correct pack is installed.

## Risk

Low. This just changes the workload manifest for net8 when using a net9 sdk.