### PR TITLE
JIT: Use faster mod for uint16 values

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4161,10 +4161,9 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeO
     }
 
     if (((tree->gtFlags & GTF_UMOD_UINT16_OPERANDS) == 0) && tree->OperIs(GT_UMOD) && op2->IsCnsIntOrI() &&
-        FitsIn<uint16_t>(op2->AsIntCon()->IconValue()) &&
+        FitsIn<uint16_t>(op2->AsIntCon()->IconValue()) && op1IsNotNegative &&
         IntegralRange::ForNode(op1, this).GetUpperBound() <= SymbolicIntegerValue::UShortMax)
     {
-        assert(IntegralRange::ForNode(op1, this).GetLowerBound() >= SymbolicIntegerValue::Zero);
         JITDUMP("Both operands for UMOD are in uint16 range...\n")
         tree->gtFlags |= GTF_UMOD_UINT16_OPERANDS;
         changed = true;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4161,7 +4161,7 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeO
     }
 
     if (((tree->gtFlags & GTF_UMOD_UINT16_OPERANDS) == 0) && tree->OperIs(GT_UMOD) && op2->IsCnsIntOrI() &&
-        op2->AsIntCon()->IconValue() <= UINT16_MAX &&
+        FitsIn<uint16_t>(op2->AsIntCon()->IconValue()) &&
         IntegralRange::ForNode(op1, this).GetUpperBound() <= SymbolicIntegerValue::UShortMax)
     {
         JITDUMP("Both operands for UMOD are in uint16 range...\n")

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4164,6 +4164,7 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeO
         FitsIn<uint16_t>(op2->AsIntCon()->IconValue()) &&
         IntegralRange::ForNode(op1, this).GetUpperBound() <= SymbolicIntegerValue::UShortMax)
     {
+        assert(IntegralRange::ForNode(op1, this).GetLowerBound() >= SymbolicIntegerValue::Zero);
         JITDUMP("Both operands for UMOD are in uint16 range...\n")
         tree->gtFlags |= GTF_UMOD_UINT16_OPERANDS;
         changed = true;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4116,7 +4116,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
 //    1) Convert DIV/MOD to UDIV/UMOD if both operands are proven to be never negative
 //    2) Marks DIV/UDIV/MOD/UMOD with GTF_DIV_MOD_NO_BY_ZERO if divisor is proven to be never zero
 //    3) Marks DIV/UDIV/MOD/UMOD with GTF_DIV_MOD_NO_OVERFLOW if both operands are proven to be never negative
-//    4) UMOD with GTF_UMOD_UINT16_OPERANDS if both operands are proven to be in uint16 range
+//    4) Marks UMOD with GTF_UMOD_UINT16_OPERANDS if both operands are proven to be in uint16 range
 //
 // Arguments:
 //    assertions - set of live assertions

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4166,14 +4166,14 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeO
         changed = true;
     }
 
-    if (((tree->gtFlags & GTF_DIV_MOD_NO_BY_ZERO) == 0) && op2IsNotZero)
+    if (op2IsNotZero)
     {
         JITDUMP("Divisor for DIV/MOD is proven to be never negative...\n")
         tree->gtFlags |= GTF_DIV_MOD_NO_BY_ZERO;
         changed = true;
     }
 
-    if (((tree->gtFlags & GTF_DIV_MOD_NO_OVERFLOW) == 0) && (op1IsNotNegative || op2IsNotNegative))
+    if (op1IsNotNegative || op2IsNotNegative)
     {
         JITDUMP("DIV/MOD is proven to never overflow...\n")
         tree->gtFlags |= GTF_DIV_MOD_NO_OVERFLOW;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4180,14 +4180,16 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeO
         changed = true;
     }
 
+#ifdef TARGET_AMD64
     if (((tree->gtFlags & GTF_UMOD_UINT16_OPERANDS) == 0) && tree->OperIs(GT_UMOD) && op2->IsCnsIntOrI() &&
-        FitsIn<uint16_t>(op2->AsIntCon()->IconValue()) &&
+        FitsIn<uint16_t>(op2->AsIntCon()->IconValue()) && op2->AsIntCon()->IconValue() > 0 &&
         IntegralRange::ForType(TYP_USHORT).Contains(IntegralRange::ForNode(op1, this)))
     {
         JITDUMP("Both operands for UMOD are in uint16 range...\n")
         tree->gtFlags |= GTF_UMOD_UINT16_OPERANDS;
         changed = true;
     }
