### PR TITLE
Baseline more pri1 tests with native AOT

### DIFF
--- a/src/tests/JIT/Methodical/delegate/_simpleoddpower_d.ilproj
+++ b/src/tests/JIT/Methodical/delegate/_simpleoddpower_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Slow delegate creation path is not supported with native AOT -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/delegate/_simpleoddpower_r.ilproj
+++ b/src/tests/JIT/Methodical/delegate/_simpleoddpower_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Slow delegate creation path is not supported with native AOT -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
I originally thought this found a real bug but this is just a really weird test exercising not just slow delegate creation path, but also quite invalid IL:

https://github.com/dotnet/runtime/blob/3d88f276b13ae4d2ffa6a66b02f32171fdc825b5/src/tests/JIT/Methodical/delegate/_simpleoddpower.il#L510-L517

(Notice that despite the newobj, the actual object instance is of a completely different type and the method is not on that type, took a while to realize the newobj is useless and unrelated.)

Cc @dotnet/ilc-contrib 