### PR TITLE
Support writing base64 JSON segments

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -681,6 +681,7 @@ namespace System.Text.Json
         public void WriteStringValue(System.Text.Json.JsonEncodedText value) { }
         public void WriteStringValueSegment(System.ReadOnlySpan<byte> value, bool isFinalSegment) { }
         public void WriteStringValueSegment(System.ReadOnlySpan<char> value, bool isFinalSegment) { }
+        public void WriteBase64StringSegment(ReadOnlySpan<byte> value, bool isFinalSegment) { }
     }
 }
 namespace System.Text.Json.Nodes

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
@@ -12,9 +12,9 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
-        private bool HasPartialCodePoint => PartialCodePointLength != 0;
+        private bool HasPartialStringData => PartialStringDataLength != 0;
 
-        private void ClearPartialCodePoint() => PartialCodePointLength = 0;
+        private void ClearPartialStringData() => PartialStringDataLength = 0;
 
         private void ValidateEncodingDidNotChange(SegmentEncoding currentSegmentEncoding)
         {
@@ -32,7 +32,7 @@ namespace System.Text.Json
             }
 
             Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.None);
-            Debug.Assert(!HasPartialCodePoint);
+            Debug.Assert(!HasPartialStringData);
         }
 
         private void ValidateWritingValue()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json
             if (_tokenType != Utf8JsonWriter.StringSegmentSentinel)
             {
                 Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.None);
-                Debug.Assert(!HasPartialCodePoint);
+                Debug.Assert(!HasPartialStringData);
 
                 if (!_options.SkipValidation)
                 {
@@ -50,7 +50,7 @@ namespace System.Text.Json
 
             // The steps to write a string segment are to complete the previous partial code point
             // and escape either of which might not be required so there is a fast path for each of these steps.
-            if (HasPartialCodePoint)
+            if (HasPartialStringData)
             {
                 WriteStringSegmentWithLeftover(value, isFinalSegment);
             }
@@ -71,35 +71,35 @@ namespace System.Text.Json
 
         private void WriteStringSegmentWithLeftover(scoped ReadOnlySpan<char> value, bool isFinalSegment)
         {
-            Debug.Assert(HasPartialCodePoint);
+            Debug.Assert(HasPartialStringData);
             Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.Utf16);
 
-            scoped ReadOnlySpan<char> partialCodePointBuffer = PartialUtf16CodePoint;
+            scoped ReadOnlySpan<char> partialStringDataBuffer = PartialUtf16StringData;
 
             Span<char> combinedBuffer = stackalloc char[2];
-            combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialCodePointBuffer, value, combinedBuffer));
+            combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialStringDataBuffer, value, combinedBuffer));
 
             switch (Rune.DecodeFromUtf16(combinedBuffer, out _, out int charsConsumed))
             {
                 case OperationStatus.NeedMoreData:
-                    Debug.Assert(value.Length + partialCodePointBuffer.Length < 2);
-                    Debug.Assert(charsConsumed == value.Length + partialCodePointBuffer.Length);
+                    Debug.Assert(value.Length + partialStringDataBuffer.Length < 2);
+                    Debug.Assert(charsConsumed == value.Length + partialStringDataBuffer.Length);
                     // Let the encoder deal with the error if this is a final buffer.
                     value = combinedBuffer.Slice(0, charsConsumed);
-                    partialCodePointBuffer = [];
+                    partialStringDataBuffer = [];
                     break;
                 case OperationStatus.Done:
-                    Debug.Assert(charsConsumed > partialCodePointBuffer.Length);
+                    Debug.Assert(charsConsumed > partialStringDataBuffer.Length);
                     Debug.Assert(charsConsumed <= 2);
                     // Divide up the code point chars into its own buffer and the remainder of the input buffer.
-                    value = value.Slice(charsConsumed - partialCodePointBuffer.Length);
-                    partialCodePointBuffer = combinedBuffer.Slice(0, charsConsumed);
+                    value = value.Slice(charsConsumed - partialStringDataBuffer.Length);
+                    partialStringDataBuffer = combinedBuffer.Slice(0, charsConsumed);
                     break;
                 case OperationStatus.InvalidData:
-                    Debug.Assert(charsConsumed >= partialCodePointBuffer.Length);
+                    Debug.Assert(charsConsumed >= partialStringDataBuffer.Length);
                     Debug.Assert(charsConsumed <= 2);
-                    value = value.Slice(charsConsumed - partialCodePointBuffer.Length);
-                    partialCodePointBuffer = combinedBuffer.Slice(0, charsConsumed);
+                    value = value.Slice(charsConsumed - partialStringDataBuffer.Length);
+                    partialStringDataBuffer = combinedBuffer.Slice(0, charsConsumed);
                     break;
                 case OperationStatus.DestinationTooSmall:
                 default:
@@ -108,7 +108,7 @@ namespace System.Text.Json
             }
 
             // The "isFinalSegment" argument indicates whether input that NeedsMoreData should be consumed as an error or not.
-            // Because we have validated above that partialCodePointBuffer will be the next consumed chars during Rune decoding
+            // Because we have validated above that partialStringDataBuffer will be the next consumed chars during Rune decoding
             // (even if this is because it is invalid), we should pass isFinalSegment = true to indicate to the decoder to
             // parse the code units without extra data.
             //
@@ -116,9 +116,9 @@ namespace System.Text.Json
             // to determine that only the first unit should be consumed (as invalid). So this method will get only ['\uD800'].
             // Because we know more data will not be able to complete this code point, we need to pass isFinalSegment = true
             // to ensure that the encoder consumes this data eagerly instead of leaving it and returning NeedsMoreData.
-            WriteStringSegmentEscape(partialCodePointBuffer, true);
+            WriteStringSegmentEscape(partialStringDataBuffer, true);
 
-            ClearPartialCodePoint();
+            ClearPartialStringData();
 
             WriteStringSegmentEscape(value, isFinalSegment);
         }
@@ -160,7 +160,7 @@ namespace System.Text.Json
             {
                 Debug.Assert(!isFinalSegment);
                 Debug.Assert(value.Length - consumed < 2);
-                PartialUtf16CodePoint = value.Slice(consumed);
+                PartialUtf16StringData = value.Slice(consumed);
             }
 
             if (valueArray != null)
@@ -207,7 +207,7 @@ namespace System.Text.Json
             if (_tokenType != Utf8JsonWriter.StringSegmentSentinel)
             {
                 Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.None);
