### PR TITLE
[release/9.0] Disable tests targetting http://corefx-net-http11.azurewebsites.net

### DIFF
--- a/src/libraries/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/libraries/Common/tests/System/Net/Configuration.Http.cs
@@ -64,9 +64,16 @@ namespace System.Net.Test.Common
                 if (PlatformDetection.IsFirefox)
                 {
                     // https://github.com/dotnet/runtime/issues/101115
-                    return [RemoteEchoServer];
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                    // return [RemoteEchoServer];
+                    return [];
                 }
-                return [RemoteEchoServer, SecureRemoteEchoServer, Http2RemoteEchoServer];
+                return [
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                    // RemoteEchoServer,
+                    SecureRemoteEchoServer,
+                    Http2RemoteEchoServer
+                ];
             }
 
             public static readonly Uri RemoteVerifyUploadServer = new Uri("http://" + Host + "/" + VerifyUploadHandler);
@@ -82,8 +89,20 @@ namespace System.Net.Test.Common
             public static Uri RemoteLoopServer => new Uri("ws://" + RemoteLoopHost + "/" + RemoteLoopHandler);
 
             public static readonly object[][] EchoServers = GetEchoServerList().Select(x => new object[] { x }).ToArray();
-            public static readonly object[][] VerifyUploadServers = { new object[] { RemoteVerifyUploadServer }, new object[] { SecureRemoteVerifyUploadServer }, new object[] { Http2RemoteVerifyUploadServer } };
-            public static readonly object[][] CompressedServers = { new object[] { RemoteDeflateServer }, new object[] { RemoteGZipServer }, new object[] { Http2RemoteDeflateServer }, new object[] { Http2RemoteGZipServer } };
+            public static readonly object[][] VerifyUploadServers = {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                // new object[] { RemoteVerifyUploadServer },
+                new object[] { SecureRemoteVerifyUploadServer },
+                new object[] { Http2RemoteVerifyUploadServer }
+            };
+
+            public static readonly object[][] CompressedServers = {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                // new object[] { RemoteDeflateServer },
+                new object[] { RemoteGZipServer },
+                new object[] { Http2RemoteDeflateServer },
+                new object[] { Http2RemoteGZipServer }
+            };
 
             public static readonly object[][] Http2Servers = { new object[] { new Uri("https://" + Http2Host) } };
             public static readonly object[][] Http2NoPushServers = { new object[] { new Uri("https://" + Http2NoPushHost) } };
@@ -97,9 +116,17 @@ namespace System.Net.Test.Common
                 if (PlatformDetection.IsFirefox)
                 {
                     // https://github.com/dotnet/runtime/issues/101115
-                    return new RemoteServer[] { RemoteHttp11Server };
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                    // return new RemoteServer[] { RemoteHttp11Server };
+                    return [];
                 }
-                return new RemoteServer[] { RemoteHttp11Server, RemoteSecureHttp11Server, RemoteHttp2Server };
+                return new RemoteServer[]
+                {
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                    // RemoteHttp11Server,
+                    RemoteSecureHttp11Server,
+                    RemoteHttp2Server
+                };
             }
 
             public static readonly IEnumerable<object[]> RemoteServersMemberData = GetRemoteServers().Select(s => new object[] { s });

--- a/src/libraries/Common/tests/System/Net/Configuration.WebSockets.cs
+++ b/src/libraries/Common/tests/System/Net/Configuration.WebSockets.cs
@@ -28,11 +28,14 @@ namespace System.Net.Test.Common
                 {
                     // https://github.com/dotnet/runtime/issues/101115
                     return new object[][] {
-                        new object[] { RemoteEchoServer },
+                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                        // new object[] { RemoteEchoServer },
+
                     };
                 }
                 return new object[][] {
-                    new object[] { RemoteEchoServer },
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                    // new object[] { RemoteEchoServer },
                     new object[] { SecureRemoteEchoServer },
                 };
             }
