### PR TITLE
Refactor geometric type converters for improved parsing

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/PointConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/PointConverter.cs
@@ -26,7 +26,7 @@ namespace System.Drawing
         {
             if (value is string strValue)
             {
-                string text = strValue.Trim();
+                ReadOnlySpan<char> text = strValue.AsSpan().Trim();
                 if (text.Length == 0)
                 {
                     return null;
@@ -37,10 +37,10 @@ namespace System.Drawing
 
                 string sep = culture.TextInfo.ListSeparator;
                 Span<Range> ranges = stackalloc Range[3];
-                int rangesCount = text.AsSpan().Split(ranges, sep);
+                int rangesCount = text.Split(ranges, sep);
                 if (rangesCount != 2)
                 {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"x{sep} y"));
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text.ToString(), $"x{sep} y"));
                 }
 
                 TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/PointConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/PointConverter.cs
@@ -63,16 +63,14 @@ namespace System.Drawing
                 {
                     culture ??= CultureInfo.CurrentCulture;
 
-                    string sep = culture.TextInfo.ListSeparator + " ";
+                    string sep = culture.TextInfo.ListSeparator;
                     TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
 
                     // Note: ConvertFromString will raise exception if value cannot be converted.
-                    string?[] args =
-                    [
-                        intConverter.ConvertToString(context, culture, pt.X),
-                        intConverter.ConvertToString(context, culture, pt.Y)
-                    ];
-                    return string.Join(sep, args);
+                    string? x = intConverter.ConvertToString(context, culture, pt.X);
+                    string? y = intConverter.ConvertToString(context, culture, pt.Y);
+
+                    return $"{x}{sep} {y}";
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/PointConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/PointConverter.cs
@@ -35,24 +35,19 @@ namespace System.Drawing
                 // Parse 2 integer values.
                 culture ??= CultureInfo.CurrentCulture;
 
-                char sep = culture.TextInfo.ListSeparator[0];
-                string[] tokens = text.Split(sep);
-                int[] values = new int[tokens.Length];
-                TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
-                for (int i = 0; i < values.Length; i++)
+                string sep = culture.TextInfo.ListSeparator;
+                Span<Range> ranges = stackalloc Range[3];
+                int rangesCount = text.AsSpan().Split(ranges, sep);
+                if (rangesCount != 2)
                 {
-                    // Note: ConvertFromString will raise exception if value cannot be converted.
-                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"x{sep} y"));
                 }
 
-                if (values.Length == 2)
-                {
-                    return new Point(values[0], values[1]);
-                }
-                else
-                {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, "x, y"));
-                }
+                TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
+                int x = (int)converter.ConvertFromString(context, culture, strValue[ranges[0]])!;
+                int y = (int)converter.ConvertFromString(context, culture, strValue[ranges[1]])!;
+
+                return new Point(x, y);
             }
 
             return base.ConvertFrom(context, culture, value);
@@ -72,16 +67,16 @@ namespace System.Drawing
                     TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
 
                     // Note: ConvertFromString will raise exception if value cannot be converted.
