### PR TITLE
don't run drawing tests on Mono

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -169,8 +169,8 @@ namespace System
             return !(bool)typeof(LambdaExpression).GetMethod("get_CanCompileToIL").Invoke(null, Array.Empty<object>());
         }
 
-        // Drawing is not supported on non windows platforms in .NET 7.0+.
-        public static bool IsDrawingSupported => IsWindows && IsNotWindowsNanoServer && IsNotWindowsServerCore;
+        // Drawing is not supported on non windows platforms in .NET 7.0+ and on Mono.
+        public static bool IsDrawingSupported => IsWindows && IsNotWindowsNanoServer && IsNotWindowsServerCore && IsNotMonoRuntime;
 
         public static bool IsAsyncFileIOSupported => !IsBrowser && !IsWasi;
 

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -67,7 +67,6 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
         [Theory]
         [SkipOnCoreClr("Takes too long on Checked", ~RuntimeConfiguration.Release)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/107553", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [MemberData(nameof(SerializableObjects_MemberData))]
         public void ValidateAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, false);


### PR DESCRIPTION
In #107553 a group of tests was failing because `Bitmap` is not supported on Mono.

```log
System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.ValidateAgainstBlobs [FAIL]
      System.TypeInitializationException : The type initializer for 'System.Drawing.DrawingCom' threw an exception.
      ---- System.PlatformNotSupportedException : Operation is not supported on this platform.
      Stack Trace:
           at System.Drawing.Bitmap..ctor(Stream stream, Boolean useIcm)
           at System.Drawing.Bitmap..ctor(Stream stream)
```

The code was already using a guard for that:

https://github.com/dotnet/runtime/blob/06a6ea78fbe99fd86f2f46df9b046cb4c4ea18a7/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTestData.cs#L1346-L1349

I decided to update the logic behind `PlatformDetection.IsDrawingSupported` as I assumed it's simply not supported and could help in other places. But I need a confirmation from @matouskozak or someone else from the Mono team.

fixes #107553