### PR TITLE
[debugger] Fix crash while Func Eval in an async break

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -15075,6 +15075,11 @@ HRESULT Debugger::FuncEvalSetup(DebuggerIPCE_FuncEvalInfo *pEvalInfo,
         return CORDBG_E_ILLEGAL_IN_STACK_OVERFLOW;
     }
 
+    if (pThread->m_hasPendingActivation)
+    {
+        return CORDBG_E_ILLEGAL_AT_APC_CALLBACK;
+    }
+
     bool fInException = pEvalInfo->evalDuringException;
 
     // The thread has to be at a GC safe place for now, just in case the func eval causes a collection. Processing an

--- a/src/coreclr/inc/corerror.xml
+++ b/src/coreclr/inc/corerror.xml
@@ -1853,9 +1853,15 @@
 </HRESULT>
 
 <HRESULT NumericValue="0x80131c26">
-	<SymbolicName>CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE</SymbolicName>
-	<Message>"The operation failed because the thread is in optimized code."</Message>
-	<Comment> The operation failed because the thread is in optimized code. </Comment>
+	<SymbolicName>CORDBG_E_ILLEGAL_AT_APC_CALLBACK</SymbolicName>
+	<Message>"The operation failed because the thread was paused in an APC."</Message>
+	<Comment> The operation failed because the thread was paused in an APC. </Comment>
+</HRESULT>
+
+<HRESULT NumericValue="0x80131c27">
+	<SymbolicName>CORDBG_E_ILLEGAL_IN_STACK_OVERFLOW</SymbolicName>
+	<Message>"The operation is illegal because of a stack overflow."</Message>
+	<Comment> the operation is illegal because of a stackoverflow. </Comment>
 </HRESULT>
 
 <HRESULT NumericValue="0x80131c28">

--- a/src/coreclr/inc/corerror.xml
+++ b/src/coreclr/inc/corerror.xml
@@ -1853,15 +1853,15 @@
 </HRESULT>
 
 <HRESULT NumericValue="0x80131c26">
-	<SymbolicName>CORDBG_E_ILLEGAL_AT_APC_CALLBACK</SymbolicName>
-	<Message>"The operation failed because the thread was paused in an APC."</Message>
-	<Comment> The operation failed because the thread was paused in an APC. </Comment>
-</HRESULT>
-
-<HRESULT NumericValue="0x80131c27">
 	<SymbolicName>CORDBG_E_ILLEGAL_IN_STACK_OVERFLOW</SymbolicName>
 	<Message>"The operation is illegal because of a stack overflow."</Message>
 	<Comment> the operation is illegal because of a stackoverflow. </Comment>
+</HRESULT>
+
+<HRESULT NumericValue="0x80131c27">
+	<SymbolicName>CORDBG_E_ILLEGAL_AT_APC_CALLBACK</SymbolicName>
+	<Message>"The operation failed because the thread was paused in an APC."</Message>
+	<Comment> The operation failed because the thread was paused in an APC. </Comment>
 </HRESULT>
 
 <HRESULT NumericValue="0x80131c28">

--- a/src/coreclr/inc/corerror.xml
+++ b/src/coreclr/inc/corerror.xml
@@ -1853,9 +1853,9 @@
 </HRESULT>
 
 <HRESULT NumericValue="0x80131c26">
-	<SymbolicName>CORDBG_E_ILLEGAL_IN_STACK_OVERFLOW</SymbolicName>
-	<Message>"The operation is illegal because of a stack overflow."</Message>
-	<Comment> the operation is illegal because of a stackoverflow. </Comment>
+	<SymbolicName>CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE</SymbolicName>
+	<Message>"The operation failed because the thread is in optimized code."</Message>
+	<Comment> The operation failed because the thread is in optimized code. </Comment>
 </HRESULT>
 
 <HRESULT NumericValue="0x80131c27">


### PR DESCRIPTION
Avoid changing IP to funceval when the thread is paused in an APC Callback.
When the APC Callback is resumed and CET is enabled it will check if the IP is equals the one before the callback, so we are not allowed to change the IP while we are inside an APC Callback, otherwise the runtime will crash.