### PR TITLE
Fix alternate stack overflow with superpmi

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -581,6 +581,11 @@ Parameters :
          If sp == 0, execute it on the original stack where the signal has occurred.
 Return :
     The return value from the signal handler
+
+Note:
+    This function is marked as noinline to reduce the stack frame space of the caller, the
+    sigsegv_handler. The sigsegv_handler is running on an alternate stack and we want to
+    avoid running out of stack space in case there are multiple PALs in the process.
 --*/
 __attribute__((noinline))
 static bool SwitchStackAndExecuteHandler(int code, siginfo_t *siginfo, void *context, size_t sp)

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -582,6 +582,7 @@ Parameters :
 Return :
     The return value from the signal handler
 --*/
+__attribute__((noinline))
 static bool SwitchStackAndExecuteHandler(int code, siginfo_t *siginfo, void *context, size_t sp)
 {
     // Establish a return point in case the common_signal_handler returns


### PR DESCRIPTION
The superpmi-shim-collector shared library registers sigsegv handler so that it can flush out the logged data in case the JIT crashes due to some null reference. The sigsegv handler of the superpmi then calls the previous handler, which is the one of coreclr. Both of these handlers run on the alternate stack. Each sigsegv handler has stack frame of about 0xd70 bytes mostly due to the `SignalHandlerWorkerReturnPoint` structure that contains `CONTEXT` structure.
The alternate stack size that we allocate is then on the tipping point of not being sufficient and some variation on how much of the alternate stack is used by the unix kernel causes it to tip over in some cases. This started to happen on x64 Linux after we've added the APX registers to the context.

The problem actually happens due to the `SwitchStackAndExecuteHandler` being inlined into the `sigsegv_handler`. That moves the large `SignalHandlerWorkerReturnPoint` structure to the frame of the `sigsegv_handler`.

This change fixes the problem by marking the
`SwitchStackAndExecuteHandler` as noinline. That makes the `sigsegv_handler` frame significantly smaller.

Close #111707