### PR TITLE
Use alternative format string specifier to ensure decimal point is present

### DIFF
--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -1914,7 +1914,7 @@ BYTE* PrettyPrintCABlobValue(PCCOR_SIGNATURE &typePtr,
                 for(n=0; n < numElements; n++)
                 {
                     if(n) appendStr(out," ");
-                    sprintf_s(str, 64, "%.*g", 8, (double)(*((float*)dataPtr)));
+                    sprintf_s(str, 64, "%#.8g", (double)(*((float*)dataPtr)));
                     float df = (float)atof(str);
                     // Must compare as underlying bytes, not floating point otherwise optimizer will
                     // try to enregister and compare 80-bit precision number with 32-bit precision number!!!!
@@ -1933,7 +1933,7 @@ BYTE* PrettyPrintCABlobValue(PCCOR_SIGNATURE &typePtr,
                 {
                     if(n) appendStr(out," ");
                     char *pch;
-                    sprintf_s(str, 64, "%.*g", 17, *((double*)dataPtr));
+                    sprintf_s(str, 64, "%#.17g", *((double*)dataPtr));
                     double df = strtod(str, &pch);
                     // Must compare as underlying bytes, not floating point otherwise optimizer will
                     // try to enregister and compare 80-bit precision number with 64-bit precision number!!!!
@@ -2608,7 +2608,7 @@ void DumpDefaultValue(mdToken tok, __inout __nullterminated char* szString, void
         case ELEMENT_TYPE_R4:
             {
                 char szf[32];
-                sprintf_s(szf, 32, "%.*g", 8, (double)MDDV.m_fltValue);
+                sprintf_s(szf, 32, "%#.8g", (double)MDDV.m_fltValue);
                 float df = (float)atof(szf);
                 // Must compare as underlying bytes, not floating point otherwise optimizer will
                 // try to enregister and compare 80-bit precision number with 32-bit precision number!!!!
@@ -2622,7 +2622,7 @@ void DumpDefaultValue(mdToken tok, __inout __nullterminated char* szString, void
         case ELEMENT_TYPE_R8:
             {
                 char szf[32], *pch;
-                sprintf_s(szf, 32, "%.*g", 17, MDDV.m_dblValue);
+                sprintf_s(szf, 32, "%#.17g", MDDV.m_dblValue);
                 double df = strtod(szf, &pch); //atof(szf);
                 szf[31]=0;
                 // Must compare as underlying bytes, not floating point otherwise optimizer will


### PR DESCRIPTION
After this change, ildasm will generate the following:

```
.class public abstract auto ansi sealed beforefieldinit Program
       extends [System.Runtime]System.Object
{
  .field public static literal float64 ValueDoubleOne = float64(1.0000000000000000)
  .field public static literal float64 ValueDoubleOnePointTwo = float64(1.2000000000000000)
  .field public static literal float64 ValueDoubleMinusOne = float64(-1.0000000000000000)
  .field public static literal float64 ValueDoubleMinusZero = float64(-0.0000000000000000)
  .field public static literal float32 ValueFloatOne = float32(1.0000000)
  .field public static literal float32 ValueFloatOnePointTwo = float32(1.2000000)
  .field public static literal float32 ValueFloatMinusOne = float32(-1.0000000)
  .field public static literal float32 ValueFloatMinusZero = float32(-0.0000000)
} // end of class Program
```

Fixes https://github.com/dotnet/runtime/issues/111014