### PR TITLE
Remove `RequiresProcessIsolation` from HFA tests

### DIFF
--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_r.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_d.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_r.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Tests using `CMakeProjectReference` seem to work just fine with the merged runner.

Before (CoreCLR, checked, Ryzen 9700X):

```
Time [secs] | Total | Passed | Failed | Skipped | Assembly Execution Summary
============================================================================
     47.303 |   112 |    112 |      0 |       0 | JIT.jit64.jit64_1
```

After:

```
Time [secs] | Total | Passed | Failed | Skipped | Assembly Execution Summary
============================================================================
      2.694 |   112 |    112 |      0 |       0 | JIT.jit64.jit64_1
```

Cc @dotnet/jit-contrib @jkoritzinsky 