### PR TITLE
Fix explicit offset of ByRefLike fields.

### DIFF
--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -169,6 +169,8 @@ Breaking Change Rules
 
 * Changing a `struct` type to a `ref struct` type and vice versa
 
+* Adding a new `ref` field to a type
+
 * Changing the underlying type of an enum
 
     This is a compile-time and behavioral breaking change as well as a binary breaking change which can make attribute arguments unparsable.

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -169,7 +169,7 @@ Breaking Change Rules
 
 * Changing a `struct` type to a `ref struct` type and vice versa
 
-* Adding a new `ref` field to a type
+* Adding a new `ref` field to a type that didn't have any `ref` field before (recursively)
 
 * Changing the underlying type of an enum
 

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -169,8 +169,6 @@ Breaking Change Rules
 
 * Changing a `struct` type to a `ref struct` type and vice versa
 
-* Adding a new `ref` field to a type that didn't have any `ref` field before (recursively)
-
 * Changing the underlying type of an enum
 
     This is a compile-time and behavioral breaking change as well as a binary breaking change which can make attribute arguments unparsable.

--- a/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
@@ -61,6 +61,12 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            Debug.Assert(!_fallbackAlgorithm.ComputeContainsByRefs(type));
+            return false;
+        }
+
         public override bool ComputeIsUnsafeValueType(DefType type)
         {
             Debug.Assert(!_fallbackAlgorithm.ComputeIsUnsafeValueType(type));

--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -133,6 +133,12 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            Debug.Assert(!_fallbackAlgorithm.ComputeContainsByRefs(type));
+            return false;
+        }
+
         public override bool ComputeIsUnsafeValueType(DefType type)
         {
             Debug.Assert(!_fallbackAlgorithm.ComputeIsUnsafeValueType(type));

--- a/src/coreclr/tools/Common/JitInterface/SwiftPhysicalLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/SwiftPhysicalLowering.cs
@@ -101,7 +101,7 @@ namespace Internal.JitInterface
                 return LoweredType.Opaque;
             }
 
-            protected override bool NeedsRecursiveLayout(int offset, TypeDesc fieldType) => fieldType.IsValueType && !fieldType.IsPrimitiveNumeric;
+            protected override bool NeedsRecursiveLayout(TypeDesc fieldType) => fieldType.IsValueType && !fieldType.IsPrimitiveNumeric;
 
             private List<FieldLayoutInterval> CreateConsolidatedIntervals()
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
@@ -78,6 +78,16 @@ namespace Internal.TypeSystem
             /// True if the type transitively has a Vector<T> in it or is Vector<T>
             /// </summary>
             public const int IsVectorTOrHasVectorTFields = 0x1000;
+
+            /// <summary>
+            /// True if ContainsByRefs has been computed
+            /// </summary>
+            public const int ComputedContainsByRefs = 0x2000;
+
+            /// <summary>
+            /// True if the type contains byrefs
+            /// </summary>
+            public const int ContainsByRefs = 0x4000;
         }
 
         private sealed class StaticBlockInfo
@@ -110,6 +120,21 @@ namespace Internal.TypeSystem
                     ComputeTypeContainsGCPointers();
                 }
                 return _fieldLayoutFlags.HasFlags(FieldLayoutFlags.ContainsGCPointers);
+            }
+        }
+
+        /// <summary>
+        /// Does a type transitively have any fields which are byrefs
+        /// </summary>
+        public bool ContainsByRefs
+        {
+            get
+            {
+                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedContainsByRefs))
+                {
+                    ComputeTypeContainsByRefs();
+                }
+                return _fieldLayoutFlags.HasFlags(FieldLayoutFlags.ContainsByRefs);
             }
         }
 
@@ -540,6 +565,20 @@ namespace Internal.TypeSystem
             if (this.Context.GetLayoutAlgorithmForType(this).ComputeContainsGCPointers(this))
             {
                 flagsToAdd |= FieldLayoutFlags.ContainsGCPointers;
+            }
+
+            _fieldLayoutFlags.AddFlags(flagsToAdd);
+        }
+
+        public void ComputeTypeContainsByRefs()
+        {
+            if (_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedContainsByRefs))
+                return;
+
+            int flagsToAdd = FieldLayoutFlags.ComputedContainsByRefs;
+            if (this.Context.GetLayoutAlgorithmForType(this).ComputeContainsByRefs(this))
+            {
+                flagsToAdd |= FieldLayoutFlags.ContainsByRefs;
             }
 
             _fieldLayoutFlags.AddFlags(flagsToAdd);

--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -74,7 +74,7 @@ namespace Internal.TypeSystem
                 }
             }
 
-            protected override bool NeedsRecursiveLayout(int offset, TypeDesc fieldType)
+            protected override bool NeedsRecursiveLayout(TypeDesc fieldType)
             {
                 if (!fieldType.IsValueType)
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -81,7 +81,7 @@ namespace Internal.TypeSystem
                     return false;
                 }
 
