### PR TITLE
SPMI: Handle sourcelink for NAOT smoke test collection

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1207,6 +1207,9 @@ class SuperPMICollect:
                         if line.startswith("--exportsfile:"):
                             arg_path = os.path.join(test_native_directory, os.path.basename(line[len("--exportsfile:"):]))
                             return f"--exportsfile:{arg_path}"
+                        elif line.startswith("--sourcelink:"):
+                            arg_path = os.path.join(test_native_directory, os.path.basename(line[len("--sourcelink:"):]))
+                            return f"--sourcelink:{arg_path}"
                         elif line.startswith("--descriptor:"):
                             arg_path = os.path.join(test_directory, os.path.basename(line[len("--descriptor:"):]))
                             return f"--descriptor:{arg_path}"


### PR DESCRIPTION
The NAOT smoke test collection is currently broken after introduction of sourcelink. We end up with an invalid path on the Helix work machines.

This really should be switched to use --make-repro-path as @MichalStrehovsky originally suggested, but that takes a bit more work.