### PR TITLE
[browser] Remove experimental args from NodeJS WBT runner

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/ConfigSrcTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/ConfigSrcTests.cs
@@ -16,7 +16,7 @@ public class ConfigSrcTests : TestMainJsTestBase
 
     // NOTE: port number determinizes dynamically, so could not generate absolute URI
     [Theory]
-    [BuildAndRun(host: RunHost.V8 | RunHost.NodeJS)]
+    [BuildAndRun(host: RunHost.V8)]
     public void ConfigSrcAbsolutePath(BuildArgs buildArgs, RunHost host, string id)
     {
         buildArgs = buildArgs with { ProjectName = $"configsrcabsolute_{buildArgs.Config}_{buildArgs.AOT}" };

--- a/src/mono/wasm/Wasm.Build.Tests/HostRunner/NodeJSHostRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/HostRunner/NodeJSHostRunner.cs
@@ -8,8 +8,8 @@ namespace Wasm.Build.Tests;
 public class NodeJSHostRunner : IHostRunner
 {
     public string GetTestCommand() => "wasm test";
-    public string GetXharnessArgsWindowsOS(XHarnessArgsOptions options) => $"--js-file={options.jsRelativePath} --engine=NodeJS -v trace --engine-arg=--experimental-wasm-simd --engine-arg=--experimental-wasm-eh";
-    public string GetXharnessArgsOtherOS(XHarnessArgsOptions options) => $"--js-file={options.jsRelativePath} --engine=NodeJS -v trace --locale={options.environmentLocale} --engine-arg=--experimental-wasm-simd --engine-arg=--experimental-wasm-eh";
+    public string GetXharnessArgsWindowsOS(XHarnessArgsOptions options) => $"--js-file={options.jsRelativePath} --engine=NodeJS -v trace";
+    public string GetXharnessArgsOtherOS(XHarnessArgsOptions options) => $"--js-file={options.jsRelativePath} --engine=NodeJS -v trace --locale={options.environmentLocale}";
     public bool UseWasmConsoleOutput() => true;
     public bool CanRunWBT() => true;
 }

--- a/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
@@ -66,7 +66,6 @@ namespace Wasm.Build.Tests
                                 DotnetWasmFromRuntimePack: false));
 
             RunAndTestWasmApp(buildArgs,
-                                extraXHarnessArgs: host == RunHost.NodeJS ? "--engine-arg=--experimental-wasm-simd --engine-arg=--experimental-wasm-eh" : "",
                                 expectedExitCode: 42,
                                 test: output =>
                                 {

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTestBase.cs
@@ -57,36 +57,9 @@ public abstract class WasmTemplateTestBase : BuildTestBase
         if (runAnalyzers)
             extraProperties += "<RunAnalyzers>true</RunAnalyzers>";
 
-        if (template == "wasmconsole")
-        {
-            UpdateRuntimeconfigTemplateForNode(_projectDir);
-        }
-
         AddItemsPropertiesToProject(projectfile, extraProperties);
 
         return projectfile;
-    }
-
-    private static void UpdateRuntimeconfigTemplateForNode(string projectDir)
-    {
-        // TODO: Can be removed once Node >= 20
-
-        string runtimeconfigTemplatePath = Path.Combine(projectDir, "runtimeconfig.template.json");
-        string runtimeconfigTemplateContent = File.ReadAllText(runtimeconfigTemplatePath);
-        var runtimeconfigTemplate = JsonObject.Parse(runtimeconfigTemplateContent);
-        if (runtimeconfigTemplate == null)
-            throw new Exception($"Unable to parse runtimeconfigtemplate at '{runtimeconfigTemplatePath}'");
-
-        var perHostConfigs = runtimeconfigTemplate?["wasmHostProperties"]?["perHostConfig"]?.AsArray();
-        if (perHostConfigs == null || perHostConfigs.Count == 0 || perHostConfigs[0] == null)
-            throw new Exception($"Unable to find perHostConfig in runtimeconfigtemplate at '{runtimeconfigTemplatePath}'");
-
-        perHostConfigs[0]!["host-args"] = new JsonArray(
-            "--experimental-wasm-simd",
-            "--experimental-wasm-eh"
-        );
-
-        File.WriteAllText(runtimeconfigTemplatePath, runtimeconfigTemplate!.ToString());
     }
 
     public (string projectDir, string buildOutput) BuildTemplateProject(BuildArgs buildArgs,


### PR DESCRIPTION
The docker image has a newer Node JS which doesn't need the arguments