### PR TITLE
Guard members of MonoType union & fix related bugs

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -779,11 +779,11 @@ mono_debugger_agent_init_internal (void)
 
 	mono_de_init (&cbs);
 	transport_init ();
-	
+
 	start_debugger_thread_func = start_debugger_thread;
 	suspend_vm_func = suspend_vm;
 	suspend_current_func = suspend_current;
-	
+
 
 	/* Need to know whenever a thread has acquired the loader mutex */
 	mono_loader_lock_track_ownership (TRUE);
@@ -1627,7 +1627,7 @@ mono_init_debugger_agent_common (MonoProfilerHandle *prof)
 	mono_profiler_set_thread_started_callback (*prof, thread_startup);
 	mono_profiler_set_thread_stopped_callback (*prof, thread_end);
 	mono_profiler_set_jit_done_callback (*prof, jit_done);
-	
+
 	mono_native_tls_alloc (&debugger_tls_id, NULL);
 
 	/* Needed by the hash_table_new_type () call below */
@@ -2634,7 +2634,7 @@ resume_vm (void)
 	mono_loader_unlock ();
 #else
 	resumed_from_wasi = TRUE;
-#endif	
+#endif
 }
 
 /*
@@ -3122,7 +3122,7 @@ compute_frame_info (MonoInternalThread *thread, DebuggerTlsData *tls, gboolean f
 #else
 		tls->frame_count = 0;
 		return;
-#endif		
+#endif
 	}
 
 	new_frame_count = g_slist_length (user_data.frames);
@@ -4629,7 +4629,7 @@ ensure_runtime_is_suspended (void)
 {
 #ifdef HOST_WASI
 	return ERR_NONE;
-#endif	
+#endif
 	if (suspend_count == 0)
 		return ERR_NOT_SUSPENDED;
 
@@ -5291,7 +5291,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 				continue;
 			if (CHECK_ICORDBG (TRUE))
 				buffer_add_int (buf, mono_class_get_field_token (f));
-			if (mono_vtype_get_field_addr (addr, f) == addr && mono_class_from_mono_type_internal (t) == mono_class_from_mono_type_internal (f->type) && !boxed_vtype) //to avoid infinite recursion 
+			if (mono_vtype_get_field_addr (addr, f) == addr && mono_class_from_mono_type_internal (t) == mono_class_from_mono_type_internal (f->type) && !boxed_vtype) //to avoid infinite recursion
 			{
 				gssize val = *(gssize*)addr;
 				if (CHECK_ICORDBG (TRUE))
@@ -5351,7 +5351,7 @@ obj_is_of_type (MonoObject *obj, MonoType *t)
 static ErrorCode
 decode_value (MonoType *t, MonoDomain *domain, gpointer void_addr, gpointer void_buf, guint8 **endbuf, guint8 *limit, gboolean check_field_datatype, guint8 **extra_space, gboolean from_by_ref_value_type);
 
-static int 
+static int
 decode_value_compute_size (MonoType *t, int type, MonoDomain *domain, guint8 *buf, guint8 **endbuf, guint8 *limit, gboolean from_by_ref_value_type);
 
 static ErrorCode
@@ -5419,7 +5419,7 @@ decode_vtype (MonoType *t, MonoDomain *domain, gpointer void_addr, gpointer void
 	return ERR_NONE;
 }
 
-static ErrorCode 
+static ErrorCode
 decode_fixed_size_array_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, guint8 *buf, guint8 **endbuf, guint8 *limit, gboolean check_field_datatype)
 {
 	ErrorCode err = ERR_NONE;
@@ -5475,7 +5475,7 @@ decode_fixed_size_array_internal (MonoType *t, int type, MonoDomain *domain, gui
 }
 
 
-static int 
+static int
 decode_fixed_size_array_compute_size_internal (MonoType *t, int type, MonoDomain *domain, guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
 	int ret = 0;
@@ -5510,7 +5510,7 @@ decode_fixed_size_array_compute_size_internal (MonoType *t, int type, MonoDomain
 				ret += sizeof(guint32);
 				break;
 			case MONO_TYPE_I8:
-			case MONO_TYPE_U8:	
+			case MONO_TYPE_U8:
 			case MONO_TYPE_R8:
 				decode_long (buf, &buf, limit);
 				ret += sizeof(guint64);
@@ -5561,7 +5561,7 @@ decode_vtype_compute_size (MonoType *t, MonoDomain *domain, gpointer void_buf, g
 			continue;
 		if (mono_field_is_deleted (f))
 			continue;
-		
+
 		gboolean cur_field_in_extra_space = from_by_ref_value_type;
   		gboolean members_in_extra_space = cur_field_in_extra_space || m_type_is_byref (f->type) || m_class_is_byreflike (mono_class_from_mono_type_internal (f->type));
 		int field_size = decode_value_compute_size (f->type, 0, domain, buf, &buf, limit, members_in_extra_space);
@@ -5587,7 +5587,7 @@ end:
 	return ret;
 }
 
-static int 
+static int
 decode_value_compute_size (MonoType *t, int type, MonoDomain *domain, guint8 *buf, guint8 **endbuf, guint8 *limit, gboolean from_by_ref_value_type)
 {
 	if (type == 0)
@@ -5632,12 +5632,12 @@ decode_value_compute_size (MonoType *t, int type, MonoDomain *domain, guint8 *bu
 		break;
 	case MONO_TYPE_I4:
 	case MONO_TYPE_U4:
-	case MONO_TYPE_R4:	
+	case MONO_TYPE_R4:
 		decode_int (buf, &buf, limit);
 		ret += sizeof(guint32);
 		break;
 	case MONO_TYPE_I8:
-	case MONO_TYPE_U8:	
+	case MONO_TYPE_U8:
 	case MONO_TYPE_R8:
 		decode_long (buf, &buf, limit);
 		ret += sizeof(guint64);
@@ -5693,8 +5693,8 @@ decode_value_compute_size (MonoType *t, int type, MonoDomain *domain, guint8 *bu
 				goto end;
 			}
 		} else if ((t->type == MONO_TYPE_GENERICINST) &&
-					mono_metadata_generic_class_is_valuetype (t->data.generic_class) &&
-					m_class_is_enumtype (t->data.generic_class->container_class)){
+					mono_metadata_generic_class_is_valuetype (m_type_data_get_generic_class (t)) &&
+					m_class_is_enumtype (m_type_data_get_generic_class (t)->container_class)){
 			ret += decode_vtype_compute_size (t, domain, buf, &buf, limit, from_by_ref_value_type);
 		} else {
 			NOT_IMPLEMENTED;
@@ -5916,8 +5916,8 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 				return ERR_INVALID_ARGUMENT;
 			}
 		} else if ((t->type == MONO_TYPE_GENERICINST) &&
-					mono_metadata_generic_class_is_valuetype (t->data.generic_class) &&
-					m_class_is_enumtype (t->data.generic_class->container_class)){
+					mono_metadata_generic_class_is_valuetype (m_type_data_get_generic_class (t)) &&
+					m_class_is_enumtype (m_type_data_get_generic_class (t)->container_class)){
 			err = decode_vtype (t, domain, addr, buf, &buf, limit, check_field_datatype, extra_space, from_by_ref_value_type);
 			if (err != ERR_NONE)
 				return err;
@@ -5944,7 +5944,7 @@ decode_value (MonoType *t, MonoDomain *domain, gpointer void_addr, gpointer void
 	int type = decode_byte (buf, &buf, limit);
 
 	if (t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t))) {
-		MonoType *targ = t->data.generic_class->context.class_inst->type_argv [0];
+		MonoType *targ = m_type_data_get_generic_class (t)->context.class_inst->type_argv [0];
 		guint8 *nullable_buf;
 
 		/*
@@ -6359,7 +6359,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 	MonoDomain *domain;
 	guint8 *this_buf;
 	guint8 *extra_space = NULL;
-	int extra_space_size = 0;	
+	int extra_space_size = 0;
 #ifdef MONO_ARCH_SOFT_DEBUG_SUPPORTED
 	MonoLMFExt ext;
 #endif
@@ -7099,7 +7099,7 @@ find_assembly_by_name (char* assembly_name)
 	//resolve the assembly
 	MonoImageOpenStatus status;
 	MonoAssemblyName* aname = mono_assembly_name_new (lookup_name);
-	g_free (lookup_name);	
+	g_free (lookup_name);
 	if (!aname) {
 		PRINT_DEBUG_MSG (1, "Could not resolve assembly %s\n", assembly_name);
 		return NULL;
@@ -7518,7 +7518,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		guint8* memory = (guint8*)GINT_TO_POINTER (decode_long (p, &p, end));
 		int size = decode_int (p, &p, end);
 		if (!valid_memory_address(memory, size))
-			return ERR_INVALID_ARGUMENT;		
+			return ERR_INVALID_ARGUMENT;
 		PRINT_DEBUG_MSG (1, "MDBGPROT_CMD_VM_READ_MEMORY - [%p] - size - %d\n", memory, size);
 		buffer_add_byte_array (buf, memory, size);
 		break;
@@ -7595,7 +7595,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 				break;
 			case MONO_TYPE_I8:
 				buffer_add_typeid (buf, mono_get_root_domain (), mono_get_int64_class ());
-				break;			
+				break;
 			case MONO_TYPE_U8:
 				buffer_add_typeid (buf, mono_get_root_domain (), mono_get_uint64_class ());
 				break;
@@ -7642,7 +7642,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 						symfile_size = ppdb_compressed_size;
 						pdb_bytes = ppdb_data;
 					}
-				}				
+				}
 			}
 			m_dbgprot_buffer_init (buf, assembly_size + symfile_size + 1024);
 			m_dbgprot_buffer_add_byte_array (buf, (uint8_t *) assembly_bytes, assembly_size);
@@ -7805,7 +7805,7 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 		if (req->event_kind == EVENT_KIND_BREAKPOINT) {
 			g_assert (method);
-			
+
 			req->info = mono_de_set_breakpoint (method, location, req, error);
 			if (!is_ok (error)) {
 				g_free (req);
@@ -8064,7 +8064,7 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		klass = decode_typeid (p, &p, end, NULL, &err);
 		int rank = decode_int (p, &p, end);
 		uintptr_t *lengths = g_newa (uintptr_t, rank);
-		intptr_t *lower_bounds = g_newa (intptr_t, rank);		
+		intptr_t *lower_bounds = g_newa (intptr_t, rank);
 		for (int i = 0 ; i < rank; i++)
 		{
 			lengths [i] = decode_int (p, &p, end);
@@ -8628,10 +8628,10 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 		{
 			if (type->type == MONO_TYPE_FNPTR)
 			{
-				buffer_add_int (buf, 1 + type->data.method->param_count);
-				buffer_add_typeid (buf, domain, mono_class_from_mono_type_internal (type->data.method->ret));
-				for (int j = 0; j < type->data.method->param_count; ++j) {
-					buffer_add_typeid (buf, domain, mono_class_from_mono_type_internal (type->data.method->params[j]));
+				buffer_add_int (buf, 1 + m_type_data_get_method (type)->param_count);
+				buffer_add_typeid (buf, domain, mono_class_from_mono_type_internal (m_type_data_get_method (type)->ret));
+				for (int j = 0; j < m_type_data_get_method (type)->param_count; ++j) {
+					buffer_add_typeid (buf, domain, mono_class_from_mono_type_internal (m_type_data_get_method (type)->params[j]));
 				}
 			} else {
 				buffer_add_int (buf, 0);
@@ -8830,7 +8830,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 	}
 	case MDBGPROT_CMD_TYPE_SET_VALUES_BY_FIELD_TOKEN: {
 		len = 0;
-		gpointer iter = NULL;		
+		gpointer iter = NULL;
 		len = decode_int (p, &p, end);
 		int field_token = decode_int (p, &p, end);
 		while ((f = mono_class_get_fields_internal (klass, &iter))) {
@@ -9122,18 +9122,18 @@ set_value:
 		g_free (type_argv);
 		break;
 	}
-	case MDBGPROT_CMD_TYPE_ELEMENT_TYPE: 
+	case MDBGPROT_CMD_TYPE_ELEMENT_TYPE:
 	{
 		buffer_add_int (buf, m_class_get_byval_arg (klass)->type);
 		buffer_add_byte (buf, GINT_TO_UINT8 (MONO_TYPE_ISSTRUCT (m_class_get_byval_arg (klass))));
 		break;
 	}
-	case MDBGPROT_CMD_TYPE_RANK: 
+	case MDBGPROT_CMD_TYPE_RANK:
 	{
 		buffer_add_byte (buf, m_class_get_rank (klass));
 		break;
 	}
-	case MDBGPROT_CMD_TYPE_GET_FIELD_RVA: 
+	case MDBGPROT_CMD_TYPE_GET_FIELD_RVA:
 	{
 		gpointer iter = NULL;
 		int field_token = decode_int (p, &p, end);
@@ -9683,9 +9683,9 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 			MonoGenericContext *context;
 			GString *res;
 			res = g_string_new ("");
-			mono_type_get_desc (res, m_class_get_byval_arg (type->data.generic_class->container_class), TRUE);
+			mono_type_get_desc (res, m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class), TRUE);
 			buffer_add_string (buf, (g_string_free (res, FALSE)));
-			context = &type->data.generic_class->context;
+			context = &m_type_data_get_generic_class (type)->context;
 			if (context->class_inst)
 				buffer_add_int (buf, context->class_inst->type_argc);
 			else
@@ -9892,7 +9892,7 @@ thread_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (suspend_count)
 				wait_for_suspend ();
 		}
-#endif		
+#endif
 		/*
 		if (suspend_count)
 			wait_for_suspend ();
@@ -10548,7 +10548,7 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				break;
 			}
 		}
-                //Above for loop might end if 'k' is null , ensure 'k' is not 
+                //Above for loop might end if 'k' is null , ensure 'k' is not
                 //null before passing it to mono_class_get_fields_internal to avoid crash
 		while (k && (f = mono_class_get_fields_internal (k, &iter))) {
 			if (mono_class_get_field_token (f) == field_token) {
@@ -10699,7 +10699,7 @@ set_field_value:
 		break;
 	case MDBGPROT_CMD_OBJECT_IS_DELEGATE: {
 		MonoType *type = m_class_get_byval_arg (obj_type);
-		if (m_class_is_delegate (obj_type) || (type->type == MONO_TYPE_GENERICINST && m_class_is_delegate (type->data.generic_class->container_class)))
+		if (m_class_is_delegate (obj_type) || (type->type == MONO_TYPE_GENERICINST && m_class_is_delegate (m_type_data_get_generic_class (type)->container_class)))
 			buffer_add_byte (buf, TRUE);
 		else
 			buffer_add_byte (buf, FALSE);
@@ -11156,7 +11156,7 @@ gboolean mono_debugger_agent_receive_and_process_command (void)
 	Buffer buf;
 	ErrorCode err;
 	gboolean no_reply;
-	
+
 	gboolean log_each_step = g_hasenv ("MONO_DEBUGGER_LOG_AFTER_COMMAND");
 
 	while (TRUE) {

--- a/src/mono/mono/component/marshal-ilgen.c
+++ b/src/mono/mono/component/marshal-ilgen.c
@@ -2628,7 +2628,7 @@ emit_marshal_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	switch (t->type) {
 	case MONO_TYPE_VALUETYPE:
-		if (m_type_data_get_klass (t) == cb_to_mono->class_try_get_handleref_class ())
+		if (m_type_data_get_klass_unchecked (t) == cb_to_mono->class_try_get_handleref_class ())
 			return emit_marshal_handleref_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 
 		return emit_marshal_vtype_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
@@ -2636,8 +2636,8 @@ emit_marshal_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		return emit_marshal_string_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_OBJECT:
-		if (cb_to_mono->try_get_safehandle_class () != NULL && m_type_data_get_klass (t) &&
-		    cb_to_mono->is_subclass_of_internal (m_type_data_get_klass (t),  cb_to_mono->try_get_safehandle_class (), FALSE))
+		if (cb_to_mono->try_get_safehandle_class () != NULL && m_type_data_get_klass_unchecked (t) &&
+		    cb_to_mono->is_subclass_of_internal (m_type_data_get_klass_unchecked (t),  cb_to_mono->try_get_safehandle_class (), FALSE))
 			return emit_marshal_safehandle_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 
 		return emit_marshal_object_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);

--- a/src/mono/mono/component/marshal-ilgen.c
+++ b/src/mono/mono/component/marshal-ilgen.c
@@ -2003,13 +2003,15 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		MonoMethod *ctor = NULL;
 		int intptr_handle_slot;
 
-		if (mono_class_is_abstract (m_type_data_get_klass (t))) {
+		MonoClass *klass_of_t = m_type_data_get_klass (t);
+
+		if (mono_class_is_abstract (klass_of_t)) {
 			cb_to_mono->methodBuilder.emit_byte (mb, CEE_POP);
 			cb_to_mono->methodBuilder.emit_exception_marshal_directive (mb, g_strdup ("Returned SafeHandles should not be abstract"));
 			break;
 		}
 
-		ctor = mono_class_get_method_from_name_checked (m_type_data_get_klass (t), ".ctor", 0, 0, error);
+		ctor = mono_class_get_method_from_name_checked (klass_of_t, ".ctor", 0, 0, error);
 		if (ctor == NULL || !is_ok (error)){
 			mono_error_cleanup (error);
 			cb_to_mono->methodBuilder.emit_byte (mb, CEE_POP);

--- a/src/mono/mono/component/marshal-ilgen.c
+++ b/src/mono/mono/component/marshal-ilgen.c
@@ -54,11 +54,11 @@ static MonoComponentMarshalILgen component_func_table = {
 	&ilgen_init_internal,
 	&emit_marshal_ilgen,
 	&ilgen_install_callbacks_mono,
-}; 
+};
 
 
 MonoComponentMarshalILgen*
-mono_component_marshal_ilgen_init (void) 
+mono_component_marshal_ilgen_init (void)
 {
 	return &component_func_table;
 }
@@ -842,7 +842,7 @@ emit_marshal_ptr_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_CONV_IN:
 		/* MS seems to allow this in some cases, ie. bxc #158 */
 		/*
-		if (MONO_TYPE_ISSTRUCT (t->data.type) && !mono_class_from_mono_type_internal (t->data.type)->blittable) {
+		if (MONO_TYPE_ISSTRUCT (m_type_data_get_type (t)) && !mono_class_from_mono_type_internal (m_type_data_get_type (t))->blittable) {
 			char *msg = g_strdup_printf ("Can not marshal 'parameter #%d': Pointers can not reference marshaled structures. Use byref instead.", argnum + 1);
 			cb_to_mono->methodBuilder.emit_exception_marshal_directive (m->mb, msg);
 		}
@@ -1965,7 +1965,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				 * leak the handle. We should move the allocation of the SafeHandle to the
 				 * input marshalling code to prevent that.
 				 */
