### PR TITLE
Improve compare-and-branch sequences produced by Emitter

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -230,6 +230,7 @@ protected:
 
     void genExitCode(BasicBlock* block);
 
+#if defined(TARGET_ARM64)
     BasicBlock* genGetThrowHelper(SpecialCodeKind codeKind);
 
     // genEmitInlineThrow: Generate code for an inline exception.
@@ -282,6 +283,7 @@ protected:
             genDefineTempLabel(over);
         }
     }
+#endif
 
     void genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKind, BasicBlock* failBlk = nullptr);
 

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -230,6 +230,54 @@ protected:
 
     void genExitCode(BasicBlock* block);
 
+    BasicBlock* genGetThrowHelper(SpecialCodeKind codeKind);
+
+    // genEmitInlineThrow: Generate code for an inline exception.
+    void genEmitInlineThrow(SpecialCodeKind codeKind)
+    {
+        genEmitHelperCall(compiler->acdHelper(codeKind), 0, EA_UNKNOWN);
+    }
+
+    // throwCodeFn callback follows concept -> void(*)(BasicBlock* target, bool isInline)
+    //
+    // For conditional jumps:
+    //     If `isInline`, invert the condition for throw and fall into the exception block.
+    //     Otherwise emit compare and jump with the normal throw condition.
+    // For unconditional jumps:
+    //     Only emit the unconditional jump when `isInline == false`.
+    //     When `isInline == true` the code will fallthrough to throw without any jump added.
+    //
+    // Parameter `target` gives a label to jump to, which is the throw block if
+    // `isInline == false`, else the continuation.
+    template <typename throwCodeFn>
+    void genJumpToThrowHlpBlk(SpecialCodeKind codeKind, throwCodeFn emitJumpCode)
+    {
+        BasicBlock* target = genGetThrowHelper(codeKind);
+        if (target)
+        {
+            // check:
+            //   if (checkPassed)
+            //     goto throw;
+            //   ...
+            // throw:
+            //   throw();
+            emitJumpCode(target, false);
+        }
+        else
+        {
+            // check:
+            //   if (!checkPassed)
+            //     goto continue;
+            //   throw();
+            // continue:
+            //   ...
+            BasicBlock* over = genCreateTempLabel();
+            emitJumpCode(over, true);
+            genEmitInlineThrow(codeKind);
+            genDefineTempLabel(over);
+        }
+    }
+
     void genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKind, BasicBlock* failBlk = nullptr);
 
 #if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
@@ -1285,6 +1333,8 @@ protected:
 #endif
 #if defined(TARGET_ARM64)
     void genCodeForJumpCompare(GenTreeOpCC* tree);
+    void genCompareImmAndJump(
+        GenCondition::Code cond, regNumber reg, ssize_t compareImm, emitAttr size, BasicBlock* target);
     void genCodeForBfiz(GenTreeOp* tree);
 #endif // TARGET_ARM64
 

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -250,10 +250,15 @@ protected:
     // Parameter `target` gives a label to jump to, which is the throw block if
     // `isInline == false`, else the continuation.
     template <typename throwCodeFn>
-    void genJumpToThrowHlpBlk(SpecialCodeKind codeKind, throwCodeFn emitJumpCode)
+    void genJumpToThrowHlpBlk(SpecialCodeKind codeKind, throwCodeFn emitJumpCode, BasicBlock* throwBlock = nullptr)
     {
-        BasicBlock* target = genGetThrowHelper(codeKind);
-        if (target)
+        if (!throwBlock)
+        {
+            // If caller didn't supply a target block, then try to find a helper block.
+            throwBlock = genGetThrowHelper(codeKind);
+        }
+
+        if (throwBlock)
         {
             // check:
             //   if (checkPassed)
@@ -261,7 +266,7 @@ protected:
             //   ...
             // throw:
             //   throw();
-            emitJumpCode(target, false);
+            emitJumpCode(throwBlock, false);
         }
         else
         {

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -5961,4 +5961,27 @@ insOpts CodeGen::ShiftOpToInsOpts(genTreeOps shiftOp)
     }
 }
 
