### PR TITLE
JIT: add missing SetMorphed call

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17306,6 +17306,7 @@ GenTree* Compiler::gtWrapWithSideEffects(GenTree*     tree,
             comma->gtVNPair =
                 vnStore->VNPWithExc(tree->gtVNPair, vnStore->VNPExceptionSet(sideEffectsSource->gtVNPair));
         }
+        comma->SetMorphed(this);
         return comma;
     }
     return tree;


### PR DESCRIPTION
to the comma created by `gtWrapWithSideEffects`.

Fixes #110960