### PR TITLE
Remove explicit __compact_unwind entries from x64 assembler

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
@@ -16,15 +16,6 @@
 
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
-#if defined(__APPLE__)
-        .set LOCAL_LABEL(\Name\()_Size), . - C_FUNC(\Name)
-        .section __LD,__compact_unwind,regular,debug
-        .quad C_FUNC(\Name)
-        .long LOCAL_LABEL(\Name\()_Size)
-        .long 0x04000000 # DWARF
-        .quad 0
-        .quad 0
-#endif
 .endm
 
 .macro PATCH_LABEL Name

--- a/src/coreclr/pal/inc/unixasmmacrosamd64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosamd64.inc
@@ -16,15 +16,6 @@
 
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
-#if defined(__APPLE__)
-        .set LOCAL_LABEL(\Name\()_Size), . - C_FUNC(\Name)
-        .section __LD,__compact_unwind,regular,debug
-        .quad C_FUNC(\Name)
-        .long LOCAL_LABEL(\Name\()_Size)
-        .long 0x04000000 # DWARF
-        .quad 0
-        .quad 0
-#endif
 .endm
 
 .macro PATCH_LABEL Name


### PR DESCRIPTION
This was originally added in https://github.com/dotnet/coreclr/commit/52bcc7ca66faa21c326ccbb0c68b2bf060fd647e. At that point in time LLVM was not generating the `__compact_unwind` section in object files and LD64 was trying to convert DWARF instructions to compact unwinding information which was buggy. The compiler landscape has changed significantly since then. LLVM now generates the `__compact_unwind` entries from DWARF information, which results in duplicated entries in the object file. Additionally, the algorithm in LD64 was changed too and LD64 itself is now deprecated and replaced by ld-prime linker.

Fixes dotnet/sdk#46006