### PR TITLE
JIT: Use `bbPostorderNum` to track ordinals in 3-opt

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6276,7 +6276,6 @@ public:
 
         Compiler* compiler;
         PriorityQueue<FlowEdge*, decltype(&ThreeOptLayout::EdgeCmp)> cutPoints;
-        unsigned* ordinals;
         BasicBlock** blockOrder;
         BasicBlock** tempOrder;
         unsigned numCandidateBlocks;


### PR DESCRIPTION
Follow-up to #111365. Instead of allocating a separate ordinal array, track each block's ordinal by overwriting its `bbPostorderNum`. We can check if a given block is in the candidate set of blocks being reordered if its ordinal is less than the number of hot blocks, and if the block at the given ordinal in `blockOrder` matches the block in question (i.e. the same implementation as `FlowGraphDfsTree::Contains`.