-                if (offset % PointerSize != 0)
+                if (!fieldType.IsByRefLike && offset % PointerSize != 0)
                 {
                     // Misaligned struct with GC pointers or ByRef
                     ThrowFieldLayoutError(offset);

--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -76,18 +76,13 @@ namespace Internal.TypeSystem
 
             protected override bool NeedsRecursiveLayout(int offset, TypeDesc fieldType)
             {
-                if (!fieldType.IsValueType || !((MetadataType)fieldType).ContainsGCPointers && !fieldType.IsByRefLike)
+                if (!fieldType.IsValueType)
                 {
                     return false;
                 }
 
-                if (!fieldType.IsByRefLike && offset % PointerSize != 0)
-                {
-                    // Misaligned struct with GC pointers or ByRef
-                    ThrowFieldLayoutError(offset);
-                }
-
-                return true;
+                // Valuetypes with GC references and byref-like types need to be checked for overlaps and alignment
+                return ((MetadataType)fieldType).ContainsGCPointers || fieldType.IsByRefLike;
             }
 
             private void ThrowFieldLayoutError(int offset)

--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -81,8 +81,9 @@ namespace Internal.TypeSystem
                     return false;
                 }
 
-                // Valuetypes with GC references and byref-like types need to be checked for overlaps and alignment
-                return ((MetadataType)fieldType).ContainsGCPointers || fieldType.IsByRefLike;
+                // Valuetypes with GC references or byrefs need to be checked for overlaps and alignment
+                var metadataType = ((MetadataType)fieldType);
+                return metadataType.ContainsGCPointers || metadataType.ContainsByRefs;
             }
 
             private void ThrowFieldLayoutError(int offset)

--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -60,12 +60,12 @@ namespace Internal.TypeSystem
                 else if (fieldType.IsValueType)
                 {
                     MetadataType mdType = (MetadataType)fieldType;
-                    if (!mdType.ContainsGCPointers && !mdType.IsByRefLike)
+                    if (!mdType.ContainsGCPointers && !mdType.ContainsByRefs)
                     {
                         // Plain value type, mark the entire range as NonORef
                         return FieldLayoutTag.NonORef;
                     }
-                    Debug.Fail("We should recurse on value types with GC pointers or ByRefLike types");
+                    Debug.Fail("We should recurse on value types with GC pointers or byrefs");
                     return FieldLayoutTag.Empty;
                 }
                 else
@@ -82,8 +82,8 @@ namespace Internal.TypeSystem
                 }
 
                 // Valuetypes with GC references or byrefs need to be checked for overlaps and alignment
-                var metadataType = ((MetadataType)fieldType);
-                return metadataType.ContainsGCPointers || metadataType.ContainsByRefs;
+                MetadataType mdType = ((MetadataType)fieldType);
+                return mdType.ContainsGCPointers || mdType.ContainsByRefs;
             }
 
             private void ThrowFieldLayoutError(int offset)

--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -82,7 +82,7 @@ namespace Internal.TypeSystem
                 }
 
                 // Valuetypes with GC references or byrefs need to be checked for overlaps and alignment
-                MetadataType mdType = ((MetadataType)fieldType);
+                MetadataType mdType = (MetadataType)fieldType;
                 return mdType.ContainsGCPointers || mdType.ContainsByRefs;
             }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -32,6 +32,11 @@ namespace Internal.TypeSystem
         public abstract bool ComputeContainsGCPointers(DefType type);
 
         /// <summary>
+        /// Compute whether the fields of the specified type contains a byref.
+        /// </summary>
+        public abstract bool ComputeContainsByRefs(DefType type);
+
+        /// <summary>
         /// Compute whether the specified type is a value type that transitively has UnsafeValueTypeAttribute
         /// </summary>
         public abstract bool ComputeIsUnsafeValueType(DefType type);

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutIntervalCalculator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutIntervalCalculator.cs
@@ -97,7 +97,7 @@ namespace Internal.TypeSystem
                     if (field.IsStatic)
                         continue;
 
-                    int fieldOffset = offset + field.Offset.AsInt;
+                    int fieldOffset = field.Offset.AsInt;
                     AddToFieldLayout(nestedIntervals, fieldOffset, field.FieldType);
                 }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutIntervalCalculator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutIntervalCalculator.cs
@@ -55,7 +55,7 @@ namespace Internal.TypeSystem
             PointerSize = pointerSize;
         }
 
-        protected abstract bool NeedsRecursiveLayout(int offset, TypeDesc fieldType);
+        protected abstract bool NeedsRecursiveLayout(TypeDesc fieldType);
 
         protected abstract TIntervalTag GetIntervalDataForType(int offset, TypeDesc fieldType);
 
