### PR TITLE
Removing deprecated helix queue

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -126,7 +126,6 @@ jobs:
             - ${{ if ne(parameters.jobParameters.testScope, 'outerloop') }}:
               - (Windows.10.Amd64.ServerRS5.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2019-helix-amd64
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatformsBuild, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-            - Windows.81.Amd64.Open
             - Windows.Amd64.Server2022.Open
             - Windows.11.Amd64.Client.Open
             - ${{ if eq(parameters.jobParameters.testScope, 'outerloop') }}:


### PR DESCRIPTION
Submitting jobs to helix queue `Windows.81.Amd64.Open` causes this warning to be shown:
> SENDHELIXJOB : warning : Helix queue windows.81.amd64.open was set for estimated removal date of 2025-01-01. In most cases the queue will be removed permanently due to end-of-life; please contact dnceng for any questions or concerns, and we can help you decide how to proceed and discuss other options. [D:\a\_work\1\s\src\libraries\sendtohelixhelp.proj]

In one of my PR's, this queue has started indefinitely timing out. I'm not sure if the queue been removed from helix yet or not, but we should no longer be submitting jobs to it. If there is another queue that should be replacing it let me know.