### PR TITLE
JIT: handle nested try case in empty try removal

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -1037,7 +1037,7 @@ PhaseStatus Compiler::fgRemoveEmptyTryCatchOrTryFault()
         //
         fgRemoveEHTableEntry(XTnum);
 
-        // (6) The old try entry may no longer needs special protection.
+        // (6) The old try entry may no longer need special protection.
         // (it may still be an entry of an enclosing try)
         //
         if (!bbIsTryBeg(firstTryBlock))

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -1037,9 +1037,13 @@ PhaseStatus Compiler::fgRemoveEmptyTryCatchOrTryFault()
         //
         fgRemoveEHTableEntry(XTnum);
 
-        // (6) The old try entry no longer needs special protection.
+        // (6) The old try entry may no longer needs special protection.
+        // (it may still be an entry of an enclosing try)
         //
-        firstTryBlock->RemoveFlags(BBF_DONT_REMOVE);
+        if (!bbIsTryBeg(firstTryBlock))
+        {
+            firstTryBlock->RemoveFlags(BBF_DONT_REMOVE);
+        }
 
         // Another one bites the dust...
         emptyCount++;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_110958/Runtime_110985.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_110958/Runtime_110985.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+// Reduced from 17.57 KB to 2.06 KB.
+
+using System.Collections.Generic;
+using System.Runtime.Intrinsics.Arm;
+using Xunit;
+
+public class Runtime_110958
+{
+    long long_30 = 5;
+    ulong ulong_36 = 0;
+    SveMaskPattern SveMaskPattern_37 = SveMaskPattern.VectorCount1;
+    private static List<string> toPrint = new List<string>();
+    private void Method0()
+    {
+        unchecked
+        {
+            ulong ulong_77 = 2;
+            SveMaskPattern SveMaskPattern_78 = SveMaskPattern_37;
+            try
+            {
+                try
+                {
+                    ulong_36 -= ulong_77;
+                }
+                catch (System.FieldAccessException)
+                { }
+                catch (System.ExecutionEngineException)
+                { }
+            }
+            catch (System.RankException)
+            {
+            }
+            catch (System.MemberAccessException)
+            {
+                do
+                {
+                    try
+                    {
+                        switch ((15 << 4) * long_30)
+                        {
+                            case -1:
+                                {
+                                    break;
+                                }
+                            default:
+                                {
+                                    break;
+                                }
+                        }
+                    }
+                    catch (System.InvalidProgramException)
+                    {
+                    }
+                    catch (System.InvalidCastException)
+                    {
+                    }
+                }
+                while (15 < 4);
+            }
+            catch (System.AggregateException)
+            {
+            }
+            finally
+            {
+            }
+            return;
+        }
+    }
+
+    [Fact]
+    public static void Problem0()
+    {
+        new Runtime_110958().Method0();
+    }
+}
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_110958/Runtime_110985.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_110958/Runtime_110985.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_110958/Runtime_110985.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_110958/Runtime_110985.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStress" Value="2" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitRandomEdgeCounts" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When we remove a try region, the try entry block may still be a try entry for enclosing try regions, so we can't unconditionally drop the DONT_REMOVE flag.

Fixes #110958