### PR TITLE
[RISC-V] JIT: Remove src/dst from CORINFO_HELP_ASSIGN_BYREF GC kill set

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10402,10 +10402,14 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
     {
         case CORINFO_HELP_ASSIGN_REF:
         case CORINFO_HELP_CHECKED_ASSIGN_REF:
+            static_assert((RBM_CALLEE_GCTRASH_WRITEBARRIER & RBM_WRITE_BARRIER_DST) == 0, "");
             result = RBM_CALLEE_GCTRASH_WRITEBARRIER;
             break;
 
         case CORINFO_HELP_ASSIGN_BYREF:
+            static_assert((RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF &
+                           (RBM_WRITE_BARRIER_SRC_BYREF | RBM_WRITE_BARRIER_DST_BYREF)) == 0,
+                          "");
             result = RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF;
             break;
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10402,14 +10402,10 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
     {
         case CORINFO_HELP_ASSIGN_REF:
         case CORINFO_HELP_CHECKED_ASSIGN_REF:
-            static_assert((RBM_CALLEE_GCTRASH_WRITEBARRIER & RBM_WRITE_BARRIER_DST) == 0, "");
             result = RBM_CALLEE_GCTRASH_WRITEBARRIER;
             break;
 
         case CORINFO_HELP_ASSIGN_BYREF:
-            static_assert((RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF &
-                           (RBM_WRITE_BARRIER_SRC_BYREF | RBM_WRITE_BARRIER_DST_BYREF)) == 0,
-                          "");
             result = RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF;
             break;
 

--- a/src/coreclr/jit/targetriscv64.h
+++ b/src/coreclr/jit/targetriscv64.h
@@ -139,7 +139,7 @@
   #define REG_WRITE_BARRIER_SRC_BYREF    REG_T5
   #define RBM_WRITE_BARRIER_SRC_BYREF    RBM_T5
 
-  #define RBM_CALLEE_TRASH_NOGC          (RBM_T0|RBM_T1|RBM_T2|RBM_T3|RBM_T4|RBM_T5|RBM_T6|RBM_DEFAULT_HELPER_CALL_TARGET)
+  #define RBM_CALLEE_TRASH_NOGC          (RBM_T0|RBM_T1|RBM_T2|RBM_T4|RBM_T6|RBM_DEFAULT_HELPER_CALL_TARGET)
 
   // Registers killed by CORINFO_HELP_ASSIGN_REF and CORINFO_HELP_CHECKED_ASSIGN_REF.
   #define RBM_CALLEE_TRASH_WRITEBARRIER         (RBM_WRITE_BARRIER_DST|RBM_CALLEE_TRASH_NOGC)
@@ -151,7 +151,7 @@
   #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF   (RBM_WRITE_BARRIER_DST_BYREF | RBM_WRITE_BARRIER_SRC_BYREF | RBM_CALLEE_TRASH_NOGC)
 
   // Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_BYREF.
-  // Note that x13 and x14 are still valid byref pointers after this helper call, despite their value being changed.
+  // Note that t3 and t5 are still valid byref pointers after this helper call, despite their value being changed.
   #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF RBM_CALLEE_TRASH_NOGC
 
   // GenericPInvokeCalliHelper VASigCookie Parameter


### PR DESCRIPTION
CORINFO_HELP_ASSIGN_BYREF (JIT_ByRefWriteBarrier) increments src/dst pointers, they are still byRef.

Fixes tests with GCStress=3 such as JIT/HardwareIntrinsics/Arm/{Sha1/Sha1_ro,Rdm/Rdm_r} failing intermittently (about 8 out of 1200 runs) on:
```
System.InvalidOperationException: Handle is not initialized.
   at System.Runtime.InteropServices.GCHandle.AddrOfPinnedObject()
   at JIT.HardwareIntrinsics.Arm._Sha1.SecureHashTernaryOpTest__HashUpdateParity_Vector128_UInt32.DataTable.get_inArray1Ptr() in /runtime/artifacts/tests/coreclr/obj/linux.riscv64.Checked/Managed/JIT/HardwareIntrinsics/Arm/Sha1/Sha1_ro/Sha1_ro/gen/HashUpdateParity.Vector128.UInt32.cs:line 110
```
When copying DataTable, GC would collect directly after the CORINFO_HELP_ASSIGN_BYREF call and relocate the target so the subsequent fields (like the GCHandle) were copied to the old location.

Part of #84834, cc @dotnet/samsung