### PR TITLE
WIP: [mono][android] Avoid using CoreCLR properties when building mono runtime tests

### DIFF
--- a/src/tests/Common/dir.common.props
+++ b/src/tests/Common/dir.common.props
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="../../coreclr/Directory.Build.props" />
+  <Import Condition="'$(RuntimeFlavor)' != 'Mono'" Project="../../coreclr/Directory.Build.props" />
+  <Import Condition="'$(RuntimeFlavor)' == 'Mono'" Project="../../mono/Directory.Build.props" />
 
   <!-- This file contains common build properties for projects under
        the test tree, and also generated test projects in

--- a/src/tests/Common/dir.common.props
+++ b/src/tests/Common/dir.common.props
@@ -1,6 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Condition="'$(RuntimeFlavor)' != 'Mono'" Project="../../coreclr/Directory.Build.props" />
-  <Import Condition="'$(RuntimeFlavor)' == 'Mono'" Project="../../mono/Directory.Build.props" />
+  <Import Project="..\..\..\Directory.Build.props" />
 
   <!-- This file contains common build properties for projects under
        the test tree, and also generated test projects in
@@ -13,7 +12,10 @@
   <PropertyGroup>
     <OSPlatformConfig>$(TargetOS).$(TargetArchitecture).$(Configuration)</OSPlatformConfig>
 
-    <BaseOutputPath>$(ArtifactsDir)tests\coreclr</BaseOutputPath>
+    <_BaseOutputPathSubDir Condition="'$(RuntimeFlavor.ToLower())' != 'mono'">coreclr</_BaseOutputPathSubDir>
+    <_BaseOutputPathSubDir Condition="'$(RuntimeFlavor.ToLower())' == 'mono'">mono</_BaseOutputPathSubDir>
+
+    <BaseOutputPath>$(ArtifactsDir)tests\$(_BaseOutputPathSubDir)</BaseOutputPath>
     <BaseOutputPathWithConfig>$([MSBuild]::NormalizePath('$(BaseOutputPath)\$(OSPlatformConfig)\'))</BaseOutputPathWithConfig>
     <TestBinDir>$(BaseOutputPathWithConfig)</TestBinDir>
 

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -23,15 +23,6 @@
     <EnableNativeSanitizers Condition="'$(__EnableNativeSanitizers)' != ''">$(__EnableNativeSanitizers)</EnableNativeSanitizers>
   </PropertyGroup>
 
-  <!-- Output paths -->
-  <PropertyGroup>
-    <!-- When not using the SDK, we want to set this property here so
-         that BuildVersionFile gets the correct value. -->
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == '' Or '$(UsingMicrosoftNETSdk)' != 'true'">$(ArtifactsDir)obj\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)\$(TargetOS).$(TargetArchitecture).$(Configuration)</IntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == ''">$(BaseIntermediateOutputPath)\coreclr\$(TargetOS).$(TargetArchitecture).$(Configuration)</OutputPath>
-  </PropertyGroup>
-
     <!-- Targeting Package paths -->
   <PropertyGroup>
     <TargetingPackPath Condition="'$(BaseTargetingPackPath)' == ''">$(ArtifactsDir)TargetingPack\</TargetingPackPath>

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -412,12 +412,12 @@ __MsbuildDebugLogsDir="$__LogsDir/MsbuildDebugLogs"
 
 # Set the remaining variables based upon the determined build configuration
 __OSPlatformConfig="$__TargetOS.$__TargetArch.$__BuildType"
-__BinDir="$__RootBinDir/bin/coreclr/$__OSPlatformConfig"
+__BinDir="$__RootBinDir/bin/$__RuntimeFlavor/$__OSPlatformConfig"
 __PackagesBinDir="$__BinDir/.nuget"
 __TestDir="$__RepoRootDir/src/tests"
-__TestBinDir="$__RootBinDir/tests/coreclr/$__OSPlatformConfig"
-__IntermediatesDir="$__RootBinDir/obj/coreclr/$__OSPlatformConfig"
-__TestIntermediatesDir="$__RootBinDir/tests/coreclr/obj/$__OSPlatformConfig"
+__TestBinDir="$__RootBinDir/tests/$__RuntimeFlavor/$__OSPlatformConfig"
+__IntermediatesDir="$__RootBinDir/obj/$__RuntimeFlavor/$__OSPlatformConfig"
+__TestIntermediatesDir="$__RootBinDir/tests/$__RuntimeFlavor/obj/$__OSPlatformConfig"
 __CrossCompIntermediatesDir="$__IntermediatesDir/crossgen"
 __MonoBinDir="$__RootBinDir/bin/mono/$__OSPlatformConfig"
 


### PR DESCRIPTION
## Description

Runtime tests build with mono is importing coreCLR properties file which can lead to unexpected build/run behavior for runtime tests (notice the subdir used):
```
    StringThrower -> /__w/1/s/artifacts/tests/coreclr/android.x64.Release/baseservices/compilerservices/RuntimeWrappedException/StringThrower/StringThrower.dll
    ExceptionInterop -> /__w/1/s/artifacts/tests/coreclr/android.x64.Release/baseservices/exceptions/exceptioninterop/ExceptionInterop/ExceptionInterop.dll
    ExceptionInterop_ro -> /__w/1/s/artifacts/tests/coreclr/android.x64.Release/baseservices/exceptions/exceptioninterop/ExceptionInterop_ro/ExceptionInterop_ro.dll

```
from : https://dev.azure.com/dnceng-public/public/_build/results?buildId=929905&view=logs&j=353cbaf6-57aa-5b05-dc8e-ce12fdf7e230&t=dbb52a6c-442b-561c-b585-094db01048b5

Order of imports:
<img width="561" alt="Screenshot 2025-01-24 at 16 17 32" src="https://github.com/user-attachments/assets/2a052e1b-7d03-461a-adb2-3ad697e51910" />


Even though it worked before, this is wrong behavior, especially since the file in question now sets:
https://github.com/dotnet/runtime/blob/2ac0591de5e95f6e98b28b7525b712ed09c73c39/src/coreclr/Directory.Build.props#L11

---
Fixes: https://github.com/dotnet/runtime/issues/111919