### PR TITLE
Workaround error G6E97C40B

### DIFF
--- a/src/native/external/zlib-ng-version.txt
+++ b/src/native/external/zlib-ng-version.txt
@@ -12,3 +12,4 @@ We have removed the following folders from our local copy as these files are not
 Also, if the next version does not yet contain the fixes included in 12bc7edc73308f017ec40c6b2db694a6e3490ac2, cherry-pick it as a patch.
 
 Apply https://github.com/zlib-ng/zlib-ng/pull/1812
+Apply https://github.com/zlib-ng/zlib-ng/pull/1853

--- a/src/native/external/zlib-ng/arch/riscv/riscv_features.c
+++ b/src/native/external/zlib-ng/arch/riscv/riscv_features.c
@@ -22,7 +22,7 @@ int Z_INTERNAL is_kernel_version_greater_or_equal_to_6_5() {
         return 0;
     }
 
-    if (major > 6 || major == 6 && minor >= 5)
+    if (major > 6 || (major == 6 && minor >= 5))
         return 1;
     return 0;
 }


### PR DESCRIPTION
```
/home/runner/work/dotnet_riscv/dotnet_riscv/runtime/src/native/external/zlib-ng/arch/riscv/riscv_features.c(25,33): error G6E97C40B: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses] [/home/runner/work/dotnet_riscv/dotnet_riscv/runtime/src/native/libs/build-native.proj]
```
when compile using GCC with RVV enabled