-                Debug.Assert(!HasPartialCodePoint);
+                Debug.Assert(!HasPartialStringData);
 
                 if (!_options.SkipValidation)
                 {
@@ -226,7 +226,7 @@ namespace System.Text.Json
 
             // The steps to write a string segment are to complete the previous partial code point
             // and escape either of which might not be required so there is a fast path for each of these steps.
-            if (HasPartialCodePoint)
+            if (HasPartialStringData)
             {
                 WriteStringSegmentWithLeftover(value, isFinalSegment);
             }
@@ -247,35 +247,35 @@ namespace System.Text.Json
 
         private void WriteStringSegmentWithLeftover(scoped ReadOnlySpan<byte> utf8Value, bool isFinalSegment)
         {
-            Debug.Assert(HasPartialCodePoint);
+            Debug.Assert(HasPartialStringData);
             Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.Utf8);
 
-            scoped ReadOnlySpan<byte> partialCodePointBuffer = PartialUtf8CodePoint;
+            scoped ReadOnlySpan<byte> partialStringDataBuffer = PartialUtf8StringData;
 
             Span<byte> combinedBuffer = stackalloc byte[4];
-            combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialCodePointBuffer, utf8Value, combinedBuffer));
+            combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialStringDataBuffer, utf8Value, combinedBuffer));
 
             switch (Rune.DecodeFromUtf8(combinedBuffer, out _, out int bytesConsumed))
             {
                 case OperationStatus.NeedMoreData:
-                    Debug.Assert(utf8Value.Length + partialCodePointBuffer.Length < 4);
-                    Debug.Assert(bytesConsumed == utf8Value.Length + partialCodePointBuffer.Length);
+                    Debug.Assert(utf8Value.Length + partialStringDataBuffer.Length < 4);
+                    Debug.Assert(bytesConsumed == utf8Value.Length + partialStringDataBuffer.Length);
                     // Let the encoder deal with the error if this is a final buffer.
                     utf8Value = combinedBuffer.Slice(0, bytesConsumed);
-                    partialCodePointBuffer = [];
+                    partialStringDataBuffer = [];
                     break;
                 case OperationStatus.Done:
-                    Debug.Assert(bytesConsumed > partialCodePointBuffer.Length);
+                    Debug.Assert(bytesConsumed > partialStringDataBuffer.Length);
                     Debug.Assert(bytesConsumed <= 4);
                     // Divide up the code point bytes into its own buffer and the remainder of the input buffer.
-                    utf8Value = utf8Value.Slice(bytesConsumed - partialCodePointBuffer.Length);
-                    partialCodePointBuffer = combinedBuffer.Slice(0, bytesConsumed);
+                    utf8Value = utf8Value.Slice(bytesConsumed - partialStringDataBuffer.Length);
+                    partialStringDataBuffer = combinedBuffer.Slice(0, bytesConsumed);
                     break;
                 case OperationStatus.InvalidData:
-                    Debug.Assert(bytesConsumed >= partialCodePointBuffer.Length);
+                    Debug.Assert(bytesConsumed >= partialStringDataBuffer.Length);
                     Debug.Assert(bytesConsumed <= 4);
-                    utf8Value = utf8Value.Slice(bytesConsumed - partialCodePointBuffer.Length);
-                    partialCodePointBuffer = combinedBuffer.Slice(0, bytesConsumed);
+                    utf8Value = utf8Value.Slice(bytesConsumed - partialStringDataBuffer.Length);
+                    partialStringDataBuffer = combinedBuffer.Slice(0, bytesConsumed);
                     break;
                 case OperationStatus.DestinationTooSmall:
                 default:
@@ -284,7 +284,7 @@ namespace System.Text.Json
             }
 
             // The "isFinalSegment" argument indicates whether input that NeedsMoreData should be consumed as an error or not.
-            // Because we have validated above that partialCodePointBuffer will be the next consumed bytes during Rune decoding
+            // Because we have validated above that partialStringDataBuffer will be the next consumed bytes during Rune decoding
             // (even if this is because it is invalid), we should pass isFinalSegment = true to indicate to the decoder to
             // parse the code units without extra data.
             //
@@ -293,9 +293,9 @@ namespace System.Text.Json
             // So this method will get only <3-size prefix code unit><continuation>. Because we know more data will not be able
             // to complete this code point, we need to pass isFinalSegment = true to ensure that the encoder consumes this data eagerly
             // instead of leaving it and returning NeedsMoreData.
-            WriteStringSegmentEscape(partialCodePointBuffer, true);
+            WriteStringSegmentEscape(partialStringDataBuffer, true);
 
-            ClearPartialCodePoint();
+            ClearPartialStringData();
 
             WriteStringSegmentEscape(utf8Value, isFinalSegment);
         }
@@ -334,7 +334,7 @@ namespace System.Text.Json
             {
                 Debug.Assert(!isFinalSegment);
                 Debug.Assert(utf8Value.Length - consumed < 4);
-                PartialUtf8CodePoint = utf8Value.Slice(consumed);
+                PartialUtf8StringData = utf8Value.Slice(consumed);
             }
 
             if (valueArray != null)
@@ -382,7 +382,7 @@ namespace System.Text.Json
             if (_tokenType != Utf8JsonWriter.StringSegmentSentinel)
             {
                 Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.None);
-                Debug.Assert(!HasPartialCodePoint);
+                Debug.Assert(!HasPartialStringData);
 
                 if (!_options.SkipValidation)
                 {
@@ -401,7 +401,7 @@ namespace System.Text.Json
 
             // The steps to write a string segment are to complete the previous partial code point
             // and escape either of which might not be required so there is a fast path for each of these steps.
-            if (HasPartialCodePoint)
+            if (HasPartialStringData)
             {
                 WriteBase64StringSegmentWithLeftover(value, isFinalSegment);
             }
@@ -422,44 +422,44 @@ namespace System.Text.Json
 
         private void WriteBase64StringSegmentWithLeftover(scoped ReadOnlySpan<byte> bytes, bool isFinalSegment)
         {
-            Debug.Assert(HasPartialCodePoint);
+            Debug.Assert(HasPartialStringData);
             Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.Base64);
 
-            scoped ReadOnlySpan<byte> partialCodePointBuffer = PartialBase64CodePoint;
+            scoped ReadOnlySpan<byte> partialStringDataBuffer = PartialBase64StringData;
 
             Span<byte> combinedBuffer = stackalloc byte[3];
-            combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialCodePointBuffer, bytes, combinedBuffer));
+            combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialStringDataBuffer, bytes, combinedBuffer));
             if (combinedBuffer.Length is 3)
             {
                 // Divide up the code point bytes into its own buffer and the remainder of the input buffer.
-                bytes = bytes.Slice(3 - partialCodePointBuffer.Length);
-                partialCodePointBuffer = combinedBuffer.Slice(0, 3);
+                bytes = bytes.Slice(3 - partialStringDataBuffer.Length);
+                partialStringDataBuffer = combinedBuffer.Slice(0, 3);
             }
             else
             {
                 Debug.Assert(combinedBuffer.Length is 1 or 2);
                 // Need more data. If this is a final segment, then the encoder will append '=' as needed.
-                Debug.Assert(bytes.Length + partialCodePointBuffer.Length < 3);
+                Debug.Assert(bytes.Length + partialStringDataBuffer.Length < 3);
                 bytes = combinedBuffer;
-                partialCodePointBuffer = [];
+                partialStringDataBuffer = [];
             }
 
             // It doesn't matter if we pass true or false for isFinalSegment since we are guaranteed to not have a partial code point
             // here (it is either empty or completed using the combined buffer above).
-            WriteBase64StringSegmentData(partialCodePointBuffer, false);
+            WriteBase64StringSegmentData(partialStringDataBuffer, false);
 
-            ClearPartialCodePoint();
+            ClearPartialStringData();
 
             WriteBase64StringSegmentData(bytes, isFinalSegment);
         }
 
-        private void WriteBase64StringSegmentData(ReadOnlySpan<byte> bytes, bool isFinal)
+        private void WriteBase64StringSegmentData(ReadOnlySpan<byte> bytes, bool isFinalSegment)
         {
             int leftoverSize;
-            if (!isFinal && (leftoverSize = bytes.Length % 3) != 0)
+            if (!isFinalSegment && (leftoverSize = bytes.Length % 3) != 0)
             {
                 // If this is not the final segment, we need to wait for more data to come in.
-                PartialBase64CodePoint = bytes.Slice(bytes.Length - leftoverSize);
+                PartialBase64StringData = bytes.Slice(bytes.Length - leftoverSize);
                 bytes = bytes.Slice(0, bytes.Length - leftoverSize);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
@@ -399,7 +399,7 @@ namespace System.Text.Json
                 ValidateEncodingDidNotChange(SegmentEncoding.Base64);
             }
 
-            // The steps to write a string segment are to complete the previous partial code point
+            // The steps to write a string segment are to complete the previous partial string data
             // and escape either of which might not be required so there is a fast path for each of these steps.
             if (HasPartialStringData)
             {
@@ -431,7 +431,7 @@ namespace System.Text.Json
             combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialStringDataBuffer, bytes, combinedBuffer));
             if (combinedBuffer.Length is 3)
             {
-                // Divide up the code point bytes into its own buffer and the remainder of the input buffer.
+                // Divide up the partial bytes into its own buffer and the remainder of the input buffer.
                 bytes = bytes.Slice(3 - partialStringDataBuffer.Length);
                 partialStringDataBuffer = combinedBuffer.Slice(0, 3);
             }
@@ -444,7 +444,7 @@ namespace System.Text.Json
                 partialStringDataBuffer = [];
             }
 
-            // It doesn't matter if we pass true or false for isFinalSegment since we are guaranteed to not have a partial code point
+            // It doesn't matter if we pass true or false for isFinalSegment since we are guaranteed to not have partial data
             // here (it is either empty or completed using the combined buffer above).
             WriteBase64StringSegmentData(partialStringDataBuffer, false);
 
