### PR TITLE
Add rune overloads from #27912

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -128,6 +128,13 @@ namespace System
             return m_value == obj;
         }
 
+        public bool Equals(char left, char right, StringComparison comparisonType)
+        {
+            ReadOnlySpan<char> leftCharsSlice = [left];
+            ReadOnlySpan<char> rightCharsSlice = [right];
+            return leftCharsSlice.Equals(rightCharsSlice, comparisonType);
+        }
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -128,9 +128,9 @@ namespace System
             return m_value == obj;
         }
 
-        public bool Equals(char left, char right, StringComparison comparisonType)
+        public bool Equals(char right, StringComparison comparisonType)
         {
-            ReadOnlySpan<char> leftCharsSlice = [left];
+            ReadOnlySpan<char> leftCharsSlice = [this];
             ReadOnlySpan<char> rightCharsSlice = [right];
             return leftCharsSlice.Equals(rightCharsSlice, comparisonType);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -462,6 +462,41 @@ namespace System.Globalization
             return c;
         }
 
+        public Rune ToLower(Rune r)
+        {
+            // Convert rune to span
+            Span<char> chars = stackalloc char[2];
+            int charsWritten = r.EncodeToUtf16(chars);
+            ReadOnlySpan<char> charsSlice = chars[..charsWritten];
+
+            // Change span to lower and convert to rune
+            if (charsSlice.Length == 2)
+            {
+                return new Rune(ToLower(charsSlice[0]), ToLower(charsSlice[1]));
+            }
+            else
+            {
+                return new Rune(ToLower(charsSlice[0]));
+            }
+        }
+        public Rune ToUpper(Rune r)
+        {
+            // Convert rune to span
+            Span<char> chars = stackalloc char[2];
+            int charsWritten = r.EncodeToUtf16(chars);
+            ReadOnlySpan<char> charsSlice = chars[..charsWritten];
+
+            // Change span to upper and convert to rune
+            if (charsSlice.Length == 2)
+            {
+                return new Rune(ToUpper(charsSlice[0]), ToUpper(charsSlice[1]));
+            }
+            else
+            {
+                return new Rune(ToUpper(charsSlice[0]));
+            }
+        }
+
         private bool IsAsciiCasingSameAsInvariant
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -557,8 +557,8 @@ namespace System.IO
             {
                 async Task WriteAsyncPair(char highSurrogate, char lowSurrogate)
                 {
-                    await WriteAsync(highSurrogate);
-                    await WriteAsync(lowSurrogate);
+                    await WriteAsync(highSurrogate).ConfigureAwait(false);
+                    await WriteAsync(lowSurrogate).ConfigureAwait(false);
                 }
                 return WriteAsyncPair(charsSlice[0], charsSlice[1]);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -591,8 +591,8 @@ namespace System.IO
             {
                 async Task WriteLineAsyncPair(char highSurrogate, char lowSurrogate)
                 {
-                    await WriteAsync(highSurrogate);
-                    await WriteLineAsync(lowSurrogate);
+                    await WriteAsync(highSurrogate).ConfigureAwait(false);
+                    await WriteLineAsync(lowSurrogate).ConfigureAwait(false);
                 }
                 return WriteLineAsyncPair(charsSlice[0], charsSlice[1]);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -534,6 +534,74 @@ namespace System.IO
             WriteLine(string.Format(FormatProvider, format, arg));
         }
 
+        public virtual void Write(Rune value)
+        {
+            // Convert value to span
+            Span<char> chars = stackalloc char[2];
+            int charsWritten = value.EncodeToUtf16(chars);
+            ReadOnlySpan<char> charsSlice = chars[..charsWritten];
+
+            // Write span
+            Write(charsSlice);
+        }
+
+        public virtual Task WriteAsync(Rune value)
+        {
+            // Convert value to span
+            Span<char> chars = stackalloc char[2];
+            int charsWritten = value.EncodeToUtf16(chars);
+            ReadOnlySpan<char> charsSlice = chars[..charsWritten];
+
+            // Write chars individually (can't use span with async)
+            if (charsSlice.Length == 2)
+            {
+                async Task WriteAsyncPair(char highSurrogate, char lowSurrogate)
+                {
+                    await WriteAsync(highSurrogate);
+                    await WriteAsync(lowSurrogate);
+                }
+                return WriteAsyncPair(charsSlice[0], charsSlice[1]);
+            }
+            else
+            {
+                return WriteAsync(charsSlice[0]);
+            }
+        }
+
+        public virtual void WriteLine(Rune value)
+        {
+            // Convert value to span
+            Span<char> chars = stackalloc char[2];
+            int charsWritten = value.EncodeToUtf16(chars);
+            ReadOnlySpan<char> charsSlice = chars[..charsWritten];
+
+            // Write span
+            WriteLine(charsSlice);
+        }
+
+        public virtual Task WriteLineAsync(Rune value)
+        {
+            // Convert value to span
+            Span<char> chars = stackalloc char[2];
+            int charsWritten = value.EncodeToUtf16(chars);
+            ReadOnlySpan<char> charsSlice = chars[..charsWritten];
+
+            // Write chars individually (can't use span with async)
+            if (charsSlice.Length == 2)
+            {
+                async Task WriteLineAsyncPair(char highSurrogate, char lowSurrogate)
+                {
+                    await WriteAsync(highSurrogate);
+                    await WriteLineAsync(lowSurrogate);
+                }
+                return WriteLineAsyncPair(charsSlice[0], charsSlice[1]);
+            }
+            else
+            {
+                return WriteLineAsync(charsSlice[0]);
+            }
+        }
+
         #region Task based Async APIs
         public virtual Task WriteAsync(char value) =>
             Task.Factory.StartNew(static state =>

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Unicode;
 
 namespace System

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -609,6 +609,29 @@ namespace System
             return ((uint)lastPos < (uint)Length) && this[lastPos] == value;
         }
 
+        public bool EndsWith(Rune value)
+        {
+            return EndsWith(value, StringComparison.Ordinal);
+        }
+
+        public bool EndsWith(Rune value, StringComparison comparisonType)
+        {
+            if (Rune.DecodeLastFromUtf16(@this, out Rune result, out _) is OperationStatus.Done)
+            {
+                return result.Equals(value, comparisonType);
+            }
+            return false;
+        }
+
+        public bool EndsWith(char value, StringComparison comparisonType)
+        {
+            if (Length == 0)
+            {
+                return false;
+            }
+            return this[^1].Equals(value, comparisonType);
+        }
+
         // Determines whether two strings match.
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
@@ -1180,6 +1203,29 @@ namespace System
             }
 
             return Length != 0 && _firstChar == value;
