### PR TITLE
Treat files in "build" directories as not generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -67,6 +67,7 @@
 # https://github.com/github/linguist/issues/1626#issuecomment-401442069
 # this only affects the repo's language statistics
 *.h linguist-language=C
+src/mono/wasm/build/** linguist-generated=false
 
 # CLR specific
 src/coreclr/pal/tests/palsuite/paltestlist.txt text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -67,7 +67,9 @@
 # https://github.com/github/linguist/issues/1626#issuecomment-401442069
 # this only affects the repo's language statistics
 *.h linguist-language=C
-src/mono/wasm/build/** linguist-generated=false
+
+# don't treat files in 'build' directories as generated
+**/build/** linguist-generated=false
 
 # CLR specific
 src/coreclr/pal/tests/palsuite/paltestlist.txt text eol=lf


### PR DESCRIPTION
Based on https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files. Searching for build files online doesn't work, because github by default ignore all files under `build` directory