### PR TITLE
Use Build.Ubuntu.2204.Amd64.Open for HttpStress

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -38,7 +38,7 @@ extends:
           DUMPS_SHARE: "$(Build.ArtifactStagingDirectory)/dumps/"
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-1804-open
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
         steps:
         - checkout: self


### PR DESCRIPTION
An attempt to fix #111660. No other pipeline is using `1es-ubuntu-1804-open`, it seems reasonable to update if we can.