### PR TITLE
JIT: Don't let 4-opt layout modify other EH regions

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5482,8 +5482,8 @@ bool Compiler::ThreeOptLayout::RunGreedyThreeOptPass(unsigned startPos, unsigned
                     continue;
                 }
 
-                // Don't consider any cut points that would move try/handler entries
-                if (compiler->bbIsTryBeg(s3BlockPrev) || compiler->bbIsHandlerBeg(s3BlockPrev))
+                // Don't consider any cut points that would disturb other EH regions
+                if (!BasicBlock::sameEHRegion(s2Block, s3Block))
                 {
                     continue;
                 }


### PR DESCRIPTION
When trying to create fallthrough for a jump that begins after an EH region, and ends before the EH region, don't consider a split point within the EH region; otherwise, the swap will break the invariant that EH entries are not moved relative to other blocks in the region. Fixes #111347.