+#endif
 
     return changed ? optAssertionProp_Update(tree, tree, stmt) : nullptr;
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2678,8 +2678,8 @@ AGAIN:
     }
     if (op1->OperIs(GT_MOD, GT_UMOD, GT_DIV, GT_UDIV))
     {
-        if ((op1->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)) !=
-            (op2->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)))
+        if ((op1->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW | GTF_UMOD_UINT16_OPERANDS)) !=
+            (op2->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW | GTF_UMOD_UINT16_OPERANDS)))
         {
             return false;
         }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -540,6 +540,8 @@ enum GenTreeFlags : unsigned int
 
     GTF_DIV_MOD_NO_OVERFLOW     = 0x40000000, // GT_DIV, GT_MOD -- Div or mod definitely does not overflow.
 
+    GTF_UMOD_UINT16_OPERANDS    = 0x80000000, // UMOD -- Both operands to a mod are in uint16 range.
+
     GTF_CHK_INDEX_INBND         = 0x80000000, // GT_BOUNDS_CHECK -- have proven this check is always in-bounds
 
     GTF_ARRLEN_NONFAULTING      = 0x20000000, // GT_ARR_LENGTH  -- An array length operation that cannot fault. Same as GT_IND_NONFAULTING.

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -540,7 +540,7 @@ enum GenTreeFlags : unsigned int
 
     GTF_DIV_MOD_NO_OVERFLOW     = 0x40000000, // GT_DIV, GT_MOD -- Div or mod definitely does not overflow.
 
-    GTF_UMOD_UINT16_OPERANDS    = 0x80000000, // UMOD -- Both operands to a mod are in uint16 range.
+    GTF_UMOD_UINT16_OPERANDS    = 0x80000000, // UMOD -- Both operands to a mod are in uint16 range. The divisor is non-zero constant.
 
     GTF_CHK_INDEX_INBND         = 0x80000000, // GT_BOUNDS_CHECK -- have proven this check is always in-bounds
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7189,6 +7189,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         return false;
     }
 
+#if defined(TARGET_64BIT)
     // Replace (uint16 % uint16) with a cheaper variant of FastMod, specialized for 16-bit operands.
     if ((divMod->gtFlags & GTF_UMOD_UINT16_OPERANDS) != 0)
     {
@@ -7229,6 +7230,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         ContainCheckRange(multiplier, divMod);
         return true;
     }
+#endif
 
 // TODO-ARM-CQ: Currently there's no GT_MULHI for ARM32
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7221,9 +7221,9 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         BlockRange().InsertBefore(divMod, multiplier, mul1, cast, shiftAmount);
         BlockRange().InsertBefore(divMod, mul2, shift);
 
-        // (int)result
+        // (int)result or (long)result
         divMod->ChangeOper(GT_CAST);
-        divMod->AsCast()->gtCastType = TYP_INT;
+        divMod->AsCast()->gtCastType = type;
         divMod->gtOp1                = shift;
         divMod->gtOp2                = nullptr;
         divMod->SetUnsigned();

