### PR TITLE
JIT: Don't move EH region entries when aligning backward jumps

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5456,6 +5456,12 @@ bool Compiler::ThreeOptLayout::RunGreedyThreeOptPass(unsigned startPos, unsigned
                     continue;
                 }
 
+                // Don't consider any cut points that would move try/handler entries
+                if (compiler->bbIsTryBeg(s3BlockPrev) || compiler->bbIsHandlerBeg(s3BlockPrev))
+                {
+                    continue;
+                }
+
                 // Compute the cost delta of this partition
                 const weight_t currCost = currCostBase + GetCost(s3BlockPrev, s3Block);
                 const weight_t newCost =


### PR DESCRIPTION
Follow-up to #110277. Fixes #110756. Don't consider 4-opt cut points that would move the entry block of a try/handler region below other blocks in the region. Previously, either future moves would put the entry block back at the top of the region, or we would get unlucky in the rare case and hit asserts.