### PR TITLE
Fix matched check for balancing groups in regex compiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -2553,18 +2553,8 @@ namespace System.Text.RegularExpressions.Generator
                 }
                 writer.WriteLine();
 
-                RegexNode child = node.Child(0);
-
-                if (uncapnum != -1)
-                {
-                    using (EmitBlock(writer, $"if (!base.IsMatched({uncapnum}))"))
-                    {
-                        Goto(doneLabel);
-                    }
-                    writer.WriteLine();
-                }
-
                 // Emit child node.
+                RegexNode child = node.Child(0);
                 string originalDoneLabel = doneLabel;
                 EmitNode(child, subsequent);
                 bool childBacktracks = doneLabel != originalDoneLabel;
@@ -2577,6 +2567,12 @@ namespace System.Text.RegularExpressions.Generator
                 }
                 else
                 {
+                    using (EmitBlock(writer, $"if (!base.IsMatched({uncapnum}))"))
+                    {
+                        Goto(doneLabel);
+                    }
+
+                    writer.WriteLine();
                     writer.WriteLine($"base.TransferCapture({capnum}, {uncapnum}, {startingPos}, pos);");
                 }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2400,18 +2400,8 @@ namespace System.Text.RegularExpressions
                 Ldloc(pos);
                 Stloc(startingPos);
 
-                RegexNode child = node.Child(0);
-
-                if (uncapnum != -1)
-                {
-                    // if (!IsMatched(uncapnum)) goto doneLabel;
-                    Ldthis();
-                    Ldc(uncapnum);
-                    Call(IsMatchedMethod);
-                    BrfalseFar(doneLabel);
-                }
-
                 // Emit child node.
+                RegexNode child = node.Child(0);
                 Label originalDoneLabel = doneLabel;
                 EmitNode(child, subsequent);
                 bool childBacktracks = doneLabel != originalDoneLabel;
@@ -2431,6 +2421,12 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
+                    // if (!IsMatched(uncapnum)) goto doneLabel;
+                    Ldthis();
+                    Ldc(uncapnum);
+                    Call(IsMatchedMethod);
+                    BrfalseFar(doneLabel);
+
                     // TransferCapture(capnum, uncapnum, startingPos, pos);
                     Ldthis();
                     Ldc(capnum);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -564,6 +564,8 @@ namespace System.Text.RegularExpressions.Tests
             {
                 // Throws NotSupported with NonBacktracking engine because of the balancing group dog-0
                 yield return (@"(?<cat>cat)\w+(?<dog-0>dog)", "cat_Hello_World_dog", RegexOptions.None, 0, 19, false, string.Empty);
+                yield return (@"(.)(?'2-1'(?'-1'))", "cat", RegexOptions.None, 0, 3, false, string.Empty);
+                yield return (@"(?'2-1'(.))", "cat", RegexOptions.None, 0, 3, true, "c");
             }
 
             // Atomic Zero-Width Assertions \A \Z \z \b \B


### PR DESCRIPTION
The emitted IsMatched check should come after processing the child, not before.

Fixes https://github.com/dotnet/runtime/issues/111630
Fixes https://github.com/dotnet/runtime/issues/111631
