### PR TITLE
Remove RawArrayData

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System
 {
@@ -378,7 +379,7 @@ namespace System
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
 
-            ref byte p = ref Unsafe.As<RawArrayData>(array).Data;
+            ref byte p = ref array.RawData;
             int lowerBound = 0;
 
             MethodTable* pMT = RuntimeHelpers.GetMethodTable(array);
@@ -598,10 +599,10 @@ namespace System
             GC.KeepAlive(this); // Keep the method table alive
         }
 
-        public int Length => checked((int)Unsafe.As<RawArrayData>(this).Length);
+        public int Length => checked((int)RawLength);
 
         // This could return a length greater than int.MaxValue
-        internal nuint NativeLength => Unsafe.As<RawArrayData>(this).Length;
+        internal nuint NativeLength => RawLength;
 
         public long LongLength => (long)NativeLength;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 
 namespace System
 {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.CoreCLR.cs
@@ -40,8 +40,8 @@ namespace System.Runtime.InteropServices
             // If needed, we can save one or two instructions per call by marking this method as intrinsic and asking the JIT
             // to special-case arrays of known type and dimension.
 
-            // See comment on RawArrayData (in RuntimeHelpers.CoreCLR.cs) for details
-            return ref Unsafe.AddByteOffset(ref Unsafe.As<RawData>(array).Data, (nuint)RuntimeHelpers.GetMethodTable(array)->BaseSize - (nuint)(2 * sizeof(IntPtr)));
+            // See comment on Array for details
+            return ref Unsafe.AddByteOffset(ref array.RawData, RuntimeHelpers.GetMethodTable(array)->BaseSize - (3 * (nuint)sizeof(IntPtr)));
         }
     }
 }

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -138,7 +138,7 @@ namespace Internal.Runtime.CompilerHelpers
 
                 // Call write barrier directly. Assigning object reference does a type check.
                 Debug.Assert((uint)moduleIndex < (uint)gcStaticBaseSpines.Length);
-                ref object rawSpineIndexData = ref Unsafe.As<byte, object>(ref Unsafe.As<RawArrayData>(gcStaticBaseSpines).Data);
+                ref object rawSpineIndexData = ref MemoryMarshal.GetArrayDataReference(gcStaticBaseSpines);
                 Unsafe.Add(ref rawSpineIndexData, moduleIndex) = spine;
             }
 
@@ -191,7 +191,7 @@ namespace Internal.Runtime.CompilerHelpers
 
             object[] spine = new object[length / (MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint))];
 
-            ref object rawSpineData = ref Unsafe.As<byte, object>(ref Unsafe.As<RawArrayData>(spine).Data);
+            ref object rawSpineData = ref MemoryMarshal.GetArrayDataReference(spine);
 
             int currentBase = 0;
             for (byte* block = (byte*)gcStaticRegionStart;

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -433,7 +433,7 @@ namespace Internal.Runtime
             get
             {
                 Debug.Assert(HasComponentSize);
-                // See comment on RawArrayData for details
+                // See comment on Array for details
                 return BaseSize > (uint)(3 * sizeof(IntPtr));
             }
         }

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Array.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Array.cs
@@ -12,28 +12,18 @@ namespace System
 
     public partial class Array
     {
-        // CS0169: The field 'Array._numComponents' is never used
-#pragma warning disable 0169
-        // This field should be the first field in Array as the runtime/compilers depend on it
-        private int _numComponents;
-#pragma warning restore
+        internal uint RawLength; // Array._numComponents padded to IntPtr
+#if TARGET_64BIT
+        internal uint RawPadding;
+#endif
+        internal byte RawData;
 
-        public int Length => (int)Unsafe.As<RawArrayData>(this).Length;
+        public int Length => (int)RawLength;
     }
 
     // To accommodate class libraries that wish to implement generic interfaces on arrays, all class libraries
     // are now required to provide an Array<T> class that derives from Array.
     internal class Array<T> : Array
     {
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal class RawArrayData
-    {
-        public uint Length; // Array._numComponents padded to IntPtr
-#if TARGET_64BIT
-        public uint Padding;
-#endif
-        public byte Data;
     }
 }

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -761,9 +761,6 @@ namespace System.Runtime
             // This will throw NullReferenceException if obj is null.
             if ((nuint)index >= (uint)array.Length)
                 ThrowIndexOutOfRangeException(array);
