### PR TITLE
JIT: Cache start of cold section for reuse in 3-opt layout

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5136,10 +5136,8 @@ void Compiler::ThreeOptLayout::ConsiderEdge(FlowEdge* edge)
     const unsigned srcPos = ordinals[srcBlk->bbPostorderNum];
     const unsigned dstPos = ordinals[dstBlk->bbPostorderNum];
 
-    // Don't consider edges from outside the hot range.
-    // If 'srcBlk' has an ordinal of zero and it isn't the first block,
-    // it's not tracked by 'ordinals', so it's not in the hot section.
-    if ((srcPos == 0) && !srcBlk->IsFirst())
+    // Don't consider edges to or from outside the hot range (i.e. ordinal doesn't match 'blockOrder' position).
+    if ((srcBlk != blockOrder[srcPos]) || (dstBlk != blockOrder[dstPos]))
     {
         return;
     }
@@ -5507,6 +5505,14 @@ bool Compiler::ThreeOptLayout::RunGreedyThreeOptPass(unsigned startPos, unsigned
         {
             ordinals[blockOrder[i]->bbPostorderNum] = i;
         }
+
+#ifdef DEBUG
+        // Verify 'ordinals' is up-to-date
+        for (unsigned i = 0; i < numCandidateBlocks; i++)
+        {
+            assert(ordinals[blockOrder[i]->bbPostorderNum] == i);
+        }
+#endif // DEBUG
 
         // Ensure this move created fallthrough from 'srcBlk' to 'dstBlk'
         assert((ordinals[srcBlk->bbPostorderNum] + 1) == ordinals[dstBlk->bbPostorderNum]);


### PR DESCRIPTION
During cold code motion, if `fgMoveColdBlocks` finds a call-finally pair that begins with a cold block, it will try to move the entire pair, regardless of whether the tail is cold or not. If the tail isn't cold, 3-opt layout's detection of the last hot block may terminate early, causing the cold part of an EH region to also be considered for reordering. Because 3-opt expects each EH subregion being reordered to be contiguous, this split causes asserts. Caching the cold region start point in `fgMoveColdBlocks` means we don't need to find the first cold block in 3-opt, thus removing the potential of getting it wrong.

While I was here, I decided to enhance `fgMoveColdBlocks` so that it can move cold call-finally pairs at the end of the hot main method body, and clean up 3-opt's initialization logic to reduce its allocation sizes. Fixes #111207.