### PR TITLE
JIT: Relax assertion about phis for handlers of unreachable try clauses

### DIFF
--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -657,7 +657,14 @@ void SsaBuilder::AddDefToEHSuccessorPhis(BasicBlock* block, unsigned lclNum, uns
                 break;
             }
         }
-        assert(phiFound);
+
+#ifdef DEBUG
+        // If 'succ' is the handler of an unreachable try it is possible for
+        // 'block' to dominate it, in which case we will not find any phi.
+        // Tolerate this case.
+        EHblkDsc* ehDsc = m_pCompiler->ehGetBlockHndDsc(succ);
+        assert(phiFound || ((ehDsc != nullptr) && !m_pCompiler->m_dfsTree->Contains(ehDsc->ebdTryBeg)));
+#endif
 
         return BasicBlockVisit::Continue;
     });


### PR DESCRIPTION
For unreachable try clauses it is possible to still see spurious flow into their handlers because of second pass EH. We can then end up with a case where a handler is dominated by one of its enclosed blocks. For definitions in that enclosed block we thus won't find any phi in the enclosing handler; tolerate this case.

Fix #111341