@@ -477,6 +477,8 @@ namespace System.Text.Json
 
             Span<byte> output = _memory.Span;
 
+            // For non-final segments, the input is sliced to be a multiple of 3 bytes above which guarantees
+            // that the base64 encoding will never end with padding since 3x input bytes turn into exactly 4x base64 bytes.
             Base64EncodeAndWrite(bytes, output);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -231,7 +231,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convenience enumeration to track the encoding of the partial code point. This must be kept in sync with the PartialStringData*Encoding flags.
+        /// Convenience enumeration to track the encoding of the partial string data. This must be kept in sync with the PartialStringData*Encoding flags.
         /// </summary>
         internal enum SegmentEncoding : byte
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -37,13 +37,13 @@ namespace System.Text.Json
         // A special value for JsonTokenType that lets the writer keep track of string segments.
         private const JsonTokenType StringSegmentSentinel = (JsonTokenType)255;
 
-        // Masks and flags for the length and encoding of the partial code point
-        private const byte PartialCodePointLengthMask =             0b000_000_11;
-        private const byte PartialCodePointEncodingMask =           0b000_111_00;
+        // Masks and flags for the length and encoding of the partial string data.
+        private const byte PartialStringDataLengthMask =            0b000_000_11;
+        private const byte PartialStringDataEncodingMask =          0b000_111_00;
 
-        private const byte PartialCodePointUtf8EncodingFlag =       0b000_001_00;
-        private const byte PartialCodePointUtf16EncodingFlag =      0b000_010_00;
-        private const byte PartialCodePointBase64EncodingFlag =     0b000_100_00;
+        private const byte PartialStringDataUtf8EncodingFlag =      0b000_001_00;
+        private const byte PartialStringDataUtf16EncodingFlag =     0b000_010_00;
+        private const byte PartialStringDataBase64EncodingFlag =    0b000_100_00;
 
         private IBufferWriter<byte>? _output;
         private Stream? _stream;
@@ -57,15 +57,15 @@ namespace System.Text.Json
         private BitStack _bitStack;
 
         /// <summary>
-        /// This 3-byte array stores the partial code point leftover when writing a string value
+        /// This 3-byte array stores the partial string data leftover when writing a string value
         /// segment that is split across multiple segment write calls.
         /// </summary>
 #if !NET
-        private byte[]? _partialCodePoint;
-        private Span<byte> PartialCodePointRaw => _partialCodePoint ??= new byte[3];
+        private byte[]? _partialStringData;
+        private Span<byte> PartialStringDataRaw => _partialStringData ??= new byte[3];
 #else
-        private Inline3ByteArray _partialCodePoint;
-        private Span<byte> PartialCodePointRaw => _partialCodePoint;
+        private Inline3ByteArray _partialStringData;
+        private Span<byte> PartialStringDataRaw => _partialStringData;
 
         [InlineArray(3)]
         private struct Inline3ByteArray
@@ -75,11 +75,11 @@ namespace System.Text.Json
 #endif
 
         /// <summary>
-        /// Stores the length and encoding of the partial code point. Outside of segment writes, this value is 0.
+        /// Stores the length and encoding of the partial string data. Outside of segment writes, this value is 0.
         /// Across segment writes, this value is always non-zero even if the length is 0, to indicate the encoding of the segment.
         /// This allows detection of encoding changes across segment writes.
         /// </summary>
-        private byte _partialCodePointFlags;
+        private byte _partialStringDataFlags;
 
         // The highest order bit of _currentDepth is used to discern whether we are writing the first item in a list or not.
         // if (_currentDepth >> 31) == 1, add a list separator before writing the item
@@ -128,96 +128,96 @@ namespace System.Text.Json
         public int CurrentDepth => _currentDepth & JsonConstants.RemoveFlagsBitMask;
 
         /// <summary>
-        /// Length of the partial code point.
+        /// Length of the partial string data.
         /// </summary>
-        private byte PartialCodePointLength
+        private byte PartialStringDataLength
         {
-            get => (byte)(_partialCodePointFlags & PartialCodePointLengthMask);
-            set => _partialCodePointFlags = (byte)((_partialCodePointFlags & ~PartialCodePointLengthMask) | value);
+            get => (byte)(_partialStringDataFlags & PartialStringDataLengthMask);
+            set => _partialStringDataFlags = (byte)((_partialStringDataFlags & ~PartialStringDataLengthMask) | value);
         }
 
         /// <summary>
         /// The partial UTF-8 code point.
         /// </summary>
-        private ReadOnlySpan<byte> PartialUtf8CodePoint
+        private ReadOnlySpan<byte> PartialUtf8StringData
         {
             get
             {
                 Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.Utf8);
 
-                ReadOnlySpan<byte> partialCodePointBytes = PartialCodePointRaw;
-                Debug.Assert(partialCodePointBytes.Length == 3);
+                ReadOnlySpan<byte> partialStringDataBytes = PartialStringDataRaw;
+                Debug.Assert(partialStringDataBytes.Length == 3);
 
-                byte length = PartialCodePointLength;
+                byte length = PartialStringDataLength;
                 Debug.Assert(length < 4);
 
-                return partialCodePointBytes.Slice(0, length);
+                return partialStringDataBytes.Slice(0, length);
             }
 
             set
             {
                 Debug.Assert(value.Length <= 3);
 
-                Span<byte> partialCodePointBytes = PartialCodePointRaw;
+                Span<byte> partialStringDataBytes = PartialStringDataRaw;
 
-                value.CopyTo(partialCodePointBytes);
-                PartialCodePointLength = (byte)value.Length;
+                value.CopyTo(partialStringDataBytes);
+                PartialStringDataLength = (byte)value.Length;
             }
         }
 
         /// <summary>
         /// The partial UTF-16 code point.
         /// </summary>
-        private ReadOnlySpan<char> PartialUtf16CodePoint
+        private ReadOnlySpan<char> PartialUtf16StringData
         {
             get
             {
                 Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.Utf16);
 
-                ReadOnlySpan<byte> partialCodePointBytes = PartialCodePointRaw;
-                Debug.Assert(partialCodePointBytes.Length == 3);
+                ReadOnlySpan<byte> partialStringDataBytes = PartialStringDataRaw;
+                Debug.Assert(partialStringDataBytes.Length == 3);
 
-                byte length = PartialCodePointLength;
+                byte length = PartialStringDataLength;
                 Debug.Assert(length is 2 or 0);
 
-                return MemoryMarshal.Cast<byte, char>(partialCodePointBytes.Slice(0, length));
+                return MemoryMarshal.Cast<byte, char>(partialStringDataBytes.Slice(0, length));
             }
             set
             {
                 Debug.Assert(value.Length <= 1);
 
-                Span<byte> partialCodePointBytes = PartialCodePointRaw;
+                Span<byte> partialStringDataBytes = PartialStringDataRaw;
 
-                value.CopyTo(MemoryMarshal.Cast<byte, char>(partialCodePointBytes));
-                PartialCodePointLength = (byte)(2 * value.Length);
+                value.CopyTo(MemoryMarshal.Cast<byte, char>(partialStringDataBytes));
+                PartialStringDataLength = (byte)(2 * value.Length);
             }
         }
 
         /// <summary>
-        /// The partial base64 code point.
+        /// The partial base64 data.
         /// </summary>
-        private ReadOnlySpan<byte> PartialBase64CodePoint
+        private ReadOnlySpan<byte> PartialBase64StringData
         {
             get
             {
                 Debug.Assert(PreviousSegmentEncoding == SegmentEncoding.Base64);
 
-                ReadOnlySpan<byte> partialCodePointBytes = PartialCodePointRaw;
-                Debug.Assert(partialCodePointBytes.Length == 3);
+                ReadOnlySpan<byte> partialStringDataBytes = PartialStringDataRaw;
+                Debug.Assert(partialStringDataBytes.Length == 3);
 
-                byte length = PartialCodePointLength;
+                byte length = PartialStringDataLength;
                 Debug.Assert(length < 3);
 
-                return partialCodePointBytes.Slice(0, length);
+                return partialStringDataBytes.Slice(0, length);
             }
             set
             {
                 Debug.Assert(value.Length < 3);
 
-                Span<byte> partialCodePointBytes = PartialCodePointRaw;
+                Span<byte> partialStringDataBytes = PartialStringDataRaw;
 
-                value.CopyTo(partialCodePointBytes);
-                PartialCodePointLength = (byte)value.Length;
+                value.CopyTo(partialStringDataBytes);
+                PartialStringDataLength = (byte)value.Length;
             }
         }
 
