### PR TITLE
Fix Encoding regression

### DIFF
--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
@@ -68,14 +68,16 @@ namespace System.Text
             return AddChar(ch, 1);
         }
 
-
         internal unsafe bool AddChar(char ch1, char ch2, int numBytes)
         {
+            if (_chars is null)
+            {
+                _charCountResult += 2;
+                return true;
+            }
+
             // Need room for 2 chars
-            // It is possible for `_chars` to be null, and in such cases, `_charEnd` will also be null.
-            // Performing `_charEnd - 1` will result in an underflow, but this is acceptable because the operation is intended to count characters without storing them in any buffer,
-            // and we want to avoid throwing an exception in this scenario.
-            if (_chars >= _charEnd - 1)
+            if (_charEnd - _chars < 2)
             {
                 // Throw maybe
                 _bytes -= numBytes;                                        // Didn't encode these bytes

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
@@ -72,7 +72,10 @@ namespace System.Text
         internal unsafe bool AddChar(char ch1, char ch2, int numBytes)
         {
             // Need room for 2 chars
-            if (_charEnd - _chars < 2)
+            // It is possible for `_chars` to be null, and in such cases, `_charEnd` will also be null.
+            // Performing `_charEnd - 1` will result in an underflow, but this is acceptable because the operation is intended to count characters without storing them in any buffer,
+            // and we want to avoid throwing an exception in this scenario.
+            if (_chars >= _charEnd - 1)
             {
                 // Throw maybe
                 _bytes -= numBytes;                                        // Didn't encode these bytes

--- a/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -519,6 +519,7 @@ namespace System.Text.Tests
             Assert.Contains(mappedEncoding, CrossplatformDefaultEncodings().Union(CodePageInfo().Select(i => Map((int)i[0], (string)i[1]))));
 
             TestRegister1252();
+            TestMultiBytesEncodingsSupportSurrogate();
         }
 
         private static void ValidateDefaultEncodings()
@@ -639,8 +640,7 @@ namespace System.Text.Tests
             Assert.All(name, c => Assert.True(c >= ' ' && c < '~' + 1, "Name: " + name + " contains character: " + c));
         }
 
-        [Fact]
-        public static void TestMultiBytesEncodingsSupportSurrogate()
+        private static void TestMultiBytesEncodingsSupportSurrogate()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 

--- a/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -639,6 +639,24 @@ namespace System.Text.Tests
             Assert.All(name, c => Assert.True(c >= ' ' && c < '~' + 1, "Name: " + name + " contains character: " + c));
         }
 
+        [Fact]
+        public static void TestMultiBytesEncodingsSupportSurrogate()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            Encoding encoding = Encoding.GetEncoding("GB18030");
+            Assert.NotNull(encoding);
+
+            string surrogatePair = "\uD840\uDE13"; // Surrogate Pair codepoint '𠈓' \U00020213
+            byte[] expectedBytes = new byte[] { 0x95, 0x32, 0xB7, 0x37 };
+
+            Assert.Equal(expectedBytes, encoding.GetBytes(surrogatePair));
+            Assert.Equal(expectedBytes.Length, encoding.GetByteCount(surrogatePair));
+
+            Assert.Equal(surrogatePair, encoding.GetString(expectedBytes));
+            Assert.Equal(surrogatePair.Length, encoding.GetCharCount(expectedBytes));
+        }
+
         // This test is run as part of the default mappings test, since it modifies global state which that test
         // depends on.
         private static void TestRegister1252()


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/110521

The change here is fixing a regression from the change https://github.com/dotnet/runtime/pull/97950. 
The regression occurs in the multi-byte encoding when handling a surrogate pair. It incorrectly throws an exception when the character buffer is null, which is not the expected behavior. The code should be resilient to a null buffer, avoiding exceptions and instead returning only the count of the decoded characters.

The change is not reverting https://github.com/dotnet/runtime/pull/97950 as the rest of the changes are beneficial.