+        }
+
+        public bool StartsWith(Rune value)
+        {
+            return StartsWith(value, StringComparison.Ordinal);
+        }
+
+        public bool StartsWith(Rune value, StringComparison comparisonType)
+        {
+            if (Rune.DecodeFromUtf16(@this, out Rune result, out _) is OperationStatus.Done)
+            {
+                return result.Equals(value, comparisonType);
+            }
+            return false;
+        }
+
+        public bool StartsWith(char value, StringComparison comparisonType)
+        {
+            if (this.Length == 0)
+            {
+                return false;
+            }
+            return this[0].Equals(value, comparisonType);
         }
 
         internal static void CheckStringComparison(StringComparison comparisonType)

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -617,7 +617,7 @@ namespace System
 
         public bool EndsWith(Rune value, StringComparison comparisonType)
         {
-            if (Rune.DecodeLastFromUtf16(@this, out Rune result, out _) is OperationStatus.Done)
+            if (Rune.DecodeLastFromUtf16(this, out Rune result, out _) is OperationStatus.Done)
             {
                 return result.Equals(value, comparisonType);
             }
@@ -1213,7 +1213,7 @@ namespace System
 
         public bool StartsWith(Rune value, StringComparison comparisonType)
         {
-            if (Rune.DecodeFromUtf16(@this, out Rune result, out _) is OperationStatus.Done)
+            if (Rune.DecodeFromUtf16(this, out Rune result, out _) is OperationStatus.Done)
             {
                 return result.Equals(value, comparisonType);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2460,7 +2460,7 @@ namespace System
             }
 
             // Trim end
-            int endIndex = this.Length - 1;
+            int endIndex = Length - 1;
             while (true)
             {
                 if (endIndex < index)
@@ -2493,7 +2493,7 @@ namespace System
             int index = 0;
             while (true)
             {
-                if (index > @this.Length)
+                if (index > Length)
                 {
                     return string.Empty;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System
 {

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -39,8 +39,18 @@ namespace System
         public bool Contains(char value, StringComparison comparisonType)
         {
 #pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'... this is the implementation of Contains!
-            return IndexOf(value, comparisonType) != -1;
+            return IndexOf(value, comparisonType) >= 0;
 #pragma warning restore CA2249
+        }
+
+        public bool Contains(Rune value)
+        {
+            return Contains(value, StringComparison.Ordinal);
+        }
+
+        public bool Contains(Rune value, StringComparison comparisonType)
+        {
+            return IndexOf(value, comparisonType) >= 0;
         }
 
         // Returns the index of the first occurrence of a specified character in the current instance.
@@ -262,6 +272,54 @@ namespace System
             };
         }
 
+        public int IndexOf(Rune value)
+        {
+            return IndexOf(value, StringComparison.Ordinal);
+        }
+
+        public int IndexOf(Rune value, int startIndex)
+        {
+            return IndexOf(value, startIndex, StringComparison.Ordinal);
+        }
+
+        public int IndexOf(Rune value, int startIndex, int count)
+        {
+            return IndexOf(value, startIndex, count, StringComparison.Ordinal);
+        }
+
+        public int IndexOf(Rune value, StringComparison comparisonType)
+        {
+            return IndexOf(value, 0, comparisonType);
+        }
+
+        public int IndexOf(Rune value, int startIndex, StringComparison comparisonType)
+        {
+            return IndexOf(value, startIndex, Length - startIndex, comparisonType);
+        }
+
+        public int IndexOf(Rune value, int startIndex, int count, StringComparison comparisonType)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 0);
+            ArgumentOutOfRangeException.ThrowIfLessThan(count, 0);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex + count, Length);
+
+            int endIndex = startIndex + count;
+
+            for (int index = startIndex; index <= endIndex;)
+            {
+                if (Rune.DecodeFromUtf16(this.AsSpan(index..endIndex), out Rune rune, out int charsConsumed) is not OperationStatus.Done)
+                {
+                    return -1;
+                }
+                if (value.Equals(rune, comparisonType))
+                {
+                    return index;
+                }
+                index += charsConsumed;
+            }
+            return -1;
+        }
+
         // Returns the index of the last occurrence of a specified character in the current instance.
         // The search starts at startIndex and runs backwards to startIndex - count + 1.
         // The character at position startIndex is included in the search.  startIndex is the larger
@@ -385,6 +443,49 @@ namespace System
                 StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase => CompareInfo.Invariant.LastIndexOf(this, value, startIndex, count, GetCompareOptionsFromOrdinalStringComparison(comparisonType)),
                 _ => throw (value is null ? new ArgumentNullException(nameof(value)) : new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType))),
             };
