### PR TITLE
JIT: Mark profile inconsistent during flow opts if OSR entry is involved

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -6108,6 +6108,15 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication /* = false */, bool isPh
         }
     } while (change);
 
+    // OSR entry blocks will frequently have a profile imbalance as original method execution was hijacked at them.
+    // Mark the profile as inconsistent if we might have propagated the OSR entry weight.
+    if (modified && opts.IsOSR())
+    {
+        JITDUMP("fgUpdateFlowGraph: Inconsistent OSR entry weight may have been propagated. Data %s consistent.\n",
+                fgPgoConsistent ? "is now" : "was already");
+        fgPgoConsistent = false;
+    }
+
 #ifdef DEBUG
     if (!isPhase)
     {


### PR DESCRIPTION
OSR entry weights are frequently imbalanced, so we skip profile consistency checks for them. However, `fgUpdateFlowGraph` can propagate these weights to normal blocks, which are checked for profile consistency. If we think this happened, liberally mark the profile as inconsistent. Fixes #111343.