### PR TITLE
Add missing X509CertificateLoader documentation

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.cs
@@ -12,10 +12,11 @@ using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography.X509Certificates
 {
+    /// <summary>
+    ///   Provides methods for loading an X.509 certificate or a PKCS#12 PFX containing certificates.
+    /// </summary>
     [UnsupportedOSPlatform("browser")]
-#pragma warning disable 1591 // TODO: Document this API. https://github.com/dotnet/runtime/issues/105974
     public static partial class X509CertificateLoader
-#pragma warning restore 1591
     {
         private const int MemoryMappedFileCutoff = 1_048_576;
 


### PR DESCRIPTION
While all of the members of `X509CertificateLoader` have doc comments, the class itself does not.

Will port to `dotnet-api-docs` when this is merged.