### PR TITLE
[S390x] Fix endian bug in minipal

### DIFF
--- a/src/native/minipal/utf8.c
+++ b/src/native/minipal/utf8.c
@@ -7,6 +7,7 @@
 #include <limits.h>
 #include <string.h>
 #include <assert.h>
+#include "minipalconfig.h"
 
 #define HIGH_SURROGATE_START 0xd800
 #define HIGH_SURROGATE_END 0xdbff


### PR DESCRIPTION
after #107889 is merged we see test cases crashing on s390x

```
Starting program: /home/sanjam/test-build-script/build-scripts-s390x/runtime/runtime/.dotnet/dotnet --info
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
[New Thread 0x3fff63008c0 (LWP 1186966)]
[New Thread 0x3fff45008c0 (LWP 1186967)]
[New Thread 0x3fff42008c0 (LWP 1186968)]
Process terminated.
Enocnueter dniifinetr ceruisnow ihell ooikgnu  perosruec' iMssniMgnafiseRtseuocr_eoNeNtuarAlms 'niS syet.mrPvita.eoCeriL.bV refi yht enitslaalitnoo  fN.TEi  socpmeleta dnd eo son tender peiairgn ,na dhttat ehs ateto  fht erpcose sah son tebocemc rourpted.

Thread 1 "dotnet" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
44            return INTERNAL_SYSCALL_ERROR_P (ret) ? INTERNAL_SYSCALL_ERRNO (ret) : 0;
```

This is primarily because the "BIGENDIAN" macro is defined in `src/native/minipal/minipalconfig.h.in` which generates a `minipalconfig.h` which needs to be included in `utf8.c` in order for the macro to be used there.