### PR TITLE
JIT: Relax address exposure check for tailcalls

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5119,11 +5119,6 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         //
         if (isImplicitOrStressTailCall)
         {
-            if (varDsc->lvHasLdAddrOp && !lvaIsImplicitByRefLocal(varNum))
-            {
-                failTailCall("Local address taken", varNum);
-                return nullptr;
-            }
             if (varDsc->IsAddressExposed())
             {
                 if (lvaIsImplicitByRefLocal(varNum))


### PR DESCRIPTION
The `lvHasLdAddrOp` based check is conservative: address exposure (as computed in local morph) is much more precise. We can switch to that check only.

This used to be a code size regression, but that's generally expected when expanding more epilogs. Now that we have perf score I want to check how it shows up in terms of perf score.