### PR TITLE
Fix hashing in Logging source gen

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -914,7 +914,7 @@ namespace Microsoft.Extensions.Logging.Generators
             uint result = 2166136261u;
             foreach (char c in s)
             {
-                result = unchecked((c ^ result) * 16777619);
+                result = (c ^ result) * 16777619;
             }
 
             return (int)(result & 0x7FFFFFFF); // Ensure the result is non-negative

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -914,9 +914,10 @@ namespace Microsoft.Extensions.Logging.Generators
             uint result = 2166136261u;
             foreach (char c in s)
             {
-                result = (c ^ result) * 16777619;
+                result = unchecked((c ^ result) * 16777619);
             }
-            return Math.Abs((int)result);
+
+            return (int)(result & 0x7FFFFFFF); // Ensure the result is non-negative
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
                     public partial void M1();
                 }
             ");
-            
+
             Assert.Equal(2, diagnostics.Count);
 
             Assert.Equal(DiagnosticDescriptors.PrimaryConstructorParameterLoggerHidden.Id, diagnostics[0].Id);
@@ -986,6 +986,23 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
             ");
 
             Assert.Empty(diagnostics);    // should fail quietly on broken code
+        }
+
+        [Fact]
+        public async Task EventIdGenerationTest()
+        {
+            // hashing Dzoggee should not result breaking generation.
+            // in our hashing, Dzoggee result to int.MinValue before we convert it to non-negative value.
+            IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@"
+                using Microsoft.Extensions.Logging;
+                internal static partial class LoggerExtensions
+                {
+                    [LoggerMessage(Level = LogLevel.Information)]
+                    public static partial void Dzoggee(this ILogger logger);
+                }
+            ");
+
+            Assert.Empty(diagnostics);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Options/gen/OptionsSourceGenContext.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/OptionsSourceGenContext.cs
@@ -67,17 +67,16 @@ namespace Microsoft.Extensions.Options.Generators
 
         /// <summary>
         /// Returns a non-randomized hash code for the given string.
-        /// We always return a positive value.
         /// </summary>
-        internal static int GetNonRandomizedHashCode(string s)
+        internal static uint GetNonRandomizedHashCode(string s)
         {
             uint result = 2166136261u;
             foreach (char c in s)
             {
-                result = (c ^ result) * 16777619;
+                result = unchecked((c ^ result) * 16777619);
             }
 
-            return Math.Abs((int)result);
+            return result;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/OptionsSourceGenContext.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/OptionsSourceGenContext.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Options.Generators
             uint result = 2166136261u;
             foreach (char c in s)
             {
-                result = unchecked((c ^ result) * 16777619);
+                result = (c ^ result) * 16777619;
             }
 
             return result;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/110698

This change to avoid throwing from the hashing method which can break logging source generation.

I'll submit another PR to fix https://github.com/dotnet/extensions/blob/20c12ef61fc33865f36c1f4f6e8e2240e8c25f32/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs#L149 after I merge this one.