### PR TITLE
[browser] mono_wasm_enable_gc and pump_count cleanup

### DIFF
--- a/src/mono/browser/runtime/runtime.c
+++ b/src/mono/browser/runtime/runtime.c
@@ -62,8 +62,6 @@
 #define EMSCRIPTEN_KEEPALIVE
 #endif
 
-int mono_wasm_enable_gc = 1;
-
 /* Missing from public headers */
 char *mono_fixup_symbol_name (const char *prefix, const char *key, const char *suffix);
 void mono_icall_table_init (void);

--- a/src/mono/browser/runtime/runtime.h
+++ b/src/mono/browser/runtime/runtime.h
@@ -13,8 +13,6 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/debug-helpers.h>
 
-extern int mono_wasm_enable_gc;
-
 MonoDomain *mono_wasm_load_runtime_common (int debug_level, MonoLogCallback log_callback, const char *interp_opts);
 MonoAssembly *mono_wasm_assembly_load (const char *name);
 MonoClass *mono_wasm_assembly_find_class (MonoAssembly *assembly, const char *namespace, const char *name);

--- a/src/mono/browser/runtime/scheduling.ts
+++ b/src/mono/browser/runtime/scheduling.ts
@@ -8,7 +8,6 @@ import { Module, loaderHelpers } from "./globals";
 import { forceThreadMemoryViewRefresh } from "./memory";
 
 let spread_timers_maximum = 0;
-let pump_count = 0;
 
 export function prevent_timer_throttling (): void {
     if (WasmEnableThreads) return;
@@ -37,7 +36,6 @@ function prevent_timer_throttling_tick () {
     }
     try {
         cwraps.mono_wasm_execute_timer();
-        pump_count++;
     } catch (ex) {
         loaderHelpers.mono_exit(1, ex);
     }
@@ -46,24 +44,24 @@ function prevent_timer_throttling_tick () {
 
 function mono_background_exec_until_done () {
     if (WasmEnableThreads) return;
+    lastScheduledBackground = undefined;
     Module.maybeExit();
+    if (!loaderHelpers.is_runtime_running()) {
+        return;
+    }
     try {
-        while (pump_count > 0) {
-            --pump_count;
-            if (!loaderHelpers.is_runtime_running()) {
-                return;
-            }
-            cwraps.mono_background_exec();
-        }
+        cwraps.mono_background_exec();
     } catch (ex) {
         loaderHelpers.mono_exit(1, ex);
     }
 }
 
+let lastScheduledBackground: any = undefined;
 export function schedule_background_exec (): void {
     if (WasmEnableThreads) return;
-    ++pump_count;
-    Module.safeSetTimeout(mono_background_exec_until_done, 0);
+    if (!lastScheduledBackground) {
+        lastScheduledBackground = Module.safeSetTimeout(mono_background_exec_until_done, 0);
+    }
 }
 
 let lastScheduledTimeoutId: any = undefined;
@@ -86,7 +84,6 @@ function mono_wasm_schedule_timer_tick () {
     lastScheduledTimeoutId = undefined;
     try {
         cwraps.mono_wasm_execute_timer();
-        pump_count++;
     } catch (ex) {
         loaderHelpers.mono_exit(1, ex);
     }

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2067,10 +2067,6 @@ pin_handle_stack_interior_ptrs (void **ptr_slot, void *user_data)
 	sgen_conservatively_pin_objects_from (ptr_slot, ptr_slot+1, ud->start_nursery, ud->end_nursery, PIN_TYPE_STACK);
 }
 
-#if defined(HOST_WASM) || defined(HOST_WASI)
-extern gboolean mono_wasm_enable_gc;
-#endif
-
 /*
  * Mark from thread stacks and registers.
  */
@@ -2079,11 +2075,6 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 {
 	scan_area_arg_start = start_nursery;
 	scan_area_arg_end = end_nursery;
-#if defined(HOST_WASM) || defined(HOST_WASI)
-	//Under WASM we don't scan thread stacks and we can't trust the values we find there either.
-	if (!mono_wasm_enable_gc)
-		return;
-#endif
 
 	SGEN_TV_DECLARE (scan_thread_data_start);
 	SGEN_TV_DECLARE (scan_thread_data_end);

--- a/src/mono/mono/sgen/sgen-gc.c
+++ b/src/mono/mono/sgen/sgen-gc.c
@@ -2733,32 +2733,9 @@ gc_pump_callback (void)
 }
 #endif
 
-#if defined(HOST_BROWSER) || defined(HOST_WASI)
-extern gboolean mono_wasm_enable_gc;
-#endif
-
 void
 sgen_perform_collection (size_t requested_size, int generation_to_collect, const char *reason, gboolean forced_serial, gboolean stw)
 {
-#if defined(HOST_BROWSER) && defined(DISABLE_THREADS)
-	if (!mono_wasm_enable_gc) {
-		g_assert (stw); //can't handle non-stw mode (IE, domain unload)
-		//we ignore forced_serial
-
-		//There's a window for racing where we're executing other bg jobs before the GC, they trigger a GC request and it overrides this one.
-		//I belive this case to be benign as it will, in the worst case, upgrade a minor to a major collection.
-		if (gc_request.generation_to_collect <= generation_to_collect) {
-			gc_request.requested_size = requested_size;
-			gc_request.generation_to_collect = generation_to_collect;
-			gc_request.reason = reason;
-			sgen_client_schedule_background_job (gc_pump_callback);
-		}
-
-		sgen_degraded_mode = 1; //enable degraded mode so allocation can continue
-		return;
-	}
-#endif
-
 	sgen_perform_collection_inner (requested_size, generation_to_collect, reason, forced_serial, stw);
 }
 /*


### PR DESCRIPTION
- remove `mono_wasm_enable_gc` which is constantly true
- remove `pump_count` and make runtime to yield to browser event loop more often. Typically in async Task on the ThreadPool queue

Motivation:
`pump_count` was forcing synchronous execution of next round of jobs created during processing of current tick. 
After this change, we will yield to browser before resuming the processing of the job queue.
This gives browser a chance to deliver events, like on-click and network messages even when there is endless chain of `Task` spinning the thread pool.

Contributes to ST event pipe effort