### PR TITLE
[release/9.0] Change were libClang.so is found when generating Android aot offsets

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -819,6 +819,7 @@ JS_ENGINES = [NODE_JS]
     <ItemGroup Condition="'$(AotHostOS)' == 'linux'">
       <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib/libclang.so" Condition=" Exists('$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib/libclang.so') "/>
       <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib64/libclang.so.*" Condition=" '$(_LibClang)' == '' "/>
+      <_LibClang Include="/usr/local/lib/libclang.so" Condition="'$(_LibClang)' == ''" />
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetsLinux)' == 'true' and '$(Platform)' == 'arm64'">
       <MonoUseCrossTool>true</MonoUseCrossTool>


### PR DESCRIPTION
Since we bumped the NDK in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1278, libClang.so is no longer found in the place we expect. As a result, the android aot offsets won't be generated and the dedicated CI leg will fail.

This change fixes the path.