### PR TITLE
Fix PAL tests compilation on Alpine Linux

### DIFF
--- a/src/coreclr/pal/tests/palsuite/c_runtime/strchr/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/c_runtime/strchr/test1/test1.cpp
@@ -62,7 +62,7 @@ PALTEST(c_runtime_strchr_test1_paltest_strchr_test1, "c_runtime/strchr/test1/pal
        result = strchr(testCases[i].string,testCases[i].character);
        if (result==NULL)
        {
-          if (testCases[i].result != (int) NULL)
+          if (testCases[i].result != 0)
           {
               Fail("Expected strchr() to return \"%s\" instead of NULL!\n",
                    testCases[i].string + testCases[i].result);

--- a/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test4/readfile.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/ReadFile/test4/readfile.cpp
@@ -80,7 +80,7 @@ PALTEST(file_io_ReadFile_test4_paltest_readfile_test4, "file_io/ReadFile/test4/p
     
     /* Set the file pointer to beginning of file.
      */
-    res = SetFilePointer(hFile, (LONG)NULL, NULL, FILE_BEGIN);
+    res = SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
 
     if( (res == INVALID_SET_FILE_POINTER) &&
         (GetLastError() != NO_ERROR))


### PR DESCRIPTION
I've noticed that coreclr PAL tests don't compile successfully on Alpine Linux in the CI. This change fixes it.