### PR TITLE
R2RDump: Fix reversed code offsets in GcInfo interruptible ranges decoder

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -381,8 +381,8 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 uint normRangeStartOffset = normLastinterruptibleRangeStopOffset + normStartDelta;
                 uint normRangeStopOffset = normRangeStartOffset + normStopDelta;
 
-                uint rangeStartOffset = _gcInfoTypes.DenormalizeCodeOffset(normRangeStopOffset);
-                uint rangeStopOffset = _gcInfoTypes.DenormalizeCodeOffset(normRangeStartOffset);
+                uint rangeStartOffset = _gcInfoTypes.DenormalizeCodeOffset(normRangeStartOffset);
+                uint rangeStopOffset = _gcInfoTypes.DenormalizeCodeOffset(normRangeStopOffset);
                 ranges.Add(new InterruptibleRange(i, rangeStartOffset, rangeStopOffset));
 
                 normLastinterruptibleRangeStopOffset = normRangeStopOffset;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection.PortableExecutable;
 using System.Text;
 
@@ -16,6 +17,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         public InterruptibleRange(uint index, uint start, uint stop)
         {
             Index = index;
+            Debug.Assert(start <= stop);
             StartOffset = start;
             StopOffset = stop;
         }


### PR DESCRIPTION
Caused a crash on RISC-V during R2RDump --in System.Private.CoreLib.dll --disasm --gc

Part of #84834, cc @dotnet/samsung @VSadov