-                    var args = new string?[]
-                    {
+                    string?[] args =
+                    [
                         intConverter.ConvertToString(context, culture, pt.X),
                         intConverter.ConvertToString(context, culture, pt.Y)
-                    };
+                    ];
                     return string.Join(sep, args);
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {
-                    ConstructorInfo? ctor = typeof(Point).GetConstructor(new Type[] { typeof(int), typeof(int) });
+                    ConstructorInfo? ctor = typeof(Point).GetConstructor([typeof(int), typeof(int)]);
                     if (ctor != null)
                     {
                         return new InstanceDescriptor(ctor, new object[] { pt.X, pt.Y });
@@ -109,7 +104,7 @@ namespace System.Drawing
 
         public override bool GetCreateInstanceSupported(ITypeDescriptorContext? context) => true;
 
-        private static readonly string[] s_propertySort = { "X", "Y" };
+        private static readonly string[] s_propertySort = ["X", "Y"];
 
         [RequiresUnreferencedCode("The Type of value cannot be statically discovered. " + AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object? value, Attribute[]? attributes)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/RectangleConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/RectangleConverter.cs
@@ -65,18 +65,16 @@ namespace System.Drawing
                 {
                     culture ??= CultureInfo.CurrentCulture;
 
-                    string sep = culture.TextInfo.ListSeparator + " ";
+                    string sep = culture.TextInfo.ListSeparator;
                     TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
 
                     // Note: ConvertToString will raise exception if value cannot be converted.
-                    string?[] args =
-                    [
-                        intConverter.ConvertToString(context, culture, rect.X),
-                        intConverter.ConvertToString(context, culture, rect.Y),
-                        intConverter.ConvertToString(context, culture, rect.Width),
-                        intConverter.ConvertToString(context, culture, rect.Height)
-                    ];
-                    return string.Join(sep, args);
+                    string? x = intConverter.ConvertToString(context, culture, rect.X);
+                    string? y = intConverter.ConvertToString(context, culture, rect.Y);
+                    string? width = intConverter.ConvertToString(context, culture, rect.Width);
+                    string? height = intConverter.ConvertToString(context, culture, rect.Height);
+
+                    return $"{x}{sep} {y}{sep} {width}{sep} {height}";
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/RectangleConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/RectangleConverter.cs
@@ -35,22 +35,21 @@ namespace System.Drawing
                 // Parse 4 integer values.
                 culture ??= CultureInfo.CurrentCulture;
 
-                char sep = culture.TextInfo.ListSeparator[0];
-                string[] tokens = text.Split(sep);
-                int[] values = new int[tokens.Length];
-                TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
-                for (int i = 0; i < values.Length; i++)
+                string sep = culture.TextInfo.ListSeparator;
+                Span<Range> ranges = stackalloc Range[5];
+                int rangesCount = text.AsSpan().Split(ranges, sep);
+                if (rangesCount != 4)
                 {
-                    // Note: ConvertFromString will raise exception if value cannot be converted.
-                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"x{sep} y{sep} width{sep} height"));
                 }
 
-                if (values.Length != 4)
-                {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, "x, y, width, height"));
-                }
+                TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
+                int x = (int)converter.ConvertFromString(context, culture, strValue[ranges[0]])!;
+                int y = (int)converter.ConvertFromString(context, culture, strValue[ranges[1]])!;
+                int width = (int)converter.ConvertFromString(context, culture, strValue[ranges[2]])!;
+                int height = (int)converter.ConvertFromString(context, culture, strValue[ranges[3]])!;
 
-                return new Rectangle(values[0], values[1], values[2], values[3]);
+                return new Rectangle(x, y, width, height);
             }
 
             return base.ConvertFrom(context, culture, value);
@@ -70,19 +69,19 @@ namespace System.Drawing
                     TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
 
                     // Note: ConvertToString will raise exception if value cannot be converted.
