### PR TITLE
Fix LoaderAllocator of DynamicMethodTable

### DIFF
--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -112,7 +112,7 @@ void DynamicMethodTable::MakeMethodTable(AllocMemTracker *pamTracker)
     }
     CONTRACTL_END;
 
-    m_pMethodTable = CreateMinimalMethodTable(m_Module, m_pDomain->GetLoaderAllocator(), pamTracker);
+    m_pMethodTable = CreateMinimalMethodTable(m_Module, m_Module->GetLoaderAllocator(), pamTracker);
 }
 
 void DynamicMethodTable::Destroy()

--- a/src/tests/Regressions/coreclr/GitHub_110987/test110987.cs
+++ b/src/tests/Regressions/coreclr/GitHub_110987/test110987.cs
@@ -19,8 +19,6 @@ public class Test110987
     [Fact]
     public static void TestDynamicMethodALC()
     {
-        string tempFilePath = Path.GetTempFileName() + ".dll";
-
         // Create a simple type
         PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssembly"), typeof(object).Assembly);
         TypeBuilder typeBuilder = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
@@ -28,11 +26,14 @@ public class Test110987
         ILGenerator ilGenerator = myMethod.GetILGenerator();
         ilGenerator.Emit(OpCodes.Ret);
         typeBuilder.CreateType();
-        ab.Save(tempFilePath);
+        MemoryStream ms = new MemoryStream()
+        ab.Save(ms);
+
+        ms.Position = 0;
 
         TestAssemblyLoadContext tlc = new TestAssemblyLoadContext();
 
-        Type typeFromDisk = tlc.LoadFromAssemblyPath(tempFilePath).GetType("MyType")!;
+        Type typeFromDisk = tlc.LoadFromStream(ms).GetType("MyType")!;
         MethodInfo methodFromDisk = typeFromDisk.GetMethod("MyMethod")!;
 
         DynamicMethod callIt = new DynamicMethod(

--- a/src/tests/Regressions/coreclr/GitHub_110987/test110987.cs
+++ b/src/tests/Regressions/coreclr/GitHub_110987/test110987.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Loader;
+using Xunit;
+
+class TestAssemblyLoadContext : AssemblyLoadContext
+{
+    public TestAssemblyLoadContext() : base(isCollectible: true)
+    {
+    }
+}
+
+public class Test110987
+{
+    [Fact]
+    public static void TestDynamicMethodALC()
+    {
+        string tempFilePath = Path.GetTempFileName() + ".dll";
+
+        // Create a simple type
+        PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssembly"), typeof(object).Assembly);
+        TypeBuilder typeBuilder = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
+        MethodBuilder myMethod = typeBuilder.DefineMethod("MyMethod", MethodAttributes.Public | MethodAttributes.Static, CallingConventions.Standard);
+        ILGenerator ilGenerator = myMethod.GetILGenerator();
+        ilGenerator.Emit(OpCodes.Ret);
+        typeBuilder.CreateType();
+        ab.Save(tempFilePath);
+
+        TestAssemblyLoadContext tlc = new TestAssemblyLoadContext();
+
+        Type typeFromDisk = tlc.LoadFromAssemblyPath(tempFilePath).GetType("MyType")!;
+        MethodInfo methodFromDisk = typeFromDisk.GetMethod("MyMethod")!;
+
+        DynamicMethod callIt = new DynamicMethod(
+            "CallIt",
+            MethodAttributes.Public | MethodAttributes.Static,
+            CallingConventions.Standard,
+            returnType: typeof(void),
+            parameterTypes: null,
+            m: typeFromDisk.Module, // Using typeof(object).Module works
+            skipVisibility: true);
+
+        ILGenerator il = callIt.GetILGenerator();
+        il.Emit(OpCodes.Call, methodFromDisk);
+        il.Emit(OpCodes.Ret);
+
+        Action invoker = (Action)callIt.CreateDelegate(typeof(Action));
+        invoker(); 
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_110987/test110987.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_110987/test110987.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test110987.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is one `DynamicMethodTable` allocated per `Module` if needed. When its instance is being created, an incorrect `LoaderAllocator` is passed to the `CreateMinimalMethodTable` function. Instead of the `Module`'s `LoaderAllocator`, it passes in the default one.
That fires an assert in non-release builds of the runtime and it results in incorrect marking of the `MethodTable` as not collectible in case the `Module`'s LoaderAllocator is collectible.

This change fixes it by passing in the `LoaderAllocator` of the module instead.

Close #110987