@@ -226,19 +226,19 @@ namespace System.Text.Json
         /// </summary>
         private SegmentEncoding PreviousSegmentEncoding
         {
-            get => (SegmentEncoding)(_partialCodePointFlags & PartialCodePointEncodingMask);
-            set => _partialCodePointFlags = (byte)((_partialCodePointFlags & ~PartialCodePointEncodingMask) | (byte)value);
+            get => (SegmentEncoding)(_partialStringDataFlags & PartialStringDataEncodingMask);
+            set => _partialStringDataFlags = (byte)((_partialStringDataFlags & ~PartialStringDataEncodingMask) | (byte)value);
         }
 
         /// <summary>
-        /// Convenience enumeration to track the encoding of the partial code point. This must be kept in sync with the PartialCodePoint*Encoding flags.
+        /// Convenience enumeration to track the encoding of the partial code point. This must be kept in sync with the PartialStringData*Encoding flags.
         /// </summary>
         internal enum SegmentEncoding : byte
         {
             None = 0,
-            Utf8 = PartialCodePointUtf8EncodingFlag,
-            Utf16 = PartialCodePointUtf16EncodingFlag,
-            Base64 = PartialCodePointBase64EncodingFlag,
+            Utf8 = PartialStringDataUtf8EncodingFlag,
+            Utf16 = PartialStringDataUtf16EncodingFlag,
+            Base64 = PartialStringDataBase64EncodingFlag,
         }
 
         private Utf8JsonWriter()
@@ -419,8 +419,8 @@ namespace System.Text.Json
 
             _bitStack = default;
 
-            _partialCodePoint = default;
-            _partialCodePointFlags = default;
+            _partialStringData = default;
+            _partialStringDataFlags = default;
         }
 
         private void CheckNotDisposed()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.Values.StringSegment.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.Values.StringSegment.cs
@@ -4,10 +4,13 @@
 
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using Xunit;
 
 namespace System.Text.Json.Tests
@@ -62,7 +65,7 @@ namespace System.Text.Json.Tests
             options.Encoder.Encode(inputArr, expectedChars, out int charsConsumed, out int charsWritten);
             Assert.Equal(inputArr.Length, charsConsumed);
 
-            SplitCodePointsHelper(inputArr, $@"""{new string(expectedChars, 0, charsWritten)}""", options);
+            SplitCodePointsHelper(inputArr, options, $@"""{new string(expectedChars, 0, charsWritten)}""", EncodingType.Utf16);
         }
 
         public static IEnumerable<byte[]> InvalidUtf8Data()
@@ -120,31 +123,34 @@ namespace System.Text.Json.Tests
 
             string expectedString = $@"""{Encoding.UTF8.GetString(expectedBytes, 0, bytesWritten)}""";
 
-            SplitCodePointsHelper(inputArr, expectedString, options);
-        }
-
-        private static void SplitCodePointsHelper<T>(
-            T[] inputArr,
-            string expected,
-            JsonWriterOptions options)
-            where T : struct
-        {
-            SplitCodePointsHelper<T>(inputArr, options, output => JsonTestHelper.AssertContents(expected, output));
+            SplitCodePointsHelper(inputArr, options, expectedString, EncodingType.Utf8);
         }
 
         private static void SplitCodePointsHelper<T>(
             T[] inputArr,
             JsonWriterOptions options,
-            Action<ArrayBufferWriter<byte>> assert)
+            string expected,
+            EncodingType encoding)
             where T : struct
         {
-            SplitCodePointsHelper<T>(inputArr.AsSpan(), options, assert);
+            SplitCodePointsHelper<T>(inputArr, options, output => JsonTestHelper.AssertContents(expected, output), encoding);
+        }
+
+        private static void SplitCodePointsHelper<T>(
+            T[] inputArr,
+            JsonWriterOptions options,
+            Action<ArrayBufferWriter<byte>> assert,
+            EncodingType encoding)
+            where T : struct
+        {
+            SplitCodePointsHelper<T>(inputArr.AsSpan(), options, assert, encoding);
         }
 
         private static void SplitCodePointsHelper<T>(
             ReadOnlySpan<T> inputArr,
             JsonWriterOptions options,
-            Action<ArrayBufferWriter<byte>> assert)
+            Action<ArrayBufferWriter<byte>> assert,
+            EncodingType encoding)
             where T : struct
         {
             ReadOnlySpan<T> input = inputArr;
@@ -155,7 +161,7 @@ namespace System.Text.Json.Tests
 
                 using (var writer = new Utf8JsonWriter(output, options))
                 {
-                    WriteStringValueHelper(writer, input);
+                    WriteStringValueHelper(writer, input, encoding);
                     writer.Flush();
                 }
 
@@ -168,7 +174,7 @@ namespace System.Text.Json.Tests
 
                 using (var writer = new Utf8JsonWriter(output, options))
                 {
-                    WriteStringValueSegmentsHelper(writer, input.Slice(0, splitIndex), input.Slice(splitIndex));
+                    WriteStringValueSegmentsHelper(writer, input.Slice(0, splitIndex), input.Slice(splitIndex), encoding);
                     writer.Flush();
                 }
 
@@ -183,7 +189,7 @@ namespace System.Text.Json.Tests
 
                     using (var writer = new Utf8JsonWriter(output, options))
                     {
-                        WriteStringValueSegmentsHelper(writer, input.Slice(0, splitIndex), input.Slice(splitIndex, splitIndex2 - splitIndex), input.Slice(splitIndex2));
+                        WriteStringValueSegmentsHelper(writer, input.Slice(0, splitIndex), input.Slice(splitIndex, splitIndex2 - splitIndex), input.Slice(splitIndex2), encoding);
                         writer.Flush();
                     }
 
@@ -201,9 +207,25 @@ namespace System.Text.Json.Tests
                 " Wor".AsSpan(),
                 "ld!".AsSpan(),
                 options.Encoder.Encode("Hello"),
-                options.Encoder.Encode(" Wor"),
-                options.Encoder.Encode("ld!"),
-                options);
+                options.Encoder.Encode("Hello Wor"),
+                options.Encoder.Encode("Hello World!"),
+                options,
+                EncodingType.Utf16);
+        }
+
+        [Theory]
+        [MemberData(nameof(BasicStringJsonOptions_TestData))]
+        public static void WriteStringValueSegment_Utf16_BasicSplit(JsonWriterOptions options)
+        {
+            WriteStringValueSegment_BasicHelper(
+                "\uD800 <- Invalid Partial -> \uD800".AsSpan(),
+                "\uDC00 <- Partial".AsSpan(),
+                " Invalid -> \uD800".AsSpan(),
+                options.Encoder.Encode("\uD800 <- Invalid Partial -> \uD800"),
+                options.Encoder.Encode("\uD800 <- Invalid Partial -> \uD800\uDC00 <- Partial"),
+                options.Encoder.Encode("\uD800 <- Invalid Partial -> \uD800\uDC00 <- Partial Invalid -> \uD800"),
+                options,
+                EncodingType.Utf16);
         }
 
         [Theory]
@@ -215,9 +237,57 @@ namespace System.Text.Json.Tests
                 " Wor"u8,
                 "ld!"u8,
                 options.Encoder.Encode("Hello"),
