### PR TITLE
[release/9.0-staging] Fix UnsafeAccessor scenario for modopts/modreqs when comparing field sigs.

### DIFF
--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1445,11 +1445,18 @@ namespace
 
         DWORD declArgCount;
         IfFailThrow(CorSigUncompressData_EndPtr(pSig1, pEndSig1, &declArgCount));
-
-        // UnsafeAccessors for fields require return types be byref.
-        // This was explicitly checked in TryGenerateUnsafeAccessor().
         if (pSig1 >= pEndSig1)
             ThrowHR(META_E_BAD_SIGNATURE);
+
+        // UnsafeAccessors for fields require return types be byref. However, we first need to
+        // consume any custom modifiers which are prior to the expected ELEMENT_TYPE_BYREF in
+        // the RetType signature (II.23.2.11).
+        _ASSERTE(state.IgnoreCustomModifiers); // We should always ignore custom modifiers for field look-up.
+        MetaSig::ConsumeCustomModifiers(pSig1, pEndSig1);
+        if (pSig1 >= pEndSig1)
+            ThrowHR(META_E_BAD_SIGNATURE);
+
+        // The ELEMENT_TYPE_BYREF was explicitly checked in TryGenerateUnsafeAccessor().
         CorElementType byRefType = CorSigUncompressElementType(pSig1);
         _ASSERTE(byRefType == ELEMENT_TYPE_BYREF);
 

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -3604,7 +3604,7 @@ ErrExit:
 #endif //!DACCESS_COMPILE
 } // CompareTypeTokens
 
-static void ConsumeCustomModifiers(PCCOR_SIGNATURE& pSig, PCCOR_SIGNATURE pEndSig)
+void MetaSig::ConsumeCustomModifiers(PCCOR_SIGNATURE& pSig, PCCOR_SIGNATURE pEndSig)
 {
     mdToken tk;
     CorElementType type;

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -945,6 +945,14 @@ class MetaSig
         //------------------------------------------------------------------
         CorElementType GetByRefType(TypeHandle* pTy) const;
 
+        //------------------------------------------------------------------
+        // Consume the custom modifiers, if any, in the current signature
+        // and update it.
+        // This is a non destructive operation if the current signature is not
+        // pointing at a sequence of ELEMENT_TYPE_CMOD_REQD or ELEMENT_TYPE_CMOD_OPT.
+        //------------------------------------------------------------------
+        static void ConsumeCustomModifiers(PCCOR_SIGNATURE& pSig, PCCOR_SIGNATURE pEndSig);
+
         // Struct used to capture in/out state during the comparison
         // of element types.
         struct CompareState

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
@@ -328,28 +328,70 @@ public static unsafe class UnsafeAccessorsTests
         extern static ref delegate*<void> GetFPtr(ref AllFields f);
     }
 
-    // Contains fields that have modopts/modreqs
-    struct FieldsWithModifiers
+    // Contains fields that are volatile
+    struct VolatileFields
     {
         private static volatile int s_vInt;
         private volatile int _vInt;
     }
 
-    [Fact]
-    public static void Verify_AccessFieldsWithModifiers()
+    // Accessors for fields that are volatile
+    static class AccessorsVolatile
     {
-        Console.WriteLine($"Running {nameof(Verify_AccessFieldsWithModifiers)}");
-
-        FieldsWithModifiers fieldsWithModifiers = default;
-
-        GetStaticVolatileInt(ref fieldsWithModifiers) = default;
-        GetVolatileInt(ref fieldsWithModifiers) = default;
-
         [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name="s_vInt")]
