### PR TITLE
[release/9.0-staging] Allow nested types inside of the <Module> type

### DIFF
--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -3482,6 +3482,12 @@ VOID ClassLoader::AddAvailableClassHaveLock(
     if (SUCCEEDED(pMDImport->GetNestedClassProps(classdef, &enclosing))) {
         // nested type
 
+        if (enclosing == COR_GLOBAL_PARENT_TOKEN)
+        {
+            // Types nested in the <module> class can't be found by lookup.
+            return;
+        }
+
         COUNT_T classEntryIndex = RidFromToken(enclosing) - 1;
         _ASSERTE(RidFromToken(enclosing) < RidFromToken(classdef));
         if (classEntries->GetCount() > classEntryIndex)


### PR DESCRIPTION
Backport of #111435 to release/9.0-staging

/cc @davidwrighton

## Customer Impact

- [x] Customer reported
- [ ] Found internally

This was reported by @4nonym0us as a regression in .NET 9 which causes some .NET obfuscators to generate faulty code with .NET 9. I do not know which obfuscators, or how prevalent this pattern is. The impact is that assemblies obfuscated by these tools will fail to load on .NET 9. An analysis of the ECMA specification indicates that this particular approach is permitted by ECMA 335 although it certainly wasn't anticipated by any of our tooling.

## Regression

- [x] Yes
- [ ] No

This was introduced with the work to improve the performance of assembly loading in scenarios where many nested types exist. See PR https://github.com/dotnet/runtime/pull/94825

## Testing

Manual testing of a repro scenario provided by @4nonym0us. It is not possible to use ilasm to add a regression test to our system, as it is unable to represent this form of metadata. To do so would require adding new functionality to ilasm, and probably ildasm to enable new syntax that would allow for types nested in the `<module>` class.

## Risk

Low , fix is effectively a check that just skips doing the problematic operation.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

## Package authoring no longer needed in .NET 9

**IMPORTANT**: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.

- This isn't disallowed by spec, although ilasm and ildasm cannot handle these cases
- Simply skip adding the type to the available class hash.

Backport of bugfix portion of PR #111435
Fixes #111164 in .NET 9