-
-            Debug.Assert(index >= 0);
-            ref object? element = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index);
 #else
             if (array is null)
             {
@@ -773,9 +770,11 @@ namespace System.Runtime
             {
                 throw elementType->GetClasslibException(ExceptionIDs.IndexOutOfRange);
             }
-            ref object rawData = ref Unsafe.As<byte, object>(ref Unsafe.As<RawArrayData>(array).Data);
-            ref object element = ref Unsafe.Add(ref rawData, index);
 #endif
+
+            Debug.Assert(index >= 0);
+            ref object? element = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index);
+
             MethodTable* arrayElemType = array.GetMethodTable()->RelatedParameterType;
 
             if (elementType != arrayElemType)
@@ -793,9 +792,6 @@ namespace System.Runtime
             // This will throw NullReferenceException if obj is null.
             if ((nuint)index >= (uint)array.Length)
                 ThrowIndexOutOfRangeException(array);
-
-            Debug.Assert(index >= 0);
-            ref object? element = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index);
 #else
             if (array is null)
             {
@@ -807,9 +803,10 @@ namespace System.Runtime
             {
                 throw array.GetMethodTable()->GetClasslibException(ExceptionIDs.IndexOutOfRange);
             }
-            ref object rawData = ref Unsafe.As<byte, object>(ref Unsafe.As<RawArrayData>(array).Data);
-            ref object element = ref Unsafe.Add(ref rawData, index);
 #endif
+
+            Debug.Assert(index >= 0);
+            ref object? element = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index);
 
             MethodTable* elementType = array.GetMethodTable()->RelatedParameterType;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
