### PR TITLE
[mono] [llvm-aot] Fixed storing Vector3 into memory

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -8434,7 +8434,6 @@ MONO_RESTORE_WARNING
 
 			dest = convert (ctx, LLVMBuildAdd (builder, convert (ctx, values [ins->inst_destbasereg], IntPtrType ()), LLVMConstInt (IntPtrType (), ins->inst_offset, FALSE), ""), pointer_type (t));
 			if (mono_class_value_size (ins->klass, NULL) == 12) {
-				LLVMTypeRef float3Type = LLVMVectorType (LLVMFloatType (), 3);
 				const int mask_values [] = { 0, 1, 2 };
 
 				LLVMValueRef truncatedVec3 = LLVMBuildShuffleVector (

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -8433,7 +8433,22 @@ MONO_RESTORE_WARNING
 			LLVMValueRef dest;
 
 			dest = convert (ctx, LLVMBuildAdd (builder, convert (ctx, values [ins->inst_destbasereg], IntPtrType ()), LLVMConstInt (IntPtrType (), ins->inst_offset, FALSE), ""), pointer_type (t));
-			mono_llvm_build_aligned_store (builder, lhs, dest, FALSE, 1);
+			if (mono_class_value_size (ins->klass, NULL) == 12) {
+				LLVMTypeRef float3Type = LLVMVectorType (LLVMFloatType (), 3);
+				const int mask_values [] = { 0, 1, 2 };
+
+				LLVMValueRef truncatedVec3 = LLVMBuildShuffleVector (
+					builder,
+					lhs,
+					LLVMGetUndef (t),
+					create_const_vector_i32 (mask_values, 3),
+					"truncated_vec3"
+				);
+
+				mono_llvm_build_aligned_store (builder, truncatedVec3, dest, FALSE, 1);
+			} else {
+				mono_llvm_build_aligned_store (builder, lhs, dest, FALSE, 1);
+			}
 			break;
 		}
 		case OP_XBINOP:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_110820/Runtime_110820.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_110820/Runtime_110820.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System.Numerics;
+
+public class Foo
+{
+    public Vector3 v1;
+    public Vector3 v2;
+}
+
+public class Runtime_110820
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        var foo = new Foo();
+        foo.v2 = new Vector3(4, 5, 6);
+        foo.v1 = new Vector3(1, 2, 3);
+        Assert.Equal(new Vector3(1, 2, 3), foo.v1);
+        Assert.Equal(new Vector3(4, 5, 6), foo.v2);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_110820/Runtime_110820.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_110820/Runtime_110820.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/110820

Vector3 is sometimes handled as Vector4 (Vector3 + 0) for perf purposes. On mono llvm aot it was incorrectly stored into memory with the trailing 0. This change fixes that behaviour. 