-                    var args = new string?[]
-                    {
+                    string?[] args =
+                    [
                         intConverter.ConvertToString(context, culture, rect.X),
                         intConverter.ConvertToString(context, culture, rect.Y),
                         intConverter.ConvertToString(context, culture, rect.Width),
                         intConverter.ConvertToString(context, culture, rect.Height)
-                    };
+                    ];
                     return string.Join(sep, args);
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {
-                    ConstructorInfo? ctor = typeof(Rectangle).GetConstructor(new Type[] {
-                        typeof(int), typeof(int), typeof(int), typeof(int)});
+                    ConstructorInfo? ctor = typeof(Rectangle).GetConstructor(
+                        [typeof(int), typeof(int), typeof(int), typeof(int)]);
 
                     if (ctor != null)
                     {
@@ -115,7 +114,7 @@ namespace System.Drawing
 
         public override bool GetCreateInstanceSupported(ITypeDescriptorContext? context) => true;
 
-        private static readonly string[] s_propertySort = { "X", "Y", "Width", "Height" };
+        private static readonly string[] s_propertySort = ["X", "Y", "Width", "Height"];
 
         [RequiresUnreferencedCode("The Type of value cannot be statically discovered. " + AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object? value, Attribute[]? attributes)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/RectangleConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/RectangleConverter.cs
@@ -26,7 +26,7 @@ namespace System.Drawing
         {
             if (value is string strValue)
             {
-                string text = strValue.Trim();
+                ReadOnlySpan<char> text = strValue.AsSpan().Trim();
                 if (text.Length == 0)
                 {
                     return null;
@@ -37,10 +37,10 @@ namespace System.Drawing
 
                 string sep = culture.TextInfo.ListSeparator;
                 Span<Range> ranges = stackalloc Range[5];
-                int rangesCount = text.AsSpan().Split(ranges, sep);
+                int rangesCount = text.Split(ranges, sep);
                 if (rangesCount != 4)
                 {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"x{sep} y{sep} width{sep} height"));
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text.ToString(), $"x{sep} y{sep} width{sep} height"));
                 }
 
                 TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeConverter.cs
@@ -63,16 +63,14 @@ namespace System.Drawing
                 {
                     culture ??= CultureInfo.CurrentCulture;
 
-                    string sep = culture.TextInfo.ListSeparator + " ";
+                    string sep = culture.TextInfo.ListSeparator;
                     TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
 
                     // Note: ConvertToString will raise exception if value cannot be converted.
-                    string?[] args =
-                    [
-                        intConverter.ConvertToString(context, culture, size.Width),
-                        intConverter.ConvertToString(context, culture, size.Height)
-                    ];
-                    return string.Join(sep, args);
+                    string? width = intConverter.ConvertToString(context, culture, size.Width);
+                    string? height = intConverter.ConvertToString(context, culture, size.Height);
+
+                    return $"{width}{sep} {height}";
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeConverter.cs
@@ -26,7 +26,7 @@ namespace System.Drawing
         {
             if (value is string strValue)
             {
-                string text = strValue.Trim();
+                ReadOnlySpan<char> text = strValue.AsSpan().Trim();
                 if (text.Length == 0)
                 {
                     return null;
@@ -37,10 +37,10 @@ namespace System.Drawing
 
                 string sep = culture.TextInfo.ListSeparator;
                 Span<Range> ranges = stackalloc Range[3];
-                int rangesCount = text.AsSpan().Split(ranges, sep);
+                int rangesCount = text.Split(ranges, sep);
                 if (rangesCount != 2)
                 {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"Width{sep} Height"));
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text.ToString(), $"Width{sep} Height"));
                 }
 
                 TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeConverter.cs
@@ -35,22 +35,19 @@ namespace System.Drawing
                 // Parse 2 integer values.
                 culture ??= CultureInfo.CurrentCulture;
 
-                char sep = culture.TextInfo.ListSeparator[0];
-                string[] tokens = text.Split(sep);
-                int[] values = new int[tokens.Length];
-                TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
-                for (int i = 0; i < values.Length; i++)
+                string sep = culture.TextInfo.ListSeparator;
+                Span<Range> ranges = stackalloc Range[3];
+                int rangesCount = text.AsSpan().Split(ranges, sep);
+                if (rangesCount != 2)
                 {
-                    // Note: ConvertFromString will raise exception if value cannot be converted.
-                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"Width{sep} Height"));
                 }
 
-                if (values.Length != 2)
-                {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, "Width,Height"));
-                }
+                TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
+                int width = (int)converter.ConvertFromString(context, culture, strValue[ranges[0]])!;
+                int height = (int)converter.ConvertFromString(context, culture, strValue[ranges[1]])!;
 
-                return new Size(values[0], values[1]);
+                return new Size(width, height);
             }
 
             return base.ConvertFrom(context, culture, value);
