### PR TITLE
[WinHTTP] Make concurrent IO check thread safe

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -941,7 +941,14 @@ namespace System.Net.Http
                 // will have the side-effect of WinHTTP cancelling any pending I/O and accelerating its callbacks
                 // on the handle and thus releasing the awaiting tasks in the loop below. This helps to provide
                 // a more timely, cooperative, cancellation pattern.
-                using (state.CancellationToken.Register(s => ((WinHttpRequestState)s!).RequestHandle!.Dispose(), state))
+                using (state.CancellationToken.Register(static s =>
+                {
+                    var state = (WinHttpRequestState)s!;
+                    lock (state.Lock)
+                    {
+                        state.RequestHandle?.Dispose();
+                    }
+                }, state))
                 {
                     do
                     {

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -150,7 +150,7 @@ namespace System.Net.Http
 
         public RendezvousAwaitable<int> LifecycleAwaitable { get; set; } = new RendezvousAwaitable<int>();
         public TaskCompletionSource<bool>? TcsInternalWriteDataToRequestStream { get; set; }
-        public bool AsyncReadInProgress { get; set; }
+        public volatile int AsyncReadInProgress;
 
         // WinHttpResponseStream state.
         public long? ExpectedBytesToRead { get; set; }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -64,7 +64,7 @@ namespace System.Net.Http
 
                 // Create response stream and wrap it in a StreamContent object.
                 var responseStream = new WinHttpResponseStream(requestHandle, state, response);
-                state.RequestHandle = null; // ownership successfully transferred to WinHttpResponseStram.
+                state.RequestHandle = null; // ownership successfully transferred to WinHttpResponseStream.
                 Stream decompressedStream = responseStream;
 
                 if (manuallyProcessedDecompressionMethods != DecompressionMethods.None)

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     {
                         await stream.ReadAsync(new byte[5]);
                     }
-                    catch (InvalidOperationException) // Expected exception for concurrent IO
+                    catch (InvalidOperationException) when (ioe.Message.Contains("concurrent I/O")) // Expected exception for concurrent IO
                     { }
                 });
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -46,6 +46,29 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
+        [OuterLoop("Uses external server.")]
+        [Fact]
+        public async Task GetAsync_ConcurrentRead_ThrowsInvalidOperationException()
+        {
+            using var client = new HttpClient(new WinHttpHandler());
+            using var response = await client.GetAsync("https://httpbin.org/stream-bytes/4096", HttpCompletionOption.ResponseHeadersRead);
+            using var stream = await response.Content.ReadAsStreamAsync();
+            var tasks = new Task[1_000];
+            for (int i = 0; i < tasks.Length; ++i)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await stream.ReadAsync(new byte[5]);
+                    }
+                    catch (InvalidOperationException) // Expected exception for concurrent IO
+                    { }
+                });
+            }
+            await Task.WhenAll(tasks);
+        }
+
         [OuterLoop]
         [Theory]
         [InlineData(CookieUsePolicy.UseInternalCookieStoreOnly, "cookieName1", "cookieValue1")]

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     {
                         await stream.ReadAsync(new byte[5]);
                     }
-                    catch (InvalidOperationException) when (ioe.Message.Contains("concurrent I/O")) // Expected exception for concurrent IO
+                    catch (InvalidOperationException ioe) when (ioe.Message.Contains("concurrent I/O")) // Expected exception for concurrent IO
                     { }
                 });
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -285,7 +285,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             TestControl.WinHttpReadData.Pause();
             Task t1 = stream.ReadAsync(new byte[1], 0, 1);
 
-            Assert.Throws<InvalidOperationException>(() => { Task t2 = stream.ReadAsync(new byte[1], 0, 1); });
+            Assert.ThrowsAsync<InvalidOperationException>(() => stream.ReadAsync(new byte[1], 0, 1));
 
             TestControl.WinHttpReadData.Resume();
             t1.Wait();


### PR DESCRIPTION
Note that this change makes the `InvalidOperationException` for concurrent IO async from sync. So now it's stored in the returned `Task` instead of being thrown synchronously.

Also, I can change this to `Interlocked.CompareExchange`. I went with the straight forward solution, for compare exchange, I'd have to change `AsyncReadInProgress` to either a method or a public field.