### PR TITLE
Block vectors test on a known issue

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -427,6 +427,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestNativeAot)' == 'true' and '$(RunDisabledNativeAotTests)' != 'true'">
+    <!-- https://github.com/dotnet/runtime/issues/111619 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Vectors\tests\System.Numerics.Vectors.Tests.csproj"
+                       Condition="'$(RuntimeConfiguration)' != 'Release'" />
+
     <!-- https://github.com/dotnet/runtime/issues/108274 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Immutable\tests\System.Collections.Immutable.Tests.csproj" />
 


### PR DESCRIPTION
We're not able to build test tree because RyuJIT asserts.

Cc @dotnet/ilc-contrib 
