### PR TITLE
[browser] Remove dotnet-experimental feed from sources

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -11,12 +11,11 @@
     <WasmRuntimeAssetsLocation>./</WasmRuntimeAssetsLocation>
   </PropertyGroup>
 
-  <!-- NativeAOT -->
+  <!-- NativeAOT (needs configuration of additional feeds to properly restore packages) -->
   <PropertyGroup Condition="'$(UsingNativeAOT)' == 'true'">
     <PublishTrimmed>true</PublishTrimmed>
     <PublishDir>$(MSBuildThisFileDirectory)/bin/$(Configuration)/AppBundle</PublishDir>
     <DebugType>none</DebugType>
-    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json</RestoreAdditionalProjectSources>
     <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
     <UsingWasiRuntimeWorkload>false</UsingWasiRuntimeWorkload>
     <UsingEmscriptenWorkload>true</UsingEmscriptenWorkload>


### PR DESCRIPTION
Based on https://github.com/dotnet/runtime/pull/110611/files/7e93640a095be8446c7dc5eea4843d49bcae53df#r1884658779