-        extern static ref int GetStaticVolatileInt(ref FieldsWithModifiers f);
+        public extern static ref int GetStaticVolatileInt(ref VolatileFields f);
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_vInt")]
-        extern static ref int GetVolatileInt(ref FieldsWithModifiers f);
+        public extern static ref int GetVolatileInt(ref VolatileFields f);
+    }
+
+    [Fact]
+    public static void Verify_AccessFieldsWithVolatile()
+    {
+        Console.WriteLine($"Running {nameof(Verify_AccessFieldsWithVolatile)}");
+
+        VolatileFields fieldsWithVolatile = default;
+
+        AccessorsVolatile.GetStaticVolatileInt(ref fieldsWithVolatile) = default;
+        AccessorsVolatile.GetVolatileInt(ref fieldsWithVolatile) = default;
+    }
+
+    // Contains fields that are readonly
+    readonly struct ReadOnlyFields
+    {
+        public static readonly int s_rInt;
+        public readonly int _rInt;
+    }
+
+    // Accessors for fields that are readonly
+    static class AccessorsReadOnly
+    {
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name="s_rInt")]
+        public extern static ref readonly int GetStaticReadOnlyInt(ref readonly ReadOnlyFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_rInt")]
+        public extern static ref readonly int GetReadOnlyInt(ref readonly ReadOnlyFields f);
+    }
+
+    [Fact]
+    public static void Verify_AccessFieldsWithReadOnlyRefs()
+    {
+        Console.WriteLine($"Running {nameof(Verify_AccessFieldsWithReadOnlyRefs)}");
+
+        ReadOnlyFields readOnlyFields = default;
+
+        Assert.True(Unsafe.AreSame(in AccessorsReadOnly.GetStaticReadOnlyInt(in readOnlyFields), in ReadOnlyFields.s_rInt));
+        Assert.True(Unsafe.AreSame(in AccessorsReadOnly.GetReadOnlyInt(in readOnlyFields), in readOnlyFields._rInt));
+
+        // Test the local declaration of the signature since it places modopts/modreqs differently.
+        Assert.True(Unsafe.AreSame(in GetStaticReadOnlyIntLocal(in readOnlyFields), in ReadOnlyFields.s_rInt));
+        Assert.True(Unsafe.AreSame(in GetReadOnlyIntLocal(in readOnlyFields), in readOnlyFields._rInt));
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name="s_rInt")]
+        extern static ref readonly int GetStaticReadOnlyIntLocal(ref readonly ReadOnlyFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_rInt")]
+        extern static ref readonly int GetReadOnlyIntLocal(ref readonly ReadOnlyFields f);
     }
 
     [Fact]


### PR DESCRIPTION
Backport of #111648 to release/9.0-staging

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Consume custom modifiers and ByRef in RetType signature prior to comparing field signature. Specifically signatures have contain modopts/modreqs. This is follow-up for https://github.com/dotnet/runtime/pull/109694, which was also a .NET 9 servicing for a regression, but missed a specific scenario involving `readonly` and was testing using a `UnsafeAccessor` declaration that did not properly validate the scenario.

Fixes https://github.com/dotnet/runtime/issues/111647

## Regression

- [x] Yes
- [ ] No

Issue https://github.com/dotnet/runtime/issues/109665 was fixed with https://github.com/dotnet/runtime/pull/109694 and assumed to also address issues with `readonly` and so tests were added with in https://github.com/dotnet/runtime/pull/109944 - these tests do pass.

The issue is best showcased with the following:

```c#
static class Accessors
{
    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "<obj>P")]
    public static extern ref readonly object MEMBER(ref readonly Foo value); 
    
    public static void A()
    {
        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "<obj>P")]
        static extern ref readonly object LOCAL(ref readonly Foo value);
    }
}
```

The `MEMBER` and `LOCAL` are the same definition, but `MEMBER` uses an `modreq` when `LOCAL` doesn't. For testing, the `LOCAL` scenario was used for validation and this created a false sense of correctness in the tests. The result is the modopt/modreq issues can still occur for fields depending on how the `UnsafeAccessor` is defined. This means we need to service .NET 9 again, see https://github.com/dotnet/runtime/pull/109709, and make the correct fix in .NET 10 along with updating the testing so we validate both types of definition.

## Testing

New tests have been added and the existing tests have been updated to cover this scenario.

## Risk

Medium. This is likely "Low" from a regression standpoint, but increases the Risk since this is a second attempt at a fix. There is much more confidence in this fix after uncovering the metadata differences in signature declaration.