### PR TITLE
Fix DateTime.Parse with AssumeUniversal style option

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3792,7 +3792,7 @@ namespace System
 
         private static DateTime GetDateTimeNow(scoped ref DateTimeResult result, scoped ref DateTimeStyles styles)
         {
-            if ((result.flags & ParseFlags.CaptureOffset) != 0 && (result.flags & ParseFlags.TimeZoneUsed) != 0)
+            if ((result.flags & (ParseFlags.CaptureOffset | ParseFlags.TimeZoneUsed)) == (ParseFlags.CaptureOffset | ParseFlags.TimeZoneUsed))
             {
                 // use the supplied offset to calculate 'Now'
                 return new DateTime(DateTime.UtcNow.Ticks + result.timeZoneOffset.Ticks, DateTimeKind.Unspecified);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3792,22 +3792,13 @@ namespace System
 
         private static DateTime GetDateTimeNow(scoped ref DateTimeResult result, scoped ref DateTimeStyles styles)
         {
-            if ((result.flags & ParseFlags.CaptureOffset) != 0)
+            if ((result.flags & ParseFlags.CaptureOffset) != 0 && (result.flags & ParseFlags.TimeZoneUsed) != 0)
             {
-                if ((result.flags & ParseFlags.TimeZoneUsed) != 0)
-                {
-                    // use the supplied offset to calculate 'Now'
-                    return new DateTime(DateTime.UtcNow.Ticks + result.timeZoneOffset.Ticks, DateTimeKind.Unspecified);
-                }
-                else if ((styles & DateTimeStyles.AssumeUniversal) != 0)
-                {
-                    // assume the offset is Utc
-                    return DateTime.UtcNow;
-                }
+                // use the supplied offset to calculate 'Now'
+                return new DateTime(DateTime.UtcNow.Ticks + result.timeZoneOffset.Ticks, DateTimeKind.Unspecified);
             }
 
-            // assume the offset is Local
-            return DateTime.Now;
+            return (styles & DateTimeStyles.AssumeUniversal) != 0 ? DateTime.UtcNow : DateTime.Now;
         }
 
         private static bool CheckDefaultDateTime(scoped ref DateTimeResult result, scoped ref Calendar cal, DateTimeStyles styles)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
@@ -2688,6 +2688,17 @@ namespace System.Tests
         }
 
         [Fact]
+        public void TestParseTimeOnlyStringWithAssumeUtcOption()
+        {
+            DateTime utcNow1 = DateTime.UtcNow;
+            DateTime dt = DateTime.Parse("13:30", null, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            DateTime utcNow2 = DateTime.UtcNow;
+
+            // Ensure the parsed date part is in UTC.
+            Assert.True(utcNow1.Date <= dt.Date && dt.Date <= utcNow2.Date);
+        }
+
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void TestTimeSynchronizationWithTheSystem()
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
@@ -2695,7 +2695,7 @@ namespace System.Tests
             DateTime utcNow2 = DateTime.UtcNow;
 
             // Ensure the parsed date part is in UTC.
-            Assert.True(utcNow1.Date <= dt.Date && dt.Date <= utcNow2.Date);
+            Assert.InRange(dt.Date, utcNow1.Date, utcNow2.Date);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/111689