### PR TITLE
Use hardlinks for mono crossaot files

### DIFF
--- a/src/mono/monoaotcross.proj
+++ b/src/mono/monoaotcross.proj
@@ -62,7 +62,9 @@
 
     <Message Text="Copying @(_MonoAOTCrossFiles) to $(RealRuntimeBinDir)cross\$(TargetOS)-$(TargetArchitecture.ToLower())\$(MonoAotTargetRid.ToLower())" Importance="High" />
 
-    <Copy SourceFiles="@(_MonoAOTCrossFiles)" DestinationFolder="$(RealRuntimeBinDir)cross\$(TargetOS)-$(TargetArchitecture.ToLower())\$(MonoAotTargetRid.ToLower())">
+    <Copy SourceFiles="@(_MonoAOTCrossFiles)"
+          DestinationFolder="$(RealRuntimeBinDir)cross\$(TargetOS)-$(TargetArchitecture.ToLower())\$(MonoAotTargetRid.ToLower())"
+          UseHardlinksIfPossible="true">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>


### PR DESCRIPTION
We are hitting disk space issues in https://github.com/dotnet/sdk/pull/45932 and I noticed that we could use hard links in this code path. From what I can see this would save a decent amount of size.