### PR TITLE
When loading libldap try libldap.so.2 first

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Linux/Interop.Libraries.cs
@@ -8,7 +8,9 @@ internal static partial class Interop
         // Duplicated from Android for Linux Bionic
         internal const string Liblog = "liblog";
 
-        internal const string OpenLdap = "libldap-2.5.so.0";
+        // As a convention, some ldap installs use this to reference the latest version.
+        internal const string OpenLdap = "libldap.so.2";
+
         internal const string MsQuic = "libmsquic.so";
     }
 }

--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -71,7 +71,8 @@ internal static partial class Interop
         {
             Assembly currentAssembly = typeof(Ldap).Assembly;
 
-            // Register callback that tries to load other libraries when the default library "libldap-2.5.so.0" not found
+            // Register callback that tries to load other libraries when the default library "libldap.so.2" is not found.
+            // It is a convention to create the symbolic link "libldap.so.2" to point to a versioned library but not all distros do that.
             AssemblyLoadContext.GetLoadContext(currentAssembly).ResolvingUnmanagedDll += (assembly, ldapName) =>
             {
                 if (assembly != currentAssembly || ldapName != Libraries.OpenLdap)
@@ -79,8 +80,9 @@ internal static partial class Interop
                     return IntPtr.Zero;
                 }
 
-                // Try load next (libldap-2.6.so.0) or previous (libldap-2.4.so.2) versions
+                // Try versioned libraries.
                 if (NativeLibrary.TryLoad("libldap-2.6.so.0", out IntPtr handle) ||
+                    NativeLibrary.TryLoad("libldap-2.5.so.0", out handle) ||
                     NativeLibrary.TryLoad("libldap-2.4.so.2", out handle))
                 {
                     return handle;

--- a/src/libraries/Common/tests/System/DirectoryServices/LDAP.Configuration.xml
+++ b/src/libraries/Common/tests/System/DirectoryServices/LDAP.Configuration.xml
@@ -4,6 +4,14 @@ To enable the tests marked with [ConditionalFact(nameof(IsLdapConfigurationExist
 
 To ship, we should test on both an Active Directory LDAP server, and at least one other server, as behaviors are a little different. However for local testing, it is easiest to connect to an OpenDJ LDAP server in a docker container (eg., in WSL2).
 
+When testing with later of versions of LDAP, the ldapsearch commands below may need to use
+
+    -H ldap://localhost:<PORT>
+
+instead of
+
+    -h localhost -p <PORT>
+
 OPENDJ SERVER
 =============
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/108448

We may want to port this to v9 and perhaps earlier versions pending verification that this addresses the issues and is requested by the community.

I ran the DirectoryServices LDAP tests on Ubuntu for manual verification (see the modified XML file here).