### PR TITLE
Add fast path to String.Equals

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4701,6 +4701,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             case NI_System_SpanHelpers_ClearWithoutReferences:
             case NI_System_SpanHelpers_Memmove:
             {
+                mustExpand = false; // It's fine for these intrinsics to call themselves recursively
                 if (sig->sigInst.methInstCount == 0)
                 {
                     // We'll try to unroll this in lower for constant input.

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -940,8 +940,8 @@ namespace System
                 else if (length >= (nuint)Vector128<byte>.Count)
                 {
 #if !MONO // Mono has performance issues with ISimdVector<T>
-                    if (((!Vector512.IsHardwareAccelerated && !Vector256.IsHardwareAccelerated) || 
-                        AdvSimd.Arm64.IsSupported) && length >= 64) // After this threshold, _LongInput will be faster
+                    if (((!Vector512.IsHardwareAccelerated && !Vector256.IsHardwareAccelerated) || AdvSimd.Arm64.IsSupported) &&
+                        length >= 64) // After this threshold, _LongInput will be faster
                     {
                         return SequenceEqual_LongInput<Vector128<byte>>(ref first, ref second, length);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -907,7 +907,7 @@ namespace System
                 {
                     if (!Vector512.IsHardwareAccelerated && length >= 256) // After this threshold, _LongInput will be faster
                     {
-                        return SequenceEqual_LongInput<Vector128<byte>>(ref first, ref second, length);
+                        return SequenceEqual_LongInput<Vector256<byte>>(ref first, ref second, length);
                     }
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)Vector256<byte>.Count;

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -26,7 +26,7 @@ namespace System
             Debug.Assert(strB != null);
             Debug.Assert(strA.Length == strB.Length);
 
-            nuint byteLength = (nuint)strA.Length * sizeof(char);
+            /*nuint byteLength = (nuint)strA.Length * sizeof(char);
             ref byte pStrA = ref Unsafe.As<char, byte>(ref strA.GetRawStringData());
             ref byte pStrB = ref Unsafe.As<char, byte>(ref strB.GetRawStringData());
 
@@ -43,7 +43,12 @@ namespace System
                 pStrB = ref Unsafe.Add(ref pStrB, sizeof(char) * 2);
                 byteLength -= sizeof(char) * 2;
             }
-            return SpanHelpers.SequenceEqual(ref pStrA, ref pStrB, byteLength);
+            return SpanHelpers.SequenceEqual(ref pStrA, ref pStrB, byteLength);*/
+
+            return SpanHelpers.SequenceEqual(
+                    ref Unsafe.As<char, byte>(ref strA.GetRawStringData()),
+                    ref Unsafe.As<char, byte>(ref strB.GetRawStringData()),
+                    ((uint)strA.Length) * sizeof(char));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Experiments with https://github.com/dotnet/runtime/pull/111586#discussion_r1929114292

Currently, our primary method for comparing strings is `SpanHelpers.SequenceEqual`. Due to the string's object layout, we always provide `SequenceEqual` with only 4-byte aligned data (the offset of String._firstChar is 12 bytes), which might negatively impact performance. `SequenceEqual` currently does not align data, meaning its Vector512 path always hits the cache line every iteration.

Also, do 64b/16b alignment inside SequenceEqual itself

We will see what the performance bot thinks about the microbenchmarks 🙂