@@ -70,16 +67,16 @@ namespace System.Drawing
                     TypeConverter intConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(int));
 
                     // Note: ConvertToString will raise exception if value cannot be converted.
-                    var args = new string?[]
-                    {
+                    string?[] args =
+                    [
                         intConverter.ConvertToString(context, culture, size.Width),
                         intConverter.ConvertToString(context, culture, size.Height)
-                    };
+                    ];
                     return string.Join(sep, args);
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {
-                    ConstructorInfo? ctor = typeof(Size).GetConstructor(new Type[] { typeof(int), typeof(int) });
+                    ConstructorInfo? ctor = typeof(Size).GetConstructor([typeof(int), typeof(int)]);
                     if (ctor != null)
                     {
                         return new InstanceDescriptor(ctor, new object[] { size.Width, size.Height });
@@ -107,7 +104,7 @@ namespace System.Drawing
 
         public override bool GetCreateInstanceSupported(ITypeDescriptorContext? context) => true;
 
-        private static readonly string[] s_propertySort = { "Width", "Height" };
+        private static readonly string[] s_propertySort = ["Width", "Height"];
 
         [RequiresUnreferencedCode("The Type of value cannot be statically discovered. " + AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeFConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeFConverter.cs
@@ -63,14 +63,12 @@ namespace System.Drawing
                 {
                     culture ??= CultureInfo.CurrentCulture;
 
-                    string sep = culture.TextInfo.ListSeparator + " ";
+                    string sep = culture.TextInfo.ListSeparator;
                     TypeConverter floatConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(float));
-                    string?[] args =
-                    [
-                        floatConverter.ConvertToString(context, culture, size.Width),
-                        floatConverter.ConvertToString(context, culture, size.Height)
-                    ];
-                    return string.Join(sep, args);
+                    string? width = floatConverter.ConvertToString(context, culture, size.Width);
+                    string? height = floatConverter.ConvertToString(context, culture, size.Height);
+
+                    return $"{width}{sep} {height}";
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeFConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeFConverter.cs
@@ -35,21 +35,19 @@ namespace System.Drawing
                 // Parse 2 integer values.
                 culture ??= CultureInfo.CurrentCulture;
 
-                char sep = culture.TextInfo.ListSeparator[0];
-                string[] tokens = text.Split(sep);
-                float[] values = new float[tokens.Length];
-                TypeConverter floatConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(float));
-                for (int i = 0; i < values.Length; i++)
+                string sep = culture.TextInfo.ListSeparator;
+                Span<Range> ranges = stackalloc Range[3];
+                int rangesCount = text.AsSpan().Split(ranges, sep);
+                if (rangesCount != 2)
                 {
-                    values[i] = (float)floatConverter.ConvertFromString(context, culture, tokens[i])!;
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"Width{sep} Height"));
                 }
 
-                if (values.Length != 2)
-                {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, "Width,Height"));
-                }
+                TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(float));
+                float width = (float)converter.ConvertFromString(context, culture, strValue[ranges[0]])!;
+                float height = (float)converter.ConvertFromString(context, culture, strValue[ranges[1]])!;
 
-                return new SizeF(values[0], values[1]);
+                return new SizeF(width, height);
             }
 
             return base.ConvertFrom(context, culture, value);
@@ -67,16 +65,16 @@ namespace System.Drawing
 
                     string sep = culture.TextInfo.ListSeparator + " ";
                     TypeConverter floatConverter = TypeDescriptor.GetConverterTrimUnsafe(typeof(float));
