### PR TITLE
NativeAOT: Skip TypeSpec for well-known custom attributes lookup

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -526,6 +526,34 @@ namespace System.Reflection.Runtime.General
                     return false;
                 return true;
             }
+            else if (handleType == HandleType.TypeSpecification)
+            {
+                Type? type = typeHandle.Resolve(reader, new TypeContext(null, null)).ToType();
+                string? namespaceName = type.Namespace;
+                int idx = name.Length;
+                ReadOnlySpan<char> typeName = name.AsSpan();
+                do
+                {
+                    idx -= type.Name.Length;
+                    if (idx < 0)
+                        return false;
+                    if (!typeName[idx..(idx + type.Name.Length)].Equals(type.Name, StringComparison.Ordinal))
+                        return false;
+                    idx--; // Skip '+'
+                }
+                while ((type = type.DeclaringType) != null);
+
+                idx = namespaceParts.Length;
+                string[] targetNamespaceParts = namespaceName?.Split('.') ?? Array.Empty<string>();
+                if (namespaceParts.Length != targetNamespaceParts.Length)
+                    return false;
+                while (idx-- != 0)
+                {
+                    if (!namespaceParts[idx].Equals(targetNamespaceParts[idx], StringComparison.Ordinal))
+                        return false;
+                }
+                return true;
+            }
             else
                 throw new NotSupportedException();
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -538,7 +538,7 @@ namespace System.Reflection.Runtime.General
                     offset -= type.Name.Length;
                     if (offset < 0)
                         return false;
-                    if (!typeName[offset..(offset + type.Name.Length)].Equals(type.Name, StringComparison.Ordinal))
+                    if (!typeName.Slice(offset, type.Name.Length).SequenceEqual(type.Name))
                         return false;
                     offset--; // Skip '+'
                 }
@@ -547,16 +547,18 @@ namespace System.Reflection.Runtime.General
                 if (offset != -1)
                     return false;
 
-                int idx = 0;
-                if (namespaceName.Length > 0)
+                int idx = 0, start = 0, end = 1;
+                while (end <= namespaceName.Length)
                 {
-                    foreach (Range range in namespaceName.Split('.'))
+                    if (end == namespaceName.Length || namespaceName[end] == '.')
                     {
                         if (idx >= namespaceParts.Length)
                             return false;
-                        if (!namespaceName[range].Equals(namespaceParts[idx++], StringComparison.Ordinal))
+                        if (!namespaceName.Slice(start, end - start).SequenceEqual(namespaceParts[idx++]))
                             return false;
+                        start = end + 1;
                     }
+                    end++;
                 }
 
                 return namespaceParts.Length == idx;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -483,17 +483,6 @@ namespace System.Reflection.Runtime.General
             Handle typeHandle = customAttributeHandle.GetCustomAttribute(reader).GetAttributeTypeHandle(reader);
             HandleType handleType = typeHandle.HandleType;
 
-            if (handleType == HandleType.TypeSpecification)
-            {
-                TypeSpecification typeSpecification = typeHandle.ToTypeSpecificationHandle(reader).GetTypeSpecification(reader);
-                if (typeSpecification.Signature.HandleType == HandleType.TypeInstantiationSignature)
-                {
-                    TypeInstantiationSignature sig = typeSpecification.Signature.ToTypeInstantiationSignatureHandle(reader).GetTypeInstantiationSignature(reader);
-                    typeHandle = sig.GenericType;
-                    handleType = typeHandle.HandleType;
-                }
-            }
-
             if (handleType == HandleType.TypeDefinition)
             {
                 TypeDefinition typeDefinition = typeHandle.ToTypeDefinitionHandle(reader).GetTypeDefinition(reader);
@@ -538,6 +527,8 @@ namespace System.Reflection.Runtime.General
                     return false;
                 return true;
             }
