### PR TITLE
[RISC-V] Synthesize some floating constants inline

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1092,8 +1092,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
 
             assert(emitter::isFloatReg(targetReg));
 
-            // Make sure we use "fmv.w.x reg, zero" only for positive zero (0.0)
-            // and not for negative zero (-0.0)
+            // Make sure we use "fmv.w.x reg, zero" only for positive zero (0.0) and not for negative zero (-0.0)
             if (FloatingPointUtils::isPositiveZero(constValue))
             {
                 // A faster/smaller way to generate 0.0
@@ -1102,19 +1101,25 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                 break;
             }
 
-            if (size == EA_4BYTE)
+            int64_t bits =
+                (size == EA_4BYTE)
+                    ? (int32_t)BitOperations::SingleToUInt32Bits(FloatingPointUtils::convertToSingle(constValue))
+                    : (int64_t)BitOperations::DoubleToUInt64Bits(constValue);
+            bool fitsInLui = ((bits & 0xfff) == 0) && emitter::isValidSimm20(bits >> 12);
+            if (fitsInLui || emitter::isValidSimm12(bits)) // can we synthesize bits with a single instruction?
             {
-                uint32_t bits = BitOperations::SingleToUInt32Bits(FloatingPointUtils::convertToSingle(constValue));
-                if ((bits << (32 - 12)) == 0) // if 12 lowest bits are zero, synthesize with a single lui instruction
+                regNumber temp = internalRegisters.GetSingle(tree);
+                if (fitsInLui)
                 {
-                    regNumber temp = internalRegisters.GetSingle(tree);
-
-                    int32_t hi20 = ((int32_t)bits) >> 12;
-                    assert(hi20 != 0);
-                    emit->emitIns_R_I(INS_lui, size, temp, hi20);
-                    emit->emitIns_R_R(INS_fmv_w_x, size, targetReg, temp);
-                    break;
+                    emit->emitIns_R_I(INS_lui, size, temp, bits >> 12);
                 }
+                else
+                {
+                    emit->emitIns_R_R_I(INS_addi, size, temp, REG_ZERO, bits);
+                }
+
+                emit->emitIns_R_R(size == EA_4BYTE ? INS_fmv_w_x : INS_fmv_d_x, size, targetReg, temp);
+                break;
             }
 
             // We must load the FP constant from the constant pool

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1109,7 +1109,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                 {
                     regNumber temp = internalRegisters.GetSingle(tree);
 
-                    uint32_t hi20 = bits >> 12;
+                    int32_t hi20 = ((int32_t)bits) >> 12;
                     assert(hi20 != 0);
                     emit->emitIns_R_I(INS_lui, size, temp, hi20);
                     emit->emitIns_R_R(INS_fmv_w_x, size, targetReg, temp);

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -180,8 +180,7 @@ static bool isValidUimm5(ssize_t value)
 // Returns true if 'value' is a legal signed immediate 20 bit encoding.
 static bool isValidSimm20(ssize_t value)
 {
-    value >>= 20;
-    return value == 0 || value == -1;
+    return -(((int)1) << 19) <= value && value < (((int)1) << 19);
 };
 
 // Returns true if 'value' is a legal unsigned immediate 20 bit encoding.

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -180,7 +180,8 @@ static bool isValidUimm5(ssize_t value)
 // Returns true if 'value' is a legal signed immediate 20 bit encoding.
 static bool isValidSimm20(ssize_t value)
 {
-    return -(((int)1) << 19) <= value && value < (((int)1) << 19);
+    value >>= 20;
+    return value == 0 || value == -1;
 };
 
 // Returns true if 'value' is a legal unsigned immediate 20 bit encoding.

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -146,10 +146,14 @@ int LinearScan::BuildNode(GenTree* tree)
             emitAttr size = emitActualTypeSize(tree);
 
             double constValue = tree->AsDblCon()->DconValue();
-            if (!FloatingPointUtils::isPositiveZero(constValue) && size == EA_4BYTE)
+            if (!FloatingPointUtils::isPositiveZero(constValue))
             {
-                uint32_t bits = BitOperations::SingleToUInt32Bits(FloatingPointUtils::convertToSingle(constValue));
-                if ((bits << (32 - 12)) == 0) // if 12 lowest bits are zero, synthesize with a single lui instruction
+                int64_t bits =
+                    (size == EA_4BYTE)
+                        ? (int32_t)BitOperations::SingleToUInt32Bits(FloatingPointUtils::convertToSingle(constValue))
+                        : (int64_t)BitOperations::DoubleToUInt64Bits(constValue);
+                bool fitsInLui = ((bits & 0xfff) == 0) && emitter::isValidSimm20(bits >> 12);
+                if (fitsInLui || emitter::isValidSimm12(bits)) // can we synthesize bits with a single instruction?
                 {
                     buildInternalIntRegisterDefForNode(tree);
                     buildInternalRegisterUses();

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -143,10 +143,14 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_CNS_DBL:
         {
-            // There is no instruction for loading float/double imm directly into FPR.
-            // Reserve int to load constant from memory (IF_LARGELDC)
-            buildInternalIntRegisterDefForNode(tree);
-            buildInternalRegisterUses();
+            emitAttr size       = emitActualTypeSize(tree);
+            double   constValue = tree->AsDblCon()->DconValue();
+
+            if (!FloatingPointUtils::isPositiveZero(constValue) && size == EA_4BYTE)
+            {
+                buildInternalIntRegisterDefForNode(tree);
+                buildInternalRegisterUses();
+            }
         }
             FALLTHROUGH;
 


### PR DESCRIPTION
Inline floating constants which can be synthesized with a single instruction. It is as fast but smaller than a load from data constant.

Part of #84834, cc @dotnet/samsung