### PR TITLE
Fix Zip64ExtraField handling

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1212,14 +1212,14 @@ namespace System.IO.Compression
                 BinaryPrimitives.WriteInt64LittleEndian(dataDescriptor[ZipLocalFileHeader.Zip64DataDescriptor.FieldLocations.CompressedSize..], _compressedSize);
                 BinaryPrimitives.WriteInt64LittleEndian(dataDescriptor[ZipLocalFileHeader.Zip64DataDescriptor.FieldLocations.UncompressedSize..], _uncompressedSize);
 
-                bytesToWrite = ZipLocalFileHeader.Zip64DataDescriptor.FieldLocations.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize;
+                bytesToWrite = ZipLocalFileHeader.Zip64DataDescriptor.FieldLocations.UncompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize;
             }
             else
             {
                 BinaryPrimitives.WriteUInt32LittleEndian(dataDescriptor[ZipLocalFileHeader.ZipDataDescriptor.FieldLocations.CompressedSize..], (uint)_compressedSize);
                 BinaryPrimitives.WriteUInt32LittleEndian(dataDescriptor[ZipLocalFileHeader.ZipDataDescriptor.FieldLocations.UncompressedSize..], (uint)_uncompressedSize);
 
-                bytesToWrite = ZipLocalFileHeader.ZipDataDescriptor.FieldLocations.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize;
+                bytesToWrite = ZipLocalFileHeader.ZipDataDescriptor.FieldLocations.UncompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize;
             }
 
             _archive.ArchiveStream.Write(dataDescriptor[..bytesToWrite]);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -340,28 +340,33 @@ namespace System.IO.Compression
         public void WriteBlock(Stream stream)
         {
             Span<byte> extraFieldData = stackalloc byte[TotalSize];
+            int startOffset = ZipGenericExtraField.FieldLocations.DynamicData;
 
             BinaryPrimitives.WriteUInt16LittleEndian(extraFieldData[FieldLocations.Tag..], TagConstant);
             BinaryPrimitives.WriteUInt16LittleEndian(extraFieldData[FieldLocations.Size..], _size);
 
             if (_uncompressedSize != null)
             {
-                BinaryPrimitives.WriteInt64LittleEndian(extraFieldData[FieldLocations.UncompressedSize..], _uncompressedSize.Value);
+                BinaryPrimitives.WriteInt64LittleEndian(extraFieldData[startOffset..], _uncompressedSize.Value);
+                startOffset += FieldLengths.UncompressedSize;
             }
 
             if (_compressedSize != null)
             {
-                BinaryPrimitives.WriteInt64LittleEndian(extraFieldData[FieldLocations.CompressedSize..], _compressedSize.Value);
+                BinaryPrimitives.WriteInt64LittleEndian(extraFieldData[startOffset..], _compressedSize.Value);
+                startOffset += FieldLengths.CompressedSize;
             }
 
             if (_localHeaderOffset != null)
             {
-                BinaryPrimitives.WriteInt64LittleEndian(extraFieldData[FieldLocations.LocalHeaderOffset..], _localHeaderOffset.Value);
+                BinaryPrimitives.WriteInt64LittleEndian(extraFieldData[startOffset..], _localHeaderOffset.Value);
+                startOffset += FieldLengths.LocalHeaderOffset;
             }
 
             if (_startDiskNumber != null)
             {
-                BinaryPrimitives.WriteUInt32LittleEndian(extraFieldData[FieldLocations.StartDiskNumber..], _startDiskNumber.Value);
+                BinaryPrimitives.WriteUInt32LittleEndian(extraFieldData[startOffset..], _startDiskNumber.Value);
+                startOffset += FieldLengths.StartDiskNumber;
             }
 
             stream.Write(extraFieldData);


### PR DESCRIPTION
Bugfix for the outer loop tests which failed after PR #103153.

The original [`Zip64ExtraField.WriteBlock`](https://github.com/dotnet/runtime/blob/10760a276d17d5729bbd57661eb9add39b3b6be5/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs#L300-L309) method contained logic to conditionally write the compressed size, uncompressed size, local header offset and starting disk number to the output stream. When this was modified to use BinaryPrimitives, ([link](https://github.com/dotnet/runtime/blob/77fc88ad405b4d7db3d0c4cdcf6694678c9883c1/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs#L340-L368)) this condition wasn't ported across properly - it conditionally wrote into the destination buffer, but used constant field offsets. There was also one error in ZipArchiveEntry.WriteDataDescriptor - that's now corrected.

I don't see this pattern repeated anywhere else in ZipBlocks or ZipArchiveEntry. ZipArchiveEntry does sometimes write a ZIP64 data descriptor ([link](https://github.com/dotnet/runtime/blob/main/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs#L1195)) but this logic is reasonable.

Outer loop tests which failed as a result of this bug:
* System.IO.Compression.Tests.zip_LargeFiles.CheckZIP64VersionIsSet_ForSmallFilesAfterBigFiles
* System.IO.Compression.Tests.zip_LargeFiles.UnzipOver4GBZipFile
* System.IO.Packaging.Tests.LargeFilesTests.CheckZIP64VersionIsSet_ForSmallFilesAfterBigFiles
These were the only tests which failed because they're the only ones which generated large enough files to trigger the logic which wrote Zip64ExtraField. They're now passing locally.

Apologies again for missing this.

@carlossanlop - if you're happy with the diff, could you run the outer loop tests against this PR again please?