@@ -43,11 +46,13 @@ namespace System.Net.Test.Common
                 {
                     // https://github.com/dotnet/runtime/issues/101115
                     return new object[][] {
-                        new object[] { RemoteEchoHeadersServer },
+                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                        // new object[] { RemoteEchoHeadersServer },
                     };
                 }
                 return new object[][] {
-                    new object[] { RemoteEchoHeadersServer },
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/110578)]
+                    // new object[] { RemoteEchoHeadersServer },
                     new object[] { SecureRemoteEchoHeadersServer },
                 };
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -70,7 +70,7 @@ namespace System.Net.Http.Functional.Tests
             handler.UseDefaultCredentials = false;
             using (HttpClient client = CreateHttpClient(handler))
             {
-                Uri uri = Configuration.Http.RemoteHttp11Server.NegotiateAuthUriForDefaultCreds;
+                Uri uri = Configuration.Http.RemoteSecureHttp11Server.NegotiateAuthUriForDefaultCreds;
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -601,9 +601,9 @@ namespace System.Net.Http.Functional.Tests
         public static IEnumerable<object[]> ExpectContinueVersion()
         {
             return
-                from expect in new bool?[] {true, false, null}
-                from version in new Version[] {new Version(1, 0), new Version(1, 1), new Version(2, 0)}
-                select new object[] {expect, version};
+                from expect in new bool?[] { true, false, null }
+                from version in new Version[] { new Version(1, 0), new Version(1, 1), new Version(2, 0) }
+                select new object[] { expect, version };
         }
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
@@ -775,7 +775,8 @@ namespace System.Net.Http.Functional.Tests
             {
                 var request = new HttpRequestMessage(
                     new HttpMethod(method),
-                    serverUri) { Version = UseVersion };
+                    serverUri)
+                { Version = UseVersion };
 
                 using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
                 {
@@ -801,7 +802,8 @@ namespace System.Net.Http.Functional.Tests
             {
                 var request = new HttpRequestMessage(
                     new HttpMethod(method),
-                    serverUri) { Version = UseVersion };
+                    serverUri)
+                { Version = UseVersion };
                 request.Content = new StringContent(ExpectedContent);
                 using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
                 {
@@ -980,6 +982,7 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Uses external servers")]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/55083", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/110578")]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttps_StatusCodeOK()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1064,9 +1067,9 @@ namespace System.Net.Http.Functional.Tests
             handler.MaxAutomaticRedirections = maxHops;
             using (HttpClient client = CreateHttpClient(handler))
             {
-                Task<HttpResponseMessage> t = client.GetAsync(Configuration.Http.RemoteHttp11Server.RedirectUriForDestinationUri(
+                Task<HttpResponseMessage> t = client.GetAsync(Configuration.Http.RemoteSecureHttp11Server.RedirectUriForDestinationUri(
                     statusCode: 302,
-                    destinationUri: Configuration.Http.RemoteHttp11Server.EchoUri,
+                    destinationUri: Configuration.Http.RemoteSecureHttp11Server.EchoUri,
                     hops: hops));
 
                 if (hops <= maxHops)
@@ -1074,7 +1077,7 @@ namespace System.Net.Http.Functional.Tests
                     using (HttpResponseMessage response = await t)
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                        Assert.Equal(Configuration.Http.RemoteEchoServer, response.RequestMessage.RequestUri);
+                        Assert.Equal(Configuration.Http.SecureRemoteEchoServer, response.RequestMessage.RequestUri);
                     }
                 }
                 else

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -97,6 +97,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/110578")]
         public async Task UseCallback_NotSecureConnection_CallbackNotCalled()
         {
             HttpClientHandler handler = CreateHttpClientHandler();

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -32,6 +32,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
         [OuterLoop]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/110578")]
         public async Task UseCallback_NotSecureConnection_CallbackNotCalled()
         {
             var handler = new WinHttpHandler();

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -55,7 +55,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             string cookieName,
             string cookieValue)
         {
-            Uri uri = System.Net.Test.Common.Configuration.Http.RemoteHttp11Server.RedirectUriForDestinationUri(302, System.Net.Test.Common.Configuration.Http.RemoteEchoServer, 1);
+            Uri uri = System.Net.Test.Common.Configuration.Http.RemoteSecureHttp11Server.RedirectUriForDestinationUri(302, System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer, 1);
             var handler = new WinHttpHandler();
             handler.WindowsProxyUsePolicy = WindowsProxyUsePolicy.UseWinInetProxy;
             handler.CookieUsePolicy = cookieUsePolicy;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -381,7 +381,7 @@ namespace System.Net.Http.Functional.Tests
             using InstrumentRecorder<long> openConnectionsRecorder = SetupInstrumentRecorder<long>(InstrumentNames.OpenConnections);
 
             Uri uri = UseVersion == HttpVersion.Version11
-                ? Test.Common.Configuration.Http.RemoteHttp11Server.EchoUri
+                ? Test.Common.Configuration.Http.RemoteSecureHttp11Server.EchoUri
                 : Test.Common.Configuration.Http.RemoteHttp2Server.EchoUri;
             IPAddress[] addresses = await Dns.GetHostAddressesAsync(uri.Host);
             addresses = addresses.Union(addresses.Select(a => a.MapToIPv6())).ToArray();
@@ -1259,7 +1259,7 @@ namespace System.Net.Http.Functional.Tests
                     });
 
                 }, options: new GenericLoopbackOptions() { UseSsl = true });
-            }, options: new GenericLoopbackOptions() { UseSsl = false});
+            }, options: new GenericLoopbackOptions() { UseSsl = false });
         }
 
         [Fact]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/110578.

## Customer Impact

None, test-only change to prevent polluting CI.

## Regression

- [ ] Yes
- [X] No

## Testing

CI tests run as part of CI.

## Risk

Low, no product changes.