-                options.Encoder.Encode(" Wor"),
-                options.Encoder.Encode("ld!"),
-                options);
+                options.Encoder.Encode("Hello Wor"),
+                options.Encoder.Encode("Hello World!"),
+                options,
+                EncodingType.Utf8);
+        }
+
+        [Theory]
+        [MemberData(nameof(BasicStringJsonOptions_TestData))]
+        public static void WriteStringValueSegment_Utf8_BasicSplit(JsonWriterOptions options)
+        {
+            byte[] segment1 = [0b10_000000, .. " <- Invalid Partial -> "u8, 0b110_11111];
+            byte[] segment2 = [0b10_111111, .. " <- Partial"u8];
+            byte[] segment3 = [.. " Invalid -> "u8, 0b110_11111];
+            WriteStringValueSegment_BasicHelper(
+                segment1,
+                segment2,
+                segment3,
+                // Since we're using string (base-16) encode for convenience, we just use an invalid utf-16 character
+                options.Encoder.Encode("\udc00 <- Invalid Partial -> \udc00"),
+                options.Encoder.Encode("\udc00 <- Invalid Partial -> \u07ff <- Partial"),
+                options.Encoder.Encode("\udc00 <- Invalid Partial -> \u07ff <- Partial Invalid -> \udc00"),
+                options,
+                EncodingType.Utf8);
+        }
+
+        [Fact]
+        public static void WriteStringValueSegment_Base64_Basic()
+        {
+            {
+                WriteStringValueSegment_BasicHelper(
+                    "Hello"u8,
+                    " Worl"u8,
+                    "d!"u8,
+                    "SGVsbG8=",
+                    "SGVsbG8gV29ybA==",
+                    "SGVsbG8gV29ybGQh",
+                    new JsonWriterOptions { Indented = false },
+                    EncodingType.Base64);
+            }
+
+            {
+                WriteStringValueSegment_BasicHelper(
+                    "Hello"u8,
+                    " Worl"u8,
+                    "d!"u8,
+                    "SGVsbG8=",
+                    "SGVsbG8gV29ybA==",
+                    "SGVsbG8gV29ybGQh",
+                    new JsonWriterOptions { Indented = true },
+                    EncodingType.Base64);
+            }
         }
 
         private static void WriteStringValueSegment_BasicHelper<T>(
@@ -227,27 +297,29 @@ namespace System.Text.Json.Tests
             string expected1,
             string expected2,
             string expected3,
-            JsonWriterOptions options)
+            JsonWriterOptions options,
+            EncodingType encoding)
             where T : struct
         {
+            JavaScriptEncoder encoder = options.Encoder ?? JavaScriptEncoder.Default;
             string indent = options.Indented ? new string(options.IndentCharacter, options.IndentSize) : "";
             string n = options.Indented ? options.NewLine : "";
             string ni = n + indent;
             string nii = ni + indent;
             string s = options.Indented ? " " : "";
             string e1 = '"' + expected1 + '"';
-            string e2 = '"' + expected1 + expected2 + '"';
-            string e3 = '"' + expected1 + expected2 + expected3 + '"';
-            string foo = '"' + options.Encoder.Encode("foo") + '"';
-            string bar = '"' + options.Encoder.Encode("bar") + '"';
-            string baz = '"' + options.Encoder.Encode("baz") + '"';
-            string inner = '"' + options.Encoder.Encode("inner") + '"';
+            string e2 = '"' + expected2 + '"';
+            string e3 = '"' + expected3 + '"';
+            string foo = '"' + encoder.Encode("foo") + '"';
+            string bar = '"' + encoder.Encode("bar") + '"';
+            string baz = '"' + encoder.Encode("baz") + '"';
+            string inner = '"' + encoder.Encode("inner") + '"';
 
             // JSON string
             {
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, encoding);
                 jsonUtf8.Flush();
 
                 JsonTestHelper.AssertContents(e1, output);
@@ -256,7 +328,7 @@ namespace System.Text.Json.Tests
             {
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, encoding);
                 jsonUtf8.Flush();
 
                 JsonTestHelper.AssertContents(e2, output);
@@ -265,7 +337,7 @@ namespace System.Text.Json.Tests
             {
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3, encoding);
                 jsonUtf8.Flush();
 
                 JsonTestHelper.AssertContents(e3, output);
@@ -276,7 +348,7 @@ namespace System.Text.Json.Tests
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, encoding);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
 
@@ -289,7 +361,7 @@ namespace System.Text.Json.Tests
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, encoding);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
 
@@ -302,7 +374,7 @@ namespace System.Text.Json.Tests
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3, encoding);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
 
@@ -317,7 +389,7 @@ namespace System.Text.Json.Tests
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteBooleanValue(true);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, encoding);
                 jsonUtf8.WriteBooleanValue(false);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
@@ -332,7 +404,7 @@ namespace System.Text.Json.Tests
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteBooleanValue(true);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, encoding);
                 jsonUtf8.WriteBooleanValue(false);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
@@ -347,7 +419,7 @@ namespace System.Text.Json.Tests
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteBooleanValue(true);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3, encoding);
                 jsonUtf8.WriteBooleanValue(false);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
@@ -364,7 +436,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteBooleanValue(true);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, encoding);
                 jsonUtf8.WriteBooleanValue(false);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.WriteEndArray();
@@ -381,7 +453,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteBooleanValue(true);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, encoding);
                 jsonUtf8.WriteBooleanValue(false);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.WriteEndArray();
@@ -398,7 +470,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteBooleanValue(true);
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3, encoding);
                 jsonUtf8.WriteBooleanValue(false);
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.WriteEndArray();
@@ -415,7 +487,7 @@ namespace System.Text.Json.Tests
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, encoding);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
@@ -429,7 +501,7 @@ namespace System.Text.Json.Tests
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, encoding);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
@@ -443,7 +515,7 @@ namespace System.Text.Json.Tests
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3, encoding);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
@@ -459,7 +531,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteBoolean("bar", true);
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, encoding);
                 jsonUtf8.WriteBoolean("baz", false);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
@@ -475,7 +547,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteBoolean("bar", true);
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, encoding);
                 jsonUtf8.WriteBoolean("baz", false);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
@@ -491,7 +563,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteBoolean("bar", true);
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3, encoding);
                 jsonUtf8.WriteBoolean("baz", false);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
@@ -509,7 +581,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartObject("inner");
                 jsonUtf8.WriteBoolean("bar", true);
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, encoding);
                 jsonUtf8.WriteBoolean("baz", false);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.WriteEndObject();
@@ -527,7 +599,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartObject("inner");
                 jsonUtf8.WriteBoolean("bar", true);
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, encoding);
                 jsonUtf8.WriteBoolean("baz", false);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.WriteEndObject();
@@ -545,7 +617,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartObject("inner");
                 jsonUtf8.WriteBoolean("bar", true);
                 jsonUtf8.WritePropertyName("foo");
-                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3);
+                WriteStringValueSegmentsHelper(jsonUtf8, segment1, segment2, segment3, encoding);
                 jsonUtf8.WriteBoolean("baz", false);
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.WriteEndObject();
@@ -639,6 +711,18 @@ namespace System.Text.Json.Tests
             JsonTestHelper.AssertContents($"{{\"full\":\"{result}\",\"segmented\":\"{result}\"}}", output);
         }
 
