### PR TITLE
Fix RhpCallCatchFunclet .text relocation on amd64.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.asm
@@ -532,7 +532,7 @@ endif
         ;; It was the ThreadAbortException, so rethrow it
         mov     rcx, STATUS_REDHAWK_THREAD_ABORT
         mov     rdx, rax                                            ;; rdx <- continuation address as exception RIP
-        mov     rax, RhpThrowHwEx                                   ;; Throw the ThreadAbortException as a special kind of hardware exception
+        lea     rax, [RhpThrowHwEx]                                 ;; Throw the ThreadAbortException as a special kind of hardware exception
 
         ;; reset RSP and jump to RAX
    @@:  mov     rsp, r8                                             ;; reset the SP to resume SP value


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/c8e4f2c465696477ab123a602ff12e8c0996d968 changed asm implementation in `RhpThrowHwEx` on amd64 from a relative jump, using `jmp RhpThrowHwEx` to a` mov rax, RhpThrowHwEx` that is later jumped to using `jmp rax`.

This introduce an `ADDR64` relocation record in the generated object file:

`000004EC  ADDR64            00000000 00000000        2A  RhpThrowHwEx`

That will then be left as a relocation that needs to be fixed up by the loader:

```
73000 RVA,        C SizeOfBlock
     F7C  DIR64      0000000140073A90  RhpThrowHwEx
       0  ABS
```

Where the RVA 73000 is part of the .text section that is read, execute section.

Having relocations done to the .text section is however not supported on all Windows platform configurations leading to loader errors blocking use of nativeaot on these configurations.

This commit change the mov to a `lea` instruction using relative offset to calculate address of `RhpThrowHwEx`. That will end up with a `REL32` relocation record in the generated object file:

`000004ED  REL32                      00000000        2A  RhpThrowHwEx`

Since this uses relative addressing it won't leave any relocation in the final image making sure the generated nativeaot image can be successfully loaded on Windows platforms configurations that prevents relocations to .text section.