### PR TITLE
Replace OPTIMIZE_FOR_SIZE with feature switch

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -25,6 +25,7 @@ using ILLink.Shared;
 
 using Debug = System.Diagnostics.Debug;
 using InstructionSet = Internal.JitInterface.InstructionSet;
+using System.Linq;
 
 namespace ILCompiler
 {
@@ -248,7 +249,7 @@ namespace ILCompiler
                 const string settingsBlobName = "g_compilerEmbeddedSettingsBlob";
                 const string knobsBlobName = "g_compilerEmbeddedKnobsBlob";
                 string[] runtimeOptions = Get(_command.RuntimeOptions);
-                string[] runtimeKnobs = Get(_command.RuntimeKnobs);
+                string[] runtimeKnobs = Get(_command.RuntimeKnobs).Concat(["System.Linq.Enumerable.IsSizeOptimized=true"]).ToArray();
                 if (nativeLib)
                 {
                     // Set owning module of generated native library startup method to compiler generated module,

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -25,7 +25,6 @@ using ILLink.Shared;
 
 using Debug = System.Diagnostics.Debug;
 using InstructionSet = Internal.JitInterface.InstructionSet;
-using System.Linq;
 
 namespace ILCompiler
 {
@@ -249,7 +248,7 @@ namespace ILCompiler
                 const string settingsBlobName = "g_compilerEmbeddedSettingsBlob";
                 const string knobsBlobName = "g_compilerEmbeddedKnobsBlob";
                 string[] runtimeOptions = Get(_command.RuntimeOptions);
-                string[] runtimeKnobs = Get(_command.RuntimeKnobs).Concat(["System.Linq.Enumerable.IsSizeOptimized=true"]).ToArray();
+                string[] runtimeKnobs = Get(_command.RuntimeKnobs);
                 if (nativeLib)
                 {
                     // Set owning module of generated native library startup method to compiler generated module,

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -373,6 +373,7 @@ namespace ILCompiler
                     throw new CommandLineException($"Unexpected feature switch pair '{switchPair}'");
                 featureSwitches[switchAndValue[0]] = switchValue;
             }
+            featureSwitches["System.Linq.Enumerable.IsSizeOptimized"] = true;
 
             BodyAndFieldSubstitutions substitutions = default;
             IReadOnlyDictionary<ModuleDesc, IReadOnlySet<string>> resourceBlocks = default;

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -373,7 +373,6 @@ namespace ILCompiler
                     throw new CommandLineException($"Unexpected feature switch pair '{switchPair}'");
                 featureSwitches[switchAndValue[0]] = switchValue;
             }
-            featureSwitches["System.Linq.Enumerable.IsSizeOptimized"] = true;
 
             BodyAndFieldSubstitutions substitutions = default;
             IReadOnlyDictionary<ModuleDesc, IReadOnlySet<string>> resourceBlocks = default;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -143,7 +143,12 @@ namespace System
         public static bool IsStartingProcessesSupported => !IsiOS && !IstvOS;
 
         public static bool IsSpeedOptimized => !IsSizeOptimized;
-        public static bool IsSizeOptimized => IsBrowser || IsWasi || IsAndroid || IsAppleMobile;
+        public static bool IsSizeOptimized => s_linqIsSizeOptimized.Value;
+        private static readonly Lazy<bool> s_linqIsSizeOptimized = new Lazy<bool>(IsLinqSizeOptimized);
+        private static bool IsLinqSizeOptimized()
+        {
+            return (bool)typeof(Enumerable).GetMethod("get_IsSizeOptimized", BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, Array.Empty<object>());
+        }
 
         public static bool IsBrowserDomSupported => IsEnvironmentVariableTrue("IsBrowserDomSupported");
         public static bool IsBrowserDomSupportedOrNotBrowser => IsNotBrowser || IsBrowserDomSupported;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -144,8 +144,8 @@ namespace System
 
         public static bool IsLinqSpeedOptimized => !IsLinqSizeOptimized;
         public static bool IsLinqSizeOptimized => s_linqIsSizeOptimized.Value;
-        private static readonly Lazy<bool> s_linqIsSizeOptimized = new Lazy<bool>(IsLinqSizeOptimized);
-        private static bool IsLinqSizeOptimized()
+        private static readonly Lazy<bool> s_linqIsSizeOptimized = new Lazy<bool>(ComputeIsLinqSizeOptimized);
+        private static bool ComputeIsLinqSizeOptimized()
         {
 #if NET
             return (bool)typeof(Enumerable).GetMethod("get_IsSizeOptimized", BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, Array.Empty<object>());

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -142,12 +142,16 @@ namespace System
 
         public static bool IsStartingProcessesSupported => !IsiOS && !IstvOS;
 
-        public static bool IsSpeedOptimized => !IsSizeOptimized;
-        public static bool IsSizeOptimized => s_linqIsSizeOptimized.Value;
+        public static bool IsLinqSpeedOptimized => !IsLinqSizeOptimized;
+        public static bool IsLinqSizeOptimized => s_linqIsSizeOptimized.Value;
         private static readonly Lazy<bool> s_linqIsSizeOptimized = new Lazy<bool>(IsLinqSizeOptimized);
         private static bool IsLinqSizeOptimized()
         {
+#if NET
             return (bool)typeof(Enumerable).GetMethod("get_IsSizeOptimized", BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, Array.Empty<object>());
+#else
+            return false;
+#endif
         }
 
         public static bool IsBrowserDomSupported => IsEnvironmentVariableTrue("IsBrowserDomSupported");

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
@@ -9,7 +9,7 @@ namespace System.IO.Compression.Tests;
 [Collection(nameof(DisableParallelization))]
 public class zip_LargeFiles : ZipFileTestBase
 {
-    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
     [OuterLoop("It requires almost 12 GB of free disk space")]
     public static void UnzipOver4GBZipFile()
     {
@@ -49,7 +49,7 @@ public class zip_LargeFiles : ZipFileTestBase
         Random.Shared.NextBytes(buffer);
     }
 
-    [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
+    [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
     [OuterLoop("It requires 5~6 GB of free disk space and a lot of CPU time for compressed tests")]
     [InlineData(false)]
     [InlineData(true)]

--- a/src/libraries/System.IO.Packaging/tests/LargeFilesTests.Net.cs
+++ b/src/libraries/System.IO.Packaging/tests/LargeFilesTests.Net.cs
@@ -15,7 +15,7 @@ public partial class LargeFilesTests
         Random.Shared.NextBytes(buffer);
     }
 
-    [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
+    [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
     [InlineData(false)]
     [InlineData(true)]
     [OuterLoop("It requires 5~6 GB of free disk space and a lot of CPU time for compressed tests")]

--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -6,86 +6,80 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="System\Linq\Skip.SizeOpt.cs" />
-    <Compile Include="System\Linq\Take.SizeOpt.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="System\Linq\AppendPrepend.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Cast.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Concat.SpeedOpt.cs" />
-    <Compile Include="System\Linq\DefaultIfEmpty.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Distinct.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Grouping.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Iterator.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Lookup.SpeedOpt.cs" />
-    <Compile Include="System\Linq\OfType.SpeedOpt.cs" />
-    <Compile Include="System\Linq\OrderedEnumerable.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Range.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Repeat.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Reverse.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Select.SpeedOpt.cs" />
-    <Compile Include="System\Linq\SelectMany.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Skip.SpeedOpt.cs" />
-    <Compile Include="System\Linq\SkipTake.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Take.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Union.SpeedOpt.cs" />
-    <Compile Include="System\Linq\Where.SpeedOpt.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="System\Linq\Aggregate.cs" />
     <Compile Include="System\Linq\AnyAll.cs" />
     <Compile Include="System\Linq\AppendPrepend.cs" />
+    <Compile Include="System\Linq\AppendPrepend.SpeedOpt.cs" />
     <Compile Include="System\Linq\Average.cs" />
     <Compile Include="System\Linq\Cast.cs" />
+    <Compile Include="System\Linq\Cast.SpeedOpt.cs" />
     <Compile Include="System\Linq\Chunk.cs" />
     <Compile Include="System\Linq\Concat.cs" />
+    <Compile Include="System\Linq\Concat.SpeedOpt.cs" />
     <Compile Include="System\Linq\Contains.cs" />
     <Compile Include="System\Linq\AggregateBy.cs" />
     <Compile Include="System\Linq\CountBy.cs" />
     <Compile Include="System\Linq\Count.cs" />
     <Compile Include="System\Linq\DebugView.cs" />
     <Compile Include="System\Linq\DefaultIfEmpty.cs" />
+    <Compile Include="System\Linq\DefaultIfEmpty.SpeedOpt.cs" />
     <Compile Include="System\Linq\Distinct.cs" />
+    <Compile Include="System\Linq\Distinct.SpeedOpt.cs" />
     <Compile Include="System\Linq\ElementAt.cs" />
     <Compile Include="System\Linq\Enumerable.cs" />
     <Compile Include="System\Linq\Except.cs" />
     <Compile Include="System\Linq\First.cs" />
     <Compile Include="System\Linq\Grouping.cs" />
+    <Compile Include="System\Linq\Grouping.SpeedOpt.cs" />
     <Compile Include="System\Linq\GroupJoin.cs" />
     <Compile Include="System\Linq\Index.cs" />
     <Compile Include="System\Linq\Intersect.cs" />
     <Compile Include="System\Linq\Iterator.cs" />
+    <Compile Include="System\Linq\Iterator.SpeedOpt.cs" />
     <Compile Include="System\Linq\Join.cs" />
     <Compile Include="System\Linq\Last.cs" />
     <Compile Include="System\Linq\LeftJoin.cs" />
     <Compile Include="System\Linq\Lookup.cs" />
+    <Compile Include="System\Linq\Lookup.SpeedOpt.cs" />
     <Compile Include="System\Linq\Max.cs" />
     <Compile Include="System\Linq\MaxMin.cs" />
     <Compile Include="System\Linq\Min.cs" />
     <Compile Include="System\Linq\OfType.cs" />
+    <Compile Include="System\Linq\OfType.SpeedOpt.cs" />
     <Compile Include="System\Linq\OrderBy.cs" />
     <Compile Include="System\Linq\OrderedEnumerable.cs" />
+    <Compile Include="System\Linq\OrderedEnumerable.SpeedOpt.cs" />
     <Compile Include="System\Linq\PartialArrayEnumerator.cs" />
     <Compile Include="System\Linq\Range.cs" />
+    <Compile Include="System\Linq\Range.SpeedOpt.cs" />
     <Compile Include="System\Linq\Repeat.cs" />
+    <Compile Include="System\Linq\Repeat.SpeedOpt.cs" />
     <Compile Include="System\Linq\Reverse.cs" />
+    <Compile Include="System\Linq\Reverse.SpeedOpt.cs" />
     <Compile Include="System\Linq\RightJoin.cs" />
     <Compile Include="System\Linq\SegmentedArrayBuilder.cs" />
     <Compile Include="System\Linq\Select.cs" />
+    <Compile Include="System\Linq\Select.SpeedOpt.cs" />
     <Compile Include="System\Linq\SelectMany.cs" />
+    <Compile Include="System\Linq\SelectMany.SpeedOpt.cs" />
     <Compile Include="System\Linq\SequenceEqual.cs" />
     <Compile Include="System\Linq\Single.cs" />
     <Compile Include="System\Linq\SingleLinkedNode.cs" />
     <Compile Include="System\Linq\Skip.cs" />
+    <Compile Include="System\Linq\Skip.SizeOpt.cs" />
+    <Compile Include="System\Linq\Skip.SpeedOpt.cs" />
+    <Compile Include="System\Linq\SkipTake.SpeedOpt.cs" />
     <Compile Include="System\Linq\Sum.cs" />
     <Compile Include="System\Linq\Take.cs" />
+    <Compile Include="System\Linq\Take.SizeOpt.cs" />
+    <Compile Include="System\Linq\Take.SpeedOpt.cs" />
     <Compile Include="System\Linq\ThrowHelper.cs" />
     <Compile Include="System\Linq\ToCollection.cs" />
     <Compile Include="System\Linq\Union.cs" />
+    <Compile Include="System\Linq\Union.SpeedOpt.cs" />
     <Compile Include="System\Linq\Utilities.cs" />
     <Compile Include="System\Linq\Where.cs" />
+    <Compile Include="System\Linq\Where.SpeedOpt.cs" />
     <Compile Include="System\Linq\Zip.cs" />
   </ItemGroup>
 

--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -1,23 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos</TargetFrameworks>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
-  <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
-  <PropertyGroup>
-    <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <OptimizeForSize Condition="'$(TargetPlatformIdentifier)' == 'browser' or '$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos'">true</OptimizeForSize>
-    <DefineConstants Condition="'$(OptimizeForSize)' == 'true'">$(DefineConstants);OPTIMIZE_FOR_SIZE</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(OptimizeForSize)' == true">
+  <ItemGroup>
     <Compile Include="System\Linq\Skip.SizeOpt.cs" />
     <Compile Include="System\Linq\Take.SizeOpt.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OptimizeForSize)' != true">
+  <ItemGroup>
     <Compile Include="System\Linq\AppendPrepend.SpeedOpt.cs" />
     <Compile Include="System\Linq\Cast.SpeedOpt.cs" />
     <Compile Include="System\Linq\Concat.SpeedOpt.cs" />

--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -20,8 +20,7 @@ namespace System.Linq
                 return gc.Count != 0;
             }
 
-#if !OPTIMIZE_FOR_SIZE
-            if (source is Iterator<TSource> iterator)
+            if (!IsSizeOptimized && source is Iterator<TSource> iterator)
             {
                 int count = iterator.GetCount(onlyIfCheap: true);
                 if (count >= 0)
@@ -32,7 +31,6 @@ namespace System.Linq
                 iterator.TryGetFirst(out bool found);
                 return found;
             }
-#endif
 
             if (source is ICollection ngc)
             {

--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -20,12 +20,10 @@ namespace System.Linq
                 return collectionoft.Count;
             }
 
-#if !OPTIMIZE_FOR_SIZE
-            if (source is Iterator<TSource> iterator)
+            if (!IsSizeOptimized && source is Iterator<TSource> iterator)
             {
                 return iterator.GetCount(onlyIfCheap: false);
             }
-#endif
 
             if (source is ICollection collection)
             {
@@ -115,8 +113,7 @@ namespace System.Linq
                 return true;
             }
 
-#if !OPTIMIZE_FOR_SIZE
-            if (source is Iterator<TSource> iterator)
+            if (!IsSizeOptimized && source is Iterator<TSource> iterator)
             {
                 int c = iterator.GetCount(onlyIfCheap: true);
                 if (c >= 0)
@@ -125,7 +122,6 @@ namespace System.Linq
                     return true;
                 }
             }
-#endif
 
             if (source is ICollection collection)
             {

--- a/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
@@ -23,9 +23,7 @@ namespace System.Linq
 
             bool found;
             TSource? element =
-#if !OPTIMIZE_FOR_SIZE
-                source is Iterator<TSource> iterator ? iterator.TryGetElementAt(index, out found) :
-#endif
+                !IsSizeOptimized && source is Iterator<TSource> iterator ? iterator.TryGetElementAt(index, out found) :
                 TryGetElementAtNonIterator(source, index, out found);
 
             if (!found)
@@ -123,9 +121,7 @@ namespace System.Linq
             }
 
             return
-#if !OPTIMIZE_FOR_SIZE
-                source is Iterator<TSource> iterator ? iterator.TryGetElementAt(index, out found) :
-#endif
+                !IsSizeOptimized && source is Iterator<TSource> iterator ? iterator.TryGetElementAt(index, out found) :
                 TryGetElementAtNonIterator(source, index, out found);
         }
 

--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -9,6 +10,9 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
+        [FeatureSwitchDefinition("System.Linq.Enumerable.IsSizeOptimized")]
+        internal static bool IsSizeOptimized { get; } = AppContext.TryGetSwitch("System.Linq.Enumerable.IsSizeOptimized", out bool isEnabled) ? isEnabled : false;
+
         public static IEnumerable<TSource> AsEnumerable<TSource>(this IEnumerable<TSource> source) => source;
 
         /// <summary>Returns an empty <see cref="IEnumerable{TResult}"/>.</summary>

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -70,9 +70,7 @@ namespace System.Linq
             }
 
             return
-#if !OPTIMIZE_FOR_SIZE
-                source is Iterator<TSource> iterator ? iterator.TryGetFirst(out found) :
-#endif
+                !IsSizeOptimized && source is Iterator<TSource> iterator ? iterator.TryGetFirst(out found) :
                 TryGetFirstNonIterator(source, out found);
         }
 

--- a/src/libraries/System.Linq/src/System/Linq/Iterator.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Iterator.cs
@@ -88,11 +88,9 @@ namespace System.Linq
             /// <typeparam name="TResult">The type of the mapped items.</typeparam>
             /// <param name="selector">The selector used to map each item.</param>
             public virtual IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
-#if OPTIMIZE_FOR_SIZE
-                new IEnumerableSelectIterator<TSource, TResult>(this, selector);
-#else
-                new IteratorSelectIterator<TSource, TResult>(this, selector);
-#endif
+                !IsSizeOptimized
+                ? new IteratorSelectIterator<TSource, TResult>(this, selector)
+                : new IEnumerableSelectIterator<TSource, TResult>(this, selector);
 
 
             /// <summary>

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -69,9 +69,7 @@ namespace System.Linq
             }
 
             return
-#if !OPTIMIZE_FOR_SIZE
-                source is Iterator<TSource> iterator ? iterator.TryGetLast(out found) :
-#endif
+                !IsSizeOptimized && source is Iterator<TSource> iterator ? iterator.TryGetLast(out found) :
                 TryGetLastNonIterator(source, out found);
         }
 