+        //[Theory]
+        //[InlineData("")]
+        //[InlineData("0 padding"]
+        //[InlineData("_1 padding")]
+        //[InlineData("__2 padding")]
+        //public static void WriteStringValueSegment_Base64_SplitCodePointsBasic(string input, string expected)
+        //{
+        //    byte[] bytes = input.Select(c => (byte)c).ToArray();
+
+        //    SplitCodePointsHelper(bytes, );
+        //}
+
         [Fact]
         public static void WriteStringValueSegment_Utf8_ClearedPartial()
         {
@@ -699,9 +783,9 @@ namespace System.Text.Json.Tests
 
                 jsonUtf8.WriteStartArray();
 
-                WriteStringValueSegmentsHelper(jsonUtf8, ['\uD800'], ['\uDC00']);
-                WriteStringValueSegmentsHelper(jsonUtf8, ['\uDC00']);
-                WriteStringValueSegmentsHelper(jsonUtf8, ['\uD800'], ['\uDC00'], ['\uDC00']);
+                WriteStringValueSegmentsHelper(jsonUtf8, ['\uD800'], ['\uDC00'], EncodingType.Utf16);
+                WriteStringValueSegmentsHelper(jsonUtf8, ['\uDC00'], EncodingType.Utf16);
+                WriteStringValueSegmentsHelper(jsonUtf8, ['\uD800'], ['\uDC00'], ['\uDC00'], EncodingType.Utf16);
 
                 jsonUtf8.WriteEndArray();
 
@@ -713,21 +797,107 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        public static void WriteStringValueSegment_Base64_ClearedPartial()
+        {
+            var output = new ArrayBufferWriter<byte>();
+
+            {
+                var expected = new StringBuilder();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+
+                jsonUtf8.WriteStartArray();
+                expected.Append('[');
+
+                // Helpers to build up the expected string
+                var buffer = new List<byte>();
+                ReadOnlySpan<byte> AddPartial(ReadOnlySpan<byte> arr)
+                {
+                    foreach (byte b in arr) buffer.Add(b);
+
+                    return arr;
+                }
+
+                ReadOnlySpan<byte> AddFinal(ReadOnlySpan<byte> arr)
+                {
+                    foreach (byte b in arr) buffer.Add(b);
+
+                    expected.Append('"');
+                    expected.Append(Convert.ToBase64String(buffer.ToArray()));
+                    expected.Append('"');
+                    expected.Append(',');
+                    buffer.Clear();
+
+                    return arr;
+                }
+
+                // 1 segment
+                WriteStringValueSegmentsHelper(jsonUtf8, AddFinal([]), EncodingType.Base64);
+                WriteStringValueSegmentsHelper(jsonUtf8, AddFinal([0]), EncodingType.Base64);
+                WriteStringValueSegmentsHelper(jsonUtf8, AddFinal([0, 1]), EncodingType.Base64);
+                WriteStringValueSegmentsHelper(jsonUtf8, AddFinal([0, 1, 2]), EncodingType.Base64);
+
+                // 2 segments
+                for (int i = 0; i <= 3; i++)
+                {
+                    for (int j = 0; j <= 3; j++)
+                    {
+                        WriteStringValueSegmentsHelper(
+                            jsonUtf8,
+                            AddPartial([..Enumerable.Range(0, i).Select(x => (byte)x)]),
+                            AddFinal([..Enumerable.Range(i, j).Select(x => (byte)x)]),
+                            EncodingType.Base64);
+                    }
+                }
+
+                // 3 segments
+                for (int i = 0; i <= 3; i++)
+                {
+                    for (int j = 0; j <= 3; j++)
+                    {
+                        for (int k = 0; k <= 3; k++)
+                        {
+                            WriteStringValueSegmentsHelper(
+                                jsonUtf8,
+                                AddPartial([..Enumerable.Range(0, i).Select(x => (byte)x)]),
+                                AddPartial([..Enumerable.Range(i, j).Select(x => (byte)x)]),
+                                AddFinal([.. Enumerable.Range(i + j, k).Select(x => (byte)x)]),
+                                EncodingType.Base64);
+                        }
+                    }
+                }
+
+                // Remove trailing comma
+                expected.Remove(expected.Length - 1, 1);
+
+                jsonUtf8.WriteEndArray();
+                expected.Append(']');
+
+                jsonUtf8.Flush();
+
+                // First code point is written and the second is replaced.
+                JsonTestHelper.AssertContents(expected.ToString(), output);
+            }
+        }
+
+        [Fact]
         public static void WriteStringValueSegment_Flush()
         {
             var noEscape = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
-            TestFlushImpl('\uD800', '\uDC00', new(), @"""\uD800\uDC00""");
-            TestFlushImpl<byte>(0b110_11111, 0b10_111111, new(), @"""\u07FF""");
-            TestFlushImpl<byte>(0b110_11111, 0b10_111111, new() { Encoder = noEscape }, "\"\u07FF\"");
+            TestFlushImpl(['\uD800'], ['\uDC00'], new(), @"""\uD800\uDC00""", EncodingType.Utf16);
+            TestFlushImpl<byte>([0b110_11111], [0b10_111111], new(), @"""\u07FF""", EncodingType.Utf8);
+            TestFlushImpl<byte>([0b110_11111], [0b10_111111], new() { Encoder = noEscape }, "\"\u07FF\"", EncodingType.Utf8);
+            TestFlushImpl<byte>([], [0, 0, 0], new(), "\"AAAA\"", EncodingType.Base64);
+            TestFlushImpl<byte>([0], [0, 0], new(), "\"AAAA\"", EncodingType.Base64);
+            TestFlushImpl<byte>([0, 0], [0], new(), "\"AAAA\"", EncodingType.Base64);
 
-            void TestFlushImpl<T>(T unit1, T unit2, JsonWriterOptions options, string expected)
+            void TestFlushImpl<T>(ReadOnlySpan<T> unit1, ReadOnlySpan<T> unit2, JsonWriterOptions options, string expected, EncodingType encoding)
                 where T : struct
             {
                 byte[] expectedBytes = Encoding.UTF8.GetBytes(expected);
                 var output = new ArrayBufferWriter<byte>();
                 using Utf8JsonWriter jsonUtf8 = new(output, options);
 
-                WriteStringValueSegmentHelper(jsonUtf8, [unit1], false);
+                WriteStringValueSegmentHelper(jsonUtf8, unit1, false, encoding);
 
                 Assert.Equal(0, output.WrittenCount);
                 Assert.Equal(0, jsonUtf8.BytesCommitted);
@@ -738,7 +908,7 @@ namespace System.Text.Json.Tests
                 Assert.Equal(1, jsonUtf8.BytesCommitted);
                 Assert.Equal(0, jsonUtf8.BytesPending);
 
-                WriteStringValueSegmentHelper(jsonUtf8, [unit2], true);
+                WriteStringValueSegmentHelper(jsonUtf8, unit2, true, encoding);
 
                 Assert.Equal(1, output.WrittenCount);
                 Assert.Equal(1, jsonUtf8.BytesCommitted);
@@ -814,6 +984,36 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        public static void WriteStringValueSegment_Base64_Reset()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            using var jsonUtf8 = new Utf8JsonWriter(output);
+
+            jsonUtf8.WriteBase64StringSegment([0], false);
+            jsonUtf8.Flush();
+
+            Assert.Equal(0, jsonUtf8.BytesPending);
+            Assert.Equal(1, jsonUtf8.BytesCommitted);
+
+            jsonUtf8.Reset();
+
+            Assert.Equal(0, jsonUtf8.BytesPending);
+            Assert.Equal(0, jsonUtf8.BytesCommitted);
+
+            jsonUtf8.WriteBase64StringSegment([0, 0, 0], true);
+
+            string expected = @"""AAAA""";
+            Assert.Equal(expected.Length, jsonUtf8.BytesPending);
+            Assert.Equal(0, jsonUtf8.BytesCommitted);
+
+            jsonUtf8.Flush();
+
+            Assert.Equal(0, jsonUtf8.BytesPending);
+            Assert.Equal(expected.Length, jsonUtf8.BytesCommitted);
+            JsonTestHelper.AssertContents('"' + expected, output);
+        }
+
+        [Fact]
         public static void WriteStringValueSegment_MixEncoding()
         {
             {
@@ -830,8 +1030,48 @@ namespace System.Text.Json.Tests
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output);
 
+                // High surrogate
+                jsonUtf8.WriteStringValueSegment("\uD8D8".AsSpan(), false);
+
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBase64StringSegment([0], true));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+
                 // Start of a 3-byte sequence
                 jsonUtf8.WriteStringValueSegment([0b1110_1111], false);
+
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValueSegment("\u8080".AsSpan(), true));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+
+                // Start of a 3-byte sequence
+                jsonUtf8.WriteStringValueSegment([0b1110_1111], false);
+
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBase64StringSegment([0], true));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+
+                // Partial Base64
+                jsonUtf8.WriteBase64StringSegment([0], false);
+
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValueSegment([0b10_111111], true));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+
+                // Partial Base64
+                jsonUtf8.WriteBase64StringSegment([0], false);
 
                 Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValueSegment("\u8080".AsSpan(), true));
             }
