### PR TITLE
Fix linux build image in eng/pipelines/libraries/stress/http.yml

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -38,7 +38,7 @@ extends:
           DUMPS_SHARE: "$(Build.ArtifactStagingDirectory)/dumps/"
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-1804-open
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
         steps:
         - checkout: self

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update -y && \
 RUN git clone --depth 1 --single-branch --branch v2.4.4 --recursive https://github.com/microsoft/msquic
 RUN cd msquic/ && \
     mkdir build && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3 -DQUIC_ENABLE_SANITIZERS=on && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3 && \
+      # -DQUIC_ENABLE_SANITIZERS=on && \
     cd build && \
     cmake --build . --config Debug
 RUN cd msquic/build/bin/Debug && \
@@ -42,7 +43,7 @@ ENV STRESS_ROLE=''
 ENV STRESS_ARGS=''
 
 # configure adress sanitizer
-ENV ASAN_OPTIONS='detect_leaks=0'
-ENV LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/12/libasan.so
+# ENV ASAN_OPTIONS='detect_leaks=0'
+# ENV LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/12/libasan.so
 
 CMD ./entrypoint.sh

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -26,6 +26,7 @@ ARG CONFIGURATION
 # Build the stress server
 WORKDIR /app
 COPY . .
+WORKDIR /app/System.Net.Http/tests/StressTests/HttpStress
 
 RUN dotnet build -c $CONFIGURATION \
     -p:NetCoreAppCurrentVersion=$VERSION \

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -26,7 +26,6 @@ ARG CONFIGURATION
 # Build the stress server
 WORKDIR /app
 COPY . .
-WORKDIR /app/System.Net.Http/tests/StressTests/HttpStress
 
 RUN dotnet build -c $CONFIGURATION \
     -p:NetCoreAppCurrentVersion=$VERSION \

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   client:
     build:
       context: ../../../../ # ~> src/libraries
-      dockerfile: ./System.Net.Security/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
+      dockerfile: ./System.Net.Http/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
     image: httpstress
     volumes:
       - "${DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"
@@ -16,7 +16,7 @@ services:
   server:
     build:
       context: ../../../../ # ~> src/libraries
-      dockerfile: ./System.Net.Security/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
+      dockerfile: ./System.Net.Http/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
     image: httpstress
     volumes:
       - "${DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
@@ -1,8 +1,9 @@
+version: '3' # Although the version attribute is obsolete and should be ignored, it's seemingly not the case on Build.Ubuntu.2204.Amd64.Open
 services:
   client:
     build:
-      context: .
-      dockerfile: ${DOCKERFILE:-Dockerfile}
+      context: ../../../../ # ~> src/libraries
+      dockerfile: ./System.Net.Security/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
     image: httpstress
     volumes:
       - "${DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"
@@ -14,8 +15,8 @@ services:
       - DUMPS_SHARE_MOUNT_ROOT=${DUMPS_SHARE_MOUNT_ROOT}
   server:
     build:
-      context: .
-      dockerfile: ${DOCKERFILE:-Dockerfile}
+      context: ../../../../ # ~> src/libraries
+      dockerfile: ./System.Net.Security/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
     image: httpstress
     volumes:
       - "${DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3' # Although the version attribute is obsolete and should be ignored,
 services:
   client:
     build:
-      context: ../../../../ # ~> src/libraries
-      dockerfile: ./System.Net.Http/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
+      context: .
+      dockerfile: ${DOCKERFILE:-Dockerfile}
     image: httpstress
     volumes:
       - "${DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"
@@ -15,8 +15,8 @@ services:
       - DUMPS_SHARE_MOUNT_ROOT=${DUMPS_SHARE_MOUNT_ROOT}
   server:
     build:
-      context: ../../../../ # ~> src/libraries
-      dockerfile: ./System.Net.Http/tests/StressTests/HttpStress/${DOCKERFILE:-Dockerfile}
+      context: .
+      dockerfile: ${DOCKERFILE:-Dockerfile}
     image: httpstress
     volumes:
       - "${DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"


### PR DESCRIPTION
@rzikm This fixes the disk space issue. It still fails to build with this error in the "Build HttpStress" step, do you have an idea:

> Invalid interpolation format for "client" option in service "services": "${DOCKERFILE:-Dockerfile}"
