### PR TITLE
Handle unicode in absolute URI path for combine.

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -1062,7 +1062,7 @@ namespace System
             }
             else
             {
-                Debug.Assert(!InFact(Flags.HasUnicode));
+                Debug.Assert(!InFact(Flags.HasUnicode) || otherUri.IsNotAbsoluteUri);
                 // Clone the other URI but develop own UriInfo member
                 // We cannot just reference otherUri._info as this UriInfo will be mutated later
                 // which could be happening concurrently and in a not thread safe manner.

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -1053,30 +1053,41 @@ namespace System
         {
             DebugAssertInCtor();
 
-            // Clone the other URI but develop own UriInfo member
-            _info = null!;
-
             _flags = otherUri._flags;
-            if (InFact(Flags.MinimalUriInfoSet))
+
+            if (InFact(Flags.AllUriInfoSet))
             {
-                _flags &= ~(Flags.MinimalUriInfoSet | Flags.AllUriInfoSet | Flags.IndexMask);
-                // Port / Path offset
-                int portIndex = otherUri._info.Offset.Path;
-                if (InFact(Flags.NotDefaultPort))
+                // We can share it now without mutation concern, for since AllUriInfoSet it is immutable.
+                _info = otherUri._info;
+            }
+            else
+            {
+                // Clone the other URI but develop own UriInfo member
+                // We cannot just reference otherUri._info as this UriInfo will be mutated later
+                // which could be happening concurrently and in a not thread safe manner.
+                _info = null!;
+
+                if (InFact(Flags.MinimalUriInfoSet))
                 {
-                    // Find the start of the port.  Account for non-canonical ports like :00123
-                    while (otherUri._string[portIndex] != ':' && portIndex > otherUri._info.Offset.Host)
+                    _flags &= ~(Flags.MinimalUriInfoSet | Flags.AllUriInfoSet | Flags.IndexMask);
+                    // Port / Path offset
+                    int portIndex = otherUri._info.Offset.Path;
+                    if (InFact(Flags.NotDefaultPort))
                     {
-                        portIndex--;
+                        // Find the start of the port.  Account for non-canonical ports like :00123
+                        while (otherUri._string[portIndex] != ':' && portIndex > otherUri._info.Offset.Host)
+                        {
+                            portIndex--;
+                        }
+                        if (otherUri._string[portIndex] != ':')
+                        {
+                            // Something wrong with the NotDefaultPort flag.  Reset to path index
+                            Debug.Fail("Uri failed to locate custom port at index: " + portIndex);
+                            portIndex = otherUri._info.Offset.Path;
+                        }
                     }
-                    if (otherUri._string[portIndex] != ':')
-                    {
-                        // Something wrong with the NotDefaultPort flag.  Reset to path index
-                        Debug.Fail("Uri failed to locate custom port at index: " + portIndex);
-                        portIndex = otherUri._info.Offset.Path;
-                    }
+                    _flags |= (Flags)portIndex; // Port or path
                 }
-                _flags |= (Flags)portIndex; // Port or path
             }
 
             _syntax = otherUri._syntax;

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -1062,6 +1062,7 @@ namespace System
             }
             else
             {
+                Debug.Assert(!InFact(Flags.HasUnicode));
                 // Clone the other URI but develop own UriInfo member
                 // We cannot just reference otherUri._info as this UriInfo will be mutated later
                 // which could be happening concurrently and in a not thread safe manner.

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -730,38 +731,22 @@ namespace System.PrivateUri.Tests
         }
 
         [Theory]
-        [InlineData("http://bar/Testue/testImage.jpg")]
+        [InlineData("http://bar/Testue/testImage.jpg", "http://bar/Testue/testImage.jpg", "http://bar/Testue/testImage.jpg", "bar")]
+        [InlineData(@"\\nas\Testue\testImage.jpg", @"file://nas/Testue/testImage.jpg", @"file://nas/Testue/testImage.jpg", "nas")]
         // Tests that internal Uri info were properly applied during a Combine operation when URI contains non-ascii character.
-        [InlineData("http://bar/Testü/testImage.jpg")]
-        public static void Uri_CombineWithAbsoluteHttpUriResultInAbsoluteHttpSchema(string fileUri)
+        [InlineData("http://bar/Testü/testImage.jpg", "http://bar/Testü/testImage.jpg", "http://bar/Test%C3%BC/testImage.jpg", "bar")]
+        [InlineData(@"\\nas\Testü\testImage.jpg", @"file://nas/Testü/testImage.jpg", @"file://nas/Test%C3%BC/testImage.jpg", "nas")]
+        public static void Uri_CombineWithAbsoluteUriResultInAbsoluteSchemaIgnoringOriginalBase(string relativeUri, string expectedUri, string expectedAbsoluteUri, string expectedHost)
         {
             string baseUriString = "combine-scheme://foo";
 
             var baseUri = new Uri(baseUriString, UriKind.Absolute);
-            var uri = new Uri(fileUri);
+            var uri = new Uri(relativeUri);
             var resultUri = new Uri(baseUri, uri);
-            string resultUriString = resultUri.ToString();
 
-            Assert.DoesNotContain(baseUriString, resultUriString);
-            Assert.Contains("http://", resultUriString);
-            Assert.Equal(fileUri, resultUriString);
-        }
-
-        [Theory]
-        [InlineData(@"\\nas\Testue\testImage.jpg")]
-        // Tests that internal Uri info were properly applied during a Combine operation when URI contains non-ascii character.
-        [InlineData(@"\\nas\Testü\testImage.jpg")]
-        public static void Uri_CombineWithAbsoluteFilePathResultInAbsoluteFileSchema(string fileUri)
-        {
-            string baseUriString = "combine-scheme://foo";
-
-            var baseUri = new Uri(baseUriString, UriKind.Absolute);
-            var uri = new Uri(fileUri);
-            var resultUri = new Uri(baseUri, uri);
-            string resultUriString = resultUri.ToString();
-
-            Assert.DoesNotContain(baseUriString, resultUriString);
-            Assert.Contains("file://", resultUriString);
+            Assert.Equal(expectedUri, resultUri.ToString());
+            Assert.Equal(expectedAbsoluteUri, resultUri.AbsoluteUri);
+            Assert.Equal(expectedHost, resultUri.Host);
         }
 
         [Fact]

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -732,10 +732,10 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [InlineData("http://bar/Testue/testImage.jpg", "http://bar/Testue/testImage.jpg", "http://bar/Testue/testImage.jpg", "bar")]
-        [InlineData(@"\\nas\Testue\testImage.jpg", @"file://nas/Testue/testImage.jpg", @"file://nas/Testue/testImage.jpg", "nas")]
+        [InlineData(@"\\nas\Testue\testImage.jpg", "file://nas/Testue/testImage.jpg", "file://nas/Testue/testImage.jpg", "nas")]
         // Tests that internal Uri info were properly applied during a Combine operation when URI contains non-ascii character.
-        [InlineData("http://bar/Testü/testImage.jpg", "http://bar/Testü/testImage.jpg", "http://bar/Test%C3%BC/testImage.jpg", "bar")]
-        [InlineData(@"\\nas\Testü\testImage.jpg", @"file://nas/Testü/testImage.jpg", @"file://nas/Test%C3%BC/testImage.jpg", "nas")]
+        [InlineData("http://bar/Test\u00fc/testImage.jpg", "http://bar/Test\u00fc/testImage.jpg", "http://bar/Test%C3%BC/testImage.jpg", "bar")]
+        [InlineData("\\\\nas\\Test\u00fc\\testImage.jpg", "file://nas/Test\u00fc/testImage.jpg", "file://nas/Test%C3%BC/testImage.jpg", "nas")]
         public static void Uri_CombineWithAbsoluteUriResultInAbsoluteSchemaIgnoringOriginalBase(string relativeUri, string expectedUri, string expectedAbsoluteUri, string expectedHost)
         {
             string baseUriString = "combine-scheme://foo";

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -729,6 +729,41 @@ namespace System.PrivateUri.Tests
             Assert.Equal(Combined, new Uri(baseUri, RelativeUriString).AbsoluteUri);
         }
 
+        [Theory]
+        [InlineData("http://bar/Testue/testImage.jpg")]
+        // Tests that internal Uri info were properly applied during a Combine operation when URI contains non-ascii character.
+        [InlineData("http://bar/Testü/testImage.jpg")]
+        public static void Uri_CombineWithAbsoluteHttpUriResultInAbsoluteHttpSchema(string fileUri)
+        {
+            string baseUriString = "combine-scheme://foo";
+
+            var baseUri = new Uri(baseUriString, UriKind.Absolute);
+            var uri = new Uri(fileUri);
+            var resultUri = new Uri(baseUri, uri);
+            string resultUriString = resultUri.ToString();
+
+            Assert.DoesNotContain(baseUriString, resultUriString);
+            Assert.Contains("http://", resultUriString);
+            Assert.Equal(fileUri, resultUriString);
+        }
+
+        [Theory]
+        [InlineData(@"\\nas\Testue\testImage.jpg")]
+        // Tests that internal Uri info were properly applied during a Combine operation when URI contains non-ascii character.
+        [InlineData(@"\\nas\Testü\testImage.jpg")]
+        public static void Uri_CombineWithAbsoluteFilePathResultInAbsoluteFileSchema(string fileUri)
+        {
+            string baseUriString = "combine-scheme://foo";
+
+            var baseUri = new Uri(baseUriString, UriKind.Absolute);
+            var uri = new Uri(fileUri);
+            var resultUri = new Uri(baseUri, uri);
+            string resultUriString = resultUri.ToString();
+
+            Assert.DoesNotContain(baseUriString, resultUriString);
+            Assert.Contains("file://", resultUriString);
+        }
+
         [Fact]
         public static void Uri_CachesIdnHost()
         {


### PR DESCRIPTION
Fixes: #111355

Changes Made:
Copy full UriInfo when flags indicate it has been fully initialized, so we can consider it immutable and freely reuse it without thread safety concerns.

Testing:
Added unit tests which failed before and passing now.

Notes:
Huge credit to: @MihaZupan


