### PR TITLE
Remove redundant 'unsafe' context

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -25,7 +25,7 @@ namespace Internal.Runtime.InteropServices
         /// </summary>
         /// <param name="moduleHandle">The native module handle for the assembly.</param>
         /// <param name="assemblyPath">The path to the assembly (as a pointer to a UTF-16 C string).</param>
-        public static unsafe void LoadInMemoryAssembly(IntPtr moduleHandle, IntPtr assemblyPath)
+        public static void LoadInMemoryAssembly(IntPtr moduleHandle, IntPtr assemblyPath)
         {
             if (!IsSupported)
                 throw new NotSupportedException(SR.NotSupported_CppCli);
@@ -37,7 +37,7 @@ namespace Internal.Runtime.InteropServices
         // It is intentionally left in the product, so developers get a warning when trimming an app which enabled `Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported`.
         // For runtime build the warning is suppressed in the ILLink.Suppressions.LibraryBuild.xml, but we only want to suppress it if the feature is enabled (IsSupported is true).
         // The call is extracted into a separate method which is the sole target of the suppression.
-        private static unsafe void LoadInMemoryAssemblyInContextWhenSupported(IntPtr moduleHandle, IntPtr assemblyPath)
+        private static void LoadInMemoryAssemblyInContextWhenSupported(IntPtr moduleHandle, IntPtr assemblyPath)
         {
 #pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
             LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath);
@@ -54,7 +54,7 @@ namespace Internal.Runtime.InteropServices
         [UnmanagedCallersOnly]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "The same C++/CLI feature switch applies to LoadInMemoryAssembly and this function. We rely on the warning from LoadInMemoryAssembly.")]
-        public static unsafe void LoadInMemoryAssemblyInContext(IntPtr moduleHandle, IntPtr assemblyPath, IntPtr loadContext)
+        public static void LoadInMemoryAssemblyInContext(IntPtr moduleHandle, IntPtr assemblyPath, IntPtr loadContext)
         {
             if (!IsSupported)
                 throw new NotSupportedException(SR.NotSupported_CppCli);

--- a/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -136,7 +136,7 @@ namespace System
         }
 
         // Gets the type of the current arg, does NOT advance the iterator
