### PR TITLE
[H/3] Do not close the connection before we process GO_AWAY / Abort

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -527,7 +527,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
-        public void InvalidateHttp3Connection(Http3Connection connection)
+        public void InvalidateHttp3Connection(Http3Connection connection, bool dispose = true)
         {
             Debug.Assert(IsHttp3Supported());
 
@@ -554,7 +554,7 @@ namespace System.Net.Http
 
             // If we found the connection in the available list, then dispose it now.
             // Otherwise, when we try to put it back in the pool, we will see it is shut down and dispose it (and adjust connection counts).
-            if (found)
+            if (found && dispose)
             {
                 connection.Dispose();
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -364,7 +364,9 @@ namespace System.Net.Http
             }
 
             // Stop sending requests to this connection.
-            _pool.InvalidateHttp3Connection(this);
+            // Do not dispose the connection when invalidating as the rest of this method does exactly that:
+            //   set up _firstRejectedStreamId, close the connection with proper error code and CheckForShutdown.
+            _pool.InvalidateHttp3Connection(this, dispose: false);
 
             long connectionResetErrorCode = (abortException as HttpProtocolException)?.ErrorCode ?? (long)Http3ErrorCode.InternalError;
 
@@ -397,7 +399,9 @@ namespace System.Net.Http
             }
 
             // Stop sending requests to this connection.
-            _pool.InvalidateHttp3Connection(this);
+            // Do not dispose the connection when invalidating as the rest of this method does exactly that:
+            //   set up _firstRejectedStreamId to the stream id from GO_AWAY frame and CheckForShutdown.
+            _pool.InvalidateHttp3Connection(this, dispose: false);
 
             var streamsToGoAway = new List<Http3RequestStream>();
 


### PR DESCRIPTION
Do not close the connection before we set GO_AWAY stream id / close connection with proper code.

The detailed description of the race is in this comment: https://github.com/dotnet/runtime/issues/111507#issuecomment-2599061012
TLDR: 
If `InvalidateHttp3Connection` disposes the connection, it can get closed before setting the GO_AWAY `_firstRejectedStreamId` (or `_abortException`). In the meantime, `Http3Connection.SendAsync` will happily pass all checks and attempt to send the request, eventually failing on unexpected exception because neither `_firstRejectedStreamId` nor `_abortException` was set before `QuicConnection.CloseAsync` was called.

Fixes https://github.com/dotnet/runtime/issues/111507 

No additional tests, I wasn't able to reproduce this race. Fix is based on dump analysis and I'm checking that it didn't break any existing tests.