--- a/src/tests/JIT/opt/Divide/Regressions/Regression4_Divide.cs
+++ b/src/tests/JIT/opt/Divide/Regressions/Regression4_Divide.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public class Program
+{
+    private static ushort s_field1;
+    private static ulong s_field2;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static uint Umod_U4_CharByZero(char c)
+    {
+        return (uint)c % 0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ushort Umod_U2_CharByConst(char c)
+    {
+        return (ushort)(c % 42);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Umod_I4_CharByConst(char c)
+    {
+        return c % 42;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static uint Umod_U4_CharByConst(char c)
+    {
+        return (uint)c % 42;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long Umod_I8_CharByConst(char c)
+    {
+        return (long)c % 42;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ulong Umod_U8_CharByConst(char c)
+    {
+        return (ulong)c % 42;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool TestIsWhiteSpace(char c)
+    {
+        ReadOnlySpan<char> HashEntries = [' ', ' ', '\u00A0', ' ', ' ', ' ', ' ', ' ', ' ', '\t', '\n', '\v', '\f', '\r', ' ', ' ', '\u2028', '\u2029', ' ', ' ', ' ', ' ', ' ', '\u202F', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '\u3000', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '\u0085', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', ' ', ' ', ' ', ' ', ' ', '\u205F', '\u1680', ' ', ' ', ' ', ' ', ' ', ' '];
+        return HashEntries[c % HashEntries.Length] == c;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ushort Umod_TZC(ulong value)
+    {
+        return (ushort)(BitOperations.TrailingZeroCount(value) % 42);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ushort Umod_TZC_Intrinsic(ulong value)
+    {
+        return (ushort)(Bmi1.X64.TrailingZeroCount(value) % 42);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Umod_UInt16Range_ByConst(int value)
+    {
+        if (value is > 0 and < 1234)
+        {
+            return value % 123;
+        }
+
+        return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void Test1()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            Core();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void Core()
+        {
+            s_field1 = (ushort)(Bmi1.X64.TrailingZeroCount(s_field2) % 42);
+        }
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        try
+        {
+            Umod_U4_CharByZero('a');
+            return 0;
+        }
+        catch (DivideByZeroException) { }
+
+        if (Umod_U2_CharByConst('a') != 13)
+            return 0;
+
+        if (Umod_I4_CharByConst('a') != 13)
+            return 0;
+
+        if (Umod_U4_CharByConst('a') != 13)
+            return 0;
+
+        if (Umod_I8_CharByConst('a') != 13)
+            return 0;
+
+        if (Umod_U8_CharByConst('a') != 13)
+            return 0;
+
+        if (!TestIsWhiteSpace(' '))
+            return 0;
+
+        if (!TestIsWhiteSpace('\u2029'))
+            return 0;
+
+        if (TestIsWhiteSpace('\0'))
+            return 0;
+
+        if (TestIsWhiteSpace('a'))
+            return 0;
+
+        if (Umod_TZC(1L << 40) != 40)
+            return 0;
+
+        if (Umod_TZC(1L << 50) != 8)
+            return 0;
+
+        if (Bmi1.X64.IsSupported)
+        {
+            if (Umod_TZC_Intrinsic(1L << 40) != 40)
+                return 0;
+
+            if (Umod_TZC_Intrinsic(1L << 50) != 8)
+                return 0;
+        }
+
+        if (Umod_UInt16Range_ByConst(0) != -1)
+            return 0;
+
+        if (Umod_UInt16Range_ByConst(42) != 42)
+            return 0;
+
+        if (Umod_UInt16Range_ByConst(123) != 0)
+            return 0;
+
+        if (Bmi1.X64.IsSupported)
+        {
+            s_field1 = 1;
+            s_field2 = 1L << 50;
+            Test1();
+
+            if (s_field1 != 8)
+                return 0;
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/opt/Divide/Regressions/Regression4_Divide.csproj
+++ b/src/tests/JIT/opt/Divide/Regressions/Regression4_Divide.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes #111492

- Remember a `GTF_UMOD_UINT16_OPERANDS` flag during assertion prop
- Expand `dividend % constDivisor` to `(ulong)(dividend * (uint.MaxValue / divisor + 1)) * divisor) >> 32` during lowering

There aren't many [diffs](https://github.com/MihuBot/runtime-utils/issues/896), but they look along the lines of
https://github.com/dotnet/runtime/blob/9aa8cbf2d27fae34c0eb46f6049d2f244998e841/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs#L2330-L2331
```diff
-       mov      edx, eax
-       imul     rdx, rdx, 0xD1FFAB1E
-       shr      rdx, 38
-       imul     edx, edx, 199
-       mov      esi, eax
-       sub      esi, edx
-       mov      dword ptr [rbp-0x34], esi
-       mov      rdx, 0xD1FFAB1E
-       mov      dword ptr [rbp-0x2C], eax
-       mul      rdx:rax, rdx
-       imul     edi, edx, 197
-       mov      eax, dword ptr [rbp-0x2C]
-       sub      eax, edi
+       imul     edi, eax, 0xD1FFAB1E
+       imul     rdx, rdi, 199
+       shr      rdx, 32
+       mov      dword ptr [rbp-0x34], edx
+       imul     edi, eax, 0xD1FFAB1E
+       imul     rax, rdi, 197
+       shr      rax, 32
```

Example use case that this makes a bit cheaper
```c#
bool IsWhiteSpace(char c)
{
    ReadOnlySpan<char> HashEntries = [' ', ' ', '\u00A0', ' ', ' ', ' ', ' ', ' ', ' ', '\t', '\n', '\v', '\f', '\r', ' ', ' ', '\u2028', '\u2029', ' ', ' ', ' ', ' ', ' ', '\u202F', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '\u3000', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '\u0085', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', ' ', ' ', ' ', ' ', ' ', '\u205F', '\u1680', ' ', ' ', ' ', ' ', ' ', ' '];
    return HashEntries[c % HashEntries.Length] == c;
}
```