### PR TITLE
Cache Exp in SoftMax calculation

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Single.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Single.cs
@@ -860,7 +860,7 @@ namespace System.Numerics.Tensors
             ValidateInputOutputSpanNonOverlapping(x, destination);
 
             InvokeSpanIntoSpan<ExpOperator_Single>(x, destination);
-            float expSum = Sum(x);
+            float expSum = Sum(destination);
             InvokeSpanScalarIntoSpan<DivideOperator_Single>(destination, expSum, destination);
         }
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Single.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Single.cs
@@ -859,9 +859,9 @@ namespace System.Numerics.Tensors
 
             ValidateInputOutputSpanNonOverlapping(x, destination);
 
-            float expSum = Aggregate<ExpOperator_Single, AddOperator_Single>(x);
-
-            InvokeSpanScalarIntoSpan<ExpOperator_Single, DivideOperator_Single>(x, expSum, destination);
+            InvokeSpanIntoSpan<ExpOperator_Single>(x, destination);
+            float expSum = Sum(x);
+            InvokeSpanScalarIntoSpan<DivideOperator_Single>(destination, expSum, destination);
         }
 
         /// <summary>Computes the element-wise difference between single-precision floating-point numbers in the specified tensors.</summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SoftMax.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SoftMax.cs
@@ -37,7 +37,7 @@ namespace System.Numerics.Tensors
             ValidateInputOutputSpanNonOverlapping(x, destination);
 
             InvokeSpanIntoSpan<T, ExpOperator<T>>(x, destination);
-            T expSum = Sum(x);
+            T expSum = Sum(destination);
             InvokeSpanScalarIntoSpan<T, DivideOperator<T>>(destination, expSum, destination);
         }
     }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SoftMax.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SoftMax.cs
@@ -36,9 +36,9 @@ namespace System.Numerics.Tensors
 
             ValidateInputOutputSpanNonOverlapping(x, destination);
 
-            T expSum = Aggregate<T, ExpOperator<T>, AddOperator<T>>(x);
-
-            InvokeSpanScalarIntoSpan<T, ExpOperator<T>, DivideOperator<T>>(x, expSum, destination);
+            InvokeSpanIntoSpan<T, ExpOperator<T>>(x, destination);
+            T expSum = Sum(x);
+            InvokeSpanScalarIntoSpan<T, DivideOperator<T>>(destination, expSum, destination);
         }
     }
 }


### PR DESCRIPTION
solves #109327 by computing Exp(x) once and caching it in destination instead of computing it twice

```
| Method  | Count   | Mean         | Error      | StdDev     | Ratio | Allocated | Alloc Ratio |
|-------- |-------- |-------------:|-----------:|-----------:|------:|----------:|------------:|
| BuiltIn | 1000    |     4.211 us |  0.0220 us |  0.0206 us |  1.00 |         - |          NA |
| Mine    | 1000    |     2.308 us |  0.0296 us |  0.0277 us |  0.55 |         - |          NA |
|         |         |              |            |            |       |           |             |
| BuiltIn | 1000000 | 4,200.558 us | 30.2029 us | 28.2518 us |  1.00 |         - |          NA |
| Mine    | 1000000 | 2,435.979 us | 21.0321 us | 19.6735 us |  0.58 |         - |          NA |
```
benchmark: https://gist.github.com/BarionLP/dd17244a59cd4470756e9219ceaeec49