### PR TITLE
[release/9.0-staging] Backport test fixes related to BinaryFormatter removal

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -168,8 +168,8 @@ namespace System
             return !(bool)typeof(LambdaExpression).GetMethod("get_CanCompileToIL").Invoke(null, Array.Empty<object>());
         }
 
-        // Drawing is not supported on non windows platforms in .NET 7.0+.
-        public static bool IsDrawingSupported => IsWindows && IsNotWindowsNanoServer && IsNotWindowsServerCore;
+        // Drawing is not supported on non windows platforms in .NET 7.0+ and on Mono.
+        public static bool IsDrawingSupported => IsWindows && IsNotWindowsNanoServer && IsNotWindowsServerCore && IsNotMonoRuntime;
 
         public static bool IsAsyncFileIOSupported => !IsBrowser && !IsWasi;
 

--- a/src/libraries/System.Formats.Nrbf/tests/ArraySinglePrimitiveRecordTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/ArraySinglePrimitiveRecordTests.cs
@@ -19,7 +19,7 @@ public class ArraySinglePrimitiveRecordTests : ReadTests
 
     public static IEnumerable<object[]> GetCanReadArrayOfAnySizeArgs()
     {
-        foreach (int size in new[] { 1, 127, 128, 512_001, 512_001 })
+        foreach (int size in new[] { 1, 127, 128, 20_001 })
         {
             yield return new object[] { size, true };
             yield return new object[] { size, false };


### PR DESCRIPTION
Backport of #110550 and #111208 to release/9.0-staging

## Customer Impact

- [ ] Customer reported
- [x] Found internally

CI only changes.

## Regression

- [ ] Yes
- [x] No

## Testing

Both fixes have been tested in the main branch.

## Risk

Very low: for #110550 we just perform fewer test cases for large inputs, for #111208 we simply don't test Drawing-related types for Mono as it's not supported.
