### PR TITLE
Removing Entry2MethodDesc as it is unnecessary

### DIFF
--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -20,7 +20,7 @@
 
 void AssertMulticoreJitAllowedModule(PCODE pTarget)
 {
-    MethodDesc* pMethod = Entry2MethodDesc(pTarget, NULL);
+    MethodDesc* pMethod = NonVirtualEntry2MethodDesc(pTarget);
 
     Module * pModule = pMethod->GetModule();
 

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -1610,7 +1610,7 @@ extern "C" PCODE QCALLTYPE Delegate_AdjustTarget(QCall::ObjectHandleOnStack targ
 
     MethodTable* pMTTarg = target.Get()->GetMethodTable();
 
-    MethodDesc *pMeth = Entry2MethodDesc(method, pMTTarg);
+    MethodDesc *pMeth = NonVirtualEntry2MethodDesc(method);
     _ASSERTE(pMeth);
     _ASSERTE(!pMeth->IsStatic());
 
@@ -1694,7 +1694,7 @@ extern "C" void QCALLTYPE Delegate_Construct(QCall::ObjectHandleOnStack _this, Q
         pMTTarg = target.Get()->GetMethodTable();
 
     MethodTable* pDelMT = refThis->GetMethodTable();
-    MethodDesc* pMethOrig = Entry2MethodDesc(method, pMTTarg);
+    MethodDesc* pMethOrig = NonVirtualEntry2MethodDesc(method);
     MethodDesc* pMeth = pMethOrig;
     _ASSERTE(pMeth != NULL);
 
@@ -1878,13 +1878,7 @@ MethodDesc *COMDelegate::GetMethodDesc(OBJECTREF orDelegate)
             // Must be a normal delegate
             code = thisDel->GetMethodPtr();
 
-            OBJECTREF orThis = thisDel->GetTarget();
-            if (orThis!=NULL)
-            {
-                pMT = orThis->GetMethodTable();
-            }
-
-            pMethodHandle = Entry2MethodDesc(code, pMT);
+            pMethodHandle = NonVirtualEntry2MethodDesc(code);
         }
     }
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2292,32 +2292,6 @@ MethodDesc* NonVirtualEntry2MethodDesc(PCODE entryPoint)
 }
 
 //*******************************************************************************
-// convert an entry point into a method desc
-MethodDesc* Entry2MethodDesc(PCODE entryPoint, MethodTable *pMT)
-{
-    CONTRACT(MethodDesc*)
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-        POSTCONDITION(RETVAL->SanityCheck());
-    }
-    CONTRACT_END
-
-    MethodDesc* pMD = NonVirtualEntry2MethodDesc(entryPoint);
-    if (pMD != NULL)
-        RETURN(pMD);
-
-    pMD = VirtualCallStubManagerManager::Entry2MethodDesc(entryPoint, pMT);
-    if (pMD != NULL)
-        RETURN(pMD);
-
-    // We should never get here
-    _ASSERTE(!"Entry2MethodDesc failed");
-    RETURN (NULL);
-}
-
-//*******************************************************************************
 BOOL MethodDesc::IsPointingToPrestub()
 {
     CONTRACTL

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2371,8 +2371,6 @@ inline MethodDescChunk *MethodDesc::GetMethodDescChunk() const
 }
 
 MethodDesc* NonVirtualEntry2MethodDesc(PCODE entryPoint);
-// convert an entry point into a MethodDesc
-MethodDesc* Entry2MethodDesc(PCODE entryPoint, MethodTable *pMT);
 
 
 typedef DPTR(class StoredSigMethodDesc) PTR_StoredSigMethodDesc;

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -1738,7 +1738,7 @@ BOOL ILStubManager::TraceManager(Thread *thread,
     PCODE stubIP = GetIP(pContext);
     *pRetAddr = (BYTE *)StubManagerHelpers::GetReturnAddress(pContext);
 
-    DynamicMethodDesc *pStubMD = Entry2MethodDesc(stubIP, NULL)->AsDynamicMethodDesc();
+    DynamicMethodDesc *pStubMD = NonVirtualEntry2MethodDesc(stubIP)->AsDynamicMethodDesc();
     TADDR arg = StubManagerHelpers::GetHiddenArg(pContext);
     Object * pThis = StubManagerHelpers::GetThisPtr(pContext);
     LOG((LF_CORDB, LL_INFO1000, "ILSM::TraceManager: Enter: StubMD 0x%p, HiddenArg 0x%p, ThisPtr 0x%p\n",

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -679,7 +679,7 @@
       <CrossgenCmd Condition="'$(__CompositeBuildMode)' == ''">$(CrossgenCmd) --crossgen2-parallelism 1</CrossgenCmd>
 
       <CrossgenCmd>$(CrossgenCmd) --verify-type-and-field-layout</CrossgenCmd>
-      <CrossgenCmd>$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2.dll"</CrossgenCmd>
+      <CrossgenCmd>$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2.exe"</CrossgenCmd>
     </PropertyGroup>
 
     <Message Importance="High" Text="$(MsgPrefix)Compiling framework using Crossgen2: $(CrossgenCmd)" />

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -679,7 +679,8 @@
       <CrossgenCmd Condition="'$(__CompositeBuildMode)' == ''">$(CrossgenCmd) --crossgen2-parallelism 1</CrossgenCmd>
 
       <CrossgenCmd>$(CrossgenCmd) --verify-type-and-field-layout</CrossgenCmd>
-      <CrossgenCmd>$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2.exe"</CrossgenCmd>
+      <CrossgenCmd Condition="'$(RunningOnUnix)' == 'true'">$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2"</CrossgenCmd>
+      <CrossgenCmd Condition="'$(RunningOnUnix)' != 'true'">$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2.exe"</CrossgenCmd>
     </PropertyGroup>
 
     <Message Importance="High" Text="$(MsgPrefix)Compiling framework using Crossgen2: $(CrossgenCmd)" />


### PR DESCRIPTION
It appears that the pathways that Entry2MethodDesc has for virtual resolution are unnecessary. Testing has shown that everything seems to work without this logic, and removing excess baggage is always good, and a bit less code should run a bit faster. As a bonus, this simplifies the logic around adding support for cached interface dispatch in CoreCLR.

Also, fix the crossgen2 test legs, as they are currently broken due to issues with the now NativeAOT'd crossgen2 binary.