--- a/src/libraries/System.Linq/src/System/Linq/Skip.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.SizeOpt.cs
@@ -7,7 +7,7 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
-        private static IEnumerable<TSource> SkipIterator<TSource>(IEnumerable<TSource> source, int count)
+        private static IEnumerable<TSource> SizeOptimizedSkipIterator<TSource>(IEnumerable<TSource> source, int count)
         {
             using IEnumerator<TSource> e = source.GetEnumerator();
             while (count > 0 && e.MoveNext()) count--;

--- a/src/libraries/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
@@ -7,7 +7,7 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
-        private static IEnumerable<TSource> SkipIterator<TSource>(IEnumerable<TSource> source, int count) =>
+        private static IEnumerable<TSource> SpeedOptimizedSkipIterator<TSource>(IEnumerable<TSource> source, int count) =>
             source is IList<TSource> sourceList ?
                 (IEnumerable<TSource>)new IListSkipTakeIterator<TSource>(sourceList, count, int.MaxValue) :
                 new IEnumerableSkipTakeIterator<TSource>(source, count, -1);

--- a/src/libraries/System.Linq/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.cs
@@ -30,14 +30,12 @@ namespace System.Linq
 
                 count = 0;
             }
-#if !OPTIMIZE_FOR_SIZE
-            else if (source is Iterator<TSource> iterator)
+            else if (!IsSizeOptimized && source is Iterator<TSource> iterator)
             {
                 return iterator.Skip(count) ?? Empty<TSource>();
             }
