### PR TITLE
Fix build with FEATURE_STANDALONE_GC disabled

### DIFF
--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -170,10 +170,7 @@ endif(CLR_CMAKE_HOST_WIN32)
 #----------------------------------
 include(clrdefinitions.cmake)
 
-if(FEATURE_STANDALONE_GC)
-  add_definitions(-DFEATURE_STANDALONE_GC)
-  add_subdirectory(gc)
-endif(FEATURE_STANDALONE_GC)
+add_subdirectory(gc)
 
 if (CLR_CMAKE_HOST_UNIX)
   include_directories("pal/inc")

--- a/src/coreclr/gc/CMakeLists.txt
+++ b/src/coreclr/gc/CMakeLists.txt
@@ -1,12 +1,16 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Local GC meta-issue: https://github.com/dotnet/runtime/issues/8061
+if(FEATURE_STANDALONE_GC)
+  add_definitions(-DFEATURE_STANDALONE_GC)
 
-# https://github.com/dotnet/runtime/issues/8059
-remove_definitions(-DSTRESS_HEAP)
+  # Local GC meta-issue: https://github.com/dotnet/runtime/issues/8061
 
-# https://github.com/dotnet/runtime/issues/8062
-remove_definitions(-DWRITE_BARRIER_CHECK)
+  # https://github.com/dotnet/runtime/issues/8059
+  remove_definitions(-DSTRESS_HEAP)
+
+  # https://github.com/dotnet/runtime/issues/8062
+  remove_definitions(-DWRITE_BARRIER_CHECK)
+endif(FEATURE_STANDALONE_GC)
 
 set(GC_SOURCES
   gceventstatus.cpp
@@ -100,37 +104,39 @@ list(APPEND GC_SOURCES ${GC_HEADERS})
 
 convert_to_absolute_path(GC_SOURCES ${GC_SOURCES})
 
-# clrgcexp is build with standalone+regions
-if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
-  add_library_clr(clrgcexp SHARED ${GC_SOURCES})
-  add_dependencies(clrgcexp eventing_headers)
-  target_link_libraries(clrgcexp PRIVATE ${GC_LINK_LIBRARIES})
-  target_compile_definitions(clrgcexp PRIVATE -DUSE_REGIONS)
-  install_clr(TARGETS clrgcexp DESTINATIONS . COMPONENT runtime)
-endif (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
+if(FEATURE_STANDALONE_GC)
+  # clrgcexp is build with standalone+regions
+  if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
+    add_library_clr(clrgcexp SHARED ${GC_SOURCES})
+    add_dependencies(clrgcexp eventing_headers)
+    target_link_libraries(clrgcexp PRIVATE ${GC_LINK_LIBRARIES})
+    target_compile_definitions(clrgcexp PRIVATE -DUSE_REGIONS)
+    install_clr(TARGETS clrgcexp DESTINATIONS . COMPONENT runtime)
+  endif (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
 
-# clrgc is build with standalone+segments
-add_library_clr(clrgc SHARED ${GC_SOURCES})
-add_dependencies(clrgc eventing_headers)
-target_link_libraries(clrgc PRIVATE ${GC_LINK_LIBRARIES})
-install_clr(TARGETS clrgc DESTINATIONS . COMPONENT runtime)
+  # clrgc is build with standalone+segments
+  add_library_clr(clrgc SHARED ${GC_SOURCES})
+  add_dependencies(clrgc eventing_headers)
+  target_link_libraries(clrgc PRIVATE ${GC_LINK_LIBRARIES})
+  install_clr(TARGETS clrgc DESTINATIONS . COMPONENT runtime)
 
-add_definitions(-DBUILD_AS_STANDALONE)
-add_definitions(-DFEATURE_CONSERVATIVE_GC)
+  add_definitions(-DBUILD_AS_STANDALONE)
+  add_definitions(-DFEATURE_CONSERVATIVE_GC)
 
-add_definitions(-DFX_VER_INTERNALNAME_STR=clrgc.dll)
-add_definitions(-DVERIFY_HEAP)
-if(CLR_CMAKE_HOST_APPLE)
-  # The implementation of GCToOSInterface on Apple platforms makes use of non-POSIX
-  # pthreads APIs, which by default are not included in the pthreads header
-  # unless we define this macro.
-  add_definitions(-D_DARWIN_C_SOURCE)
-endif(CLR_CMAKE_HOST_APPLE)
+  add_definitions(-DFX_VER_INTERNALNAME_STR=clrgc.dll)
+  add_definitions(-DVERIFY_HEAP)
+  if(CLR_CMAKE_HOST_APPLE)
+    # The implementation of GCToOSInterface on Apple platforms makes use of non-POSIX
+    # pthreads APIs, which by default are not included in the pthreads header
+    # unless we define this macro.
+    add_definitions(-D_DARWIN_C_SOURCE)
+  endif(CLR_CMAKE_HOST_APPLE)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/env)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/env)
 
-install_clr(TARGETS clrgc DESTINATIONS . sharedFramework COMPONENT runtime)
-if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
-  install_clr(TARGETS clrgcexp DESTINATIONS . sharedFramework COMPONENT runtime)
-endif (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
+  install_clr(TARGETS clrgc DESTINATIONS . sharedFramework COMPONENT runtime)
+  if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
+    install_clr(TARGETS clrgcexp DESTINATIONS . sharedFramework COMPONENT runtime)
+  endif (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_AMD64)
+endif(FEATURE_STANDALONE_GC)

--- a/src/coreclr/gc/CMakeLists.txt
+++ b/src/coreclr/gc/CMakeLists.txt
@@ -2,13 +2,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 if(FEATURE_STANDALONE_GC)
   add_definitions(-DFEATURE_STANDALONE_GC)
-
-  # Local GC meta-issue: https://github.com/dotnet/runtime/issues/8061
-
-  # https://github.com/dotnet/runtime/issues/8059
   remove_definitions(-DSTRESS_HEAP)
-
-  # https://github.com/dotnet/runtime/issues/8062
   remove_definitions(-DWRITE_BARRIER_CHECK)
 endif(FEATURE_STANDALONE_GC)
 


### PR DESCRIPTION
Currently, the build fails, because the gc_pal is built only when standalone GC is enabled, but it is used for the built-in GC as well.

This change fixes it.