@@ -84,7 +84,7 @@ namespace Internal.TypeSystem
 
         public void AddToFieldLayout(int offset, TypeDesc fieldType, bool addTrailingEmptyInterval)
         {
-            if (NeedsRecursiveLayout(offset, fieldType))
+            if (NeedsRecursiveLayout(fieldType))
             {
                 if (fieldType is MetadataType { IsInlineArray: true } mdType)
                 {
@@ -97,7 +97,7 @@ namespace Internal.TypeSystem
                     if (field.IsStatic)
                         continue;
 
-                    int fieldOffset = field.Offset.AsInt;
+                    int fieldOffset = offset + field.Offset.AsInt;
                     AddToFieldLayout(nestedIntervals, fieldOffset, field.FieldType);
                 }
 
@@ -126,7 +126,7 @@ namespace Internal.TypeSystem
 
         private void AddToFieldLayout(List<FieldLayoutInterval> fieldLayout, int offset, TypeDesc fieldType)
         {
-            if (NeedsRecursiveLayout(offset, fieldType))
+            if (NeedsRecursiveLayout(fieldType))
             {
                 if (fieldType is MetadataType { IsInlineArray: true } mdType)
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -281,7 +281,7 @@ namespace Internal.TypeSystem
 
                 TypeDesc fieldType = field.FieldType;
                 if (fieldType.IsByRef
-                    || ((fieldType is DefType df) && df.ContainsByRefs))
+                    || (fieldType.IsByRefLike && ((DefType)fieldType).ContainsByRefs))
                 {
                     return true;
                 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -329,13 +329,11 @@ namespace Internal.TypeSystem
                 LayoutInt computedOffset = fieldAndOffset.Offset + cumulativeInstanceFieldPos + offsetBias;
 
                 // GC pointers MUST be aligned.
-                // We treat byref-like structs as GC pointers too.
                 bool needsToBeAligned =
                     !computedOffset.IsIndeterminate
                     &&
                     (
                         fieldType.IsGCPointer
-                        || fieldType.IsByRefLike
                         || (fieldType.IsValueType && ((DefType)fieldType).ContainsGCPointers)
                     );
                 if (needsToBeAligned)

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -280,8 +280,11 @@ namespace Internal.TypeSystem
                     continue;
 
                 TypeDesc fieldType = field.FieldType;
-                if (fieldType.IsByRef)
+                if (fieldType.IsByRef
+                    || ((fieldType is DefType df) && df.ContainsByRefs))
+                {
                     return true;
+                }
             }
 
             return false;

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -207,7 +207,7 @@ namespace Internal.TypeSystem
                 }
 
                 ref StaticsBlock block = ref GetStaticsBlockForField(ref result, field);
-                SizeAndAlignment sizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, hasLayout: false, context.Target.DefaultPackingSize, out bool _, out bool _, out bool _, out bool _);
+                SizeAndAlignment sizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, hasLayout: false, context.Target.DefaultPackingSize, out ComputedFieldData _);
 
                 block.Size = LayoutInt.AlignUp(block.Size, sizeAndAlignment.Alignment, context.Target);
                 result.Offsets[index] = new FieldAndOffset(field, block.Size);
@@ -291,7 +291,7 @@ namespace Internal.TypeSystem
             LayoutInt cumulativeInstanceFieldPos = CalculateFieldBaseOffset(type, requiresAlign8: false, requiresAlignedBase: false) - offsetBias;
             LayoutInt instanceSize = cumulativeInstanceFieldPos + offsetBias;
 
-            var layoutMetadata = type.GetClassLayout();
+            ClassLayoutMetadata layoutMetadata = type.GetClassLayout();
             int packingSize = ComputePackingSize(type, layoutMetadata);
             LayoutInt largestAlignmentRequired = LayoutInt.One;
 
@@ -308,17 +308,17 @@ namespace Internal.TypeSystem
                 hasVectorTField = type.BaseType.IsVectorTOrHasVectorTFields;
             }
 
-            foreach (var fieldAndOffset in layoutMetadata.Offsets)
+            foreach (FieldAndOffset fieldAndOffset in layoutMetadata.Offsets)
             {
                 TypeDesc fieldType = fieldAndOffset.Field.FieldType;
-                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType.UnderlyingType, hasLayout: true, packingSize, out bool fieldLayoutAbiStable, out bool fieldHasAutoLayout, out bool fieldHasInt128Field, out bool fieldHasVectorTField);
-                if (!fieldLayoutAbiStable)
+                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType.UnderlyingType, hasLayout: true, packingSize, out ComputedFieldData fieldData);
+                if (!fieldData.LayoutAbiStable)
                     layoutAbiStable = false;
-                if (fieldHasAutoLayout)
+                if (fieldData.HasAutoLayout)
                     hasAutoLayoutField = true;
