### PR TITLE
DnsAddresses throw PlatformNotSupportedException if /etc/resolv.conf is missing

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -25,7 +25,7 @@ namespace System.Net.NetworkInformation
             internal string[]? IPv4Routes;
             internal string[]? IPv6Routes;
             internal string? DnsSuffix;
-            internal IPAddressCollection? DnsAddresses;
+            internal IPAddressCollection DnsAddresses;
 
             internal LinuxNetworkInterfaceSystemProperties()
             {
@@ -59,6 +59,7 @@ namespace System.Net.NetworkInformation
                 }
                 catch (Exception e) when (e is FileNotFoundException || e is UnauthorizedAccessException)
                 {
+                    DnsAddresses = new InternalIPAddressCollection();
                 }
             }
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
@@ -13,7 +13,7 @@ namespace System.Net.NetworkInformation
         private MulticastIPAddressInformationCollection? _multicastAddreses;
         private readonly UnixNetworkInterface _uni;
         internal string? _dnsSuffix;
-        internal IPAddressCollection? _dnsAddresses;
+        internal IPAddressCollection _dnsAddresses;
 
         public UnixIPInterfaceProperties(UnixNetworkInterface uni, bool globalConfig = false)
         {
@@ -22,6 +22,10 @@ namespace System.Net.NetworkInformation
             {
                 _dnsSuffix = GetDnsSuffix();
                 _dnsAddresses = GetDnsAddresses();
+            }
+            else
+            {
+                _dnsAddresses = new InternalIPAddressCollection();
             }
         }
 
@@ -33,15 +37,7 @@ namespace System.Net.NetworkInformation
 
         public override bool IsDnsEnabled
         {
-            get
-            {
-                if (_dnsAddresses == null)
-                {
-                    throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-                }
-
-                return _dnsAddresses.Count > 0;
-            }
+            get => _dnsAddresses.Count > 0;
         }
 
         public sealed override string DnsSuffix
@@ -59,15 +55,7 @@ namespace System.Net.NetworkInformation
 
         public sealed override IPAddressCollection DnsAddresses
         {
-            get
-            {
-                if (_dnsAddresses == null)
-                {
-                    throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-                }
-
-                return _dnsAddresses;
-            }
+            get => _dnsAddresses;
         }
 
         private static UnicastIPAddressInformationCollection GetUnicastAddresses(UnixNetworkInterface uni)
@@ -108,7 +96,7 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        private static InternalIPAddressCollection? GetDnsAddresses()
+        private static InternalIPAddressCollection GetDnsAddresses()
         {
             try
             {
@@ -117,7 +105,7 @@ namespace System.Net.NetworkInformation
             }
             catch (FileNotFoundException)
             {
-                return null;
+                return new InternalIPAddressCollection();
             }
         }
     }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
@@ -113,16 +113,6 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public void Dumb()
-        {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
-            {
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-                Assert.Empty(ipProperties.DnsAddresses);
-            }
-        }
-
-        [Fact]
         public async Task IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
             await Task.Run(() =>

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
@@ -113,6 +113,16 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        public void Dumb()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+                Assert.Empty(ipProperties.DnsAddresses);
+            }
+        }
+
+        [Fact]
         public async Task IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
             await Task.Run(() =>

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
@@ -41,19 +41,14 @@ namespace System.Net.NetworkInformation.Tests
 
                     Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DhcpServerAddresses);
 
-                    try
+                    Assert.NotNull(ipProperties.DnsAddresses);
+                    _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
+                    foreach (IPAddress dns in ipProperties.DnsAddresses)
                     {
-                        Assert.NotNull(ipProperties.DnsAddresses);
-                        _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
-                        foreach (IPAddress dns in ipProperties.DnsAddresses)
-                        {
-                            _log.WriteLine("-- " + dns.ToString());
-                        }
-                        Assert.NotNull(ipProperties.DnsSuffix);
-                        _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
+                        _log.WriteLine("-- " + dns.ToString());
                     }
-                    // If /etc/resolv.conf does not exist, DNS values cannot be retrieved.
-                    catch (PlatformNotSupportedException) { }
+                    Assert.NotNull(ipProperties.DnsSuffix);
+                    _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
 
                     Assert.NotNull(ipProperties.GatewayAddresses);
                     _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);


### PR DESCRIPTION
Fixes #109582