### PR TITLE
[mono][mini] Disable inlining if we encounter class initialization failure

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10142,6 +10142,8 @@ calli_end:
 							EMIT_NEW_PCONST (cfg, *sp, NULL);
 							sp++;
 						} else if (il_op == MONO_CEE_LDFLD || il_op == MONO_CEE_LDSFLD) {
+							// method_make_alwaysthrow_typeloadfailure currently doesn't work with inlining
+							INLINE_FAILURE("type load error");
 							// An object is expected here. It may be impossible to correctly infer its type,
 							// we turn this entire method into a throw.
 							method_make_alwaysthrow_typeloadfailure (cfg, klass);


### PR DESCRIPTION
method_make_alwaysthrow_typeloadfailure replaces the entire method code with a throw of type load exception. This behaviour not only seem dubious, if it is triggered from inlining a method, that might never even get called, but it also does changes to the set of basic blocks that can lead to crashes later on during compilation.