### PR TITLE
Simplify MonoCrossAOT compiler infrastructure

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -566,7 +566,7 @@
         </When>
         <When Condition="'$(BuildMonoAOTCrossCompilerOnly)' == 'true'">
           <ItemGroup Condition="'$(MonoCrossAOTTargetOS)' != ''">
-            <ProjectToBuild Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\monocrossaot.sfxproj" Category="packs" />
+            <ProjectToBuild Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\monocrossaot.proj" Category="packs" />
           </ItemGroup>
         </When>
         <Otherwise>
@@ -591,7 +591,7 @@
             <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-host.proj" />
             <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-hostfxr.proj" />
             <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-runtime-deps\*.proj" />
-            <SharedFrameworkProjectToBuild Condition="'$(MonoCrossAOTTargetOS)' != ''" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\monocrossaot.sfxproj" />
+            <SharedFrameworkProjectToBuild Condition="'$(MonoCrossAOTTargetOS)' != ''" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\monocrossaot.proj" />
           </ItemGroup>
           <ItemGroup>
             <ProjectToBuild Condition="'$(NativeAotSupported)' == 'true' and '$(RuntimeFlavor)' != 'Mono' and '$(TargetsMobile)' != 'true' and '$(TargetsLinuxBionic)' != 'true'" Include="$(InstallerProjectRoot)\pkg\projects\nativeaot-packages.proj" Category="packs" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -3,17 +3,13 @@
 
   <PropertyGroup>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <PlatformPackageType>RuntimePack</PlatformPackageType>
+    <PlatformPackageType>ToolPack</PlatformPackageType>
     <SharedFrameworkName>Microsoft.NETCore.App.MonoCrossAOT</SharedFrameworkName>
     <OverridePackageId>Microsoft.NETCore.App.Runtime.AOT.$(RuntimeIdentifier).Cross.$(TargetCrossRid)</OverridePackageId>
-    <SharedFrameworkHostFileNameOverride>monocrossaot</SharedFrameworkHostFileNameOverride>
     <RuntimeIdentifiers>linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64;win-x64;win-arm64</RuntimeIdentifiers>
     <GenerateInstallers>false</GenerateInstallers>
-    <PublishReadyToRun>false</PublishReadyToRun>
-    <HostJsonTargetPath>tools/</HostJsonTargetPath>
     <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
-    <AotCompilerFileName>mono-aot-cross</AotCompilerFileName>
-    <AotCompilerFileName Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(AotCompilerFileName).exe</AotCompilerFileName>
+    <AotCompilerFileName>mono-aot-cross$(ExeSuffix)</AotCompilerFileName>
     <SkipInstallersPackageReference>true</SkipInstallersPackageReference>
   </PropertyGroup>
 

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/monocrossaot.proj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/monocrossaot.proj
@@ -11,21 +11,13 @@
     <SkipInstallersPackageReference>true</SkipInstallersPackageReference>
   </PropertyGroup>
 
-  <ItemGroup>
-    <MonoAotTargetRids Include="$(MonoAotTargets.Split(';'))" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Microsoft.NETCore.App.MonoCrossAOT.sfxproj" Build="false" />
+  <!-- Only restore the target sfxproj once to avoid any parallel restore issues. -->
+  <ItemGroup Condition="'$(MSBuildRestoreSessionId)' == ''">
+    <MonoAotTargetRids Include="$(MonoAotTargets.Split(';'))" Properties="TargetCrossRid=%(Identity);RealRuntimeBinDir=$(RuntimeBinDir)" />
+    <ProjectReference Include="@(MonoAotTargetRids->'$(MSBuildThisFileDirectory)Microsoft.NETCore.App.MonoCrossAOT.sfxproj')" />
   </ItemGroup>
 
-  <Target Name="BuildMonoCrossAllTargets" AfterTargets="Build">
-    <MSBuild Targets="BuildMonoCrossTarget"
-             Projects="$(MSBuildThisFileFullPath)"
-             BuildInParallel="true"
-             Properties="MonoAotTargetRid=%(MonoAotTargetRids.Identity);RealRuntimeBinDir=$(RuntimeBinDir)" />
-  </Target>
-
-  <Target Name="BuildMonoCrossTarget">
-    <MSBuild Targets="GenerateNuspec"
-             Projects="$(MSBuildThisFileDirectory)Microsoft.NETCore.App.MonoCrossAOT.sfxproj"
-             Properties="TargetCrossRid=$(MonoAotTargetRid)" />
-  </Target>
+  <ItemGroup Condition="'$(MSBuildRestoreSessionId)' != ''">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Microsoft.NETCore.App.MonoCrossAOT.sfxproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Call from the monocrossaot traversal project into the sfxproj using the regular ProjectReference flow. Simplify the sfxproj to not do unnecessary additional work.

Contributes to unblocking https://github.com/dotnet/sdk/pull/45932