### PR TITLE
Fix failed assertion 'FPbased == FPbased2'

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12311,12 +12311,12 @@ SKIP_GC_UPDATE:
 
                 // If there are 2 GC vars in this instrDesc, get the 2nd variable
                 // that should be tracked.
-                adr2     = emitComp->lvaFrameAddress(varNum2, &FPbased2, true);
+                adr2     = emitComp->lvaFrameAddress(varNum2, &FPbased2, FPbased);
                 ofs2Dist = EA_SIZE_IN_BYTES(size);
 #ifdef DEBUG
+                assert(FPbased == FPbased2);
                 if (!FPbased)
                 {
-                    assert(FPbased == FPbased2);
                     assert(encodingZRtoSP(id->idReg3()) == REG_SP);
                 }
                 assert(varNum2 != -1);

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12314,9 +12314,9 @@ SKIP_GC_UPDATE:
                 adr2     = emitComp->lvaFrameAddress(varNum2, &FPbased2, true);
                 ofs2Dist = EA_SIZE_IN_BYTES(size);
 #ifdef DEBUG
-                assert(FPbased == FPbased2);
                 if (!FPbased)
                 {
+                    assert(FPbased == FPbased2);
                     assert(encodingZRtoSP(id->idReg3()) == REG_SP);
                 }
                 assert(varNum2 != -1);


### PR DESCRIPTION
When `lvaFrameAddress` optimizes one of the temporary variables (referenced as FP-m) to be placed next to existing SP+n variable (eg. `OutgoingArgSpace` at SP+0) we may end up coalescing a pair-wise load/store between them. A previous attempt to handle the case only accounted for the `lvaFrameAddress` optimization being applied to both of the variables or neither of them, but it didn't correctly handle the mixed variant.

Fixes #111777