### PR TITLE
Use ConnectionGuid to call CustomValidationCallback once on WinHttpHandler

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -173,6 +173,8 @@ internal static partial class Interop
         public const uint WINHTTP_OPTION_STREAM_ERROR_CODE = 159;
         public const uint WINHTTP_OPTION_REQUIRE_STREAM_END = 160;
 
+        public const uint WINHTTP_OPTION_CONNECTION_GUID = 178;
+
         public enum WINHTTP_WEB_SOCKET_BUFFER_TYPE
         {
             WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE = 0,

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -46,8 +46,9 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
-        [Fact]
-        public void SendAsync_ServerCertificateValidationCallback_CalledOnce()
+        [OuterLoop]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version22000OrGreater))]
+        public async Task SendAsync_ServerCertificateValidationCallback_CalledOnce()
         {
             int callbackCount = 0;
             var handler = new WinHttpHandler()
@@ -64,8 +65,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 {
                     var response = client.GetAsync(System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer).Result;
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    var responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                    _output.WriteLine(responseContent);
+                    _ = await response.Content.ReadAsStringAsync();
                 }
                 Assert.Equal(1, callbackCount);
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -9,7 +9,7 @@ using System.Net.Test.Common;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
+using TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -63,7 +63,39 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             {
                 for (int i = 0; i < 5; i++)
                 {
-                    var response = client.GetAsync(System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer).Result;
+                    var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, Configuration.Http.SecureRemoteEchoServer)
+                    {
+                        Version = HttpVersion.Version11
+                    });
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    _ = await response.Content.ReadAsStringAsync();
+                }
+                Assert.Equal(1, callbackCount);
+            }
+        }
+
+        [OuterLoop]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version22000OrGreater))]
+        public async Task SendAsync_ServerCertificateValidationCallbackHttp2_CalledOnce()
+        {
+            using TestEventListener testEventListener = new TestEventListener(_output, TestEventListener.NetworkingEvents);
+            int callbackCount = 0;
+            var handler = new WinHttpHandler()
+            {
+                ServerCertificateValidationCallback = (m, cert, chain, err) =>
+                {
+                    Interlocked.Increment(ref callbackCount);
+                    return true;
+                }
+            };
+            using (var client = new HttpClient(handler))
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, System.Net.Test.Common.Configuration.Http.Http2RemoteEchoServer)
+                    {
+                        Version = HttpVersion20.Value
+                    });
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     _ = await response.Content.ReadAsStringAsync();
                 }


### PR DESCRIPTION
Usage of Connection GUID for WinHttpHandler to eliminate calling custom validation callback per request.

This feature (ConnectionGuid) is available since Windows 21H2 (22000), so it's not going to work on older versions and we will fallback to the original behavior, calling CustomValidationCallback per request.