+        }
+
+        public int LastIndexOf(Rune value)
+        {
+            return LastIndexOf(value, StringComparison.Ordinal);
+        }
+        public int LastIndexOf(Rune value, int startIndex)
+        {
+            return LastIndexOf(value, startIndex, StringComparison.Ordinal);
+        }
+        public int LastIndexOf(Rune value, int startIndex, int count)
+        {
+            return LastIndexOf(value, startIndex, count, StringComparison.Ordinal);
+        }
+        public int LastIndexOf(Rune value, StringComparison comparisonType)
+        {
+            return LastIndexOf(value, Length - 1, comparisonType);
+        }
+        public int LastIndexOf(Rune value, int startIndex, StringComparison comparisonType)
+        {
+            return LastIndexOf(value, startIndex, startIndex, comparisonType);
+        }
+        public int LastIndexOf(Rune value, int startIndex, int count, StringComparison comparisonType)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 0);
+            ArgumentOutOfRangeException.ThrowIfLessThan(count, 0);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex - count, Length);
+
+            int endIndex = startIndex - count;
+
+            for (int index = startIndex; index >= endIndex;)
+            {
+                if (Rune.DecodeLastFromUtf16(this.AsSpan(endIndex..(index + 1)), out Rune rune, out int charsConsumed) is not OperationStatus.Done)
+                {
+                    return -1;
+                }
+                if (value.Equals(rune, comparisonType))
+                {
+                    return index - (charsConsumed - 1);
+                }
+                index -= charsConsumed;
+            }
+            return -1;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -781,12 +781,12 @@ namespace System.Text
 
         public bool Equals(Rune other, StringComparison comparisonType) => Equals(this, other, comparisonType);
 
-        public static bool Equals(this Rune left, Rune right)
+        public static bool Equals(Rune left, Rune right)
         {
             return left == right;
         }
 
-        public static bool Equals(this Rune left, Rune right, StringComparison comparisonType)
+        public static bool Equals(Rune left, Rune right, StringComparison comparisonType)
         {
             if (comparisonType is StringComparison.Ordinal)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -777,7 +777,35 @@ namespace System.Text
 
         public override bool Equals([NotNullWhen(true)] object? obj) => (obj is Rune other) && Equals(other);
 
-        public bool Equals(Rune other) => this == other;
+        public bool Equals(Rune other) => Equals(this, other);
+
+        public bool Equals(Rune other, StringComparison comparisonType) => Equals(this, other, comparisonType);
+
+        public static bool Equals(this Rune left, Rune right)
+        {
+            return left == right;
+        }
+
+        public static bool Equals(this Rune left, Rune right, StringComparison comparisonType)
+        {
+            if (comparisonType is StringComparison.Ordinal)
+            {
+                return left == right;
+            }
+
+            // Convert left to span
+            Span<char> leftChars = stackalloc char[2];
+            int leftCharsWritten = left.EncodeToUtf16(leftChars);
+            ReadOnlySpan<char> leftCharsSlice = leftChars[..leftCharsWritten];
+
+            // Convert right to span
+            Span<char> rightChars = stackalloc char[2];
+            int rightCharsWritten = right.EncodeToUtf16(rightChars);
+            ReadOnlySpan<char> rightCharsSlice = rightChars[..rightCharsWritten];
+
+            // Compare span equality
+            return leftCharsSlice.Equals(rightCharsSlice, comparisonType);
+        }
 
         public override int GetHashCode() => Value;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;


### PR DESCRIPTION
This pull request attempts to add the `System.Text.Rune` methods from #27912.

I'm not experienced with `dotnet/runtime` at all, so the implementations are incomplete and untested. Notably there are 2 methods which need overloads to remove redundant allocations (see "TODO" comments).

All the methods here were previously developed and tested as extension methods in [Joy-less/System.Text.Rune-APIs](https://github.com/Joy-less/System.Text.Rune-APIs).

Please see #27912.