### PR TITLE
Mark JsonNode.WriteTo as obsolete with SYSLIB0060

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -114,6 +114,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0057`__ | Loading certificate data through the constructor or Import is obsolete. Use X509CertificateLoader instead to load certificates. |
 |  __`SYSLIB0058`__ | KeyExchangeAlgorithm, KeyExchangeStrength, CipherAlgorithm, CipherAlgorithmStrength, HashAlgorithm and HashStrength properties of SslStream are obsolete. Use NegotiatedCipherSuite instead. |
 |  __`SYSLIB0059`__ | SystemEvents.EventsThreadShutdown callbacks are not run before the process exits. Use AppDomain.ProcessExit instead. |
+|  __`SYSLIB0060`__ | JsonNode.WriteTo are obsolete. Use JsonSerializer.Serialize{Async} instead. |
 
 ## Analyzer Warnings
 

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -190,6 +190,9 @@ namespace System
         internal const string SystemEventsEventsThreadShutdownMessage = "SystemEvents.EventsThreadShutdown callbacks are not run before the process exits. Use AppDomain.ProcessExit instead.";
         internal const string SystemEventsEventsThreadShutdownDiagId = "SYSLIB0059";
 
+        internal const string JsonNodeWriteToMessage = "JsonNode.WriteTo are obsolete. Use JsonSerializer.Serialize{Async} instead.";
+        internal const string JsonNodeWriteToDiagId = "SYSLIB0060";
+
         // When adding a new diagnostic ID, add it to the table in docs\project\list-of-diagnostics.md as well.
         // Keep new const identifiers above this comment.
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
@@ -261,6 +261,7 @@ namespace System.Text.Json.Nodes
         }
 
         /// <inheritdoc/>
+        [Obsolete(Obsoletions.JsonNodeWriteToMessage, DiagnosticId = Obsoletions.JsonNodeWriteToDiagId)]
         public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)
         {
             if (writer is null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
@@ -25,7 +25,9 @@ namespace System.Text.Json.Nodes
             Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(writerOptions, defaultBufferSize, out PooledByteBufferWriter output);
             try
             {
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
                 WriteTo(writer, options);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
                 writer.Flush();
                 return JsonHelpers.Utf8GetString(output.WrittenMemory.Span);
             }
@@ -58,7 +60,9 @@ namespace System.Text.Json.Nodes
             Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(new JsonWriterOptions { Indented = true }, JsonSerializerOptions.BufferSizeDefault, out PooledByteBufferWriter output);
             try
             {
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
                 WriteTo(writer);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
                 writer.Flush();
                 return JsonHelpers.Utf8GetString(output.WrittenMemory.Span);
             }
@@ -76,6 +80,7 @@ namespace System.Text.Json.Nodes
         ///   The <paramref name="writer"/> parameter is <see langword="null"/>.
         /// </exception>
         /// <param name="options">Options to control the serialization behavior.</param>
+        [Obsolete(Obsoletions.JsonNodeWriteToMessage, DiagnosticId = Obsoletions.JsonNodeWriteToDiagId)]
         public abstract void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -129,6 +129,7 @@ namespace System.Text.Json.Nodes
         }
 
         /// <inheritdoc/>
+        [Obsolete(Obsoletions.JsonNodeWriteToMessage, DiagnosticId = Obsoletions.JsonNodeWriteToDiagId)]
         public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)
         {
             if (writer is null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -141,7 +141,9 @@ namespace System.Text.Json.Nodes
 
                 try
                 {
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
                     node.WriteTo(writer);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
                     writer.Flush();
                     Utf8JsonReader reader = new(output.WrittenMemory.Span);
                     backingDocument = JsonDocument.ParseValue(ref reader);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfElement.cs
@@ -194,6 +194,7 @@ namespace System.Text.Json.Nodes
             return false;
         }
 
+        [Obsolete(Obsoletions.JsonNodeWriteToMessage, DiagnosticId = Obsoletions.JsonNodeWriteToDiagId)]
         public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)
         {
             if (writer is null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTCustomized.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTCustomized.cs
@@ -26,6 +26,8 @@ namespace System.Text.Json.Nodes
         private protected override JsonValueKind GetValueKindCore() => _valueKind ??= ComputeValueKind();
         internal override JsonNode DeepCloneCore() => JsonSerializer.SerializeToNode(Value, _jsonTypeInfo)!;
 
+
+        [Obsolete(Obsoletions.JsonNodeWriteToMessage, DiagnosticId = Obsoletions.JsonNodeWriteToDiagId)]
         public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)
         {
             if (writer is null)
@@ -52,7 +54,9 @@ namespace System.Text.Json.Nodes
             Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(options: default, JsonSerializerOptions.BufferSizeDefault, out PooledByteBufferWriter output);
             try
             {
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
                 WriteTo(writer);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
                 writer.Flush();
                 Utf8JsonReader reader = new(output.WrittenMemory.Span);
                 bool success = reader.Read();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTPrimitive.cs
@@ -39,6 +39,7 @@ namespace System.Text.Json.Nodes
             return base.DeepEqualsCore(otherNode);
         }
 
+        [Obsolete(Obsoletions.JsonNodeWriteToMessage, DiagnosticId = Obsoletions.JsonNodeWriteToDiagId)]
         public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null)
         {
             if (writer is null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonArrayConverter.cs
@@ -17,7 +17,9 @@ namespace System.Text.Json.Serialization.Converters
                 return;
             }
 
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
             value.WriteTo(writer, options);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
         }
 
         public override JsonArray? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonNodeConverter.cs
@@ -32,7 +32,9 @@ namespace System.Text.Json.Serialization.Converters
             }
             else
             {
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
                 value.WriteTo(writer, options);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
@@ -42,7 +42,9 @@ namespace System.Text.Json.Serialization.Converters
                 return;
             }
 
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
             value.WriteTo(writer, options);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
         }
 
         public override JsonObject? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
@@ -17,7 +17,9 @@ namespace System.Text.Json.Serialization.Converters
                 return;
             }
 
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
             value.WriteTo(writer, options);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
         }
 
         public override JsonValue? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Node.cs
@@ -165,7 +165,9 @@ namespace System.Text.Json
                 }
                 else
                 {
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
                     node.WriteTo(writer, options);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
                 }
             }
 
@@ -186,7 +188,9 @@ namespace System.Text.Json
                 }
                 else
                 {
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
                     node.WriteTo(writer, options);
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
@@ -56,6 +56,7 @@ namespace System.Text.Json.Nodes.Tests
                 Assert.Throws<InvalidOperationException>(() => JsonArray.Create(document.RootElement));
         }
 
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
         [Fact]
         public static void WriteTo_Validation()
         {
@@ -104,6 +105,7 @@ namespace System.Text.Json.Nodes.Tests
             json = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Equal("[\"42\"]", json);
         }
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
 
         [Fact]
         public static void Clear()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
@@ -326,6 +326,7 @@ namespace System.Text.Json.Nodes.Tests
             }
         }
 
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
         [Fact]
         public static void WriteTo_Validation()
         {
@@ -346,6 +347,7 @@ namespace System.Text.Json.Nodes.Tests
             string json = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Equal(Json, json);
         }
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
 
         [Fact]
         public static void CopyTo()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -288,6 +288,7 @@ namespace System.Text.Json.Nodes.Tests
                 Assert.Throws<InvalidOperationException>(() => JsonValue.Create(document.RootElement));
         }
 
+#pragma warning disable SYSLIB0060 // Type or member is obsolete
         [Fact]
         public static void WriteTo_Validation()
         {
@@ -308,6 +309,7 @@ namespace System.Text.Json.Nodes.Tests
             string json = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Equal(Json, json);
         }
+#pragma warning restore SYSLIB0060 // Type or member is obsolete
 
         [Fact]
         public static void DeepCloneNotTrimmable()


### PR DESCRIPTION
Close #108643

This commit introduces the diagnostic ID `SYSLIB0060` for the obsolescence of the `JsonNode.WriteTo` method. Users are advised to use `JsonSerializer.Serialize{Async}` instead.

The new diagnostic message and ID have been added to the `Obsoletions` class, and the documentation in `list-of-diagnostics.md` has been updated accordingly.

The `[Obsolete]` attribute has been applied to the `WriteTo` method in `JsonArray`, `JsonNode`, `JsonObject`, and `JsonValue`.

Additionally, warnings related to the use of the obsolete method have been suppressed in various locations.