### PR TITLE
Adjust hashing in logging source gen

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -917,7 +917,8 @@ namespace Microsoft.Extensions.Logging.Generators
                 result = (c ^ result) * 16777619;
             }
 
-            return (int)(result & 0x7FFFFFFF); // Ensure the result is non-negative
+            int ret = (int)result;
+            return ret == int.MinValue ? 0 : Math.Abs(ret); // Ensure the result is non-negative
         }
     }
 }


### PR DESCRIPTION
We had the [fix](https://github.com/dotnet/runtime/pull/111073) to avoid having the hashing throw exception when using `Math.Abs`. The fix is not done in compatible way which will make the hashing generate different values than what it used to generate. The change here is to make hashing return the same value as it used to return.