### PR TITLE
Use hardlinks when copying LLVM into the tree

### DIFF
--- a/src/mono/llvm/llvm-init.proj
+++ b/src/mono/llvm/llvm-init.proj
@@ -92,7 +92,11 @@
       <LLVMFiles Include="$(_LocalLLVMArtifacts)\obj\InstallRoot-$(BuildArchitecture)\**"
                  FileArch="%(PackageReference.PackageArch)"  Condition="'$(_LocalLLVMArtifacts)' != ''" />
     </ItemGroup>
-    <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(LLVMFiles.FileArch)\%(RecursiveDir)" UseHardlinksIfPossible="true">
+    <PropertyGroup>
+      <_CopyLLVMWithHardlinks>false</_CopyLLVMWithHardlinks>
+      <_CopyLLVMWithHardlinks Condition="'$(_LocalLLVMArtifacts)' == ''">true</_CopyLLVMWithHardlinks>
+    </PropertyGroup>
+    <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(LLVMFiles.FileArch)\%(RecursiveDir)" UseHardlinksIfPossible="$(_CopyLLVMWithHardlinks)">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>

--- a/src/mono/llvm/llvm-init.proj
+++ b/src/mono/llvm/llvm-init.proj
@@ -92,7 +92,7 @@
       <LLVMFiles Include="$(_LocalLLVMArtifacts)\obj\InstallRoot-$(BuildArchitecture)\**"
                  FileArch="%(PackageReference.PackageArch)"  Condition="'$(_LocalLLVMArtifacts)' != ''" />
     </ItemGroup>
-    <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(LLVMFiles.FileArch)\%(RecursiveDir)">
+    <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(LLVMFiles.FileArch)\%(RecursiveDir)" UseHardlinksIfPossible="true">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>


### PR DESCRIPTION
LLVM is quite large, so we should use hardlinks when copying the files into the tree