### PR TITLE
Improve char.IsWhiteSpace for non-ASCII

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
@@ -443,6 +443,7 @@ namespace System.Globalization
         /// information is stored. Used for getting the Unicode category, bidi information,
         /// and whitespace information.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static nuint GetCategoryCasingTableOffsetNoBoundsChecks(uint codePoint)
         {
             UnicodeDebug.AssertIsValidCodePoint(codePoint);


### PR DESCRIPTION
`char.IsWhiteSpace` looks something like
```c#
bool IsWhiteSpace(char c)
{
    if (c < 256) return Latin1LookupTable[c]:

    return Fallback(c);
}

static bool Fallback(char ch)
{
    nuint offset = GetCategoryCasingTableOffsetNoBoundsChecks(ch);
    return (sbyte)Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(CategoriesValues), offset) < 0;
}
```

If you just run a microbenchmark over this with non-ASCII input, things will be fine as PGO will inline the whole thing together.

But if `IsWhiteSpace` ends up tiering up without seeing data super skewed for non-ASCII, the `GetCategoryCasingTableOffsetNoBoundsChecks` call in the fallback case won't be inlined, slowing down any future queries for non-ASCII chars.

```c#
public class NonAsciiTest
{
    private readonly string _text = string.Create(50, 0, (buffer, _) => new Random(42).NextBytes(MemoryMarshal.Cast<char, byte>(buffer)));

    public NonAsciiTest()
    {
        for (int i = 0; i < 20; i++)
        {
            for (int j = 0; j < 150; j++)
            {
                _ = char.IsWhiteSpace((char)j);
            }

            Thread.Sleep(16);
        }
    }

    [Benchmark]
    public int CountWhiteSpace()
    {
        int count = 0;
        foreach (char c in _text)
        {
            if (char.IsWhiteSpace(c))
            {
                count++;
            }
        }
        return count;
    }
}
```

| Method          | Toolchain  | Mean      | Error    | Ratio |
|---------------- |----------- |----------:|---------:|------:|
| CountWhiteSpace | main       | 152.94 ns | 3.041 ns |  1.00 |
| CountWhiteSpace | pr         |  95.31 ns | 0.439 ns |  0.62 |