### PR TITLE
Skip Init and Static helpers when looking for a caller

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1287,6 +1287,8 @@ bool SystemDomain::IsReflectionInvocationMethod(MethodDesc* pMeth)
         CLASS__DELEGATE,
         CLASS__MULTICAST_DELEGATE,
         CLASS__METHODBASEINVOKER,
+        CLASS__INITHELPERS,
+        CLASS__STATICSHELPERS,
     };
 
     static bool fInited = false;

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyTests.cs
@@ -733,6 +733,29 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51673", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69919", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+        public void GetCallingAssemblyInCctor()
+        {
+            TestGetCallingAssemblyInCctor.Run();
+        }
+
+        private class TestGetCallingAssemblyInCctor
+        {
+            private static Assembly _callingAssembly;
+
+            static TestGetCallingAssemblyInCctor()
+            {
+                _callingAssembly = Assembly.GetCallingAssembly();
+            }
+
+            public static void Run()
+            {
+                Assert.Equal(typeof(AssemblyTests).Assembly, _callingAssembly);
+            }
+        }
+
+        [Fact]
         public void GetExecutingAssembly()
         {
             Assert.True(typeof(AssemblyTests).Assembly.Equals(Assembly.GetExecutingAssembly()));


### PR DESCRIPTION
We have learned that real world code may call Assembly.GetCallingAssembly in a static constructor. It returns different value now that there is an extra managed frame introduced by HMF removal. The fix adds the managed helper types to the long ad-hoc list of types that should be skipped for this and similar APIs. It does not change the fact that Assembly.GetCallingAssembly is a slow fragile unreliable API that should not be used.

Fixes #111399