### PR TITLE
[LoongArch64] Disabled the `largeframe secondary` case in stackoverflow tests for LA64.

### DIFF
--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -115,10 +115,12 @@ namespace TestStackOverflow
         [Fact]
         public static void TestStackOverflowLargeFrameMainThread()
         {
-            if (((RuntimeInformation.ProcessArchitecture == Architecture.Arm64) || (RuntimeInformation.ProcessArchitecture == Architecture.RiscV64)) &&
+            if (((RuntimeInformation.ProcessArchitecture == Architecture.Arm64) || (RuntimeInformation.ProcessArchitecture == Architecture.RiscV64) ||
+                (RuntimeInformation.ProcessArchitecture == Architecture.LoongArch64)) &&
                 ((Environment.OSVersion.Platform == PlatformID.Unix) || (Environment.OSVersion.Platform == PlatformID.MacOSX)))
             {
-                // Disabled on Unix RISCV64, similar to ARM64.
+                // Disabled on Unix RISCV64 and LoongArch64, similar to ARM64.
+                // LoongArch64 hit this issue on Alpine. TODO: implement stack probing using helpers.
                 // Disabled on Unix ARM64 due to https://github.com/dotnet/runtime/issues/13519
                 // The current stack probing doesn't move the stack pointer and so the runtime sometimes cannot
                 // recognize the underlying sigsegv as stack overflow when it probes too far from SP.
@@ -182,10 +184,12 @@ namespace TestStackOverflow
         [Fact]
         public static void TestStackOverflowLargeFrameSecondaryThread()
         {
-            if (((RuntimeInformation.ProcessArchitecture == Architecture.Arm64) || (RuntimeInformation.ProcessArchitecture == Architecture.RiscV64)) &&
+            if (((RuntimeInformation.ProcessArchitecture == Architecture.Arm64) || (RuntimeInformation.ProcessArchitecture == Architecture.RiscV64) ||
+                (RuntimeInformation.ProcessArchitecture == Architecture.LoongArch64)) &&
                 ((Environment.OSVersion.Platform == PlatformID.Unix) || (Environment.OSVersion.Platform == PlatformID.MacOSX)))
             {
-                // Disabled on Unix RISCV64, similar to ARM64.
+                // Disabled on Unix RISCV64 and LoongArch64, similar to ARM64.
+                // LoongArch64 hit this issue on Alpine. TODO: implement stack probing using helpers.
                 // Disabled on Unix ARM64 due to https://github.com/dotnet/runtime/issues/13519
                 // The current stack probing doesn't move the stack pointer and so the runtime sometimes cannot
                 // recognize the underlying sigsegv as stack overflow when it probes too far from SP.


### PR DESCRIPTION
This is the same case with issue https://github.com/dotnet/runtime/issues/13519 and LA64 hit this on Alpine.
* The `failureAddress` is too far from `SP` that don't match the condition `if ((failureAddress - (sp - GetVirtualPageSize())) < 2 * GetVirtualPageSize())` in `sigsegv_handler()` to trigger the EH print of stackoverflow stack message.
* Should implement stack probing using helpers for LA64 in the future.