### PR TITLE
Allow nested types inside of the <Module> type

### DIFF
--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -1414,7 +1414,7 @@ mdToken ResolveReflectionNotation(BYTE* dataPtr,
             if(mAsmRefs)
             {
                 mdToken tkResScope = 0;
-                mdToken tk=TokenFromRid(mdtAssemblyRef,1), tkmax=TokenFromRid(mdtAssemblyRef,mAsmRefs);
+                mdToken tk=TokenFromRid(1, mdtAssemblyRef), tkmax=TokenFromRid(mAsmRefs, mdtAssemblyRef);
                 LPCSTR szAsmRefName;
                 // these are dummies
                 const void* pPKT, *pHash;

--- a/src/coreclr/md/compiler/filtermanager.cpp
+++ b/src/coreclr/md/compiler/filtermanager.cpp
@@ -11,7 +11,7 @@
 #include "stdafx.h"
 #include "filtermanager.h"
 
-#define IsGlobalTypeDef(td) ((td) == TokenFromRid(mdtTypeDef, 1))
+#define IsGlobalTypeDef(td) ((td) == COR_GLOBAL_PARENT_TOKEN)
 
 //*****************************************************************************
 // Walk up to the containing tree and

--- a/src/coreclr/md/compiler/regmeta_emit.cpp
+++ b/src/coreclr/md/compiler/regmeta_emit.cpp
@@ -1202,7 +1202,7 @@ HRESULT RegMeta::_SetImplements(        // S_OK or error.
 
         i++;
 
-        IfFailGo(UpdateENCLog(TokenFromRid(mdtInterfaceImpl, iInterfaceImpl)));
+        IfFailGo(UpdateENCLog(TokenFromRid(iInterfaceImpl, mdtInterfaceImpl)));
     }
 ErrExit:
 

--- a/src/coreclr/md/runtime/metamodelro.cpp
+++ b/src/coreclr/md/runtime/metamodelro.cpp
@@ -411,7 +411,7 @@ CMiniMd::CommonGetCustomAttributeByNameEx(
                 IfFailGo(GetCustomAttributeRecord(ridStart, &pRec));
                 IfFailGo(getValueOfCustomAttribute(pRec, reinterpret_cast<const BYTE **>(ppData), pcbData));
                 if (ptkCA)
-                    *ptkCA = TokenFromRid(mdtCustomAttribute, ridStart);
+                    *ptkCA = TokenFromRid(ridStart, mdtCustomAttribute);
             }
             break;
         }

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -2418,7 +2418,7 @@ HRESULT Assembly::GetDebuggingCustomAttributes(DWORD *pdwFlags)
     ULONG size;
     BYTE *blob;
     IMDInternalImport* mdImport = GetPEAssembly()->GetMDImport();
-    mdAssembly asTK = TokenFromRid(mdtAssembly, 1);
+    mdAssembly asTK = TokenFromRid(1, mdtAssembly);
 
     HRESULT hr = mdImport->GetCustomAttributeByName(asTK,
                                             DEBUGGABLE_ATTRIBUTE_TYPE,

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -3461,7 +3461,7 @@ VOID ClassLoader::AddAvailableClassHaveLock(
     if (SUCCEEDED(pMDImport->GetNestedClassProps(classdef, &enclosing))) {
         // nested type
 
-        if (enclosing == TokenFromRid(mdtTypeDef, 1))
+        if (enclosing == COR_GLOBAL_PARENT_TOKEN)
         {
             // Types nested in the <module> class can't be found by lookup.
             return;

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -3461,6 +3461,12 @@ VOID ClassLoader::AddAvailableClassHaveLock(
     if (SUCCEEDED(pMDImport->GetNestedClassProps(classdef, &enclosing))) {
         // nested type
 
+        if (enclosing == TokenFromRid(mdtTypeDef, 1))
+        {
+            // Types nested in the <module> class can't be found by lookup.
+            return;
+        }
+
         COUNT_T classEntryIndex = RidFromToken(enclosing) - 1;
         _ASSERTE(RidFromToken(enclosing) < RidFromToken(classdef));
         if (classEntries->GetCount() > classEntryIndex)


### PR DESCRIPTION
- This isn't disallowed by spec, although ilasm and ildasm cannot handle these cases, so we can't easily build a regression test
- Simply skip adding the type to the available class hash.

Fix #111164