### PR TITLE
Make cdac APIs public but experimental

### DIFF
--- a/src/native/managed/cdacreader/Directory.Build.props
+++ b/src/native/managed/cdacreader/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <Import Project="..\Directory.Build.props" />
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExperimentalAttribute">
+        <_Parameter1>NETCDAC0001</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+</Project>

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.DataContractReader;
 /// <summary>
 /// A registry of all the contracts that may be provided by a target.
 /// </summary>
-internal abstract class ContractRegistry
+public abstract class ContractRegistry
 {
     /// <summary>
     /// Gets an instance of the Exception contract for the target.

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/Extensions/ICodeVersionsExtensions.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/Extensions/ICodeVersionsExtensions.cs
@@ -3,9 +3,9 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts.Extensions;
 
-internal static class ICodeVersionsExtensions
+public static class ICodeVersionsExtensions
 {
-    internal static NativeCodeVersionHandle GetActiveNativeCodeVersion(this ICodeVersions cv, TargetPointer methodDesc)
+    public static NativeCodeVersionHandle GetActiveNativeCodeVersion(this ICodeVersions cv, TargetPointer methodDesc)
     {
         ILCodeVersionHandle ilCodeVersionHandle = cv.GetActiveILCodeVersion(methodDesc);
         return cv.GetActiveNativeCodeVersionForILCodeVersion(methodDesc, ilCodeVersionHandle);

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/Extensions/IReJITExtensions.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/Extensions/IReJITExtensions.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts.Extensions;
 
-internal static class IReJITExtensions
+public static class IReJITExtensions
 {
     public static IEnumerable<TargetNUInt> GetRejitIds(this IReJIT rejit, Target target, TargetPointer methodDesc)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ICodeVersions.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ICodeVersions.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal interface ICodeVersions : IContract
+public interface ICodeVersions : IContract
 {
     static string IContract.Name { get; } = nameof(CodeVersions);
 
@@ -27,11 +27,11 @@ internal interface ICodeVersions : IContract
     public virtual bool CodeVersionManagerSupportsMethod(TargetPointer methodDesc) => throw new NotImplementedException();
 }
 
-internal readonly struct ILCodeVersionHandle
+public readonly struct ILCodeVersionHandle
 {
-    internal readonly TargetPointer Module;
-    internal readonly uint MethodDefinition;
-    internal readonly TargetPointer ILCodeVersionNode;
+    public readonly TargetPointer Module;
+    public readonly uint MethodDefinition;
+    public readonly TargetPointer ILCodeVersionNode;
     private ILCodeVersionHandle(TargetPointer module, uint methodDef, TargetPointer ilCodeVersionNodeAddress)
     {
         if (module != TargetPointer.Null && ilCodeVersionNodeAddress != TargetPointer.Null)
@@ -49,23 +49,23 @@ internal readonly struct ILCodeVersionHandle
     }
 
     // for more information on Explicit/Synthetic code versions see docs/design/features/code-versioning.md
-    internal static ILCodeVersionHandle CreateExplicit(TargetPointer ilCodeVersionNodeAddress) =>
+    public static ILCodeVersionHandle CreateExplicit(TargetPointer ilCodeVersionNodeAddress) =>
         new ILCodeVersionHandle(TargetPointer.Null, 0, ilCodeVersionNodeAddress);
-    internal static ILCodeVersionHandle CreateSynthetic(TargetPointer module, uint methodDef) =>
+    public static ILCodeVersionHandle CreateSynthetic(TargetPointer module, uint methodDef) =>
         new ILCodeVersionHandle(module, methodDef, TargetPointer.Null);
 
     public static ILCodeVersionHandle Invalid { get; } = new(TargetPointer.Null, 0, TargetPointer.Null);
 
     public bool IsValid => Module != TargetPointer.Null || ILCodeVersionNode != TargetPointer.Null;
 
-    internal bool IsExplicit => ILCodeVersionNode != TargetPointer.Null;
+    public bool IsExplicit => ILCodeVersionNode != TargetPointer.Null;
 }
 
-internal readonly struct NativeCodeVersionHandle
+public readonly struct NativeCodeVersionHandle
 {
     // no public constructors
-    internal readonly TargetPointer MethodDescAddress;
-    internal readonly TargetPointer CodeVersionNodeAddress;
+    public readonly TargetPointer MethodDescAddress;
+    public readonly TargetPointer CodeVersionNodeAddress;
     private NativeCodeVersionHandle(TargetPointer methodDescAddress, TargetPointer codeVersionNodeAddress)
     {
         if (methodDescAddress != TargetPointer.Null && codeVersionNodeAddress != TargetPointer.Null)
@@ -77,19 +77,19 @@ internal readonly struct NativeCodeVersionHandle
     }
 
     // for more information on Explicit/Synthetic code versions see docs/design/features/code-versioning.md
-    internal static NativeCodeVersionHandle CreateExplicit(TargetPointer codeVersionNodeAddress) =>
+    public static NativeCodeVersionHandle CreateExplicit(TargetPointer codeVersionNodeAddress) =>
         new NativeCodeVersionHandle(TargetPointer.Null, codeVersionNodeAddress);
-    internal static NativeCodeVersionHandle CreateSynthetic(TargetPointer methodDescAddress) =>
+    public static NativeCodeVersionHandle CreateSynthetic(TargetPointer methodDescAddress) =>
         new NativeCodeVersionHandle(methodDescAddress, TargetPointer.Null);
 
     public static NativeCodeVersionHandle Invalid { get; } = new(TargetPointer.Null, TargetPointer.Null);
 
     public bool Valid => MethodDescAddress != TargetPointer.Null || CodeVersionNodeAddress != TargetPointer.Null;
 
-    internal bool IsExplicit => CodeVersionNodeAddress != TargetPointer.Null;
+    public bool IsExplicit => CodeVersionNodeAddress != TargetPointer.Null;
 }
 
-internal readonly struct CodeVersions : ICodeVersions
+public readonly struct CodeVersions : ICodeVersions
 {
     // throws NotImplementedException for all methods
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ICodeVersions.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ICodeVersions.cs
@@ -29,6 +29,7 @@ public interface ICodeVersions : IContract
 
 public readonly struct ILCodeVersionHandle
 {
+    // TODO-Layering: These members should be accessible only to contract implementations.
     public readonly TargetPointer Module;
     public readonly uint MethodDefinition;
     public readonly TargetPointer ILCodeVersionNode;
@@ -64,6 +65,7 @@ public readonly struct ILCodeVersionHandle
 public readonly struct NativeCodeVersionHandle
 {
     // no public constructors
+    // TODO-Layering: These members should be accessible only to contract implementations.
     public readonly TargetPointer MethodDescAddress;
     public readonly TargetPointer CodeVersionNodeAddress;
     private NativeCodeVersionHandle(TargetPointer methodDescAddress, TargetPointer codeVersionNodeAddress)

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IContract.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IContract.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal interface IContract
+public interface IContract
 {
     static virtual string Name => throw new NotImplementedException();
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IDacStreams.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IDacStreams.cs
@@ -5,13 +5,13 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal interface IDacStreams : IContract
+public interface IDacStreams : IContract
 {
     static string IContract.Name { get; } = nameof(DacStreams);
     public virtual string? StringFromEEAddress(TargetPointer address) => throw new NotImplementedException();
 }
 
-internal readonly struct DacStreams : IDacStreams
+public readonly struct DacStreams : IDacStreams
 {
     // Everything throws NotImplementedException
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IEcmaMetadata.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IEcmaMetadata.cs
@@ -6,14 +6,14 @@ using System.Reflection.Metadata;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal interface IEcmaMetadata : IContract
+public interface IEcmaMetadata : IContract
 {
     static string IContract.Name { get; } = nameof(EcmaMetadata);
     public virtual TargetSpan GetReadOnlyMetadataAddress(ModuleHandle handle) => throw new NotImplementedException();
     public virtual MetadataReader? GetMetadata(ModuleHandle module) => throw new NotImplementedException();
 }
 
-internal readonly struct EcmaMetadata : IEcmaMetadata
+public readonly struct EcmaMetadata : IEcmaMetadata
 {
     // Everything throws NotImplementedException
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IException.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IException.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal record struct ExceptionData(
+public record struct ExceptionData(
     TargetPointer Message,
     TargetPointer InnerException,
     TargetPointer StackTrace,
@@ -15,7 +15,7 @@ internal record struct ExceptionData(
     int HResult,
     int XCode);
 
-internal interface IException : IContract
+public interface IException : IContract
 {
     static string IContract.Name { get; } = nameof(Exception);
 
@@ -23,7 +23,7 @@ internal interface IException : IContract
     public virtual ExceptionData GetExceptionData(TargetPointer managedException) => throw new NotImplementedException();
 }
 
-internal readonly struct Exception : IException
+public readonly struct Exception : IException
 {
     // Everything throws NotImplementedException
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
@@ -5,13 +5,13 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal struct CodeBlockHandle
+public struct CodeBlockHandle
 {
     public readonly TargetPointer Address;
-    internal CodeBlockHandle(TargetPointer address) => Address = address;
+    public CodeBlockHandle(TargetPointer address) => Address = address;
 }
 
-internal interface IExecutionManager : IContract
+public interface IExecutionManager : IContract
 {
     static string IContract.Name { get; } = nameof(ExecutionManager);
     CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => throw new NotImplementedException();
@@ -19,7 +19,7 @@ internal interface IExecutionManager : IContract
     TargetCodePointer GetStartAddress(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
 }
 
-internal readonly struct ExecutionManager : IExecutionManager
+public readonly struct ExecutionManager : IExecutionManager
 {
 
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 public struct CodeBlockHandle
 {
+    // TODO-Layering: These members should be accessible only to contract implementations.
     public readonly TargetPointer Address;
     public CodeBlockHandle(TargetPointer address) => Address = address;
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -6,24 +6,24 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal readonly struct ModuleHandle
+public readonly struct ModuleHandle
 {
-    internal ModuleHandle(TargetPointer address)
+    public ModuleHandle(TargetPointer address)
     {
         Address = address;
     }
 
-    internal TargetPointer Address { get; }
+    public TargetPointer Address { get; }
 }
 
 [Flags]
-internal enum ModuleFlags
+public enum ModuleFlags
 {
     EditAndContinue = 0x00000008,   // Edit and Continue is enabled for this module
     ReflectionEmit = 0x00000040,    // Reflection.Emit was used to create this module
 }
 
-internal record struct ModuleLookupTables(
+public record struct ModuleLookupTables(
     TargetPointer FieldDefToDesc,
     TargetPointer ManifestModuleReferences,
     TargetPointer MemberRefToDesc,
@@ -32,7 +32,7 @@ internal record struct ModuleLookupTables(
     TargetPointer TypeRefToMethodTable,
     TargetPointer MethodDefToILCodeVersioningState);
 
-internal interface ILoader : IContract
+public interface ILoader : IContract
 {
     static string IContract.Name => nameof(Loader);
 
@@ -52,7 +52,7 @@ internal interface ILoader : IContract
     public virtual bool IsCollectible(ModuleHandle handle) => throw new NotImplementedException();
 }
 
-internal readonly struct Loader : ILoader
+public readonly struct Loader : ILoader
 {
     // Everything throws NotImplementedException
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IObject.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IObject.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal interface IObject : IContract
+public interface IObject : IContract
 {
     static string IContract.Name { get; } = nameof(Object);
     public virtual TargetPointer GetMethodTableAddress(TargetPointer address) => throw new NotImplementedException();
@@ -14,7 +14,7 @@ internal interface IObject : IContract
     public virtual bool GetBuiltInComData(TargetPointer address, out TargetPointer rcw, out TargetPointer ccw) => throw new NotImplementedException();
 }
 
-internal readonly struct Object : IObject
+public readonly struct Object : IObject
 {
     // Everything throws NotImplementedException
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IPlatformMetadata.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IPlatformMetadata.cs
@@ -5,20 +5,20 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal enum CodePointerFlags : byte
+public enum CodePointerFlags : byte
 {
     HasArm32ThumbBit = 0x1,
     HasArm64PtrAuth = 0x2,
 }
 
-internal interface IPlatformMetadata : IContract
+public interface IPlatformMetadata : IContract
 {
     static string IContract.Name { get; } = nameof(PlatformMetadata);
     TargetPointer GetPrecodeMachineDescriptor() => throw new NotImplementedException();
     CodePointerFlags GetCodePointerFlags() => throw new NotImplementedException();
 }
 
-internal readonly struct PlatformMetadata : IPlatformMetadata
+public readonly struct PlatformMetadata : IPlatformMetadata
 {
 
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IPrecodeStubs.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IPrecodeStubs.cs
@@ -5,13 +5,13 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal interface IPrecodeStubs : IContract
+public interface IPrecodeStubs : IContract
 {
     static string IContract.Name { get; } = nameof(PrecodeStubs);
     TargetPointer GetMethodDescFromStubAddress(TargetCodePointer entryPoint) => throw new NotImplementedException();
 }
 
-internal readonly struct PrecodeStubs : IPrecodeStubs
+public readonly struct PrecodeStubs : IPrecodeStubs
 {
 
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IReJIT.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IReJIT.cs
@@ -12,7 +12,7 @@ public enum RejitState
     Active
 }
 
-internal interface IReJIT : IContract
+public interface IReJIT : IContract
 {
     static string IContract.Name { get; } = nameof(ReJIT);
 
@@ -23,7 +23,7 @@ internal interface IReJIT : IContract
     TargetNUInt GetRejitId(ILCodeVersionHandle codeVersionHandle) => throw new NotImplementedException();
 }
 
-internal readonly struct ReJIT : IReJIT
+public readonly struct ReJIT : IReJIT
 {
 
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -6,19 +6,19 @@ using System;
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 // an opaque handle to a type handle.  See IMetadata.GetMethodTableData
-internal readonly struct TypeHandle
+public readonly struct TypeHandle
 {
-    internal TypeHandle(TargetPointer address)
+    public TypeHandle(TargetPointer address)
     {
         Address = address;
     }
 
-    internal TargetPointer Address { get; }
+    public TargetPointer Address { get; }
 
-    internal bool IsNull => Address == 0;
+    public bool IsNull => Address == 0;
 }
 
-internal enum CorElementType
+public enum CorElementType
 {
     Void = 1,
     Boolean = 2,
@@ -55,14 +55,14 @@ internal enum CorElementType
     Sentinel = 0x41,
 }
 
-internal readonly struct MethodDescHandle
+public readonly struct MethodDescHandle
 {
-    internal MethodDescHandle(TargetPointer address)
+    public MethodDescHandle(TargetPointer address)
     {
         Address = address;
     }
 
-    internal TargetPointer Address { get; }
+    public TargetPointer Address { get; }
 }
 
 public enum ArrayFunctionType
@@ -73,7 +73,7 @@ public enum ArrayFunctionType
     Constructor = 3
 }
 
-internal interface IRuntimeTypeSystem : IContract
+public interface IRuntimeTypeSystem : IContract
 {
     static string IContract.Name => nameof(RuntimeTypeSystem);
 
@@ -171,7 +171,7 @@ internal interface IRuntimeTypeSystem : IContract
     #endregion MethodDesc inspection APIs
 }
 
-internal struct RuntimeTypeSystem : IRuntimeTypeSystem
+public struct RuntimeTypeSystem : IRuntimeTypeSystem
 {
     // Everything throws NotImplementedException
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 // an opaque handle to a type handle.  See IMetadata.GetMethodTableData
 public readonly struct TypeHandle
 {
+    // TODO-Layering: These members should be accessible only to contract implementations.
     public TypeHandle(TargetPointer address)
     {
         Address = address;
@@ -57,6 +58,7 @@ public enum CorElementType
 
 public readonly struct MethodDescHandle
 {
+    // TODO-Layering: These members should be accessible only to contract implementations.
     public MethodDescHandle(TargetPointer address)
     {
         Address = address;

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -5,20 +5,20 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal record struct ThreadStoreData(
+public record struct ThreadStoreData(
     int ThreadCount,
     TargetPointer FirstThread,
     TargetPointer FinalizerThread,
     TargetPointer GCThread);
 
-internal record struct ThreadStoreCounts(
+public record struct ThreadStoreCounts(
     int UnstartedThreadCount,
     int BackgroundThreadCount,
     int PendingThreadCount,
     int DeadThreadCount);
 
 [Flags]
-internal enum ThreadState
+public enum ThreadState
 {
     Unknown             = 0x00000000,
     Hijacked            = 0x00000080,   // Return address has been hijacked
@@ -28,7 +28,7 @@ internal enum ThreadState
     ThreadPoolWorker    = 0x01000000,   // Thread is a thread pool worker thread
 }
 
-internal record struct ThreadData(
+public record struct ThreadData(
     uint Id,
     TargetNUInt OSId,
     ThreadState State,
@@ -41,7 +41,7 @@ internal record struct ThreadData(
     TargetPointer LastThrownObjectHandle,
     TargetPointer NextThread);
 
-internal interface IThread : IContract
+public interface IThread : IContract
 {
     static string IContract.Name { get; } = nameof(Thread);
 
@@ -50,7 +50,7 @@ internal interface IThread : IContract
     public virtual ThreadData GetThreadData(TargetPointer thread) => throw new NotImplementedException();
 }
 
-internal readonly struct Thread : IThread
+public readonly struct Thread : IThread
 {
     // Everything throws NotImplementedException
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Data/IData.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Data/IData.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal interface IData<TSelf> where TSelf : IData<TSelf>
+public interface IData<TSelf> where TSelf : IData<TSelf>
 {
     static abstract TSelf Create(Target target, TargetPointer address);
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/IContractFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/IContractFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader;
 
-internal interface IContractFactory<out TContract> where TContract : Contracts.IContract
+public interface IContractFactory<out TContract> where TContract : Contracts.IContract
 {
     TContract CreateContract(Target target, int version);
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
@@ -10,12 +10,4 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader.Tests" />
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader.Contracts" />
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader" />
-    <InternalsVisibleTo Include="cdacreader" Condition="'$(TargetsWindows)' == 'true'"/>
-    <InternalsVisibleTo Include="libcdacreader" Condition="'$(TargetsWindows)' != 'true'"/>
-  </ItemGroup>
 </Project>

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Properties/InternalsVisibleTo.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Properties/InternalsVisibleTo.cs
@@ -1,7 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Runtime.CompilerServices;
-
-// Allows Moq framework to mock internal types (for example, contract interfaces)
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.DataContractReader;
 /// information. Like the contracts themselves in cdacreader, these are throwing APIs. Any callers at the boundaries
 /// (for example, unmanaged entry points, COM) should handle any exceptions.
 /// </remarks>
-internal abstract class Target
+public abstract class Target
 {
     /// <summary>
     /// Pointer size of the target

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetNUInt.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetNUInt.cs
@@ -12,7 +12,7 @@ public readonly struct TargetNUInt : IEquatable<TargetNUInt>
     public readonly ulong Value;
     public TargetNUInt(ulong value) => Value = value;
 
-    internal string Hex => $"0x{Value:x}";
+    public string Hex => $"0x{Value:x}";
 
     public override bool Equals(object? obj) => obj is TargetNUInt other && Equals(other);
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetNUInt.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetNUInt.cs
@@ -12,7 +12,7 @@ public readonly struct TargetNUInt : IEquatable<TargetNUInt>
     public readonly ulong Value;
     public TargetNUInt(ulong value) => Value = value;
 
-    public string Hex => $"0x{Value:x}";
+    internal string Hex => $"0x{Value:x}";
 
     public override bool Equals(object? obj) => obj is TargetNUInt other && Equals(other);
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
@@ -47,4 +47,16 @@ public static class Constants
         public const string HashMapSlotsPerBucket = nameof(HashMapSlotsPerBucket);
         public const string HashMapValueMask = nameof(HashMapValueMask);
     }
+    public static class FieldNames
+    {
+        public static class Array
+        {
+            public const string NumComponents = $"m_{nameof(NumComponents)}";
+        }
+
+        public static class ModuleLookupMap
+        {
+            public const string TableData = nameof(TableData);
+        }
+    }
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
@@ -3,48 +3,48 @@
 
 namespace Microsoft.Diagnostics.DataContractReader;
 
-internal static class Constants
+public static class Constants
 {
-    internal static class Globals
+    public static class Globals
     {
         // See src/coreclr/debug/runtimeinfo/datadescriptor.h
-        internal const string AppDomain = nameof(AppDomain);
-        internal const string ThreadStore = nameof(ThreadStore);
-        internal const string FinalizerThread = nameof(FinalizerThread);
-        internal const string GCThread = nameof(GCThread);
+        public const string AppDomain = nameof(AppDomain);
+        public const string ThreadStore = nameof(ThreadStore);
+        public const string FinalizerThread = nameof(FinalizerThread);
+        public const string GCThread = nameof(GCThread);
 
-        internal const string FeatureCOMInterop = nameof(FeatureCOMInterop);
-        internal const string FeatureEHFunclets = nameof(FeatureEHFunclets);
+        public const string FeatureCOMInterop = nameof(FeatureCOMInterop);
+        public const string FeatureEHFunclets = nameof(FeatureEHFunclets);
 
-        internal const string ObjectToMethodTableUnmask = nameof(ObjectToMethodTableUnmask);
-        internal const string SOSBreakingChangeVersion = nameof(SOSBreakingChangeVersion);
+        public const string ObjectToMethodTableUnmask = nameof(ObjectToMethodTableUnmask);
+        public const string SOSBreakingChangeVersion = nameof(SOSBreakingChangeVersion);
 
-        internal const string ExceptionMethodTable = nameof(ExceptionMethodTable);
-        internal const string FreeObjectMethodTable = nameof(FreeObjectMethodTable);
-        internal const string ObjectMethodTable = nameof(ObjectMethodTable);
-        internal const string ObjectArrayMethodTable = nameof(ObjectArrayMethodTable);
-        internal const string StringMethodTable = nameof(StringMethodTable);
+        public const string ExceptionMethodTable = nameof(ExceptionMethodTable);
+        public const string FreeObjectMethodTable = nameof(FreeObjectMethodTable);
+        public const string ObjectMethodTable = nameof(ObjectMethodTable);
+        public const string ObjectArrayMethodTable = nameof(ObjectArrayMethodTable);
+        public const string StringMethodTable = nameof(StringMethodTable);
 
-        internal const string MiniMetaDataBuffAddress = nameof(MiniMetaDataBuffAddress);
-        internal const string MiniMetaDataBuffMaxSize = nameof(MiniMetaDataBuffMaxSize);
+        public const string MiniMetaDataBuffAddress = nameof(MiniMetaDataBuffAddress);
+        public const string MiniMetaDataBuffMaxSize = nameof(MiniMetaDataBuffMaxSize);
 
-        internal const string MethodDescAlignment = nameof(MethodDescAlignment);
-        internal const string ObjectHeaderSize = nameof(ObjectHeaderSize);
-        internal const string SyncBlockValueToObjectOffset = nameof(SyncBlockValueToObjectOffset);
+        public const string MethodDescAlignment = nameof(MethodDescAlignment);
+        public const string ObjectHeaderSize = nameof(ObjectHeaderSize);
+        public const string SyncBlockValueToObjectOffset = nameof(SyncBlockValueToObjectOffset);
 
-        internal const string SyncTableEntries = nameof(SyncTableEntries);
+        public const string SyncTableEntries = nameof(SyncTableEntries);
 
-        internal const string ArrayBoundsZero = nameof(ArrayBoundsZero);
+        public const string ArrayBoundsZero = nameof(ArrayBoundsZero);
 
-        internal const string MethodDescTokenRemainderBitCount = nameof(MethodDescTokenRemainderBitCount);
-        internal const string DirectorySeparator = nameof(DirectorySeparator);
+        public const string MethodDescTokenRemainderBitCount = nameof(MethodDescTokenRemainderBitCount);
+        public const string DirectorySeparator = nameof(DirectorySeparator);
 
-        internal const string ExecutionManagerCodeRangeMapAddress = nameof(ExecutionManagerCodeRangeMapAddress);
-        internal const string StubCodeBlockLast = nameof(StubCodeBlockLast);
-        internal const string PlatformMetadata = nameof(PlatformMetadata);
-        internal const string ProfilerControlBlock = nameof(ProfilerControlBlock);
+        public const string ExecutionManagerCodeRangeMapAddress = nameof(ExecutionManagerCodeRangeMapAddress);
+        public const string StubCodeBlockLast = nameof(StubCodeBlockLast);
+        public const string PlatformMetadata = nameof(PlatformMetadata);
+        public const string ProfilerControlBlock = nameof(ProfilerControlBlock);
 
-        internal const string HashMapSlotsPerBucket = nameof(HashMapSlotsPerBucket);
-        internal const string HashMapValueMask = nameof(HashMapValueMask);
+        public const string HashMapSlotsPerBucket = nameof(HashMapSlotsPerBucket);
+        public const string HashMapValueMask = nameof(HashMapValueMask);
     }
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersionsFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersionsFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class CodeVersionsFactory : IContractFactory<ICodeVersions>
+public sealed class CodeVersionsFactory : IContractFactory<ICodeVersions>
 {
     ICodeVersions IContractFactory<ICodeVersions>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DacStreamsFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DacStreamsFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class DacStreamsFactory : IContractFactory<IDacStreams>
+public sealed class DacStreamsFactory : IContractFactory<IDacStreams>
 {
     IDacStreams IContractFactory<IDacStreams>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DacStreams_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DacStreams_1.cs
@@ -8,7 +8,7 @@ using Microsoft.Diagnostics.DataContractReader.Data;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal class DacStreams_1 : IDacStreams
+internal sealed class DacStreams_1 : IDacStreams
 {
     private readonly Target _target;
 
@@ -29,7 +29,7 @@ internal class DacStreams_1 : IDacStreams
         _target = target;
     }
 
-    public virtual string? StringFromEEAddress(TargetPointer address)
+    public string? StringFromEEAddress(TargetPointer address)
     {
         // We use the data subsystem to handle caching results from processing this data
         var dictionary = _target.ProcessedData.GetOrAdd<DacStreams_1_Data>(0).EEObjectToString;
@@ -38,7 +38,7 @@ internal class DacStreams_1 : IDacStreams
         return result;
     }
 
-    internal class DacStreams_1_Data : IData<DacStreams_1_Data>
+    internal sealed class DacStreams_1_Data : IData<DacStreams_1_Data>
     {
         static DacStreams_1_Data IData<DacStreams_1_Data>.Create(Target target, TargetPointer address) => new DacStreams_1_Data(target);
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadataFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadataFactory.cs
@@ -6,7 +6,7 @@ using System.Reflection.Metadata;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class EcmaMetadataFactory : IContractFactory<IEcmaMetadata>
+public sealed class EcmaMetadataFactory : IContractFactory<IEcmaMetadata>
 {
     IEcmaMetadata IContractFactory<IEcmaMetadata>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal class EcmaMetadata_1(Target target) : IEcmaMetadata
+internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
 {
     private Dictionary<ModuleHandle, MetadataReaderProvider?> _metadata = new();
 
@@ -246,7 +246,7 @@ internal class EcmaMetadata_1(Target target) : IEcmaMetadata
         public readonly bool VariableSizedColumnsAreAll4BytesLong;
     }
 
-    private class TargetEcmaMetadata
+    private sealed class TargetEcmaMetadata
     {
         public TargetEcmaMetadata(EcmaMetadataSchema schema,
                             TargetSpan[] tables,

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExceptionFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExceptionFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ExceptionFactory : IContractFactory<IException>
+public sealed class ExceptionFactory : IContractFactory<IException>
 {
     IException IContractFactory<IException>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.EEJitManager.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.EEJitManager.cs
@@ -8,9 +8,9 @@ using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal partial class ExecutionManagerBase<T> : IExecutionManager
+internal partial class ExecutionManagerCore<T> : IExecutionManager
 {
-    private class EEJitManager : JitManager
+    private sealed class EEJitManager : JitManager
     {
         private readonly INibbleMap _nibbleMap;
         public EEJitManager(Target target, INibbleMap nibbleMap) : base(target)

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
@@ -8,9 +8,9 @@ using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal partial class ExecutionManagerBase<T> : IExecutionManager
+internal partial class ExecutionManagerCore<T> : IExecutionManager
 {
-    private class ReadyToRunJitManager : JitManager
+    private sealed class ReadyToRunJitManager : JitManager
     {
         private readonly uint _runtimeFunctionSize;
         private readonly PtrHashMapLookup _hashMap;

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
@@ -8,7 +8,7 @@ using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal partial class ExecutionManagerBase<T> : IExecutionManager
+internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
     where T : INibbleMap
 {
     internal readonly Target _target;
@@ -20,7 +20,7 @@ internal partial class ExecutionManagerBase<T> : IExecutionManager
     private readonly EEJitManager _eeJitManager;
     private readonly ReadyToRunJitManager _r2rJitManager;
 
-    public ExecutionManagerBase(Target target, Data.RangeSectionMap topRangeSectionMap)
+    public ExecutionManagerCore(Target target, Data.RangeSectionMap topRangeSectionMap)
     {
         _target = target;
         _topRangeSectionMap = topRangeSectionMap;
@@ -31,7 +31,7 @@ internal partial class ExecutionManagerBase<T> : IExecutionManager
     }
 
     // Note, because of RelativeOffset, this code info is per code pointer, not per method
-    private class CodeBlock
+    private sealed class CodeBlock
     {
         public TargetCodePointer StartAddress { get; }
         public TargetPointer MethodDescAddress { get; }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerFactory.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ExecutionManagerFactory : IContractFactory<IExecutionManager>
+public sealed class ExecutionManagerFactory : IContractFactory<IExecutionManager>
 {
     IExecutionManager IContractFactory<IExecutionManager>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_1.cs
@@ -5,9 +5,16 @@ using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ExecutionManager_1 : ExecutionManagerBase<NibbleMapLinearLookup>
+public sealed class ExecutionManager_1 : IExecutionManager
 {
-    public ExecutionManager_1(Target target, Data.RangeSectionMap topRangeSectionMap) : base(target, topRangeSectionMap)
+    private IExecutionManager _executionManagerCore;
+
+    internal ExecutionManager_1(Target target, Data.RangeSectionMap topRangeSectionMap)
     {
+        _executionManagerCore = new ExecutionManagerCore<NibbleMapLinearLookup>(target, topRangeSectionMap);
     }
+
+    public CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => _executionManagerCore.GetCodeBlockHandle(ip);
+    public TargetPointer GetMethodDesc(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetMethodDesc(codeInfoHandle);
+    public TargetCodePointer GetStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetStartAddress(codeInfoHandle);
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_2.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_2.cs
@@ -5,9 +5,16 @@ using Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ExecutionManager_2 : ExecutionManagerBase<NibbleMapConstantLookup>
+public sealed class ExecutionManager_2 : IExecutionManager
 {
-    public ExecutionManager_2(Target target, Data.RangeSectionMap topRangeSectionMap) : base(target, topRangeSectionMap)
+    private IExecutionManager _executionManagerCore;
+
+    internal ExecutionManager_2(Target target, Data.RangeSectionMap topRangeSectionMap)
     {
+        _executionManagerCore = new ExecutionManagerCore<NibbleMapConstantLookup>(target, topRangeSectionMap);
     }
+
+    public CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => _executionManagerCore.GetCodeBlockHandle(ip);
+    public TargetPointer GetMethodDesc(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetMethodDesc(codeInfoHandle);
+    public TargetCodePointer GetStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetStartAddress(codeInfoHandle);
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/NibbleMapConstantLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/NibbleMapConstantLookup.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 // In this implementation we may "extend" the lookup period of a function several hundred bytes
 // if there is not another function following it.
 
-internal class NibbleMapConstantLookup : INibbleMap
+internal sealed class NibbleMapConstantLookup : INibbleMap
 {
     private readonly Target _target;
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/NibbleMapLinearLookup.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/NibbleMapLinearLookup.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.DataContractReader.ExecutionManagerHelpers;
 // We will then align the map index to the start of the current map unit (map index 8) and move back to the previous map unit (map index 7)
 // At that point, we scan backwards for non-zero map units. Since there are none, we return null.
 
-internal class NibbleMapLinearLookup : INibbleMap
+internal sealed class NibbleMapLinearLookup : INibbleMap
 {
     private readonly Target _target;
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/LoaderFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/LoaderFactory.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class LoaderFactory : IContractFactory<ILoader>
+public sealed class LoaderFactory : IContractFactory<ILoader>
 {
     ILoader IContractFactory<ILoader>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ObjectFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ObjectFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ObjectFactory : IContractFactory<IObject>
+public sealed class ObjectFactory : IContractFactory<IObject>
 {
     IObject IContractFactory<IObject>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Object_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Object_1.cs
@@ -88,7 +88,7 @@ internal readonly struct Object_1 : IObject
         else
         {
             // Single-dimensional, zero-based - doesn't have bounds
-            boundsStart = address + (ulong)arrayTypeInfo.Fields[Data.Array.FieldNames.NumComponents].Offset;
+            boundsStart = address + (ulong)arrayTypeInfo.Fields[Constants.FieldNames.Array.NumComponents].Offset;
             lowerBounds = _target.ReadGlobalPointer(Constants.Globals.ArrayBoundsZero);
         }
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PlatformMetadataFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PlatformMetadataFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class PlatformMetadataFactory : IContractFactory<IPlatformMetadata>
+public sealed class PlatformMetadataFactory : IContractFactory<IPlatformMetadata>
 {
     IPlatformMetadata IContractFactory<IPlatformMetadata>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PrecodeStubsFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PrecodeStubsFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class PrecodeStubsFactory : IContractFactory<IPrecodeStubs>
+public sealed class PrecodeStubsFactory : IContractFactory<IPrecodeStubs>
 {
     IPrecodeStubs IContractFactory<IPrecodeStubs>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PrecodeStubs_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PrecodeStubs_1.cs
@@ -47,12 +47,12 @@ internal readonly struct PrecodeStubs_1 : IPrecodeStubs
         }
     }
 
-    internal sealed class PInvokeImportPrecode : StubPrecode
+    public sealed class PInvokeImportPrecode : StubPrecode
     {
         internal PInvokeImportPrecode(TargetPointer instrPointer) : base(instrPointer, KnownPrecodeType.PInvokeImport) { }
     }
 
-    internal sealed class FixupPrecode : ValidPrecode
+    public sealed class FixupPrecode : ValidPrecode
     {
         internal FixupPrecode(TargetPointer instrPointer) : base(instrPointer, KnownPrecodeType.Fixup) { }
         internal override TargetPointer GetMethodDesc(Target target, Data.PrecodeMachineDescriptor precodeMachineDescriptor)
@@ -64,7 +64,7 @@ internal readonly struct PrecodeStubs_1 : IPrecodeStubs
         }
     }
 
-    internal sealed class ThisPtrRetBufPrecode : ValidPrecode
+    public sealed class ThisPtrRetBufPrecode : ValidPrecode
     {
         internal ThisPtrRetBufPrecode(TargetPointer instrPointer) : base(instrPointer, KnownPrecodeType.ThisPtrRetBuf) { }
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ReJITFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ReJITFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ReJITFactory : IContractFactory<IReJIT>
+public sealed class ReJITFactory : IContractFactory<IReJIT>
 {
     IReJIT IContractFactory<IReJIT>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystemFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystemFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class RuntimeTypeSystemFactory : IContractFactory<IRuntimeTypeSystem>
+public sealed class RuntimeTypeSystemFactory : IContractFactory<IRuntimeTypeSystem>
 {
     IRuntimeTypeSystem IContractFactory<IRuntimeTypeSystem>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -170,7 +170,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     }
 
-    private class InstantiatedMethodDesc : IData<InstantiatedMethodDesc>
+    private sealed class InstantiatedMethodDesc : IData<InstantiatedMethodDesc>
     {
         public static InstantiatedMethodDesc Create(Target target, TargetPointer address) => new InstantiatedMethodDesc(target, address);
 
@@ -207,7 +207,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         public TypeHandle[] Instantiation { get; }
     }
 
-    private class DynamicMethodDesc : IData<DynamicMethodDesc>
+    private sealed class DynamicMethodDesc : IData<DynamicMethodDesc>
     {
         public static DynamicMethodDesc Create(Target target, TargetPointer address) => new DynamicMethodDesc(target, address);
 
@@ -234,7 +234,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         public bool IsILStub => ExtendedFlags.HasFlag(DynamicMethodDescExtendedFlags.IsILStub);
     }
 
-    private class StoredSigMethodDesc : IData<StoredSigMethodDesc>
+    private sealed class StoredSigMethodDesc : IData<StoredSigMethodDesc>
     {
         public static StoredSigMethodDesc Create(Target target, TargetPointer address) => new StoredSigMethodDesc(target, address);
 
@@ -408,7 +408,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return _target.ProcessedData.GetOrAdd<TypeInstantiation>(typeHandle.Address).TypeHandles;
     }
 
-    private class TypeInstantiation : IData<TypeInstantiation>
+    private sealed class TypeInstantiation : IData<TypeInstantiation>
     {
         public static TypeInstantiation Create(Target target, TargetPointer address) => new TypeInstantiation(target, address);
 
@@ -582,7 +582,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return true;
     }
 
-    private class FunctionPointerRetAndArgs : IData<FunctionPointerRetAndArgs>
+    private sealed class FunctionPointerRetAndArgs : IData<FunctionPointerRetAndArgs>
     {
         public static FunctionPointerRetAndArgs Create(Target target, TargetPointer address) => new FunctionPointerRetAndArgs(target, address);
 
@@ -1026,7 +1026,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return TargetPointer.Null;
     }
 
-    private class NonValidatedMethodTableQueries : MethodValidation.IMethodTableQueries
+    private sealed class NonValidatedMethodTableQueries : MethodValidation.IMethodTableQueries
     {
         private readonly RuntimeTypeSystem_1 _rts;
         public NonValidatedMethodTableQueries(RuntimeTypeSystem_1 rts)

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ThreadFactory.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ThreadFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal sealed class ThreadFactory : IContractFactory<IThread>
+public sealed class ThreadFactory : IContractFactory<IThread>
 {
     IThread IContractFactory<IThread>.CreateContract(Target target, int version)
     {

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Array.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Array.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-public sealed class Array : IData<Array>
+internal sealed class Array : IData<Array>
 {
     static Array IData<Array>.Create(Target target, TargetPointer address)
         => new Array(target, address);
@@ -12,13 +12,8 @@ public sealed class Array : IData<Array>
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.Array);
 
-        NumComponents = target.Read<uint>(address + (ulong)type.Fields[FieldNames.NumComponents].Offset);
+        NumComponents = target.Read<uint>(address + (ulong)type.Fields[Constants.FieldNames.Array.NumComponents].Offset);
     }
 
     public uint NumComponents { get; init; }
-
-    public static class FieldNames
-    {
-        public const string NumComponents = $"m_{nameof(NumComponents)}";
-    }
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Array.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Array.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal sealed class Array : IData<Array>
+public sealed class Array : IData<Array>
 {
     static Array IData<Array>.Create(Target target, TargetPointer address)
         => new Array(target, address);
@@ -17,8 +17,8 @@ internal sealed class Array : IData<Array>
 
     public uint NumComponents { get; init; }
 
-    internal static class FieldNames
+    public static class FieldNames
     {
-        internal const string NumComponents = $"m_{nameof(NumComponents)}";
+        public const string NumComponents = $"m_{nameof(NumComponents)}";
     }
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DynamicMetadata.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DynamicMetadata.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal class DynamicMetadata : IData<DynamicMetadata>
+internal sealed class DynamicMetadata : IData<DynamicMetadata>
 {
     static DynamicMetadata IData<DynamicMetadata>.Create(Target target, TargetPointer address) => new DynamicMetadata(target, address);
     public DynamicMetadata(Target target, TargetPointer address)

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/GenericsDictInfo.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/GenericsDictInfo.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal class GenericsDictInfo : IData<GenericsDictInfo>
+internal sealed class GenericsDictInfo : IData<GenericsDictInfo>
 {
     static GenericsDictInfo IData<GenericsDictInfo>.Create(Target target, TargetPointer address) => new GenericsDictInfo(target, address);
     public GenericsDictInfo(Target target, TargetPointer address)

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ModuleLookupMap.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ModuleLookupMap.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-public sealed class ModuleLookupMap : IData<ModuleLookupMap>
+internal sealed class ModuleLookupMap : IData<ModuleLookupMap>
 {
     static ModuleLookupMap IData<ModuleLookupMap>.Create(Target target, TargetPointer address) => new ModuleLookupMap(target, address);
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ModuleLookupMap.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ModuleLookupMap.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal sealed class ModuleLookupMap : IData<ModuleLookupMap>
+public sealed class ModuleLookupMap : IData<ModuleLookupMap>
 {
     static ModuleLookupMap IData<ModuleLookupMap>.Create(Target target, TargetPointer address) => new ModuleLookupMap(target, address);
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TypeDesc.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TypeDesc.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal class TypeDesc : IData<TypeDesc>
+internal sealed class TypeDesc : IData<TypeDesc>
 {
     static TypeDesc IData<TypeDesc>.Create(Target target, TargetPointer address) => new TypeDesc(target, address);
     public TypeDesc(Target target, TargetPointer address)
@@ -15,7 +15,7 @@ internal class TypeDesc : IData<TypeDesc>
     public uint TypeAndFlags { get; init; }
 }
 
-internal class ParamTypeDesc : IData<ParamTypeDesc>
+internal sealed class ParamTypeDesc : IData<ParamTypeDesc>
 {
     static ParamTypeDesc IData<ParamTypeDesc>.Create(Target target, TargetPointer address) => new ParamTypeDesc(target, address);
     public ParamTypeDesc(Target target, TargetPointer address)
@@ -31,7 +31,7 @@ internal class ParamTypeDesc : IData<ParamTypeDesc>
     public TargetPointer TypeArg { get; init; }
 }
 
-internal class TypeVarTypeDesc : IData<TypeVarTypeDesc>
+internal sealed class TypeVarTypeDesc : IData<TypeVarTypeDesc>
 {
     static TypeVarTypeDesc IData<TypeVarTypeDesc>.Create(Target target, TargetPointer address) => new TypeVarTypeDesc(target, address);
     public TypeVarTypeDesc(Target target, TargetPointer address)
@@ -50,7 +50,7 @@ internal class TypeVarTypeDesc : IData<TypeVarTypeDesc>
     public uint Token { get; init; }
 }
 
-internal class FnPtrTypeDesc : IData<FnPtrTypeDesc>
+internal sealed class FnPtrTypeDesc : IData<FnPtrTypeDesc>
 {
     static FnPtrTypeDesc IData<FnPtrTypeDesc>.Create(Target target, TargetPointer address) => new FnPtrTypeDesc(target, address);
     public FnPtrTypeDesc(Target target, TargetPointer address)

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Diagnostics.DataContractReader.Abstractions\Microsoft.Diagnostics.DataContractReader.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
@@ -12,13 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader.Tests" />
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader" />
-    <InternalsVisibleTo Include="cdacreader" Condition="'$(TargetsWindows)' == 'true'"/>
-    <InternalsVisibleTo Include="libcdacreader" Condition="'$(TargetsWindows)' != 'true'"/>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Diagnostics.DataContractReader.Abstractions\Microsoft.Diagnostics.DataContractReader.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodValidation.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodValidation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
 // to an unmapped memory region.
 // All types here have not been validated as actually representing a MethodTable, EEClass, etc.
 // All checks are unsafe and may throw if we access an invalid address in target memory.
-internal class MethodValidation
+internal sealed class MethodValidation
 {
     internal interface IMethodTableQueries
     {
@@ -19,7 +19,7 @@ internal class MethodValidation
         bool SlotIsVtableSlot(TargetPointer methodTablePointer, uint slot);
     }
 
-    private class NIEMethodTableQueries : IMethodTableQueries
+    private sealed class NIEMethodTableQueries : IMethodTableQueries
     {
         public TargetPointer GetAddressOfMethodTableSlot(TargetPointer methodTablePointer, uint slot) =>  throw new NotImplementedException();
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/TypeValidation.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/TypeValidation.cs
@@ -6,7 +6,7 @@ using Microsoft.Diagnostics.DataContractReader.Data;
 
 namespace Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
 
-internal class TypeValidation
+internal sealed class TypeValidation
 {
     private readonly Target _target;
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.DataContractReader;
 /// <summary>
 /// Contract registry that caches contracts for a target
 /// </summary>
-public sealed class CachingContractRegistry : ContractRegistry
+internal sealed class CachingContractRegistry : ContractRegistry
 {
     public delegate bool TryGetContractVersionDelegate(string contractName, out int version);
     // Contracts that have already been created for a target.

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.DataContractReader;
 /// <summary>
 /// Contract registry that caches contracts for a target
 /// </summary>
-internal sealed class CachingContractRegistry : ContractRegistry
+public sealed class CachingContractRegistry : ContractRegistry
 {
     public delegate bool TryGetContractVersionDelegate(string contractName, out int version);
     // Contracts that have already been created for a target.

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.DataContractReader;
 /// these are throwing APIs. Any callers at the boundaries (for example, unmanaged entry points, COM)
 /// should handle any exceptions.
 /// </remarks>
-internal sealed unsafe class ContractDescriptorTarget : Target
+public sealed unsafe class ContractDescriptorTarget : Target
 {
     private const int StackAllocByteThreshold = 1024;
 
@@ -481,7 +481,7 @@ internal sealed unsafe class ContractDescriptorTarget : Target
     /// Store of addresses that have already been read into corresponding data models.
     /// This is simply used to avoid re-processing data on every request.
     /// </summary>
-    internal sealed class DataCache : Target.IDataCache
+    public sealed class DataCache : Target.IDataCache
     {
         private readonly ContractDescriptorTarget _target;
         private readonly Dictionary<(ulong, Type), object?> _readDataByAddress = [];

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
@@ -14,11 +14,6 @@
   <ItemGroup>
     <Compile Include="$(LibrariesProjectRoot)Common\src\System\HResults.cs" Link="Common\System\HResults.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader.Tests" />
-    <InternalsVisibleTo Include="cdacreader" Condition="'$(TargetsWindows)' == 'true'"/>
-    <InternalsVisibleTo Include="libcdacreader" Condition="'$(TargetsWindows)' != 'true'"/>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Diagnostics.DataContractReader.Abstractions\Microsoft.Diagnostics.DataContractReader.Abstractions.csproj" />

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -792,7 +792,7 @@ internal sealed unsafe partial class SOSDacImpl
             data->ThunkHeap = contract.GetThunkHeap(handle);
 
             Target.TypeInfo lookupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
-            ulong tableDataOffset = (ulong)lookupMapTypeInfo.Fields[nameof(Data.ModuleLookupMap.TableData)].Offset;
+            ulong tableDataOffset = (ulong)lookupMapTypeInfo.Fields[Constants.FieldNames.ModuleLookupMap.TableData].Offset;
 
             Contracts.ModuleLookupTables tables = contract.GetLookupTables(handle);
             data->FieldDefToDescMap = _target.ReadPointer(tables.FieldDefToDesc + tableDataOffset);
@@ -900,7 +900,7 @@ internal sealed unsafe partial class SOSDacImpl
 
             data->MethodTable = mt;
             data->Size = runtimeTypeSystemContract.GetBaseSize(handle);
-            data->dwComponentSize = runtimeTypeSystemContract.GetComponentSize(handle); ;
+            data->dwComponentSize = runtimeTypeSystemContract.GetComponentSize(handle);
 
             if (runtimeTypeSystemContract.IsFreeObjectMethodTable(handle))
             {
@@ -909,7 +909,7 @@ internal sealed unsafe partial class SOSDacImpl
                 // Free objects have their component count explicitly set at the same offset as that for arrays
                 // Update the size to include those components
                 Target.TypeInfo arrayTypeInfo = _target.GetTypeInfo(DataType.Array);
-                ulong numComponentsOffset = (ulong)_target.GetTypeInfo(DataType.Array).Fields[Data.Array.FieldNames.NumComponents].Offset;
+                ulong numComponentsOffset = (ulong)_target.GetTypeInfo(DataType.Array).Fields[Constants.FieldNames.Array.NumComponents].Offset;
                 data->Size += _target.Read<uint>(objAddr + numComponentsOffset) * data->dwComponentSize;
             }
             else if (mt == _stringMethodTable.Value)

--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
+    <Compile Include="$(LibrariesProjectRoot)Common\src\System\HResults.cs" Link="Common\System\HResults.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Diagnostics.DataContractReader.Tests" />


### PR DESCRIPTION
Make the cdac APIs public but experimental to make them easier to experiment with in other projects while we are still stabilizing the API surface.

Any usages outside of the cdac folder (or outside the repo entirely) will need to actively opt-in to using these APIs by suppressing the warning from the Experimental attribute.

Also address feedback from analyzers that kicked in as soon as I removed all of the IVT attributes. Keep the IVT for the tests though as they use a lot of "internal" types.

I've tried to limit the public API surface to the contract abstractions and the contract factories, at least as a starting baseline. I did make public all types used in the SOS-Dac interface implementation.