### PR TITLE
JIT: fix loop cloning when loop's last block is within a hander

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2070,6 +2070,21 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
     BasicBlock* bottom  = loop->GetLexicallyBottomMostBlock();
     BasicBlock* newPred = bottom;
 
+    // Ensure the slow loop preheader ends up in the same EH region
+    // as the preheader.
+    //
+    while (!BasicBlock::sameEHRegion(newPred, preheader))
+    {
+        BasicBlock* const next = newPred->Next();
+        if (next == nullptr)
+        {
+            // Insert at end. We will handle this case of
+            // EH region mismatch below.
+            break;
+        }
+        newPred = next;
+    }
+
     // Create a new preheader for the slow loop immediately before the slow
     // loop itself. All failed conditions will branch to the slow preheader.
     // The slow preheader will unconditionally branch to the slow loop header.

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2067,22 +2067,18 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
     // bottomRedirBlk [BBJ_ALWAYS --> bottomNext]
     // ... slow cloned loop (not yet inserted)
     // bottomNext
-    BasicBlock* bottom  = loop->GetLexicallyBottomMostBlock();
-    BasicBlock* newPred = bottom;
+    BasicBlock* bottom              = loop->GetLexicallyBottomMostBlock();
+    BasicBlock* beforeSlowPreheader = bottom;
 
     // Ensure the slow loop preheader ends up in the same EH region
     // as the preheader.
     //
-    while (!BasicBlock::sameEHRegion(newPred, preheader))
+    bool           inTry           = false;
+    unsigned const enclosingRegion = ehGetMostNestedRegionIndex(preheader, &inTry);
+    if (!BasicBlock::sameEHRegion(beforeSlowPreheader, preheader))
     {
-        BasicBlock* const next = newPred->Next();
-        if (next == nullptr)
-        {
-            // Insert at end. We will handle this case of
-            // EH region mismatch below.
-            break;
-        }
-        newPred = next;
+        beforeSlowPreheader = fgFindInsertPoint(enclosingRegion, inTry, bottom, /* endBlk */ nullptr,
+                                                /* nearBlk */ bottom, /* jumpBlk */ nullptr, /* runRarely */ false);
     }
 
     // Create a new preheader for the slow loop immediately before the slow
@@ -2093,22 +2089,20 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
     // The slow preheader needs to go in the same EH region as the preheader.
     //
     JITDUMP("Create unique preheader for slow path loop\n");
-    const bool  extendRegion  = BasicBlock::sameEHRegion(bottom, preheader);
-    BasicBlock* slowPreheader = fgNewBBafter(BBJ_ALWAYS, newPred, extendRegion);
-    JITDUMP("Adding " FMT_BB " after " FMT_BB "\n", slowPreheader->bbNum, newPred->bbNum);
-    slowPreheader->bbWeight = newPred->isRunRarely() ? BB_ZERO_WEIGHT : ambientWeight;
-    slowPreheader->CopyFlags(newPred, (BBF_PROF_WEIGHT | BBF_RUN_RARELY));
+    const bool  extendRegion  = BasicBlock::sameEHRegion(beforeSlowPreheader, preheader);
+    BasicBlock* slowPreheader = fgNewBBafter(BBJ_ALWAYS, beforeSlowPreheader, extendRegion);
+    JITDUMP("Adding " FMT_BB " after " FMT_BB "\n", slowPreheader->bbNum, beforeSlowPreheader->bbNum);
+    slowPreheader->bbWeight = preheader->isRunRarely() ? BB_ZERO_WEIGHT : ambientWeight;
+    slowPreheader->CopyFlags(preheader, (BBF_PROF_WEIGHT | BBF_RUN_RARELY));
     slowPreheader->scaleBBWeight(LoopCloneContext::slowPathWeightScaleFactor);
 
-    // If we didn't extend the region above (because the last loop
+    // If we didn't extend the region above (because the beforeSlowPreheader
     // block was in some enclosed EH region), put the slow preheader
     // into the appropriate region, and make appropriate extent updates.
     //
     if (!extendRegion)
     {
         slowPreheader->copyEHRegion(preheader);
-        bool     isTry           = false;
-        unsigned enclosingRegion = ehGetMostNestedRegionIndex(slowPreheader, &isTry);
 
         if (enclosingRegion != 0)
         {
@@ -2126,11 +2120,11 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
             }
         }
     }
-    newPred = slowPreheader;
 
     // Now we'll clone the blocks of the loop body. These cloned blocks will be the slow path.
-
+    //
     BlockToBlockMap* blockMap = new (getAllocator(CMK_LoopClone)) BlockToBlockMap(getAllocator(CMK_LoopClone));
+    BasicBlock*      newPred  = slowPreheader;
 
     if (cloneLoopsWithEH)
     {


### PR DESCRIPTION
In some unusual cases the last block of a loop might be in the middle of a handler region (say the loop backedge is in a catch, and the catch has alternate flow that exits the loop).

Make sure that we properly place the slow loop preheader into the same EH regions as the fast loop preheader.

Fixes #111344