### PR TITLE
 [browser] Old headless mode has been removed, use the new parameter

### DIFF
--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -23,7 +23,7 @@ pr:
     - eng/pipelines/coreclr/templates/run-scenarios-job.yml
     - eng/testing/performance/*
     - eng/testing/BrowserVersions.props
-    - src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+    - src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -23,6 +23,7 @@ pr:
     - eng/pipelines/coreclr/templates/run-scenarios-job.yml
     - eng/testing/performance/*
     - eng/testing/BrowserVersions.props
+    - src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/src/mono/browser/README.md
+++ b/src/mono/browser/README.md
@@ -367,7 +367,7 @@ Tests are run with V8, Chrome, node, and wasmtime for the various jobs.
 
 ### `eng/testing/BrowserVersions.props`
 
-This file is updated once a week by a github action `.github/workflows/bump-chrome-version.yml`, and the version is obtained by `src/tasks/WasmBuildTasks/GetChromeVersions.cs` task.
+This file is updated once a week by a github action `.github/workflows/bump-chrome-version.yml`, and the version is obtained by `src/tasks/WasmBuildTasks/UpdateChromeVersions.cs` task.
 
 # Perf pipeline
 

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -119,6 +120,8 @@ internal class BrowserRunner : IAsyncDisposable
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         // codespaces: ignore certificate error -> Microsoft.Playwright.PlaywrightException : net::ERR_CERT_AUTHORITY_INVALID
         string[] chromeArgs = new[] { $"--explicitly-allowed-ports={url.Port}", "--ignore-certificate-errors", $"--lang={locale}" };
+        if (headless)
+            chromeArgs = chromeArgs.Append("--headless=new").ToArray();
         _testOutput.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
 
         int attempt = 0;

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -120,8 +119,6 @@ internal class BrowserRunner : IAsyncDisposable
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         // codespaces: ignore certificate error -> Microsoft.Playwright.PlaywrightException : net::ERR_CERT_AUTHORITY_INVALID
         string[] chromeArgs = new[] { $"--explicitly-allowed-ports={url.Port}", "--ignore-certificate-errors", $"--lang={locale}" };
-        if (headless)
-            chromeArgs = chromeArgs.Append("--headless=new").ToArray();
         _testOutput.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
 
         int attempt = 0;

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -47,7 +47,7 @@ public partial class UpdateChromeVersions : MBU.Task
     [Required, NotNull]
     public string EnvVarsForPRPath { get; set; } = string.Empty;
 
-    public MessageImportance OutputImportance { get; set; } = MessageImportance.Low;
+    public MessageImportance MessageImportance { get; set; } = MessageImportance.Low;
 
     public int MaxMajorVersionsToCheck { get; set; } = 2;
 
@@ -220,7 +220,7 @@ public partial class UpdateChromeVersions : MBU.Task
                 int minorForV8 = ver.Major % 10;
 
                 string lkgUrl = $"https://raw.githubusercontent.com/v8/v8/{majorForV8}.{minorForV8}-lkgr/include/v8-version.h";
-                Log.LogMessage(OutputImportance, $"Checking {lkgUrl} ...");
+                Log.LogMessage(MessageImportance, $"Checking {lkgUrl} ...");
                 string v8VersionHContents = await s_httpClient.GetStringAsync(lkgUrl).ConfigureAwait(false);
 
                 var m = V8BuildNumberRegex().Match(v8VersionHContents);
@@ -248,7 +248,7 @@ public partial class UpdateChromeVersions : MBU.Task
         if (File.Exists(filePath) &&
             (DateTime.UtcNow - File.GetLastWriteTimeUtc(filePath)).TotalDays < s_versionCheckThresholdDays)
         {
-            Log.LogMessage(OutputImportance,
+            Log.LogMessage(MessageImportance,
                                 $"{url} will not be downloaded again, as ${filePath} " +
                                 $"is less than {s_versionCheckThresholdDays} old.");
         }
@@ -256,7 +256,7 @@ public partial class UpdateChromeVersions : MBU.Task
         {
             try
             {
-                Log.LogMessage(OutputImportance, $"Downloading {url} ...");
+                Log.LogMessage(MessageImportance, $"Downloading {url} ...");
                 using Stream stream = await s_httpClient.GetStreamAsync(url).ConfigureAwait(false);
                 using FileStream fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
                 await stream.CopyToAsync(fs).ConfigureAwait(false);
@@ -280,13 +280,13 @@ public partial class UpdateChromeVersions : MBU.Task
             string branchUrl = $"{baseUrl}/{branchPosition}";
             string url = $"{branchUrl}/REVISIONS";
 
-            Log.LogMessage(OutputImportance, $"Checking if {url} exists ..");
+            Log.LogMessage(MessageImportance, $"Checking if {url} exists ..");
             HttpResponseMessage response = await s_httpClient
                                                     .GetAsync(url, HttpCompletionOption.ResponseHeadersRead)
                                                     .ConfigureAwait(false);
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                Log.LogMessage(OutputImportance, $"Found url = {url} with branchUrl = ${branchUrl}");
+                Log.LogMessage(MessageImportance, $"Found url = {url} with branchUrl = ${branchUrl}");
                 return branchUrl;
             }
 
@@ -300,7 +300,7 @@ public partial class UpdateChromeVersions : MBU.Task
         if (throwIfNotFound)
             throw new LogAsErrorException(message);
         else
-            Log.LogMessage(OutputImportance, message);
+            Log.LogMessage(MessageImportance, message);
 
         return null;
     }

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -47,7 +47,7 @@ public partial class UpdateChromeVersions : MBU.Task
     [Required, NotNull]
     public string EnvVarsForPRPath { get; set; } = string.Empty;
 
-    public MessageImportance OutputImportance { get; set; } = MessageImportance.High;
+    public MessageImportance OutputImportance { get; set; } = MessageImportance.Low;
 
     public int MaxMajorVersionsToCheck { get; set; } = 2;
 


### PR DESCRIPTION
Fix for https://github.com/dotnet/runtime/pull/111580. Checking if perf tests are affected.

1) Unify logging level in `UpdateChromeVersions` task (easier debugging).
2) Rename `GetChromeVersions.cs` -> `UpdateChromeVersions.cs` (remove inconsistency from docs).
3) Change `--headless` to `--headless=new` (bug fix).