### PR TITLE
Fix a typo in UnixNativeCodeManager.cpp

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -1248,7 +1248,7 @@ bool UnixNativeCodeManager::GetReturnAddressHijackInfo(MethodInfo *    pMethodIn
     }
 
     *ppvRetAddrLocation = (PTR_PTR_VOID)pRegisterSet->pLR;
-#elif
+#else
     PTR_uintptr_t pRA = pRegisterSet->pRA;
     if (!VirtualUnwind(pMethodInfo, pRegisterSet))
     {


### PR DESCRIPTION
Fix a typo introduced from #110799.

@shushanhf @LuckyXu-HF 