-				ctor = mono_class_get_method_from_name_checked (t->data.klass, ".ctor", 0, 0, local_error);
+				ctor = mono_class_get_method_from_name_checked (m_type_data_get_klass (t), ".ctor", 0, 0, local_error);
 				if (ctor == NULL || !is_ok (local_error)){
 					cb_to_mono->methodBuilder.emit_exception (mb, "MissingMethodException", "parameterless constructor required");
 					mono_error_cleanup (local_error);
@@ -2003,13 +2003,13 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		MonoMethod *ctor = NULL;
 		int intptr_handle_slot;
 
-		if (mono_class_is_abstract (t->data.klass)) {
+		if (mono_class_is_abstract (m_type_data_get_klass (t))) {
 			cb_to_mono->methodBuilder.emit_byte (mb, CEE_POP);
 			cb_to_mono->methodBuilder.emit_exception_marshal_directive (mb, g_strdup ("Returned SafeHandles should not be abstract"));
 			break;
 		}
 
-		ctor = mono_class_get_method_from_name_checked (t->data.klass, ".ctor", 0, 0, error);
+		ctor = mono_class_get_method_from_name_checked (m_type_data_get_klass (t), ".ctor", 0, 0, error);
 		if (ctor == NULL || !is_ok (error)){
 			mono_error_cleanup (error);
 			cb_to_mono->methodBuilder.emit_byte (mb, CEE_POP);
@@ -2628,7 +2628,7 @@ emit_marshal_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	switch (t->type) {
 	case MONO_TYPE_VALUETYPE:
-		if (t->data.klass == cb_to_mono->class_try_get_handleref_class ())
+		if (m_type_data_get_klass (t) == cb_to_mono->class_try_get_handleref_class ())
 			return emit_marshal_handleref_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 
 		return emit_marshal_vtype_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
@@ -2636,8 +2636,8 @@ emit_marshal_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		return emit_marshal_string_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_OBJECT:
-		if (cb_to_mono->try_get_safehandle_class () != NULL && t->data.klass &&
-		    cb_to_mono->is_subclass_of_internal (t->data.klass,  cb_to_mono->try_get_safehandle_class (), FALSE))
+		if (cb_to_mono->try_get_safehandle_class () != NULL && m_type_data_get_klass (t) &&
+		    cb_to_mono->is_subclass_of_internal (m_type_data_get_klass (t),  cb_to_mono->try_get_safehandle_class (), FALSE))
 			return emit_marshal_safehandle_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 
 		return emit_marshal_object_ilgen (m, argnum, t, spec, conv_arg, conv_arg_type, action);

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -1554,8 +1554,15 @@ bulk_type_log_single_type (
 	// Sets val variable sized parameter type data, type_parameters_count, and mono_type_parameters associated
 	// with arrays or generics to be recursively batched in the same ep_rt_mono_log_type_and_parameters call
 	switch (mono_underlying_type->type) {
-	case MONO_TYPE_ARRAY:
 	case MONO_TYPE_SZARRAY:
+	{
+		// FIXME: Previously was handled by below ARRAY block but that is incorrect; this implementation is speculative -kg
+		val->fixed_sized_data.flags |= TYPE_FLAGS_ARRAY;
+		// FIXME: Do we have to encode the rank of 1 explicitly?
+		// FIXME: Encode the mono_type_parameters and type_parameters_count
+		break;
+	}
+	case MONO_TYPE_ARRAY:
 	{
 		MonoArrayType *mono_array_type = mono_type_get_array_type (mono_type);
 		val->fixed_sized_data.flags |= TYPE_FLAGS_ARRAY;

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -1560,7 +1560,7 @@ bulk_type_log_single_type (
 		val->fixed_sized_data.flags |= TYPE_FLAGS_ARRAY;
 		// mono arrays are always arrays of by value types
 		val->mono_type_parameters = mono_mempool_alloc0 (type_logger->mem_pool, 1 * sizeof (MonoType*));
-		*val->mono_type_parameters = m_class_get_byval_arg (mono_type_data_get_klass (mono_underlying_type));
+		*val->mono_type_parameters = m_class_get_byval_arg (m_type_data_get_klass (mono_underlying_type));
 		val->type_parameters_count++;
 		break;
 	}

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -1585,7 +1585,7 @@ bulk_type_log_single_type (
 	}
 	case MONO_TYPE_GENERICINST:
 	{
-		MonoGenericInst *class_inst = mono_type->data.generic_class->context.class_inst;
+		MonoGenericInst *class_inst = m_type_data_get_generic_class (mono_type)->context.class_inst;
 		val->type_parameters_count = class_inst->type_argc;
 		val->mono_type_parameters = mono_mempool_alloc0 (type_logger->mem_pool, val->type_parameters_count * sizeof (MonoType*));
 		memcpy (val->mono_type_parameters, class_inst->type_argv, val->type_parameters_count * sizeof (MonoType*));

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -1560,7 +1560,7 @@ bulk_type_log_single_type (
 		val->fixed_sized_data.flags |= TYPE_FLAGS_ARRAY;
 		// mono arrays are always arrays of by value types
 		val->mono_type_parameters = mono_mempool_alloc0 (type_logger->mem_pool, 1 * sizeof (MonoType*));
-		*val->mono_type_parameters = m_class_get_byval_arg (m_type_data_get_klass (mono_underlying_type));
+		*val->mono_type_parameters = m_class_get_byval_arg (m_type_data_get_klass_unchecked (mono_underlying_type));
 		val->type_parameters_count++;
 		break;
 	}
@@ -1585,7 +1585,7 @@ bulk_type_log_single_type (
 	}
 	case MONO_TYPE_GENERICINST:
 	{
-		MonoGenericInst *class_inst = m_type_data_get_generic_class (mono_type)->context.class_inst;
+		MonoGenericInst *class_inst = m_type_data_get_generic_class_unchecked (mono_type)->context.class_inst;
 		val->type_parameters_count = class_inst->type_argc;
 		val->mono_type_parameters = mono_mempool_alloc0 (type_logger->mem_pool, val->type_parameters_count * sizeof (MonoType*));
 		memcpy (val->mono_type_parameters, class_inst->type_argv, val->type_parameters_count * sizeof (MonoType*));

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -1558,23 +1558,23 @@ bulk_type_log_single_type (
 	{
 		// FIXME: Previously was handled by below ARRAY block but that is incorrect; this implementation is speculative -kg
 		val->fixed_sized_data.flags |= TYPE_FLAGS_ARRAY;
-		// FIXME: Do we have to encode the rank of 1 explicitly?
-		// FIXME: Encode the mono_type_parameters and type_parameters_count
+		// mono arrays are always arrays of by value types
+		val->mono_type_parameters = mono_mempool_alloc0 (type_logger->mem_pool, 1 * sizeof (MonoType*));
+		*val->mono_type_parameters = m_class_get_byval_arg (mono_type_data_get_klass (mono_underlying_type));
+		val->type_parameters_count++;
 		break;
 	}
 	case MONO_TYPE_ARRAY:
 	{
 		MonoArrayType *mono_array_type = mono_type_get_array_type (mono_type);
 		val->fixed_sized_data.flags |= TYPE_FLAGS_ARRAY;
-		if (mono_underlying_type->type == MONO_TYPE_ARRAY) {
-			// Only ranks less than TypeFlagsArrayRankMax are supported.
-			// Fortunately TypeFlagsArrayRankMax should be greater than the
-			// number of ranks the type loader will support
-			uint32_t rank = mono_array_type->rank;
-			if (rank < TYPE_FLAGS_ARRAY_RANK_MAX) {
-				rank <<= 8;
-				val->fixed_sized_data.flags |= rank;
-			}
+		// Only ranks less than TypeFlagsArrayRankMax are supported.
+		// Fortunately TypeFlagsArrayRankMax should be greater than the
+		// number of ranks the type loader will support
+		uint32_t rank = mono_array_type->rank;
+		if (rank < TYPE_FLAGS_ARRAY_RANK_MAX) {
+			rank <<= 8;
+			val->fixed_sized_data.flags |= rank;
 		}
 
 		// mono arrays are always arrays of by value types

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1887,7 +1887,7 @@ type_has_references (MonoClass *klass, MonoType *ftype)
 	if (MONO_TYPE_IS_REFERENCE (ftype) || IS_GC_REFERENCE (klass, ftype) || ((MONO_TYPE_ISSTRUCT (ftype) && class_has_references (mono_class_from_mono_type_internal (ftype)))))
 		return TRUE;
 	if (!m_type_is_byref (ftype) && (ftype->type == MONO_TYPE_VAR || ftype->type == MONO_TYPE_MVAR)) {
-		MonoGenericParam *gparam = m_type_get_generic_param(ftype);
+		MonoGenericParam *gparam = m_type_data_get_generic_param (ftype);
 
 		if (gparam->gshared_constraint)
 			return class_has_references (mono_class_from_mono_type_internal (gparam->gshared_constraint));
@@ -1935,7 +1935,7 @@ mono_class_is_gparam_with_nonblittable_parent (MonoClass *klass)
 {
 	MonoType *type = m_class_get_byval_arg (klass);
 	g_assert (mono_type_is_generic_parameter (type));
-	MonoGenericParam *gparam = m_type_get_generic_param(type);
+	MonoGenericParam *gparam = m_type_data_get_generic_param (type);
 	if ((mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) != 0)
 		return TRUE;
 	if ((mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT) != 0)
@@ -2699,7 +2699,7 @@ setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **met
 	if (mono_class_is_gtd (iface)) {
 		MonoType *ty = mono_class_gtd_get_canonical_inst (iface);
 		g_assert (ty->type == MONO_TYPE_GENERICINST);
-		gclass = m_type_get_generic_class(ty);
+		gclass = m_type_data_get_generic_class (ty);
 	} else
 		gclass = mono_class_get_generic_class (iface);
 

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1887,7 +1887,7 @@ type_has_references (MonoClass *klass, MonoType *ftype)
 	if (MONO_TYPE_IS_REFERENCE (ftype) || IS_GC_REFERENCE (klass, ftype) || ((MONO_TYPE_ISSTRUCT (ftype) && class_has_references (mono_class_from_mono_type_internal (ftype)))))
 		return TRUE;
 	if (!m_type_is_byref (ftype) && (ftype->type == MONO_TYPE_VAR || ftype->type == MONO_TYPE_MVAR)) {
-		MonoGenericParam *gparam = ftype->data.generic_param;
+		MonoGenericParam *gparam = m_type_get_generic_param(ftype);
 
 		if (gparam->gshared_constraint)
 			return class_has_references (mono_class_from_mono_type_internal (gparam->gshared_constraint));
@@ -1935,7 +1935,7 @@ mono_class_is_gparam_with_nonblittable_parent (MonoClass *klass)
 {
 	MonoType *type = m_class_get_byval_arg (klass);
 	g_assert (mono_type_is_generic_parameter (type));
-	MonoGenericParam *gparam = type->data.generic_param;
+	MonoGenericParam *gparam = m_type_get_generic_param(type);
 	if ((mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) != 0)
 		return TRUE;
 	if ((mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT) != 0)
@@ -2699,7 +2699,7 @@ setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **met
 	if (mono_class_is_gtd (iface)) {
 		MonoType *ty = mono_class_gtd_get_canonical_inst (iface);
 		g_assert (ty->type == MONO_TYPE_GENERICINST);
-		gclass = ty->data.generic_class;
+		gclass = m_type_get_generic_class(ty);
 	} else
 		gclass = mono_class_get_generic_class (iface);
 

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1938,7 +1938,7 @@ mono_class_is_gparam_with_nonblittable_parent (MonoClass *klass)
 {
 	MonoType *type = m_class_get_byval_arg (klass);
 	g_assert (mono_type_is_generic_parameter (type));
-	MonoGenericParam *gparam = m_type_data_get_generic_param (type);
+	MonoGenericParam *gparam = m_type_data_get_generic_param_unchecked (type);
 	if ((mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) != 0)
 		return TRUE;
 	if ((mono_generic_param_info (gparam)->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT) != 0)

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1887,7 +1887,7 @@ type_has_references (MonoClass *klass, MonoType *ftype)
 	if (MONO_TYPE_IS_REFERENCE (ftype) || IS_GC_REFERENCE (klass, ftype) || ((MONO_TYPE_ISSTRUCT (ftype) && class_has_references (mono_class_from_mono_type_internal (ftype)))))
 		return TRUE;
 	if (!m_type_is_byref (ftype) && (ftype->type == MONO_TYPE_VAR || ftype->type == MONO_TYPE_MVAR)) {
-		MonoGenericParam *gparam = m_type_data_get_generic_param (ftype);
+		MonoGenericParam *gparam = m_type_data_get_generic_param_unchecked (ftype);
 
 		if (gparam->gshared_constraint)
 			return class_has_references (mono_class_from_mono_type_internal (gparam->gshared_constraint));
@@ -2699,7 +2699,7 @@ setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **met
 	if (mono_class_is_gtd (iface)) {
 		MonoType *ty = mono_class_gtd_get_canonical_inst (iface);
 		g_assert (ty->type == MONO_TYPE_GENERICINST);
-		gclass = m_type_data_get_generic_class (ty);
+		gclass = m_type_data_get_generic_class_unchecked (ty);
 	} else
 		gclass = mono_class_get_generic_class (iface);
 

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -524,7 +524,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		mono_class_set_generic_container (klass, generic_container);
 		MonoType *canonical_inst = &((MonoClassGtd*)klass)->canonical_inst;
 		canonical_inst->type = MONO_TYPE_GENERICINST;
-		canonical_inst->data.generic_class = mono_metadata_lookup_generic_class (klass, context->class_inst, FALSE);
+		m_type_data_set_generic_class_unchecked (canonical_inst, mono_metadata_lookup_generic_class (klass, context->class_inst, FALSE));
 		enable_gclass_recording ();
 	}
 
@@ -535,10 +535,10 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		if (mono_metadata_token_table (parent_token) == MONO_TABLE_TYPESPEC) {
 			/*WARNING: this must satisfy mono_metadata_type_hash*/
 			klass->this_arg.byref__ = 1;
-			klass->this_arg.data.klass = klass;
 			klass->this_arg.type = MONO_TYPE_CLASS;
-			klass->_byval_arg.data.klass = klass;
+			m_type_data_set_klass_unchecked (&klass->this_arg, klass);
 			klass->_byval_arg.type = MONO_TYPE_CLASS;
+			m_type_data_set_klass_unchecked (&klass->_byval_arg, klass);
 		}
 		parent = mono_class_get_checked (image, parent_token, error);
 		if (parent && context) /* Always inflate */
@@ -937,7 +937,8 @@ mono_class_create_generic_inst (MonoGenericClass *gclass)
 
 	klass->_byval_arg.type = MONO_TYPE_GENERICINST;
 	klass->this_arg.type = m_class_get_byval_arg (klass)->type;
-	klass->this_arg.data.generic_class = klass->_byval_arg.data.generic_class = gclass;
+	m_type_data_set_generic_class_unchecked (&klass->this_arg, gclass);
+	m_type_data_set_generic_class_unchecked (&klass->_byval_arg, gclass);
 	klass->this_arg.byref__ = TRUE;
 	klass->is_inlinearray = gklass->is_inlinearray;
 	mono_class_set_inlinearray_value(klass, mono_class_get_inlinearray_value(gklass));
@@ -1218,13 +1219,13 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 	if ((rank > 1) || bounded) {
 		MonoArrayType *at = mm ? (MonoArrayType *)mono_mem_manager_alloc0 (mm, sizeof (MonoArrayType)) : (MonoArrayType *)mono_image_alloc0 (image, sizeof (MonoArrayType));
 		klass->_byval_arg.type = MONO_TYPE_ARRAY;
-		klass->_byval_arg.data.array = at;
+		m_type_data_set_array_unchecked (&klass->_byval_arg, at);
 		at->eklass = eclass;
 		at->rank = GUINT32_TO_UINT8 (rank);
 		/* FIXME: complete.... */
 	} else {
 		klass->_byval_arg.type = MONO_TYPE_SZARRAY;
-		klass->_byval_arg.data.klass = eclass;
+		m_type_data_set_klass_unchecked (&klass->_byval_arg, eclass);
 	}
 	klass->this_arg = klass->_byval_arg;
 	klass->this_arg.byref__ = 1;
@@ -1398,8 +1399,8 @@ make_generic_param_class (MonoGenericParam *param)
 	MonoTypeEnum t = is_mvar ? MONO_TYPE_MVAR : MONO_TYPE_VAR;
 	klass->_byval_arg.type = t;
 	klass->this_arg.type = t;
-	CHECKED_METADATA_WRITE_PTR ( klass->this_arg.data.generic_param ,  param );
-	CHECKED_METADATA_WRITE_PTR ( klass->_byval_arg.data.generic_param , param );
+	CHECKED_METADATA_WRITE_PTR ( klass->this_arg.data__.generic_param ,  param );
+	CHECKED_METADATA_WRITE_PTR ( klass->_byval_arg.data__.generic_param , param );
 	klass->this_arg.byref__ = TRUE;
 
 	/* We don't use type_token for VAR since only classes can use it (not arrays, pointer, VARs, etc) */
@@ -1543,7 +1544,8 @@ mono_class_create_ptr (MonoType *type)
 	class_composite_fixup_cast_class (result, TRUE);
 
 	result->this_arg.type = result->_byval_arg.type = MONO_TYPE_PTR;
-	result->this_arg.data.type = result->_byval_arg.data.type = m_class_get_byval_arg (el_class);
+	m_type_data_set_type_unchecked (&result->this_arg, m_class_get_byval_arg (el_class));
+	m_type_data_set_type_unchecked (&result->_byval_arg, m_class_get_byval_arg (el_class));
 	result->this_arg.byref__ = TRUE;
 
 	mono_class_setup_supertypes (result);
@@ -1609,7 +1611,8 @@ mono_class_create_fnptr (MonoMethodSignature *sig)
 	result->min_align = sizeof (gpointer);
 	result->cast_class = result->element_class = result;
 	result->this_arg.type = result->_byval_arg.type = MONO_TYPE_FNPTR;
-	result->this_arg.data.method = result->_byval_arg.data.method = sig;
+	m_type_data_set_method_unchecked (&result->this_arg, sig);
+	m_type_data_set_method_unchecked (&result->_byval_arg, sig);
 	result->this_arg.byref__ = TRUE;
 	result->blittable = TRUE;
 	result->inited = TRUE;
@@ -3325,10 +3328,10 @@ mono_class_setup_mono_type (MonoClass *klass)
 	gboolean is_corlib = mono_is_corlib_image (klass->image);
 
 	klass->this_arg.byref__ = 1;
-	klass->this_arg.data.klass = klass;
 	klass->this_arg.type = MONO_TYPE_CLASS;
-	klass->_byval_arg.data.klass = klass;
 	klass->_byval_arg.type = MONO_TYPE_CLASS;
+	m_type_data_set_klass_unchecked (&klass->this_arg, klass);
+	m_type_data_set_klass_unchecked (&klass->_byval_arg, klass);
 
 	if (is_corlib && !strcmp (nspace, "System")) {
 		if (!strcmp (name, "ValueType")) {

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -545,13 +545,13 @@ mono_generic_param_name (MonoGenericParam *p)
 static inline MonoGenericContainer *
 mono_type_get_generic_param_owner (MonoType *t)
 {
-	return mono_generic_param_owner (m_type_get_generic_param(t));
+	return mono_generic_param_owner (m_type_data_get_generic_param (t));
 }
 
 static inline guint16
 mono_type_get_generic_param_num (MonoType *t)
 {
-	return mono_generic_param_num (m_type_get_generic_param(t));
+	return mono_generic_param_num (m_type_data_get_generic_param (t));
 }
 
 /*

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -545,13 +545,13 @@ mono_generic_param_name (MonoGenericParam *p)
 static inline MonoGenericContainer *
 mono_type_get_generic_param_owner (MonoType *t)
 {
-	return mono_generic_param_owner (t->data.generic_param);
+	return mono_generic_param_owner (m_type_get_generic_param(t));
 }
 
 static inline guint16
 mono_type_get_generic_param_num (MonoType *t)
 {
-	return mono_generic_param_num (t->data.generic_param);
+	return mono_generic_param_num (m_type_get_generic_param(t));
 }
 
 /*

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -783,7 +783,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		if (!inflated)
 			return type;
 		nt = mono_metadata_type_dup (image, type);
-		nt->data.klass = mono_class_from_mono_type_internal (inflated);
+		m_type_data_set_klass (nt, mono_class_from_mono_type_internal (inflated));
 		mono_metadata_free_type (inflated);
 		return nt;
 	}
@@ -795,7 +795,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		if (!inflated)
 			return type;
 		nt = mono_metadata_type_dup (image, type);
-		nt->data.array->eklass = mono_class_from_mono_type_internal (inflated);
+		m_type_data_get_array (nt)->eklass = mono_class_from_mono_type_internal (inflated);
 		mono_metadata_free_type (inflated);
 		return nt;
 	}
@@ -824,7 +824,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		}
 
 		nt = mono_metadata_type_dup (image, type);
-		nt->data.generic_class = gclass;
+		m_type_data_set_generic_class (nt, gclass);
 		return nt;
 	}
 	case MONO_TYPE_CLASS:
@@ -857,7 +857,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 
 		nt = mono_metadata_type_dup (image, type);
 		nt->type = MONO_TYPE_GENERICINST;
-		nt->data.generic_class = gclass;
+		m_type_data_set_generic_class (nt, gclass);
 		return nt;
 	}
 	case MONO_TYPE_PTR: {
@@ -867,7 +867,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		if (!inflated && changed)
 			return type;
 		nt = mono_metadata_type_dup (image, type);
-		nt->data.type = inflated;
+		m_type_data_set_type (nt, inflated);
 		return nt;
 	}
 	case MONO_TYPE_FNPTR: {
@@ -892,7 +892,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 				return type;
 		}
 		MonoType *nt = mono_metadata_type_dup (image, type);
-		nt->data.method = new_sig;
+		m_type_data_set_method (nt, new_sig);
 		return nt;
 	}
 	default:

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1671,11 +1671,11 @@ mono_type_has_exceptions (MonoType *type)
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_SZARRAY:
-		return mono_class_has_failure (m_type_data_get_klass (type));
+		return mono_class_has_failure (m_type_data_get_klass_unchecked (type));
 	case MONO_TYPE_ARRAY:
-		return mono_class_has_failure (m_type_data_get_array (type)->eklass);
+		return mono_class_has_failure (m_type_data_get_array_unchecked (type)->eklass);
 	case MONO_TYPE_GENERICINST:
-		return mono_class_has_failure (mono_class_create_generic_inst (m_type_data_get_generic_class (type)));
+		return mono_class_has_failure (mono_class_create_generic_inst (m_type_data_get_generic_class_unchecked (type)));
 	default:
 		return FALSE;
 	}
@@ -3877,10 +3877,10 @@ mono_gparam_is_assignable_from (MonoClass *target, MonoClass *candidate)
 static MonoType*
 mono_type_get_underlying_type_ignore_byref (MonoType *type)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (type)))
-		return mono_class_enum_basetype_internal (m_type_data_get_klass (type));
-	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (m_type_data_get_generic_class (type)->container_class))
-		return mono_class_enum_basetype_internal (m_type_data_get_generic_class (type)->container_class);
+	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (type)))
+		return mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
+	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (m_type_data_get_generic_class_unchecked (type)->container_class))
+		return mono_class_enum_basetype_internal (m_type_data_get_generic_class_unchecked (type)->container_class);
 	return type;
 }
 
@@ -3910,7 +3910,7 @@ mono_byref_type_is_assignable_from (MonoType *type, MonoType *ctype, gboolean si
 	if (mono_type_is_primitive (t)) {
 		return mono_type_is_primitive (ot) && m_class_get_instance_size (klass) == m_class_get_instance_size (klassc);
 	} else if (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) {
-		return t->type == ot->type && m_type_data_get_generic_param (t)->num == m_type_data_get_generic_param (ot)->num;
+		return t->type == ot->type && m_type_data_get_generic_param_unchecked (t)->num == m_type_data_get_generic_param_unchecked (ot)->num;
 	} else if (t->type == MONO_TYPE_PTR || t->type == MONO_TYPE_FNPTR) {
 		return t->type == ot->type;
 	} else {
@@ -4815,14 +4815,14 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return 8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			klass = m_class_get_element_class (klass);
 			goto handle_enum;
 		}
 		return mono_class_value_size (klass, NULL);
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR: {
@@ -6312,15 +6312,15 @@ can_access_instantiation (MonoClass *access_klass, MonoGenericInst *ginst)
 		MonoType *type = ginst->type_argv[i];
 		switch (type->type) {
 		case MONO_TYPE_SZARRAY:
-			if (!can_access_type (access_klass, m_type_data_get_klass (type)))
+			if (!can_access_type (access_klass, m_type_data_get_klass_unchecked (type)))
 				return FALSE;
 			break;
 		case MONO_TYPE_ARRAY:
-			if (!can_access_type (access_klass, m_type_data_get_array (type)->eklass))
+			if (!can_access_type (access_klass, m_type_data_get_array_unchecked (type)->eklass))
 				return FALSE;
 			break;
 		case MONO_TYPE_PTR:
-			if (!can_access_type (access_klass, mono_class_from_mono_type_internal (m_type_data_get_type (type))))
+			if (!can_access_type (access_klass, mono_class_from_mono_type_internal (m_type_data_get_type_unchecked (type))))
 				return FALSE;
 			break;
 		case MONO_TYPE_CLASS:
@@ -6919,7 +6919,7 @@ mono_method_get_base_method (MonoMethod *method, gboolean definition, MonoError 
 		 * up the class hierarchy. */
 		MonoType *ty = mono_class_gtd_get_canonical_inst (klass);
 		g_assert (ty->type == MONO_TYPE_GENERICINST);
-		MonoGenericClass *gklass = m_type_data_get_generic_class (ty);
+		MonoGenericClass *gklass = m_type_data_get_generic_class_unchecked (ty);
 		generic_inst = mono_generic_class_get_context (gklass);
 		klass = gklass->container_class;
 	} else if (mono_class_is_ginst (klass)) {

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2265,64 +2265,53 @@ mono_class_from_mono_type (MonoType *type)
 MonoClass *
 mono_class_from_mono_type_internal (MonoType *type)
 {
+
+#define CASE_KLASS_OR_DEFAULT_FOR_TYPE(enum_value, default_expr) \
+	case enum_value: \
+		return m_type_data_get_klass_unchecked (type) ? m_type_data_get_klass_unchecked (type) : default_expr;
+
 	g_assert (type);
 	switch (type->type) {
-	case MONO_TYPE_OBJECT:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.object_class;
-	case MONO_TYPE_VOID:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.void_class;
-	case MONO_TYPE_BOOLEAN:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.boolean_class;
-	case MONO_TYPE_CHAR:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.char_class;
-	case MONO_TYPE_I1:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.sbyte_class;
-	case MONO_TYPE_U1:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.byte_class;
-	case MONO_TYPE_I2:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int16_class;
-	case MONO_TYPE_U2:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint16_class;
-	case MONO_TYPE_I4:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int32_class;
-	case MONO_TYPE_U4:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint32_class;
-	case MONO_TYPE_I:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int_class;
-	case MONO_TYPE_U:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint_class;
-	case MONO_TYPE_I8:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int64_class;
-	case MONO_TYPE_U8:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint64_class;
-	case MONO_TYPE_R4:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.single_class;
-	case MONO_TYPE_R8:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.double_class;
-	case MONO_TYPE_STRING:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.string_class;
-	case MONO_TYPE_TYPEDBYREF:
-		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.typed_reference_class;
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_OBJECT, mono_defaults.object_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_VOID, mono_defaults.void_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_BOOLEAN, mono_defaults.boolean_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_CHAR, mono_defaults.char_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_I1, mono_defaults.sbyte_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_U1, mono_defaults.byte_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_I2, mono_defaults.int16_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_U2, mono_defaults.uint16_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_I4, mono_defaults.int32_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_U4, mono_defaults.uint32_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_I, mono_defaults.int_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_U, mono_defaults.uint_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_I8, mono_defaults.int64_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_U8, mono_defaults.uint64_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_R4, mono_defaults.single_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_R8, mono_defaults.double_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_STRING, mono_defaults.string_class);
+	CASE_KLASS_OR_DEFAULT_FOR_TYPE(MONO_TYPE_TYPEDBYREF, mono_defaults.typed_reference_class);
 	case MONO_TYPE_ARRAY:
-		return mono_class_create_bounded_array (m_type_data_get_array (type)->eklass, m_type_data_get_array (type)->rank, TRUE);
+		return mono_class_create_bounded_array (m_type_data_get_array_unchecked (type)->eklass, m_type_data_get_array_unchecked (type)->rank, TRUE);
 	case MONO_TYPE_PTR:
-		return mono_class_create_ptr (m_type_data_get_type (type));
+		return mono_class_create_ptr (m_type_data_get_type_unchecked (type));
 	case MONO_TYPE_FNPTR:
-		return mono_class_create_fnptr (m_type_data_get_method (type));
+		return mono_class_create_fnptr (m_type_data_get_method_unchecked (type));
 	case MONO_TYPE_SZARRAY:
-		return mono_class_create_array (m_type_data_get_klass (type), 1);
+		return mono_class_create_array (m_type_data_get_klass_unchecked (type), 1);
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		return m_type_data_get_klass (type);
+		return m_type_data_get_klass_unchecked (type);
 	case MONO_TYPE_GENERICINST:
-		return mono_class_create_generic_inst (m_type_data_get_generic_class (type));
+		return mono_class_create_generic_inst (m_type_data_get_generic_class_unchecked (type));
 	case MONO_TYPE_MVAR:
 	case MONO_TYPE_VAR:
-		return mono_class_create_generic_parameter (m_type_data_get_generic_param (type));
+		return mono_class_create_generic_parameter (m_type_data_get_generic_param_unchecked (type));
 	default:
 		g_warning ("mono_class_from_mono_type_internal: implement me 0x%02x\n", type->type);
 		g_assert_not_reached ();
 	}
+
+#undef CASE_KLASS_OR_DEFAULT_FOR_TYPE
 
 	// Yes, this returns NULL, even if it is documented as not doing so, but there
 	// is no way for the code to make it this far, due to the assert above.

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -857,7 +857,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 
 		nt = mono_metadata_type_dup (image, type);
 		nt->type = MONO_TYPE_GENERICINST;
-		m_type_data_set_generic_class (nt, gclass);
+		m_type_data_set_generic_class_unchecked (nt, gclass);
 		return nt;
 	}
 	case MONO_TYPE_PTR: {

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1747,7 +1747,7 @@ mono_type_get_basic_type_from_generic (MonoType *type)
 {
 	/* When we do generic sharing we let type variables stand for reference/primitive types. */
 	if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) &&
-		(!m_type_data_get_generic_param (type)->gshared_constraint || m_type_data_get_generic_param (type)->gshared_constraint->type == MONO_TYPE_OBJECT))
+		(!m_type_data_get_generic_param_unchecked (type)->gshared_constraint || m_type_data_get_generic_param_unchecked (type)->gshared_constraint->type == MONO_TYPE_OBJECT))
 		return mono_get_object_type ();
 	return type;
 }
@@ -3706,7 +3706,7 @@ mono_gparam_is_reference_conversible (MonoClass *target, MonoClass *candidate, g
 	if (check_for_reference_conv &&
 		mono_type_is_generic_argument (m_class_get_byval_arg (target)) &&
 		mono_type_is_generic_argument (m_class_get_byval_arg (candidate))) {
-		MonoGenericParam *gparam = m_type_data_get_generic_param (m_class_get_byval_arg (candidate));
+		MonoGenericParam *gparam = m_type_data_get_generic_param_unchecked (m_class_get_byval_arg (candidate));
 		MonoGenericParamInfo *pinfo = mono_generic_param_info (gparam);
 
 		if (!pinfo || (pinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) == 0)
@@ -4127,7 +4127,7 @@ mono_class_is_assignable_from_general (MonoClass *klass, MonoClass *oklass, gboo
 	 * In this case, Foo is assignable from T1.
 	 */
 	if (mono_type_is_generic_argument (oklass_byval_arg)) {
-		MonoGenericParam *gparam = m_type_data_get_generic_param (oklass_byval_arg);
+		MonoGenericParam *gparam = m_type_data_get_generic_param_unchecked (oklass_byval_arg);
 		MonoClass **constraints = mono_generic_container_get_param_info (gparam->owner, gparam->num)->constraints;
 		int i;
 
@@ -4295,7 +4295,7 @@ mono_class_is_assignable_from_general (MonoClass *klass, MonoClass *oklass, gboo
 		if (MONO_CLASS_IS_INTERFACE_INTERNAL (eclass)) {
 			MonoType *eoclass_byval_arg = m_class_get_byval_arg (eoclass);
 			if (mono_type_is_generic_argument (eoclass_byval_arg)) {
-				MonoGenericParam *eoparam = m_type_data_get_generic_param (eoclass_byval_arg);
+				MonoGenericParam *eoparam = m_type_data_get_generic_param_unchecked (eoclass_byval_arg);
 				MonoGenericParamInfo *eoinfo = mono_generic_param_info (eoparam);
 				int eomask = eoinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_SPECIAL_CONSTRAINTS_MASK;
 				// check for class constraint
@@ -4642,7 +4642,7 @@ mono_generic_param_get_base_type (MonoClass *klass)
 	MonoType *type = m_class_get_byval_arg (klass);
 	g_assert (mono_type_is_generic_argument (type));
 
-	MonoGenericParam *gparam = m_type_data_get_generic_param (type);
+	MonoGenericParam *gparam = m_type_data_get_generic_param_unchecked (type);
 
 	g_assert (gparam->owner && !gparam->owner->is_anonymous);
 
@@ -4660,7 +4660,7 @@ mono_generic_param_get_base_type (MonoClass *klass)
 
 			MonoType *constraint_type = m_class_get_byval_arg (constraint);
 			if (mono_type_is_generic_argument (constraint_type)) {
-				MonoGenericParam *constraint_param = m_type_data_get_generic_param (constraint_type);
+				MonoGenericParam *constraint_param = m_type_data_get_generic_param_unchecked (constraint_type);
 				MonoGenericParamInfo *constraint_info = mono_generic_param_info (constraint_param);
 				if ((constraint_info->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) == 0 &&
 				    (constraint_info->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT) == 0)

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -354,14 +354,14 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 
 	switch (type->type) {
 	case MONO_TYPE_ARRAY: {
-		int i, rank = m_type_get_array(type)->rank;
+		int i, rank = m_type_data_get_array (type)->rank;
 		MonoTypeNameFormat nested_format;
 
 		nested_format = format == MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED ?
 			MONO_TYPE_NAME_FORMAT_FULL_NAME : format;
 
 		mono_type_get_name_recurse (
-			m_class_get_byval_arg (m_type_get_array(type)->eklass), str, FALSE, nested_format);
+			m_class_get_byval_arg (m_type_data_get_array (type)->eklass), str, FALSE, nested_format);
 		g_string_append_c (str, '[');
 		if (rank == 1)
 			g_string_append_c (str, '*');
@@ -376,7 +376,7 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 		mono_type_name_check_byref (type, str);
 
 		if (format == MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED)
-			_mono_type_get_assembly_name (m_type_get_array(type)->eklass, str);
+			_mono_type_get_assembly_name (m_type_data_get_array (type)->eklass, str);
 		break;
 	}
 	case MONO_TYPE_SZARRAY: {
@@ -386,13 +386,13 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 			MONO_TYPE_NAME_FORMAT_FULL_NAME : format;
 
 		mono_type_get_name_recurse (
-			m_class_get_byval_arg (m_type_get_klass(type)), str, FALSE, nested_format);
+			m_class_get_byval_arg (m_type_data_get_klass (type)), str, FALSE, nested_format);
 		g_string_append (str, "[]");
 
 		mono_type_name_check_byref (type, str);
 
 		if (format == MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED)
-			_mono_type_get_assembly_name (m_type_get_klass(type), str);
+			_mono_type_get_assembly_name (m_type_data_get_klass (type), str);
 		break;
 	}
 	case MONO_TYPE_PTR: {
@@ -402,21 +402,21 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 			MONO_TYPE_NAME_FORMAT_FULL_NAME : format;
 
 		mono_type_get_name_recurse (
-			m_type_get_type(type), str, FALSE, nested_format);
+			m_type_data_get_type (type), str, FALSE, nested_format);
 		g_string_append_c (str, '*');
 
 		mono_type_name_check_byref (type, str);
 
 		if (format == MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED)
-			_mono_type_get_assembly_name (mono_class_from_mono_type_internal (m_type_get_type(type)), str);
+			_mono_type_get_assembly_name (mono_class_from_mono_type_internal (m_type_data_get_type (type)), str);
 		break;
 	}
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		if (!mono_generic_param_name (m_type_get_generic_param(type)))
-			g_string_append_printf (str, "%s%d", type->type == MONO_TYPE_VAR ? "!" : "!!", m_type_get_generic_param(type)->num);
+		if (!mono_generic_param_name (m_type_data_get_generic_param (type)))
+			g_string_append_printf (str, "%s%d", type->type == MONO_TYPE_VAR ? "!" : "!!", m_type_data_get_generic_param (type)->num);
 		else
-			g_string_append (str, mono_generic_param_name (m_type_get_generic_param(type)));
+			g_string_append (str, mono_generic_param_name (m_type_data_get_generic_param (type)));
 
 		mono_type_name_check_byref (type, str);
 
@@ -427,12 +427,12 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 		nested_format = format == MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED ?
 			MONO_TYPE_NAME_FORMAT_FULL_NAME : format;
 
-		mono_type_get_name_recurse (m_type_get_method(type)->ret, str, FALSE, nested_format);
+		mono_type_get_name_recurse (m_type_data_get_method (type)->ret, str, FALSE, nested_format);
 
 		g_string_append_c (str, '(');
-		for (int i = 0; i < m_type_get_method(type)->param_count; ++i) {
-			mono_type_get_name_recurse (m_type_get_method(type)->params[i], str, FALSE, nested_format);
-			if (i != m_type_get_method(type)->param_count - 1)
+		for (int i = 0; i < m_type_data_get_method (type)->param_count; ++i) {
+			mono_type_get_name_recurse (m_type_data_get_method (type)->params[i], str, FALSE, nested_format);
+			if (i != m_type_data_get_method (type)->param_count - 1)
 				g_string_append (str, ", ");
 		}
 		g_string_append_c (str, ')');
@@ -592,10 +592,10 @@ mono_type_get_name (MonoType *type)
 MonoType*
 mono_type_get_underlying_type (MonoType *type)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_get_klass(type)) && !m_type_is_byref (type))
-		return mono_class_enum_basetype_internal (m_type_get_klass(type));
-	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (m_type_get_generic_class(type)->container_class) && !m_type_is_byref (type))
-		return mono_class_enum_basetype_internal (m_type_get_generic_class(type)->container_class);
+	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (type)) && !m_type_is_byref (type))
+		return mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (m_type_data_get_generic_class (type)->container_class) && !m_type_is_byref (type))
+		return mono_class_enum_basetype_internal (m_type_data_get_generic_class (type)->container_class);
 	return type;
 }
 
@@ -619,16 +619,16 @@ mono_class_is_open_constructed_type (MonoType *t)
 	case MONO_TYPE_MVAR:
 		return TRUE;
 	case MONO_TYPE_SZARRAY:
-		return mono_class_is_open_constructed_type (m_class_get_byval_arg (m_type_get_klass(t)));
+		return mono_class_is_open_constructed_type (m_class_get_byval_arg (m_type_data_get_klass (t)));
 	case MONO_TYPE_ARRAY:
-		return mono_class_is_open_constructed_type (m_class_get_byval_arg (m_type_get_array(t)->eklass));
+		return mono_class_is_open_constructed_type (m_class_get_byval_arg (m_type_data_get_array (t)->eklass));
 	case MONO_TYPE_PTR:
-		return mono_class_is_open_constructed_type (m_type_get_type(t));
+		return mono_class_is_open_constructed_type (m_type_data_get_type (t));
 	case MONO_TYPE_GENERICINST:
-		return m_type_get_generic_class(t)->context.class_inst->is_open;
+		return m_type_data_get_generic_class (t)->context.class_inst->is_open;
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		return mono_class_is_gtd (m_type_get_klass(t));
+		return mono_class_is_gtd (m_type_data_get_klass (t));
 	default:
 		return FALSE;
 	}
@@ -659,7 +659,7 @@ can_inflate_gparam_with (MonoGenericParam *gparam, MonoType *type)
 	MonoGenericParamInfo *info = mono_generic_param_info (gparam);
 	if (info && (info->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT)) {
 		if (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) {
-			MonoGenericParam *inst_gparam = m_type_get_generic_param(type);
+			MonoGenericParam *inst_gparam = m_type_data_get_generic_param (type);
 			if (inst_gparam->gshared_constraint && inst_gparam->gshared_constraint->type == MONO_TYPE_OBJECT)
 				return FALSE;
 		}
@@ -702,7 +702,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 			else
 				return type;
 		}
-		MonoGenericParam *gparam = m_type_get_generic_param(type);
+		MonoGenericParam *gparam = m_type_data_get_generic_param (type);
 		if (num >= inst->type_argc) {
 			const char *pname = mono_generic_param_name (gparam);
 			mono_error_set_bad_image (error, image, "MVAR %d (%s) cannot be expanded in this context with %d instantiations",
@@ -736,7 +736,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 			else
 				return type;
 		}
-		MonoGenericParam *gparam = m_type_get_generic_param(type);
+		MonoGenericParam *gparam = m_type_data_get_generic_param (type);
 		if (num >= inst->type_argc) {
 			const char *pname = mono_generic_param_name (gparam);
 			mono_error_set_bad_image (error, image, "VAR %hu (%s) cannot be expanded in this context with %d instantiations",
@@ -776,7 +776,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		return nt;
 	}
 	case MONO_TYPE_SZARRAY: {
-		MonoClass *eclass = m_type_get_klass(type);
+		MonoClass *eclass = m_type_data_get_klass (type);
 		MonoType *nt, *inflated = inflate_generic_type (NULL, m_class_get_byval_arg (eclass), context, error);
 		if ((!inflated && !changed) || !is_ok (error))
 			return NULL;
@@ -788,7 +788,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		return nt;
 	}
 	case MONO_TYPE_ARRAY: {
-		MonoClass *eclass = m_type_get_array(type)->eklass;
+		MonoClass *eclass = m_type_data_get_array (type)->eklass;
 		MonoType *nt, *inflated = inflate_generic_type (NULL, m_class_get_byval_arg (eclass), context, error);
 		if ((!inflated && !changed) || !is_ok (error))
 			return NULL;
@@ -800,7 +800,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		return nt;
 	}
 	case MONO_TYPE_GENERICINST: {
-		MonoGenericClass *gclass = m_type_get_generic_class(type);
+		MonoGenericClass *gclass = m_type_data_get_generic_class (type);
 		MonoGenericInst *inst;
 		MonoType *nt;
 		if (!gclass->context.class_inst->is_open) {
@@ -816,7 +816,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		if (inst != gclass->context.class_inst)
 			gclass = mono_metadata_lookup_generic_class (gclass->container_class, inst, gclass->is_dynamic);
 
-		if (gclass == m_type_get_generic_class(type)) {
+		if (gclass == m_type_data_get_generic_class (type)) {
 			if (!changed)
 				return NULL;
 			else
@@ -829,7 +829,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 	}
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE: {
-		MonoClass *klass = m_type_get_klass(type);
+		MonoClass *klass = m_type_data_get_klass (type);
 		MonoGenericContainer *container = mono_class_try_get_generic_container (klass);
 		MonoGenericInst *inst;
 		MonoGenericClass *gclass = NULL;
@@ -861,7 +861,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		return nt;
 	}
 	case MONO_TYPE_PTR: {
-		MonoType *nt, *inflated = inflate_generic_type (image, m_type_get_type(type), context, error);
+		MonoType *nt, *inflated = inflate_generic_type (image, m_type_data_get_type (type), context, error);
 		if ((!inflated && !changed) || !is_ok (error))
 			return NULL;
 		if (!inflated && changed)
@@ -871,7 +871,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		return nt;
 	}
 	case MONO_TYPE_FNPTR: {
-		MonoMethodSignature *in_sig = m_type_get_method(type);
+		MonoMethodSignature *in_sig = m_type_data_get_method (type);
 		// quick bail out - if there are no type variables anywhere in the signature,
 		// there's nothing that could get inflated.
 		if (!in_sig->has_type_parameters) {
@@ -1671,11 +1671,11 @@ mono_type_has_exceptions (MonoType *type)
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_SZARRAY:
-		return mono_class_has_failure (m_type_get_klass(type));
+		return mono_class_has_failure (m_type_data_get_klass (type));
 	case MONO_TYPE_ARRAY:
-		return mono_class_has_failure (m_type_get_array(type)->eklass);
+		return mono_class_has_failure (m_type_data_get_array (type)->eklass);
 	case MONO_TYPE_GENERICINST:
-		return mono_class_has_failure (mono_class_create_generic_inst (m_type_get_generic_class(type)));
+		return mono_class_has_failure (mono_class_create_generic_inst (m_type_data_get_generic_class (type)));
 	default:
 		return FALSE;
 	}
@@ -1747,7 +1747,7 @@ mono_type_get_basic_type_from_generic (MonoType *type)
 {
 	/* When we do generic sharing we let type variables stand for reference/primitive types. */
 	if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) &&
-		(!m_type_get_generic_param(type)->gshared_constraint || m_type_get_generic_param(type)->gshared_constraint->type == MONO_TYPE_OBJECT))
+		(!m_type_data_get_generic_param (type)->gshared_constraint || m_type_data_get_generic_param (type)->gshared_constraint->type == MONO_TYPE_OBJECT))
 		return mono_get_object_type ();
 	return type;
 }
@@ -2268,57 +2268,57 @@ mono_class_from_mono_type_internal (MonoType *type)
 	g_assert (type);
 	switch (type->type) {
 	case MONO_TYPE_OBJECT:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.object_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.object_class;
 	case MONO_TYPE_VOID:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.void_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.void_class;
 	case MONO_TYPE_BOOLEAN:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.boolean_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.boolean_class;
 	case MONO_TYPE_CHAR:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.char_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.char_class;
 	case MONO_TYPE_I1:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.sbyte_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.sbyte_class;
 	case MONO_TYPE_U1:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.byte_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.byte_class;
 	case MONO_TYPE_I2:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.int16_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int16_class;
 	case MONO_TYPE_U2:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.uint16_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint16_class;
 	case MONO_TYPE_I4:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.int32_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int32_class;
 	case MONO_TYPE_U4:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.uint32_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint32_class;
 	case MONO_TYPE_I:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.int_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int_class;
 	case MONO_TYPE_U:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.uint_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint_class;
 	case MONO_TYPE_I8:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.int64_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.int64_class;
 	case MONO_TYPE_U8:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.uint64_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.uint64_class;
 	case MONO_TYPE_R4:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.single_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.single_class;
 	case MONO_TYPE_R8:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.double_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.double_class;
 	case MONO_TYPE_STRING:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.string_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.string_class;
 	case MONO_TYPE_TYPEDBYREF:
-		return m_type_get_klass(type)? m_type_get_klass(type): mono_defaults.typed_reference_class;
+		return m_type_data_get_klass (type)? m_type_data_get_klass (type): mono_defaults.typed_reference_class;
 	case MONO_TYPE_ARRAY:
-		return mono_class_create_bounded_array (m_type_get_array(type)->eklass, m_type_get_array(type)->rank, TRUE);
+		return mono_class_create_bounded_array (m_type_data_get_array (type)->eklass, m_type_data_get_array (type)->rank, TRUE);
 	case MONO_TYPE_PTR:
-		return mono_class_create_ptr (m_type_get_type(type));
+		return mono_class_create_ptr (m_type_data_get_type (type));
 	case MONO_TYPE_FNPTR:
-		return mono_class_create_fnptr (m_type_get_method(type));
+		return mono_class_create_fnptr (m_type_data_get_method (type));
 	case MONO_TYPE_SZARRAY:
-		return mono_class_create_array (m_type_get_klass(type), 1);
+		return mono_class_create_array (m_type_data_get_klass (type), 1);
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		return m_type_get_klass(type);
+		return m_type_data_get_klass (type);
 	case MONO_TYPE_GENERICINST:
-		return mono_class_create_generic_inst (m_type_get_generic_class(type));
+		return mono_class_create_generic_inst (m_type_data_get_generic_class (type));
 	case MONO_TYPE_MVAR:
 	case MONO_TYPE_VAR:
-		return mono_class_create_generic_parameter (m_type_get_generic_param(type));
+		return mono_class_create_generic_parameter (m_type_data_get_generic_param (type));
 	default:
 		g_warning ("mono_class_from_mono_type_internal: implement me 0x%02x\n", type->type);
 		g_assert_not_reached ();
@@ -3717,7 +3717,7 @@ mono_gparam_is_reference_conversible (MonoClass *target, MonoClass *candidate, g
 	if (check_for_reference_conv &&
 		mono_type_is_generic_argument (m_class_get_byval_arg (target)) &&
 		mono_type_is_generic_argument (m_class_get_byval_arg (candidate))) {
-		MonoGenericParam *gparam = m_type_get_generic_param (m_class_get_byval_arg (candidate));
+		MonoGenericParam *gparam = m_type_data_get_generic_param (m_class_get_byval_arg (candidate));
 		MonoGenericParamInfo *pinfo = mono_generic_param_info (gparam);
 
 		if (!pinfo || (pinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) == 0)
@@ -3796,8 +3796,8 @@ mono_gparam_is_assignable_from (MonoClass *target, MonoClass *candidate)
 	if (target_byval_arg->type != candidate_byval_arg->type)
 		return FALSE;
 
-	gparam = m_type_get_generic_param(target_byval_arg);
-	ogparam = m_type_get_generic_param(candidate_byval_arg);
+	gparam = m_type_data_get_generic_param (target_byval_arg);
+	ogparam = m_type_data_get_generic_param (candidate_byval_arg);
 	tinfo = mono_generic_param_info (gparam);
 	cinfo = mono_generic_param_info (ogparam);
 
@@ -3888,10 +3888,10 @@ mono_gparam_is_assignable_from (MonoClass *target, MonoClass *candidate)
 static MonoType*
 mono_type_get_underlying_type_ignore_byref (MonoType *type)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_get_klass(type)))
-		return mono_class_enum_basetype_internal (m_type_get_klass(type));
-	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (m_type_get_generic_class(type)->container_class))
-		return mono_class_enum_basetype_internal (m_type_get_generic_class(type)->container_class);
+	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (type)))
+		return mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (m_type_data_get_generic_class (type)->container_class))
+		return mono_class_enum_basetype_internal (m_type_data_get_generic_class (type)->container_class);
 	return type;
 }
 
@@ -3921,7 +3921,7 @@ mono_byref_type_is_assignable_from (MonoType *type, MonoType *ctype, gboolean si
 	if (mono_type_is_primitive (t)) {
 		return mono_type_is_primitive (ot) && m_class_get_instance_size (klass) == m_class_get_instance_size (klassc);
 	} else if (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) {
-		return t->type == ot->type && m_type_get_generic_param(t)->num == m_type_get_generic_param(ot)->num;
+		return t->type == ot->type && m_type_data_get_generic_param (t)->num == m_type_data_get_generic_param (ot)->num;
 	} else if (t->type == MONO_TYPE_PTR || t->type == MONO_TYPE_FNPTR) {
 		return t->type == ot->type;
 	} else {
@@ -4138,7 +4138,7 @@ mono_class_is_assignable_from_general (MonoClass *klass, MonoClass *oklass, gboo
 	 * In this case, Foo is assignable from T1.
 	 */
 	if (mono_type_is_generic_argument (oklass_byval_arg)) {
-		MonoGenericParam *gparam = m_type_get_generic_param(oklass_byval_arg);
+		MonoGenericParam *gparam = m_type_data_get_generic_param (oklass_byval_arg);
 		MonoClass **constraints = mono_generic_container_get_param_info (gparam->owner, gparam->num)->constraints;
 		int i;
 
@@ -4306,7 +4306,7 @@ mono_class_is_assignable_from_general (MonoClass *klass, MonoClass *oklass, gboo
 		if (MONO_CLASS_IS_INTERFACE_INTERNAL (eclass)) {
 			MonoType *eoclass_byval_arg = m_class_get_byval_arg (eoclass);
 			if (mono_type_is_generic_argument (eoclass_byval_arg)) {
-				MonoGenericParam *eoparam = m_type_get_generic_param(eoclass_byval_arg);
+				MonoGenericParam *eoparam = m_type_data_get_generic_param (eoclass_byval_arg);
 				MonoGenericParamInfo *eoinfo = mono_generic_param_info (eoparam);
 				int eomask = eoinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_SPECIAL_CONSTRAINTS_MASK;
 				// check for class constraint
@@ -4337,7 +4337,7 @@ mono_class_is_assignable_from_general (MonoClass *klass, MonoClass *oklass, gboo
 		}
 
 		if (m_class_get_byval_arg (klass)->type == MONO_TYPE_FNPTR) {
-			if (mono_metadata_signature_equal (m_type_get_method(klass_byval_arg), m_type_get_method(oklass_byval_arg))) {
+			if (mono_metadata_signature_equal (m_type_data_get_method (klass_byval_arg), m_type_data_get_method (oklass_byval_arg))) {
 				*result = TRUE;
 				return;
 			}
@@ -4653,7 +4653,7 @@ mono_generic_param_get_base_type (MonoClass *klass)
 	MonoType *type = m_class_get_byval_arg (klass);
 	g_assert (mono_type_is_generic_argument (type));
 
-	MonoGenericParam *gparam = m_type_get_generic_param(type);
+	MonoGenericParam *gparam = m_type_data_get_generic_param (type);
 
 	g_assert (gparam->owner && !gparam->owner->is_anonymous);
 
@@ -4671,7 +4671,7 @@ mono_generic_param_get_base_type (MonoClass *klass)
 
 			MonoType *constraint_type = m_class_get_byval_arg (constraint);
 			if (mono_type_is_generic_argument (constraint_type)) {
-				MonoGenericParam *constraint_param = m_type_get_generic_param(constraint_type);
+				MonoGenericParam *constraint_param = m_type_data_get_generic_param (constraint_type);
 				MonoGenericParamInfo *constraint_info = mono_generic_param_info (constraint_param);
 				if ((constraint_info->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) == 0 &&
 				    (constraint_info->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT) == 0)
@@ -4826,14 +4826,14 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return 8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			klass = m_class_get_element_class (klass);
 			goto handle_enum;
 		}
 		return mono_class_value_size (klass, NULL);
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR: {
@@ -6323,15 +6323,15 @@ can_access_instantiation (MonoClass *access_klass, MonoGenericInst *ginst)
 		MonoType *type = ginst->type_argv[i];
 		switch (type->type) {
 		case MONO_TYPE_SZARRAY:
-			if (!can_access_type (access_klass, m_type_get_klass(type)))
+			if (!can_access_type (access_klass, m_type_data_get_klass (type)))
 				return FALSE;
 			break;
 		case MONO_TYPE_ARRAY:
-			if (!can_access_type (access_klass, m_type_get_array(type)->eklass))
+			if (!can_access_type (access_klass, m_type_data_get_array (type)->eklass))
 				return FALSE;
 			break;
 		case MONO_TYPE_PTR:
-			if (!can_access_type (access_klass, mono_class_from_mono_type_internal (m_type_get_type(type))))
+			if (!can_access_type (access_klass, mono_class_from_mono_type_internal (m_type_data_get_type (type))))
 				return FALSE;
 			break;
 		case MONO_TYPE_CLASS:
@@ -6930,7 +6930,7 @@ mono_method_get_base_method (MonoMethod *method, gboolean definition, MonoError 
 		 * up the class hierarchy. */
 		MonoType *ty = mono_class_gtd_get_canonical_inst (klass);
 		g_assert (ty->type == MONO_TYPE_GENERICINST);
-		MonoGenericClass *gklass = m_type_get_generic_class(ty);
+		MonoGenericClass *gklass = m_type_data_get_generic_class (ty);
 		generic_inst = mono_generic_class_get_context (gklass);
 		klass = gklass->container_class;
 	} else if (mono_class_is_ginst (klass)) {

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -320,7 +320,7 @@ load_cattr_value (MonoImage *image, MonoType *t, MonoObject **out_obj, const cha
 	error_init (error);
 
 	if (type == MONO_TYPE_GENERICINST) {
-		MonoGenericClass * mgc = m_type_data_get_generic_class (t);
+		MonoGenericClass * mgc = m_type_data_get_generic_class_unchecked (t);
 		MonoClass * cc = mgc->container_class;
 		if (m_class_is_enumtype (cc)) {
 			tklass = m_class_get_element_class (cc);
@@ -332,6 +332,8 @@ load_cattr_value (MonoImage *image, MonoType *t, MonoObject **out_obj, const cha
 	}
 
 handle_enum:
+	// the _unchecked MonoType accessors are not used here because the gotos to handle_enum doesn't necessarily keep
+	//  type and t in sync so it's not guaranteed that accessing the union members is safe
 	switch (type) {
 	case MONO_TYPE_U1:
 	case MONO_TYPE_I1:
@@ -657,6 +659,8 @@ load_cattr_value_noalloc (MonoImage *image, MonoType *t, const char *p, const ch
 	result->type = type;
 
 handle_enum:
+	// the _unchecked MonoType accessors are not used here because the gotos to handle_enum doesn't necessarily keep
+	//  type and t in sync so it's not guaranteed that accessing the union members is safe
 	switch (type) {
 	case MONO_TYPE_U1:
 	case MONO_TYPE_I1:

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -115,9 +115,9 @@ get_attr_ctor_method_from_handle (MonoReflectionCustomAttrHandle cattr, MonoRefl
  * \param ctor_method (out param) the custom attribute constructor as MonoMethod if the custom attribute is visible, otherwise NULL
  *
  * \returns TRUE if the custom attribute is visible on a decorated type, otherwise FALSE
- * 
+ *
  * Determines if a custom attribute is visible for a decorated target \p target_image
- * 
+ *
  * FIXME: the return value is also TRUE when custom attribute constructor is NULL, which is probably a bug
  */
 static gboolean
@@ -312,7 +312,7 @@ load_cattr_value (MonoImage *image, MonoType *t, MonoObject **out_obj, const cha
 {
 	int type = t->type;
 	guint32 slen;
-	MonoClass *tklass = t->data.klass;
+	MonoClass *tklass = m_type_data_get_klass (t);
 
 	if (out_obj)
 		*out_obj = NULL;
@@ -320,7 +320,7 @@ load_cattr_value (MonoImage *image, MonoType *t, MonoObject **out_obj, const cha
 	error_init (error);
 
 	if (type == MONO_TYPE_GENERICINST) {
-		MonoGenericClass * mgc = t->data.generic_class;
+		MonoGenericClass * mgc = m_type_data_get_generic_class (t);
 		MonoClass * cc = mgc->container_class;
 		if (m_class_is_enumtype (cc)) {
 			tklass = m_class_get_element_class (cc);
@@ -389,11 +389,11 @@ handle_enum:
 		return val;
 	}
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (t->data.klass)) {
-			type = mono_class_enum_basetype_internal (t->data.klass)->type;
+		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (t))->type;
 			goto handle_enum;
 		} else {
-			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
+			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (m_type_data_get_klass (t)));
 		}
 		break;
 
@@ -525,7 +525,7 @@ MONO_RESTORE_WARNING
 			basetype = mono_class_enum_basetype_internal (tklass)->type;
 
 		if (basetype == MONO_TYPE_GENERICINST) {
-			MonoGenericClass * mgc = m_class_get_byval_arg (tklass)->data.generic_class;
+			MonoGenericClass * mgc = m_type_data_get_generic_class (m_class_get_byval_arg (tklass));
 			MonoClass * cc = mgc->container_class;
 			if (m_class_is_enumtype (cc)) {
 				basetype = m_class_get_byval_arg (m_class_get_element_class (cc))->type;
@@ -637,14 +637,14 @@ load_cattr_value_noalloc (MonoImage *image, MonoType *t, const char *p, const ch
 {
 	int type = t->type;
 	guint32 slen;
-	MonoClass *tklass = t->data.klass;
+	MonoClass *tklass = m_type_data_get_klass (t);
 	MonoCustomAttrValue* result = (MonoCustomAttrValue *)g_malloc (sizeof (MonoCustomAttrValue));
 
 	g_assert (boundp);
 	error_init (error);
 
 	if (type == MONO_TYPE_GENERICINST) {
-		MonoGenericClass * mgc = t->data.generic_class;
+		MonoGenericClass * mgc = m_type_data_get_generic_class (t);
 		MonoClass * cc = mgc->container_class;
 		if (m_class_is_enumtype (cc)) {
 			tklass = m_class_get_element_class (cc);
@@ -719,11 +719,11 @@ handle_enum:
 		return result;
 	}
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (t->data.klass)) {
-			type = mono_class_enum_basetype_internal (t->data.klass)->type;
+		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (t))->type;
 			goto handle_enum;
 		} else {
-			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
+			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (m_type_data_get_klass (t)));
 		}
 		break;
 
@@ -2062,7 +2062,7 @@ mono_method_get_unsafe_accessor_attr_data (MonoMethod *method, int *accessor_kin
 	}
 
 	MonoDecodeCustomAttr *decoded_args = mono_reflection_create_custom_attr_data_args_noalloc (m_class_get_image (attr->ctor->klass), attr->ctor, attr->data, attr->data_size, error);
-	
+
 	if (!is_ok (error)) {
 		mono_error_cleanup (error);
 		mono_reflection_free_custom_attr_data_args_noalloc (decoded_args);

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -390,15 +390,16 @@ handle_enum:
 		*end = p + 8;
 		return val;
 	}
-	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (t))->type;
+	case MONO_TYPE_VALUETYPE: {
+		MonoClass *klass_of_t = m_type_data_get_klass (t);
+		if (m_class_is_enumtype (klass_of_t)) {
+			type = mono_class_enum_basetype_internal (klass_of_t)->type;
 			goto handle_enum;
 		} else {
-			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (m_type_data_get_klass (t)));
+			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (klass_of_t));
 		}
 		break;
-
+	}
 	case MONO_TYPE_STRING: {
 		if (!bcheck_blob (p, 0, boundp, error))
 			return NULL;
@@ -722,14 +723,16 @@ handle_enum:
 		result->value.primitive = val;
 		return result;
 	}
-	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (t))->type;
+	case MONO_TYPE_VALUETYPE: {
+		MonoClass *klass_of_t = m_type_data_get_klass (t);
+		if (m_class_is_enumtype (klass_of_t)) {
+			type = mono_class_enum_basetype_internal (klass_of_t)->type;
 			goto handle_enum;
 		} else {
-			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (m_type_data_get_klass (t)));
+			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (klass_of_t));
 		}
 		break;
+	}
 
 	case MONO_TYPE_STRING: {
 		const char *start = p;

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -170,30 +170,30 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	case MONO_TYPE_OBJECT:
 		g_string_append (res, "object"); break;
 	case MONO_TYPE_PTR:
-		mono_type_get_desc (res, type->data.type, include_namespace);
+		mono_type_get_desc (res, m_type_data_get_type (type), include_namespace);
 		g_string_append_c (res, '*');
 		break;
 	case MONO_TYPE_ARRAY:
-		mono_type_get_desc (res, &type->data.array->eklass->_byval_arg, include_namespace);
+		mono_type_get_desc (res, &m_type_data_get_array (type)->eklass->_byval_arg, include_namespace);
 		g_string_append_c (res, '[');
-		for (guint8 i = 1; i < type->data.array->rank; ++i)
+		for (guint8 i = 1; i < m_type_data_get_array (type)->rank; ++i)
 			g_string_append_c (res, ',');
 		g_string_append_c (res, ']');
 		break;
 	case MONO_TYPE_SZARRAY:
-		mono_type_get_desc (res, &type->data.klass->_byval_arg, include_namespace);
+		mono_type_get_desc (res, &m_type_data_get_klass (type)->_byval_arg, include_namespace);
 		g_string_append (res, "[]");
 		break;
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		append_class_name (res, type->data.klass, include_namespace);
+		append_class_name (res, m_type_data_get_klass (type), include_namespace);
 		break;
 	case MONO_TYPE_GENERICINST: {
 		MonoGenericContext *context;
 
-		mono_type_get_desc (res, &type->data.generic_class->container_class->_byval_arg, include_namespace);
+		mono_type_get_desc (res, &m_type_data_get_generic_class (type)->container_class->_byval_arg, include_namespace);
 		g_string_append (res, "<");
-		context = &type->data.generic_class->context;
+		context = &m_type_data_get_generic_class (type)->context;
 		if (context->class_inst) {
 			for (guint i = 0; i < context->class_inst->type_argc; ++i) {
 				if (i > 0)
@@ -215,12 +215,12 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	}
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		if (type->data.generic_param) {
-			const char *name = mono_generic_param_name (type->data.generic_param);
+		if (m_type_data_get_generic_param (type)) {
+			const char *name = mono_generic_param_name (m_type_data_get_generic_param (type));
 			if (name)
 				g_string_append (res, name);
 			else
-				g_string_append_printf (res, "%s%hu", type->type == MONO_TYPE_VAR ? "!" : "!!", mono_generic_param_num (type->data.generic_param));
+				g_string_append_printf (res, "%s%hu", type->type == MONO_TYPE_VAR ? "!" : "!!", mono_generic_param_num (m_type_data_get_generic_param (type)));
 		} else {
 			g_string_append (res, "<unknown>");
 		}

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -170,30 +170,30 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	case MONO_TYPE_OBJECT:
 		g_string_append (res, "object"); break;
 	case MONO_TYPE_PTR:
-		mono_type_get_desc (res, m_type_data_get_type (type), include_namespace);
+		mono_type_get_desc (res, m_type_data_get_type_unchecked (type), include_namespace);
 		g_string_append_c (res, '*');
 		break;
 	case MONO_TYPE_ARRAY:
-		mono_type_get_desc (res, &m_type_data_get_array (type)->eklass->_byval_arg, include_namespace);
+		mono_type_get_desc (res, &m_type_data_get_array_unchecked (type)->eklass->_byval_arg, include_namespace);
 		g_string_append_c (res, '[');
-		for (guint8 i = 1; i < m_type_data_get_array (type)->rank; ++i)
+		for (guint8 i = 1; i < m_type_data_get_array_unchecked (type)->rank; ++i)
 			g_string_append_c (res, ',');
 		g_string_append_c (res, ']');
 		break;
 	case MONO_TYPE_SZARRAY:
-		mono_type_get_desc (res, &m_type_data_get_klass (type)->_byval_arg, include_namespace);
+		mono_type_get_desc (res, &m_type_data_get_klass_unchecked (type)->_byval_arg, include_namespace);
 		g_string_append (res, "[]");
 		break;
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		append_class_name (res, m_type_data_get_klass (type), include_namespace);
+		append_class_name (res, m_type_data_get_klass_unchecked (type), include_namespace);
 		break;
 	case MONO_TYPE_GENERICINST: {
 		MonoGenericContext *context;
 
-		mono_type_get_desc (res, &m_type_data_get_generic_class (type)->container_class->_byval_arg, include_namespace);
+		mono_type_get_desc (res, &m_type_data_get_generic_class_unchecked (type)->container_class->_byval_arg, include_namespace);
 		g_string_append (res, "<");
-		context = &m_type_data_get_generic_class (type)->context;
+		context = &m_type_data_get_generic_class_unchecked (type)->context;
 		if (context->class_inst) {
 			for (guint i = 0; i < context->class_inst->type_argc; ++i) {
 				if (i > 0)
@@ -215,12 +215,12 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	}
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		if (m_type_data_get_generic_param (type)) {
-			const char *name = mono_generic_param_name (m_type_data_get_generic_param (type));
+		if (m_type_data_get_generic_param_unchecked (type)) {
+			const char *name = mono_generic_param_name (m_type_data_get_generic_param_unchecked (type));
 			if (name)
 				g_string_append (res, name);
 			else
-				g_string_append_printf (res, "%s%hu", type->type == MONO_TYPE_VAR ? "!" : "!!", mono_generic_param_num (m_type_data_get_generic_param (type)));
+				g_string_append_printf (res, "%s%hu", type->type == MONO_TYPE_VAR ? "!" : "!!", mono_generic_param_num (m_type_data_get_generic_param_unchecked (type)));
 		} else {
 			g_string_append (res, "<unknown>");
 		}

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6592,7 +6592,7 @@ ves_icall_property_info_get_default_value (MonoReflectionPropertyHandle property
 {
 	MonoReflectionProperty* property = MONO_HANDLE_RAW (property_handle);
 
-	MonoType blob_type;
+	MonoType blob_type = { 0 };
 	MonoProperty *prop = property->property;
 	MonoType *type = get_property_type (prop);
 	MonoTypeEnum def_type;

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6577,7 +6577,6 @@ static void
 mono_type_from_blob_type (MonoType *type, MonoTypeEnum blob_type, MonoType *real_type)
 {
 	type->type = blob_type;
-	m_type_data_set_klass (type, NULL);
 	if (blob_type == MONO_TYPE_CLASS)
 		m_type_data_set_klass_unchecked (type, mono_defaults.object_class);
 	else if (real_type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (real_type))) {

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -344,12 +344,12 @@ handle_enum:
 				break;
 			}
 
-			t = m_class_get_byval_arg (t->data.generic_class->container_class);
+			t = m_class_get_byval_arg (m_type_data_get_generic_class (t)->container_class);
 			type = t->type;
 			goto handle_enum;
 		case MONO_TYPE_VALUETYPE:
-			if (type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (t->data.klass)) {
-				type = mono_class_enum_basetype_internal (t->data.klass)->type;
+			if (type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (t))) {
+				type = mono_class_enum_basetype_internal (m_type_data_get_klass (t))->type;
 				goto handle_enum;
 			}
 			mono_mb_emit_no_nullcheck (mb);
@@ -1009,9 +1009,9 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 			case MONO_TYPE_VOID:
 				break;
 			case MONO_TYPE_VALUETYPE:
-				klass = sig->ret->data.klass;
+				klass = m_type_data_get_klass (sig->ret);
 				if (m_class_is_enumtype (klass)) {
-					type = mono_class_enum_basetype_internal (sig->ret->data.klass)->type;
+					type = mono_class_enum_basetype_internal (m_type_data_get_klass (sig->ret))->type;
 					goto handle_enum;
 				}
 				mono_emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);

--- a/src/mono/mono/metadata/marshal-shared.c
+++ b/src/mono/mono/metadata/marshal-shared.c
@@ -507,7 +507,7 @@ mono_marshal_shared_emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *ty
 		int esize;
 
 		if (type->type == MONO_TYPE_SZARRAY) {
-			eklass = type->data.klass;
+			eklass = m_type_data_get_klass (type);
 		} else {
 			g_assert_not_reached ();
 		}
@@ -873,8 +873,8 @@ mono_marshal_shared_emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *kla
 				MonoType *etype;
 				int len;
 
-				if (t == MONO_TYPE_VALUETYPE && m_class_is_enumtype (ftype->data.klass)) {
-					ftype = mono_class_enum_basetype_internal (ftype->data.klass);
+				if (t == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (ftype))) {
+					ftype = mono_class_enum_basetype_internal (m_type_data_get_klass (ftype));
 					goto handle_enum;
 				}
 
@@ -1060,9 +1060,9 @@ mono_marshal_shared_emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *ty
 		int esize;
 
 		if (type->type == MONO_TYPE_SZARRAY) {
-			eklass = type->data.klass;
+			eklass = m_type_data_get_klass (type);
 		} else if (type->type == MONO_TYPE_ARRAY) {
-			eklass = type->data.array->eklass;
+			eklass = m_type_data_get_array (type)->eklass;
 			g_assert(m_class_is_blittable (eklass));
 		} else {
 			g_assert_not_reached ();

--- a/src/mono/mono/metadata/marshal-shared.c
+++ b/src/mono/mono/metadata/marshal-shared.c
@@ -507,7 +507,7 @@ mono_marshal_shared_emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *ty
 		int esize;
 
 		if (type->type == MONO_TYPE_SZARRAY) {
-			eklass = m_type_data_get_klass (type);
+			eklass = m_type_data_get_klass_unchecked (type);
 		} else {
 			g_assert_not_reached ();
 		}
@@ -873,8 +873,8 @@ mono_marshal_shared_emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *kla
 				MonoType *etype;
 				int len;
 
-				if (t == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (ftype))) {
-					ftype = mono_class_enum_basetype_internal (m_type_data_get_klass (ftype));
+				if (t == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (ftype))) {
+					ftype = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (ftype));
 					goto handle_enum;
 				}
 
@@ -1060,9 +1060,9 @@ mono_marshal_shared_emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *ty
 		int esize;
 
 		if (type->type == MONO_TYPE_SZARRAY) {
-			eklass = m_type_data_get_klass (type);
+			eklass = m_type_data_get_klass_unchecked (type);
 		} else if (type->type == MONO_TYPE_ARRAY) {
-			eklass = m_type_data_get_array (type)->eklass;
+			eklass = m_type_data_get_array_unchecked (type)->eklass;
 			g_assert(m_class_is_blittable (eklass));
 		} else {
 			g_assert_not_reached ();

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -1347,15 +1347,15 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return CEE_LDIND_R8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_get_klass(type))) {
+			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
 			goto handle_enum;
 		}
 		return CEE_LDOBJ;
 	case MONO_TYPE_TYPEDBYREF:
 		return CEE_LDOBJ;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (type->data.generic_class->container_class);
+		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
 		goto handle_enum;
 	default:
 		g_error ("unknown type 0x%02x in type_to_ldind", type->type);
@@ -1401,15 +1401,15 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return CEE_STIND_R8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_get_klass(type))) {
+			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
 			goto handle_enum;
 		}
 		return CEE_STOBJ;
 	case MONO_TYPE_TYPEDBYREF:
 		return CEE_STOBJ;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (type->data.generic_class->container_class);
+		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
 		goto handle_enum;
 	default:
 		g_error ("unknown type 0x%02x in type_to_stind", type->type);
@@ -1602,7 +1602,7 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 		return TRUE;
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_CLASS:
-		if (t->data.klass == mono_class_try_get_stringbuilder_class ()) {
+		if (m_type_get_klass(t) == mono_class_try_get_stringbuilder_class ()) {
 			gboolean need_free;
 			mono_marshal_get_ptr_to_stringbuilder_conv (piinfo, spec, &need_free);
 			return need_free;
@@ -2495,8 +2495,8 @@ handle_enum:
 	case MONO_TYPE_U:
 		return mono_get_int_type ();
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (t->data.klass)) {
-			t = mono_class_enum_basetype_internal (t->data.klass);
+		if (m_class_is_enumtype (m_type_get_klass(t))) {
+			t = mono_class_enum_basetype_internal (m_type_get_klass(t));
 			goto handle_enum;
 		}
 		return t;
@@ -5364,7 +5364,7 @@ mono_marshal_get_unsafe_accessor_wrapper (MonoMethod *accessor_method, MonoUnsaf
 			return res;
 	}
 	// printf ("Cache miss\n");
-	
+
 	mb = mono_mb_new (accessor_method->klass, accessor_method->name, MONO_WRAPPER_OTHER);
 	if (generic_wrapper) {
 		// If the accessor method was generic, make the wrapper generic, too.
@@ -6325,7 +6325,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE: {
 
-		MonoClass *klass = t->data.klass;
+		MonoClass *klass = m_type_get_klass(t);
 
 		if (mono_class_is_auto_layout (klass))
 			break;
@@ -6349,7 +6349,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 	}
 	case MONO_TYPE_SZARRAY: {
 		//TODO: Implement structs and in-params for all value types
-		MonoClass *klass = t->data.klass;
+		MonoClass *klass = m_type_get_klass(t);
 		MonoClass *eklass = m_class_get_element_class (klass);
 		MonoArray *arr = (MonoArray *) MONO_HANDLE_RAW (o);
 
@@ -6412,7 +6412,7 @@ mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNativ
 		break;
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE: {
-		MonoClass *klass = t->data.klass;
+		MonoClass *klass = m_type_get_klass(t);
 
 		if (m_class_is_valuetype (klass) && (mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass) || m_class_is_enumtype (klass)))
 			break;
@@ -6437,7 +6437,7 @@ mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNativ
 		break;
 	}
 	case MONO_TYPE_SZARRAY: {
-		MonoClass *klass = t->data.klass;
+		MonoClass *klass = m_type_get_klass(t);
 		MonoClass *eklass = m_class_get_element_class (klass);
 		MonoArray *arr = (MonoArray *) MONO_HANDLE_RAW (o);
 
@@ -6751,7 +6751,7 @@ typedef enum {
 	SWIFT_DOUBLE,
 } SwiftPhysicalLoweringKind;
 
-static int get_swift_lowering_alignment (SwiftPhysicalLoweringKind kind) 
+static int get_swift_lowering_alignment (SwiftPhysicalLoweringKind kind)
 {
 	switch (kind) {
 	case SWIFT_INT64:
@@ -6764,19 +6764,19 @@ static int get_swift_lowering_alignment (SwiftPhysicalLoweringKind kind)
 	}
 }
 
-static void set_lowering_range(guint8* lowered_bytes, guint32 offset, guint32 size, SwiftPhysicalLoweringKind kind) 
+static void set_lowering_range(guint8* lowered_bytes, guint32 offset, guint32 size, SwiftPhysicalLoweringKind kind)
 {
 	bool force_opaque = false;
-	
+
 	if (offset != ALIGN_TO(offset, get_swift_lowering_alignment(kind))) {
 		// If the start of the range is not aligned, we need to force the entire range to be opaque.
 		force_opaque = true;
 	}
-	
+
         // Check if any of the range is non-empty.
         // If so, we need to force this range to be opaque
         // and extend the range to the existing tag's range and mark as opaque in addition to the requested range.
-	
+
 	for (guint32 i = 0; i < size; ++i) {
 		SwiftPhysicalLoweringKind current = (SwiftPhysicalLoweringKind)lowered_bytes[offset + i];
 		if (current != SWIFT_EMPTY && current != kind) {
@@ -6796,7 +6796,7 @@ static void set_lowering_range(guint8* lowered_bytes, guint32 offset, guint32 si
 
 static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoType* type, guint32 offset);
 
-static void record_inlinearray_struct_physical_lowering (guint8* lowered_bytes, MonoClass* klass, guint32 offset) 
+static void record_inlinearray_struct_physical_lowering (guint8* lowered_bytes, MonoClass* klass, guint32 offset)
 {
 	int align;
 	int type_offset = MONO_ABI_SIZEOF (MonoObject);
@@ -6841,7 +6841,7 @@ static void record_struct_physical_lowering (guint8* lowered_bytes, MonoClass* k
 	}
 }
 
-static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoType* type, guint32 offset) 
+static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoType* type, guint32 offset)
 {
 	int align;
 
@@ -6864,7 +6864,7 @@ static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoTy
 		else if (type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR
 			|| type->type == MONO_TYPE_I || type->type == MONO_TYPE_U) {
 			kind = SWIFT_INT64;
-		} 
+		}
 #endif
 		else if (type->type == MONO_TYPE_R4) {
 			kind = SWIFT_FLOAT;
@@ -6913,7 +6913,7 @@ mono_marshal_get_swift_physical_lowering (MonoType *type, gboolean native_layout
 	}
 
 	guint8 lowered_bytes[TARGET_SIZEOF_VOID_P * 4] = { 0 };
-	
+
 	// Loop through all fields and get the physical lowering for each field
 	record_struct_physical_lowering(lowered_bytes, klass, 0);
 
@@ -6943,7 +6943,7 @@ mono_marshal_get_swift_physical_lowering (MonoType *type, gboolean native_layout
 			|| (i == ALIGN_TO(i, 8) && (current == SWIFT_DOUBLE || current == SWIFT_INT64))
 			// We've changed interval types
 			|| current != lowered_bytes[i - 1];
-		
+
 		if (start_new_interval) {
 			struct _SwiftInterval interval = { i, 1, current };
 			g_array_append_val(intervals, interval);
@@ -6973,7 +6973,7 @@ mono_marshal_get_swift_physical_lowering (MonoType *type, gboolean native_layout
 	MonoType *lowered_types[4];
 	guint32 offsets[4];
 	guint32 num_lowered_types = 0;
-	
+
 	for (int i = 0; i < intervals->len; ++i) {
 		if (num_lowered_types == 4) {
 			// We can't handle more than 4 fields
@@ -6983,7 +6983,7 @@ mono_marshal_get_swift_physical_lowering (MonoType *type, gboolean native_layout
 		}
 
 		struct _SwiftInterval interval = g_array_index(intervals, struct _SwiftInterval, i);
-		
+
 		offsets[num_lowered_types] = interval.start;
 
 		switch (interval.kind) {

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6358,6 +6358,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 		if ((param_attrs & PARAM_ATTRIBUTE_IN) && eklass != mono_get_char_class ())
 			break;
 
+		// FIXME: SZARRAY rank is always 1; this is either never true or is trying to check for T[][,]. I suspect this is just a dead if. -kg
 		if (m_class_get_rank (klass) > 1)
 			break;
 
@@ -6448,6 +6449,8 @@ mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNativ
 
 		mono_unichar2 *utf16_array = g_utf8_to_utf16 ((const char *)ptr, arr->max_length, NULL, NULL, NULL);
 		g_free (ptr);
+		// g_utf8_to_utf16 can fail and return NULL. In that case we can't do anything except either continue or crash.
+		g_assert (utf16_array);
 		memcpy (arr->vector, utf16_array, arr->max_length * sizeof (mono_unichar2));
 		g_free (utf16_array);
 		break;

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -1347,15 +1347,15 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return CEE_LDIND_R8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto handle_enum;
 		}
 		return CEE_LDOBJ;
 	case MONO_TYPE_TYPEDBYREF:
 		return CEE_LDOBJ;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto handle_enum;
 	default:
 		g_error ("unknown type 0x%02x in type_to_ldind", type->type);
@@ -1401,15 +1401,15 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return CEE_STIND_R8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto handle_enum;
 		}
 		return CEE_STOBJ;
 	case MONO_TYPE_TYPEDBYREF:
 		return CEE_STOBJ;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto handle_enum;
 	default:
 		g_error ("unknown type 0x%02x in type_to_stind", type->type);
@@ -1602,7 +1602,7 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 		return TRUE;
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_CLASS:
-		if (m_type_data_get_klass (t) == mono_class_try_get_stringbuilder_class ()) {
+		if (m_type_data_get_klass_unchecked (t) == mono_class_try_get_stringbuilder_class ()) {
 			gboolean need_free;
 			mono_marshal_get_ptr_to_stringbuilder_conv (piinfo, spec, &need_free);
 			return need_free;
@@ -2495,8 +2495,8 @@ handle_enum:
 	case MONO_TYPE_U:
 		return mono_get_int_type ();
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
-			t = mono_class_enum_basetype_internal (m_type_data_get_klass (t));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (t))) {
+			t = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (t));
 			goto handle_enum;
 		}
 		return t;
@@ -6325,7 +6325,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE: {
 
-		MonoClass *klass = m_type_data_get_klass (t);
+		MonoClass *klass = m_type_data_get_klass_unchecked (t);
 
 		if (mono_class_is_auto_layout (klass))
 			break;
@@ -6349,7 +6349,8 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 	}
 	case MONO_TYPE_SZARRAY: {
 		//TODO: Implement structs and in-params for all value types
-		MonoClass *klass = m_type_data_get_klass (t);
+		// FIXME: This appears to be incorrect, t->data->klass is initialized to the eklass. -kg
+		MonoClass *klass = m_type_data_get_klass_unchecked (t);
 		MonoClass *eklass = m_class_get_element_class (klass);
 		MonoArray *arr = (MonoArray *) MONO_HANDLE_RAW (o);
 
@@ -6412,7 +6413,7 @@ mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNativ
 		break;
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE: {
-		MonoClass *klass = m_type_data_get_klass (t);
+		MonoClass *klass = m_type_data_get_klass_unchecked (t);
 
 		if (m_class_is_valuetype (klass) && (mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass) || m_class_is_enumtype (klass)))
 			break;
@@ -6437,7 +6438,8 @@ mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNativ
 		break;
 	}
 	case MONO_TYPE_SZARRAY: {
-		MonoClass *klass = m_type_data_get_klass (t);
+		// FIXME: t->data->klass should already be the eklass. -kg
+		MonoClass *klass = m_type_data_get_klass_unchecked (t);
 		MonoClass *eklass = m_class_get_element_class (klass);
 		MonoArray *arr = (MonoArray *) MONO_HANDLE_RAW (o);
 

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -1347,15 +1347,15 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return CEE_LDIND_R8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto handle_enum;
 		}
 		return CEE_LDOBJ;
 	case MONO_TYPE_TYPEDBYREF:
 		return CEE_LDOBJ;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto handle_enum;
 	default:
 		g_error ("unknown type 0x%02x in type_to_ldind", type->type);
@@ -1401,15 +1401,15 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return CEE_STIND_R8;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto handle_enum;
 		}
 		return CEE_STOBJ;
 	case MONO_TYPE_TYPEDBYREF:
 		return CEE_STOBJ;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto handle_enum;
 	default:
 		g_error ("unknown type 0x%02x in type_to_stind", type->type);
@@ -1602,7 +1602,7 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 		return TRUE;
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_CLASS:
-		if (m_type_get_klass(t) == mono_class_try_get_stringbuilder_class ()) {
+		if (m_type_data_get_klass (t) == mono_class_try_get_stringbuilder_class ()) {
 			gboolean need_free;
 			mono_marshal_get_ptr_to_stringbuilder_conv (piinfo, spec, &need_free);
 			return need_free;
@@ -2495,8 +2495,8 @@ handle_enum:
 	case MONO_TYPE_U:
 		return mono_get_int_type ();
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(t))) {
-			t = mono_class_enum_basetype_internal (m_type_get_klass(t));
+		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
+			t = mono_class_enum_basetype_internal (m_type_data_get_klass (t));
 			goto handle_enum;
 		}
 		return t;
@@ -6325,7 +6325,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE: {
 
-		MonoClass *klass = m_type_get_klass(t);
+		MonoClass *klass = m_type_data_get_klass (t);
 
 		if (mono_class_is_auto_layout (klass))
 			break;
@@ -6349,7 +6349,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 	}
 	case MONO_TYPE_SZARRAY: {
 		//TODO: Implement structs and in-params for all value types
-		MonoClass *klass = m_type_get_klass(t);
+		MonoClass *klass = m_type_data_get_klass (t);
 		MonoClass *eklass = m_class_get_element_class (klass);
 		MonoArray *arr = (MonoArray *) MONO_HANDLE_RAW (o);
 
@@ -6412,7 +6412,7 @@ mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNativ
 		break;
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE: {
-		MonoClass *klass = m_type_get_klass(t);
+		MonoClass *klass = m_type_data_get_klass (t);
 
 		if (m_class_is_valuetype (klass) && (mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass) || m_class_is_enumtype (klass)))
 			break;
@@ -6437,7 +6437,7 @@ mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNativ
 		break;
 	}
 	case MONO_TYPE_SZARRAY: {
-		MonoClass *klass = m_type_get_klass(t);
+		MonoClass *klass = m_type_data_get_klass (t);
 		MonoClass *eklass = m_class_get_element_class (klass);
 		MonoArray *arr = (MonoArray *) MONO_HANDLE_RAW (o);
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1348,7 +1348,15 @@ m_type_data_get_klass (const MonoType *type)
 	}
 }
 
-/* unfortunately there's no way to generate doc comments for these that gets picked up on by IDEs */
+/**
+ * when using _unchecked accessors for performance, it is your responsibility to check
+ * MonoType->type first and make sure you are accessing the correct member!
+ * m_type_data_get_generic_param is legal for MONO_TYPE_VAR and MONO_TYPE_MVAR.
+ * m_type_data_get_array is legal for MONO_TYPE_ARRAY but *not* MONO_TYPE_SZARRAY.
+ * m_type_data_get_type is legal for MONO_TYPE_PTR.
+ * m_type_data_get_method is legal for MONO_TYPE_FNPTR.
+ * m_type_data_get_generic_class is legal for MONO_TYPE_GENERICINST.
+ */
 #define DEFINE_TYPE_GETTER(field_type, field_name, predicate) \
 	static inline field_type \
 	m_type_data_get_ ## field_name (const MonoType *type) \
@@ -1365,25 +1373,10 @@ m_type_data_get_klass (const MonoType *type)
 		return type->data.field_name; \
 	}
 
-/**
- * legal for MONO_TYPE_VAR and MONO_TYPE_MVAR.
- */
 DEFINE_TYPE_GETTER(MonoGenericParam *, generic_param, ((type->type == MONO_TYPE_VAR) || (type->type == MONO_TYPE_MVAR)));
-/**
- * legal for MONO_TYPE_ARRAY but *not* MONO_TYPE_SZARRAY.
- */
 DEFINE_TYPE_GETTER(MonoArrayType *, array, (type->type == MONO_TYPE_ARRAY));
-/**
- * legal for MONO_TYPE_PTR.
- */
 DEFINE_TYPE_GETTER(MonoType *, type, (type->type == MONO_TYPE_PTR));
-/**
- * legal for MONO_TYPE_FNPTR.
- */
 DEFINE_TYPE_GETTER(MonoMethodSignature *, method, (type->type == MONO_TYPE_FNPTR));
-/**
- * legal for MONO_TYPE_GENERICINST.
- */
 DEFINE_TYPE_GETTER(MonoGenericClass *, generic_class, (type->type == MONO_TYPE_GENERICINST));
 
 #undef DEFINE_TYPE_GETTER

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1317,36 +1317,51 @@ m_type_get_klass (const MonoType *type)
 static inline MonoGenericParam *
 m_type_get_generic_param (const MonoType *type)
 {
-	g_assert ((type->type == MONO_TYPE_VAR) || (type->type == MONO_TYPE_MVAR));
-	return type->data.generic_param;
+	if (G_LIKELY((type->type == MONO_TYPE_VAR) || (type->type == MONO_TYPE_MVAR)))
+		return type->data.generic_param;
+
+	m_type_invalid_access ("m_type_get_generic_param", type->type);
+	return NULL;
 }
 
 static inline MonoArrayType *
 m_type_get_array (const MonoType *type)
 {
-	g_assert (type->type == MONO_TYPE_ARRAY);
-	return type->data.array;
+	if (G_LIKELY(type->type == MONO_TYPE_ARRAY))
+		return type->data.array;
+
+	m_type_invalid_access ("m_type_get_array", type->type);
+	return NULL;
 }
 
 static inline MonoType *
 m_type_get_type (const MonoType *type)
 {
-	g_assert (type->type == MONO_TYPE_PTR);
-	return type->data.type;
+	if (G_LIKELY(type->type == MONO_TYPE_PTR))
+		return type->data.type;
+
+	m_type_invalid_access ("m_type_get_type", type->type);
+	return NULL;
 }
 
 static inline MonoMethodSignature *
 m_type_get_method (const MonoType *type)
 {
-	g_assert (type->type == MONO_TYPE_FNPTR);
-	return type->data.method;
+	if (G_LIKELY(type->type == MONO_TYPE_FNPTR))
+		return type->data.method;
+
+	m_type_invalid_access ("m_type_get_method", type->type);
+	return NULL;
 }
 
 static inline MonoGenericClass *
 m_type_get_generic_class (const MonoType *type)
 {
-	g_assert (type->type == MONO_TYPE_GENERICINST);
-	return type->data.generic_class;
+	if (G_LIKELY(type->type == MONO_TYPE_GENERICINST))
+		return type->data.generic_class;
+
+	m_type_invalid_access ("m_type_get_generic_class", type->type);
+	return NULL;
 }
 
 /**

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1301,6 +1301,7 @@ m_type_invalid_access (const char *fn_name, MonoTypeEnum actual_type);
 
 /*
  * You want mono_class_from_mono_type_internal unless you've already checked type->type.
+ * for MONO_TYPE_SZARRAY this returns the element klass for the array, not T[].
  */
 static inline MonoClass *
 m_type_data_get_klass_unchecked (const MonoType *type)
@@ -1309,7 +1310,10 @@ m_type_data_get_klass_unchecked (const MonoType *type)
 }
 
 /*
- * Legal for various types. You probably want mono_class_from_mono_type_internal unless you've already checked type->type.
+ * It is only valid to call this function if \p type is a \c MONO_TYPE_CLASS or a
+ * \c MONO_TYPE_VALUETYPE . For more general functionality, use \c mono_class_from_mono_type_internal,
+ * instead.
+ * for MONO_TYPE_SZARRAY this returns the element klass for the array, not T[].
  */
 static inline MonoClass *
 m_type_data_get_klass (const MonoType *type)

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1303,10 +1303,27 @@ static inline MonoClass *
 m_type_data_get_klass (const MonoType *type)
 {
 	switch (type->type) {
+		// list based on class.c mono_class_from_mono_type_internal cases
+		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_VOID:
+		case MONO_TYPE_BOOLEAN:
+		case MONO_TYPE_CHAR:
+		case MONO_TYPE_I1:
+		case MONO_TYPE_U1:
+		case MONO_TYPE_I2:
+		case MONO_TYPE_U2:
+		case MONO_TYPE_I4:
+		case MONO_TYPE_U4:
+		case MONO_TYPE_I:
+		case MONO_TYPE_U:
+		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
+		case MONO_TYPE_R4:
+		case MONO_TYPE_R8:
+		case MONO_TYPE_STRING:
+		case MONO_TYPE_TYPEDBYREF:
 		case MONO_TYPE_CLASS:
 		case MONO_TYPE_VALUETYPE:
-		case MONO_TYPE_STRING:
-		case MONO_TYPE_OBJECT:
 		case MONO_TYPE_SZARRAY:
 			return type->data.klass;
 		default:

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1296,8 +1296,11 @@ m_type_is_byref (const MonoType *type)
 	return type->byref__;
 }
 
-MONO_NEVER_INLINE void
-m_type_invalid_access (const char *fn_name, MonoTypeEnum actual_type);
+static MONO_NEVER_INLINE void
+m_type_invalid_access (const char *fn_name, MonoTypeEnum actual_type)
+{
+	g_error ("MonoType with type %d accessed by %s", actual_type, fn_name);
+}
 
 /*
  * You want mono_class_from_mono_type_internal unless you've already checked type->type.

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -30,7 +30,7 @@ struct _MonoType {
 		MonoMethodSignature *method;
 		MonoGenericParam *generic_param; /* for VAR and MVAR */
 		MonoGenericClass *generic_class; /* for GENERICINST */
-	} data; /* don't access directly, use m_type_get_<name> */
+	} data; /* don't access directly, use m_type_data_get_<name> */
 	unsigned int attrs    : 16; /* param attributes or field flags */
 	MonoTypeEnum type     : 8;
 	unsigned int has_cmods : 1;
@@ -1296,17 +1296,18 @@ m_type_is_byref (const MonoType *type)
 	return type->byref__;
 }
 
-void
-m_type_invalid_access (const char * fn_name, MonoTypeEnum actual_type);
+MONO_NEVER_INLINE void
+m_type_invalid_access (const char *fn_name, MonoTypeEnum actual_type);
 
 static inline MonoClass *
-m_type_get_klass (const MonoType *type)
+m_type_data_get_klass (const MonoType *type)
 {
 	switch (type->type) {
 		case MONO_TYPE_CLASS:
 		case MONO_TYPE_VALUETYPE:
 		case MONO_TYPE_STRING:
 		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_SZARRAY:
 			return type->data.klass;
 		default:
 			m_type_invalid_access ("m_type_get_klass", type->type);
@@ -1315,7 +1316,7 @@ m_type_get_klass (const MonoType *type)
 }
 
 static inline MonoGenericParam *
-m_type_get_generic_param (const MonoType *type)
+m_type_data_get_generic_param (const MonoType *type)
 {
 	if (G_LIKELY((type->type == MONO_TYPE_VAR) || (type->type == MONO_TYPE_MVAR)))
 		return type->data.generic_param;
@@ -1325,7 +1326,7 @@ m_type_get_generic_param (const MonoType *type)
 }
 
 static inline MonoArrayType *
-m_type_get_array (const MonoType *type)
+m_type_data_get_array (const MonoType *type)
 {
 	if (G_LIKELY(type->type == MONO_TYPE_ARRAY))
 		return type->data.array;
@@ -1335,7 +1336,7 @@ m_type_get_array (const MonoType *type)
 }
 
 static inline MonoType *
-m_type_get_type (const MonoType *type)
+m_type_data_get_type (const MonoType *type)
 {
 	if (G_LIKELY(type->type == MONO_TYPE_PTR))
 		return type->data.type;
@@ -1345,7 +1346,7 @@ m_type_get_type (const MonoType *type)
 }
 
 static inline MonoMethodSignature *
-m_type_get_method (const MonoType *type)
+m_type_data_get_method (const MonoType *type)
 {
 	if (G_LIKELY(type->type == MONO_TYPE_FNPTR))
 		return type->data.method;
@@ -1355,7 +1356,7 @@ m_type_get_method (const MonoType *type)
 }
 
 static inline MonoGenericClass *
-m_type_get_generic_class (const MonoType *type)
+m_type_data_get_generic_class (const MonoType *type)
 {
 	if (G_LIKELY(type->type == MONO_TYPE_GENERICINST))
 		return type->data.generic_class;
@@ -1376,7 +1377,7 @@ static inline MonoClass*
 mono_type_get_class_internal (MonoType *type)
 {
 	/* FIXME: review the runtime users before adding the assert here */
-	return m_type_get_klass(type);
+	return m_type_data_get_klass (type);
 }
 
 /**
@@ -1390,7 +1391,7 @@ mono_type_get_class_internal (MonoType *type)
 static inline MonoArrayType*
 mono_type_get_array_type_internal (MonoType *type)
 {
-	return m_type_get_array(type);
+	return m_type_data_get_array (type);
 }
 
 static inline int

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1327,7 +1327,7 @@ m_type_data_get_klass (const MonoType *type)
 		case MONO_TYPE_SZARRAY:
 			return type->data.klass;
 		default:
-			m_type_invalid_access ("m_type_get_klass", type->type);
+			m_type_invalid_access (__func__, type->type);
 			return NULL;
 	}
 }
@@ -1338,7 +1338,7 @@ m_type_data_get_generic_param (const MonoType *type)
 	if (G_LIKELY((type->type == MONO_TYPE_VAR) || (type->type == MONO_TYPE_MVAR)))
 		return type->data.generic_param;
 
-	m_type_invalid_access ("m_type_get_generic_param", type->type);
+	m_type_invalid_access (__func__, type->type);
 	return NULL;
 }
 
@@ -1348,7 +1348,7 @@ m_type_data_get_array (const MonoType *type)
 	if (G_LIKELY(type->type == MONO_TYPE_ARRAY))
 		return type->data.array;
 
-	m_type_invalid_access ("m_type_get_array", type->type);
+	m_type_invalid_access (__func__, type->type);
 	return NULL;
 }
 
@@ -1358,7 +1358,7 @@ m_type_data_get_type (const MonoType *type)
 	if (G_LIKELY(type->type == MONO_TYPE_PTR))
 		return type->data.type;
 
-	m_type_invalid_access ("m_type_get_type", type->type);
+	m_type_invalid_access (__func__, type->type);
 	return NULL;
 }
 
@@ -1368,7 +1368,7 @@ m_type_data_get_method (const MonoType *type)
 	if (G_LIKELY(type->type == MONO_TYPE_FNPTR))
 		return type->data.method;
 
-	m_type_invalid_access ("m_type_get_method", type->type);
+	m_type_invalid_access (__func__, type->type);
 	return NULL;
 }
 
@@ -1378,7 +1378,7 @@ m_type_data_get_generic_class (const MonoType *type)
 	if (G_LIKELY(type->type == MONO_TYPE_GENERICINST))
 		return type->data.generic_class;
 
-	m_type_invalid_access ("m_type_get_generic_class", type->type);
+	m_type_invalid_access (__func__, type->type);
 	return NULL;
 }
 

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -7030,7 +7030,7 @@ handle_enum:
 		if (mspec) {
 			switch (mspec->native) {
 			case MONO_NATIVE_BYVALARRAY:
-				if ((m_class_get_element_class (m_type_data_get_klass (type)) == mono_defaults.char_class) && !unicode)
+				if ((m_class_get_element_class (mono_class_from_mono_type_internal (type)) == mono_defaults.char_class) && !unicode)
 					*conv = MONO_MARSHAL_CONV_ARRAY_BYVALCHARARRAY;
 				else
 					*conv = MONO_MARSHAL_CONV_ARRAY_BYVALARRAY;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1854,7 +1854,7 @@ mono_type_hash (gconstpointer data)
 {
 	const MonoType *type = (const MonoType *) data;
 	if (type->type == MONO_TYPE_GENERICINST)
-		return mono_generic_class_hash (m_type_get_generic_class(type));
+		return mono_generic_class_hash (m_type_data_get_generic_class (type));
 	else
 		return type->type | ((m_type_is_byref (type) ? 1 : 0) << 8) | (type->attrs << 9);
 }
@@ -2091,7 +2091,7 @@ try_get_canonical_type (MonoType *type, MonoType **canonical_type)
 	 */
 	g_assert (!type->has_cmods);
 	if ((type->type == MONO_TYPE_CLASS || type->type == MONO_TYPE_VALUETYPE) && !type->pinned && !type->attrs) {
-		MonoType *ret = m_type_is_byref (type) ? m_class_get_this_arg (m_type_get_klass(type)) : m_class_get_byval_arg (m_type_get_klass(type));
+		MonoType *ret = m_type_is_byref (type) ? m_class_get_this_arg (m_type_data_get_klass (type)) : m_class_get_byval_arg (m_type_data_get_klass (type));
 
 		/* Consider the case:
 
@@ -2111,7 +2111,7 @@ try_get_canonical_type (MonoType *type, MonoType **canonical_type)
 		   LOCKING: even though we don't explicitly hold a lock, in the problematic case 'ret' is a field
 		   of a MonoClass which currently holds the loader lock.  'type' is local.
 		*/
-		if (m_type_get_klass(ret) == m_type_get_klass(type)) {
+		if (m_type_data_get_klass (ret) == m_type_data_get_klass (type)) {
 			*canonical_type = ret;
 			return TRUE;
 		}
@@ -2997,24 +2997,24 @@ retry:
 
 	switch (type->type) {
 	case MONO_TYPE_GENERICINST:
-		return gclass_in_image (m_type_get_generic_class(type), image);
+		return gclass_in_image (m_type_data_get_generic_class (type), image);
 	case MONO_TYPE_PTR:
-		type = m_type_get_type(type);
+		type = m_type_data_get_type (type);
 		goto retry;
 	case MONO_TYPE_SZARRAY:
-		type = m_class_get_byval_arg (m_type_get_klass(type));
+		type = m_class_get_byval_arg (m_type_data_get_klass (type));
 		goto retry;
 	case MONO_TYPE_ARRAY:
-		type = m_class_get_byval_arg (m_type_get_array(type)->eklass);
+		type = m_class_get_byval_arg (m_type_data_get_array (type)->eklass);
 		goto retry;
 	case MONO_TYPE_FNPTR:
-		return signature_in_image (m_type_get_method(type), image);
+		return signature_in_image (m_type_data_get_method (type), image);
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		if (image == mono_get_image_for_generic_param (m_type_get_generic_param(type)))
+		if (image == mono_get_image_for_generic_param (m_type_data_get_generic_param (type)))
 			return TRUE;
-		else if (m_type_get_generic_param(type)->gshared_constraint) {
-			type = m_type_get_generic_param(type)->gshared_constraint;
+		else if (m_type_data_get_generic_param (type)->gshared_constraint) {
+			type = m_type_data_get_generic_param (type)->gshared_constraint;
 			goto retry;
 		}
 		return FALSE;
@@ -3168,26 +3168,26 @@ retry:
 
 	switch (type->type) {
 	case MONO_TYPE_GENERICINST:
-		collect_gclass_images (m_type_get_generic_class(type), data);
+		collect_gclass_images (m_type_data_get_generic_class (type), data);
 		break;
 	case MONO_TYPE_PTR:
-		type = m_type_get_type(type);
+		type = m_type_data_get_type (type);
 		goto retry;
 	case MONO_TYPE_SZARRAY:
-		type = m_class_get_byval_arg (m_type_get_klass(type));
+		type = m_class_get_byval_arg (m_type_data_get_klass (type));
 		goto retry;
 	case MONO_TYPE_ARRAY:
-		type = m_class_get_byval_arg (m_type_get_array(type)->eklass);
+		type = m_class_get_byval_arg (m_type_data_get_array (type)->eklass);
 		goto retry;
 	case MONO_TYPE_FNPTR:
-		collect_signature_images (m_type_get_method(type), data);
+		collect_signature_images (m_type_data_get_method (type), data);
 		break;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
 	{
-		MonoImage *image = mono_get_image_for_generic_param (m_type_get_generic_param(type));
+		MonoImage *image = mono_get_image_for_generic_param (m_type_data_get_generic_param (type));
 		add_image (image, data);
-		type = m_type_get_generic_param(type)->gshared_constraint;
+		type = m_type_data_get_generic_param (type)->gshared_constraint;
 		if (type)
 			goto retry;
 		break;
@@ -3422,7 +3422,7 @@ type_is_gtd (MonoType *type)
 	switch (type->type) {
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		return mono_class_is_gtd (m_type_get_klass(type));
+		return mono_class_is_gtd (m_type_data_get_klass (type));
 	default:
 		return FALSE;
 	}
@@ -3458,7 +3458,7 @@ mono_metadata_get_generic_inst (int type_argc, MonoType **type_argv)
 	for (i = 0; i < type_argc; ++i) {
 		MonoType *t = ginst->type_argv [i];
 		if (type_is_gtd (t)) {
-			ginst->type_argv [i] = mono_class_gtd_get_canonical_inst (m_type_get_klass(t));
+			ginst->type_argv [i] = mono_class_gtd_get_canonical_inst (m_type_data_get_klass (t));
 		}
 	}
 
@@ -3959,12 +3959,12 @@ mono_metadata_get_shared_type (MonoType *type)
 	switch (type->type){
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_get_mem_manager (m_type_get_klass(type))->collectible)
+		if (m_class_get_mem_manager (m_type_data_get_klass (type))->collectible)
 			/* These can be unloaded, so references to them shouldn't be shared */
 			return NULL;
-		if (type == m_class_get_byval_arg (m_type_get_klass(type)))
+		if (type == m_class_get_byval_arg (m_type_data_get_klass (type)))
 			return type;
-		if (type == m_class_get_this_arg (m_type_get_klass(type)))
+		if (type == m_class_get_this_arg (m_type_data_get_klass (type)))
 			return type;
 		break;
 	default:
@@ -4181,22 +4181,22 @@ mono_metadata_free_type (MonoType *type)
 	switch (type->type){
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_STRING:
-		if (!m_type_get_klass(type))
+		if (!m_type_data_get_klass (type))
 			break;
 		/* fall through */
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_VALUETYPE:
-		if (type == m_class_get_byval_arg (m_type_get_klass(type)) || type == m_class_get_this_arg (m_type_get_klass(type)))
+		if (type == m_class_get_byval_arg (m_type_data_get_klass (type)) || type == m_class_get_this_arg (m_type_data_get_klass (type)))
 			return;
 		break;
 	case MONO_TYPE_PTR:
-		mono_metadata_free_type (m_type_get_type(type));
+		mono_metadata_free_type (m_type_data_get_type (type));
 		break;
 	case MONO_TYPE_FNPTR:
-		mono_metadata_free_method_signature (m_type_get_method(type));
+		mono_metadata_free_method_signature (m_type_data_get_method (type));
 		break;
 	case MONO_TYPE_ARRAY:
-		mono_metadata_free_array (m_type_get_array(type));
+		mono_metadata_free_array (m_type_data_get_array (type));
 		break;
 	default:
 		break;
@@ -5363,10 +5363,10 @@ mono_type_size (MonoType *t, int *align)
 		*align = MONO_ABI_ALIGNOF (gpointer);
 		return MONO_ABI_SIZEOF (gpointer);
 	case MONO_TYPE_VALUETYPE: {
-		if (m_class_is_enumtype (m_type_get_klass(t)))
-			return mono_type_size (mono_class_enum_basetype_internal (m_type_get_klass(t)), align);
+		if (m_class_is_enumtype (m_type_data_get_klass (t)))
+			return mono_type_size (mono_class_enum_basetype_internal (m_type_data_get_klass (t)), align);
 		else
-			return mono_class_value_size (m_type_get_klass(t), (guint32*)align);
+			return mono_class_value_size (m_type_data_get_klass (t), (guint32*)align);
 	}
 	case MONO_TYPE_STRING:
 	case MONO_TYPE_OBJECT:
@@ -5380,7 +5380,7 @@ mono_type_size (MonoType *t, int *align)
 	case MONO_TYPE_TYPEDBYREF:
 		return mono_class_value_size (mono_defaults.typed_reference_class, (guint32*)align);
 	case MONO_TYPE_GENERICINST: {
-		MonoGenericClass *gclass = m_type_get_generic_class(t);
+		MonoGenericClass *gclass = m_type_data_get_generic_class (t);
 		MonoClass *container_class = gclass->container_class;
 
 		// g_assert (!gclass->inst->is_open);
@@ -5397,12 +5397,12 @@ mono_type_size (MonoType *t, int *align)
 	}
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		if (!m_type_get_generic_param(t)->gshared_constraint || m_type_get_generic_param(t)->gshared_constraint->type == MONO_TYPE_VALUETYPE) {
+		if (!m_type_data_get_generic_param (t)->gshared_constraint || m_type_data_get_generic_param (t)->gshared_constraint->type == MONO_TYPE_VALUETYPE) {
 			*align = MONO_ABI_ALIGNOF (gpointer);
 			return MONO_ABI_SIZEOF (gpointer);
 		} else {
 			/* The gparam can only match types given by gshared_constraint */
-			return mono_type_size (m_type_get_generic_param(t)->gshared_constraint, align);
+			return mono_type_size (m_type_data_get_generic_param (t)->gshared_constraint, align);
 			goto again;
 		}
 	default:
@@ -5465,12 +5465,12 @@ mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open)
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
 		g_assert (allow_open);
-		if (!m_type_get_generic_param(t)->gshared_constraint || m_type_get_generic_param(t)->gshared_constraint->type == MONO_TYPE_VALUETYPE) {
+		if (!m_type_data_get_generic_param (t)->gshared_constraint || m_type_data_get_generic_param (t)->gshared_constraint->type == MONO_TYPE_VALUETYPE) {
 			*align = stack_slot_align;
 			return stack_slot_size;
 		} else {
 			/* The gparam can only match types given by gshared_constraint */
-			return mono_type_stack_size_internal (m_type_get_generic_param(t)->gshared_constraint, align, allow_open);
+			return mono_type_stack_size_internal (m_type_data_get_generic_param (t)->gshared_constraint, align, allow_open);
 		}
 	case MONO_TYPE_TYPEDBYREF:
 		*align = stack_slot_align;
@@ -5488,10 +5488,10 @@ mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open)
 	case MONO_TYPE_VALUETYPE: {
 		guint32 size;
 
-		if (m_class_is_enumtype (m_type_get_klass(t)))
-			return mono_type_stack_size_internal (mono_class_enum_basetype_internal (m_type_get_klass(t)), align, allow_open);
+		if (m_class_is_enumtype (m_type_data_get_klass (t)))
+			return mono_type_stack_size_internal (mono_class_enum_basetype_internal (m_type_data_get_klass (t)), align, allow_open);
 		else {
-			size = mono_class_value_size (m_type_get_klass(t), (guint32*)align);
+			size = mono_class_value_size (m_type_data_get_klass (t), (guint32*)align);
 
 			*align = *align + stack_slot_align - 1;
 			*align &= ~(stack_slot_align - 1);
@@ -5503,7 +5503,7 @@ mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open)
 		}
 	}
 	case MONO_TYPE_GENERICINST: {
-		MonoGenericClass *gclass = m_type_get_generic_class(t);
+		MonoGenericClass *gclass = m_type_data_get_generic_class (t);
 		MonoClass *container_class = gclass->container_class;
 
 		if (!allow_open)
@@ -5538,7 +5538,7 @@ gboolean
 mono_type_generic_inst_is_valuetype (MonoType *type)
 {
 	g_assert (type->type == MONO_TYPE_GENERICINST);
-	return m_class_is_valuetype (m_type_get_generic_class(type)->container_class);
+	return m_class_is_valuetype (m_type_data_get_generic_class (type)->container_class);
 }
 
 /**
@@ -5635,7 +5635,7 @@ mono_metadata_type_hash (MonoType *t1)
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_SZARRAY: {
-		MonoClass *klass = m_type_get_klass(t1);
+		MonoClass *klass = m_type_data_get_klass (t1);
 		/*
 		 * Dynamic classes must not be hashed on their type since it can change
 		 * during runtime. For example, if we hash a reference type that is
@@ -5649,14 +5649,14 @@ mono_metadata_type_hash (MonoType *t1)
 		return ((hash << 5) - hash) ^ m_class_get_name_hash (klass);
 	}
 	case MONO_TYPE_PTR:
-		return ((hash << 5) - hash) ^ mono_metadata_type_hash (m_type_get_type(t1));
+		return ((hash << 5) - hash) ^ mono_metadata_type_hash (m_type_data_get_type (t1));
 	case MONO_TYPE_ARRAY:
-		return ((hash << 5) - hash) ^ mono_metadata_type_hash (m_class_get_byval_arg (m_type_get_array(t1)->eklass));
+		return ((hash << 5) - hash) ^ mono_metadata_type_hash (m_class_get_byval_arg (m_type_data_get_array (t1)->eklass));
 	case MONO_TYPE_GENERICINST:
-		return ((hash << 5) - hash) ^ mono_generic_class_hash (m_type_get_generic_class(t1));
+		return ((hash << 5) - hash) ^ mono_generic_class_hash (m_type_data_get_generic_class (t1));
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		return ((hash << 5) - hash) ^ mono_metadata_generic_param_hash (m_type_get_generic_param(t1));
+		return ((hash << 5) - hash) ^ mono_metadata_generic_param_hash (m_type_data_get_generic_param (t1));
 	default:
 		return hash;
 	}
@@ -5734,22 +5734,22 @@ mono_metadata_class_equal (MonoClass *c1, MonoClass *c2, gboolean signature_only
 	MonoType *c2_type = m_class_get_byval_arg (c2);
 	if ((c1_type->type == MONO_TYPE_VAR) && (c2_type->type == MONO_TYPE_VAR))
 		return mono_metadata_generic_param_equal_internal (
-			m_type_get_generic_param(c1_type), m_type_get_generic_param(c2_type), signature_only);
+			m_type_data_get_generic_param (c1_type), m_type_data_get_generic_param (c2_type), signature_only);
 	if ((c1_type->type == MONO_TYPE_MVAR) && (c2_type->type == MONO_TYPE_MVAR))
 		return mono_metadata_generic_param_equal_internal (
-			m_type_get_generic_param(c1_type), m_type_get_generic_param(c2_type), signature_only);
+			m_type_data_get_generic_param (c1_type), m_type_data_get_generic_param (c2_type), signature_only);
 	if (signature_only &&
 	    (c1_type->type == MONO_TYPE_SZARRAY) && (c2_type->type == MONO_TYPE_SZARRAY))
-		return mono_metadata_class_equal (m_type_get_klass(c1_type), m_type_get_klass(c2_type), signature_only);
+		return mono_metadata_class_equal (m_type_data_get_klass (c1_type), m_type_data_get_klass (c2_type), signature_only);
 	if (signature_only &&
 	    (c1_type->type == MONO_TYPE_ARRAY) && (c2_type->type == MONO_TYPE_ARRAY))
 		return do_mono_metadata_type_equal (c1_type, c2_type, signature_only ? MONO_TYPE_EQ_FLAGS_SIG_ONLY : 0);
 	if (signature_only &&
 		(c1_type->type == MONO_TYPE_PTR) && (c2_type->type == MONO_TYPE_PTR))
-		return do_mono_metadata_type_equal (m_type_get_type(c1_type), m_type_get_type(c2_type), signature_only ? MONO_TYPE_EQ_FLAGS_SIG_ONLY : 0);
+		return do_mono_metadata_type_equal (m_type_data_get_type (c1_type), m_type_data_get_type (c2_type), signature_only ? MONO_TYPE_EQ_FLAGS_SIG_ONLY : 0);
 	if (signature_only &&
 		(c1_type->type == MONO_TYPE_FNPTR) && (c2_type->type == MONO_TYPE_FNPTR))
-		return mono_metadata_fnptr_equal (m_type_get_method(c1_type), m_type_get_method(c2_type), signature_only ? MONO_TYPE_EQ_FLAGS_SIG_ONLY : 0);
+		return mono_metadata_fnptr_equal (m_type_data_get_method (c1_type), m_type_data_get_method (c2_type), signature_only ? MONO_TYPE_EQ_FLAGS_SIG_ONLY : 0);
 	return FALSE;
 }
 
@@ -5891,31 +5891,31 @@ do_mono_metadata_type_equal (MonoType *t1, MonoType *t2, int equiv_flags)
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_SZARRAY:
-		result = mono_metadata_class_equal (m_type_get_klass(t1), m_type_get_klass(t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
+		result = mono_metadata_class_equal (m_type_data_get_klass (t1), m_type_data_get_klass (t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
 		break;
 	case MONO_TYPE_PTR:
-		result = do_mono_metadata_type_equal (m_type_get_type(t1), m_type_get_type(t2), equiv_flags);
+		result = do_mono_metadata_type_equal (m_type_data_get_type (t1), m_type_data_get_type (t2), equiv_flags);
 		break;
 	case MONO_TYPE_ARRAY:
-		if (m_type_get_array(t1)->rank != m_type_get_array(t2)->rank)
+		if (m_type_data_get_array (t1)->rank != m_type_data_get_array (t2)->rank)
 			result = FALSE;
 		else
-			result = mono_metadata_class_equal (m_type_get_array(t1)->eklass, m_type_get_array(t2)->eklass, (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
+			result = mono_metadata_class_equal (m_type_data_get_array (t1)->eklass, m_type_data_get_array (t2)->eklass, (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
 		break;
 	case MONO_TYPE_GENERICINST:
 		result = _mono_metadata_generic_class_equal (
-			m_type_get_generic_class(t1), m_type_get_generic_class(t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
+			m_type_data_get_generic_class (t1), m_type_data_get_generic_class (t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
 		break;
 	case MONO_TYPE_VAR:
 		result = mono_metadata_generic_param_equal_internal (
-			m_type_get_generic_param(t1), m_type_get_generic_param(t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
+			m_type_data_get_generic_param (t1), m_type_data_get_generic_param (t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
 		break;
 	case MONO_TYPE_MVAR:
 		result = mono_metadata_generic_param_equal_internal (
-			m_type_get_generic_param(t1), m_type_get_generic_param(t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
+			m_type_data_get_generic_param (t1), m_type_data_get_generic_param (t2), (equiv_flags & MONO_TYPE_EQ_FLAGS_SIG_ONLY) != 0);
 		break;
 	case MONO_TYPE_FNPTR:
-		result = mono_metadata_fnptr_equal (m_type_get_method(t1), m_type_get_method(t2), equiv_flags);
+		result = mono_metadata_fnptr_equal (m_type_data_get_method (t1), m_type_data_get_method (t2), equiv_flags);
 		break;
 	default:
 		g_error ("implement type compare for %0x!", t1->type);
@@ -7011,11 +7011,11 @@ handle_enum:
 		if (mspec && mspec->native == MONO_NATIVE_CUSTOM)
 			return MONO_NATIVE_CUSTOM;
 
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			t = mono_class_enum_basetype_internal (m_type_get_klass(type))->type;
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			t = mono_class_enum_basetype_internal (m_type_data_get_klass (type))->type;
 			goto handle_enum;
 		}
-		if (m_type_get_klass(type) == mono_class_try_get_handleref_class ()){
+		if (m_type_data_get_klass (type) == mono_class_try_get_handleref_class ()){
 			*conv = MONO_MARSHAL_CONV_HANDLEREF;
 			return MONO_NATIVE_INT;
 		}
@@ -7025,7 +7025,7 @@ handle_enum:
 		if (mspec) {
 			switch (mspec->native) {
 			case MONO_NATIVE_BYVALARRAY:
-				if ((m_class_get_element_class (m_type_get_klass(type)) == mono_defaults.char_class) && !unicode)
+				if ((m_class_get_element_class (m_type_data_get_klass (type)) == mono_defaults.char_class) && !unicode)
 					*conv = MONO_MARSHAL_CONV_ARRAY_BYVALCHARARRAY;
 				else
 					*conv = MONO_MARSHAL_CONV_ARRAY_BYVALARRAY;
@@ -7077,9 +7077,9 @@ handle_enum:
 				*conv = MONO_MARSHAL_CONV_OBJECT_IUNKNOWN;
 				return MONO_NATIVE_IUNKNOWN;
 			case MONO_NATIVE_FUNC:
-				if (t == MONO_TYPE_CLASS && (m_type_get_klass(type) == mono_defaults.multicastdelegate_class ||
-											 m_type_get_klass(type) == mono_defaults.delegate_class ||
-							     				m_class_get_parent (m_type_get_klass(type)) == mono_defaults.multicastdelegate_class)) {
+				if (t == MONO_TYPE_CLASS && (m_type_data_get_klass (type) == mono_defaults.multicastdelegate_class ||
+											 m_type_data_get_klass (type) == mono_defaults.delegate_class ||
+							     				m_class_get_parent (m_type_data_get_klass (type)) == mono_defaults.multicastdelegate_class)) {
 					*conv = MONO_MARSHAL_CONV_DEL_FTN;
 					return MONO_NATIVE_FUNC;
 				}
@@ -7088,14 +7088,14 @@ handle_enum:
 				g_error ("cant marshal object as native type %02x", mspec->native);
 			}
 		}
-		if (t == MONO_TYPE_CLASS && (m_type_get_klass(type) == mono_defaults.multicastdelegate_class ||
-					     m_type_get_klass(type) == mono_defaults.delegate_class ||
-					     m_class_get_parent (m_type_get_klass(type)) == mono_defaults.multicastdelegate_class)) {
+		if (t == MONO_TYPE_CLASS && (m_type_data_get_klass (type) == mono_defaults.multicastdelegate_class ||
+					     m_type_data_get_klass (type) == mono_defaults.delegate_class ||
+					     m_class_get_parent (m_type_data_get_klass (type)) == mono_defaults.multicastdelegate_class)) {
 			*conv = MONO_MARSHAL_CONV_DEL_FTN;
 			return MONO_NATIVE_FUNC;
 		}
-		if (mono_class_try_get_safehandle_class () && m_type_get_klass(type) != NULL &&
-			mono_class_is_subclass_of_internal (m_type_get_klass(type),  mono_class_try_get_safehandle_class (), FALSE)){
+		if (mono_class_try_get_safehandle_class () && m_type_data_get_klass (type) != NULL &&
+			mono_class_is_subclass_of_internal (m_type_data_get_klass (type),  mono_class_try_get_safehandle_class (), FALSE)){
 			*conv = MONO_MARSHAL_CONV_SAFEHANDLE;
 			return MONO_NATIVE_INT;
 		}
@@ -7104,7 +7104,7 @@ handle_enum:
 	}
 	case MONO_TYPE_FNPTR: return MONO_NATIVE_FUNC;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		t = type->type;
 		goto handle_enum;
 	case MONO_TYPE_TYPEDBYREF:
@@ -7619,7 +7619,7 @@ MonoType*
 mono_type_get_ptr_type (MonoType *type)
 {
 	g_assert (type->type == MONO_TYPE_PTR);
-	return m_type_get_type(type);
+	return m_type_data_get_type (type);
 }
 
 /**
@@ -7642,10 +7642,10 @@ mono_bool
 mono_type_is_struct (MonoType *type)
 {
 	return (!m_type_is_byref (type) && ((type->type == MONO_TYPE_VALUETYPE &&
-		!m_class_is_enumtype (m_type_get_klass(type))) || (type->type == MONO_TYPE_TYPEDBYREF) ||
+		!m_class_is_enumtype (m_type_data_get_klass (type))) || (type->type == MONO_TYPE_TYPEDBYREF) ||
 		((type->type == MONO_TYPE_GENERICINST) &&
-		mono_metadata_generic_class_is_valuetype (m_type_get_generic_class(type)) &&
-		!m_class_is_enumtype (m_type_get_generic_class(type)->container_class))));
+		mono_metadata_generic_class_is_valuetype (m_type_data_get_generic_class (type)) &&
+		!m_class_is_enumtype (m_type_data_get_generic_class (type)->container_class))));
 }
 
 /**
@@ -7691,7 +7691,7 @@ mono_type_is_reference (MonoType *type)
 		(type->type == MONO_TYPE_SZARRAY) || (type->type == MONO_TYPE_CLASS) ||
 		(type->type == MONO_TYPE_OBJECT) || (type->type == MONO_TYPE_ARRAY)) ||
 		((type->type == MONO_TYPE_GENERICINST) &&
-		!mono_metadata_generic_class_is_valuetype (m_type_get_generic_class(type)))));
+		!mono_metadata_generic_class_is_valuetype (m_type_data_get_generic_class (type)))));
 }
 
 mono_bool
@@ -8110,7 +8110,7 @@ dn_simdhash_assert_fail (const char *file, int line, const char *condition) {
 	mono_assertion_message (file, line, condition);
 }
 
-void
+MONO_NEVER_INLINE void
 m_type_invalid_access (const char * fn_name, MonoTypeEnum actual_type)
 {
 	g_error ("MonoType with type %d accessed by %s", actual_type, fn_name);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -7007,18 +7007,21 @@ handle_enum:
 		}
 	case MONO_TYPE_PTR: return MONO_NATIVE_UINT;
 	case MONO_TYPE_VALUETYPE: /*FIXME*/
+	{
 		if (mspec && mspec->native == MONO_NATIVE_CUSTOM)
 			return MONO_NATIVE_CUSTOM;
 
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			t = mono_class_enum_basetype_internal (m_type_data_get_klass (type))->type;
+		MonoClass *type_klass = m_type_data_get_klass (type);
+		if (m_class_is_enumtype (type_klass)) {
+			t = mono_class_enum_basetype_internal (type_klass)->type;
 			goto handle_enum;
 		}
-		if (m_type_data_get_klass (type) == mono_class_try_get_handleref_class ()){
+		if (type_klass == mono_class_try_get_handleref_class ()){
 			*conv = MONO_MARSHAL_CONV_HANDLEREF;
 			return MONO_NATIVE_INT;
 		}
 		return MONO_NATIVE_STRUCT;
+	}
 	case MONO_TYPE_SZARRAY:
 	case MONO_TYPE_ARRAY:
 		if (mspec) {
@@ -7076,13 +7079,16 @@ handle_enum:
 				*conv = MONO_MARSHAL_CONV_OBJECT_IUNKNOWN;
 				return MONO_NATIVE_IUNKNOWN;
 			case MONO_NATIVE_FUNC:
-				if (t == MONO_TYPE_CLASS && (m_type_data_get_klass (type) == mono_defaults.multicastdelegate_class ||
-											 m_type_data_get_klass (type) == mono_defaults.delegate_class ||
-							     				m_class_get_parent (m_type_data_get_klass (type)) == mono_defaults.multicastdelegate_class)) {
+			{
+				MonoClass *type_klass = m_type_data_get_klass (type);
+				if (t == MONO_TYPE_CLASS && (type_klass == mono_defaults.multicastdelegate_class ||
+								 type_klass == mono_defaults.delegate_class ||
+								m_class_get_parent (type_klass) == mono_defaults.multicastdelegate_class)) {
 					*conv = MONO_MARSHAL_CONV_DEL_FTN;
 					return MONO_NATIVE_FUNC;
 				}
 				/* Fall through */
+			}
 			default:
 				g_error ("cant marshal object as native type %02x", mspec->native);
 			}

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -8114,10 +8114,3 @@ void
 dn_simdhash_assert_fail (const char *file, int line, const char *condition) {
 	mono_assertion_message (file, line, condition);
 }
-
-MONO_NEVER_INLINE void
-m_type_invalid_access (const char * fn_name, MonoTypeEnum actual_type)
-{
-	g_error ("MonoType with type %d accessed by %s", actual_type, fn_name);
-	g_assert_not_reached ();
-}

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -2624,7 +2624,7 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	for (int i = 0; i < sig->param_count; i++) {
 		MonoType *t = sig->params [i];
-		if (t->type == MONO_TYPE_GENERICINST && t->data.generic_class->container_class == mono_defaults.generic_nullable_class) {
+		if (t->type == MONO_TYPE_GENERICINST && m_type_data_get_generic_class (t)->container_class == mono_defaults.generic_nullable_class) {
 			MonoClass *klass = mono_class_from_mono_type_internal (t);
 			MonoObject *boxed_vt = (MonoObject*)params [i];
 			gpointer nullable_vt = g_alloca (mono_class_value_size (klass, NULL));
@@ -2667,7 +2667,7 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 		// to return it as boxed vt or NULL
 		for (int i = 0; i < sig->param_count; i++) {
 			MonoType *t = sig->params [i];
-			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && t->data.generic_class->container_class == mono_defaults.generic_nullable_class) {
+			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && m_type_data_get_generic_class (t)->container_class == mono_defaults.generic_nullable_class) {
 				MonoClass *klass = mono_class_from_mono_type_internal (t);
 				gpointer nullable_vt = params_arg [i];
 				params [i] = mono_nullable_box (nullable_vt, klass, error);
@@ -2950,8 +2950,8 @@ handle_enum:
 	}
 	case MONO_TYPE_VALUETYPE:
 		/* note that 't' and 'type->type' can be different */
-		if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass)) {
-			t = mono_class_enum_basetype_internal (type->data.klass)->type;
+		if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (type))) {
+			t = mono_class_enum_basetype_internal (m_type_data_get_klass (type))->type;
 			goto handle_enum;
 		} else {
 			MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2963,7 +2963,7 @@ handle_enum:
 		}
 		return;
 	case MONO_TYPE_GENERICINST:
-		t = m_class_get_byval_arg (type->data.generic_class->container_class)->type;
+		t = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class)->type;
 		goto handle_enum;
 	default:
 		g_error ("got type %x", type->type);
@@ -4985,9 +4985,9 @@ again:
 			break;
 		case MONO_TYPE_GENERICINST:
 			if (m_type_is_byref (t))
-				t = m_class_get_this_arg (t->data.generic_class->container_class);
+				t = m_class_get_this_arg (m_type_data_get_generic_class (t)->container_class);
 			else
-				t = m_class_get_byval_arg (t->data.generic_class->container_class);
+				t = m_class_get_byval_arg (m_type_data_get_generic_class (t)->container_class);
 			goto again;
 		case MONO_TYPE_PTR: {
 			MonoObject *arg;
@@ -5106,7 +5106,7 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 		// to return it as boxed vt or NULL
 		for (int i = 0; i < param_count; i++) {
 			MonoType *t = sig->params [i];
-			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && t->data.generic_class->container_class == mono_defaults.generic_nullable_class) {
+			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && m_type_data_get_generic_class (t)->container_class == mono_defaults.generic_nullable_class) {
 				MonoClass *klass = mono_class_from_mono_type_internal (t);
 				MonoObject *boxed_vt = mono_nullable_box (pa [i], klass, error);
 				goto_if_nok (error, return_error);
@@ -5160,9 +5160,9 @@ again:
 			break;
 		case MONO_TYPE_GENERICINST:
 			if (m_type_is_byref (t))
-				t = m_class_get_this_arg (t->data.generic_class->container_class);
+				t = m_class_get_this_arg (m_type_data_get_generic_class (t)->container_class);
 			else
-				t = m_class_get_byval_arg (t->data.generic_class->container_class);
+				t = m_class_get_byval_arg (m_type_data_get_generic_class (t)->container_class);
 			goto again;
 		case MONO_TYPE_PTR:
 		case MONO_TYPE_FNPTR:

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -2624,7 +2624,7 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	for (int i = 0; i < sig->param_count; i++) {
 		MonoType *t = sig->params [i];
-		if (t->type == MONO_TYPE_GENERICINST && m_type_data_get_generic_class (t)->container_class == mono_defaults.generic_nullable_class) {
+		if (t->type == MONO_TYPE_GENERICINST && m_type_data_get_generic_class_unchecked (t)->container_class == mono_defaults.generic_nullable_class) {
 			MonoClass *klass = mono_class_from_mono_type_internal (t);
 			MonoObject *boxed_vt = (MonoObject*)params [i];
 			gpointer nullable_vt = g_alloca (mono_class_value_size (klass, NULL));
@@ -2667,7 +2667,7 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 		// to return it as boxed vt or NULL
 		for (int i = 0; i < sig->param_count; i++) {
 			MonoType *t = sig->params [i];
-			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && m_type_data_get_generic_class (t)->container_class == mono_defaults.generic_nullable_class) {
+			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && m_type_data_get_generic_class_unchecked (t)->container_class == mono_defaults.generic_nullable_class) {
 				MonoClass *klass = mono_class_from_mono_type_internal (t);
 				gpointer nullable_vt = params_arg [i];
 				params [i] = mono_nullable_box (nullable_vt, klass, error);
@@ -4985,9 +4985,9 @@ again:
 			break;
 		case MONO_TYPE_GENERICINST:
 			if (m_type_is_byref (t))
-				t = m_class_get_this_arg (m_type_data_get_generic_class (t)->container_class);
+				t = m_class_get_this_arg (m_type_data_get_generic_class_unchecked (t)->container_class);
 			else
-				t = m_class_get_byval_arg (m_type_data_get_generic_class (t)->container_class);
+				t = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (t)->container_class);
 			goto again;
 		case MONO_TYPE_PTR: {
 			MonoObject *arg;
@@ -5106,7 +5106,7 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 		// to return it as boxed vt or NULL
 		for (int i = 0; i < param_count; i++) {
 			MonoType *t = sig->params [i];
-			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && m_type_data_get_generic_class (t)->container_class == mono_defaults.generic_nullable_class) {
+			if (t->type == MONO_TYPE_GENERICINST && m_type_is_byref (t) && m_type_data_get_generic_class_unchecked (t)->container_class == mono_defaults.generic_nullable_class) {
 				MonoClass *klass = mono_class_from_mono_type_internal (t);
 				MonoObject *boxed_vt = mono_nullable_box (pa [i], klass, error);
 				goto_if_nok (error, return_error);
@@ -5160,9 +5160,9 @@ again:
 			break;
 		case MONO_TYPE_GENERICINST:
 			if (m_type_is_byref (t))
-				t = m_class_get_this_arg (m_type_data_get_generic_class (t)->container_class);
+				t = m_class_get_this_arg (m_type_data_get_generic_class_unchecked (t)->container_class);
 			else
-				t = m_class_get_byval_arg (m_type_data_get_generic_class (t)->container_class);
+				t = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (t)->container_class);
 			goto again;
 		case MONO_TYPE_PTR:
 		case MONO_TYPE_FNPTR:

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -392,7 +392,7 @@ mono_type_normalize (MonoType *type)
 	if (type->type != MONO_TYPE_GENERICINST)
 		return type;
 
-	gclass = m_type_data_get_generic_class (type);
+	gclass = m_type_data_get_generic_class_unchecked (type);
 	ginst = gclass->context.class_inst;
 	if (!ginst->is_open)
 		return type;
@@ -403,7 +403,7 @@ mono_type_normalize (MonoType *type)
 
 	for (guint i = 0; i < ginst->type_argc; ++i) {
 		MonoType *t = ginst->type_argv [i], *norm;
-		if (t->type != MONO_TYPE_VAR || m_type_data_get_generic_param (t)->num != i || m_type_data_get_generic_param (t)->owner != gcontainer)
+		if (t->type != MONO_TYPE_VAR || m_type_data_get_generic_param_unchecked (t)->num != i || m_type_data_get_generic_param_unchecked (t)->owner != gcontainer)
 			is_denorm_gtd = FALSE;
 		norm = mono_type_normalize (t);
 		argv [i] = norm;
@@ -570,7 +570,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 		goto leave;
 	}
 
-	if ((type->type == MONO_TYPE_GENERICINST) && m_type_data_get_generic_class (type)->is_dynamic && !m_class_was_typebuilder (m_type_data_get_generic_class (type)->container_class)) {
+	if ((type->type == MONO_TYPE_GENERICINST) && m_type_data_get_generic_class_unchecked (type)->is_dynamic && !m_class_was_typebuilder (m_type_data_get_generic_class_unchecked (type)->container_class)) {
 		/* This can happen if a TypeBuilder for a generic class K<T,U>
 		 * had reflection_create_generic_class) called on it, but not
 		 * ves_icall_TypeBuilder_create_runtime_class.  This can happen
@@ -1033,10 +1033,9 @@ add_parameter_object_to_array (MonoMethod *method, MonoObjectHandle member, int 
 		MonoType blob_type;
 
 		blob_type.type = (MonoTypeEnum)blob_type_enum;
-		m_type_data_set_klass_unchecked (&blob_type, NULL);
 		if (blob_type_enum == MONO_TYPE_CLASS)
 			m_type_data_set_klass_unchecked (&blob_type, mono_defaults.object_class);
-		else if ((sig_param->type == MONO_TYPE_VALUETYPE) && m_class_is_enumtype (m_type_data_get_klass (sig_param))) {
+		else if ((sig_param->type == MONO_TYPE_VALUETYPE) && m_class_is_enumtype (m_type_data_get_klass_unchecked (sig_param))) {
 			/* For enums, types [i] contains the base type */
 
 			blob_type.type = MONO_TYPE_VALUETYPE;

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1030,7 +1030,7 @@ add_parameter_object_to_array (MonoMethod *method, MonoObjectHandle member, int 
 			def_value = get_dbnull (dbnull, error);
 		goto_if_nok (error, leave);
 	} else {
-		MonoType blob_type;
+		MonoType blob_type = { 0 };
 
 		blob_type.type = (MonoTypeEnum)blob_type_enum;
 		if (blob_type_enum == MONO_TYPE_CLASS)
@@ -1041,9 +1041,6 @@ add_parameter_object_to_array (MonoMethod *method, MonoObjectHandle member, int 
 			blob_type.type = MONO_TYPE_VALUETYPE;
 			m_type_data_set_klass_unchecked (&blob_type, mono_class_from_mono_type_internal (sig_param));
 		} else {
-			// HACK: Necessary for the (incorrect?) mono_class_from_mono_type_internal call on &blob_type to not crash. -kg
-			// We previously had a set_klass_unchecked with NULL above but in debug/checked builds that will potentially fail.
-			blob_type.data__.klass = NULL;
 			// FIXME: Should this be called on sig_param, not &blob_type? The other similar if/elseif/else chain in the codebase doesn't match this.
 			// See icall.c mono_type_from_blob_type
 			m_type_data_set_klass (&blob_type, mono_class_from_mono_type_internal (&blob_type));

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -392,7 +392,7 @@ mono_type_normalize (MonoType *type)
 	if (type->type != MONO_TYPE_GENERICINST)
 		return type;
 
-	gclass = type->data.generic_class;
+	gclass = m_type_data_get_generic_class (type);
 	ginst = gclass->context.class_inst;
 	if (!ginst->is_open)
 		return type;
@@ -403,7 +403,7 @@ mono_type_normalize (MonoType *type)
 
 	for (guint i = 0; i < ginst->type_argc; ++i) {
 		MonoType *t = ginst->type_argv [i], *norm;
-		if (t->type != MONO_TYPE_VAR || t->data.generic_param->num != i || t->data.generic_param->owner != gcontainer)
+		if (t->type != MONO_TYPE_VAR || m_type_data_get_generic_param (t)->num != i || m_type_data_get_generic_param (t)->owner != gcontainer)
 			is_denorm_gtd = FALSE;
 		norm = mono_type_normalize (t);
 		argv [i] = norm;
@@ -570,7 +570,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 		goto leave;
 	}
 
-	if ((type->type == MONO_TYPE_GENERICINST) && type->data.generic_class->is_dynamic && !m_class_was_typebuilder (type->data.generic_class->container_class)) {
+	if ((type->type == MONO_TYPE_GENERICINST) && m_type_data_get_generic_class (type)->is_dynamic && !m_class_was_typebuilder (m_type_data_get_generic_class (type)->container_class)) {
 		/* This can happen if a TypeBuilder for a generic class K<T,U>
 		 * had reflection_create_generic_class) called on it, but not
 		 * ves_icall_TypeBuilder_create_runtime_class.  This can happen
@@ -1033,16 +1033,16 @@ add_parameter_object_to_array (MonoMethod *method, MonoObjectHandle member, int 
 		MonoType blob_type;
 
 		blob_type.type = (MonoTypeEnum)blob_type_enum;
-		blob_type.data.klass = NULL;
+		m_type_data_set_klass_unchecked (&blob_type, NULL);
 		if (blob_type_enum == MONO_TYPE_CLASS)
-			blob_type.data.klass = mono_defaults.object_class;
-		else if ((sig_param->type == MONO_TYPE_VALUETYPE) && m_class_is_enumtype (sig_param->data.klass)) {
+			m_type_data_set_klass_unchecked (&blob_type, mono_defaults.object_class);
+		else if ((sig_param->type == MONO_TYPE_VALUETYPE) && m_class_is_enumtype (m_type_data_get_klass (sig_param))) {
 			/* For enums, types [i] contains the base type */
 
 			blob_type.type = MONO_TYPE_VALUETYPE;
-			blob_type.data.klass = mono_class_from_mono_type_internal (sig_param);
+			m_type_data_set_klass_unchecked (&blob_type, mono_class_from_mono_type_internal (sig_param));
 		} else
-			blob_type.data.klass = mono_class_from_mono_type_internal (&blob_type);
+			m_type_data_set_klass (&blob_type, mono_class_from_mono_type_internal (&blob_type));
 
 		def_value = mono_get_object_from_blob (&blob_type, blob, MONO_HANDLE_NEW (MonoString, NULL), error);
 		goto_if_nok (error, leave);

--- a/src/mono/mono/metadata/sre-encode.c
+++ b/src/mono/mono/metadata/sre-encode.c
@@ -187,11 +187,11 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 		break;
 	case MONO_TYPE_PTR:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, m_type_data_get_type (type), buf);
+		encode_type (assembly, m_type_data_get_type_unchecked (type), buf);
 		break;
 	case MONO_TYPE_SZARRAY:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, m_class_get_byval_arg (m_type_data_get_klass (type)), buf);
+		encode_type (assembly, m_class_get_byval_arg (m_type_data_get_klass_unchecked (type)), buf);
 		break;
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS: {
@@ -216,13 +216,13 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 	}
 	case MONO_TYPE_ARRAY:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, m_class_get_byval_arg (m_type_data_get_array (type)->eklass), buf);
-		sigbuffer_add_value (buf, m_type_data_get_array (type)->rank);
+		encode_type (assembly, m_class_get_byval_arg (m_type_data_get_array_unchecked (type)->eklass), buf);
+		sigbuffer_add_value (buf, m_type_data_get_array_unchecked (type)->rank);
 		sigbuffer_add_value (buf, 0); /* FIXME: set to 0 for now */
 		sigbuffer_add_value (buf, 0);
 		break;
 	case MONO_TYPE_GENERICINST:
-		encode_generic_class (assembly, m_type_data_get_generic_class (type), buf);
+		encode_generic_class (assembly, m_type_data_get_generic_class_unchecked (type), buf);
 		break;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:

--- a/src/mono/mono/metadata/sre-encode.c
+++ b/src/mono/mono/metadata/sre-encode.c
@@ -187,11 +187,11 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 		break;
 	case MONO_TYPE_PTR:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, type->data.type, buf);
+		encode_type (assembly, m_type_data_get_type (type), buf);
 		break;
 	case MONO_TYPE_SZARRAY:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, m_class_get_byval_arg (type->data.klass), buf);
+		encode_type (assembly, m_class_get_byval_arg (m_type_data_get_klass (type)), buf);
 		break;
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS: {
@@ -216,13 +216,13 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 	}
 	case MONO_TYPE_ARRAY:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, m_class_get_byval_arg (type->data.array->eklass), buf);
-		sigbuffer_add_value (buf, type->data.array->rank);
+		encode_type (assembly, m_class_get_byval_arg (m_type_data_get_array (type)->eklass), buf);
+		sigbuffer_add_value (buf, m_type_data_get_array (type)->rank);
 		sigbuffer_add_value (buf, 0); /* FIXME: set to 0 for now */
 		sigbuffer_add_value (buf, 0);
 		break;
 	case MONO_TYPE_GENERICINST:
-		encode_generic_class (assembly, type->data.generic_class, buf);
+		encode_generic_class (assembly, m_type_data_get_generic_class (type), buf);
 		break;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -2039,11 +2039,11 @@ handle_enum:
 		p += 8;
 		break;
 	case MONO_TYPE_VALUETYPE:
-		if (m_type_get_klass(type)->enumtype) {
-			simple_type = mono_class_enum_basetype_internal (m_type_get_klass(type))->type;
+		if (m_type_data_get_klass (type)->enumtype) {
+			simple_type = mono_class_enum_basetype_internal (m_type_data_get_klass (type))->type;
 			goto handle_enum;
 		} else {
-			g_warning ("generic valuetype %s not handled in custom attr value decoding", m_type_get_klass(type)->name);
+			g_warning ("generic valuetype %s not handled in custom attr value decoding", m_type_data_get_klass (type)->name);
 		}
 		break;
 	case MONO_TYPE_STRING: {
@@ -2119,7 +2119,7 @@ MONO_RESTORE_WARNING
 		*p++ = (len >> 24) & 0xff;
 		*retp = p;
 		*retbuffer = buffer;
-		eclass = m_type_get_klass(type);
+		eclass = m_type_data_get_klass (type);
 		arg_eclass = mono_object_class (arg)->element_class;
 
 		if (!eclass) {
@@ -2229,7 +2229,7 @@ MONO_RESTORE_WARNING
 static void
 encode_field_or_prop_type (MonoType *type, char *p, char **retp)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && m_type_get_klass(type)->enumtype) {
+	if (type->type == MONO_TYPE_VALUETYPE && m_type_data_get_klass (type)->enumtype) {
 		char *str = type_get_qualified_name (type, NULL);
 		size_t slen = strlen (str);
 
@@ -2251,7 +2251,7 @@ encode_field_or_prop_type (MonoType *type, char *p, char **retp)
 		mono_metadata_encode_value (type->type, p, &p);
 		if (type->type == MONO_TYPE_SZARRAY)
 			/* See the examples in Partition VI, Annex B */
-			encode_field_or_prop_type (m_class_get_byval_arg (m_type_get_klass(type)), p, &p);
+			encode_field_or_prop_type (m_class_get_byval_arg (m_type_data_get_klass (type)), p, &p);
 	}
 
 	*retp = p;
@@ -2266,12 +2266,12 @@ encode_named_val (MonoReflectionAssembly *assembly, char *buffer, char *p, char 
 	error_init (error);
 
 	/* Preallocate a large enough buffer */
-	if (type->type == MONO_TYPE_VALUETYPE && m_type_get_klass(type)->enumtype) {
+	if (type->type == MONO_TYPE_VALUETYPE && m_type_data_get_klass (type)->enumtype) {
 		char *str = type_get_qualified_name (type, NULL);
 		len = strlen (str);
 		g_free (str);
-	} else if (type->type == MONO_TYPE_SZARRAY && m_type_get_klass(type)->enumtype) {
-		char *str = type_get_qualified_name (m_class_get_byval_arg (m_type_get_klass(type)), NULL);
+	} else if (type->type == MONO_TYPE_SZARRAY && m_type_data_get_klass (type)->enumtype) {
+		char *str = type_get_qualified_name (m_class_get_byval_arg (m_type_data_get_klass (type)), NULL);
 		len = strlen (str);
 		g_free (str);
 	} else {
@@ -2711,7 +2711,7 @@ reflection_init_generic_class (MonoReflectionTypeBuilderHandle ref_tb, MonoError
 		MONO_HANDLE_ARRAY_GETREF (ref_gparam, generic_params, i);
 		MonoType *param_type = mono_reflection_type_handle_mono_type (MONO_HANDLE_CAST (MonoReflectionType, ref_gparam), error);
 		goto_if_nok (error, leave);
-		MonoGenericParamFull *param = (MonoGenericParamFull *) m_type_get_generic_param(param_type);
+		MonoGenericParamFull *param = (MonoGenericParamFull *) m_type_data_get_generic_param (param_type);
 		generic_container->type_params [i] = *param;
 		/*Make sure we are a different type instance */
 		generic_container->type_params [i].owner = generic_container;
@@ -3001,7 +3001,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 				mono_array_get_internal (rmb->generic_params, MonoReflectionGenericParam*, i);
 			MonoType *gp_type = mono_reflection_type_get_handle ((MonoReflectionType*)gp, error);
 			mono_error_assert_ok (error);
-			MonoGenericParamFull *param = (MonoGenericParamFull *) m_type_get_generic_param(gp_type);
+			MonoGenericParamFull *param = (MonoGenericParamFull *) m_type_data_get_generic_param (gp_type);
 			container->type_params [i] = *param;
 			container->type_params [i].owner = container;
 
@@ -3019,7 +3019,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 		for (gint32 i = 0; i < m->signature->param_count; ++i) {
 			MonoType *t = m->signature->params [i];
 			if (t->type == MONO_TYPE_MVAR) {
-				MonoGenericParam *gparam =  m_type_get_generic_param(t);
+				MonoGenericParam *gparam =  m_type_data_get_generic_param (t);
 				if (gparam->num < count) {
 					m->signature->params [i] = mono_metadata_type_dup (image, m->signature->params [i]);
 					m->signature->params [i]->data.generic_param = mono_generic_container_get_param (container, gparam->num);
@@ -3722,7 +3722,7 @@ remove_instantiations_of_and_ensure_contents (gpointer key,
 	ERROR_DECL (lerror);
 	MonoError *error = already_failed ? lerror : data->error;
 
-	if ((type->type == MONO_TYPE_GENERICINST) && (m_type_get_generic_class(type)->container_class == klass)) {
+	if ((type->type == MONO_TYPE_GENERICINST) && (m_type_data_get_generic_class (type)->container_class == klass)) {
 		MonoClass *inst_klass = mono_class_from_mono_type_internal (type);
 		//Ensure it's safe to use it.
 		if (!fix_partial_generic_class (inst_klass, error)) {
@@ -4209,7 +4209,7 @@ mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **h
 		goto_if_nok (error, return_null);
 		MonoClass *klass;
 
-		klass = m_type_get_klass(type);
+		klass = m_type_data_get_klass (type);
 		if (klass->wastypebuilder) {
 			/* Already created */
 			result = klass;

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -2229,7 +2229,7 @@ MONO_RESTORE_WARNING
 static void
 encode_field_or_prop_type (MonoType *type, char *p, char **retp)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && m_type_data_get_klass (type)->enumtype) {
+	if (type->type == MONO_TYPE_VALUETYPE && m_type_data_get_klass_unchecked (type)->enumtype) {
 		char *str = type_get_qualified_name (type, NULL);
 		size_t slen = strlen (str);
 
@@ -2251,7 +2251,7 @@ encode_field_or_prop_type (MonoType *type, char *p, char **retp)
 		mono_metadata_encode_value (type->type, p, &p);
 		if (type->type == MONO_TYPE_SZARRAY)
 			/* See the examples in Partition VI, Annex B */
-			encode_field_or_prop_type (m_class_get_byval_arg (m_type_data_get_klass (type)), p, &p);
+			encode_field_or_prop_type (m_class_get_byval_arg (m_type_data_get_klass_unchecked (type)), p, &p);
 	}
 
 	*retp = p;
@@ -2266,12 +2266,12 @@ encode_named_val (MonoReflectionAssembly *assembly, char *buffer, char *p, char 
 	error_init (error);
 
 	/* Preallocate a large enough buffer */
-	if (type->type == MONO_TYPE_VALUETYPE && m_type_data_get_klass (type)->enumtype) {
+	if (type->type == MONO_TYPE_VALUETYPE && m_type_data_get_klass_unchecked (type)->enumtype) {
 		char *str = type_get_qualified_name (type, NULL);
 		len = strlen (str);
 		g_free (str);
-	} else if (type->type == MONO_TYPE_SZARRAY && m_type_data_get_klass (type)->enumtype) {
-		char *str = type_get_qualified_name (m_class_get_byval_arg (m_type_data_get_klass (type)), NULL);
+	} else if (type->type == MONO_TYPE_SZARRAY && m_type_data_get_klass_unchecked (type)->enumtype) {
+		char *str = type_get_qualified_name (m_class_get_byval_arg (m_type_data_get_klass_unchecked (type)), NULL);
 		len = strlen (str);
 		g_free (str);
 	} else {
@@ -3019,10 +3019,10 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 		for (gint32 i = 0; i < m->signature->param_count; ++i) {
 			MonoType *t = m->signature->params [i];
 			if (t->type == MONO_TYPE_MVAR) {
-				MonoGenericParam *gparam =  m_type_data_get_generic_param (t);
+				MonoGenericParam *gparam =  m_type_data_get_generic_param_unchecked (t);
 				if (gparam->num < count) {
 					m->signature->params [i] = mono_metadata_type_dup (image, m->signature->params [i]);
-					m_type_data_set_generic_param (m->signature->params [i], mono_generic_container_get_param (container, gparam->num));
+					m_type_data_set_generic_param_unchecked (m->signature->params [i], mono_generic_container_get_param (container, gparam->num));
 				}
 
 			}
@@ -3722,7 +3722,7 @@ remove_instantiations_of_and_ensure_contents (gpointer key,
 	ERROR_DECL (lerror);
 	MonoError *error = already_failed ? lerror : data->error;
 
-	if ((type->type == MONO_TYPE_GENERICINST) && (m_type_data_get_generic_class (type)->container_class == klass)) {
+	if ((type->type == MONO_TYPE_GENERICINST) && (m_type_data_get_generic_class_unchecked (type)->container_class == klass)) {
 		MonoClass *inst_klass = mono_class_from_mono_type_internal (type);
 		//Ensure it's safe to use it.
 		if (!fix_partial_generic_class (inst_klass, error)) {

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -2011,6 +2011,7 @@ encode_cattr_value (MonoAssembly *assembly, char *buffer, char *p, char **retbuf
 		argval = (const char*)mono_object_get_data (arg);
 	simple_type = type->type;
 handle_enum:
+	// Because simple_type != type->type after a goto targeting handle_enum, we have to use checked m_type_data accessors inside this switch
 	switch (simple_type) {
 	case MONO_TYPE_BOOLEAN:
 	case MONO_TYPE_U1:

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -2039,14 +2039,16 @@ handle_enum:
 		swap_with_size (p, argval, 8, 1);
 		p += 8;
 		break;
-	case MONO_TYPE_VALUETYPE:
-		if (m_type_data_get_klass (type)->enumtype) {
-			simple_type = mono_class_enum_basetype_internal (m_type_data_get_klass (type))->type;
+	case MONO_TYPE_VALUETYPE: {
+		MonoClass *klass_of_type = m_type_data_get_klass (type);
+		if (klass_of_type->enumtype) {
+			simple_type = mono_class_enum_basetype_internal (klass_of_type)->type;
 			goto handle_enum;
 		} else {
-			g_warning ("generic valuetype %s not handled in custom attr value decoding", m_type_data_get_klass (type)->name);
+			g_warning ("generic valuetype %s not handled in custom attr value decoding", klass_of_type->name);
 		}
 		break;
+	}
 	case MONO_TYPE_STRING: {
 		char *str;
 		size_t slen;

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -1714,11 +1714,11 @@ mono_reflection_type_handle_mono_type (MonoReflectionTypeHandle ref, MonoError *
 				result = mono_image_new0 (eclass->image, MonoType, 1);
 				if (rank == 0)  {
 					result->type = MONO_TYPE_SZARRAY;
-					result->data.klass = eclass;
+					m_type_data_set_klass_unchecked (result, eclass);
 				} else {
 					MonoArrayType *at = (MonoArrayType *)mono_image_alloc0 (eclass->image, sizeof (MonoArrayType));
 					result->type = MONO_TYPE_ARRAY;
-					result->data.array = at;
+					m_type_data_set_array_unchecked (result, at);
 					at->eklass = eclass;
 					at->rank = rank;
 				}
@@ -2727,7 +2727,7 @@ reflection_init_generic_class (MonoReflectionTypeBuilderHandle ref_tb, MonoError
 	MonoType *canonical_inst;
 	canonical_inst = &((MonoClassGtd*)klass)->canonical_inst;
 	canonical_inst->type = MONO_TYPE_GENERICINST;
-	canonical_inst->data.generic_class = mono_metadata_lookup_generic_class (klass, context->class_inst, FALSE);
+	m_type_data_set_generic_class_unchecked (canonical_inst, mono_metadata_lookup_generic_class (klass, context->class_inst, FALSE));
 
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (is_ok (error));
@@ -3005,7 +3005,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 			container->type_params [i] = *param;
 			container->type_params [i].owner = container;
 
-			gp->type.type->data.generic_param = (MonoGenericParam*)&container->type_params [i];
+			m_type_data_set_generic_param (gp->type.type, (MonoGenericParam*)&container->type_params [i]);
 
 			MonoClass *gklass = mono_class_from_mono_type_internal (gp_type);
 			gklass->wastypebuilder = TRUE;
@@ -3022,7 +3022,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 				MonoGenericParam *gparam =  m_type_data_get_generic_param (t);
 				if (gparam->num < count) {
 					m->signature->params [i] = mono_metadata_type_dup (image, m->signature->params [i]);
-					m->signature->params [i]->data.generic_param = mono_generic_container_get_param (container, gparam->num);
+					m_type_data_set_generic_param (m->signature->params [i], mono_generic_container_get_param (container, gparam->num));
 				}
 
 			}

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3485,7 +3485,7 @@ encode_klass_ref_inner (MonoAotCompile *acfg, MonoClass *klass, guint8 *buf, gui
 		}
 	} else if ((m_class_get_byval_arg (klass)->type == MONO_TYPE_VAR) || (m_class_get_byval_arg (klass)->type == MONO_TYPE_MVAR)) {
 		MonoGenericContainer *container = mono_type_get_generic_param_owner (m_class_get_byval_arg (klass));
-		MonoGenericParam *par = m_class_get_byval_arg (klass)->data.generic_param;
+		MonoGenericParam *par = m_type_data_get_generic_param (m_class_get_byval_arg (klass));
 
 		encode_value (MONO_AOT_TYPEREF_VAR, p, &p);
 
@@ -3726,24 +3726,24 @@ encode_type (MonoAotCompile *acfg, MonoType *t, guint8 *buf, guint8 **endbuf)
 		encode_klass_ref (acfg, mono_class_from_mono_type_internal (t), p, &p);
 		break;
 	case MONO_TYPE_SZARRAY:
-		encode_klass_ref (acfg, t->data.klass, p, &p);
+		encode_klass_ref (acfg, m_type_data_get_klass (t), p, &p);
 		break;
 	case MONO_TYPE_PTR:
-		encode_type (acfg, t->data.type, p, &p);
+		encode_type (acfg, m_type_data_get_type (t), p, &p);
 		break;
 	case MONO_TYPE_FNPTR:
-		encode_signature (acfg, t->data.method, p, &p);
+		encode_signature (acfg, m_type_data_get_method (t), p, &p);
 		break;
 	case MONO_TYPE_GENERICINST: {
-		MonoClass *gclass = t->data.generic_class->container_class;
-		MonoGenericInst *inst = t->data.generic_class->context.class_inst;
+		MonoClass *gclass = m_type_data_get_generic_class (t)->container_class;
+		MonoGenericInst *inst = m_type_data_get_generic_class (t)->context.class_inst;
 
 		encode_klass_ref (acfg, gclass, p, &p);
 		encode_ginst (acfg, inst, p, &p);
 		break;
 	}
 	case MONO_TYPE_ARRAY: {
-		MonoArrayType *array = t->data.array;
+		MonoArrayType *array = m_type_data_get_array (t);
 		int i;
 
 		encode_klass_ref (acfg, array->eklass, p, &p);
@@ -5666,7 +5666,7 @@ check_type_depth (MonoType *t, int depth)
 
 	switch (t->type) {
 	case MONO_TYPE_GENERICINST: {
-		MonoGenericClass *gklass = t->data.generic_class;
+		MonoGenericClass *gklass = m_type_data_get_generic_class (t);
 		MonoGenericInst *ginst = gklass->context.class_inst;
 
 		if (ginst) {
@@ -9390,7 +9390,7 @@ add_referenced_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, int depth)
 							m = gen;
 						}
 					}
-					
+
 					add_extra_method_with_depth (acfg, m, depth + 1);
 					add_types_from_method_header (acfg, m);
 				}
@@ -10486,8 +10486,8 @@ append_mangled_ginst (GString *str, MonoGenericInst *ginst)
 		case MONO_TYPE_VAR:
 		case MONO_TYPE_MVAR: {
 			MonoType *constraint = NULL;
-			if (type->data.generic_param)
-				constraint = type->data.generic_param->gshared_constraint;
+			if (m_type_data_get_generic_param (type))
+				constraint = m_type_data_get_generic_param (type)->gshared_constraint;
 			if (constraint) {
 				g_assert (constraint->type != MONO_TYPE_VAR && constraint->type != MONO_TYPE_MVAR);
 				g_string_append (str, "gshared:");
@@ -11218,11 +11218,11 @@ mono_aot_type_hash (MonoType *t1)
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_SZARRAY:
 		/* check if the distribution is good enough */
-		return ((hash << 5) - hash) ^ m_class_get_name_hash (t1->data.klass);
+		return ((hash << 5) - hash) ^ m_class_get_name_hash (m_type_data_get_klass (t1));
 	case MONO_TYPE_PTR:
-		return ((hash << 5) - hash) ^ mono_metadata_type_hash (t1->data.type);
+		return ((hash << 5) - hash) ^ mono_metadata_type_hash (m_type_data_get_type (t1));
 	case MONO_TYPE_ARRAY:
-		return ((hash << 5) - hash) ^ mono_metadata_type_hash (m_class_get_byval_arg (t1->data.array->eklass));
+		return ((hash << 5) - hash) ^ mono_metadata_type_hash (m_class_get_byval_arg (m_type_data_get_array (t1)->eklass));
 	case MONO_TYPE_GENERICINST:
 		return ((hash << 5) - hash) ^ 0;
 	default:

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -53,8 +53,8 @@ handle_enum:
 	case MONO_TYPE_VOID:
 		return 'V';
 	case MONO_TYPE_VALUETYPE: {
-		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
-			t = mono_class_enum_basetype_internal (m_type_data_get_klass (t));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (t))) {
+			t = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (t));
 			goto handle_enum;
 		}
 
@@ -72,7 +72,8 @@ handle_enum:
 		return 'I';
 	}
 	case MONO_TYPE_GENERICINST: {
-		if (m_class_is_valuetype (m_type_data_get_klass (t))) {
+		// This previously erroneously used m_type_data_get_klass which isn't legal for genericinst, we have to use class_from_mono_type_internal
+		if (m_class_is_valuetype (mono_class_from_mono_type_internal (t))) {
 			MonoType *scalar_vtype;
 			if (mini_wasm_is_scalar_vtype (t, &scalar_vtype))
 				return type_to_c (scalar_vtype, NULL);

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -53,8 +53,8 @@ handle_enum:
 	case MONO_TYPE_VOID:
 		return 'V';
 	case MONO_TYPE_VALUETYPE: {
-		if (m_class_is_enumtype (t->data.klass)) {
-			t = mono_class_enum_basetype_internal (t->data.klass);
+		if (m_class_is_enumtype (m_type_data_get_klass (t))) {
+			t = mono_class_enum_basetype_internal (m_type_data_get_klass (t));
 			goto handle_enum;
 		}
 
@@ -72,7 +72,7 @@ handle_enum:
 		return 'I';
 	}
 	case MONO_TYPE_GENERICINST: {
-		if (m_class_is_valuetype (t->data.klass)) {
+		if (m_class_is_valuetype (m_type_data_get_klass (t))) {
 			MonoType *scalar_vtype;
 			if (mini_wasm_is_scalar_vtype (t, &scalar_vtype))
 				return type_to_c (scalar_vtype, NULL);

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -760,23 +760,23 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:
 		m_type_data_set_klass_unchecked (t, decode_klass_ref (module, p, &p, error));
-		if (!m_type_data_get_klass (t))
+		if (!m_type_data_get_klass_unchecked (t))
 			goto fail;
 		break;
 	case MONO_TYPE_SZARRAY:
 		m_type_data_set_klass_unchecked (t, decode_klass_ref (module, p, &p, error));
 
-		if (!m_type_data_get_klass (t))
+		if (!m_type_data_get_klass_unchecked (t))
 			goto fail;
 		break;
 	case MONO_TYPE_PTR:
 		m_type_data_set_type_unchecked (t, decode_type (module, p, &p, error));
-		if (!m_type_data_get_type (t))
+		if (!m_type_data_get_type_unchecked (t))
 			goto fail;
 		break;
 	case MONO_TYPE_FNPTR:
 		m_type_data_set_method_unchecked (t, decode_signature (module, p, &p));
-		if (!m_type_data_get_method (t))
+		if (!m_type_data_get_method_unchecked (t))
 			goto fail;
 		break;
 	case MONO_TYPE_GENERICINST: {
@@ -4598,7 +4598,7 @@ inst_is_private (MonoGenericInst *inst)
 	for (guint i = 0; i < inst->type_argc; ++i) {
 		MonoType *t = inst->type_argv [i];
 		if ((t->type == MONO_TYPE_CLASS || t->type == MONO_TYPE_VALUETYPE)) {
-			int access_level = mono_class_get_flags (m_type_data_get_klass (t)) & TYPE_ATTRIBUTE_VISIBILITY_MASK;
+			int access_level = mono_class_get_flags (m_type_data_get_klass_unchecked (t)) & TYPE_ATTRIBUTE_VISIBILITY_MASK;
 			if (access_level == TYPE_ATTRIBUTE_NESTED_PRIVATE || access_level == TYPE_ATTRIBUTE_NOT_PUBLIC)
 				return TRUE;
 		}

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -614,11 +614,11 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError
 			t = g_new0 (MonoType, 1);
 			t->type = (MonoTypeEnum)type;
 			if (is_not_anonymous) {
-				t->data.generic_param = mono_generic_container_get_param (container, num);
+				m_type_data_set_generic_param (t, mono_generic_container_get_param (container, num));
 			} else {
 				/* Anonymous */
 				MonoGenericParam *par = mono_metadata_create_anon_gparam (module->assembly->image, num, type == MONO_TYPE_MVAR);
-				t->data.generic_param = par;
+				m_type_data_set_generic_param (t, par);
 				// FIXME: maybe do this for all anon gparams?
 				((MonoGenericParamFull*)par)->info.name = mono_make_generic_name_string (module->assembly->image, num);
 			}
@@ -759,24 +759,24 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 		break;
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:
-		t->data.klass = decode_klass_ref (module, p, &p, error);
-		if (!t->data.klass)
+		m_type_data_set_klass_unchecked (t, decode_klass_ref (module, p, &p, error));
+		if (!m_type_data_get_klass (t))
 			goto fail;
 		break;
 	case MONO_TYPE_SZARRAY:
-		t->data.klass = decode_klass_ref (module, p, &p, error);
+		m_type_data_set_klass_unchecked (t, decode_klass_ref (module, p, &p, error));
 
-		if (!t->data.klass)
+		if (!m_type_data_get_klass (t))
 			goto fail;
 		break;
 	case MONO_TYPE_PTR:
-		t->data.type = decode_type (module, p, &p, error);
-		if (!t->data.type)
+		m_type_data_set_type_unchecked (t, decode_type (module, p, &p, error));
+		if (!m_type_data_get_type (t))
 			goto fail;
 		break;
 	case MONO_TYPE_FNPTR:
-		t->data.method = decode_signature (module, p, &p);
-		if (!t->data.method)
+		m_type_data_set_method_unchecked (t, decode_signature (module, p, &p));
+		if (!m_type_data_get_method (t))
 			goto fail;
 		break;
 	case MONO_TYPE_GENERICINST: {
@@ -798,7 +798,7 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 		if (!type)
 			goto fail;
 		klass = mono_class_from_mono_type_internal (type);
-		t->data.generic_class = mono_class_get_generic_class (klass);
+		m_type_data_set_generic_class_unchecked (t, mono_class_get_generic_class (klass));
 		break;
 	}
 	case MONO_TYPE_ARRAY: {
@@ -823,7 +823,7 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 			array->lobounds = (int *)g_malloc0 (sizeof (int) * array->numlobounds);
 		for (i = 0; i < array->numlobounds; ++i)
 			array->lobounds [i] = decode_value (p, &p);
-		t->data.array = array;
+		m_type_data_set_array_unchecked (t, array);
 		break;
 	}
 	case MONO_TYPE_VAR:
@@ -831,7 +831,7 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 		MonoClass *klass = decode_klass_ref (module, p, &p, error);
 		if (!klass)
 			goto fail;
-		t->data.generic_param = m_class_get_byval_arg (klass)->data.generic_param;
+		m_type_data_set_generic_param_unchecked (t, m_type_data_get_generic_param (m_class_get_byval_arg (klass)));
 		break;
 	}
 	default:
@@ -2119,10 +2119,10 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 		void *handle;
 
 		g_assert (info);
-		
+
 		// Copy aotid to MonoImage
 		memcpy(&assembly->image->aotid, info->aotid, 16);
-		
+
 		if (info->flags & MONO_AOT_FILE_FLAG_SEPARATE_DATA) {
 			aot_data = open_aot_data (assembly, info, &handle);
 
@@ -4598,7 +4598,7 @@ inst_is_private (MonoGenericInst *inst)
 	for (guint i = 0; i < inst->type_argc; ++i) {
 		MonoType *t = inst->type_argv [i];
 		if ((t->type == MONO_TYPE_CLASS || t->type == MONO_TYPE_VALUETYPE)) {
-			int access_level = mono_class_get_flags (t->data.klass) & TYPE_ATTRIBUTE_VISIBILITY_MASK;
+			int access_level = mono_class_get_flags (m_type_data_get_klass (t)) & TYPE_ATTRIBUTE_VISIBILITY_MASK;
 			if (access_level == TYPE_ATTRIBUTE_NESTED_PRIVATE || access_level == TYPE_ATTRIBUTE_NOT_PUBLIC)
 				return TRUE;
 		}

--- a/src/mono/mono/mini/calls.c
+++ b/src/mono/mono/mini/calls.c
@@ -118,8 +118,8 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return calli? OP_FCALL_REG: virt? OP_FCALL_MEMBASE: OP_FCALL;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto handle_enum;
 		} else {
 			if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
@@ -132,7 +132,7 @@ handle_enum:
 	case MONO_TYPE_GENERICINST: {
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return calli? OP_XCALL_REG: virt? OP_XCALL_MEMBASE: OP_XCALL;
-		type = m_class_get_byval_arg (type->data.generic_class->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto handle_enum;
 	}
 	case MONO_TYPE_VAR:

--- a/src/mono/mono/mini/calls.c
+++ b/src/mono/mono/mini/calls.c
@@ -118,8 +118,8 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return calli? OP_FCALL_REG: virt? OP_FCALL_MEMBASE: OP_FCALL;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto handle_enum;
 		} else {
 			if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
@@ -132,7 +132,7 @@ handle_enum:
 	case MONO_TYPE_GENERICINST: {
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return calli? OP_XCALL_REG: virt? OP_XCALL_MEMBASE: OP_XCALL;
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto handle_enum;
 	}
 	case MONO_TYPE_VAR:

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -843,15 +843,15 @@ stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean
 		result->data.p = *(gpointer*)data;
 		break;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			stackval_from_data (mono_class_enum_basetype_internal (type->data.klass), result, data, pinvoke);
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			stackval_from_data (mono_class_enum_basetype_internal (m_type_data_get_klass (type)), result, data, pinvoke);
 			break;
 		} else {
 			int size;
 			if (pinvoke)
-				size = mono_class_native_size (type->data.klass, NULL);
+				size = mono_class_native_size (m_type_data_get_klass (type), NULL);
 			else
-				size = mono_class_value_size (type->data.klass, NULL);
+				size = mono_class_value_size (m_type_data_get_klass (type), NULL);
 			memcpy (result, data, size);
 			break;
 		}
@@ -866,7 +866,7 @@ stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean
 			memcpy (result, data, size);
 			break;
 		}
-		stackval_from_data (m_class_get_byval_arg (type->data.generic_class->container_class), result, data, pinvoke);
+		stackval_from_data (m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class), result, data, pinvoke);
 		break;
 	}
 	default:
@@ -949,21 +949,21 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 		return MINT_STACK_SLOT_SIZE;
 	}
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			return stackval_to_data (mono_class_enum_basetype_internal (type->data.klass), val, data, pinvoke);
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			return stackval_to_data (mono_class_enum_basetype_internal (m_type_data_get_klass (type)), val, data, pinvoke);
 		} else {
 			int size;
 			if (pinvoke) {
-				size = mono_class_native_size (type->data.klass, NULL);
+				size = mono_class_native_size (m_type_data_get_klass (type), NULL);
 				memcpy (data, val, size);
 			} else {
-				size = mono_class_value_size (type->data.klass, NULL);
-				mono_value_copy_internal (data, val, type->data.klass);
+				size = mono_class_value_size (m_type_data_get_klass (type), NULL);
+				mono_value_copy_internal (data, val, m_type_data_get_klass (type));
 			}
 			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 	case MONO_TYPE_GENERICINST: {
-		MonoClass *container_class = type->data.generic_class->container_class;
+		MonoClass *container_class = m_type_data_get_generic_class (type)->container_class;
 
 		if (m_class_is_valuetype (container_class) && !m_class_is_enumtype (container_class)) {
 			MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -977,7 +977,7 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 			}
 			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
-		return stackval_to_data (m_class_get_byval_arg (type->data.generic_class->container_class), val, data, pinvoke);
+		return stackval_to_data (m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class), val, data, pinvoke);
 	}
 	default:
 		g_error ("got type %x", type->type);
@@ -1426,8 +1426,8 @@ retry:
 			flen++;
 			break;
 		case MONO_TYPE_VALUETYPE:
-			if (m_class_is_enumtype (type->data.klass)) {
-				type = mono_class_enum_basetype_internal (type->data.klass);
+			if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+				type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 				goto retry;
 			}
 			info->arg_types [i] = PINVOKE_ARG_VTYPE;
@@ -1446,7 +1446,7 @@ retry:
 			break;
 		case MONO_TYPE_GENERICINST: {
 			// FIXME: Should mini_wasm_is_scalar_vtype stuff go in here?
-			MonoClass *container_class = type->data.generic_class->container_class;
+			MonoClass *container_class = m_type_data_get_generic_class (type)->container_class;
 			type = m_class_get_byval_arg (container_class);
 			goto retry;
 		}
@@ -2046,7 +2046,7 @@ dump_stackval (GString *str, stackval *s, MonoType *type)
 		g_string_append_printf (str, "[%p] ", s->data.p);
 		break;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass))
+		if (m_class_is_enumtype (m_type_data_get_klass (type)))
 			g_string_append_printf (str, "[%d] ", s->data.i);
 		else
 			g_string_append_printf (str, "[vt:%p] ", s->data.p);
@@ -3209,9 +3209,9 @@ interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untype
 			size = mono_class_value_size (mono_class_from_mono_type_internal (type), NULL);
 		} else if (type->type == MONO_TYPE_VALUETYPE) {
 			if (sig->pinvoke && !sig->marshalling_disabled)
-				size = mono_class_native_size (type->data.klass, NULL);
+				size = mono_class_native_size (m_type_data_get_klass (type), NULL);
 			else
-				size = mono_class_value_size (type->data.klass, NULL);
+				size = mono_class_value_size (m_type_data_get_klass (type), NULL);
 		} else {
 			size = MINT_STACK_SLOT_SIZE;
 		}

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -843,15 +843,15 @@ stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean
 		result->data.p = *(gpointer*)data;
 		break;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			stackval_from_data (mono_class_enum_basetype_internal (m_type_data_get_klass (type)), result, data, pinvoke);
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			stackval_from_data (mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type)), result, data, pinvoke);
 			break;
 		} else {
 			int size;
 			if (pinvoke)
-				size = mono_class_native_size (m_type_data_get_klass (type), NULL);
+				size = mono_class_native_size (m_type_data_get_klass_unchecked (type), NULL);
 			else
-				size = mono_class_value_size (m_type_data_get_klass (type), NULL);
+				size = mono_class_value_size (m_type_data_get_klass_unchecked (type), NULL);
 			memcpy (result, data, size);
 			break;
 		}
@@ -866,7 +866,7 @@ stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean
 			memcpy (result, data, size);
 			break;
 		}
-		stackval_from_data (m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class), result, data, pinvoke);
+		stackval_from_data (m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class), result, data, pinvoke);
 		break;
 	}
 	default:
@@ -949,21 +949,21 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 		return MINT_STACK_SLOT_SIZE;
 	}
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			return stackval_to_data (mono_class_enum_basetype_internal (m_type_data_get_klass (type)), val, data, pinvoke);
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			return stackval_to_data (mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type)), val, data, pinvoke);
 		} else {
 			int size;
 			if (pinvoke) {
-				size = mono_class_native_size (m_type_data_get_klass (type), NULL);
+				size = mono_class_native_size (m_type_data_get_klass_unchecked (type), NULL);
 				memcpy (data, val, size);
 			} else {
-				size = mono_class_value_size (m_type_data_get_klass (type), NULL);
-				mono_value_copy_internal (data, val, m_type_data_get_klass (type));
+				size = mono_class_value_size (m_type_data_get_klass_unchecked (type), NULL);
+				mono_value_copy_internal (data, val, m_type_data_get_klass_unchecked (type));
 			}
 			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 	case MONO_TYPE_GENERICINST: {
-		MonoClass *container_class = m_type_data_get_generic_class (type)->container_class;
+		MonoClass *container_class = m_type_data_get_generic_class_unchecked (type)->container_class;
 
 		if (m_class_is_valuetype (container_class) && !m_class_is_enumtype (container_class)) {
 			MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -977,7 +977,7 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 			}
 			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
-		return stackval_to_data (m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class), val, data, pinvoke);
+		return stackval_to_data (m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class), val, data, pinvoke);
 	}
 	default:
 		g_error ("got type %x", type->type);
@@ -1426,8 +1426,8 @@ retry:
 			flen++;
 			break;
 		case MONO_TYPE_VALUETYPE:
-			if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-				type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+			if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+				type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 				goto retry;
 			}
 			info->arg_types [i] = PINVOKE_ARG_VTYPE;
@@ -1446,7 +1446,7 @@ retry:
 			break;
 		case MONO_TYPE_GENERICINST: {
 			// FIXME: Should mini_wasm_is_scalar_vtype stuff go in here?
-			MonoClass *container_class = m_type_data_get_generic_class (type)->container_class;
+			MonoClass *container_class = m_type_data_get_generic_class_unchecked (type)->container_class;
 			type = m_class_get_byval_arg (container_class);
 			goto retry;
 		}
@@ -2046,7 +2046,7 @@ dump_stackval (GString *str, stackval *s, MonoType *type)
 		g_string_append_printf (str, "[%p] ", s->data.p);
 		break;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type)))
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type)))
 			g_string_append_printf (str, "[%d] ", s->data.i);
 		else
 			g_string_append_printf (str, "[vt:%p] ", s->data.p);
@@ -3209,9 +3209,9 @@ interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untype
 			size = mono_class_value_size (mono_class_from_mono_type_internal (type), NULL);
 		} else if (type->type == MONO_TYPE_VALUETYPE) {
 			if (sig->pinvoke && !sig->marshalling_disabled)
-				size = mono_class_native_size (m_type_data_get_klass (type), NULL);
+				size = mono_class_native_size (m_type_data_get_klass_unchecked (type), NULL);
 			else
-				size = mono_class_value_size (m_type_data_get_klass (type), NULL);
+				size = mono_class_value_size (m_type_data_get_klass_unchecked (type), NULL);
 		} else {
 			size = MINT_STACK_SLOT_SIZE;
 		}

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -906,7 +906,7 @@ lookup_packedsimd_intrinsic (const char *name, MonoType *arg1)
 	if (m_class_is_simd_type (vector_klass)) {
 		arg_type = mono_class_get_context (vector_klass)->class_inst->type_argv [0];
 	} else if (arg1->type == MONO_TYPE_PTR) {
-		arg_type = m_type_data_get_type (arg1);
+		arg_type = m_type_data_get_type_unchecked (arg1);
 	} else {
 		// g_printf ("%s arg1 type was not pointer or simd type: %s\n", name, m_class_get_name (vector_klass));
 		return FALSE;

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -640,7 +640,7 @@ emit_sri_vector128_t (TransformData *td, MonoMethod *cmethod, MonoMethodSignatur
 			explicitly_implemented = true;
 		}
 	}
-	
+
 	int id = lookup_intrins (sri_vector128_t_methods, sizeof (sri_vector128_t_methods), cmethod->name);
 	if (id == -1) {
 		if (explicitly_implemented) {
@@ -689,7 +689,7 @@ emit_sn_vector_t (TransformData *td, MonoMethod *cmethod, MonoMethodSignature *c
 			cmethod_name += 77;
 		}
 	}
-	
+
 	int id = lookup_intrins (sn_vector_t_methods, sizeof (sn_vector_t_methods), cmethod_name);
 	if (id == -1)
 		return FALSE;
@@ -906,7 +906,7 @@ lookup_packedsimd_intrinsic (const char *name, MonoType *arg1)
 	if (m_class_is_simd_type (vector_klass)) {
 		arg_type = mono_class_get_context (vector_klass)->class_inst->type_argv [0];
 	} else if (arg1->type == MONO_TYPE_PTR) {
-		arg_type = arg1->data.type;
+		arg_type = m_type_data_get_type (arg1);
 	} else {
 		// g_printf ("%s arg1 type was not pointer or simd type: %s\n", name, m_class_get_name (vector_klass));
 		return FALSE;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -330,15 +330,15 @@ enum_type:
 	case MONO_TYPE_ARRAY:
 		return MINT_TYPE_O;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_get_klass(type))) {
+			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
 			goto enum_type;
 		} else
 			return MINT_TYPE_VT;
 	case MONO_TYPE_TYPEDBYREF:
 		return MINT_TYPE_VT;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (type->data.generic_class->container_class);
+		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
 		goto enum_type;
 	case MONO_TYPE_VOID:
 		return MINT_TYPE_VOID;
@@ -2748,7 +2748,7 @@ interp_type_as_ptr (MonoType *tp)
 		return TRUE;
 	if ((tp)->type == MONO_TYPE_CHAR)
 		return TRUE;
-	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (tp->data.klass))
+	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_get_klass(tp)))
 		return TRUE;
 	if (is_scalar_vtype (tp))
 		return TRUE;
@@ -4580,8 +4580,8 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 		int mt = mono_mint_type (header->locals [i]);
 		size = mono_interp_type_size (header->locals [i], mt, &align);
 		if (header->locals [i]->type == MONO_TYPE_VALUETYPE) {
-			if (mono_class_has_failure (header->locals [i]->data.klass)) {
-				mono_error_set_for_class_failure (error, header->locals [i]->data.klass);
+			if (mono_class_has_failure (m_type_get_klass (header->locals [i]))) {
+				mono_error_set_for_class_failure (error, m_type_get_klass (header->locals [i]));
 				return;
 			}
 		}

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -330,15 +330,15 @@ enum_type:
 	case MONO_TYPE_ARRAY:
 		return MINT_TYPE_O;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto enum_type;
 		} else
 			return MINT_TYPE_VT;
 	case MONO_TYPE_TYPEDBYREF:
 		return MINT_TYPE_VT;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto enum_type;
 	case MONO_TYPE_VOID:
 		return MINT_TYPE_VOID;
@@ -2748,7 +2748,7 @@ interp_type_as_ptr (MonoType *tp)
 		return TRUE;
 	if ((tp)->type == MONO_TYPE_CHAR)
 		return TRUE;
-	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_get_klass(tp)))
+	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (tp)))
 		return TRUE;
 	if (is_scalar_vtype (tp))
 		return TRUE;
@@ -4580,8 +4580,8 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 		int mt = mono_mint_type (header->locals [i]);
 		size = mono_interp_type_size (header->locals [i], mt, &align);
 		if (header->locals [i]->type == MONO_TYPE_VALUETYPE) {
-			if (mono_class_has_failure (m_type_get_klass (header->locals [i]))) {
-				mono_error_set_for_class_failure (error, m_type_get_klass (header->locals [i]));
+			if (mono_class_has_failure (m_type_data_get_klass (header->locals [i]))) {
+				mono_error_set_for_class_failure (error, m_type_data_get_klass (header->locals [i]));
 				return;
 			}
 		}

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -330,15 +330,15 @@ enum_type:
 	case MONO_TYPE_ARRAY:
 		return MINT_TYPE_O;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto enum_type;
 		} else
 			return MINT_TYPE_VT;
 	case MONO_TYPE_TYPEDBYREF:
 		return MINT_TYPE_VT;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto enum_type;
 	case MONO_TYPE_VOID:
 		return MINT_TYPE_VOID;
@@ -2748,7 +2748,7 @@ interp_type_as_ptr (MonoType *tp)
 		return TRUE;
 	if ((tp)->type == MONO_TYPE_CHAR)
 		return TRUE;
-	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (tp)))
+	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (tp)))
 		return TRUE;
 	if (is_scalar_vtype (tp))
 		return TRUE;
@@ -4580,8 +4580,8 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 		int mt = mono_mint_type (header->locals [i]);
 		size = mono_interp_type_size (header->locals [i], mt, &align);
 		if (header->locals [i]->type == MONO_TYPE_VALUETYPE) {
-			if (mono_class_has_failure (m_type_data_get_klass (header->locals [i]))) {
-				mono_error_set_for_class_failure (error, m_type_data_get_klass (header->locals [i]));
+			if (mono_class_has_failure (m_type_data_get_klass_unchecked (header->locals [i]))) {
+				mono_error_set_for_class_failure (error, m_type_data_get_klass_unchecked (header->locals [i]));
 				return;
 			}
 		}

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -951,7 +951,7 @@ get_rttype_ins_relation (MonoCompile *cfg, MonoInst *ins1, MonoInst *ins2, gbool
 
 		/* Common case in gshared BCL code: t1 is a gshared type like T_INT, and t2 is a concrete type */
 		if (mono_class_is_gparam (k1)) {
-			MonoGenericParam *gparam = t1->data.generic_param;
+			MonoGenericParam *gparam = m_type_data_get_generic_param (t1);
 			constraint1 = gparam->gshared_constraint;
 		}
 		if (constraint1) {
@@ -1742,7 +1742,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				i2u_cmp->sreg1 = args[2]->dreg;
 				MONO_ADD_INS (cfg->cbb, i2u_cmp);
 			}
-			
+
 			if (is_ref && !mini_debug_options.weak_memory_model)
 				mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
@@ -2206,7 +2206,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 
 			/* Common case in gshared BCL code: t1 is a gshared type like T_INT */
 			if (mono_class_is_gparam (k1)) {
-				MonoGenericParam *gparam = t1->data.generic_param;
+				MonoGenericParam *gparam = m_type_data_get_generic_param (t1);
 				constraint1 = gparam->gshared_constraint;
 				if (constraint1) {
 					if (constraint1->type == MONO_TYPE_OBJECT) {
@@ -2353,7 +2353,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				cmethod_name += 80;
 			}
 		}
-		
+
 		if (!strcmp (cmethod_name, "get_IsHardwareAccelerated")) {
 			EMIT_NEW_ICONST (cfg, ins, 0);
 			ins->type = STACK_I4;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -334,8 +334,8 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return OP_FMOVE;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto handle_enum;
 		}
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
@@ -346,7 +346,7 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return OP_XMOVE;
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
@@ -826,8 +826,8 @@ handle_enum:
 		inst->type = STACK_R8;
 		return;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto handle_enum;
 		} else {
 			inst->klass = klass;
@@ -839,7 +839,7 @@ handle_enum:
 		inst->type = STACK_VTYPE;
 		return;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
@@ -2084,8 +2084,8 @@ handle_enum:
 				return TRUE;
 			continue;
 		case MONO_TYPE_VALUETYPE:
-			if (m_class_is_enumtype (m_type_data_get_klass (simple_type))) {
-				simple_type = mono_class_enum_basetype_internal (m_type_data_get_klass (simple_type));
+			if (m_class_is_enumtype (m_type_data_get_klass_unchecked (simple_type))) {
+				simple_type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (simple_type));
 				goto handle_enum;
 			}
 			if (args [i]->type != STACK_VTYPE)
@@ -2096,7 +2096,7 @@ handle_enum:
 				return TRUE;
 			continue;
 		case MONO_TYPE_GENERICINST:
-			simple_type = m_class_get_byval_arg (m_type_data_get_generic_class (simple_type)->container_class);
+			simple_type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (simple_type)->container_class);
 			goto handle_enum;
 		case MONO_TYPE_VAR:
 		case MONO_TYPE_MVAR:
@@ -5395,8 +5395,8 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		return 0;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto handle_enum;
 		}
 		return 0;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10544,8 +10544,8 @@ calli_end:
 					int ro_type = ftype->type;
 					if (!addr)
 						addr = mono_static_field_get_addr (vtable, field);
-					if (ro_type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (ftype))) {
-						ro_type = mono_class_enum_basetype_internal (m_type_data_get_klass (ftype))->type;
+					if (ro_type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (ftype))) {
+						ro_type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (ftype))->type;
 					}
 
 					GSHAREDVT_FAILURE (il_op);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -334,8 +334,8 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return OP_FMOVE;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto handle_enum;
 		}
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
@@ -346,7 +346,7 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return OP_XMOVE;
-		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
@@ -826,8 +826,8 @@ handle_enum:
 		inst->type = STACK_R8;
 		return;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto handle_enum;
 		} else {
 			inst->klass = klass;
@@ -839,7 +839,7 @@ handle_enum:
 		inst->type = STACK_VTYPE;
 		return;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
@@ -2084,8 +2084,8 @@ handle_enum:
 				return TRUE;
 			continue;
 		case MONO_TYPE_VALUETYPE:
-			if (m_class_is_enumtype (m_type_get_klass(simple_type))) {
-				simple_type = mono_class_enum_basetype_internal (m_type_get_klass(simple_type));
+			if (m_class_is_enumtype (m_type_data_get_klass (simple_type))) {
+				simple_type = mono_class_enum_basetype_internal (m_type_data_get_klass (simple_type));
 				goto handle_enum;
 			}
 			if (args [i]->type != STACK_VTYPE)
@@ -2096,7 +2096,7 @@ handle_enum:
 				return TRUE;
 			continue;
 		case MONO_TYPE_GENERICINST:
-			simple_type = m_class_get_byval_arg (m_type_get_generic_class(simple_type)->container_class);
+			simple_type = m_class_get_byval_arg (m_type_data_get_generic_class (simple_type)->container_class);
 			goto handle_enum;
 		case MONO_TYPE_VAR:
 		case MONO_TYPE_MVAR:
@@ -5395,8 +5395,8 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		return 0;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_get_klass(type))) {
-			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto handle_enum;
 		}
 		return 0;
@@ -5931,7 +5931,7 @@ handle_constrained_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignat
 				constrained_partial_call = TRUE;
 
 			MonoType *t = m_class_get_byval_arg (constrained_class);
-			MonoGenericParam *gparam = m_type_get_generic_param(t);
+			MonoGenericParam *gparam = m_type_data_get_generic_param (t);
 			gshared_constraint = gparam->gshared_constraint;
 		}
 	}
@@ -10544,8 +10544,8 @@ calli_end:
 					int ro_type = ftype->type;
 					if (!addr)
 						addr = mono_static_field_get_addr (vtable, field);
-					if (ro_type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_get_klass(ftype))) {
-						ro_type = mono_class_enum_basetype_internal (m_type_get_klass(ftype))->type;
+					if (ro_type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (ftype))) {
+						ro_type = mono_class_enum_basetype_internal (m_type_data_get_klass (ftype))->type;
 					}
 
 					GSHAREDVT_FAILURE (il_op);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -334,8 +334,8 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return OP_FMOVE;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_get_klass(type))) {
+			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
 			goto handle_enum;
 		}
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
@@ -346,7 +346,7 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return OP_XMOVE;
-		type = m_class_get_byval_arg (type->data.generic_class->container_class);
+		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
@@ -826,8 +826,8 @@ handle_enum:
 		inst->type = STACK_R8;
 		return;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_get_klass(type))) {
+			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
 			goto handle_enum;
 		} else {
 			inst->klass = klass;
@@ -839,7 +839,7 @@ handle_enum:
 		inst->type = STACK_VTYPE;
 		return;
 	case MONO_TYPE_GENERICINST:
-		type = m_class_get_byval_arg (type->data.generic_class->container_class);
+		type = m_class_get_byval_arg (m_type_get_generic_class(type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
@@ -2084,8 +2084,8 @@ handle_enum:
 				return TRUE;
 			continue;
 		case MONO_TYPE_VALUETYPE:
-			if (m_class_is_enumtype (simple_type->data.klass)) {
-				simple_type = mono_class_enum_basetype_internal (simple_type->data.klass);
+			if (m_class_is_enumtype (m_type_get_klass(simple_type))) {
+				simple_type = mono_class_enum_basetype_internal (m_type_get_klass(simple_type));
 				goto handle_enum;
 			}
 			if (args [i]->type != STACK_VTYPE)
@@ -2096,7 +2096,7 @@ handle_enum:
 				return TRUE;
 			continue;
 		case MONO_TYPE_GENERICINST:
-			simple_type = m_class_get_byval_arg (simple_type->data.generic_class->container_class);
+			simple_type = m_class_get_byval_arg (m_type_get_generic_class(simple_type)->container_class);
 			goto handle_enum;
 		case MONO_TYPE_VAR:
 		case MONO_TYPE_MVAR:
@@ -5395,8 +5395,8 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		return 0;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_get_klass(type))) {
+			type = mono_class_enum_basetype_internal (m_type_get_klass(type));
 			goto handle_enum;
 		}
 		return 0;
@@ -5931,7 +5931,7 @@ handle_constrained_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignat
 				constrained_partial_call = TRUE;
 
 			MonoType *t = m_class_get_byval_arg (constrained_class);
-			MonoGenericParam *gparam = t->data.generic_param;
+			MonoGenericParam *gparam = m_type_get_generic_param(t);
 			gshared_constraint = gparam->gshared_constraint;
 		}
 	}
@@ -10544,8 +10544,8 @@ calli_end:
 					int ro_type = ftype->type;
 					if (!addr)
 						addr = mono_static_field_get_addr (vtable, field);
-					if (ro_type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (ftype->data.klass)) {
-						ro_type = mono_class_enum_basetype_internal (ftype->data.klass)->type;
+					if (ro_type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_get_klass(ftype))) {
+						ro_type = mono_class_enum_basetype_internal (m_type_get_klass(ftype))->type;
 					}
 
 					GSHAREDVT_FAILURE (il_op);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -311,7 +311,7 @@ merge_argument_class_from_type (MonoType *type, ArgumentClass class1)
 		}
 		/* fall through */
 	case MONO_TYPE_VALUETYPE: {
-		MonoMarshalType *info = mono_marshal_load_type_info (ptype->data.klass);
+		MonoMarshalType *info = mono_marshal_load_type_info (m_type_data_get_klass (ptype));
 		for (guint32 i = 0; i < info->num_fields; ++i) {
 			class2 = class1;
 			class2 = merge_argument_class_from_type (info->fields [i].field->type, class2);
@@ -625,13 +625,13 @@ add_return_valuetype_swiftcall (ArgInfo *ainfo, MonoType *type, guint32 *gr, gui
 	// The structs that cannot be lowered, we pass them by reference
 	if (lowered_swift_struct.by_reference) {
 		ainfo->storage = ArgValuetypeAddrInIReg;
-		/* 
+		/*
 		 * On x64, Swift calls expect the return buffer to be passed in RAX.
 		 * However, since RAX mono reg allocator could assign RAX to a different value,
 		 * the R10 register is used instead and before the native call,
 		 * the value is moved from R10 to RAX (`amd64_handle_swift_return_buffer_reg`).
 		 */
-		ainfo->reg = AMD64_R10; 
+		ainfo->reg = AMD64_R10;
 		return;
 	}
 
@@ -987,9 +987,9 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 			if (cinfo->ret.storage == ArgValuetypeAddrInIReg) {
 				/*
 				 * We need to set this even when sig->pinvoke is FALSE, because the `cinfo` gets copied to the
-				 * `cfg->arch` on the first pass. However, later in `amd64_handle_swift_return_buffer_reg` we 
+				 * `cfg->arch` on the first pass. However, later in `amd64_handle_swift_return_buffer_reg` we
 				 * condition the Swift return buffer handling only to P/Invoke calls. This however can trigger
-				 * a false positive in some scenarios where the Swift return buffer is not needed. 
+				 * a false positive in some scenarios where the Swift return buffer is not needed.
 				 */
 				cinfo->need_swift_return_buffer = TRUE;
 			}
@@ -998,7 +998,7 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 		{
 			add_valuetype (sig, &cinfo->ret, ret_type, TRUE, &tmp_gr, &tmp_fr, &tmp_stacksize);
 		}
-		g_assert (cinfo->ret.storage != ArgInIReg);		
+		g_assert (cinfo->ret.storage != ArgInIReg);
 		break;
 	}
 	case MONO_TYPE_VAR:
@@ -1038,8 +1038,8 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 
 		if (ret_storage == ArgValuetypeAddrInIReg || ret_storage == ArgGsharedvtVariableInReg) {
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
-			// When Swift struct is returned by reference, we use the R10 register to hold the return buffer. 
-			if (!(cinfo->need_swift_return_buffer && cinfo->ret.reg == AMD64_R10 && 
+			// When Swift struct is returned by reference, we use the R10 register to hold the return buffer.
+			if (!(cinfo->need_swift_return_buffer && cinfo->ret.reg == AMD64_R10 &&
 				sig->pinvoke && mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL)))
 #endif
 			{
@@ -1306,7 +1306,7 @@ arg_get_val (CallContext *ccontext, ArgInfo *ainfo, gpointer dest)
 		g_assert_not_reached ();
 	}
 
-	
+
 }
 
 static void
@@ -1361,7 +1361,7 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 	default:
 		g_assert_not_reached ();
 	}
-	
+
 }
 
 gpointer
@@ -2041,7 +2041,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 			} else {
 				offset += cinfo->ret.arg_size;
 				cfg->ret->inst_offset = - offset;
-			}	
+			}
 			break;
 #endif /* MONO_ARCH_HAVE_SWIFTCALL */
 		default:
@@ -5476,11 +5476,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			amd64_div_reg_size (code, ins->sreg3, FALSE, 4);
 			break;
 		case OP_X86_IDIVREM2:
-			if (ins->dreg != AMD64_RDX) 
+			if (ins->dreg != AMD64_RDX)
 				amd64_mov_reg_reg (code, ins->dreg, AMD64_RDX, 4);
 			break;
 		case OP_X86_LDIVREM2:
-			if (ins->dreg != AMD64_RDX) 
+			if (ins->dreg != AMD64_RDX)
 				amd64_mov_reg_reg (code, ins->dreg, AMD64_RDX, 8);
 			break;
 
@@ -8465,7 +8465,7 @@ MONO_RESTORE_WARNING
 		if (cfg->vret_addr && (cfg->vret_addr->opcode != OP_REGVAR)) {
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 			if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL) && sig->pinvoke &&
-	    		cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED && 
+	    		cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED &&
 	    		cfg->arch.cinfo->need_swift_return_buffer && cinfo->ret.reg == AMD64_R10) {
 				// Save the return buffer passed by the Swift caller
 				amd64_mov_membase_reg (code, cfg->vret_addr->inst_basereg, cfg->vret_addr->inst_offset, SWIFT_RETURN_BUFFER_REG, 8);
@@ -8478,8 +8478,8 @@ MONO_RESTORE_WARNING
 	}
 
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
-	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL) && 
-	    cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED && 
+	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL) &&
+	    cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED &&
 	    cfg->arch.cinfo->need_swift_return_buffer) {
 		amd64_mov_reg_reg (code, AMD64_R10, SWIFT_RETURN_BUFFER_REG, 8);
 	}

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -311,7 +311,8 @@ merge_argument_class_from_type (MonoType *type, ArgumentClass class1)
 		}
 		/* fall through */
 	case MONO_TYPE_VALUETYPE: {
-		MonoMarshalType *info = mono_marshal_load_type_info (m_type_data_get_klass (ptype));
+		// We have to use mono_class_from_mono_type_internal here due to the fallthrough from GENERICINST
+		MonoMarshalType *info = mono_marshal_load_type_info (mono_class_from_mono_type_internal (ptype));
 		for (guint32 i = 0; i < info->num_fields; ++i) {
 			class2 = class1;
 			class2 = merge_argument_class_from_type (info->fields [i].field->type, class2);

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -82,6 +82,7 @@ type_check_context_used (MonoType *type, gboolean recursive)
 		return MONO_GENERIC_CONTEXT_USED_CLASS;
 	case MONO_TYPE_MVAR:
 		return MONO_GENERIC_CONTEXT_USED_METHOD;
+	// FIXME: This is inconsistent - for SZARRAY it is checking T[] while for ARRAY it is checking T -kg
 	case MONO_TYPE_SZARRAY:
 		return mono_class_check_context_used (mono_type_get_class_internal (type));
 	case MONO_TYPE_ARRAY:

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -94,7 +94,7 @@ type_check_context_used (MonoType *type, gboolean recursive)
 			return 0;
 	case MONO_TYPE_GENERICINST:
 		if (recursive) {
-			MonoGenericClass *gclass = type->data.generic_class;
+			MonoGenericClass *gclass = m_type_data_get_generic_class (type);
 
 			g_assert (mono_class_is_gtd (gclass->container_class));
 			return mono_generic_context_check_used (&gclass->context);
@@ -1895,7 +1895,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 	int retval_var = 0;
 	if (return_native_struct) {
 		retval_var = mono_mb_add_local (mb, int_type);
-		mono_mb_emit_icon (mb, mono_class_native_size (sig->ret->data.klass, NULL));
+		mono_mb_emit_icon (mb, mono_class_native_size (m_type_data_get_klass (sig->ret), NULL));
 		mono_mb_emit_byte (mb, CEE_PREFIX1);
 		mono_mb_emit_byte (mb, CEE_LOCALLOC);
 		mono_mb_emit_stloc (mb, retval_var);
@@ -1964,7 +1964,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 	if (return_native_struct) {
 		mono_mb_emit_ldloc (mb, retval_var);
 		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_op (mb, CEE_MONO_LDNATIVEOBJ, sig->ret->data.klass);
+		mono_mb_emit_op (mb, CEE_MONO_LDNATIVEOBJ, m_type_data_get_klass (sig->ret));
 	} else if (sig->ret->type != MONO_TYPE_VOID) {
 		mono_mb_emit_ldloc (mb, retval_var);
 	}
@@ -3405,7 +3405,7 @@ static gboolean
 type_is_sharable (MonoType *type, gboolean allow_type_vars, gboolean allow_partial)
 {
 	if (allow_type_vars && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
-		MonoType *constraint = type->data.generic_param->gshared_constraint;
+		MonoType *constraint = m_type_data_get_generic_param (type)->gshared_constraint;
 		if (!constraint)
 			return TRUE;
 		type = constraint;
@@ -3415,11 +3415,11 @@ type_is_sharable (MonoType *type, gboolean allow_type_vars, gboolean allow_parti
 		return TRUE;
 
 	/* Allow non ref arguments if they are primitive types or enums (partial sharing). */
-	if (allow_partial && !m_type_is_byref (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))))
+	if (allow_partial && !m_type_is_byref (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass (type)))))
 		return TRUE;
 
 	if (allow_partial && !m_type_is_byref (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
-		MonoGenericClass *gclass = type->data.generic_class;
+		MonoGenericClass *gclass = m_type_data_get_generic_class (type);
 
 		if (gclass->context.class_inst && !mini_generic_inst_is_sharable (gclass->context.class_inst, allow_type_vars, allow_partial))
 			return FALSE;
@@ -3619,8 +3619,8 @@ is_async_method (MonoMethod *method)
 	/* Do less expensive checks first */
 	sig = mono_method_signature_internal (method);
 	if (attr_class && sig && ((sig->ret->type == MONO_TYPE_VOID) ||
-				(sig->ret->type == MONO_TYPE_CLASS && !strcmp (m_class_get_name (sig->ret->data.generic_class->container_class), "Task")) ||
-				(sig->ret->type == MONO_TYPE_GENERICINST && !strcmp (m_class_get_name (sig->ret->data.generic_class->container_class), "Task`1")))) {
+				(sig->ret->type == MONO_TYPE_CLASS && !strcmp (m_class_get_name (m_type_data_get_generic_class (sig->ret)->container_class), "Task")) ||
+				(sig->ret->type == MONO_TYPE_GENERICINST && !strcmp (m_class_get_name (m_type_data_get_generic_class (sig->ret)->container_class), "Task`1")))) {
 		//printf ("X: %s\n", mono_method_full_name (method, TRUE));
 		cattr = mono_custom_attrs_from_method_checked (method, error);
 		if (!is_ok (error)) {
@@ -4007,7 +4007,7 @@ mini_get_basic_type_from_generic (MonoType *type)
 	if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
 		return type;
 	else if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
-		MonoType *constraint = type->data.generic_param->gshared_constraint;
+		MonoType *constraint = m_type_data_get_generic_param (type)->gshared_constraint;
 		/* The gparam constraint encodes the type this gparam can represent */
 		if (!constraint) {
 			return mono_get_object_type ();
@@ -4129,7 +4129,7 @@ gboolean
 mini_type_var_is_vt (MonoType *type)
 {
 	if (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) {
-		return type->data.generic_param->gshared_constraint && (type->data.generic_param->gshared_constraint->type == MONO_TYPE_VALUETYPE || type->data.generic_param->gshared_constraint->type == MONO_TYPE_GENERICINST);
+		return m_type_data_get_generic_param (type)->gshared_constraint && (m_type_data_get_generic_param (type)->gshared_constraint->type == MONO_TYPE_VALUETYPE || m_type_data_get_generic_param (type)->gshared_constraint->type == MONO_TYPE_GENERICINST);
 	} else {
 		g_assert_not_reached ();
 		return FALSE;
@@ -4213,7 +4213,7 @@ gboolean
 mini_is_gsharedvt_gparam (MonoType *t)
 {
 	/* Matches get_gsharedvt_type () */
-	return (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) && t->data.generic_param->gshared_constraint && t->data.generic_param->gshared_constraint->type == MONO_TYPE_VALUETYPE;
+	return (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) && m_type_data_get_generic_param (t)->gshared_constraint && m_type_data_get_generic_param (t)->gshared_constraint->type == MONO_TYPE_VALUETYPE;
 }
 
 static char*
@@ -4277,7 +4277,7 @@ MonoType*
 mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 {
 	MonoMemoryManager *mm;
-	MonoGenericParam *par = t->data.generic_param;
+	MonoGenericParam *par = m_type_data_get_generic_param (t);
 	MonoGSharedGenericParam *copy, key;
 	MonoType *res;
 	char *name;
@@ -4320,7 +4320,7 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	copy->param.gshared_constraint = constraint;
 	copy->parent = par;
 	res = mono_metadata_type_dup (NULL, t);
-	res->data.generic_param = (MonoGenericParam*)copy;
+	m_type_data_set_generic_param (res, (MonoGenericParam*)copy);
 
 	mono_mem_manager_lock (mm);
 	/* Duplicates are ok */
@@ -4340,7 +4340,7 @@ get_shared_type (MonoType *t, MonoType *type)
 
 	if (!m_type_is_byref (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
 		ERROR_DECL (error);
-		MonoGenericClass *gclass = type->data.generic_class;
+		MonoGenericClass *gclass = m_type_data_get_generic_class (type);
 		MonoGenericContext context;
 		MonoClass *k;
 
@@ -4362,14 +4362,14 @@ get_shared_type (MonoType *t, MonoType *type)
 	/* Create a type variable with a constraint which encodes which types can match it */
 	ttype = type->type;
 	if (type->type == MONO_TYPE_VALUETYPE) {
-		ttype = mono_class_enum_basetype_internal (type->data.klass)->type;
-	} else if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype(type->data.generic_class->container_class)) {
+		ttype = mono_class_enum_basetype_internal (m_type_data_get_klass (type))->type;
+	} else if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype(m_type_data_get_generic_class (type)->container_class)) {
 		ttype = mono_class_enum_basetype_internal (mono_class_from_mono_type_internal (type))->type;
 	} else if (MONO_TYPE_IS_REFERENCE (type)) {
 		ttype = MONO_TYPE_OBJECT;
 	} else if (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) {
-		if (type->data.generic_param->gshared_constraint)
-			return mini_get_shared_gparam (t, type->data.generic_param->gshared_constraint);
+		if (m_type_data_get_generic_param (type)->gshared_constraint)
+			return mini_get_shared_gparam (t, m_type_data_get_generic_param (type)->gshared_constraint);
 		ttype = MONO_TYPE_OBJECT;
 	}
 
@@ -4644,10 +4644,10 @@ mini_is_gsharedvt_type (MonoType *t)
 {
 	if (m_type_is_byref (t))
 		return FALSE;
-	if ((t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) && t->data.generic_param->gshared_constraint && t->data.generic_param->gshared_constraint->type == MONO_TYPE_VALUETYPE)
+	if ((t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) && m_type_data_get_generic_param (t)->gshared_constraint && m_type_data_get_generic_param (t)->gshared_constraint->type == MONO_TYPE_VALUETYPE)
 		return TRUE;
 	else if (t->type == MONO_TYPE_GENERICINST) {
-		MonoGenericClass *gclass = t->data.generic_class;
+		MonoGenericClass *gclass = m_type_data_get_generic_class (t);
 		MonoGenericContext *context = &gclass->context;
 		MonoGenericInst *inst;
 
@@ -4701,11 +4701,11 @@ mini_is_gsharedvt_variable_type (MonoType *t)
 	if (!mini_is_gsharedvt_type (t))
 		return FALSE;
 	if (t->type == MONO_TYPE_GENERICINST) {
-		MonoGenericClass *gclass = t->data.generic_class;
+		MonoGenericClass *gclass = m_type_data_get_generic_class (t);
 		MonoGenericContext *context = &gclass->context;
 		MonoGenericInst *inst;
 
-		if (m_class_get_byval_arg (t->data.generic_class->container_class)->type != MONO_TYPE_VALUETYPE || m_class_is_enumtype  (t->data.generic_class->container_class))
+		if (m_class_get_byval_arg (m_type_data_get_generic_class (t)->container_class)->type != MONO_TYPE_VALUETYPE || m_class_is_enumtype  (m_type_data_get_generic_class (t)->container_class))
 			return FALSE;
 
 		inst = context->class_inst;
@@ -4733,7 +4733,7 @@ is_variable_size (MonoType *t)
 		return FALSE;
 
 	if (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) {
-		MonoGenericParam *param = t->data.generic_param;
+		MonoGenericParam *param = m_type_data_get_generic_param (t);
 
 		if (param->gshared_constraint && param->gshared_constraint->type != MONO_TYPE_VALUETYPE && param->gshared_constraint->type != MONO_TYPE_GENERICINST)
 			return FALSE;
@@ -4741,8 +4741,8 @@ is_variable_size (MonoType *t)
 			return is_variable_size (param->gshared_constraint);
 		return TRUE;
 	}
-	if (t->type == MONO_TYPE_GENERICINST && m_class_get_byval_arg (t->data.generic_class->container_class)->type == MONO_TYPE_VALUETYPE) {
-		MonoGenericClass *gclass = t->data.generic_class;
+	if (t->type == MONO_TYPE_GENERICINST && m_class_get_byval_arg (m_type_data_get_generic_class (t)->container_class)->type == MONO_TYPE_VALUETYPE) {
+		MonoGenericClass *gclass = m_type_data_get_generic_class (t);
 		MonoGenericContext *context = &gclass->context;
 		MonoGenericInst *inst;
 

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -3619,8 +3619,8 @@ is_async_method (MonoMethod *method)
 	/* Do less expensive checks first */
 	sig = mono_method_signature_internal (method);
 	if (attr_class && sig && ((sig->ret->type == MONO_TYPE_VOID) ||
-				(sig->ret->type == MONO_TYPE_CLASS && !strcmp (m_class_get_name (m_type_data_get_generic_class (sig->ret)->container_class), "Task")) ||
-				(sig->ret->type == MONO_TYPE_GENERICINST && !strcmp (m_class_get_name (m_type_data_get_generic_class (sig->ret)->container_class), "Task`1")))) {
+				(sig->ret->type == MONO_TYPE_CLASS && !strcmp (m_class_get_name (m_type_data_get_klass_unchecked (sig->ret)), "Task")) ||
+				(sig->ret->type == MONO_TYPE_GENERICINST && !strcmp (m_class_get_name (m_type_data_get_generic_class_unchecked (sig->ret)->container_class), "Task`1")))) {
 		//printf ("X: %s\n", mono_method_full_name (method, TRUE));
 		cattr = mono_custom_attrs_from_method_checked (method, error);
 		if (!is_ok (error)) {

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -698,7 +698,7 @@ simd_valuetuple_to_llvm_type (EmitContext *ctx, MonoClass *klass)
 	MonoGenericInst *class_inst = mono_class_get_generic_class (klass)->context.class_inst;
 	MonoType *etype = class_inst->type_argv [0];
 	g_assert (etype->type == MONO_TYPE_GENERICINST);
-	MonoClass *eklass = m_type_data_get_generic_class (etype)->cached_class;
+	MonoClass *eklass = m_type_data_get_generic_class_unchecked (etype)->cached_class;
 	LLVMTypeRef ltype = simd_class_to_llvm_type (ctx, eklass);
 	return LLVMArrayType (ltype, class_inst->type_argc);
 }

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -698,7 +698,7 @@ simd_valuetuple_to_llvm_type (EmitContext *ctx, MonoClass *klass)
 	MonoGenericInst *class_inst = mono_class_get_generic_class (klass)->context.class_inst;
 	MonoType *etype = class_inst->type_argv [0];
 	g_assert (etype->type == MONO_TYPE_GENERICINST);
-	MonoClass *eklass = etype->data.generic_class->cached_class;
+	MonoClass *eklass = m_type_data_get_generic_class (etype)->cached_class;
 	LLVMTypeRef ltype = simd_class_to_llvm_type (ctx, eklass);
 	return LLVMArrayType (ltype, class_inst->type_argc);
 }
@@ -11736,7 +11736,7 @@ MONO_RESTORE_WARNING
 			default:
 				g_assert_not_reached ();
 				break;
-			
+
 			}
 
 			lhs = LLVMBuildLoad2 (builder, ret_t, addresses [ins->sreg1]->value, "");
@@ -11944,7 +11944,7 @@ MONO_RESTORE_WARNING
 				default:
 					g_assert_not_reached ();
 					break;
-				
+
 				}
 			}
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -673,7 +673,7 @@ mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 		mono_error_assert_ok (error);
 		trampoline = mono_create_ftnptr ((gpointer)trampoline);
 
-		
+
 		mono_atomic_cas_ptr ((volatile gpointer*)&callinfo->trampoline, (gpointer)trampoline, NULL);
 
 		return (gconstpointer)mono_atomic_load_ptr ((volatile gpointer*)&callinfo->trampoline);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -673,7 +673,7 @@ mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 		mono_error_assert_ok (error);
 		trampoline = mono_create_ftnptr ((gpointer)trampoline);
 
-
+		
 		mono_atomic_cas_ptr ((volatile gpointer*)&callinfo->trampoline, (gpointer)trampoline, NULL);
 
 		return (gconstpointer)mono_atomic_load_ptr ((volatile gpointer*)&callinfo->trampoline);

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -353,8 +353,8 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return OP_STORER8_MEMBASE_REG;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
-			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
+		if (m_class_is_enumtype (m_type_data_get_klass_unchecked (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (type));
 			goto handle_enum;
 		}
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
@@ -365,7 +365,7 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return OP_STOREX_MEMBASE;
-		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class_unchecked (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -1058,6 +1058,8 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 		if (cfg->disable_reuse_stack_slots)
 			reuse_slot = FALSE;
 
+		MonoClass *class_of_t = NULL;
+
 		t = mini_get_underlying_type (t);
 		switch (t->type) {
 		case MONO_TYPE_GENERICINST:
@@ -1070,8 +1072,9 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 			if (!vtype_stack_slots)
 				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * vtype_stack_slots_size);
 			int i;
+			class_of_t = mono_class_from_mono_type_internal (t);
 			for (i = 0; i < nvtypes; ++i)
-				if (m_type_data_get_klass (t) == vtype_stack_slots [i].vtype)
+				if (class_of_t == vtype_stack_slots [i].vtype)
 					break;
 			if (i < nvtypes)
 				slot_info = &vtype_stack_slots [i];
@@ -1085,7 +1088,7 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 					vtype_stack_slots = new_slots;
 					vtype_stack_slots_size = new_slots_size;
 				}
-				vtype_stack_slots [nvtypes].vtype = m_type_data_get_klass (t);
+				vtype_stack_slots [nvtypes].vtype = class_of_t;
 				slot_info = &vtype_stack_slots [nvtypes];
 				nvtypes ++;
 			}

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -1369,6 +1369,8 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 		if (cfg->disable_reuse_stack_slots)
 			reuse_slot = FALSE;
 
+		MonoClass *class_of_t = NULL;
+
 		t = mini_get_underlying_type (t);
 		switch (t->type) {
 		case MONO_TYPE_GENERICINST:
@@ -1381,8 +1383,9 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 			if (!vtype_stack_slots)
 				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * vtype_stack_slots_size);
 			int i;
+			class_of_t = mono_class_from_mono_type_internal (t);
 			for (i = 0; i < nvtypes; ++i)
-				if (m_type_data_get_klass (t) == vtype_stack_slots [i].vtype)
+				if (class_of_t == vtype_stack_slots [i].vtype)
 					break;
 			if (i < nvtypes)
 				slot_info = &vtype_stack_slots [i];
@@ -1396,7 +1399,7 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 					vtype_stack_slots = new_slots;
 					vtype_stack_slots_size = new_slots_size;
 				}
-				vtype_stack_slots [nvtypes].vtype = m_type_data_get_klass (t);
+				vtype_stack_slots [nvtypes].vtype = class_of_t;
 				slot_info = &vtype_stack_slots [nvtypes];
 				nvtypes ++;
 			}

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -353,8 +353,8 @@ handle_enum:
 	case MONO_TYPE_R8:
 		return OP_STORER8_MEMBASE_REG;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype_internal (type->data.klass);
+		if (m_class_is_enumtype (m_type_data_get_klass (type))) {
+			type = mono_class_enum_basetype_internal (m_type_data_get_klass (type));
 			goto handle_enum;
 		}
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
@@ -365,7 +365,7 @@ handle_enum:
 	case MONO_TYPE_GENERICINST:
 		if (mini_class_is_simd (cfg, mono_class_from_mono_type_internal (type)))
 			return OP_STOREX_MEMBASE;
-		type = m_class_get_byval_arg (type->data.generic_class->container_class);
+		type = m_class_get_byval_arg (m_type_data_get_generic_class (type)->container_class);
 		goto handle_enum;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
@@ -1071,7 +1071,7 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * vtype_stack_slots_size);
 			int i;
 			for (i = 0; i < nvtypes; ++i)
-				if (t->data.klass == vtype_stack_slots [i].vtype)
+				if (m_type_data_get_klass (t) == vtype_stack_slots [i].vtype)
 					break;
 			if (i < nvtypes)
 				slot_info = &vtype_stack_slots [i];
@@ -1085,7 +1085,7 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 					vtype_stack_slots = new_slots;
 					vtype_stack_slots_size = new_slots_size;
 				}
-				vtype_stack_slots [nvtypes].vtype = t->data.klass;
+				vtype_stack_slots [nvtypes].vtype = m_type_data_get_klass (t);
 				slot_info = &vtype_stack_slots [nvtypes];
 				nvtypes ++;
 			}
@@ -1382,7 +1382,7 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * vtype_stack_slots_size);
 			int i;
 			for (i = 0; i < nvtypes; ++i)
-				if (t->data.klass == vtype_stack_slots [i].vtype)
+				if (m_type_data_get_klass (t) == vtype_stack_slots [i].vtype)
 					break;
 			if (i < nvtypes)
 				slot_info = &vtype_stack_slots [i];
@@ -1396,7 +1396,7 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 					vtype_stack_slots = new_slots;
 					vtype_stack_slots_size = new_slots_size;
 				}
-				vtype_stack_slots [nvtypes].vtype = t->data.klass;
+				vtype_stack_slots [nvtypes].vtype = m_type_data_get_klass (t);
 				slot_info = &vtype_stack_slots [nvtypes];
 				nvtypes ++;
 			}

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -488,7 +488,7 @@ add_type (MonoProfiler *prof, MonoType *type)
 	switch (type->type) {
 #if 0
 	case MONO_TYPE_SZARRAY: {
-		int eid = add_type (prof, m_class_get_byval_arg (m_type_data_get_klass (type)));
+		int eid = add_type (prof, m_class_get_byval_arg (m_type_data_get_klass_unchecked (type)));
 		if (eid == -1)
 			return -1;
 		int id = prof->id ++;

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -488,7 +488,7 @@ add_type (MonoProfiler *prof, MonoType *type)
 	switch (type->type) {
 #if 0
 	case MONO_TYPE_SZARRAY: {
-		int eid = add_type (prof, m_class_get_byval_arg (type->data.klass));
+		int eid = add_type (prof, m_class_get_byval_arg (m_type_data_get_klass (type)));
 		if (eid == -1)
 			return -1;
 		int id = prof->id ++;


### PR DESCRIPTION
There is a class of issue where we fail to properly check the type of a MonoType before accessing the members of its data union, which can lead to type confusion or null pointer dereference bugs.

This PR adds dedicated access helpers for every member of the union that do a type check, renames the union to make direct accesses obvious, and removes almost all direct uses of the union members.

The process of adding the access helpers and auditing related code revealed multiple bugs; I've either fixed those bugs in this PR or added FIXME comments describing the bug.

For accesses that were obviously correct (I could see a type check right above the accessor call) I used the `_unchecked` variant to optimize out the type check.

As a follow-up later on in the .NET 10 cycle we can remove the type check from these accessors to make them more efficient if we need to. I don't think we'll need to, though.