### PR TITLE
[release/9.0-staging] Fixed android build with NDK 23

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -818,8 +818,8 @@ JS_ENGINES = [NODE_JS]
     <!-- Linux specific options -->
     <ItemGroup Condition="'$(AotHostOS)' == 'linux'">
       <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib/libclang.so" Condition=" Exists('$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib/libclang.so') "/>
-      <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib64/libclang.so.*" Condition=" '$(_LibClang)' == '' "/>
-      <_LibClang Include="/usr/local/lib/libclang.so" Condition="'$(_LibClang)' == ''" />
+      <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib64/libclang.so.*" Condition=" '@(_LibClang)' == '' "/>
+      <_LibClang Include="/usr/local/lib/libclang.so" Condition="'@(_LibClang)' == ''" />
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetsLinux)' == 'true' and '$(Platform)' == 'arm64'">
       <MonoUseCrossTool>true</MonoUseCrossTool>


### PR DESCRIPTION
## Customer Impact

- [ ] Customer reported
- [x] Found internally

Building locally mono android with NDK 23 leads to an error where `_LibClang` item holds two different paths at once. The problem was caused by `_LibClang`  being treated like a property in `proj` file while being an item. This PR fixes the issue by referring to it using `@` instead of `$`.

Fixes #111695. 

## Regression

- [x] Yes
- [ ] No

The bug was introduced to .NET 9 branch in https://github.com/dotnet/runtime/commit/63cb882afa85ee0160999ab1c0b727e866a29aef to fix .NET 9 CI after NDK 27 bump.

## Testing

This affects the local build only (as we build .NET 9 with NDK 27) so I verified locally that the error is no longer present. 

## Risk

Very low.