+//---------------------------------------------------------------------------------
+// genGetThrowHelper: Search for the throw helper for the exception kind `codeKind`
+BasicBlock* CodeGen::genGetThrowHelper(SpecialCodeKind codeKind)
+{
+    BasicBlock* excpRaisingBlock = nullptr;
+    if (compiler->fgUseThrowHelperBlocks())
+    {
+        // For code with throw helper blocks, find and use the helper block for
+        // raising the exception. The block may be shared by other trees too.
+        Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
+        PREFIX_ASSUME_MSG((add != nullptr), ("ERROR: failed to find exception throw block"));
+        assert(add->acdUsed);
+        excpRaisingBlock = add->acdDstBlk;
+#if !FEATURE_FIXED_OUT_ARGS
+        assert(add->acdStkLvlInit || isFramePointerUsed());
+#endif // !FEATURE_FIXED_OUT_ARGS
+
+        noway_assert(excpRaisingBlock != nullptr);
+    }
+
+    return excpRaisingBlock;
+}
+
 #endif // TARGET_ARM64

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1472,6 +1472,23 @@ void CodeGen::genRangeCheck(GenTree* oper)
         src1    = arrLen;
         src2    = arrIndex;
         jmpKind = EJ_ls;
+
+#if defined(TARGET_ARM64)
+        if (arrIndex->IsIntegralConst(0))
+        {
+            assert(!arrLen->isContained());
+            // For (index == 0), we can just test if (length == 0) as this is the only case that would throw.
+            // This may lead to an optimization by using cbz/tbnz.
+            genJumpToThrowHlpBlk(
+                bndsChk->gtThrowKind,
+                [&](BasicBlock* target, bool isInline) {
+                genCompareImmAndJump(isInline ? GenCondition::NE : GenCondition::EQ, arrLen->GetReg(), 0,
+                                     emitActualTypeSize(arrLen), target);
+            },
+                bndsChk->gtIndRngFailBB);
+            return;
+        }
+#endif
     }
     else
     {

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1482,7 +1482,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
             genJumpToThrowHlpBlk(
                 bndsChk->gtThrowKind,
                 [&](BasicBlock* target, bool isInline) {
-                genCompareImmAndJump(isInline ? GenCondition::NE : GenCondition::EQ, arrLen->GetReg(), 0,
+                genCompareImmAndJump(isInline ? GenCondition::NE : GenCondition::EQ, arrLen->GetRegNum(), 0,
                                      emitActualTypeSize(arrLen), target);
             },
                 bndsChk->gtIndRngFailBB);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1550,36 +1550,6 @@ void CodeGen::genExitCode(BasicBlock* block)
     genReserveEpilog(block);
 }
 
-//---------------------------------------------------------------------------------
-// genGetThrowHelper: Search for the throw helper for the exception kind `codeKind`
-BasicBlock* CodeGen::genGetThrowHelper(SpecialCodeKind codeKind)
-{
-    bool useThrowHlpBlk = compiler->fgUseThrowHelperBlocks();
-#if defined(UNIX_X86_ABI)
-    // TODO: Is this really UNIX_X86_ABI specific? Should we guard with compiler->UsesFunclets() instead?
-    // Inline exception-throwing code in funclet to make it possible to unwind funclet frames.
-    useThrowHlpBlk = useThrowHlpBlk && (compiler->funCurrentFunc()->funKind == FUNC_ROOT);
-#endif // UNIX_X86_ABI
-
-    BasicBlock* excpRaisingBlock = nullptr;
-    if (useThrowHlpBlk)
-    {
-        // For code with throw helper blocks, find and use the helper block for
-        // raising the exception. The block may be shared by other trees too.
-        Compiler::AddCodeDsc* add = compiler->fgFindExcptnTarget(codeKind, compiler->compCurBB);
-        PREFIX_ASSUME_MSG((add != nullptr), ("ERROR: failed to find exception throw block"));
-        assert(add->acdUsed);
-        excpRaisingBlock = add->acdDstBlk;
-#if !FEATURE_FIXED_OUT_ARGS
-        assert(add->acdStkLvlInit || isFramePointerUsed());
-#endif // !FEATURE_FIXED_OUT_ARGS
-
-        noway_assert(excpRaisingBlock != nullptr);
-    }
-
-    return excpRaisingBlock;
-}
-
 //------------------------------------------------------------------------
 // genJumpToThrowHlpBlk: Generate code for an out-of-line exception.
 //


### PR DESCRIPTION
Introduces an overload of `genJumpToThrowHlpBlk` that allows you to pass a function that generates the branch code, before it creates an inline throw block. This allows us to choose compare-and-branch sequences such as `cbz` on ARM64 for checks added in the emitter, such as divide-by-zero.

Working towards #68028, I'll be looking into something similar for #42514 next using this helper I've added.

```
<==
cmp     w1, #0
beq     G_M17037_IG05
==>
cbz     w1, G_M17037_IG05
```