-                    var args = new string?[]
-                    {
+                    string?[] args =
+                    [
                         floatConverter.ConvertToString(context, culture, size.Width),
                         floatConverter.ConvertToString(context, culture, size.Height)
-                    };
+                    ];
                     return string.Join(sep, args);
                 }
                 else if (destinationType == typeof(InstanceDescriptor))
                 {
-                    ConstructorInfo? ctor = typeof(SizeF).GetConstructor(new Type[] { typeof(float), typeof(float) });
+                    ConstructorInfo? ctor = typeof(SizeF).GetConstructor([typeof(float), typeof(float)]);
                     if (ctor != null)
                     {
                         return new InstanceDescriptor(ctor, new object[] { size.Width, size.Height });
@@ -104,7 +102,7 @@ namespace System.Drawing
 
         public override bool GetCreateInstanceSupported(ITypeDescriptorContext? context) => true;
 
-        private static readonly string[] s_propertySort = { "Width", "Height" };
+        private static readonly string[] s_propertySort = ["Width", "Height"];
 
         [RequiresUnreferencedCode("The Type of value cannot be statically discovered. " + AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeFConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Drawing/SizeFConverter.cs
@@ -26,7 +26,7 @@ namespace System.Drawing
         {
             if (value is string strValue)
             {
-                string text = strValue.Trim();
+                ReadOnlySpan<char> text = strValue.AsSpan().Trim();
                 if (text.Length == 0)
                 {
                     return null;
@@ -37,10 +37,10 @@ namespace System.Drawing
 
                 string sep = culture.TextInfo.ListSeparator;
                 Span<Range> ranges = stackalloc Range[3];
-                int rangesCount = text.AsSpan().Split(ranges, sep);
+                int rangesCount = text.Split(ranges, sep);
                 if (rangesCount != 2)
                 {
-                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, $"Width{sep} Height"));
+                    throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text.ToString(), $"Width{sep} Height"));
                 }
 
                 TypeConverter converter = TypeDescriptor.GetConverterTrimUnsafe(typeof(float));

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Drawing/SizeConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Drawing/SizeConverterTests.cs
@@ -80,18 +80,17 @@ namespace System.ComponentModel.TypeConverterTests
         }
 
         public static IEnumerable<object[]> SizeData =>
-            new[]
-            {
-                new object[] {0, 0},
-                new object[] {1, 1},
-                new object[] {-1, 1},
-                new object[] {1, -1},
-                new object[] {-1, -1},
-                new object[] {int.MaxValue, int.MaxValue},
-                new object[] {int.MinValue, int.MaxValue},
-                new object[] {int.MaxValue, int.MinValue},
-                new object[] {int.MinValue, int.MinValue},
-            };
+            [
+                [0, 1],
+                [1, 0],
+                [-1, 1],
+                [1, -1],
+                [-1, -2],
+                [int.MaxValue, int.MaxValue - 1],
+                [int.MinValue, int.MaxValue],
+                [int.MaxValue, int.MinValue],
+                [int.MinValue, int.MinValue + 1],
+            ];
 
         [Theory]
         [MemberData(nameof(SizeData))]
@@ -102,7 +101,9 @@ namespace System.ComponentModel.TypeConverterTests
 
         [Theory]
         [InlineData("1")]
-        [InlineData("1, 1, 1")]
+        [InlineData("*1")]
+        [InlineData("1, 2, 3")]
+        [InlineData("*1, 2, 3")]
         public void ConvertFrom_ArgumentException(string value)
         {
             ConvertFromThrowsArgumentExceptionForString(value);
@@ -112,6 +113,14 @@ namespace System.ComponentModel.TypeConverterTests
         public void ConvertFrom_Invalid()
         {
             ConvertFromThrowsFormatInnerExceptionForString("*1, 1");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" \t ")]
+        public void ConvertFrom_WhiteSpace(string value)
+        {
+            Assert.Null(Converter.ConvertFromString(value));
         }
 
         public static IEnumerable<object[]> ConvertFrom_NotSupportedData =>
@@ -153,7 +162,7 @@ namespace System.ComponentModel.TypeConverterTests
         public void ConvertTo_NullCulture()
         {
             string listSep = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
-            Assert.Equal($"1{listSep} 1", Converter.ConvertTo(null, null, new Size(1, 1), typeof(string)));
+            Assert.Equal($"1{listSep} 2", Converter.ConvertTo(null, null, new Size(1, 2), typeof(string)));
         }
 
         [Fact]
@@ -172,31 +181,31 @@ namespace System.ComponentModel.TypeConverterTests
         [Fact]
         public void GetProperties()
         {
-            var pt = new Size(1, 1);
-            var props = Converter.GetProperties(new Size(1, 1));
+            var pt = new Size(1, 2);
+            var props = Converter.GetProperties(new Size(3, 4));
             Assert.Equal(2, props.Count);
             Assert.Equal(1, props["Width"].GetValue(pt));
-            Assert.Equal(1, props["Height"].GetValue(pt));
+            Assert.Equal(2, props["Height"].GetValue(pt));
 
-            props = Converter.GetProperties(null, new Size(1, 1));
+            props = Converter.GetProperties(null, new Size(3, 4));
             Assert.Equal(2, props.Count);
             Assert.Equal(1, props["Width"].GetValue(pt));
-            Assert.Equal(1, props["Height"].GetValue(pt));
+            Assert.Equal(2, props["Height"].GetValue(pt));
 
-            props = Converter.GetProperties(null, new Size(1, 1), null);
+            props = Converter.GetProperties(null, new Size(3, 4), null);
             Assert.Equal(3, props.Count);
             Assert.Equal(1, props["Width"].GetValue(pt));
-            Assert.Equal(1, props["Height"].GetValue(pt));
+            Assert.Equal(2, props["Height"].GetValue(pt));
             Assert.Equal((object)false, props["IsEmpty"].GetValue(pt));
 
-            props = Converter.GetProperties(null, new Size(1, 1), new Attribute[0]);
+            props = Converter.GetProperties(null, new Size(3, 4), new Attribute[0]);
             Assert.Equal(3, props.Count);
             Assert.Equal(1, props["Width"].GetValue(pt));
-            Assert.Equal(1, props["Height"].GetValue(pt));
+            Assert.Equal(2, props["Height"].GetValue(pt));
             Assert.Equal((object)false, props["IsEmpty"].GetValue(pt));
 
             // Pick an attribute that cannot be applied to properties to make sure everything gets filtered
-            props = Converter.GetProperties(null, new Size(1, 1), new Attribute[] { new System.Reflection.AssemblyCopyrightAttribute("")});
+            props = Converter.GetProperties(null, new Size(3, 4), new Attribute[] { new System.Reflection.AssemblyCopyrightAttribute("")});
             Assert.Equal(0, props.Count);
         }
 
@@ -218,7 +227,7 @@ namespace System.ComponentModel.TypeConverterTests
         [Fact]
         public void ConvertFromInvariantString_FormatException()
         {
-            ConvertFromInvariantStringThrowsFormatInnerException("hello");
+            ConvertFromInvariantStringThrowsFormatInnerException("hello, hello");
         }
 
         [Theory]
@@ -241,7 +250,8 @@ namespace System.ComponentModel.TypeConverterTests
         [Fact]
         public void ConvertFromString_FormatException()
         {
-            ConvertFromStringThrowsFormatInnerException("hello");
+            var sep = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+            ConvertFromStringThrowsFormatInnerException($"hello{sep} hello");
         }
 
         [Theory]


### PR DESCRIPTION
Close #92424

This commit refactors the parsing logic for string representations of geometric types (Point, Rectangle, Size, SizeF) by using `Span<Range>` to enhance performance and reduce memory allocations.

Exception handling has been improved with more specific error messages for parsing failures.

Additionally, tests have been updated to reflect changes in expected values and formats, covering a wider range of cases, including edge cases and whitespace handling.

The syntax for array initialization has been modernized to use collection initializers for better readability.

Overall, these changes enhance the robustness, readability, and performance of the type conversion code.