### PR TITLE
Disable polyrec test on native AOT

### DIFF
--- a/src/tests/Loader/regressions/polyrec/Polyrec.csproj
+++ b/src/tests/Loader/regressions/polyrec/Polyrec.csproj
@@ -3,6 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- This test leaves threads running at exit -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Deep generic recursion -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="polyrec.cs" />


### PR DESCRIPTION
This has a deep generic recursion that generates throwing code. It also uses threads so the unhandled exception crashes the merged test runner instead of being reported as a failure. The reporting at the end of test run then reports 0 failing test. I assume this would still be failing in Helix, so it's not a big deal, but I missed a couple failing tests from the Loader tree that I need to bucket.