-        public unsafe RuntimeTypeHandle GetNextArgType()
+        public RuntimeTypeHandle GetNextArgType()
         {
             return RuntimeTypeHandle.FromIntPtr(GetNextArgType(ThisPtr));
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -109,7 +109,7 @@ namespace System
         // instance & might fail when called from within a CER, or if the
         // reliable flag is true, it will either always succeed or always
         // throw an exception with no side effects.
-        private static unsafe void CopySlow(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length, ArrayAssignType assignType)
+        private static void CopySlow(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length, ArrayAssignType assignType)
         {
             Debug.Assert(sourceArray.Rank == destinationArray.Rank);
 
@@ -605,7 +605,7 @@ namespace System
 
         public long LongLength => (long)NativeLength;
 
-        public unsafe int Rank
+        public int Rank
         {
             get
             {
@@ -615,7 +615,7 @@ namespace System
         }
 
         [Intrinsic]
-        public unsafe int GetLength(int dimension)
+        public int GetLength(int dimension)
         {
             int rank = RuntimeHelpers.GetMultiDimensionalArrayRank(this);
             if (rank == 0 && dimension == 0)
@@ -628,7 +628,7 @@ namespace System
         }
 
         [Intrinsic]
-        public unsafe int GetUpperBound(int dimension)
+        public int GetUpperBound(int dimension)
         {
             int rank = RuntimeHelpers.GetMultiDimensionalArrayRank(this);
             if (rank == 0 && dimension == 0)
@@ -642,7 +642,7 @@ namespace System
         }
 
         [Intrinsic]
-        public unsafe int GetLowerBound(int dimension)
+        public int GetLowerBound(int dimension)
         {
             int rank = RuntimeHelpers.GetMultiDimensionalArrayRank(this);
             if (rank == 0 && dimension == 0)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -302,7 +302,7 @@ namespace System.Reflection
 
         #region Constructor
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern unsafe IntPtr GetMetadataImport(RuntimeModule module);
+        private static extern IntPtr GetMetadataImport(RuntimeModule module);
 
         internal MetadataImport(RuntimeModule module)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
@@ -9,7 +9,7 @@ using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
 {
-    internal sealed unsafe class RtFieldInfo : RuntimeFieldInfo, IRuntimeFieldInfo
+    internal sealed class RtFieldInfo : RuntimeFieldInfo, IRuntimeFieldInfo
     {
         #region Private Data Members
         // aggressive caching

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -8,7 +8,7 @@ using MdToken = System.Reflection.MetadataToken;
 
 namespace System.Reflection
 {
-    internal sealed unsafe class RuntimeParameterInfo : ParameterInfo
+    internal sealed class RuntimeParameterInfo : ParameterInfo
     {
         #region Static Members
         internal static ParameterInfo[] GetParameters(IRuntimeMethodInfo method, MemberInfo member, Signature sig)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -489,7 +489,7 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        private static unsafe void ArrayTypeCheck(object obj, Array array)
+        private static void ArrayTypeCheck(object obj, Array array)
         {
             Debug.Assert(obj != null);
 
@@ -507,7 +507,7 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static unsafe void ArrayTypeCheck_Helper(object obj, void* elementType)
+        private static void ArrayTypeCheck_Helper(object obj, void* elementType)
         {
             Debug.Assert(obj != null);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericsHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericsHelpers.cs
@@ -28,7 +28,7 @@ internal static unsafe partial class GenericsHelpers
     }
 
     [DebuggerHidden]
-    public static unsafe IntPtr MethodWithSlotAndModule(IntPtr methodHnd, GenericHandleArgs * pArgs)
+    public static IntPtr MethodWithSlotAndModule(IntPtr methodHnd, GenericHandleArgs * pArgs)
     {
         return GenericHandleWorker(methodHnd, IntPtr.Zero, pArgs->signature, pArgs->dictionaryIndexAndSlot, pArgs->module);
     }
@@ -40,7 +40,7 @@ internal static unsafe partial class GenericsHelpers
     }
 
     [DebuggerHidden]
-    public static unsafe IntPtr ClassWithSlotAndModule(IntPtr classHnd, GenericHandleArgs * pArgs)
+    public static IntPtr ClassWithSlotAndModule(IntPtr classHnd, GenericHandleArgs * pArgs)
     {
         return GenericHandleWorker(IntPtr.Zero, classHnd, pArgs->signature, pArgs->dictionaryIndexAndSlot, pArgs->module);
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -286,7 +286,7 @@ namespace System.Runtime.CompilerServices
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern unsafe bool ContentEquals(object o1, object o2);
+        private static extern bool ContentEquals(object o1, object o2);
 
         [Obsolete("OffsetToStringData has been deprecated. Use string.GetPinnableReference() instead.")]
         public static int OffsetToStringData
@@ -414,7 +414,7 @@ namespace System.Runtime.CompilerServices
 
         // Returns pointer to the multi-dimensional array bounds.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe ref int GetMultiDimensionalArrayBounds(Array array)
+        internal static ref int GetMultiDimensionalArrayBounds(Array array)
         {
             Debug.Assert(GetMultiDimensionalArrayRank(array) > 0);
             // See comment on RawArrayData for details
@@ -553,7 +553,7 @@ namespace System.Runtime.CompilerServices
         /// <exception cref="ArgumentNullException">The specified type handle is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">The specified type cannot have a boxed instance of itself created.</exception>
         /// <exception cref="NotSupportedException">The passed in type is a by-ref-like type.</exception>
-        public static unsafe object? Box(ref byte target, RuntimeTypeHandle type)
+        public static object? Box(ref byte target, RuntimeTypeHandle type)
         {
             if (type.IsNullHandle())
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.type);
@@ -574,7 +574,7 @@ namespace System.Runtime.CompilerServices
         /// <remarks>
         /// This API returns the same value as <see cref="Unsafe.SizeOf{T}"/> for the type that <paramref name="type"/> represents.
         /// </remarks>
-        public static unsafe int SizeOf(RuntimeTypeHandle type)
+        public static int SizeOf(RuntimeTypeHandle type)
         {
             if (type.IsNullHandle())
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.type);
@@ -951,11 +951,11 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        internal unsafe MethodTable* _methodTable;
+        internal MethodTable* _methodTable;
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal unsafe ref struct GenericsStaticsInfo
+    internal ref struct GenericsStaticsInfo
     {
         // Pointer to field descs for statics
         internal IntPtr _pFieldDescs;
@@ -963,7 +963,7 @@ namespace System.Runtime.CompilerServices
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal unsafe ref struct ThreadStaticsInfo
+    internal ref struct ThreadStaticsInfo
     {
         internal int _nonGCTlsIndex;
         internal int _gcTlsIndex;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/VirtualDispatchHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/VirtualDispatchHelpers.cs
@@ -63,7 +63,7 @@ internal static unsafe partial class VirtualDispatchHelpers
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     [DebuggerHidden]
-    private static unsafe IntPtr VirtualFunctionPointerSlow(object obj, IntPtr classHandle, IntPtr methodHandle)
+    private static IntPtr VirtualFunctionPointerSlow(object obj, IntPtr classHandle, IntPtr methodHandle)
     {
         IntPtr result = ResolveVirtualFunctionPointer(ObjectHandleOnStack.Create(ref obj), classHandle, methodHandle);
         s_virtualFunctionPointerCache.TrySet(new VirtualResolutionData(RuntimeHelpers.GetMethodTable(obj), classHandle, methodHandle), result);
@@ -72,7 +72,7 @@ internal static unsafe partial class VirtualDispatchHelpers
     }
 
     [DebuggerHidden]
-    private static unsafe IntPtr VirtualFunctionPointer(object obj, IntPtr classHandle, IntPtr methodHandle)
+    private static IntPtr VirtualFunctionPointer(object obj, IntPtr classHandle, IntPtr methodHandle)
     {
         if (s_virtualFunctionPointerCache.TryGet(new VirtualResolutionData(RuntimeHelpers.GetMethodTable(obj), classHandle, methodHandle), out IntPtr result))
         {
@@ -82,7 +82,7 @@ internal static unsafe partial class VirtualDispatchHelpers
     }
 
     [DebuggerHidden]
-    private static unsafe IntPtr VirtualFunctionPointer_Dynamic(object obj, ref VirtualFunctionPointerArgs virtualFunctionPointerArgs)
+    private static IntPtr VirtualFunctionPointer_Dynamic(object obj, ref VirtualFunctionPointerArgs virtualFunctionPointerArgs)
     {
         IntPtr classHandle = virtualFunctionPointerArgs.classHnd;
         IntPtr methodHandle = virtualFunctionPointerArgs.methodHnd;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.InteropServices
         /// it is important for the caller to understand the COM object may have apartment affinity and therefore
         /// if the current thread is not in the correct apartment or the COM object is not a proxy this call may fail.
         /// </remarks>
-        public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
+        public static bool TryGetComInstance(object obj, out IntPtr unknown)
         {
             if (obj == null)
             {
@@ -61,7 +61,7 @@ namespace System.Runtime.InteropServices
         /// <param name="unknown">An unmanaged wrapper</param>
         /// <param name="obj">A managed object</param>
         /// <returns>True if the wrapper was resolved to a managed object, otherwise false.</returns>
-        public static unsafe bool TryGetObject(IntPtr unknown, [NotNullWhen(true)] out object? obj)
+        public static bool TryGetObject(IntPtr unknown, [NotNullWhen(true)] out object? obj)
         {
             obj = null;
             if (unknown == IntPtr.Zero)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -643,7 +643,7 @@ namespace System
         // Since the returned string is a pointer into metadata, the caller should
         // ensure the passed in type is alive for at least as long as returned result is
         // needed.
-        internal static unsafe MdUtf8String GetUtf8Name(RuntimeType type)
+        internal static MdUtf8String GetUtf8Name(RuntimeType type)
         {
             TypeHandle th = type.GetNativeTypeHandle();
             if (th.IsTypeDesc || th.AsMethodTable()->IsArray)
@@ -673,7 +673,7 @@ namespace System
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetDeclaringTypeHandle")]
         private static partial IntPtr GetDeclaringTypeHandle(IntPtr typeHandle);
 
-        internal static unsafe RuntimeType? GetDeclaringType(RuntimeType type)
+        internal static RuntimeType? GetDeclaringType(RuntimeType type)
         {
             IntPtr retTypeHandle = IntPtr.Zero;
             TypeHandle typeHandle = type.GetNativeTypeHandle();

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -863,7 +863,7 @@ namespace System
                     }
                 }
 
-                private unsafe void PopulateRtFields(Filter filter,
+                private void PopulateRtFields(Filter filter,
                     ReadOnlySpan<IntPtr> fieldHandles, RuntimeType declaringType, ref ListBuilder<RuntimeFieldInfo> list)
                 {
                     Debug.Assert(declaringType != null);

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -504,7 +504,7 @@ namespace System.StubHelpers
 
     internal sealed class HandleMarshaler
     {
-        internal static unsafe IntPtr ConvertSafeHandleToNative(SafeHandle? handle, ref CleanupWorkListElement? cleanupWorkList)
+        internal static IntPtr ConvertSafeHandleToNative(SafeHandle? handle, ref CleanupWorkListElement? cleanupWorkList)
         {
             if (Unsafe.IsNullRef(ref cleanupWorkList))
             {
@@ -516,12 +516,12 @@ namespace System.StubHelpers
             return StubHelpers.AddToCleanupList(ref cleanupWorkList, handle);
         }
 
-        internal static unsafe void ThrowSafeHandleFieldChanged()
+        internal static void ThrowSafeHandleFieldChanged()
         {
             throw new NotSupportedException(SR.Interop_Marshal_CannotCreateSafeHandleField);
         }
 
-        internal static unsafe void ThrowCriticalHandleFieldChanged()
+        internal static void ThrowCriticalHandleFieldChanged()
         {
             throw new NotSupportedException(SR.Interop_Marshal_CannotCreateCriticalHandleField);
         }
@@ -797,7 +797,7 @@ namespace System.StubHelpers
 
     internal static unsafe partial class MngdRefCustomMarshaler
     {
-        internal static unsafe void ConvertContentsToNative(ICustomMarshaler marshaler, in object pManagedHome, IntPtr* pNativeHome)
+        internal static void ConvertContentsToNative(ICustomMarshaler marshaler, in object pManagedHome, IntPtr* pNativeHome)
         {
             // COMPAT: We never pass null to MarshalManagedToNative.
             if (pManagedHome is null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
@@ -11,7 +11,7 @@ namespace System.Threading
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "WaitHandle_WaitOneCore")]
         private static partial int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout, [MarshalAs(UnmanagedType.Bool)] bool useTrivialWaits);
 
-        private static unsafe int WaitMultipleIgnoringSyncContextCore(ReadOnlySpan<IntPtr> waitHandles, bool waitAll, int millisecondsTimeout)
+        private static int WaitMultipleIgnoringSyncContextCore(ReadOnlySpan<IntPtr> waitHandles, bool waitAll, int millisecondsTimeout)
             => WaitMultipleIgnoringSyncContext(waitHandles, waitHandles.Length, waitAll, millisecondsTimeout);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "WaitHandle_WaitMultipleIgnoringSyncContext")]

--- a/src/coreclr/System.Private.CoreLib/src/System/Variant.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Variant.cs
@@ -35,7 +35,7 @@ namespace System
             return pUnk == IntPtr.Zero ? null : Marshal.GetObjectForIUnknown(pUnk);
         }
 
-        private static unsafe object? ConvertWrappedObject(object? wrapped)
+        private static object? ConvertWrappedObject(object? wrapped)
         {
             // Historically, for UnknownWrapper and DispatchWrapper, the wrapped object is passed
             // into Variant.SetFieldsObject, and the result set in objRef field is used for

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -148,7 +148,7 @@ namespace System.Runtime
         {
         }
 
-        internal static unsafe void* PointerAlign(void* ptr, int alignmentInBytes)
+        internal static void* PointerAlign(void* ptr, int alignmentInBytes)
         {
             int alignMask = alignmentInBytes - 1;
 #if TARGET_64BIT
@@ -205,7 +205,7 @@ namespace System.Runtime
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static unsafe void UnhandledExceptionFailFastViaClasslib(
+        internal static void UnhandledExceptionFailFastViaClasslib(
             RhFailFastReason reason, object unhandledException, IntPtr classlibAddress, ref ExInfo exInfo)
         {
 #if NATIVEAOT

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CMSG_CMS_RECIPIENT_INFO.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CMSG_CMS_RECIPIENT_INFO.cs
@@ -20,7 +20,7 @@ internal static partial class Interop
             //
             private void* pRecipientInfo;  // Do NOT add an underscore - this name still maps to a C++ Win32 header definition.
 
-            internal unsafe CMSG_KEY_TRANS_RECIPIENT_INFO* KeyTrans
+            internal CMSG_KEY_TRANS_RECIPIENT_INFO* KeyTrans
             {
                 get
                 {
@@ -29,7 +29,7 @@ internal static partial class Interop
                 }
             }
 
-            internal unsafe CMSG_KEY_AGREE_RECIPIENT_INFO* KeyAgree
+            internal CMSG_KEY_AGREE_RECIPIENT_INFO* KeyAgree
             {
                 get
                 {

--- a/src/libraries/Common/src/Interop/Windows/Interop.OBJECT_ATTRIBUTES.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.OBJECT_ATTRIBUTES.cs
@@ -43,7 +43,7 @@ internal static partial class Interop
         /// <summary>
         /// Equivalent of InitializeObjectAttributes macro with the exception that you can directly set SQOS.
         /// </summary>
-        public unsafe OBJECT_ATTRIBUTES(UNICODE_STRING* objectName, ObjectAttributes attributes, IntPtr rootDirectory, SECURITY_QUALITY_OF_SERVICE* securityQualityOfService = null)
+        public OBJECT_ATTRIBUTES(UNICODE_STRING* objectName, ObjectAttributes attributes, IntPtr rootDirectory, SECURITY_QUALITY_OF_SERVICE* securityQualityOfService = null)
         {
             Length = (uint)sizeof(OBJECT_ATTRIBUTES);
             RootDirectory = rootDirectory;

--- a/src/libraries/Common/src/Interop/Windows/Interop.SECURITY_QUALITY_OF_SERVICE.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.SECURITY_QUALITY_OF_SERVICE.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         public ContextTrackingMode ContextTrackingMode;
         public BOOLEAN EffectiveOnly;
 
-        public unsafe SECURITY_QUALITY_OF_SERVICE(ImpersonationLevel impersonationLevel, ContextTrackingMode contextTrackingMode, bool effectiveOnly)
+        public SECURITY_QUALITY_OF_SERVICE(ImpersonationLevel impersonationLevel, ContextTrackingMode contextTrackingMode, bool effectiveOnly)
         {
             Length = (uint)sizeof(SECURITY_QUALITY_OF_SERVICE);
             ImpersonationLevel = impersonationLevel;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.REPARSE_DATA_BUFFER.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.REPARSE_DATA_BUFFER.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -15,7 +14,7 @@ internal static partial class Interop
 
         // https://msdn.microsoft.com/library/windows/hardware/ff552012.aspx
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct SymbolicLinkReparseBuffer
+        internal struct SymbolicLinkReparseBuffer
         {
             internal uint ReparseTag;
             internal ushort ReparseDataLength;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.STORAGE_READ_CAPACITY.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.STORAGE_READ_CAPACITY.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -10,7 +9,7 @@ internal static partial class Interop
     {
         // https://learn.microsoft.com/windows/win32/devio/storage-read-capacity
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct STORAGE_READ_CAPACITY
+        internal struct STORAGE_READ_CAPACITY
         {
             internal uint Version;
             internal uint Size;

--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_DIR_INFORMATION.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_DIR_INFORMATION.cs
@@ -54,7 +54,7 @@ internal static partial class Interop
             public uint EaSize;
 
             private char _fileName;
-            public unsafe ReadOnlySpan<char> FileName => MemoryMarshal.CreateReadOnlySpan(ref _fileName, (int)FileNameLength / sizeof(char));
+            public ReadOnlySpan<char> FileName => MemoryMarshal.CreateReadOnlySpan(ref _fileName, (int)FileNameLength / sizeof(char));
 
             /// <summary>
             /// Gets the next info pointer or null if there are no more.

--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.DumpBuffer.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.DumpBuffer.cs
@@ -35,7 +35,7 @@ namespace System.Net
             Log.DumpBuffer(IdOf(thisOrContextObject), memberName, buffer.Slice(0, Math.Min(buffer.Length, MaxDumpSize)).ToArray());
 
         [Event(DumpArrayEventId, Level = EventLevel.Verbose, Keywords = Keywords.Debug)]
-        private unsafe void DumpBuffer(string thisOrContextObject, string? memberName, byte[] buffer) =>
+        private void DumpBuffer(string thisOrContextObject, string? memberName, byte[] buffer) =>
             WriteEvent(DumpArrayEventId, thisOrContextObject, memberName ?? MissingMember, buffer);
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -69,7 +69,7 @@ namespace System.Net
             address.CopyTo(buffer.Slice(8));
         }
 
-        public static unsafe void Clear(Span<byte> buffer)
+        public static void Clear(Span<byte> buffer)
         {
             AddressFamily family = GetAddressFamily(buffer);
             buffer.Clear();

--- a/src/libraries/Common/src/System/Number.Formatting.Common.cs
+++ b/src/libraries/Common/src/System/Number.Formatting.Common.cs
@@ -52,7 +52,7 @@ namespace System
             "(#)", "-#", "- #", "#-", "# -",
         ];
 
-        internal static unsafe char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
+        internal static char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
         {
             char c = default;
             if (format.Length > 0)

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -1225,7 +1225,7 @@ namespace Microsoft.Win32
             SetValue(name, value, RegistryValueKind.Unknown);
         }
 
-        public unsafe void SetValue(string? name, object value, RegistryValueKind valueKind)
+        public void SetValue(string? name, object value, RegistryValueKind valueKind)
         {
             ArgumentNullException.ThrowIfNull(value);
 

--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -115,7 +115,7 @@ namespace System.Collections
             _version = 0;
         }
 
-        public unsafe BitArray(bool[] values)
+        public BitArray(bool[] values)
         {
             ArgumentNullException.ThrowIfNull(values);
 
@@ -312,7 +312,7 @@ namespace System.Collections
         ** Exceptions: ArgumentException if value == null or
         **             value.Length != this.Length.
         =========================================================================*/
-        public unsafe BitArray And(BitArray value)
+        public BitArray And(BitArray value)
         {
             ArgumentNullException.ThrowIfNull(value);
 
@@ -385,7 +385,7 @@ namespace System.Collections
         ** Exceptions: ArgumentException if value == null or
         **             value.Length != this.Length.
         =========================================================================*/
-        public unsafe BitArray Or(BitArray value)
+        public BitArray Or(BitArray value)
         {
             ArgumentNullException.ThrowIfNull(value);
 
@@ -458,7 +458,7 @@ namespace System.Collections
         ** Exceptions: ArgumentException if value == null or
         **             value.Length != this.Length.
         =========================================================================*/
-        public unsafe BitArray Xor(BitArray value)
+        public BitArray Xor(BitArray value)
         {
             ArgumentNullException.ThrowIfNull(value);
 
@@ -531,7 +531,7 @@ namespace System.Collections
         ** off/false. Off/false bit values are turned on/true. The current instance
         ** is updated and returned.
         =========================================================================*/
-        public unsafe BitArray Not()
+        public BitArray Not()
         {
             // This method uses unsafe code to manipulate data in the BitArray.  To avoid issues with
             // buggy code concurrently mutating this instance in a way that could cause memory corruption,

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -2004,7 +2004,7 @@ namespace System.Diagnostics
         /// Sets the bytes in 'outBytes' to be random values. outBytes.Length must be either 8 or 16 bytes.
         /// </summary>
         /// <param name="outBytes"></param>
-        internal static unsafe void SetToRandomBytes(Span<byte> outBytes)
+        internal static void SetToRandomBytes(Span<byte> outBytes)
         {
             Debug.Assert(outBytes.Length == 16 || outBytes.Length == 8);
             RandomNumberGenerator r = RandomNumberGenerator.Current;

--- a/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
@@ -114,7 +114,7 @@ namespace System.Diagnostics
         /// underlying ConditionalWeakTable doesn't keep the assembly alive, so cached types will be
         /// correctly invalidated when the Assembly is unloaded by the GC.
         /// </remarks>
-        private unsafe MetadataReader? TryGetReader(Assembly assembly, string assemblyPath, IntPtr loadedPeAddress, int loadedPeSize, bool isFileLayout, IntPtr inMemoryPdbAddress, int inMemoryPdbSize)
+        private MetadataReader? TryGetReader(Assembly assembly, string assemblyPath, IntPtr loadedPeAddress, int loadedPeSize, bool isFileLayout, IntPtr inMemoryPdbAddress, int inMemoryPdbSize)
         {
             if (loadedPeAddress == IntPtr.Zero && assemblyPath == null && inMemoryPdbAddress == IntPtr.Zero)
             {

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborHelpers.netstandard.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborHelpers.netstandard.cs
@@ -182,7 +182,7 @@ namespace System.Formats.Cbor
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe float ReadSingleBigEndian(ReadOnlySpan<byte> source)
+        public static float ReadSingleBigEndian(ReadOnlySpan<byte> source)
         {
             return BitConverter.IsLittleEndian ?
                 Int32BitsToSingle(BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<int>(source))) :
@@ -190,7 +190,7 @@ namespace System.Formats.Cbor
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe void WriteSingleBigEndian(Span<byte> destination, float value)
+        public static void WriteSingleBigEndian(Span<byte> destination, float value)
         {
             if (BitConverter.IsLittleEndian)
             {
@@ -212,7 +212,7 @@ namespace System.Formats.Cbor
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe void WriteDoubleBigEndian(Span<byte> destination, double value)
+        public static void WriteDoubleBigEndian(Span<byte> destination, double value)
         {
             if (BitConverter.IsLittleEndian)
             {

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/HalfHelpers.netstandard.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/HalfHelpers.netstandard.cs
@@ -28,7 +28,7 @@ namespace System.Formats.Cbor
         public static double HalfToDouble(ushort value)
             => (double)HalfToFloat(value);
 
-        public static unsafe float HalfToFloat(ushort value)
+        public static float HalfToFloat(ushort value)
         {
             const ushort ExponentMask = 0x7C00;
             const ushort ExponentShift = 10;

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -290,7 +290,7 @@ namespace System.IO
 
             return handle;
 
-            static unsafe SafeFileHandle CreateFileHandleInternal(string fullPath, FileMode mode, FileSystemRights rights, FileShare share, int flagsAndAttributes, Interop.Kernel32.SECURITY_ATTRIBUTES* secAttrs)
+            static SafeFileHandle CreateFileHandleInternal(string fullPath, FileMode mode, FileSystemRights rights, FileShare share, int flagsAndAttributes, Interop.Kernel32.SECURITY_ATTRIBUTES* secAttrs)
             {
                 SafeFileHandle handle;
                 using (DisableMediaInsertionPrompt.Create())

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -86,7 +86,7 @@ namespace System.Net.Sockets
         internal unsafe AcceptExDelegate GetAcceptExDelegate(SafeSocketHandle socketHandle)
             => _acceptEx ?? CreateDelegate(ptr => new SocketDelegateHelper(ptr).AcceptEx, ref _acceptEx, socketHandle, "b5367df1cbac11cf95ca00805f48a192");
 
-        internal unsafe GetAcceptExSockaddrsDelegate GetGetAcceptExSockaddrsDelegate(SafeSocketHandle socketHandle)
+        internal GetAcceptExSockaddrsDelegate GetGetAcceptExSockaddrsDelegate(SafeSocketHandle socketHandle)
             => _getAcceptExSockaddrs ?? CreateDelegate<GetAcceptExSockaddrsDelegate>(ptr => new SocketDelegateHelper(ptr).GetAcceptExSockaddrs, ref _getAcceptExSockaddrs, socketHandle, "b5367df2cbac11cf95ca00805f48a192");
 
         internal unsafe ConnectExDelegate GetConnectExDelegate(SafeSocketHandle socketHandle)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3589,7 +3589,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue, bool silent)
+        internal void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue, bool silent)
         {
             // WASI is always set to receive PacketInformation
             if (OperatingSystem.IsWasi() && optionName == SocketOptionName.PacketInformation)

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -4,14 +4,12 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Internal.Runtime.CompilerHelpers
 {
     [StackTraceHidden]
     [DebuggerStepThrough]
-    internal static unsafe partial class ThrowHelpers
+    internal static partial class ThrowHelpers
     {
         [DoesNotReturn]
         [DebuggerHidden]

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -110,7 +110,7 @@ namespace Internal.Runtime.InteropServices
         [UnsupportedOSPlatform("maccatalyst")]
         [UnsupportedOSPlatform("tvos")]
         [UnmanagedCallersOnly]
-        public static unsafe int LoadAssembly(IntPtr assemblyPathNative, IntPtr loadContext, IntPtr reserved)
+        public static int LoadAssembly(IntPtr assemblyPathNative, IntPtr loadContext, IntPtr reserved)
         {
             if (!IsSupported)
                 return HostFeatureDisabled;

--- a/src/libraries/System.Private.CoreLib/src/Internal/Win32/RegistryKey.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Win32/RegistryKey.cs
@@ -143,7 +143,7 @@ namespace Internal.Win32
             return names.ToArray();
         }
 
-        public unsafe string[] GetValueNames()
+        public string[] GetValueNames()
         {
             var names = new List<string>();
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Win32.SafeHandles
             return _lengthCanBeCached && cachedLength >= 0;
         }
 
-        internal static unsafe SafeFileHandle Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, UnixFileMode? unixCreateMode = null)
+        internal static SafeFileHandle Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, UnixFileMode? unixCreateMode = null)
         {
             Debug.Assert(!unixCreateMode.HasValue);
 

--- a/src/libraries/System.Private.CoreLib/src/System/ArgumentNullException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ArgumentNullException.cs
@@ -84,7 +84,7 @@ namespace System
         /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
         /// <param name="argument">The pointer argument to validate as non-null.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
-        internal static unsafe void ThrowIfNull(IntPtr argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        internal static void ThrowIfNull(IntPtr argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             if (argument == IntPtr.Zero)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -892,7 +892,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A 64-bit signed integer whose bits are identical to <paramref name="value"/>.</returns>
         [Intrinsic]
-        public static unsafe long DoubleToInt64Bits(double value) => Unsafe.BitCast<double, long>(value);
+        public static long DoubleToInt64Bits(double value) => Unsafe.BitCast<double, long>(value);
 
         /// <summary>
         /// Converts the specified 64-bit signed integer to a double-precision floating point number.
@@ -900,7 +900,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A double-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [Intrinsic]
-        public static unsafe double Int64BitsToDouble(long value) => Unsafe.BitCast<long, double>(value);
+        public static double Int64BitsToDouble(long value) => Unsafe.BitCast<long, double>(value);
 
         /// <summary>
         /// Converts the specified single-precision floating point number to a 32-bit signed integer.
@@ -908,7 +908,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A 32-bit signed integer whose bits are identical to <paramref name="value"/>.</returns>
         [Intrinsic]
-        public static unsafe int SingleToInt32Bits(float value) => Unsafe.BitCast<float, int>(value);
+        public static int SingleToInt32Bits(float value) => Unsafe.BitCast<float, int>(value);
 
         /// <summary>
         /// Converts the specified 32-bit signed integer to a single-precision floating point number.
@@ -916,7 +916,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A single-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [Intrinsic]
-        public static unsafe float Int32BitsToSingle(int value) => Unsafe.BitCast<int, float>(value);
+        public static float Int32BitsToSingle(int value) => Unsafe.BitCast<int, float>(value);
 
         /// <summary>
         /// Converts the specified half-precision floating point number to a 16-bit signed integer.
@@ -924,7 +924,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A 16-bit signed integer whose bits are identical to <paramref name="value"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe short HalfToInt16Bits(Half value) => (short)value._value;
+        public static short HalfToInt16Bits(Half value) => (short)value._value;
 
         /// <summary>
         /// Converts the specified 16-bit signed integer to a half-precision floating point number.
@@ -932,7 +932,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Half Int16BitsToHalf(short value) => new Half((ushort)(value));
+        public static Half Int16BitsToHalf(short value) => new Half((ushort)(value));
 
         /// <summary>
         /// Converts the specified double-precision floating point number to a 64-bit unsigned integer.
@@ -941,7 +941,7 @@ namespace System
         /// <returns>A 64-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [Intrinsic]
-        public static unsafe ulong DoubleToUInt64Bits(double value) => Unsafe.BitCast<double, ulong>(value);
+        public static ulong DoubleToUInt64Bits(double value) => Unsafe.BitCast<double, ulong>(value);
 
         /// <summary>
         /// Converts the specified 64-bit unsigned integer to a double-precision floating point number.
@@ -950,7 +950,7 @@ namespace System
         /// <returns>A double-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [Intrinsic]
-        public static unsafe double UInt64BitsToDouble(ulong value) => Unsafe.BitCast<ulong, double>(value);
+        public static double UInt64BitsToDouble(ulong value) => Unsafe.BitCast<ulong, double>(value);
 
         /// <summary>
         /// Converts the specified single-precision floating point number to a 32-bit unsigned integer.
@@ -959,7 +959,7 @@ namespace System
         /// <returns>A 32-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [Intrinsic]
-        public static unsafe uint SingleToUInt32Bits(float value) => Unsafe.BitCast<float, uint>(value);
+        public static uint SingleToUInt32Bits(float value) => Unsafe.BitCast<float, uint>(value);
 
         /// <summary>
         /// Converts the specified 32-bit unsigned integer to a single-precision floating point number.
@@ -968,7 +968,7 @@ namespace System
         /// <returns>A single-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [Intrinsic]
-        public static unsafe float UInt32BitsToSingle(uint value) => Unsafe.BitCast<uint, float>(value);
+        public static float UInt32BitsToSingle(uint value) => Unsafe.BitCast<uint, float>(value);
 
         /// <summary>
         /// Converts the specified half-precision floating point number to a 16-bit unsigned integer.
@@ -977,7 +977,7 @@ namespace System
         /// <returns>A 16-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ushort HalfToUInt16Bits(Half value) => value._value;
+        public static ushort HalfToUInt16Bits(Half value) => value._value;
 
         /// <summary>
         /// Converts the specified 16-bit unsigned integer to a half-precision floating point number.
@@ -986,6 +986,6 @@ namespace System
         /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Half UInt16BitsToHalf(ushort value) => new Half(value);
+        public static Half UInt16BitsToHalf(ushort value) => new Half(value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -13,7 +13,7 @@ namespace System
         // respecting types.  This calls memmove internally.  The count and
         // offset parameters here are in bytes.  If you want to use traditional
         // array element indices and counts, use Array.Copy.
-        public static unsafe void BlockCopy(Array src, int srcOffset, Array dst, int dstOffset, int count)
+        public static void BlockCopy(Array src, int srcOffset, Array dst, int dstOffset, int count)
         {
             ArgumentNullException.ThrowIfNull(src);
             ArgumentNullException.ThrowIfNull(dst);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
@@ -38,7 +38,7 @@ namespace System.Buffers
         private bool _trimCallbackCreated;
 
         /// <summary>Allocate a new <see cref="SharedArrayPoolPartitions"/> and try to store it into the <see cref="_buckets"/> array.</summary>
-        private unsafe SharedArrayPoolPartitions CreatePerCorePartitions(int bucketIndex)
+        private SharedArrayPoolPartitions CreatePerCorePartitions(int bucketIndex)
         {
             var inst = new SharedArrayPoolPartitions();
             return Interlocked.CompareExchange(ref _buckets[bucketIndex], inst, null) ?? inst;

--- a/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
@@ -41,7 +41,7 @@ namespace System
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            private static unsafe ComInfo? FromObjectSlow(object target)
+            private static ComInfo? FromObjectSlow(object target)
             {
                 IntPtr pComWeakRef = ObjectToComWeakRef(target, out long wrapperId);
                 if (pComWeakRef == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2470,7 +2470,7 @@ namespace System
         /// <param name="bytes">The bytes to encode.</param>
         /// <param name="chars">The destination buffer large enough to handle the encoded chars.</param>
         /// <param name="charLengthRequired">The pre-calculated, exact number of chars that will be written.</param>
-        private static unsafe void ToBase64CharsLargeNoLineBreaks(ReadOnlySpan<byte> bytes, Span<char> chars, int charLengthRequired)
+        private static void ToBase64CharsLargeNoLineBreaks(ReadOnlySpan<byte> bytes, Span<char> chars, int charLengthRequired)
         {
             // For large enough inputs, it's beneficial to use the vectorized UTF8-based Base64 encoding
             // and then widen the resulting bytes into chars.

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -154,7 +154,7 @@ namespace System
 
 #region Decimal Math Helpers
 
-            private static unsafe uint GetExponent(float f)
+            private static uint GetExponent(float f)
             {
                 // Based on pulling out the exp from this single struct layout
                 // typedef struct {
@@ -166,7 +166,7 @@ namespace System
                 return (byte)(BitConverter.SingleToUInt32Bits(f) >> 23);
             }
 
-            private static unsafe uint GetExponent(double d)
+            private static uint GetExponent(double d)
             {
                 // Based on pulling out the exp from this double struct layout
                 // typedef struct {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -55,7 +55,7 @@ namespace System.Diagnostics.Tracing
         [StructLayout(LayoutKind.Sequential)]
         public struct EventData
         {
-            internal unsafe ulong Ptr;
+            internal ulong Ptr;
             internal uint Size;
             internal uint Reserved;
         }
@@ -105,7 +105,7 @@ namespace System.Diagnostics.Tracing
         /// <summary>
         /// This method registers the provider with the backing tracing mechanism, either ETW or EventPipe.
         /// </summary>
-        internal unsafe void Register(Guid id, string name)
+        internal void Register(Guid id, string name)
         {
             _providerName = name;
             _providerId = id;
@@ -940,7 +940,7 @@ namespace System.Diagnostics.Tracing
         /// to get the data. The function returns an array of bytes representing the data, the index into that byte array
         /// where the data starts, and the command being issued associated with that data.
         /// </summary>
-        private unsafe bool TryReadRegistryFilterData(int etwSessionId, out ControllerCommand command, out byte[]? data)
+        private bool TryReadRegistryFilterData(int etwSessionId, out ControllerCommand command, out byte[]? data)
         {
             command = ControllerCommand.Update;
             data = null;
@@ -1320,7 +1320,7 @@ namespace System.Diagnostics.Tracing
             return idx;
         }
 
-        protected static unsafe IDictionary<string, string?>? ParseFilterData(byte[]? data)
+        protected static IDictionary<string, string?>? ParseFilterData(byte[]? data)
         {
             Dictionary<string, string?>? args = null;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2082,7 +2082,7 @@ namespace System.Diagnostics.Tracing
             Justification = "EnsureDescriptorsInitialized's use of GetType preserves this method which " +
                             "requires unreferenced code, but EnsureDescriptorsInitialized does not access this member and is safe to call.")]
         [RequiresUnreferencedCode(EventSourceRequiresUnreferenceMessage)]
-        private unsafe object?[] SerializeEventArgs(int eventId, object?[] args)
+        private object?[] SerializeEventArgs(int eventId, object?[] args)
         {
             Debug.Assert(m_eventData != null);
             TraceLoggingEventTypes eventTypes = m_eventData[eventId].TraceLoggingEventTypes;
@@ -2177,7 +2177,7 @@ namespace System.Diagnostics.Tracing
             DispatchToAllListeners(eventCallbackArgs);
         }
 
-        internal unsafe void DispatchToAllListeners(EventWrittenEventArgs eventCallbackArgs)
+        internal void DispatchToAllListeners(EventWrittenEventArgs eventCallbackArgs)
         {
             int eventId = eventCallbackArgs.EventId;
             Exception? lastThrownException = null;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tracing
             ContentionStop(ContentionFlagsMap.Managed, DefaultClrInstanceId, durationNs);
 
         [Event(50, Level = EventLevel.Informational, Message = Messages.WorkerThread, Task = Tasks.ThreadPoolWorkerThread, Opcode = EventOpcode.Start, Version = 0, Keywords = Keywords.ThreadingKeyword)]
-        public unsafe void ThreadPoolWorkerThreadStart(
+        public void ThreadPoolWorkerThreadStart(
             uint ActiveWorkerThreadCount,
             uint RetiredWorkerThreadCount = 0,
             ushort ClrInstanceID = DefaultClrInstanceId)
@@ -175,7 +175,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [Event(54, Level = EventLevel.Informational, Message = Messages.WorkerThreadAdjustmentSample, Task = Tasks.ThreadPoolWorkerThreadAdjustment, Opcode = Opcodes.Sample, Version = 0, Keywords = Keywords.ThreadingKeyword)]
-        public unsafe void ThreadPoolWorkerThreadAdjustmentSample(
+        public void ThreadPoolWorkerThreadAdjustmentSample(
             double Throughput,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
@@ -187,7 +187,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [Event(55, Level = EventLevel.Informational, Message = Messages.WorkerThreadAdjustmentAdjustment, Task = Tasks.ThreadPoolWorkerThreadAdjustment, Opcode = Opcodes.Adjustment, Version = 0, Keywords = Keywords.ThreadingKeyword)]
-        public unsafe void ThreadPoolWorkerThreadAdjustmentAdjustment(
+        public void ThreadPoolWorkerThreadAdjustmentAdjustment(
             double AverageThroughput,
             uint NewWorkerThreadCount,
             ThreadAdjustmentReasonMap Reason,
@@ -201,7 +201,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [Event(56, Level = EventLevel.Verbose, Message = Messages.WorkerThreadAdjustmentStats, Task = Tasks.ThreadPoolWorkerThreadAdjustment, Opcode = Opcodes.Stats, Version = 0, Keywords = Keywords.ThreadingKeyword)]
-        public unsafe void ThreadPoolWorkerThreadAdjustmentStats(
+        public void ThreadPoolWorkerThreadAdjustmentStats(
             double Duration,
             double Throughput,
             double ThreadWave,
@@ -222,7 +222,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [Event(63, Level = EventLevel.Verbose, Message = Messages.IOEnqueue, Task = Tasks.ThreadPool, Opcode = Opcodes.IOEnqueue, Version = 0, Keywords = Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword)]
-        private unsafe void ThreadPoolIOEnqueue(
+        private void ThreadPoolIOEnqueue(
             IntPtr NativeOverlapped,
             IntPtr Overlapped, // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             bool MultiDequeues,
@@ -264,7 +264,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [Event(64, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IODequeue, Version = 0, Keywords = Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword)]
-        private unsafe void ThreadPoolIODequeue(
+        private void ThreadPoolIODequeue(
             IntPtr NativeOverlapped,
             IntPtr Overlapped, // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             ushort ClrInstanceID = DefaultClrInstanceId)
@@ -302,7 +302,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [Event(60, Level = EventLevel.Verbose, Message = Messages.WorkingThreadCount, Task = Tasks.ThreadPoolWorkingThreadCount, Opcode = EventOpcode.Start, Version = 0, Keywords = Keywords.ThreadingKeyword)]
-        public unsafe void ThreadPoolWorkingThreadCount(uint Count, ushort ClrInstanceID = DefaultClrInstanceId)
+        public void ThreadPoolWorkingThreadCount(uint Count, ushort ClrInstanceID = DefaultClrInstanceId)
         {
             if (!IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
             {
@@ -329,7 +329,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [Event(65, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IOPack, Version = 0, Keywords = Keywords.ThreadingKeyword)]
-        private unsafe void ThreadPoolIOPack(
+        private void ThreadPoolIOPack(
             IntPtr NativeOverlapped,
             IntPtr Overlapped,  // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             ushort ClrInstanceID = DefaultClrInstanceId)
@@ -339,7 +339,7 @@ namespace System.Diagnostics.Tracing
 
 
         [Event(59, Level = EventLevel.Informational, Message = Messages.MinMaxThreads, Task = Tasks.ThreadPoolMinMaxThreads, Opcode = EventOpcode.Info, Version = 0, Keywords = Keywords.ThreadingKeyword)]
-        public unsafe void ThreadPoolMinMaxThreads(
+        public void ThreadPoolMinMaxThreads(
             ushort MinWorkerThreads,
             ushort MaxWorkerThreads,
             ushort MinIOCompletionThreads,
@@ -364,7 +364,7 @@ namespace System.Diagnostics.Tracing
 
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public unsafe void WaitHandleWaitStart(
+        public void WaitHandleWaitStart(
             WaitHandleWaitSourceMap waitSource = WaitHandleWaitSourceMap.Unknown,
             object? associatedObject = null) =>
             WaitHandleWaitStart(waitSource, ObjectIDForEvents(associatedObject));

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -911,7 +911,7 @@ namespace System
         }
 
         /// <summary>Core implementation for all {Try}Parse methods, both generic and non-generic, parsing either by value or by name.</summary>
-        private static unsafe bool TryParseByValueOrName<TUnderlying, TStorage>(
+        private static bool TryParseByValueOrName<TUnderlying, TStorage>(
             RuntimeType enumType, ReadOnlySpan<char> value, bool ignoreCase, bool throwOnFailure, out TUnderlying result)
             where TUnderlying : unmanaged, IBinaryIntegerParseAndFormatInfo<TUnderlying>
             where TStorage : unmanaged, IBinaryIntegerParseAndFormatInfo<TStorage>
@@ -969,7 +969,7 @@ namespace System
             return false;
         }
 
-        private static unsafe bool TryParseRareTypeByValueOrName<TUnderlying, TStorage>(
+        private static bool TryParseRareTypeByValueOrName<TUnderlying, TStorage>(
             RuntimeType enumType, ReadOnlySpan<char> value, bool ignoreCase, bool throwOnFailure, out TUnderlying result)
             where TUnderlying : struct, INumber<TUnderlying>, IBitwiseOperators<TUnderlying, TUnderlying, TUnderlying>, IMinMaxValue<TUnderlying>
             where TStorage : struct, INumber<TStorage>, IBitwiseOperators<TStorage, TStorage, TStorage>, IMinMaxValue<TStorage>

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -485,7 +485,7 @@ namespace System.Globalization
                 message: ((options & CompareOptions.Ordinal) != 0) ? SR.Argument_CompareOptionOrdinal : SR.Argument_InvalidFlag);
         }
 
-        private unsafe int CompareStringCore(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options) =>
+        private int CompareStringCore(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options) =>
             GlobalizationMode.UseNls ?
                 NlsCompareString(string1, string2, options) :
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
@@ -863,7 +863,7 @@ namespace System.Globalization
             return IndexOf(source, value, startIndex, count, CompareOptions.None);
         }
 
-        public unsafe int IndexOf(string source, char value, int startIndex, int count, CompareOptions options)
+        public int IndexOf(string source, char value, int startIndex, int count, CompareOptions options)
         {
             if (source == null)
             {
@@ -893,7 +893,7 @@ namespace System.Globalization
             return result;
         }
 
-        public unsafe int IndexOf(string source, string value, int startIndex, int count, CompareOptions options)
+        public int IndexOf(string source, string value, int startIndex, int count, CompareOptions options)
         {
             if (source == null)
             {
@@ -1579,7 +1579,7 @@ namespace System.Globalization
             }
         }
 
-        private unsafe int GetHashCodeOfStringCore(ReadOnlySpan<char> source, CompareOptions options) =>
+        private int GetHashCodeOfStringCore(ReadOnlySpan<char> source, CompareOptions options) =>
             GlobalizationMode.UseNls ?
                 NlsGetHashCodeOfString(source, options) :
                 IcuGetHashCodeOfString(source, options);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -294,7 +294,7 @@ namespace System.Globalization
             return CompareStringIgnoreCase(ref Unsafe.AddByteOffset(ref charA, byteOffset), length, ref Unsafe.AddByteOffset(ref charB, byteOffset), length) == 0;
         }
 
-        internal static unsafe int IndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
+        internal static int IndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             if (source == null)
             {
@@ -593,7 +593,7 @@ namespace System.Globalization
             return result;
         }
 
-        internal static unsafe int LastIndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
+        internal static int LastIndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             if (source == null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -515,7 +515,7 @@ namespace System.Globalization
         /// influence which letter or letters of a "word" are uppercased when titlecasing strings.  For example
         /// "l'arbre" is considered two words in French, whereas "can't" is considered one word in English.
         /// </summary>
-        public unsafe string ToTitleCase(string str)
+        public string ToTitleCase(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -60,7 +60,7 @@ namespace System.IO
         /// <returns>An object that represents the directory that was created.</returns>
         /// <exception cref="ArgumentException"><paramref name="prefix" /> contains a directory separator.</exception>
         /// <exception cref="IOException">A new directory cannot be created.</exception>
-        public static unsafe DirectoryInfo CreateTempSubdirectory(string? prefix = null)
+        public static DirectoryInfo CreateTempSubdirectory(string? prefix = null)
         {
             EnsureNoDirectorySeparators(prefix);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Windows.cs
@@ -22,7 +22,7 @@ namespace System.IO.Enumeration
             entry.OriginalRootDirectory = originalRootDirectory;
         }
 
-        internal unsafe Interop.NtDll.FILE_FULL_DIR_INFORMATION* _info;
+        internal Interop.NtDll.FILE_FULL_DIR_INFORMATION* _info;
 
         /// <summary>Gets the full path of the directory this entry resides in.</summary>
         /// <value>The full path of this entry's directory.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -78,7 +78,7 @@ namespace System.IO.Enumeration
         /// </summary>
         /// <returns>'true' if new data was found</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe bool GetData()
+        private bool GetData()
         {
             Debug.Assert(_directoryHandle != (IntPtr)(-1) && _directoryHandle != IntPtr.Zero && !_lastEntryFound);
 
@@ -121,7 +121,7 @@ namespace System.IO.Enumeration
             }
         }
 
-        private unsafe IntPtr CreateRelativeDirectoryHandle(ReadOnlySpan<char> relativePath, string fullPath)
+        private IntPtr CreateRelativeDirectoryHandle(ReadOnlySpan<char> relativePath, string fullPath)
         {
             (uint status, IntPtr handle) = Interop.NtDll.CreateFile(
                 relativePath,
@@ -270,7 +270,7 @@ namespace System.IO.Enumeration
             }
         }
 
-        private unsafe void FindNextEntry()
+        private void FindNextEntry()
         {
             _entry = Interop.NtDll.FILE_FULL_DIR_INFORMATION.GetNextInfo(_entry);
             if (_entry != null)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -154,7 +154,7 @@ namespace System.IO
             return path;
         }
 
-        private static unsafe delegate* unmanaged<int, char*, uint> GetGetTempPathWFunc()
+        private static delegate* unmanaged<int, char*, uint> GetGetTempPathWFunc()
         {
             IntPtr kernel32 = Interop.Kernel32.LoadLibraryEx(Interop.Libraries.Kernel32, 0, Interop.Kernel32.LOAD_LIBRARY_SEARCH_SYSTEM32);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -700,7 +700,7 @@ namespace System.IO
             return JoinInternal(first.AsSpan(), second.AsSpan(), third.AsSpan(), fourth.AsSpan());
         }
 
-        private static unsafe string JoinInternal(ReadOnlySpan<char> first, ReadOnlySpan<char> second)
+        private static string JoinInternal(ReadOnlySpan<char> first, ReadOnlySpan<char> second)
         {
             Debug.Assert(first.Length > 0 && second.Length > 0, "should have dealt with empty paths");
 
@@ -711,7 +711,7 @@ namespace System.IO
                 string.Concat(first, PathInternal.DirectorySeparatorCharAsString, second);
         }
 
-        private static unsafe string JoinInternal(ReadOnlySpan<char> first, ReadOnlySpan<char> second, ReadOnlySpan<char> third)
+        private static string JoinInternal(ReadOnlySpan<char> first, ReadOnlySpan<char> second, ReadOnlySpan<char> third)
         {
             Debug.Assert(first.Length > 0 && second.Length > 0 && third.Length > 0, "should have dealt with empty paths");
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -765,7 +765,7 @@ namespace System.IO
         {
             return new IOCompletionCallback(Callback);
 
-            static unsafe void Callback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
+            static void Callback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
             {
                 CallbackResetEvent state = (CallbackResetEvent)ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped)!;
                 state.ReleaseRefCount(pOverlapped);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
@@ -74,7 +74,7 @@ namespace System.IO.Strategies
 
         public sealed override bool CanWrite => !_fileHandle.IsClosed && (_access & FileAccess.Write) != 0;
 
-        public sealed override unsafe long Length => _fileHandle.GetFileLength();
+        public sealed override long Length => _fileHandle.GetFileLength();
 
         // in case of concurrent incomplete reads, there can be multiple threads trying to update the position
         // at the same time. That is why we are using Interlocked here.
@@ -184,7 +184,7 @@ namespace System.IO.Strategies
             SetLengthCore(value);
         }
 
-        protected unsafe void SetLengthCore(long value)
+        protected void SetLengthCore(long value)
         {
             Debug.Assert(value >= 0);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStreamWrapper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStreamWrapper.cs
@@ -87,7 +87,7 @@ namespace System.IO
             return _unmanagedStream.Seek(offset, loc);
         }
 
-        public override unsafe byte[] ToArray()
+        public override byte[] ToArray()
         {
             byte[] buffer = new byte[_unmanagedStream.Length];
             _unmanagedStream.Read(buffer, 0, (int)_unmanagedStream.Length);
@@ -110,7 +110,7 @@ namespace System.IO
         }
 
         // Writes this MemoryStream to another stream.
-        public override unsafe void WriteTo(Stream stream)
+        public override void WriteTo(Stream stream)
         {
             ArgumentNullException.ThrowIfNull(stream);
 

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -314,7 +314,7 @@ namespace System
         /// <inheritdoc cref="Contains{T}(ReadOnlySpan{T}, T)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe bool Contains<T>(this Span<T> span, T value) where T : IEquatable<T>? =>
+        public static bool Contains<T>(this Span<T> span, T value) where T : IEquatable<T>? =>
             Contains((ReadOnlySpan<T>)span, value);
 
         /// <summary>
@@ -594,7 +594,7 @@ namespace System
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int IndexOf<T>(this Span<T> span, T value) where T : IEquatable<T>? =>
+        public static int IndexOf<T>(this Span<T> span, T value) where T : IEquatable<T>? =>
             IndexOf((ReadOnlySpan<T>)span, value);
 
         /// <summary>
@@ -604,7 +604,7 @@ namespace System
         /// <param name="value">The sequence to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
+        public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
             IndexOf((ReadOnlySpan<T>)span, value);
 
         /// <summary>
@@ -614,7 +614,7 @@ namespace System
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int LastIndexOf<T>(this Span<T> span, T value) where T : IEquatable<T>? =>
+        public static int LastIndexOf<T>(this Span<T> span, T value) where T : IEquatable<T>? =>
             LastIndexOf((ReadOnlySpan<T>)span, value);
 
         /// <summary>
@@ -624,7 +624,7 @@ namespace System
         /// <param name="value">The sequence to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int LastIndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
+        public static int LastIndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
             LastIndexOf((ReadOnlySpan<T>)span, value);
 
         /// <summary>Searches for the first index of any value other than the specified <paramref name="value"/>.</summary>
@@ -1530,7 +1530,7 @@ namespace System
         [Intrinsic] // Unrolled and vectorized for half-constant input
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe bool SequenceEqual<T>(this Span<T> span, ReadOnlySpan<T> other) where T : IEquatable<T>? =>
+        public static bool SequenceEqual<T>(this Span<T> span, ReadOnlySpan<T> other) where T : IEquatable<T>? =>
             SequenceEqual((ReadOnlySpan<T>)span, other);
 
         /// <summary>
@@ -1688,7 +1688,7 @@ namespace System
         /// <param name="value1">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int IndexOfAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>? =>
+        public static int IndexOfAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>? =>
             IndexOfAny((ReadOnlySpan<T>)span, value0, value1);
 
         /// <summary>
@@ -1700,7 +1700,7 @@ namespace System
         /// <param name="value2">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int IndexOfAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
+        public static int IndexOfAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
             IndexOfAny((ReadOnlySpan<T>)span, value0, value1, value2);
 
         /// <summary>
@@ -1942,7 +1942,7 @@ namespace System
         /// <param name="value1">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int LastIndexOfAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>? =>
+        public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>? =>
             LastIndexOfAny((ReadOnlySpan<T>)span, value0, value1);
 
         /// <summary>
@@ -1954,7 +1954,7 @@ namespace System
         /// <param name="value2">One of the values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe int LastIndexOfAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
+        public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
             LastIndexOfAny((ReadOnlySpan<T>)span, value0, value1, value2);
 
         /// <summary>
@@ -2251,7 +2251,7 @@ namespace System
         /// Determines the relative order of the sequences being compared by comparing the elements using IComparable{T}.CompareTo(T).
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int SequenceCompareTo<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other) where T : IComparable<T>?
+        public static int SequenceCompareTo<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other) where T : IComparable<T>?
         {
             // Can't use IsBitwiseEquatable<T>() below because that only tells us about
             // equality checks, not about CompareTo checks.
@@ -2279,7 +2279,7 @@ namespace System
         [Intrinsic] // Unrolled and vectorized for half-constant input
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [OverloadResolutionPriority(-1)]
-        public static unsafe bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
+        public static bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
             StartsWith((ReadOnlySpan<T>)span, value);
 
         /// <summary>
@@ -2308,7 +2308,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Intrinsic] // Unrolled and vectorized for half-constant input
         [OverloadResolutionPriority(-1)]
-        public static unsafe bool EndsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
+        public static bool EndsWith<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>? =>
             EndsWith((ReadOnlySpan<T>)span, value);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
@@ -10,7 +10,7 @@ namespace System
     // The backing algorithm and the proofs behind it are described in more detail here:  https://www.cs.indiana.edu/~dyb/pubs/FP-Printing-PLDI96.pdf
     internal static partial class Number
     {
-        public static unsafe void Dragon4<TNumber>(TNumber value, int cutoffNumber, bool isSignificantDigits, ref NumberBuffer number)
+        public static void Dragon4<TNumber>(TNumber value, int cutoffNumber, bool isSignificantDigits, ref NumberBuffer number)
             where TNumber : unmanaged, IBinaryFloatParseAndFormatInfo<TNumber>
         {
             TNumber v = TNumber.IsNegative(value) ? -value : value;

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -598,7 +598,7 @@ namespace System.Numerics
         /// <param name="rotation">When this method returns, contains the rotation component of the transformation matrix if the operation succeeded.</param>
         /// <param name="translation">When the method returns, contains the translation component of the transformation matrix if the operation succeeded.</param>
         /// <returns><see langword="true" /> if <paramref name="matrix" /> was decomposed successfully; otherwise,  <see langword="false" />.</returns>
-        public static unsafe bool Decompose(Matrix4x4 matrix, out Vector3 scale, out Quaternion rotation, out Vector3 translation)
+        public static bool Decompose(Matrix4x4 matrix, out Vector3 scale, out Quaternion rotation, out Vector3 translation)
             => Impl.Decompose(in matrix.AsImpl(), out scale, out rotation, out translation);
 
         /// <summary>Tries to invert the specified matrix. The return value indicates whether the operation succeeded.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Plane.Extensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Plane.Extensions.cs
@@ -1,13 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics;
 
 namespace System.Numerics
 {
-    public static unsafe partial class Vector
+    public static partial class Vector
     {
         /// <summary>Reinterprets a <see cref="Plane" /> as a new <see cref="Vector4" />.</summary>
         /// <param name="value">The plane to reinterpret.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Quaternion.Extensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Quaternion.Extensions.cs
@@ -1,13 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics;
 
 namespace System.Numerics
 {
-    public static unsafe partial class Vector
+    public static partial class Vector
     {
         /// <summary>Reinterprets a <see cref="Quaternion" /> as a new <see cref="Vector4" />.</summary>
         /// <param name="value">The quaternion to reinterpret.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/ParseNumbers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ParseNumbers.cs
@@ -14,7 +14,7 @@ namespace System
         internal const int TreatAsI2 = 0x0800;
         internal const int IsTight = 0x1000;
 
-        public static unsafe long StringToLong(ReadOnlySpan<char> s, int radix, int flags)
+        public static long StringToLong(ReadOnlySpan<char> s, int radix, int flags)
         {
             int pos = 0;
             return StringToLong(s, radix, flags, ref pos);

--- a/src/libraries/System.Private.CoreLib/src/System/Random.CompatImpl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.CompatImpl.cs
@@ -193,7 +193,7 @@ namespace System
             }
 
             /// <summary>Produces a value in the range [0, ulong.MaxValue].</summary>
-            private unsafe ulong NextUInt64() =>
+            private ulong NextUInt64() =>
                  ((ulong)(uint)_parent.Next(1 << 22)) |
                 (((ulong)(uint)_parent.Next(1 << 22)) << 22) |
                 (((ulong)(uint)_parent.Next(1 << 20)) << 44);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
@@ -16,7 +16,7 @@ namespace System.Reflection
         internal delegate object? InvokeFunc_ObjSpanArgs(object? obj, Span<object?> arguments);
         internal delegate object? InvokeFunc_Obj4Args(object? obj, object? arg1, object? arg2, object? arg3, object? arg4);
 
-        public static unsafe InvokeFunc_Obj4Args CreateInvokeDelegate_Obj4Args(MethodBase method, bool backwardsCompat)
+        public static InvokeFunc_Obj4Args CreateInvokeDelegate_Obj4Args(MethodBase method, bool backwardsCompat)
         {
             Debug.Assert(!method.ContainsGenericParameters);
 
@@ -83,7 +83,7 @@ namespace System.Reflection
             return (InvokeFunc_Obj4Args)dm.CreateDelegate(typeof(InvokeFunc_Obj4Args), target: null);
         }
 
-        public static unsafe InvokeFunc_ObjSpanArgs CreateInvokeDelegate_ObjSpanArgs(MethodBase method, bool backwardsCompat)
+        public static InvokeFunc_ObjSpanArgs CreateInvokeDelegate_ObjSpanArgs(MethodBase method, bool backwardsCompat)
         {
             Debug.Assert(!method.ContainsGenericParameters);
 
@@ -140,7 +140,7 @@ namespace System.Reflection
             return (InvokeFunc_ObjSpanArgs)dm.CreateDelegate(typeof(InvokeFunc_ObjSpanArgs), target: null);
         }
 
-        public static unsafe InvokeFunc_RefArgs CreateInvokeDelegate_RefArgs(MethodBase method, bool backwardsCompat)
+        public static InvokeFunc_RefArgs CreateInvokeDelegate_RefArgs(MethodBase method, bool backwardsCompat)
         {
             Debug.Assert(!method.ContainsGenericParameters);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
@@ -62,7 +62,7 @@ namespace System.Reflection
             }
         }
 
-        internal unsafe object? InvokeWithOneArg(
+        internal object? InvokeWithOneArg(
             object? obj,
             BindingFlags invokeAttr,
             Binder? binder,
@@ -108,7 +108,7 @@ namespace System.Reflection
             return ret;
         }
 
-        internal unsafe object? InvokeWithFewArgs(
+        internal object? InvokeWithFewArgs(
             object? obj,
             BindingFlags invokeAttr,
             Binder? binder,

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Pointer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Pointer.cs
@@ -40,7 +40,7 @@ namespace System.Reflection
             throw new ArgumentException(SR.Arg_MustBePointer, nameof(ptr));
         }
 
-        public override unsafe bool Equals([NotNullWhen(true)] object? obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
             if (obj is Pointer pointer)
             {
@@ -50,7 +50,7 @@ namespace System.Reflection
             return false;
         }
 
-        public override unsafe int GetHashCode() => ((nuint)_ptr).GetHashCode();
+        public override int GetHashCode() => ((nuint)_ptr).GetHashCode();
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
@@ -40,7 +40,7 @@ namespace System.Runtime.CompilerServices
 
     // NOTE: It is ok if TKey contains references, but we want it to be a struct,
     //       so that equality is devirtualized.
-    internal unsafe struct GenericCache<TKey, TValue>
+    internal struct GenericCache<TKey, TValue>
         where TKey : struct, IEquatable<TKey>
     {
         private struct Entry

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -150,7 +150,7 @@ namespace System.Runtime.CompilerServices
         /// <exception cref="ArgumentException"><paramref name="fldHandle"/> does not refer to a field which is an Rva, is misaligned, or T is of an invalid type.</exception>
         /// <remarks>This method is intended for compiler use rather than use directly in code. T must be one of byte, sbyte, bool, char, short, ushort, int, uint, long, ulong, float, or double.</remarks>
         [Intrinsic]
-        public static unsafe ReadOnlySpan<T> CreateSpan<T>(RuntimeFieldHandle fldHandle)
+        public static ReadOnlySpan<T> CreateSpan<T>(RuntimeFieldHandle fldHandle)
             => new ReadOnlySpan<T>(ref Unsafe.As<byte, T>(ref GetSpanDataFrom(fldHandle, typeof(T).TypeHandle, out int length)), length);
 
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/StackAllocatedBox.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/StackAllocatedBox.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.CompilerServices
 {
     [NonVersionable]
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    internal unsafe struct StackAllocatedBox<T>
+    internal struct StackAllocatedBox<T>
     {
         // These fields are only accessed from jitted code
         private IntPtr _pMethodTable;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
@@ -26,10 +26,10 @@ namespace System.Runtime
 
 #if CORECLR
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe void RegisterForGCReporting(GCFrameRegistration* pRegistration);
+        internal static extern void RegisterForGCReporting(GCFrameRegistration* pRegistration);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe void UnregisterForGCReporting(GCFrameRegistration* pRegistration);
+        internal static extern void UnregisterForGCReporting(GCFrameRegistration* pRegistration);
 #endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Windows.cs
@@ -199,7 +199,7 @@ namespace System.Runtime.InteropServices
             return bstr;
         }
 
-        internal static unsafe IntPtr AllocBSTRByteLen(uint length)
+        internal static IntPtr AllocBSTRByteLen(uint length)
         {
             IntPtr bstr = Interop.OleAut32.SysAllocStringByteLen(null, length);
             if (bstr == IntPtr.Zero)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1172,7 +1172,7 @@ namespace System.Runtime.InteropServices
             FreeBSTR(s);
         }
 
-        public static unsafe void ZeroFreeCoTaskMemAnsi(IntPtr s)
+        public static void ZeroFreeCoTaskMemAnsi(IntPtr s)
         {
             ZeroFreeCoTaskMemUTF8(s);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Supports marshalling from managed into unmanaged in a call from unmanaged code to managed code.
         /// </summary>
-        public static unsafe class UnmanagedToManagedOut
+        public static class UnmanagedToManagedOut
         {
             /// <summary>
             /// Allocates the space to store the unmanaged elements.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.cs
@@ -46,7 +46,7 @@ namespace System.Runtime.InteropServices
         ///     <para>The behavior when <paramref name="ptr" /> is <see langword="null"/> and <paramref name="byteCount" /> is greater than <c>0</c> is undefined.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        public static unsafe void Clear(void* ptr, nuint byteCount)
+        public static void Clear(void* ptr, nuint byteCount)
         {
             SpanHelpers.ClearWithoutReferences(ref *(byte*)ptr, byteCount);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
@@ -57,7 +57,7 @@ namespace System.Runtime.InteropServices.Swift
     /// </para>
     /// </remarks>
     [Intrinsic]
-    public readonly unsafe struct SwiftSelf<T> where T: unmanaged
+    public readonly struct SwiftSelf<T> where T: unmanaged
     {
         /// <summary>
         /// Creates a new instance of the SwiftSelf struct with the specified value.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.Intrinsics
 
         /// <summary>Gets the number of <typeparamref name="T" /> that are in a <see cref="Vector64{T}" />.</summary>
         /// <exception cref="NotSupportedException">The type of the vector (<typeparamref name="T" />) is not supported.</exception>
-        public static unsafe int Count
+        public static int Count
         {
             [Intrinsic]
             get

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
@@ -3,14 +3,13 @@
 
 using System.Diagnostics;
 using System.Numerics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System.Runtime.Intrinsics
 {
-    internal static unsafe class VectorMath
+    internal static class VectorMath
     {
         public static TVectorDouble CosDouble<TVectorDouble, TVectorInt64>(TVectorDouble x)
             where TVectorDouble : unmanaged, ISimdVector<TVectorDouble, double>

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
@@ -52,7 +52,7 @@ namespace System.Buffers
         }
 
         // valuesPtr must remain valid for as long as this ProbabilisticMapState is used.
-        public unsafe ProbabilisticMapState(ReadOnlySpan<char>* valuesPtr)
+        public ProbabilisticMapState(ReadOnlySpan<char>* valuesPtr)
         {
             Debug.Assert((IntPtr)valuesPtr != IntPtr.Zero);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -175,7 +175,7 @@ namespace System
         /// <summary>Determines whether the specified value is infinite.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsInfinity(float f)
+        public static bool IsInfinity(float f)
         {
             uint bits = BitConverter.SingleToUInt32Bits(f);
             return (bits & ~SignMask) == PositiveInfinityBits;
@@ -184,7 +184,7 @@ namespace System
         /// <summary>Determines whether the specified value is NaN.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsNaN(float f)
+        public static bool IsNaN(float f)
         {
             // A NaN will never equal itself so this is an
             // easy and efficient way to check for NaN.
@@ -205,7 +205,7 @@ namespace System
         /// <summary>Determines whether the specified value is negative.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsNegative(float f)
+        public static bool IsNegative(float f)
         {
             return BitConverter.SingleToInt32Bits(f) < 0;
         }
@@ -213,7 +213,7 @@ namespace System
         /// <summary>Determines whether the specified value is negative infinity.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsNegativeInfinity(float f)
+        public static bool IsNegativeInfinity(float f)
         {
             return f == NegativeInfinity;
         }
@@ -222,7 +222,7 @@ namespace System
         /// <remarks>This effectively checks the value is not NaN, not infinite, not subnormal, and not zero.</remarks>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsNormal(float f)
+        public static bool IsNormal(float f)
         {
             uint bits = BitConverter.SingleToUInt32Bits(f);
             return ((bits & ~SignMask) - SmallestNormalBits) < (PositiveInfinityBits - SmallestNormalBits);
@@ -231,7 +231,7 @@ namespace System
         /// <summary>Determines whether the specified value is positive infinity.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsPositiveInfinity(float f)
+        public static bool IsPositiveInfinity(float f)
         {
             return f == PositiveInfinity;
         }
@@ -240,7 +240,7 @@ namespace System
         /// <remarks>This effectively checks the value is not NaN, not infinite, not normal, and not zero.</remarks>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsSubnormal(float f)
+        public static bool IsSubnormal(float f)
         {
             uint bits = BitConverter.SingleToUInt32Bits(f);
             return ((bits & ~SignMask) - 1) < MaxTrailingSignificand;

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -293,7 +293,7 @@ namespace System
         /// Fills the contents of this span with the given value.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Fill(T value)
+        public void Fill(T value)
         {
             SpanHelpers.Fill(ref _reference, (uint)_length, value);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -34,7 +34,7 @@ namespace System
 #endif // HAS_CUSTOM_BLOCKS
 
         [Intrinsic] // Unrolled for small constant lengths
-        internal static unsafe void Memmove(ref byte dest, ref byte src, nuint len)
+        internal static void Memmove(ref byte dest, ref byte src, nuint len)
         {
             // P/Invoke into the native version when the buffers are overlapping.
             if ((nuint)Unsafe.ByteOffset(ref src, ref dest) < len ||
@@ -243,7 +243,7 @@ namespace System
         }
 
         [Intrinsic] // Unrolled for small sizes
-        public static unsafe void ClearWithoutReferences(ref byte dest, nuint len)
+        public static void ClearWithoutReferences(ref byte dest, nuint len)
         {
             if (len == 0)
                 return;

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2014,17 +2014,14 @@ namespace System
             // This optimizes for chars being unlikely to match a separator.
             else
             {
-                unsafe
-                {
-                    var map = new ProbabilisticMap(separators);
-                    ref uint charMap = ref Unsafe.As<ProbabilisticMap, uint>(ref map);
+                var map = new ProbabilisticMap(separators);
+                ref uint charMap = ref Unsafe.As<ProbabilisticMap, uint>(ref map);
 
-                    for (int i = 0; i < source.Length; i++)
+                for (int i = 0; i < source.Length; i++)
+                {
+                    if (ProbabilisticMap.Contains(ref charMap, separators, source[i]))
                     {
-                        if (ProbabilisticMap.Contains(ref charMap, separators, source[i]))
-                        {
-                            sepListBuilder.Append(i);
-                        }
+                        sepListBuilder.Append(i);
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -83,7 +83,7 @@ namespace System
             return SpanHelpers.IndexOfChar(ref _firstChar, value, Length);
         }
 
-        public unsafe int IndexOf(char value, int startIndex, int count)
+        public int IndexOf(char value, int startIndex, int count)
         {
             if ((uint)startIndex > (uint)Length)
             {
@@ -274,7 +274,7 @@ namespace System
             return LastIndexOf(value, startIndex, startIndex + 1);
         }
 
-        public unsafe int LastIndexOf(char value, int startIndex, int count)
+        public int LastIndexOf(char value, int startIndex, int count)
         {
             if (Length == 0)
             {
@@ -317,7 +317,7 @@ namespace System
             return LastIndexOfAny(anyOf, startIndex, startIndex + 1);
         }
 
-        public unsafe int LastIndexOfAny(char[] anyOf, int startIndex, int count)
+        public int LastIndexOfAny(char[] anyOf, int startIndex, int count)
         {
             if (anyOf is null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -308,7 +308,7 @@ namespace System
 #endif
         public extern String(ReadOnlySpan<char> value);
 
-        private static unsafe string Ctor(ReadOnlySpan<char> value)
+        private static string Ctor(ReadOnlySpan<char> value)
         {
             if (value.Length == 0)
                 return Empty;
@@ -394,7 +394,7 @@ namespace System
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This API should not be used to create mutable strings. See https://go.microsoft.com/fwlink/?linkid=2084035 for alternatives.")]
-        public static unsafe string Copy(string str)
+        public static string Copy(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
 
@@ -413,7 +413,7 @@ namespace System
         // sourceIndex + count - 1 to the character array buffer, beginning
         // at destinationIndex.
         //
-        public unsafe void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+        public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
         {
             ArgumentNullException.ThrowIfNull(destination);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
@@ -378,7 +378,7 @@ namespace System.Text
             return bytesWritten;
         }
 
-        private protected sealed override unsafe int GetBytesWithFallback(ReadOnlySpan<char> chars, int originalCharsLength, Span<byte> bytes, int originalBytesLength, EncoderNLS? encoder, bool throwForDestinationOverflow = true)
+        private protected sealed override int GetBytesWithFallback(ReadOnlySpan<char> chars, int originalCharsLength, Span<byte> bytes, int originalBytesLength, EncoderNLS? encoder, bool throwForDestinationOverflow = true)
         {
             // We special-case EncoderReplacementFallback if it's telling us to write a single ASCII char,
             // since we believe this to be relatively common and we can handle it more efficiently than
@@ -667,7 +667,7 @@ namespace System.Text
             return bytesConsumed;
         }
 
-        private protected sealed override unsafe int GetCharsWithFallback(ReadOnlySpan<byte> bytes, int originalBytesLength, Span<char> chars, int originalCharsLength, DecoderNLS? decoder, bool throwForDestinationOverflow = true)
+        private protected sealed override int GetCharsWithFallback(ReadOnlySpan<byte> bytes, int originalBytesLength, Span<char> chars, int originalCharsLength, DecoderNLS? decoder, bool throwForDestinationOverflow = true)
         {
             // We special-case DecoderReplacementFallback if it's telling us to write a single BMP char,
             // since we believe this to be relatively common and we can handle it more efficiently than

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2206,7 +2206,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe bool HasMatch<TVectorByte>(TVectorByte vector)
+        private static bool HasMatch<TVectorByte>(TVectorByte vector)
             where TVectorByte : unmanaged, ISimdVector<TVectorByte, byte>
         {
             return !(vector & TVectorByte.Create((byte)0x80)).Equals(TVectorByte.Zero);
@@ -2214,7 +2214,7 @@ namespace System.Text
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe (TVectorUInt16 Lower, TVectorUInt16 Upper) Widen<TVectorByte, TVectorUInt16>(TVectorByte vector)
+        private static (TVectorUInt16 Lower, TVectorUInt16 Upper) Widen<TVectorByte, TVectorUInt16>(TVectorByte vector)
             where TVectorByte : unmanaged, ISimdVector<TVectorByte, byte>
             where TVectorUInt16 : unmanaged, ISimdVector<TVectorUInt16, ushort>
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
@@ -437,7 +437,7 @@ namespace System.Text
             }
         }
 
-        public override unsafe int ReadByte()
+        public override int ReadByte()
         {
             byte b = 0;
             return Read(new Span<byte>(ref b)) != 0 ? b : -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -631,7 +631,7 @@ namespace System.Text
             return (int)(pOutputBufferRemaining - pChars);
         }
 
-        private protected sealed override unsafe int GetCharsWithFallback(ReadOnlySpan<byte> bytes, int originalBytesLength, Span<char> chars, int originalCharsLength, DecoderNLS? decoder, bool throwForDestinationOverflow = true)
+        private protected sealed override int GetCharsWithFallback(ReadOnlySpan<byte> bytes, int originalBytesLength, Span<char> chars, int originalCharsLength, DecoderNLS? decoder, bool throwForDestinationOverflow = true)
         {
             // We special-case DecoderReplacementFallback if it's telling us to write a single U+FFFD char,
             // since we believe this to be relatively common and we can handle it more efficiently than

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8.cs
@@ -813,7 +813,7 @@ namespace System.Text.Unicode
         /// </summary>
         /// <param name="value">The <see cref="ReadOnlySpan{T}"/> string.</param>
         /// <returns><c>true</c> if value is well-formed UTF-8, <c>false</c> otherwise.</returns>
-        public static unsafe bool IsValid(ReadOnlySpan<byte> value) =>
+        public static bool IsValid(ReadOnlySpan<byte> value) =>
             Utf8Utility.GetIndexOfFirstInvalidUtf8Sequence(value, out _) < 0;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
@@ -82,7 +82,7 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of location1 is a null pointer.</exception>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe byte Exchange(ref byte location1, byte value)
+        public static byte Exchange(ref byte location1, byte value)
         {
 #if (MONO && (TARGET_AMD64 || TARGET_ARM64 || TARGET_WASM)) || (!MONO && (TARGET_X86 || TARGET_AMD64 || TARGET_ARM64))
             return Exchange(ref location1, value); // Must expand intrinsic
@@ -121,7 +121,7 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static unsafe ushort Exchange(ref ushort location1, ushort value)
+        public static ushort Exchange(ref ushort location1, ushort value)
         {
 #if ((MONO && (TARGET_AMD64 || TARGET_ARM64 || TARGET_WASM)) || !MONO && (TARGET_X86 || TARGET_AMD64 || TARGET_ARM64))
             return Exchange(ref location1, value); // Must expand intrinsic
@@ -320,7 +320,7 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe byte CompareExchange(ref byte location1, byte value, byte comparand)
+        public static byte CompareExchange(ref byte location1, byte value, byte comparand)
         {
 #if (MONO && (TARGET_ARM64 || TARGET_AMD64 || TARGET_WASM)) || (!MONO && (TARGET_X86 || TARGET_AMD64 || TARGET_ARM64))
             return CompareExchange(ref location1, value, comparand); // Must expand intrinsic
@@ -363,7 +363,7 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static unsafe ushort CompareExchange(ref ushort location1, ushort value, ushort comparand)
+        public static ushort CompareExchange(ref ushort location1, ushort value, ushort comparand)
         {
 #if (MONO && (TARGET_ARM64 || TARGET_AMD64 || TARGET_WASM)) || (!MONO && (TARGET_X86 || TARGET_AMD64 || TARGET_ARM64))
             return CompareExchange(ref location1, value, comparand); // Must expand intrinsic

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -608,7 +608,7 @@ namespace System.Threading
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private unsafe AutoResetEvent CreateWaitEvent(bool areContentionEventsEnabled)
+        private AutoResetEvent CreateWaitEvent(bool areContentionEventsEnabled)
         {
             var newWaitEvent = new AutoResetEvent(false);
             AutoResetEvent? waitEventBeforeUpdate = Interlocked.CompareExchange(ref _waitEvent, newWaitEvent, null);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.Windows.cs
@@ -144,7 +144,7 @@ namespace System.Threading
             Dispose();
         }
 
-        unsafe void IDeferredDisposable.OnFinalRelease(bool disposed)
+        void IDeferredDisposable.OnFinalRelease(bool disposed)
         {
             if (ThreadPool.UseWindowsThreadPool)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -502,7 +502,7 @@ namespace System.Threading.Tasks
         }
 
         [NonEvent]
-        public unsafe void RunningContinuation(int TaskID, object Object) => RunningContinuation(TaskID, ObjectIDForEvents(Object));
+        public void RunningContinuation(int TaskID, object Object) => RunningContinuation(TaskID, ObjectIDForEvents(Object));
         [Event(20, Keywords = Keywords.Debug)]
         private void RunningContinuation(int TaskID, long Object)
         {
@@ -511,7 +511,7 @@ namespace System.Threading.Tasks
         }
 
         [NonEvent]
-        public unsafe void RunningContinuationList(int TaskID, int Index, object Object) => RunningContinuationList(TaskID, Index, ObjectIDForEvents(Object));
+        public void RunningContinuationList(int TaskID, int Index, object Object) => RunningContinuationList(TaskID, Index, ObjectIDForEvents(Object));
 
         [Event(21, Keywords = Keywords.Debug)]
         public void RunningContinuationList(int TaskID, int Index, long Object)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
@@ -154,7 +154,7 @@ namespace System.Threading
             }
         }
 
-        public unsafe ref struct Scope
+        public ref struct Scope
         {
             private object? _object;
             private ThreadBlockingInfo _blockingInfo;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -157,7 +157,7 @@ namespace System.Threading
         /// <summary>
         /// This method is called to request a new thread pool worker to handle pending work.
         /// </summary>
-        internal static unsafe void RequestWorkerThread()
+        internal static void RequestWorkerThread()
         {
             if (ThreadPool.UseWindowsThreadPool)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.Windows.cs
@@ -113,7 +113,7 @@ namespace System.Threading
         ///     <see cref="ThreadPoolBoundHandle"/> does not take ownership of <paramref name="handle"/>,
         ///     it remains the responsibility of the caller to call <see cref="SafeHandle.Dispose()"/>.
         /// </remarks>
-        public static unsafe ThreadPoolBoundHandle BindHandle(SafeHandle handle) =>
+        public static ThreadPoolBoundHandle BindHandle(SafeHandle handle) =>
             ThreadPool.UseWindowsThreadPool ? BindHandleWindowsThreadPool(handle) : BindHandleCore(handle);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -8,7 +8,7 @@ using System.Runtime.Versioning;
 namespace System.Threading
 {
     /// <summary>Methods for accessing memory with volatile semantics.</summary>
-    public static unsafe class Volatile
+    public static class Volatile
     {
         // The runtime may replace these implementations with more efficient ones in some cases.
         // In coreclr, for example, see importercalls.cpp.

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -1101,7 +1101,7 @@ namespace System
         /// <param name="ianaId">The IANA time zone ID.</param>
         /// <param name="windowsId">String object holding the Windows ID which resulted from the IANA ID conversion.</param>
         /// <returns>True if the ID conversion succeeded, false otherwise.</returns>
-        public static unsafe bool TryConvertIanaIdToWindowsId(string ianaId, [NotNullWhen(true)] out string? windowsId) => TryConvertIanaIdToWindowsId(ianaId, allocate: true, out windowsId);
+        public static bool TryConvertIanaIdToWindowsId(string ianaId, [NotNullWhen(true)] out string? windowsId) => TryConvertIanaIdToWindowsId(ianaId, allocate: true, out windowsId);
 
         /// <summary>
         /// Tries to convert a Windows time zone ID to an IANA ID.
@@ -1118,7 +1118,7 @@ namespace System
         /// <param name="region">The ISO 3166 code for the country/region.</param>
         /// <param name="ianaId">String object holding the IANA ID which resulted from the Windows ID conversion.</param>
         /// <returns>True if the ID conversion succeeded, false otherwise.</returns>
-        public static unsafe bool TryConvertWindowsIdToIanaId(string windowsId, string? region, [NotNullWhen(true)] out string? ianaId) => TryConvertWindowsIdToIanaId(windowsId, region, allocate: true, out ianaId);
+        public static bool TryConvertWindowsIdToIanaId(string windowsId, string? region, [NotNullWhen(true)] out string? ianaId) => TryConvertWindowsIdToIanaId(windowsId, region, allocate: true, out ianaId);
 
         void IDeserializationCallback.OnDeserialization(object? sender)
         {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
@@ -89,7 +89,7 @@ namespace Internal.Cryptography.Pal.AnyOS
                 }
             }
 
-            public static unsafe ContentInfo? TryDecryptCore(
+            public static ContentInfo? TryDecryptCore(
                 byte[] cek,
                 string contentType,
                 ReadOnlyMemory<byte>? content,

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
@@ -155,7 +155,7 @@ namespace Internal.Cryptography.Pal.Windows
             return hCertContext;
         }
 
-        public static unsafe byte[] GetSubjectKeyIdentifier(this SafeCertContextHandle hCertContext)
+        public static byte[] GetSubjectKeyIdentifier(this SafeCertContextHandle hCertContext)
         {
             int cbData = 0;
             if (!Interop.Crypt32.CertGetCertificateContextProperty(hCertContext, CertContextPropId.CERT_KEY_IDENTIFIER_PROP_ID, null, ref cbData))


### PR DESCRIPTION
There are more cases (e.g. when a class is marked with `unsafe` but only a few methods need it)