### PR TITLE
[mono] Run runtime-llvm and runtime-ioslike on Mono LLVM PRs

### DIFF
--- a/eng/pipelines/runtime-ioslike.yml
+++ b/eng/pipelines/runtime-ioslike.yml
@@ -4,6 +4,21 @@
 
 trigger: none
 
+# To reduce the load on the pipeline, enable it only for PRs that affect Mono LLVM related code.
+pr:
+  branches:
+    include:
+    - main
+    - release/*.*
+
+  paths:
+    include:
+      - src/mono/mono/mini/aot-*.*
+      - src/mono/mono/mini/llvm-*.*
+      - src/mono/mono/mini/mini-llvm-*.*
+      - src/mono/mono/mini/intrinsics.c
+      - src/mono/mono/mini/simd-*.*
+
 variables:
   - template: /eng/pipelines/common/variables.yml
 

--- a/eng/pipelines/runtime-ioslike.yml
+++ b/eng/pipelines/runtime-ioslike.yml
@@ -18,6 +18,9 @@ pr:
       - src/mono/mono/mini/mini-llvm-*.*
       - src/mono/mono/mini/intrinsics.c
       - src/mono/mono/mini/simd-*.*
+      - src/mono/mono/mini/decompose.c
+      - src/mono/mono/mini/method-to-ir.c
+      - src/mono/mono/mini/mini.c
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -28,6 +28,21 @@ schedules:
       - main
     always: false # run only if there were changes since the last successful scheduled run.
 
+# To reduce the load on the pipeline, enable it only for PRs that affect Mono LLVM related code.
+pr:
+  branches:
+    include:
+    - main
+    - release/*.*
+
+  paths:
+    include:
+      - src/mono/mono/mini/aot-*.*
+      - src/mono/mono/mini/llvm-*.*
+      - src/mono/mono/mini/mini-llvm-*.*
+      - src/mono/mono/mini/intrinsics.c
+      - src/mono/mono/mini/simd-*.*
+
 variables:
   - template: /eng/pipelines/common/variables.yml
 

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -42,6 +42,9 @@ pr:
       - src/mono/mono/mini/mini-llvm-*.*
       - src/mono/mono/mini/intrinsics.c
       - src/mono/mono/mini/simd-*.*
+      - src/mono/mono/mini/decompose.c
+      - src/mono/mono/mini/method-to-ir.c
+      - src/mono/mono/mini/mini.c
 
 variables:
   - template: /eng/pipelines/common/variables.yml


### PR DESCRIPTION
This PR enables running of `runtime-llvm` and `runtime-ioslike` pipelines, by default, on PRs touching the following code:
- src/mono/mono/mini/aot-\*.\*
- src/mono/mono/mini/llvm-\*.\*
- src/mono/mono/mini/mini-llvm-\*.\*
- src/mono/mono/mini/intrinsics.c
- src/mono/mono/mini/simd-\*.\*
- src/mono/mono/mini/decompose.c
- src/mono/mono/mini/method-to-ir.c
- src/mono/mono/mini/mini.c

This is to ensure that we have proper coverage over Mono AOT-llvm when changes are made as we don't test these scenarios as part of the `runtime` pipeline.

Note: we need to enable `runtime-ioslike` in addition to `runtime-llvm` because we are currently missing coverage for arm64 AOT Linux scenario (https://github.com/dotnet/runtime/issues/90427). `runtime-ioslike` provides coverage over arm64-based TvOS devices which run AOT-llvm by default.

---

Follow-up: Remove the setting in the AzDO pipeline settings to trigger on comments only
