### PR TITLE
[System.Diagnostics.DiagnosticSource.Activity] Reset recorded flag when creating activity when not requested by sampler(s)

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1244,6 +1244,12 @@ namespace System.Diagnostics
             {
                 activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
             }
+            else
+            {
+                // Note: Recorded may be inherited from the parent so it needs
+                // to be cleared for the Activity being created when not desired
+                activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+            }
 
             if (startTime != default)
             {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1233,7 +1233,9 @@ namespace System.Diagnostics
                     activity._parentSpanId = parentContext.SpanId.ToString();
                 }
 
-                activity.ActivityTraceFlags = parentContext.TraceFlags;
+                // Note: Don't inherit Recorded from parent as it is set below
+                // based on sampling decision
+                activity.ActivityTraceFlags = parentContext.TraceFlags & ~ActivityTraceFlags.Recorded;
                 activity._parentTraceFlags = (byte)parentContext.TraceFlags;
                 activity.HasRemoteParent = parentContext.IsRemote;
             }
@@ -1243,12 +1245,6 @@ namespace System.Diagnostics
             if (request == ActivitySamplingResult.AllDataAndRecorded)
             {
                 activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-            }
-            else
-            {
-                // Note: Recorded may be inherited from the parent so it needs
-                // to be cleared for the Activity being created when not desired
-                activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
             }
 
             if (startTime != default)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -486,7 +486,10 @@ namespace System.Diagnostics.Tests
 
                     Assert.Equal(ctx.TraceId, activity.TraceId);
                     Assert.Equal(ctx.SpanId, activity.ParentSpanId);
-                    Assert.Equal(ctx.TraceFlags, activity.ActivityTraceFlags);
+                    Assert.NotEqual(ctx.TraceFlags, activity.ActivityTraceFlags);
+                    Assert.True(ctx.TraceFlags.HasFlag(ActivityTraceFlags.Recorded));
+                    Assert.False(activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded));
+                    Assert.False(activity.Recorded);
                     Assert.Equal(ctx.TraceState, activity.TraceStateString);
                     Assert.Equal(ActivityIdFormat.W3C, activity.IdFormat);
 


### PR DESCRIPTION
## Changes

* Reset `ActivityTraceFlags.Recorded` when creating activity if not requested by sampler(s) because it may be inherited from a parent

## Details

[Ran into this while working on [#6058](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6058).]

Scenario:

* We have an incoming request with `traceparent` marked as `Recorded`.
* OTel sampler decides to drop for whatever reason.
* Because this is a root, even though a drop was requested, OTel SDK will still create a propagation-only span/activity.
* Here is the issue: The created span/activity [inherits recorded from the parent context](https://github.com/dotnet/runtime/blob/bc2ac2f3d51ee9ee58a01ee17ac254ac09e5f3cd/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs#L1236) and therefore has `Recorded=true`. A propagation-only span should have `Recorded=false`.

/cc @tarekgh @noahfalk @samsp-msft @cijothomas @alanwest 