### PR TITLE
[mono][arm64] Remove MonoAOT aarch64 linux-gnu-5 build conditions and use the gnu-7 by default

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -814,7 +814,6 @@ JS_ENGINES = [NODE_JS]
       <MonoAotAbi>aarch64-linux-gnu</MonoAotAbi>
       <MonoAotOffsetsFile>$(MonoObjCrossDir)offsets-aarch-linux-gnu.h</MonoAotOffsetsFile>
       <MonoAotOffsetsPrefix>$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/7</MonoAotOffsetsPrefix>
-      <MonoAotOffsetsPrefix Condition="'$(Platform)' == 'arm64'">$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/5</MonoAotOffsetsPrefix>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(MonoUseLLVMPackage)' == 'true'">


### PR DESCRIPTION
The new .NET 10 build arm64 cross build images don't have linux-gnu 5 installed, thus the builds are failing with

`2024-12-27T08:08:33.1176807Z   provided path via --prefix ("/crossrootfs/arm64/usr/lib/gcc/aarch64-linux-gnu/5") doesn't exist.`

Verified fix on internal perf job run https://dev.azure.com/dnceng/internal/_build/results?buildId=2608807&view=logs&j=29aef6bf-22ff-5269-0c67-e98540f696db

Fixes https://github.com/dotnet/runtime/issues/110963