### PR TITLE
Pass the -pack switch to repo source-build leg

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -50,8 +50,9 @@
            Properties that control flags from the VMR build, and the expected output for the VMR build should be added to this file. -->
 
       <!-- Enable regular Arcade signing and publishing in VMR build -->
-      <InnerBuildArgs Condition="'$(DotNetBuildOrchestrator)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack $(FlagParameterPrefix)publish</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DotNetBuildOrchestrator)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)publish</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetBuildOrchestrator)' == 'true' and '$(Sign)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)sign</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)pack</InnerBuildArgs>
 
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)arch $(TargetArch)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)os $(TargetOS)</InnerBuildArgs>

--- a/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
@@ -30,4 +30,5 @@
   </Target>
 
   <Target Name="Restore" />
+  <Target Name="Pack" />
 </Project>


### PR DESCRIPTION
The -pack switch is necessary to create the rid agnostic libraries packages which are then wrapped into the source-build intermediate package.

Regressed with 19c25fd93aa1c4b392de9981573e3fc5a88fb003 Unblocks https://github.com/dotnet/runtime/pull/111010