### PR TITLE
JIT: Fix embedded broadcast SimdSize assert

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -9602,10 +9602,6 @@ void Lowering::TryFoldCnsVecForEmbeddedBroadcast(GenTreeHWIntrinsic* parentNode,
 {
     assert(!childNode->IsAllBitsSet());
     assert(!childNode->IsZero());
-    var_types   simdType            = parentNode->TypeGet();
-    var_types   simdBaseType        = parentNode->GetSimdBaseType();
-    CorInfoType simdBaseJitType     = parentNode->GetSimdBaseJitType();
-    bool        isCreatedFromScalar = true;
 
     if (!comp->canUseEmbeddedBroadcast())
     {
@@ -9613,10 +9609,16 @@ void Lowering::TryFoldCnsVecForEmbeddedBroadcast(GenTreeHWIntrinsic* parentNode,
         return;
     }
 
-    if (simdType == TYP_MASK)
-    {
-        simdType = Compiler::getSIMDTypeForSize(parentNode->GetSimdSize());
-    }
+    // We use the child node's size for the broadcast node, because the parent may consume more than its own size.
+    // The containment check has already validated that the child is sufficiently large.
+    //
+    // We use the parent node's base type, because we must ensure that the constant repeats correctly for that size,
+    // regardless of how the constant vector was created.
+
+    var_types   simdType            = childNode->TypeGet();
+    var_types   simdBaseType        = parentNode->GetSimdBaseType();
+    CorInfoType simdBaseJitType     = parentNode->GetSimdBaseJitType();
+    bool        isCreatedFromScalar = true;
 
     if (varTypeIsSmall(simdBaseType))
     {


### PR DESCRIPTION
Fixes #111613

This ensures that when a constant vector is replaced with a broadcast node, the replacement node is of the correct size.  Since only the scalar is read from the broadcast node, SIMD size doesn't really matter for codegen, but this fix satisfies the assert in #111613 by ensuring we replace like for like.