-                if (fieldHasInt128Field)
+                if (fieldData.HasInt128Field)
                     hasInt128Field = true;
-                if (fieldHasVectorTField)
+                if (fieldData.HasVectorTField)
                     hasVectorTField = true;
 
                 largestAlignmentRequired = LayoutInt.Max(fieldSizeAndAlignment.Alignment, largestAlignmentRequired);
@@ -420,14 +420,14 @@ namespace Internal.TypeSystem
                 if (field.IsStatic)
                     continue;
 
-                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(field.FieldType.UnderlyingType, hasLayout: true, packingSize, out bool fieldLayoutAbiStable, out bool fieldHasAutoLayout, out bool fieldHasInt128Field, out bool fieldHasVectorTField);
-                if (!fieldLayoutAbiStable)
+                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(field.FieldType.UnderlyingType, hasLayout: true, packingSize, out ComputedFieldData fieldData);
+                if (!fieldData.LayoutAbiStable)
                     layoutAbiStable = false;
-                if (fieldHasAutoLayout)
+                if (fieldData.HasAutoLayout)
                     hasAutoLayoutField = true;
-                if (fieldHasInt128Field)
+                if (fieldData.HasInt128Field)
                     hasInt128Field = true;
-                if (fieldHasVectorTField)
+                if (fieldData.HasVectorTField)
                     hasVectorTField = true;
 
                 largestAlignmentRequirement = LayoutInt.Max(fieldSizeAndAlignment.Alignment, largestAlignmentRequirement);
@@ -557,7 +557,7 @@ namespace Internal.TypeSystem
                 {
                     Debug.Assert(fieldType.IsPrimitive || fieldType.IsPointer || fieldType.IsFunctionPointer || fieldType.IsEnum || fieldType.IsByRef);
 
-                    var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, hasLayout, packingSize, out bool _, out bool _, out bool _, out bool _);
+                    var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, hasLayout, packingSize, out ComputedFieldData _);
                     instanceNonGCPointerFieldsCount[CalculateLog2(fieldSizeAndAlignment.Size.AsInt)]++;
                 }
             }
@@ -594,8 +594,8 @@ namespace Internal.TypeSystem
 
                 TypeDesc fieldType = field.FieldType;
 
-                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, hasLayout, packingSize, out bool fieldLayoutAbiStable, out bool _, out bool _, out bool _);
-                if (!fieldLayoutAbiStable)
+                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, hasLayout, packingSize, out ComputedFieldData fieldData);
+                if (!fieldData.LayoutAbiStable)
                     layoutAbiStable = false;
 
                 if (IsByValueClass(fieldType))
@@ -680,7 +680,7 @@ namespace Internal.TypeSystem
                         int j;
 
                         // Check if the position is aligned such that we could place a larger type