@@ -25,19 +25,10 @@ namespace System
     // IList<U> and IReadOnlyList<U>, where T : U dynamically.  See the SZArrayHelper class for details.
     public abstract partial class Array : ICollection, IEnumerable, IList, IStructuralComparable, IStructuralEquatable, ICloneable
     {
-        // CS0169: The field 'Array._numComponents' is never used
-        // CA1823: Unused field '_numComponents'
-#pragma warning disable 0169
-#pragma warning disable CA1823
-        // This field should be the first field in Array as the runtime/compilers depend on it
-        [NonSerialized]
-        private int _numComponents;
-#pragma warning restore
-
-        public int Length => checked((int)Unsafe.As<RawArrayData>(this).Length);
+        public int Length => checked((int)RawLength);
 
         // This could return a length greater than int.MaxValue
-        internal nuint NativeLength => Unsafe.As<RawArrayData>(this).Length;
+        internal nuint NativeLength => RawLength;
 
         public long LongLength => (long)NativeLength;
 
@@ -159,7 +150,7 @@ namespace System
         private ref int GetRawMultiDimArrayBounds()
         {
             Debug.Assert(!IsSzArray);
-            return ref Unsafe.As<byte, int>(ref Unsafe.As<RawArrayData>(this).Data);
+            return ref Unsafe.As<byte, int>(ref RawData);
         }
 
         // Provides a strong exception guarantee - either it succeeds, or
@@ -579,7 +570,7 @@ namespace System
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
 
-            ref byte p = ref Unsafe.As<RawArrayData>(array).Data;
+            ref byte p = ref array.RawData;
             int lowerBound = 0;
 
             MethodTable* mt = array.GetMethodTable();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -195,10 +195,10 @@ namespace System.Runtime.CompilerServices
         {
             MethodTable* pMT = GetMethodTable(obj);
 
-            // See comment on RawArrayData for details
+            // See comment on Array for details
             nuint rawSize = pMT->BaseSize - (nuint)(2 * sizeof(IntPtr));
             if (pMT->HasComponentSize)
-                rawSize += (uint)Unsafe.As<RawArrayData>(obj).Length * (nuint)pMT->ComponentSize;
+                rawSize += (uint)Unsafe.As<Array>(obj).RawLength * (nuint)pMT->ComponentSize;
 
             GC.KeepAlive(obj); // Keep MethodTable alive
 
@@ -412,24 +412,6 @@ namespace System.Runtime.CompilerServices
 
             return nint.Size;
         }
-    }
-
-    // CLR arrays are laid out in memory as follows (multidimensional array bounds are optional):
-    // [ sync block || pMethodTable || num components || MD array bounds || array data .. ]
-    //                 ^               ^                 ^                  ^ returned reference
-    //                 |               |                 \-- ref Unsafe.As<RawArrayData>(array).Data
-    //                 \-- array       \-- ref Unsafe.As<RawData>(array).Data
-    // The BaseSize of an array includes all the fields before the array data,
-    // including the sync block and method table. The reference to RawData.Data
-    // points at the number of components, skipping over these two pointer-sized fields.
-    [StructLayout(LayoutKind.Sequential)]
-    internal class RawArrayData
-    {
-        public uint Length; // Array._numComponents padded to IntPtr
-#if TARGET_64BIT
-        public uint Padding;
-#endif
-        public byte Data;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -198,7 +198,7 @@ namespace System.Runtime.CompilerServices
             // See comment on Array for details
             nuint rawSize = pMT->BaseSize - (nuint)(2 * sizeof(IntPtr));
             if (pMT->HasComponentSize)
-                rawSize += (uint)Unsafe.As<Array>(obj).RawLength * (nuint)pMT->ComponentSize;
+                rawSize += Unsafe.As<Array>(obj).RawLength * (nuint)pMT->ComponentSize;
 
             GC.KeepAlive(obj); // Keep MethodTable alive
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.NativeAot.cs
@@ -42,8 +42,8 @@ namespace System.Runtime.InteropServices
             // If needed, we can save one or two instructions per call by marking this method as intrinsic and asking the JIT
             // to special-case arrays of known type and dimension.
 
-            // See comment on RawArrayData (in RuntimeHelpers.CoreCLR.cs) for details
-            return ref Unsafe.AddByteOffset(ref Unsafe.As<RawData>(array).Data, (nuint)array.GetMethodTable()->BaseSize - (nuint)(2 * sizeof(IntPtr)));
+            // See comment on Array for details
+            return ref Unsafe.AddByteOffset(ref array.RawData, array.GetMethodTable()->BaseSize - (3 * (nuint)sizeof(IntPtr)));
         }
     }
 }

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -339,6 +339,10 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
         pClass->SetRank (Rank);
         pClass->SetMethodTable (pMT);
 