-#endif
 
-            return SkipIterator(source, count);
+            return IsSizeOptimized ? SizeOptimizedSkipIterator(source, count) : SpeedOptimizedSkipIterator(source, count);
         }
 
         public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)

--- a/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
@@ -8,7 +8,7 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
-        private static IEnumerable<TSource> TakeIterator<TSource>(IEnumerable<TSource> source, int count)
+        private static IEnumerable<TSource> SizeOptimizedTakeIterator<TSource>(IEnumerable<TSource> source, int count)
         {
             Debug.Assert(count > 0);
 
@@ -19,7 +19,7 @@ namespace System.Linq
             }
         }
 
-        private static IEnumerable<TSource> TakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
+        private static IEnumerable<TSource> SizeOptimizedTakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
         {
             Debug.Assert(source is not null);
             Debug.Assert(startIndex >= 0 && startIndex < endIndex);

--- a/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
@@ -8,7 +8,7 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
-        private static IEnumerable<TSource> TakeIterator<TSource>(IEnumerable<TSource> source, int count)
+        private static IEnumerable<TSource> SpeedOptimizedTakeIterator<TSource>(IEnumerable<TSource> source, int count)
         {
             Debug.Assert(source is not null && !IsEmptyArray(source));
             Debug.Assert(count > 0);
@@ -19,7 +19,7 @@ namespace System.Linq
                 new IEnumerableSkipTakeIterator<TSource>(source, 0, count - 1);
         }
 
-        private static IEnumerable<TSource> TakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
+        private static IEnumerable<TSource> SpeedOptimizedTakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
         {
             Debug.Assert(source is not null && !IsEmptyArray(source));
             Debug.Assert(startIndex >= 0 && startIndex < endIndex);

--- a/src/libraries/System.Linq/src/System/Linq/ToCollection.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ToCollection.cs
@@ -11,12 +11,10 @@ namespace System.Linq
     {
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source)
         {
-#if !OPTIMIZE_FOR_SIZE
-            if (source is Iterator<TSource> iterator)
+            if (!IsSizeOptimized && source is Iterator<TSource> iterator)
             {
                 return iterator.ToArray();
             }
-#endif
 
             if (source is ICollection<TSource> collection)
             {
@@ -64,12 +62,10 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-#if !OPTIMIZE_FOR_SIZE
-            if (source is Iterator<TSource> iterator)
+            if (!IsSizeOptimized && source is Iterator<TSource> iterator)
             {
                 return iterator.ToList();
             }
-#endif
 
             return new List<TSource>(source);
         }

--- a/src/libraries/System.Linq/tests/ConcatTests.cs
+++ b/src/libraries/System.Linq/tests/ConcatTests.cs
@@ -320,7 +320,7 @@ namespace System.Linq.Tests
             yield return [Enumerable.Range(0, 500).Select(i => Enumerable.Repeat(i, 1)).Reverse()];
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void CountOfConcatIteratorShouldThrowExceptionOnIntegerOverflow()
         {
             var supposedlyLargeCollection = new DelegateBasedCollection<int> { CountWorker = () => int.MaxValue };

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -181,7 +181,7 @@ namespace System.Linq.Tests
             yield return WrapArgs(100, Enumerable.Range(1, 100));
             yield return WrapArgs(80, Enumerable.Repeat(1, 80));
 
-            if (PlatformDetection.IsSpeedOptimized)
+            if (PlatformDetection.IsLinqSpeedOptimized)
             {
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(4, new int[] { 1, 2, 3, 4 }.Select(x => x + 1));
@@ -201,7 +201,7 @@ namespace System.Linq.Tests
             yield return WrapArgs(new Stack<int>([1, 2, 3, 4]).Select(x => x + 1));
             yield return WrapArgs(Enumerable.Range(1, 100).Distinct());
 
-            if (!PlatformDetection.IsSpeedOptimized)
+            if (!PlatformDetection.IsLinqSpeedOptimized)
             {
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(new int[] { 1, 2, 3, 4 }.Select(x => x + 1));            

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -178,10 +178,11 @@ namespace System.Linq.Tests
 
             yield return WrapArgs(0, Enumerable.Empty<string>());
 
+            yield return WrapArgs(100, Enumerable.Range(1, 100));
+            yield return WrapArgs(80, Enumerable.Repeat(1, 80));
+
             if (PlatformDetection.IsSpeedOptimized)
             {
-                yield return WrapArgs(100, Enumerable.Range(1, 100));
-                yield return WrapArgs(80, Enumerable.Repeat(1, 80));
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(4, new int[] { 1, 2, 3, 4 }.Select(x => x + 1));
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
@@ -202,8 +203,6 @@ namespace System.Linq.Tests
 
             if (!PlatformDetection.IsSpeedOptimized)
             {
-                yield return WrapArgs(Enumerable.Range(1, 100));
-                yield return WrapArgs(Enumerable.Repeat(1, 80));
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(new int[] { 1, 2, 3, 4 }.Select(x => x + 1));            
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));

--- a/src/libraries/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/libraries/System.Linq/tests/OrderedSubsetting.cs
@@ -224,7 +224,7 @@ namespace System.Linq.Tests
             Assert.Equal(Enumerable.Range(10, 1), ordered.Take(11).Skip(10));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void TakeAndSkip_DoesntIterateRangeUnlessNecessary()
         {
             Assert.Empty(Enumerable.Range(0, int.MaxValue).Take(int.MaxValue).OrderBy(i => i).Skip(int.MaxValue - 4).Skip(15));

--- a/src/libraries/System.Linq/tests/RangeTests.cs
+++ b/src/libraries/System.Linq/tests/RangeTests.cs
@@ -210,19 +210,19 @@ namespace System.Linq.Tests
             Assert.Equal(-100, Enumerable.Range(-100, int.MaxValue).FirstOrDefault());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void Last()
         {
             Assert.Equal(1000000056, Enumerable.Range(57, 1000000000).Last());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void LastOrDefault()
         {
             Assert.Equal(int.MaxValue - 101, Enumerable.Range(-100, int.MaxValue).LastOrDefault());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void IListImplementationIsValid()
         {
             Validate(Enumerable.Range(42, 10), [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]);

--- a/src/libraries/System.Linq/tests/RepeatTests.cs
+++ b/src/libraries/System.Linq/tests/RepeatTests.cs
@@ -234,7 +234,7 @@ namespace System.Linq.Tests
             Assert.Equal(42, Enumerable.Repeat("Test", 42).Count());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void ICollectionImplementationIsValid()
         {
             Validate(Enumerable.Repeat(42, 10), [42, 42, 42, 42, 42, 42, 42, 42, 42, 42]);

--- a/src/libraries/System.Linq/tests/SelectManyTests.cs
+++ b/src/libraries/System.Linq/tests/SelectManyTests.cs
@@ -470,7 +470,7 @@ namespace System.Linq.Tests
             return lengths.SelectMany(l => lengths, (l1, l2) => new object[] { l1, l2 });
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         [InlineData(new[] { int.MaxValue, 1 })]
         [InlineData(new[] { 2, int.MaxValue - 1 })]
         [InlineData(new[] { 123, 456, int.MaxValue - 100000, 123456 })]

--- a/src/libraries/System.Linq/tests/TakeTests.cs
+++ b/src/libraries/System.Linq/tests/TakeTests.cs
@@ -1079,7 +1079,7 @@ namespace System.Linq.Tests
             Assert.Equal(taken5, taken5);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         [InlineData(1000)]
         [InlineData(1000000)]
         [InlineData(int.MaxValue)]
@@ -2033,7 +2033,7 @@ namespace System.Linq.Tests
             Assert.Empty(EnumerablePartitionOrEmpty(source).Take(^6..^7));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void SkipTakeOnIListIsIList()
         {
             IList<int> list = new ReadOnlyCollection<int>(Enumerable.Range(0, 100).ToList());

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WasmFeatures.props
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WasmFeatures.props
@@ -3,6 +3,7 @@
     <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
     <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
     <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+    <UseSizeOptimizedLinq Condition="'$(UseSizeOptimizedLinq)' == ''">true</UseSizeOptimizedLinq>
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
     <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
     <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>


### PR DESCRIPTION
When I was looking at this last time, I noticed the virtual method overrides and though it's not solvable with feature switches. But looks like the virtual methods are not actually called outside `!OPTIMIZE_FOR_SIZE` code so we might still be able to trim things correctly if it's a feature switch (we can remove unused virtual methods).

The only problem is maintainability - how do we remember that we should only call the virtuals under a `!IsSizeOptimized` check. The ifdef was a nice forcing function enforced by the compiler.