### PR TITLE
Fix accidentally duplicated global-build-step.yml in runtime-official.yml

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -87,7 +87,6 @@ extends:
               parameters:
                 buildArgs: -s clr.corelib+clr.nativecorelib+clr.nativeaotlibs+clr.tools+clr.packages+mono+libs+host+packs -c $(_BuildConfig) /p:DotNetBuildAllRuntimePacks=true
                 displayName: Build managed CoreCLR components, Mono, all libraries, hosts, and packs
-            - template: /eng/pipelines/common/templates/global-build-step.yml
 
             # Upload the results.
             - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml


### PR DESCRIPTION
Regressed with https://github.com/dotnet/runtime/pull/111136

I noticed because a second "Build product" step got injected that was building Debug in runtime-official