### PR TITLE
Fail tests if LTCG is used

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -28,6 +28,7 @@
     <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
     <IlcFrameworkPath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkPath>
     <IlcFrameworkNativePath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkNativePath>
+    <IlcCppLinkerCustomWarningRegularExpression>module compiled with /GL found</IlcCppLinkerCustomWarningRegularExpression>
     <NoWarn>$(NoWarn);IL1005;IL2122;IL3000;IL3001;IL3002;IL3003;IL3050;IL3051;IL3052;IL3053</NoWarn>
     <TrimMode>partial</TrimMode>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>

--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -28,7 +28,7 @@
     <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
     <IlcFrameworkPath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkPath>
     <IlcFrameworkNativePath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkNativePath>
-    <IlcCppLinkerCustomWarningRegularExpression>module compiled with /GL found</IlcCppLinkerCustomWarningRegularExpression>
+    <IlcCppLinkerCustomWarningRegularExpression>module compiled with</IlcCppLinkerCustomWarningRegularExpression>
     <NoWarn>$(NoWarn);IL1005;IL2122;IL3000;IL3001;IL3002;IL3003;IL3050;IL3051;IL3052;IL3053</NoWarn>
     <TrimMode>partial</TrimMode>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>

--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -28,7 +28,7 @@
     <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
     <IlcFrameworkPath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkPath>
     <IlcFrameworkNativePath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkNativePath>
-    <IlcCppLinkerCustomWarningRegularExpression>module compiled with</IlcCppLinkerCustomWarningRegularExpression>
+    <IlcCppLinkerCustomWarningRegularExpression>module compiled with /GL found</IlcCppLinkerCustomWarningRegularExpression>
     <NoWarn>$(NoWarn);IL1005;IL2122;IL3000;IL3001;IL3002;IL3003;IL3050;IL3051;IL3052;IL3053</NoWarn>
     <TrimMode>partial</TrimMode>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -372,14 +372,11 @@ The .NET Foundation licenses this file to you under the MIT license.
     <!-- write linker script for lld (13+) to retain the __modules section -->
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)sections.ld" Lines="OVERWRITE_SECTIONS { __modules : { KEEP(*(__modules)) } }" Overwrite="true" Condition="'$(LinkerFlavor)' == 'lld' and '$(_LinkerVersion)' &gt; '12'" />
 
-    <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')"
-      Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'"
-      IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)"
-      CustomWarningRegularExpression="$(IlcCppLinkerCustomWarningRegularExpression)" />
+    <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'" IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)" />
     <Exec Command="&quot;$(CppLibCreator)&quot; @(CustomLibArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' == 'Static'" />
 
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)link.rsp" Lines="@(CustomLinkerArg)" Overwrite="true" Encoding="utf-8" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' != 'Static'" />
-    <Exec Command="&quot;$(CppLinker)&quot; @&quot;$(NativeIntermediateOutputPath)link.rsp&quot;" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' != 'Static'" />
+    <Exec Command="&quot;$(CppLinker)&quot; @&quot;$(NativeIntermediateOutputPath)link.rsp&quot;" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' != 'Static'" CustomWarningRegularExpression="$(IlcCppLinkerCustomWarningRegularExpression)" />
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)lib.rsp" Lines="@(CustomLibArg)" Overwrite="true" Encoding="utf-8" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' == 'Static'" />
     <Exec Command="&quot;$(CppLibCreator)&quot; @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' == 'Static'" />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -372,11 +372,16 @@ The .NET Foundation licenses this file to you under the MIT license.
     <!-- write linker script for lld (13+) to retain the __modules section -->
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)sections.ld" Lines="OVERWRITE_SECTIONS { __modules : { KEEP(*(__modules)) } }" Overwrite="true" Condition="'$(LinkerFlavor)' == 'lld' and '$(_LinkerVersion)' &gt; '12'" />
 
-    <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'" IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)" />
+    <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')"
+      Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'"
+      IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)"
+      CustomWarningRegularExpression="$(IlcCppLinkerCustomWarningRegularExpression)" />
     <Exec Command="&quot;$(CppLibCreator)&quot; @(CustomLibArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' == 'Static'" />
 
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)link.rsp" Lines="@(CustomLinkerArg)" Overwrite="true" Encoding="utf-8" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' != 'Static'" />
-    <Exec Command="&quot;$(CppLinker)&quot; @&quot;$(NativeIntermediateOutputPath)link.rsp&quot;" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' != 'Static'" CustomWarningRegularExpression="$(IlcCppLinkerCustomWarningRegularExpression)" />
+    <Exec Command="&quot;$(CppLinker)&quot; @&quot;$(NativeIntermediateOutputPath)link.rsp&quot;"
+      Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' != 'Static'"
+      CustomWarningRegularExpression="$(IlcCppLinkerCustomWarningRegularExpression)" />
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)lib.rsp" Lines="@(CustomLibArg)" Overwrite="true" Encoding="utf-8" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' == 'Static'" />
     <Exec Command="&quot;$(CppLibCreator)&quot; @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' == 'Static'" />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -372,7 +372,10 @@ The .NET Foundation licenses this file to you under the MIT license.
     <!-- write linker script for lld (13+) to retain the __modules section -->
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)sections.ld" Lines="OVERWRITE_SECTIONS { __modules : { KEEP(*(__modules)) } }" Overwrite="true" Condition="'$(LinkerFlavor)' == 'lld' and '$(_LinkerVersion)' &gt; '12'" />
 
-    <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'" IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)" />
+    <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')"
+      Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'"
+      IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)"
+      CustomWarningRegularExpression="$(IlcCppLinkerCustomWarningRegularExpression)" />
     <Exec Command="&quot;$(CppLibCreator)&quot; @(CustomLibArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' == 'Static'" />
 
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)link.rsp" Lines="@(CustomLinkerArg)" Overwrite="true" Encoding="utf-8" Condition="'$(_targetOS)' == 'win' and '$(NativeLib)' != 'Static'" />


### PR DESCRIPTION
#111566 is not the first time we accidentally shipped something built with LTCG. We should ideally not allow merging such code into `main`.

Cc @dotnet/ilc-contrib 