### PR TITLE
Adding padding to precode

### DIFF
--- a/src/coreclr/vm/arm64/thunktemplates.S
+++ b/src/coreclr/vm/arm64/thunktemplates.S
@@ -12,6 +12,9 @@
         ldr x10, DATA_SLOT(StubPrecode, Target)
         ldr x12, DATA_SLOT(StubPrecode, MethodDesc)
         br x10
+        nop
+        nop
+        nop
     LEAF_END_MARKED StubPrecodeCode\STUB_PAGE_SIZE
 
     LEAF_ENTRY FixupPrecodeCode\STUB_PAGE_SIZE
@@ -20,6 +23,7 @@
         ldr x12, DATA_SLOT(FixupPrecode, MethodDesc)
         ldr x11, DATA_SLOT(FixupPrecode, PrecodeFixupThunk)
         br  x11        
+        nop
     LEAF_END_MARKED FixupPrecodeCode\STUB_PAGE_SIZE
 
     LEAF_ENTRY CallCountingStubCode\STUB_PAGE_SIZE

--- a/src/coreclr/vm/arm64/thunktemplates.S
+++ b/src/coreclr/vm/arm64/thunktemplates.S
@@ -12,9 +12,6 @@
         ldr x10, DATA_SLOT(StubPrecode, Target)
         ldr x12, DATA_SLOT(StubPrecode, MethodDesc)
         br x10
-        nop
-        nop
-        nop
     LEAF_END_MARKED StubPrecodeCode\STUB_PAGE_SIZE
 
     LEAF_ENTRY FixupPrecodeCode\STUB_PAGE_SIZE
@@ -22,8 +19,7 @@
         br  x11
         ldr x12, DATA_SLOT(FixupPrecode, MethodDesc)
         ldr x11, DATA_SLOT(FixupPrecode, PrecodeFixupThunk)
-        br  x11        
-        nop
+        br  x11
     LEAF_END_MARKED FixupPrecodeCode\STUB_PAGE_SIZE
 
     LEAF_ENTRY CallCountingStubCode\STUB_PAGE_SIZE

--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -320,6 +320,8 @@ void CallCountingStub::StaticInitialize()
 
 void CallCountingStub::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)
 {
+    SIZE_T actualSize = (SIZE_T)((BYTE*)CallCountingStubCode_End - (BYTE*)CallCountingStubCode);
+    SIZE_T paddingSize= CallCountingStub::CodeSize - actualSize;
 #ifdef TARGET_X86
     int totalCodeSize = (pageSize / CallCountingStub::CodeSize) * CallCountingStub::CodeSize;
 
@@ -338,7 +340,7 @@ void CallCountingStub::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T
         *(BYTE**)(pageBase + i + SYMBOL_VALUE(CallCountingStubCode_TargetForThresholdReached_Offset)) = pCountReachedZeroSlot;
     }
 #else // TARGET_X86
-    FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)CallCountingStubCode), CallCountingStub::CodeSize, pageSize);
+    FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)CallCountingStubCode), CallCountingStub::CodeSize, pageSize, paddingSize);
 #endif
 }
 

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -445,6 +445,8 @@ void StubPrecode::StaticInitialize()
 
 void StubPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)
 {
+    SIZE_T actualSize = (SIZE_T)((BYTE*)StubPrecodeCode_End - (BYTE*)StubPrecodeCode);
+    SIZE_T paddingSize = StubPrecode::CodeSize - actualSize;
 #ifdef TARGET_X86
     int totalCodeSize = (pageSize / StubPrecode::CodeSize) * StubPrecode::CodeSize;
     for (int i = 0; i < totalCodeSize; i += StubPrecode::CodeSize)
@@ -458,7 +460,7 @@ void StubPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T page
         *(BYTE**)(pageBase + i + SYMBOL_VALUE(StubPrecodeCode_MethodDesc_Offset)) = pMethodDescSlot;
     }
 #else // TARGET_X86
-    FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)StubPrecodeCode), StubPrecode::CodeSize, pageSize);
+    FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)StubPrecodeCode), StubPrecode::CodeSize, pageSize, paddingSize);
 #endif // TARGET_X86
 }
 
@@ -564,6 +566,8 @@ void FixupPrecode::StaticInitialize()
 
 void FixupPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)
 {
+    SIZE_T actualSize = (SIZE_T)((BYTE*)FixupPrecodeCode_End - (BYTE*)FixupPrecodeCode);
+    SIZE_T paddingSize= FixupPrecode::CodeSize - actualSize;
 #ifdef TARGET_X86
     int totalCodeSize = (pageSize / FixupPrecode::CodeSize) * FixupPrecode::CodeSize;
 
@@ -580,7 +584,7 @@ void FixupPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pag
         *(BYTE**)(pageBase + i + SYMBOL_VALUE(FixupPrecodeCode_PrecodeFixupThunk_Offset)) = pPrecodeFixupThunkSlot;
     }
 #else // TARGET_X86
-    FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)FixupPrecodeCode), FixupPrecode::CodeSize, pageSize);
+    FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)FixupPrecodeCode), FixupPrecode::CodeSize, pageSize, paddingSize);
 #endif // TARGET_X86
 }
 

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -1953,11 +1953,12 @@ HRESULT GetFileVersion(                     // S_OK or error
 
 Volatile<double> NormalizedTimer::s_frequency = -1.0;
 
-void FillStubCodePage(BYTE* pageBase, const void* code, SIZE_T codeSize, SIZE_T pageSize)
+void FillStubCodePage(BYTE* pageBase, const void* code, SIZE_T codeSize, SIZE_T pageSize, SIZE_T paddingSize = 0)
 {
     SIZE_T totalCodeSize = (pageSize / codeSize) * codeSize;
-
-    memcpy(pageBase, code, codeSize);
+    SIZE_T actualSize = codeSize - paddingSize;
+    memcpy(pageBase, code, actualSize);
+    memset(pageBase + actualSize, 0, paddingSize);
 
     SIZE_T i;
     for (i = codeSize; i < pageSize / 2; i *= 2)

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -886,7 +886,7 @@ HRESULT GetFileVersion(LPCWSTR wszFilePath, ULARGE_INTEGER* pFileVersion);
     ENUM_PAGE_SIZE(32768) \
     ENUM_PAGE_SIZE(65536)
 
-void FillStubCodePage(BYTE* pageBase, const void* code, SIZE_T codeSize, SIZE_T pageSize);
+void FillStubCodePage(BYTE* pageBase, const void* code, SIZE_T codeSize, SIZE_T pageSize, SIZE_T paddingSize);
 
 #ifdef TARGET_64BIT
 // We use modified Daniel Lemire's fastmod algorithm (https://github.com/dotnet/runtime/pull/406),


### PR DESCRIPTION
Add padding to precode to align the StubPrecode with the offset of the data.
We have a single constant “StubPrecode::CodeSize” that is 24 in this case. This address is used to help access the the size of the code that gets copied from the template code. The effect is that instead of having 12 bytes of StubPrecode code followed by e.g. 12 zeros, we have 12 bytes of StubPrecode code followed by 12 bytes from the beginning of the FixupPrecodeCode.
That leads to the misdetection of stubStartAddress - FixupPrecode::FixupCodeOffset as FixupPrecode, because there in fact is part of its code.