### PR TITLE
Wrap temporary event handle in using statement

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
@@ -257,7 +257,7 @@ namespace System.Diagnostics.Eventing.Reader
         {
             get
             {
-                using(EventLogHandle bookmarkHandle = NativeWrapper.EvtCreateBookmark(null))
+                using (EventLogHandle bookmarkHandle = NativeWrapper.EvtCreateBookmark(null))
                 {
                     NativeWrapper.EvtUpdateBookmark(bookmarkHandle, Handle);
                     string bookmarkText = NativeWrapper.EvtRenderBookmark(bookmarkHandle);

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
@@ -257,11 +257,13 @@ namespace System.Diagnostics.Eventing.Reader
         {
             get
             {
-                EventLogHandle bookmarkHandle = NativeWrapper.EvtCreateBookmark(null);
-                NativeWrapper.EvtUpdateBookmark(bookmarkHandle, Handle);
-                string bookmarkText = NativeWrapper.EvtRenderBookmark(bookmarkHandle);
+                using(EventLogHandle bookmarkHandle = NativeWrapper.EvtCreateBookmark(null))
+                {
+                    NativeWrapper.EvtUpdateBookmark(bookmarkHandle, Handle);
+                    string bookmarkText = NativeWrapper.EvtRenderBookmark(bookmarkHandle);
 
-                return new EventBookmark(bookmarkText);
+                    return new EventBookmark(bookmarkText);
+                }
             }
         }
 


### PR DESCRIPTION
The temporary EventLogHandle created when the Bookmark in the EventLogRecord is read is not disposed at the end of the block, so it stays until the GC decides to call the finalizer. 

Wrap the EventLogHandle in a using statement to release the handle when it's no longer needed. 

Our application does a lot of queries to the event log and I noticed this when profiling.
![image](https://github.com/user-attachments/assets/c0fc8c11-e5a5-4d80-8748-27626bceb05b)