+            else if (handleType == HandleType.TypeSpecification)
+                return false;
             else
                 throw new NotSupportedException();
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -482,7 +482,6 @@ namespace System.Reflection.Runtime.General
         {
             Handle typeHandle = customAttributeHandle.GetCustomAttribute(reader).GetAttributeTypeHandle(reader);
             HandleType handleType = typeHandle.HandleType;
-
             if (handleType == HandleType.TypeDefinition)
             {
                 TypeDefinition typeDefinition = typeHandle.ToTypeDefinitionHandle(reader).GetTypeDefinition(reader);

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -2704,11 +2704,14 @@ internal static class ReflectionTest
     // Regression test for https://github.com/dotnet/runtime/issues/111578
     class TestGenericAttributesOnEnum
     {
+        [AttributeUsage(AttributeTargets.Enum, AllowMultiple = true)]
         class MyAttribute<T> : Attribute { }
+        [AttributeUsage(AttributeTargets.Enum, AllowMultiple = true)]
         class MyAttribute<T, U> : Attribute { }
 
         [MyAttribute<int>]
         [MyAttribute<string>]
+        [MyAttribute<float, long>]
         [MyAttribute<int, string>]
         enum MyEnum { A, B, C, D }
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -2704,15 +2704,10 @@ internal static class ReflectionTest
     // Regression test for https://github.com/dotnet/runtime/issues/111578
     class TestGenericAttributesOnEnum
     {
-        [AttributeUsage(AttributeTargets.Enum, AllowMultiple = true)]
+        [AttributeUsage(AttributeTargets.Enum)]
         class MyAttribute<T> : Attribute { }
-        [AttributeUsage(AttributeTargets.Enum, AllowMultiple = true)]
-        class MyAttribute<T, U> : Attribute { }
 
         [MyAttribute<int>]
-        [MyAttribute<string>]
-        [MyAttribute<float, long>]
-        [MyAttribute<int, string>]
         enum MyEnum { A, B, C, D }
 
         private static void GetEnumValues()

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -92,6 +92,7 @@ internal static class ReflectionTest
         TestAssemblyLoad.Run();
         TestBaseOnlyUsedFromCode.Run();
         TestEntryPoint.Run();
+        TestGenericAttributesOnEnum.Run();
 
         return 100;
     }
@@ -2697,6 +2698,33 @@ internal static class ReflectionTest
             ReflectionInLocalFunction();
             ReflectionInAsync();
             ReflectionInLambdaAsync();
+        }
+    }
+
+    // Regression test for https://github.com/dotnet/runtime/issues/111578
+    class TestGenericAttributesOnEnum
+    {
+        class MyAttribute<T> : Attribute { }
+        class MyAttribute<T, U> : Attribute { }
+
+        [MyAttribute<int>]
+        [MyAttribute<string>]
+        [MyAttribute<int, string>]
+        enum MyEnum { A, B, C, D }
+
+        private static void GetEnumValues()
+        {
+            var values = Enum.GetValues<MyEnum>();
+            Assert.Equal(4, values.Length);
+            Assert.Equal(MyEnum.A, values[0]);
+            Assert.Equal(MyEnum.B, values[1]);
+            Assert.Equal(MyEnum.C, values[2]);
+            Assert.Equal(MyEnum.D, values[3]);
+        }
+
+        public static void Run()
+        {
+            GetEnumValues();
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -2704,25 +2704,18 @@ internal static class ReflectionTest
     // Regression test for https://github.com/dotnet/runtime/issues/111578
     class TestGenericAttributesOnEnum
     {
-        [AttributeUsage(AttributeTargets.Enum)]
         class MyAttribute<T> : Attribute { }
 
-        [MyAttribute<int>]
-        enum MyEnum { A, B, C, D }
+        [My<int>]
+        enum MyEnum { A = 1, B = 2 }
 
-        private static void GetEnumValues()
-        {
-            var values = Enum.GetValues<MyEnum>();
-            Assert.Equal(4, values.Length);
-            Assert.Equal(MyEnum.A, values[0]);
-            Assert.Equal(MyEnum.B, values[1]);
-            Assert.Equal(MyEnum.C, values[2]);
-            Assert.Equal(MyEnum.D, values[3]);
-        }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static object GetVal() => MyEnum.A | MyEnum.B;
 
         public static void Run()
         {
-            GetEnumValues();
+            if (GetVal().ToString() != "3")
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
Skip checking TypeSpec for well-known custom attributes.
Fixes #111578

/cc: @MichalStrehovsky 