### PR TITLE
Simplify `AssemblyName.EscapeCodeBase` and remove `unsafe`.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.ComponentModel;
 using System.Configuration.Assemblies;
 using System.Diagnostics.CodeAnalysis;
@@ -375,7 +376,7 @@ namespace System.Reflection
 
                         prevInputPos = i + 1;
                     }
-                    else if (!IsReservedUnreservedOrHash(ch))
+                    else if (!UnreservedReserved.Contains(ch))
                     {
                         dest = EnsureDestinationSize(pStr, dest, i, c_EncodedCharsPerByte,
                             c_MaxAsciiCharsReallocate * c_EncodedCharsPerByte, ref destPos, prevInputPos);
@@ -424,29 +425,11 @@ namespace System.Reflection
             to[pos++] = HexConverter.ToCharUpper(ch);
         }
 
-        private static bool IsReservedUnreservedOrHash(char c)
-        {
-            if (IsUnreserved(c))
-            {
-                return true;
-            }
-            return RFC3986ReservedMarks.Contains(c);
-        }
-
-        internal static bool IsUnreserved(char c)
-        {
-            if (char.IsAsciiLetterOrDigit(c))
-            {
-                return true;
-            }
-            return RFC3986UnreservedMarks.Contains(c);
-        }
+        private static readonly SearchValues<char> UnreservedReserved = SearchValues.Create("!#$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~");
 
         private const short c_MaxAsciiCharsReallocate = 40;
         private const short c_MaxUnicodeCharsReallocate = 40;
         private const short c_MaxUTF_8BytesPerUnicodeChar = 4;
         private const short c_EncodedCharsPerByte = 3;
-        private const string RFC3986ReservedMarks = ":/?#[]@!$&'()*+,;=";
-        private const string RFC3986UnreservedMarks = "-._~";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -327,7 +327,7 @@ namespace System.Reflection
 
             EscapeStringToBuilder(codebase.AsSpan(indexOfFirstToEscape), ref vsb);
 
-            string result = string.Concat(codebase.AsSpan(0, indexOfFirstToEscape), vsb.ToString());
+            string result = string.Concat(codebase.AsSpan(0, indexOfFirstToEscape), vsb.AsSpan());
             vsb.Dispose();
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -387,7 +387,7 @@ namespace System.Reflection
             HexConverter.ToCharsBuffer(ch, vsb.AppendSpan(2), 0, HexConverter.Casing.Upper);
         }
 
-        private static readonly SearchValues<char> UnreservedReserved = SearchValues.Create("!#$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~");
+        private static SearchValues<char> UnreservedReserved => field ??= SearchValues.Create("!#$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~");
 
         private const int StackallocThreshold = 512;
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -387,7 +387,9 @@ namespace System.Reflection
             HexConverter.ToCharsBuffer(ch, vsb.AppendSpan(2), 0, HexConverter.Casing.Upper);
         }
 
+#pragma warning disable CS9264 // nullability of `field`: https://github.com/dotnet/csharplang/issues/8425
         private static SearchValues<char> UnreservedReserved => field ??= SearchValues.Create("!#$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~");
+#pragma warning restore CS9264
 
         private const int StackallocThreshold = 512;
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -363,7 +363,7 @@ namespace System.Reflection
                 else if (!UnreservedReserved.Contains(ch))
                 {
                     PercentEncodeByte((byte)ch, ref vsb);
-                    stringToEscape = stringToEscape[1..];
+                    stringToEscape = stringToEscape.Slice(1);
                 }
                 else
                 {
@@ -387,9 +387,8 @@ namespace System.Reflection
             HexConverter.ToCharsBuffer(ch, vsb.AppendSpan(2), 0, HexConverter.Casing.Upper);
         }
 
-#pragma warning disable CS9264 // nullability of `field`: https://github.com/dotnet/csharplang/issues/8425
+        [field: AllowNull]
         private static SearchValues<char> UnreservedReserved => field ??= SearchValues.Create("!#$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~");
-#pragma warning restore CS9264
 
         private const int StackallocThreshold = 512;
     }


### PR DESCRIPTION
This PR updates the implementation of `AssemblyName.EscapeCodeBase` to match the [current](https://github.com/dotnet/runtime/blob/dae890906431049d32e24d498a1d707a441a64a8/src/libraries/System.Private.Uri/src/System/UriHelper.cs#L189-L213) implementation of `UriHelper.EscapeString`, after simplifying it to remove unneeded capabilities. As a result, the code has become simpler, more efficient, and no longer `unsafe`.

Related to #94941.