-                        int offsetModulo = cumulativeInstanceFieldPos.AsInt % (1 << (i+1));
+                        int offsetModulo = cumulativeInstanceFieldPos.AsInt % (1 << (i + 1));
                         if (offsetModulo == 0)
                         {
                             continue;
@@ -764,8 +764,8 @@ namespace Internal.TypeSystem
             for (int i = 0; i < instanceValueClassFieldsArr.Length; i++)
             {
                 // Align the cumulative field offset to the indeterminate value
-                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(instanceValueClassFieldsArr[i].FieldType, hasLayout, packingSize, out bool fieldLayoutAbiStable, out bool _, out bool _, out bool _);
-                if (!fieldLayoutAbiStable)
+                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(instanceValueClassFieldsArr[i].FieldType, hasLayout, packingSize, out ComputedFieldData fieldData);
+                if (!fieldData.LayoutAbiStable)
                     layoutAbiStable = false;
 
                 cumulativeInstanceFieldPos = AlignUpInstanceFieldOffset(cumulativeInstanceFieldPos, fieldSizeAndAlignment.Alignment, context.Target);
@@ -835,7 +835,7 @@ namespace Internal.TypeSystem
 
         private static void PlaceInstanceField(FieldDesc field, bool hasLayout, int packingSize, FieldAndOffset[] offsets, ref LayoutInt instanceFieldPos, ref int fieldOrdinal, LayoutInt offsetBias)
         {
-            var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(field.FieldType, hasLayout, packingSize, out bool _, out bool _, out bool _, out bool _);
+            var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(field.FieldType, hasLayout, packingSize, out ComputedFieldData _);
 
             instanceFieldPos = AlignUpInstanceFieldOffset(instanceFieldPos, fieldSizeAndAlignment.Alignment, field.Context.Target);
             offsets[fieldOrdinal] = new FieldAndOffset(field, instanceFieldPos + offsetBias);
@@ -848,9 +848,9 @@ namespace Internal.TypeSystem
         // This will calculate the next multiple of 4 that is greater than or equal to the instance size
         private static LayoutInt GetAlignedNumInstanceFieldBytes(LayoutInt instanceSize)
         {
-            uint inputSize = (uint) instanceSize.AsInt;
+            uint inputSize = (uint)instanceSize.AsInt;
             uint result = (uint)(((inputSize + 3) & (~3)));
-            return new LayoutInt((int) result);
+            return new LayoutInt((int)result);
         }
 
         private static int CalculateLog2(int size)
@@ -859,7 +859,7 @@ namespace Internal.TypeSystem
             Debug.Assert(size > 0);
 
             // Size must be a power of 2
-            Debug.Assert( 0 == (size & (size - 1)));
+            Debug.Assert(0 == (size & (size - 1)));
 
             int log2size;
             for (log2size = 0; size > 1; log2size++)
@@ -895,13 +895,25 @@ namespace Internal.TypeSystem
             return cumulativeInstanceFieldPos;
         }
 
-        private static SizeAndAlignment ComputeFieldSizeAndAlignment(TypeDesc fieldType, bool hasLayout, int packingSize, out bool layoutAbiStable, out bool fieldTypeHasAutoLayout, out bool fieldTypeHasInt128Field, out bool fieldTypeHasVectorTField)
+        private struct ComputedFieldData
+        {
+            public bool LayoutAbiStable;
+            public bool HasAutoLayout;
+            public bool HasInt128Field;
+            public bool HasVectorTField;
+        }
+
+        private static SizeAndAlignment ComputeFieldSizeAndAlignment(TypeDesc fieldType, bool hasLayout, int packingSize, out ComputedFieldData fieldData)
         {
             SizeAndAlignment result;
-            layoutAbiStable = true;
-            fieldTypeHasAutoLayout = true;
-            fieldTypeHasInt128Field = false;
-            fieldTypeHasVectorTField = false;
+            fieldData = new()
+            {
+                // Initialize to expected default value
+                LayoutAbiStable = true,
+                HasAutoLayout = true,
+                HasInt128Field = false,
+                HasVectorTField = false
+            };
 
             if (fieldType.IsDefType)
             {
@@ -910,10 +922,10 @@ namespace Internal.TypeSystem
                     DefType defType = (DefType)fieldType;
                     result.Size = defType.InstanceFieldSize;
                     result.Alignment = defType.InstanceFieldAlignment;
-                    layoutAbiStable = defType.LayoutAbiStable;
-                    fieldTypeHasAutoLayout = defType.IsAutoLayoutOrHasAutoLayoutFields;
-                    fieldTypeHasInt128Field = defType.IsInt128OrHasInt128Fields;
-                    fieldTypeHasVectorTField = defType.IsVectorTOrHasVectorTFields;
+                    fieldData.LayoutAbiStable = defType.LayoutAbiStable;
+                    fieldData.HasAutoLayout = defType.IsAutoLayoutOrHasAutoLayoutFields;
+                    fieldData.HasInt128Field = defType.IsInt128OrHasInt128Fields;
+                    fieldData.HasVectorTField = defType.IsVectorTOrHasVectorTFields;
                 }
                 else
                 {
@@ -934,7 +946,7 @@ namespace Internal.TypeSystem
                 Debug.Assert(fieldType.IsPointer || fieldType.IsFunctionPointer || fieldType.IsByRef);
                 result.Size = fieldType.Context.Target.LayoutPointerSize;
                 result.Alignment = fieldType.Context.Target.LayoutPointerSize;
-                fieldTypeHasAutoLayout = fieldType.IsByRef;
+                fieldData.HasAutoLayout = fieldType.IsByRef;
             }
 
             // For non-auto layouts, we need to respect tighter packing requests for alignment.

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -269,6 +269,24 @@ namespace Internal.TypeSystem
             return someFieldContainsPointers;
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            if (!type.IsByRefLike)
+                return false;
+
+            foreach (var field in type.GetFields())
+            {
+                if (field.IsStatic)
+                    continue;
+
+                TypeDesc fieldType = field.FieldType;
+                if (fieldType.IsByRef)
+                    return true;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Called during static field layout to setup initial contents of statics blocks
         /// </summary>
@@ -335,6 +353,7 @@ namespace Internal.TypeSystem
                     (
                         fieldType.IsGCPointer
                         || (fieldType.IsValueType && ((DefType)fieldType).ContainsGCPointers)
+                        || (fieldType.IsByRefLike && ((DefType)fieldType).ContainsByRefs)
                     );
                 if (needsToBeAligned)
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs
@@ -65,6 +65,11 @@ namespace Internal.TypeSystem
             return _fallbackAlgorithm.ComputeContainsGCPointers(((TypeWithRepeatedFields)type).MetadataType);
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            return _fallbackAlgorithm.ComputeContainsByRefs(((TypeWithRepeatedFields)type).MetadataType);
+        }
+
         public override bool ComputeIsUnsafeValueType(DefType type)
         {
             return _fallbackAlgorithm.ComputeIsUnsafeValueType(((TypeWithRepeatedFields)type).MetadataType);

--- a/src/coreclr/tools/Common/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
@@ -17,6 +17,12 @@ namespace Internal.TypeSystem
             throw new NotSupportedException();
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            // This should never be called
+            throw new NotSupportedException();
+        }
+
         public override ComputedInstanceFieldLayout ComputeInstanceLayout(DefType type, InstanceLayoutKind layoutKind)
         {
             return new ComputedInstanceFieldLayout()

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
@@ -48,6 +48,14 @@ namespace Internal.TypeSystem
             return canonicalType.ContainsGCPointers;
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            RuntimeDeterminedType runtimeDeterminedType = (RuntimeDeterminedType)type;
+            DefType canonicalType = runtimeDeterminedType.CanonicalType;
+
+            return canonicalType.ContainsByRefs;
+        }
+
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
             RuntimeDeterminedType runtimeDeterminedType = (RuntimeDeterminedType)type;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VectorOfTFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VectorOfTFieldLayoutAlgorithm.cs
@@ -68,6 +68,11 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            return false;
+        }
+
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
             if (type.Context.Target.Architecture == TargetArchitecture.ARM64 &&

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -226,6 +226,11 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            return false;
+        }
+
         public override bool ComputeIsUnsafeValueType(DefType type)
         {
             return false;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
@@ -50,6 +50,11 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeContainsByRefs(DefType type)
+        {
+            return false;
+        }
+
         public override bool ComputeIsUnsafeValueType(DefType type)
         {
             return false;

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -118,6 +118,7 @@ namespace Explicit
 
     ref struct ByRefStruct
     {
+        public ref int R;
     }
 }
 

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -118,7 +118,9 @@ namespace Explicit
 
     ref struct ByRefStruct
     {
+#pragma warning disable CS9265 // Field is never ref-assigned to, and will always have its default value (null reference)
         public ref int R;
+#pragma warning restore CS9265
     }
 }
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -8677,30 +8677,28 @@ MethodTableBuilder::HandleExplicitLayout(
             else
             {
                 MethodTable *pByValueMT = pByValueClassCache[valueClassCacheIndex];
-                if (pByValueMT->IsByRefLike() || pByValueMT->ContainsGCPointers())
+                BOOL hasGcPointers = pByValueMT->ContainsGCPointers();
+                if (hasGcPointers || pByValueMT->IsByRefLike())
                 {
-                    if ((pFD->GetOffset() & ((ULONG)TARGET_POINTER_SIZE - 1)) != 0)
+                    if (hasGcPointers && ((pFD->GetOffset() & ((ULONG)TARGET_POINTER_SIZE - 1)) != 0))
                     {
-                        // If we got here, then a ByRefLike valuetype or a valuetype containing an OREF was misaligned.
+                        // If we got here, then a valuetype containing an OREF was misaligned.
                         badOffset = pFD->GetOffset();
                         fieldTrust.SetTrust(ExplicitFieldTrust::kNone);
                         break;
                     }
 
-                    ExplicitFieldTrust::TrustLevel trust = CheckValueClassLayout(pByValueMT, &pFieldLayout[pFD->GetOffset()]);
+                    ExplicitFieldTrust::TrustLevel trust = CheckValueClassLayout(pByValueMT, &pFieldLayout[pFD->GetOffset()], pFD->GetOffset());
                     fieldTrust.SetTrust(trust);
 
-                    if (trust != ExplicitFieldTrust::kNone)
-                    {
-                        continue;
-                    }
-                    else
+                    if (trust == ExplicitFieldTrust::kNone)
                     {
                         // If we got here, then an OREF/BYREF inside the valuetype illegally overlapped a non-OREF field. THROW.
                         badOffset = pFD->GetOffset();
                         break;
                     }
-                    break;
+
+                    continue;
                 }
                 // no pointers so fall through to do standard checking
                 fieldSize = pByValueMT->GetNumInstanceFieldBytes();
@@ -8855,13 +8853,13 @@ MethodTableBuilder::HandleExplicitLayout(
 
 //*******************************************************************************
 // make sure that no object fields are overlapped incorrectly, returns the trust level
-/*static*/ ExplicitFieldTrust::TrustLevel MethodTableBuilder::CheckValueClassLayout(MethodTable * pMT, bmtFieldLayoutTag *pFieldLayout)
+/*static*/ ExplicitFieldTrust::TrustLevel MethodTableBuilder::CheckValueClassLayout(MethodTable * pMT, bmtFieldLayoutTag *pFieldLayout, UINT fieldBaseOffset)
 {
     STANDARD_VM_CONTRACT;
 
     // ByRefLike types need to be checked for ByRef fields.
     if (pMT->IsByRefLike())
-        return CheckByRefLikeValueClassLayout(pMT, pFieldLayout);
+        return CheckByRefLikeValueClassLayout(pMT, pFieldLayout, fieldBaseOffset);
 
     // Build a layout of the value class (vc). Don't know the sizes of all the fields easily, but
     // do know (a) vc is already consistent so don't need to check it's overlaps and
@@ -8947,7 +8945,7 @@ MethodTableBuilder::HandleExplicitLayout(
 
 //*******************************************************************************
 // make sure that no byref/object fields are overlapped, returns the trust level
-/*static*/ ExplicitFieldTrust::TrustLevel MethodTableBuilder::CheckByRefLikeValueClassLayout(MethodTable * pMT, bmtFieldLayoutTag *pFieldLayout)
+/*static*/ ExplicitFieldTrust::TrustLevel MethodTableBuilder::CheckByRefLikeValueClassLayout(MethodTable * pMT, bmtFieldLayoutTag *pFieldLayout, UINT fieldBaseOffset)
 {
     STANDARD_VM_CONTRACT;
     _ASSERTE(pMT->IsByRefLike());
@@ -8964,17 +8962,21 @@ MethodTableBuilder::HandleExplicitLayout(
         if (pFD->GetFieldType() == ELEMENT_TYPE_VALUETYPE)
         {
             MethodTable *pFieldMT = pFD->GetApproxFieldTypeHandleThrowing().AsMethodTable();
-            trust = CheckValueClassLayout(pFieldMT, &pFieldLayout[fieldStartIndex]);
+            trust = CheckValueClassLayout(pFieldMT, &pFieldLayout[fieldStartIndex], fieldBaseOffset + fieldStartIndex);
         }
         else if (pFD->IsObjRef())
         {
-            _ASSERTE(fieldStartIndex % TARGET_POINTER_SIZE == 0);
-            trust = MarkTagType(&pFieldLayout[fieldStartIndex], TARGET_POINTER_SIZE, oref);
+            UINT absOffset = fieldBaseOffset + fieldStartIndex;
+            trust = (absOffset % TARGET_POINTER_SIZE == 0)
+                ? MarkTagType(&pFieldLayout[fieldStartIndex], TARGET_POINTER_SIZE, oref)
+                : ExplicitFieldTrust::kNone;
         }
         else if (pFD->IsByRef())
         {
-            _ASSERTE(fieldStartIndex % TARGET_POINTER_SIZE == 0);
-            trust = MarkTagType(&pFieldLayout[fieldStartIndex], TARGET_POINTER_SIZE, byref);
+            UINT absOffset = fieldBaseOffset + fieldStartIndex;
+            trust = (absOffset % TARGET_POINTER_SIZE == 0)
+                ? MarkTagType(&pFieldLayout[fieldStartIndex], TARGET_POINTER_SIZE, byref)
+                : ExplicitFieldTrust::kNone;
         }
         else
         {

--- a/src/coreclr/vm/methodtablebuilder.h
+++ b/src/coreclr/vm/methodtablebuilder.h
@@ -2878,11 +2878,13 @@ private:
 
     static ExplicitFieldTrust::TrustLevel CheckValueClassLayout(
         MethodTable * pMT,
-        bmtFieldLayoutTag* pFieldLayout);
+        bmtFieldLayoutTag* pFieldLayout,
+        UINT fieldBaseOffset);
 
     static ExplicitFieldTrust::TrustLevel CheckByRefLikeValueClassLayout(
         MethodTable * pMT,
-        bmtFieldLayoutTag* pFieldLayout);
+        bmtFieldLayoutTag* pFieldLayout,
+        UINT fieldBaseOffset);
 
     static ExplicitFieldTrust::TrustLevel MarkTagType(
         bmtFieldLayoutTag* field,

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2381,7 +2381,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 			}
 			ftype = mono_type_get_underlying_type (field->type);
 			ftype = mono_type_get_basic_type_from_generic (ftype);
-			if (type_has_references (klass, ftype) || m_type_is_byref (ftype)) {
+			if (type_has_references (klass, ftype) || type_has_ref_fields (ftype) || m_type_is_byref (ftype)) {
 				if (field_offsets [i] % TARGET_SIZEOF_VOID_P) {
 					mono_class_set_type_load_failure (klass, "Reference typed field '%s' has explicit offset that is not pointer-size aligned.", field->name);
 				}

--- a/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
+++ b/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
@@ -54,6 +54,20 @@ public class Test
         }
     }
 
+    [StructLayout(LayoutKind.Explicit)]
+    public ref struct Explicit4
+    {
+        [FieldOffset(0)]
+        public Size4Bytes Field1;
+        [FieldOffset(4)]
+        public Size4Bytes Field2;
+
+        public ref struct Size4Bytes
+        {
+            public uint Value;
+        }
+    }
+
     [Fact]
     public static void Validate_Explicit1()
     {
@@ -87,6 +101,63 @@ public class Test
         static string Load3()
         {
             return typeof(Explicit3).ToString();
+        }
+    }
+
+    [Fact]
+    public static void Validate_Explicit4()
+    {
+        Load4();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string Load4()
+        {
+            return typeof(Explicit4).ToString();
+        }
+    }
+
+    // Invalid. Explicit offset on second field is invalid
+    // since first field on type will be misaligned.
+    [StructLayout(LayoutKind.Explicit)]
+    public ref struct Explicit_Invalid32bit
+    {
+        [FieldOffset(0)]
+        public WithByRefs Field1;
+        [FieldOffset(2)]
+        public WithByRefs Field2;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public ref struct Explicit_Invalid64bit
+    {
+        [FieldOffset(0)]
+        public WithByRefs Field1;
+        [FieldOffset(4)]
+        public WithByRefs Field2;
+    }
+
+    [Fact]
+    public static void Validate_Throws_Explicit()
+    {
+        if (Environment.Is64BitProcess)
+        {
+            Assert.Throws<TypeLoadException>(() => Load64());
+        }
+        else
+        {
+            Assert.Throws<TypeLoadException>(() => Load32());
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string Load32()
+        {
+            return typeof(Explicit_Invalid32bit).ToString();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string Load64()
+        {
+            return typeof(Explicit_Invalid64bit).ToString();
         }
     }
 }

--- a/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
+++ b/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
@@ -54,17 +54,17 @@ public class Test
         }
     }
 
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Explicit, Size = 2)]
     public ref struct Explicit4
     {
         [FieldOffset(0)]
-        public Size4Bytes Field1;
-        [FieldOffset(4)]
-        public Size4Bytes Field2;
+        public Size1Byte Field1;
+        [FieldOffset(1)]
+        public Size1Byte Field2;
 
-        public ref struct Size4Bytes
+        public ref struct Size1Byte
         {
-            public uint Value;
+            public byte Value;
         }
     }
 
@@ -119,7 +119,7 @@ public class Test
     // Invalid. Explicit offset on second field is invalid
     // since first field on type will be misaligned.
     [StructLayout(LayoutKind.Explicit)]
-    public ref struct Explicit_Invalid32bit
+    public ref struct Explicit5a_Invalid32
     {
         [FieldOffset(0)]
         public WithByRefs Field1;
@@ -128,7 +128,16 @@ public class Test
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    public ref struct Explicit_Invalid64bit
+    public ref struct Explicit5b_Invalid32
+    {
+        [FieldOffset(0)]
+        public WithORefs Field1;
+        [FieldOffset(2)]
+        public WithORefs Field2;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public ref struct Explicit5a_Invalid64
     {
         [FieldOffset(0)]
         public WithByRefs Field1;
@@ -136,28 +145,51 @@ public class Test
         public WithByRefs Field2;
     }
 
+    [StructLayout(LayoutKind.Explicit)]
+    public ref struct Explicit5b_Invalid64
+    {
+        [FieldOffset(0)]
+        public WithORefs Field1;
+        [FieldOffset(4)]
+        public WithORefs Field2;
+    }
+
     [Fact]
-    public static void Validate_Throws_Explicit()
+    public static void Validate_Explicit5_Invalid()
     {
         if (Environment.Is64BitProcess)
         {
-            Assert.Throws<TypeLoadException>(() => Load64());
+            Assert.Throws<TypeLoadException>(() => LoadA64());
+            Assert.Throws<TypeLoadException>(() => LoadB64());
         }
         else
         {
-            Assert.Throws<TypeLoadException>(() => Load32());
+            Assert.Throws<TypeLoadException>(() => LoadA32());
+            Assert.Throws<TypeLoadException>(() => LoadB32());
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static string Load32()
+        static string LoadA32()
         {
-            return typeof(Explicit_Invalid32bit).ToString();
+            return typeof(Explicit5a_Invalid32).ToString();
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static string Load64()
+        static string LoadB32()
         {
-            return typeof(Explicit_Invalid64bit).ToString();
+            return typeof(Explicit5b_Invalid32).ToString();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string LoadA64()
+        {
+            return typeof(Explicit5a_Invalid64).ToString();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string LoadB64()
+        {
+            return typeof(Explicit5b_Invalid64).ToString();
         }
     }
 }


### PR DESCRIPTION
A ByRefLike type was previously forced to be pointer aligned so `ref` fields were implicitly aligned. Using Explicit layout one can create valid aligned ByRefLike types with no object pointers. This change propagates the base offset of the ByRefLike type and includes that for determining offsets of fields in the ByRefLike type.

Fixes dotnet/runtime#111260 