### PR TITLE
Do not substitute return values of constrained calls

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -748,12 +748,12 @@ namespace ILCompiler
                     {
                         BodySubstitution substitution = _substitutionProvider.GetSubstitution(method);
                         if (substitution != null && substitution.Value is int
-                            && (opcode != ILOpcode.callvirt || !method.IsVirtual))
+                            && ((opcode != ILOpcode.callvirt && !method.Signature.IsStatic) || !method.IsVirtual))
                         {
                             constant = (int)substitution.Value;
                             return true;
                         }
-                        if ((opcode != ILOpcode.callvirt || !method.IsVirtual)
+                        if (((opcode != ILOpcode.callvirt && !method.Signature.IsStatic) || !method.IsVirtual)
                             && TryGetMethodConstantValue(method, out constant))
                         {
                             return true;

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -12,6 +12,7 @@ class DeadCodeElimination
     public static int Run()
     {
         SanityTest.Run();
+        Test110932Regression.Run();
         TestInstanceMethodOptimization.Run();
         TestReflectionInvokeSignatures.Run();
         TestAbstractTypeNeverDerivedVirtualsOptimization.Run();
@@ -49,6 +50,34 @@ class DeadCodeElimination
                 throw new Exception();
 
             ThrowIfPresent(typeof(SanityTest), nameof(NotPresentType));
+        }
+    }
+
+    class Test110932Regression
+    {
+        static bool s_trueConst = true;
+        static bool s_falseConst = false;
+
+        interface I
+        {
+            static virtual bool GetValue() => false;
+        }
+
+        class C : I
+        {
+            static bool I.GetValue() => true;
+        }
+
+        public static void Run()
+        {
+            if (!Call<C>())
+                throw new Exception();
+        }
+        static bool Call<T>() where T : I
+        {
+            if (T.GetValue())
+                return s_trueConst;
+            return s_falseConst;
         }
     }
 


### PR DESCRIPTION
Fixes #110932.

The constraint would need to be resolved first.

Cc @dotnet/ilc-contrib 