@@ -855,6 +1095,22 @@ namespace System.Text.Json.Tests
             {
                 var output = new ArrayBufferWriter<byte>();
                 using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteStringValueSegment([0b110_11111], false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty base64 sequence will still keep the partial code point
+                jsonUtf8.WriteStringValueSegment(ReadOnlySpan<byte>.Empty, false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty UTF-8 sequence will throw
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBase64StringSegment(ReadOnlySpan<byte>.Empty, false));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
                 jsonUtf8.WriteStringValueSegment(['\uD800'], false);
                 jsonUtf8.Flush();
                 JsonTestHelper.AssertContents("\"", output);
@@ -864,8 +1120,56 @@ namespace System.Text.Json.Tests
                 jsonUtf8.Flush();
                 JsonTestHelper.AssertContents("\"", output);
 
-                // Writing empty UTF-8 sequence will dump the partial UTF-16 code point
+                // Writing empty UTF-8 sequence will throw
                 Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValueSegment(ReadOnlySpan<byte>.Empty, false));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteStringValueSegment(['\uD800'], false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty UTF-16 sequence will still keep the partial code point
+                jsonUtf8.WriteStringValueSegment(ReadOnlySpan<char>.Empty, false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty base64 sequence will throw
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBase64StringSegment(ReadOnlySpan<byte>.Empty, false));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteBase64StringSegment([0], false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty base64 sequence will still keep the partial code point
+                jsonUtf8.WriteBase64StringSegment(ReadOnlySpan<byte>.Empty, false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty UTF-8 sequence will throw
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValueSegment(ReadOnlySpan<byte>.Empty, false));
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteBase64StringSegment([0], false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty base64 sequence will still keep the partial code point
+                jsonUtf8.WriteBase64StringSegment(ReadOnlySpan<byte>.Empty, false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+
+                // Writing empty UTF-16 sequence will throw
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValueSegment(ReadOnlySpan<char>.Empty, false));
             }
         }
 
@@ -941,146 +1245,191 @@ namespace System.Text.Json.Tests
                 jsonUtf8.Flush();
                 JsonTestHelper.AssertContents("\"\"", output);
             }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteBase64StringSegment([], true);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"\"", output);
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteBase64StringSegment([], false);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"", output);
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteBase64StringSegment([], false);
+                jsonUtf8.WriteBase64StringSegment([], true);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"\"", output);
+            }
+
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output);
+                jsonUtf8.WriteBase64StringSegment([], false);
+                jsonUtf8.WriteBase64StringSegment([], false);
+                jsonUtf8.WriteBase64StringSegment([], true);
+                jsonUtf8.Flush();
+                JsonTestHelper.AssertContents("\"\"", output);
+            }
         }
 
-        // Switch this to use an enum discriminator input when base64 is supported
-        private static void WriteStringValueHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value)
-            where T : struct
+        enum EncodingType
         {
-            if (typeof(T) == typeof(char))
-            {
-                writer.WriteStringValue(MemoryMarshal.Cast<T, char>(value));
-            }
-            else if (typeof(T) == typeof(byte))
-            {
-                writer.WriteStringValue(MemoryMarshal.Cast<T, byte>(value));
-            }
-            else
+            Utf8,
+            Utf16,
+            Base64,
+        }
+
+        private static void EnsureByteOrChar<T>([CallerMemberName]string caller = "<unknown>")
+        {
+            if (typeof(T) != typeof(byte) && typeof(T) != typeof(char))
             {
                 if (typeof(T) == typeof(int))
                 {
-                    Assert.Fail($"Did you pass in int or int[] instead of byte or byte[]? Type {typeof(T)} is not supported by {nameof(WriteStringValueHelper)}.");
+                    Assert.Fail($"Did you pass in int or int[] instead of byte or byte[]? Type {typeof(T)} is not supported by {caller}.");
                 }
-                else
-                {
-                    Assert.Fail($"Type {typeof(T)} is not supported by {nameof(WriteStringValueHelper)}.");
-                }
+
+                Assert.Fail($"Type {typeof(T)} is not supported by {caller}.");
+            }
+        }
+
+        private static void WriteStringValueHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value, EncodingType encoding)
+            where T : struct
+        {
+            EnsureByteOrChar<T>();
+
+            switch (encoding)
+            {
+                case EncodingType.Utf16:
+                    writer.WriteStringValue(MemoryMarshal.Cast<T, char>(value));
+                    break;
+                case EncodingType.Utf8:
+                    writer.WriteStringValue(MemoryMarshal.Cast<T, byte>(value));
+                    break;
+                case EncodingType.Base64:
+                    writer.WriteBase64StringValue(MemoryMarshal.Cast<T, byte>(value));
+                    break;
+                default:
+                    Assert.Fail($"Encoding {encoding} not valid.");
+                    break;
+            }
+        }
+
+        private static void WriteStringValueSegmentHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value, bool isFinal, EncodingType encoding)
+            where T : struct
+        {
+            EnsureByteOrChar<T>();
+
+            switch (encoding)
+            {
+                case EncodingType.Utf16:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value), isFinal);
+                    break;
+                case EncodingType.Utf8:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value), isFinal);
+                    break;
+                case EncodingType.Base64:
+                    writer.WriteBase64StringSegment(MemoryMarshal.Cast<T, byte>(value), isFinal);
+                    break;
+                default:
+                    Assert.Fail($"Encoding {encoding} not valid.");
+                    break;
+            }
+        }
+
+        private static void WriteStringValueSegmentsHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value, EncodingType encoding)
+            where T : struct
+        {
+            EnsureByteOrChar<T>();
+
+            switch (encoding)
+            {
+                case EncodingType.Utf16:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value), true);
+                    break;
+                case EncodingType.Utf8:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value), true);
+                    break;
+                case EncodingType.Base64:
+                    writer.WriteBase64StringSegment(MemoryMarshal.Cast<T, byte>(value), true);
+                    break;
+                default:
+                    Assert.Fail($"Encoding {encoding} not valid.");
+                    break;
             }
         }
 
         // Switch this to use an enum discriminator input when base64 is supported
-        private static void WriteStringValueSegmentHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value, bool isFinal)
+        private static void WriteStringValueSegmentsHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value1, ReadOnlySpan<T> value2, EncodingType encoding)
             where T : struct
         {
-            if (typeof(T) == typeof(char))
+            EnsureByteOrChar<T>();
+
+            switch (encoding)
             {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value), isFinal);
-            }
-            else if (typeof(T) == typeof(byte))
-            {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value), isFinal);
-            }
-            else
-            {
-                if (typeof(T) == typeof(int))
-                {
-                    Assert.Fail($"Did you pass in int or int[] instead of byte or byte[]? Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
-                else
-                {
-                    Assert.Fail($"Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
+                case EncodingType.Utf16:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value1), false);
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value2), true);
+                    break;
+                case EncodingType.Utf8:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value1), false);
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value2), true);
+                    break;
+                case EncodingType.Base64:
+                    writer.WriteBase64StringSegment(MemoryMarshal.Cast<T, byte>(value1), false);
+                    writer.WriteBase64StringSegment(MemoryMarshal.Cast<T, byte>(value2), true);
+                    break;
+                default:
+                    Assert.Fail($"Encoding {encoding} not valid.");
+                    break;
             }
         }
 
         // Switch this to use an enum discriminator input when base64 is supported
-        private static void WriteStringValueSegmentsHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value)
+        private static void WriteStringValueSegmentsHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value1, ReadOnlySpan<T> value2, ReadOnlySpan<T> value3, EncodingType encoding)
             where T : struct
         {
-            if (typeof(T) == typeof(char))
+            EnsureByteOrChar<T>();
+
+            switch (encoding)
             {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value), true);
-            }
-            else if (typeof(T) == typeof(byte))
-            {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value), true);
-            }
-            else
-            {
-                if (typeof(T) == typeof(int))
-                {
-                    Assert.Fail($"Did you pass in int or int[] instead of byte or byte[]? Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
-                else
-                {
-                    Assert.Fail($"Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
+                case EncodingType.Utf16:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value1), false);
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value2), false);
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value3), true);
+                    break;
+                case EncodingType.Utf8:
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value1), false);
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value2), false);
+                    writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value3), true);
+                    break;
+                case EncodingType.Base64:
+                    writer.WriteBase64StringSegment(MemoryMarshal.Cast<T, byte>(value1), false);
+                    writer.WriteBase64StringSegment(MemoryMarshal.Cast<T, byte>(value2), false);
+                    writer.WriteBase64StringSegment(MemoryMarshal.Cast<T, byte>(value3), true);
+                    break;
+                default:
+                    Assert.Fail($"Encoding {encoding} not valid.");
+                    break;
             }
         }
 