+        // this only reflects the fields declared in IL, not actual layout
+        // only used for debug asserts
+        INDEBUG(pClass->SetNumInstanceFields(ARRAY_ILFIELDS));
+
         // Fill In the method table
         pClass->SetNumMethods(static_cast<WORD>(numVirtuals + numNonVirtualSlots));
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -109,6 +109,11 @@ DEFINE_METHOD(ARG_ITERATOR,         CTOR2,                  .ctor,              
 DEFINE_CLASS(ARGUMENT_HANDLE,       System,                 RuntimeArgumentHandle)
 
 DEFINE_CLASS(ARRAY,                 System,                 Array)
+DEFINE_FIELD(ARRAY,                 LENGTH,                 RawLength)
+#ifdef TARGET_64BIT
+DEFINE_FIELD(ARRAY,                 PADDING,                RawPadding)
+#endif
+DEFINE_FIELD(ARRAY,                 DATA,                   RawData)
 
 DEFINE_CLASS(ARRAY_WITH_OFFSET,     Interop,                ArrayWithOffset)
 DEFINE_FIELD(ARRAY_WITH_OFFSET,     M_ARRAY,                m_array)
@@ -721,13 +726,6 @@ DEFINE_METHOD(INTERLOCKED,          COMPARE_EXCHANGE_LONG,  CompareExchange, SM_
 
 DEFINE_CLASS(RAW_DATA,              CompilerServices,       RawData)
 DEFINE_FIELD(RAW_DATA,              DATA,                   Data)
-
-DEFINE_CLASS(RAW_ARRAY_DATA,        CompilerServices,       RawArrayData)
-DEFINE_FIELD(RAW_ARRAY_DATA,        LENGTH,                 Length)
-#ifdef TARGET_64BIT
-DEFINE_FIELD(RAW_ARRAY_DATA,        PADDING,                Padding)
-#endif
-DEFINE_FIELD(RAW_ARRAY_DATA,        DATA,                   Data)
 
 DEFINE_CLASS(PORTABLE_TAIL_CALL_FRAME, CompilerServices,              PortableTailCallFrame)
 DEFINE_FIELD(PORTABLE_TAIL_CALL_FRAME, TAILCALL_AWARE_RETURN_ADDRESS, TailCallAwareReturnAddress)

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -100,6 +100,12 @@ struct RCW;
 #define ARRAYBASE_SIZE      (OBJECT_SIZE /* m_pMethTab */ + sizeof(DWORD) /* m_NumComponents */)
 #endif
 
+#ifdef TARGET_64BIT
+#define ARRAY_ILFIELDS      3
+#else
+#define ARRAY_ILFIELDS      2
+#endif
+
 #define ARRAYBASE_BASESIZE  (OBJHEADER_SIZE + ARRAYBASE_SIZE)
 
 //

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
@@ -109,7 +109,7 @@ namespace System.Runtime.CompilerServices
         private static ref Entry TableData(Entry[] table)
         {
             // points to element 0, which is used for embedded aux data
-            return ref Unsafe.As<byte, Entry>(ref Unsafe.As<RawArrayData>(table).Data);
+            return ref MemoryMarshal.GetArrayDataReference(table);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,8 +134,9 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ref Entry Element(Entry[] table, int index)
         {
+            Debug.Assert(index >= 0);
             // element 0 is used for embedded aux data, skip it
-            return ref Unsafe.Add(ref Unsafe.As<byte, Entry>(ref Unsafe.As<RawArrayData>(table).Data), index + 1);
+            return ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(table), (uint)index + 1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/mono/System.Private.CoreLib/src/System/Array.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Array.Mono.cs
@@ -12,17 +12,6 @@ namespace System
 {
     public partial class Array
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal sealed class RawData
-        {
-            public IntPtr Bounds;
-            public uint Count;
-#if !TARGET_32BIT
-            private uint _Pad;
-#endif
-            public byte Data;
-        }
-
         public int Length
         {
             [Intrinsic]
@@ -32,7 +21,7 @@ namespace System
         // This could return a length greater than int.MaxValue
         internal nuint NativeLength
         {
-            get => (nuint)Unsafe.As<RawData>(this).Count;
+            get => RawLength;
         }
 
         public long LongLength

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.Mono.cs
@@ -21,8 +21,8 @@ namespace System.Runtime.InteropServices
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T GetArrayDataReference<T>(T[] array) =>
-            // Mono uses same layout for SZARRAY and MDARRAY; see comment on Array+RawData (in Array.Mono.cs) for details
-            ref Unsafe.As<byte, T>(ref Unsafe.As<Array.RawData>(array).Data);
+            // Mono uses same layout for SZARRAY and MDARRAY; see comment on Array for details
+            ref Unsafe.As<byte, T>(ref array.RawData);
 
         /// <summary>
         /// Returns a reference to the 0th element of <paramref name="array"/>. If the array is empty, returns a reference to where the 0th element
@@ -38,7 +38,7 @@ namespace System.Runtime.InteropServices
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref byte GetArrayDataReference(Array array) =>
-            // Mono uses same layout for SZARRAY and MDARRAY; see comment on Array+RawData (in Array.Mono.cs) for details
-            ref Unsafe.As<Array.RawData>(array).Data;
+            // Mono uses same layout for SZARRAY and MDARRAY; see comment on Array for details
+            ref array.RawData;
     }
 }


### PR DESCRIPTION
Removes RawArrayData and makes Array reflect the actual runtime layout instead.

Makes code a bit safer by removing `Unsafe.As` usages with invalid types.

cc @EgorBo @tannergooding I ended up doing this after the discussion on Discord
cc @jkotas There was one CoreCLR assert here due to array MT creation not setting the field count, I made it set it here in debug to avoid that and any perf impact in release, is that okay to do?