### PR TITLE
Remove some unused configuration knobs for PAL object types

### DIFF
--- a/src/coreclr/pal/src/file/file.cpp
+++ b/src/coreclr/pal/src/file/file.cpp
@@ -73,11 +73,6 @@ CObjectType CorUnix::otFile(
                 NULL,   // No immutable data cleanup routine
                 sizeof(CFileProcessLocalData),
                 CFileProcessLocalDataCleanupRoutine,
-                GENERIC_READ|GENERIC_WRITE,  // Ignored -- no Win32 object security support
-                CObjectType::SecuritySupported,
-                CObjectType::OSPersistedSecurityInfo,
-                CObjectType::UnnamedObject,
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::UnwaitableObject,
                 CObjectType::SignalingNotApplicable,
                 CObjectType::ThreadReleaseNotApplicable,

--- a/src/coreclr/pal/src/include/pal/corunix.hpp
+++ b/src/coreclr/pal/src/include/pal/corunix.hpp
@@ -189,24 +189,6 @@ namespace CorUnix
     // supported generic access rights (e.g., GENERIC_READ) map to the
     // specific access rights for this object type.
     //
-    // If instances of this object may have a security descriptor set on
-    // them eSecuritySupport should be set to SecuritySupported. If the OS can
-    // persist security information for the object type (as would be the case
-    // for, say, files) eSecurityPersistence should be set to
-    // OSPersistedSecurityInfo.
-    //
-    // If the object may have a name eObjectNameSupport should be
-    // ObjectCanHaveName. A named object can be opened in more than one
-    // process.
-    //
-    // If it is possible to duplicate a handle to an object across process
-    // boundaries then eHandleDuplicationSupport should be set to
-    // CrossProcessDuplicationAllowed. Note that it is possible to have
-    // an object type where eObjectNameSupport is ObjectCanHaveName and
-    // eHandleDuplicationSupport is LocalDuplicationOnly. For these object
-    // types an unnamed object instance will only have references from
-    // the creating process.
-    //
     // If the object may be waited on eSynchronizationSupport should be
     // WaitableObject. (Note that this implies that object type supports
     // the SYNCHRONIZE access right.)
@@ -232,31 +214,6 @@ namespace CorUnix
     class CObjectType
     {
     public:
-
-        enum SecuritySupport
-        {
-            SecuritySupported,
-            SecurityNotSupported
-        };
-
-        enum SecurityPersistence
-        {
-            OSPersistedSecurityInfo,
-            SecurityInfoNotPersisted
-        };
-
-        enum ObjectNameSupport
-        {
-            ObjectCanHaveName,
-            UnnamedObject
-        };
-
-        enum HandleDuplicationSupport
-        {
-            CrossProcessDuplicationAllowed,
-            LocalDuplicationOnly
-        };
-
         enum SynchronizationSupport
         {
             WaitableObject,
@@ -300,12 +257,7 @@ namespace CorUnix
         OBJECT_IMMUTABLE_DATA_CLEANUP_ROUTINE m_pImmutableDataCleanupRoutine;
         DWORD m_dwProcessLocalDataSize;
         OBJECT_PROCESS_LOCAL_DATA_CLEANUP_ROUTINE m_pProcessLocalDataCleanupRoutine;
-        DWORD m_dwSupportedAccessRights;
         // Generic access rights mapping
-        SecuritySupport m_eSecuritySupport;
-        SecurityPersistence m_eSecurityPersistence;
-        ObjectNameSupport m_eObjectNameSupport;
-        HandleDuplicationSupport m_eHandleDuplicationSupport;
         SynchronizationSupport m_eSynchronizationSupport;
         SignalingSemantics m_eSignalingSemantics;
         ThreadReleaseSemantics m_eThreadReleaseSemantics;
@@ -321,11 +273,6 @@ namespace CorUnix
             OBJECT_IMMUTABLE_DATA_CLEANUP_ROUTINE pImmutableDataCleanupRoutine,
             DWORD dwProcessLocalDataSize,
             OBJECT_PROCESS_LOCAL_DATA_CLEANUP_ROUTINE pProcessLocalDataCleanupRoutine,
-            DWORD dwSupportedAccessRights,
-            SecuritySupport eSecuritySupport,
-            SecurityPersistence eSecurityPersistence,
-            ObjectNameSupport eObjectNameSupport,
-            HandleDuplicationSupport eHandleDuplicationSupport,
             SynchronizationSupport eSynchronizationSupport,
             SignalingSemantics eSignalingSemantics,
             ThreadReleaseSemantics eThreadReleaseSemantics,
@@ -339,11 +286,6 @@ namespace CorUnix
             m_pImmutableDataCleanupRoutine(pImmutableDataCleanupRoutine),
             m_dwProcessLocalDataSize(dwProcessLocalDataSize),
             m_pProcessLocalDataCleanupRoutine(pProcessLocalDataCleanupRoutine),
-            m_dwSupportedAccessRights(dwSupportedAccessRights),
-            m_eSecuritySupport(eSecuritySupport),
-            m_eSecurityPersistence(eSecurityPersistence),
-            m_eObjectNameSupport(eObjectNameSupport),
-            m_eHandleDuplicationSupport(eHandleDuplicationSupport),
             m_eSynchronizationSupport(eSynchronizationSupport),
             m_eSignalingSemantics(eSignalingSemantics),
             m_eThreadReleaseSemantics(eThreadReleaseSemantics),
@@ -433,47 +375,7 @@ namespace CorUnix
             return m_pProcessLocalDataCleanupRoutine;
         }
 
-        DWORD
-        GetSupportedAccessRights(
-            void
-            )
-        {
-            return m_dwSupportedAccessRights;
-        };
-
         // Generic access rights mapping
-
-        SecuritySupport
-        GetSecuritySupport(
-            void
-            )
-        {
-            return  m_eSecuritySupport;
-        };
-
-        SecurityPersistence
-        GetSecurityPersistence(
-            void
-            )
-        {
-            return  m_eSecurityPersistence;
-        };
-
-        ObjectNameSupport
-        GetObjectNameSupport(
-            void
-            )
-        {
-            return  m_eObjectNameSupport;
-        };
-
-        HandleDuplicationSupport
-        GetHandleDuplicationSupport(
-            void
-            )
-        {
-            return  m_eHandleDuplicationSupport;
-        };
 
         SynchronizationSupport
         GetSynchronizationSupport(

--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -133,11 +133,6 @@ CObjectType CorUnix::otFileMapping(
                 CFileMappingImmutableDataCleanupRoutine,
                 sizeof(CFileMappingProcessLocalData),
                 NULL,   // No process local data cleanup routine
-                PAGE_READWRITE | PAGE_READONLY | PAGE_WRITECOPY,
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject,
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::UnwaitableObject,
                 CObjectType::SignalingNotApplicable,
                 CObjectType::ThreadReleaseNotApplicable,

--- a/src/coreclr/pal/src/synchmgr/synchcontrollers.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchcontrollers.cpp
@@ -772,9 +772,7 @@ namespace CorUnix
     SynchData (e.g. modifying the object signal count accordingly with its
     thread release semantics)
 
-    Note: this method must be called while holding the appropriate
-          synchronization locks (the local process synch lock if the target
-          object is local, both local and shared one if the object is shared).
+    Note: this method must be called while holding the local process synch lock.
     --*/
     PAL_ERROR CSynchData::ReleaseWaiterWithoutBlocking(
         CPalThread * pthrCurrent,

--- a/src/coreclr/pal/src/synchobj/event.cpp
+++ b/src/coreclr/pal/src/synchobj/event.cpp
@@ -37,11 +37,6 @@ CObjectType CorUnix::otManualResetEvent(
                 NULL,   // No immutable data cleanup routine
                 0,      // No process local data
                 NULL,   // No process local data cleanup routine
-                EVENT_ALL_ACCESS, // Currently ignored (no Win32 security)
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject,
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::WaitableObject,
                 CObjectType::ObjectCanBeUnsignaled,
                 CObjectType::ThreadReleaseHasNoSideEffects,
@@ -56,11 +51,6 @@ CObjectType CorUnix::otAutoResetEvent(
                 NULL,   // No immutable data cleanup routine
                 0,      // No process local data
                 NULL,   // No process local data cleanup routine
-                EVENT_ALL_ACCESS, // Currently ignored (no Win32 security)
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject,
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::WaitableObject,
                 CObjectType::ObjectCanBeUnsignaled,
                 CObjectType::ThreadReleaseAltersSignalCount,

--- a/src/coreclr/pal/src/synchobj/mutex.cpp
+++ b/src/coreclr/pal/src/synchobj/mutex.cpp
@@ -48,11 +48,6 @@ CObjectType CorUnix::otMutex(
                 NULL,   // No immutable data cleanup routine
                 0,      // No process local data
                 NULL,   // No process local data cleanup routine
-                0,      // Should be MUTEX_ALL_ACCESS; currently ignored (no Win32 security)
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject,
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::WaitableObject,
                 CObjectType::ObjectCanBeUnsignaled,
                 CObjectType::ThreadReleaseAltersSignalCount,
@@ -69,11 +64,6 @@ CObjectType CorUnix::otNamedMutex(
                 NULL,   // No immutable data cleanup routine
                 0,      // No process local data
                 NULL,   // No process local data cleanup routine
-                0,      // Should be MUTEX_ALL_ACCESS; currently ignored (no Win32 security)
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject, // PAL's naming infrastructure is not used
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::UnwaitableObject, // PAL's waiting infrastructure is not used
                 CObjectType::SignalingNotApplicable, // PAL's signaling infrastructure is not used
                 CObjectType::ThreadReleaseNotApplicable, // PAL's signaling infrastructure is not used

--- a/src/coreclr/pal/src/synchobj/semaphore.cpp
+++ b/src/coreclr/pal/src/synchobj/semaphore.cpp
@@ -37,11 +37,6 @@ CObjectType CorUnix::otSemaphore(
                 NULL,   // No immutable data cleanup routine
                 0,      // No process local data
                 NULL,   // No process local data cleanup routine
-                0,      // Should be SEMAPHORE_ALL_ACCESS; currently ignored (no Win32 security)
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject,
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::WaitableObject,
                 CObjectType::ObjectCanBeUnsignaled,
                 CObjectType::ThreadReleaseAltersSignalCount,

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -137,11 +137,6 @@ CObjectType CorUnix::otProcess(
                 NULL,   // No immutable data cleanup routine
                 sizeof(CProcProcessLocalData),
                 NULL,   // No process local data cleanup routine
-                PROCESS_ALL_ACCESS,
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject,
-                CObjectType::CrossProcessDuplicationAllowed,
                 CObjectType::WaitableObject,
                 CObjectType::SingleTransitionObject,
                 CObjectType::ThreadReleaseHasNoSideEffects,

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -99,11 +99,6 @@ CObjectType CorUnix::otThread(
                 NULL,   // No immutable data cleanup routine
                 sizeof(CThreadProcessLocalData),
                 NULL,   // No process local data cleanup routine
-                0,      // THREAD_ALL_ACCESS,
-                CObjectType::SecuritySupported,
-                CObjectType::SecurityInfoNotPersisted,
-                CObjectType::UnnamedObject,
-                CObjectType::LocalDuplicationOnly,
                 CObjectType::WaitableObject,
                 CObjectType::SingleTransitionObject,
                 CObjectType::ThreadReleaseHasNoSideEffects,


### PR DESCRIPTION
Win32 security, PAL object naming, and cross-process duplication are all unused features. Remove the dead code.