### PR TITLE
Special case List<ClaimsIdentity> in SelectPrimaryIdentity

### DIFF
--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -61,11 +61,31 @@ namespace System.Security.Claims
         {
             ArgumentNullException.ThrowIfNull(identities);
 
-            foreach (ClaimsIdentity identity in identities)
+            // If the identities value is exactly a List<ClaimsIdentity>, special case it so that
+            // the enumerator allocation can be skipped. Doing this for List<ClaimsIdentity> is the 99%
+            // case because it is normally used on the _identities value, which is a List<ClaimsIdentity>.
+            if (identities.GetType() == typeof(List<ClaimsIdentity>))
             {
-                if (identity != null)
+                List<ClaimsIdentity> identitiesList = (identities as List<ClaimsIdentity>)!;
+
+                for (int i = 0; i < identitiesList.Count; i++)
                 {
-                    return identity;
+                    ClaimsIdentity identity = identitiesList[i];
+
+                    if (identity != null)
+                    {
+                        return identity;
+                    }
+                }
+            }
+            else
+            {
+                foreach (ClaimsIdentity identity in identities)
+                {
+                    if (identity != null)
+                    {
+                        return identity;
+                    }
                 }
             }
 

--- a/src/libraries/System.Security.Claims/tests/ClaimsPrincipalTests.cs
+++ b/src/libraries/System.Security.Claims/tests/ClaimsPrincipalTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -240,6 +241,72 @@ namespace System.Security.Claims
                 Thread.CurrentPrincipal = null;
                 Assert.IsType<GenericPrincipal>(ClaimsPrincipal.Current);
             }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void PrimaryIdentitySelector_Default()
+        {
+            RemoteExecutor.Invoke(static () =>
+            {
+                ClaimsIdentity identity0 = null;
+                ClaimsIdentity identity1 = new([new Claim("type", "value")]);
+                ClaimsIdentity identity2 = new([new Claim("type", "value")]);
+                IEnumerable<ClaimsIdentity> identities = [identity0, identity1, identity2];
+                Func<IEnumerable<ClaimsIdentity>, ClaimsIdentity> selector = ClaimsPrincipal.PrimaryIdentitySelector;
+
+                Assert.Same(identity1, selector(identities));
+                Assert.Null(selector([]));
+                AssertExtensions.Throws<ArgumentNullException>("identities", () => selector(null));
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void PrimaryIdentitySelector_DefaultDoesNotSpecialCaseInterfaceList()
+        {
+            RemoteExecutor.Invoke(static () =>
+            {
+                ClaimsIdentity identity0 = null;
+                ClaimsIdentity identity1 = new([new Claim("type", "value")]);
+                ClaimsIdentity identity2 = new([new Claim("type", "value")]);
+                ClaimsIdentityList identities = [identity0, identity1, identity2];
+                Func<IEnumerable<ClaimsIdentity>, ClaimsIdentity> selector = ClaimsPrincipal.PrimaryIdentitySelector;
+
+                Assert.Same(identity1, selector(identities));
+                Assert.True(identities.EnumeratedAtLeastOnce, nameof(identities.EnumeratedAtLeastOnce));
+                Assert.Null(selector(new ClaimsIdentityList()));
+            }).Dispose();
+        }
+
+        private sealed class ClaimsIdentityList : IList<ClaimsIdentity>
+        {
+            private readonly List<ClaimsIdentity> _claimsIdentities = [];
+
+            public bool EnumeratedAtLeastOnce { get; set; }
+
+            public ClaimsIdentity this[int index]
+            {
+                get => _claimsIdentities[index];
+                set => _claimsIdentities[index] = value;
+            }
+
+            public int Count => _claimsIdentities.Count;
+            public bool IsReadOnly => ((ICollection<ClaimsIdentity>)_claimsIdentities).IsReadOnly;
+            public void Add(ClaimsIdentity item) => _claimsIdentities.Add(item);
+            public void Clear() => _claimsIdentities.Clear();
+            public bool Contains(ClaimsIdentity item) => _claimsIdentities.Contains(item);
+            public void CopyTo(ClaimsIdentity[] array, int arrayIndex) => _claimsIdentities.CopyTo(array, arrayIndex);
+            public int IndexOf(ClaimsIdentity item) => _claimsIdentities.IndexOf(item);
+            public void Insert(int index, ClaimsIdentity item) => _claimsIdentities.Insert(index, item);
+            public bool Remove(ClaimsIdentity item) => _claimsIdentities.Remove(item);
+            public void RemoveAt(int index) => _claimsIdentities.RemoveAt(index);
+
+            public IEnumerator<ClaimsIdentity> GetEnumerator()
+            {
+                EnumeratedAtLeastOnce = true;
+                return _claimsIdentities.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<ClaimsIdentity>)this).GetEnumerator();
         }
 
         private class NonClaimsPrincipal : IPrincipal


### PR DESCRIPTION
This special-cases `SelectPrimaryIdentity` to avoid allocating an enumerator instance if the underlying list of claims is a `List<ClaimsIdentity>`. We only do this if the type is exactly the List<T>, no derived types and no `IList<T>`.

Fixes https://github.com/dotnet/runtime/issues/107861