-        // Switch this to use an enum discriminator input when base64 is supported
-        private static void WriteStringValueSegmentsHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value1, ReadOnlySpan<T> value2)
-            where T : struct
-        {
-            if (typeof(T) == typeof(char))
-            {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value1), false);
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value2), true);
-            }
-            else if (typeof(T) == typeof(byte))
-            {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value1), false);
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value2), true);
-            }
-            else
-            {
-                if (typeof(T) == typeof(int))
-                {
-                    Assert.Fail($"Did you pass in int or int[] instead of byte or byte[]? Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
-                else
-                {
-                    Assert.Fail($"Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
-            }
-        }
+        private static void WriteStringValueSegmentsHelper(Utf8JsonWriter writer, string value, EncodingType encoding)
+            => WriteStringValueSegmentsHelper(writer, value.AsSpan(), encoding);
 
-        // Switch this to use an enum discriminator input when base64 is supported
-        private static void WriteStringValueSegmentsHelper<T>(Utf8JsonWriter writer, ReadOnlySpan<T> value1, ReadOnlySpan<T> value2, ReadOnlySpan<T> value3)
-            where T : struct
-        {
-            if (typeof(T) == typeof(char))
-            {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value1), false);
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value2), false);
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, char>(value3), true);
-            }
-            else if (typeof(T) == typeof(byte))
-            {
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value1), false);
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value2), false);
-                writer.WriteStringValueSegment(MemoryMarshal.Cast<T, byte>(value3), true);
-            }
-            else
-            {
-                if (typeof(T) == typeof(int))
-                {
-                    Assert.Fail($"Did you pass in int or int[] instead of byte or byte[]? Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
-                else
-                {
-                    Assert.Fail($"Type {typeof(T)} is not supported by {nameof(WriteStringValueSegmentsHelper)}.");
-                }
-            }
-        }
+        private static void WriteStringValueSegmentsHelper(Utf8JsonWriter writer, string value1, string value2, EncodingType encoding)
+            => WriteStringValueSegmentsHelper(writer, value1.AsSpan(), value2.AsSpan(), encoding);
 
-        private static void WriteStringValueSegmentsHelper(Utf8JsonWriter writer, string value)
-            => WriteStringValueSegmentsHelper(writer, value.AsSpan());
-
-        private static void WriteStringValueSegmentsHelper(Utf8JsonWriter writer, string value1, string value2)
-            => WriteStringValueSegmentsHelper(writer, value1.AsSpan(), value2.AsSpan());
-
-        private static void WriteStringValueSegmentsHelper(Utf8JsonWriter writer, string value1, string value2, string value3)
-            => WriteStringValueSegmentsHelper(writer, value1.AsSpan(), value2.AsSpan(), value3.AsSpan());
+        private static void WriteStringValueSegmentsHelper(Utf8JsonWriter writer, string value1, string value2, string value3, EncodingType encoding)
+            => WriteStringValueSegmentsHelper(writer, value1.AsSpan(), value2.AsSpan(), value3.AsSpan(), encoding);
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -272,17 +272,17 @@ namespace System.Text.Json.Tests
 
                     if (dataLength < 10)
                     {
-                        SplitCodePointsHelper(newStr.AsSpan(), writerOptions, output =>
+                        SplitStringDataHelper(newStr.AsSpan(), writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(requiresEscaping ? (i + 1) : -1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf16);
+                        }, StringValueEncodingType.Utf16);
 
-                        SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                        SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(requiresEscaping ? (i + 1) : -1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf8);
+                        }, StringValueEncodingType.Utf8);
                     }
                 }
 
@@ -303,17 +303,17 @@ namespace System.Text.Json.Tests
 
                     if (dataLength < 10)
                     {
-                        SplitCodePointsHelper(changed, writerOptions, output =>
+                        SplitStringDataHelper(changed, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(requiresEscaping ? 1 : -1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf16);
+                        }, StringValueEncodingType.Utf16);
 
-                        SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                        SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(requiresEscaping ? 1 : -1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf8);
+                        }, StringValueEncodingType.Utf8);
                     }
                 }
             }
@@ -427,15 +427,15 @@ namespace System.Text.Json.Tests
 
                 if (dataLength < 10)
                 {
-                    SplitCodePointsHelper(str, writerOptions, output =>
+                    SplitStringDataHelper(str, writerOptions, output =>
                     {
                         Assert.Equal(-1, output.WrittenSpan.IndexOf((byte)'\\'));
-                    }, EncodingType.Utf16);
+                    }, StringValueEncodingType.Utf16);
 
-                    SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                    SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                     {
                         Assert.Equal(-1, output.WrittenSpan.IndexOf((byte)'\\'));
-                    }, EncodingType.Utf8);
+                    }, StringValueEncodingType.Utf8);
                 }
 
                 for (int i = 0; i < dataLength; i++)
@@ -455,19 +455,19 @@ namespace System.Text.Json.Tests
 
                     if (dataLength < 10)
                     {
-                        SplitCodePointsHelper(source.AsSpan(), writerOptions, output =>
+                        SplitStringDataHelper(source.AsSpan(), writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             // Each CJK character expands to 3 utf-8 bytes.
                             Assert.Equal(requiresEscaping ? ((i * 3) + 1) : -1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf16);
+                        }, StringValueEncodingType.Utf16);
 
-                        SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                        SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             // Each CJK character expands to 3 utf-8 bytes.
                             Assert.Equal(requiresEscaping ? ((i * 3) + 1) : -1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf8);
+                        }, StringValueEncodingType.Utf8);
                     }
                 }
             }
@@ -538,15 +538,15 @@ namespace System.Text.Json.Tests
 
                 if (dataLength < 10)
                 {
-                    SplitCodePointsHelper(str, writerOptions, output =>
+                    SplitStringDataHelper(str, writerOptions, output =>
                     {
                         Assert.Equal(-1, output.WrittenSpan.IndexOf((byte)'\\'));
-                    }, EncodingType.Utf16);
+                    }, StringValueEncodingType.Utf16);
 
-                    SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                    SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                     {
                         Assert.Equal(-1, output.WrittenSpan.IndexOf((byte)'\\'));
-                    }, EncodingType.Utf8);
+                    }, StringValueEncodingType.Utf8);
                 }
 
                 for (int i = 0; i < dataLength - 1; i++)
@@ -567,17 +567,17 @@ namespace System.Text.Json.Tests
 
                     if (dataLength < 10)
                     {
-                        SplitCodePointsHelper(changed, writerOptions, output =>
+                        SplitStringDataHelper(changed, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(i + 1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf16);
+                        }, StringValueEncodingType.Utf16);
 
-                        SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                        SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(i + 1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf8);
+                        }, StringValueEncodingType.Utf8);
                     }
                 }
 
@@ -603,17 +603,17 @@ namespace System.Text.Json.Tests
 
                     if (dataLength < 10)
                     {
-                        SplitCodePointsHelper(changed, writerOptions, output =>
+                        SplitStringDataHelper(changed, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf16);
+                        }, StringValueEncodingType.Utf16);
 
-                        SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                        SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                         {
                             escapedIndex = output.WrittenSpan.IndexOf((byte)'\\');
                             Assert.Equal(1, escapedIndex);  // Account for the start quote
-                        }, EncodingType.Utf8);
+                        }, StringValueEncodingType.Utf8);
                     }
                 }
             }
@@ -667,15 +667,15 @@ namespace System.Text.Json.Tests
 
                     if (dataLength < 10)
                     {
-                        SplitCodePointsHelper(changed, writerOptions, output =>
+                        SplitStringDataHelper(changed, writerOptions, output =>
                         {
                             Assert.True(BeginsWithReplacementCharacter(output.WrittenSpan.Slice(i + 1))); // +1 to account for starting quote
-                        }, EncodingType.Utf16);
+                        }, StringValueEncodingType.Utf16);
 
-                        SplitCodePointsHelper(sourceUtf8, writerOptions, output =>
+                        SplitStringDataHelper(sourceUtf8, writerOptions, output =>
                         {
                             Assert.True(BeginsWithReplacementCharacter(output.WrittenSpan.Slice(i + 1))); // +1 to account for starting quote
-                        }, EncodingType.Utf8);
+                        }, StringValueEncodingType.Utf8);
                     }
                 }
             }


### PR DESCRIPTION
Adds support to the Utf8JsonWriter for writing string value segments of `byte[]` encoded as Base64 UTF-8.

Closes #67337 