### PR TITLE
JIT: don't block tail calls for unreferenced exposed locals

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5110,7 +5110,16 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
     bool hasStructParam = false;
     for (unsigned varNum = 0; varNum < lvaCount; varNum++)
     {
-        LclVarDsc* varDsc = lvaGetDesc(varNum);
+        LclVarDsc* const varDsc = lvaGetDesc(varNum);
+
+        // Ignore any local that is unreferenced.
+        //
+        const unsigned totalAppearances = varDsc->lvRefCnt(RCS_EARLY);
+
+        if (totalAppearances == 0)
+        {
+            continue;
+        }
 
         // If the method is marked as an explicit tail call we will skip the
         // following three hazard checks.


### PR DESCRIPTION
Ignore unreferenced address exposed locals when determining if it's safe to make an implicit tail call. We consult the RCS_EARLY ref count for this; hopefully it's conservatively correct.

This fixes some cases that come up if we stack allocate and then dead code a new array, as well as other cases we're currently missing.