### PR TITLE
Implement PKCS12 Export in terms of Pkcs12Builder for non-Windows

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/PkcsHelpers.cs
@@ -1,0 +1,346 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Asn1;
+using System.Security.Cryptography.Pkcs;
+using System.Text;
+
+namespace Internal.Cryptography
+{
+    internal static partial class PkcsHelpers
+    {
+#if BUILDING_PKCS
+        private static readonly bool s_oidIsInitOnceOnly = DetectInitOnlyOid();
+
+        private static bool DetectInitOnlyOid()
+        {
+            Oid testOid = new Oid(Oids.Sha256, null);
+
+            try
+            {
+                testOid.Value = Oids.Sha384;
+                return false;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return true;
+            }
+        }
+#endif
+
+        internal static List<AttributeAsn> BuildAttributes(CryptographicAttributeObjectCollection? attributes)
+        {
+            List<AttributeAsn> signedAttrs = new List<AttributeAsn>();
+
+            if (attributes == null || attributes.Count == 0)
+            {
+                return signedAttrs;
+            }
+
+            foreach (CryptographicAttributeObject attributeObject in attributes)
+            {
+                AttributeAsn newAttr = new AttributeAsn
+                {
+                    AttrType = attributeObject.Oid!.Value!,
+                    AttrValues = new ReadOnlyMemory<byte>[attributeObject.Values.Count],
+                };
+
+                for (int i = 0; i < attributeObject.Values.Count; i++)
+                {
+                    newAttr.AttrValues[i] = attributeObject.Values[i].RawData;
+                }
+
+                signedAttrs.Add(newAttr);
+            }
+
+            return signedAttrs;
+        }
+
+        public static void EnsureSingleBerValue(ReadOnlySpan<byte> source)
+        {
+            if (!AsnDecoder.TryReadEncodedValue(source, AsnEncodingRules.BER, out _, out _, out _, out int consumed) ||
+                consumed != source.Length)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+        }
+
+        public static byte[] EncodeOctetString(byte[] octets)
+        {
+            // Write using DER to support the most readers.
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+            writer.WriteOctetString(octets);
+            return writer.Encode();
+        }
+
+        public static byte[] DecodeOctetString(ReadOnlyMemory<byte> encodedOctets)
+        {
+            try
+            {
+                // Read using BER because the CMS specification says the encoding is BER.
+                byte[] ret = AsnDecoder.ReadOctetString(encodedOctets.Span, AsnEncodingRules.BER, out int consumed);
+
+                if (consumed != encodedOctets.Length)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                return ret;
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+
+        public static string DecodeOid(ReadOnlySpan<byte> encodedOid)
+        {
+            // Windows compat for a zero length OID.
+            if (encodedOid.Length == 2 && encodedOid[0] == 0x06 && encodedOid[1] == 0x00)
+            {
+                return string.Empty;
+            }
+
+            // Read using BER because the CMS specification says the encoding is BER.
+            try
+            {
+                string value = AsnDecoder.ReadObjectIdentifier(
+                    encodedOid,
+                    AsnEncodingRules.BER,
+                    out int consumed);
+
+                if (consumed != encodedOid.Length)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                return value;
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+
+        public static byte[] UnicodeToOctetString(this string s)
+        {
+            byte[] octets = new byte[2 * (s.Length + 1)];
+            Encoding.Unicode.GetBytes(s, 0, s.Length, octets, 0);
+            return octets;
+        }
+
+        public static string OctetStringToUnicode(this byte[] octets)
+        {
+            if (octets.Length < 2)
+                return string.Empty;   // .NET Framework compat: 0-length byte array maps to string.empty. 1-length byte array gets passed to Marshal.PtrToStringUni() with who knows what outcome.
+
+            int end = octets.Length;
+            int endMinusOne = end - 1;
+
+            // Truncate the string to before the first embedded \0 (probably the last two bytes).
+            for (int i = 0; i < endMinusOne; i += 2)
+            {
+                if (octets[i] == 0 && octets[i + 1] == 0)
+                {
+                    end = i;
+                    break;
+                }
+            }
+
+            string s = Encoding.Unicode.GetString(octets, 0, end);
+            return s;
+        }
+
+        public static ReadOnlyMemory<byte> DecodeOctetStringAsMemory(ReadOnlyMemory<byte> encodedOctetString)
+        {
+#if BUILDING_PKCS
+            try
+            {
+                ReadOnlySpan<byte> input = encodedOctetString.Span;
+
+                if (AsnDecoder.TryReadPrimitiveOctetString(
+                    input,
+                    AsnEncodingRules.BER,
+                    out ReadOnlySpan<byte> primitive,
+                    out int consumed))
+                {
+                    if (consumed != input.Length)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+
+                    if (input.Overlaps(primitive, out int offset))
+                    {
+                        return encodedOctetString.Slice(offset, primitive.Length);
+                    }
+
+                    Debug.Fail("input.Overlaps(primitive) failed after TryReadPrimitiveOctetString succeeded");
+                }
+
+                byte[] ret = AsnDecoder.ReadOctetString(input, AsnEncodingRules.BER, out consumed);
+
+                if (consumed != input.Length)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                return ret;
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+#else
+            return Helpers.DecodeOctetStringAsMemory(encodedOctetString);
+#endif
+        }
+
+        internal static string GetOidFromHashAlgorithm(HashAlgorithmName algName)
+        {
+            if (algName == HashAlgorithmName.MD5)
+                return Oids.Md5;
+            if (algName == HashAlgorithmName.SHA1)
+                return Oids.Sha1;
+            if (algName == HashAlgorithmName.SHA256)
+                return Oids.Sha256;
+            if (algName == HashAlgorithmName.SHA384)
+                return Oids.Sha384;
+            if (algName == HashAlgorithmName.SHA512)
+                return Oids.Sha512;
+#if NET8_0_OR_GREATER
+            if (algName == HashAlgorithmName.SHA3_256)
+                return Oids.Sha3_256;
+            if (algName == HashAlgorithmName.SHA3_384)
+                return Oids.Sha3_384;
+            if (algName == HashAlgorithmName.SHA3_512)
+                return Oids.Sha3_512;
+#endif
+
+            throw new CryptographicException(SR.Cryptography_Cms_UnknownAlgorithm, algName.Name);
+        }
+
+        // Creates a defensive copy of an OID on platforms where OID
+        // is mutable. On platforms where OID is immutable, return the OID as-is.
+        [return: NotNullIfNotNull(nameof(oid))]
+        public static Oid? CopyOid(this Oid? oid)
+        {
+#if BUILDING_PKCS
+            if (s_oidIsInitOnceOnly)
+            {
+                return oid;
+            }
+            else
+            {
+                return oid is null ? null : new Oid(oid);
+            }
+#else
+            return oid; // If we are in System.Security.Cryptography, then Oids are known to be immutable.
+#endif
+        }
+
+        internal static CryptographicAttributeObjectCollection MakeAttributeCollection(AttributeAsn[]? attributes)
+        {
+            var coll = new CryptographicAttributeObjectCollection();
+
+            if (attributes == null)
+                return coll;
+
+            foreach (AttributeAsn attribute in attributes)
+            {
+                coll.AddWithoutMerge(MakeAttribute(attribute));
+            }
+
+            return coll;
+        }
+
+        internal static CryptographicAttributeObject MakeAttribute(AttributeAsn attribute)
+        {
+            Oid type = new Oid(attribute.AttrType);
+            AsnEncodedDataCollection valueColl = new AsnEncodedDataCollection();
+
+            foreach (ReadOnlyMemory<byte> attrValue in attribute.AttrValues)
+            {
+                valueColl.Add(CreateBestPkcs9AttributeObjectAvailable(type, attrValue.ToArray()));
+            }
+
+            return new CryptographicAttributeObject(type, valueColl);
+        }
+
+        public static byte[] EncodeUtcTime(DateTime utcTime)
+        {
+            const int maxLegalYear = 2049;
+            // Write using DER to support the most readers.
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+
+            try
+            {
+                // Sending the DateTime through ToLocalTime here will cause the right normalization
+                // of DateTimeKind.Unknown.
+                //
+                // Unknown => Local (adjust) => UTC (adjust "back", add Z marker; matches Windows)
+                if (utcTime.Kind == DateTimeKind.Unspecified)
+                {
+                    writer.WriteUtcTime(utcTime.ToLocalTime(), maxLegalYear);
+                }
+                else
+                {
+                    writer.WriteUtcTime(utcTime, maxLegalYear);
+                }
+
+                return writer.Encode();
+            }
+            catch (ArgumentException ex)
+            {
+                throw new CryptographicException(ex.Message, ex);
+            }
+        }
+
+        public static DateTime DecodeUtcTime(byte[] encodedUtcTime)
+        {
+            // Read using BER because the CMS specification says the encoding is BER.
+            try
+            {
+                DateTimeOffset value = AsnDecoder.ReadUtcTime(
+                    encodedUtcTime,
+                    AsnEncodingRules.BER,
+                    out int consumed);
+
+                if (consumed != encodedUtcTime.Length)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                return value.UtcDateTime;
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+
+        /// <summary>
+        /// Useful helper for "upgrading" well-known CMS attributes to type-specific objects such as Pkcs9DocumentName, Pkcs9DocumentDescription, etc.
+        /// </summary>
+        public static Pkcs9AttributeObject CreateBestPkcs9AttributeObjectAvailable(Oid oid, ReadOnlySpan<byte> encodedAttribute)
+        {
+            return oid.Value switch
+            {
+                Oids.DocumentName => new Pkcs9DocumentName(encodedAttribute),
+                Oids.DocumentDescription => new Pkcs9DocumentDescription(encodedAttribute),
+                Oids.SigningTime => new Pkcs9SigningTime(encodedAttribute),
+                Oids.ContentType => new Pkcs9ContentType(encodedAttribute),
+                Oids.MessageDigest => new Pkcs9MessageDigest(encodedAttribute),
+#if NET || NETSTANDARD2_1
+                Oids.LocalKeyId => new Pkcs9LocalKeyId() { RawData = encodedAttribute.ToArray() },
+#endif
+                _ => new Pkcs9AttributeObject(oid, encodedAttribute),
+            };
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SecretBagAsn.xml
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SecretBagAsn.xml
@@ -2,7 +2,7 @@
 <asn:Sequence
   xmlns:asn="http://schemas.dot.net/asnxml/201808/"
   name="SecretBagAsn"
-  namespace="System.Security.Cryptography.Pkcs.Asn1">
+  namespace="System.Security.Cryptography.Asn1.Pkcs12">
 
   <!--
     https://tools.ietf.org/html/rfc7292#section-4.2.5

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SecretBagAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SecretBagAsn.xml.cs
@@ -6,7 +6,7 @@ using System;
 using System.Formats.Asn1;
 using System.Runtime.InteropServices;
 
-namespace System.Security.Cryptography.Pkcs.Asn1
+namespace System.Security.Cryptography.Asn1.Pkcs12
 {
     [StructLayout(LayoutKind.Sequential)]
     internal partial struct SecretBagAsn

--- a/src/libraries/Common/src/System/Security/Cryptography/CryptographicAttributeObject.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CryptographicAttributeObject.cs
@@ -7,7 +7,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
-    public sealed class CryptographicAttributeObject
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class CryptographicAttributeObject
     {
         //
         // Constructors.

--- a/src/libraries/Common/src/System/Security/Cryptography/CryptographicAttributeObjectCollection.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CryptographicAttributeObjectCollection.cs
@@ -10,7 +10,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
-    public sealed class CryptographicAttributeObjectCollection : ICollection
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class CryptographicAttributeObjectCollection : ICollection
     {
         public CryptographicAttributeObjectCollection()
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/CryptographicAttributeObjectEnumerator.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CryptographicAttributeObjectEnumerator.cs
@@ -7,7 +7,13 @@ using System.Diagnostics;
 
 namespace System.Security.Cryptography
 {
-    public sealed class CryptographicAttributeObjectEnumerator : IEnumerator
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class CryptographicAttributeObjectEnumerator : IEnumerator
     {
         internal CryptographicAttributeObjectEnumerator(CryptographicAttributeObjectCollection attributes)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12Builder.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12Builder.cs
@@ -10,7 +10,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs12Builder
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs12Builder
     {
         private ReadOnlyMemory<byte> _sealedData;
         private List<ContentInfoAsn>? _contents;

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12CertBag.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12CertBag.cs
@@ -8,7 +8,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs12CertBag : Pkcs12SafeBag
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs12CertBag : Pkcs12SafeBag
     {
         private Oid? _certTypeOid;
         private readonly CertBagAsn _decoded;

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12ConfidentialityMode.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12ConfidentialityMode.cs
@@ -3,7 +3,12 @@
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public enum Pkcs12ConfidentialityMode
+#if BUILDING_PKCS
+    public
+#else
+    internal
+#endif
+    enum Pkcs12ConfidentialityMode
     {
         Unknown = 0,
         None = 1,

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12KeyBag.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12KeyBag.cs
@@ -3,7 +3,13 @@
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs12KeyBag : Pkcs12SafeBag
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs12KeyBag : Pkcs12SafeBag
     {
         public Pkcs12KeyBag(ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false)
             : base(Oids.Pkcs12KeyBag, pkcs8PrivateKey, skipCopy)

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeBag.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeBag.cs
@@ -9,7 +9,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public abstract class Pkcs12SafeBag
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    abstract class Pkcs12SafeBag
     {
         private readonly string _bagIdValue;
         private Oid? _bagOid;
@@ -77,7 +83,7 @@ namespace System.Security.Cryptography.Pkcs
 
             if (_attributes?.Count > 0)
             {
-                List<AttributeAsn> attrs = CmsSigner.BuildAttributes(_attributes);
+                List<AttributeAsn> attrs = PkcsHelpers.BuildAttributes(_attributes);
 
                 writer.PushSetOf();
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContents.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContents.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Formats.Asn1;
-using System.Linq;
 using System.Security.Cryptography.Asn1.Pkcs12;
 using System.Security.Cryptography.Asn1.Pkcs7;
 using System.Security.Cryptography.X509Certificates;
@@ -12,7 +11,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs12SafeContents
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs12SafeContents
     {
         private ReadOnlyMemory<byte> _encrypted;
         private List<Pkcs12SafeBag>? _bags;
@@ -287,7 +292,7 @@ namespace System.Security.Cryptography.Pkcs
 
             if (_bags == null)
             {
-                return Enumerable.Empty<Pkcs12SafeBag>();
+                return [];
             }
 
             return _bags.AsReadOnly();
@@ -359,7 +364,7 @@ namespace System.Security.Cryptography.Pkcs
 
                 bag ??= new Pkcs12SafeBag.UnknownBag(serializedBags[i].BagId, bagValue);
 
-                bag.Attributes = SignerInfo.MakeAttributeCollection(serializedBags[i].BagAttributes);
+                bag.Attributes = PkcsHelpers.MakeAttributeCollection(serializedBags[i].BagAttributes);
                 bags.Add(bag);
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContentsBag.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContentsBag.cs
@@ -6,7 +6,13 @@ using System.Formats.Asn1;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs12SafeContentsBag : Pkcs12SafeBag
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs12SafeContentsBag : Pkcs12SafeBag
     {
         public Pkcs12SafeContents? SafeContents { get; private set; }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SecretBag.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SecretBag.cs
@@ -3,12 +3,18 @@
 
 using System.Diagnostics;
 using System.Formats.Asn1;
-using System.Security.Cryptography.Pkcs.Asn1;
+using System.Security.Cryptography.Asn1.Pkcs12;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs12SecretBag : Pkcs12SafeBag
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs12SecretBag : Pkcs12SafeBag
     {
         private Oid? _secretTypeOid;
         private readonly SecretBagAsn _decoded;

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12ShroudedKeyBag.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12ShroudedKeyBag.cs
@@ -3,7 +3,13 @@
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs12ShroudedKeyBag : Pkcs12SafeBag
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs12ShroudedKeyBag : Pkcs12SafeBag
     {
         public Pkcs12ShroudedKeyBag(ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false)
             : base(Oids.Pkcs12ShroudedKeyBag, encryptedPkcs8PrivateKey, skipCopy)

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9AttributeObject.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9AttributeObject.cs
@@ -6,7 +6,13 @@ using System.Diagnostics;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public class Pkcs9AttributeObject : AsnEncodedData
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    class Pkcs9AttributeObject : AsnEncodedData
     {
         //
         // Constructors.

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
@@ -1,25 +1,32 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Formats.Asn1;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs9MessageDigest : Pkcs9AttributeObject
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs9ContentType : Pkcs9AttributeObject
     {
         //
         // Constructors.
         //
 
-        public Pkcs9MessageDigest()
-            : base(Oids.MessageDigestOid.CopyOid())
+        public Pkcs9ContentType()
+            : base(Oids.ContentTypeOid.CopyOid())
         {
         }
 
-        internal Pkcs9MessageDigest(ReadOnlySpan<byte> rawData)
-            : base(Oids.MessageDigestOid.CopyOid(), rawData)
+        internal Pkcs9ContentType(ReadOnlySpan<byte> rawData)
+            : base(Oids.ContentTypeOid.CopyOid(), rawData)
         {
         }
 
@@ -27,18 +34,18 @@ namespace System.Security.Cryptography.Pkcs
         // Public properties.
         //
 
-        public byte[] MessageDigest
+        public Oid ContentType
         {
             get
             {
-                return _lazyMessageDigest ??= Decode(RawData);
+                return _lazyContentType ??= Decode(RawData);
             }
         }
 
         public override void CopyFrom(AsnEncodedData asnEncodedData)
         {
             base.CopyFrom(asnEncodedData);
-            _lazyMessageDigest = null;
+            _lazyContentType = null;
         }
 
         //
@@ -46,14 +53,15 @@ namespace System.Security.Cryptography.Pkcs
         //
 
         [return: NotNullIfNotNull(nameof(rawData))]
-        private static byte[]? Decode(byte[]? rawData)
+        private static Oid? Decode(byte[]? rawData)
         {
             if (rawData == null)
                 return null;
 
-            return PkcsHelpers.DecodeOctetString(rawData);
+            string contentTypeValue = PkcsHelpers.DecodeOid(rawData);
+            return new Oid(contentTypeValue);
         }
 
-        private volatile byte[]? _lazyMessageDigest;
+        private volatile Oid? _lazyContentType;
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
@@ -8,7 +8,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs9DocumentDescription : Pkcs9AttributeObject
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs9DocumentDescription : Pkcs9AttributeObject
     {
         //
         // Constructors.

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
@@ -8,7 +8,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs9DocumentName : Pkcs9AttributeObject
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs9DocumentName : Pkcs9AttributeObject
     {
         //
         // Constructors.

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
@@ -7,7 +7,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs9LocalKeyId : Pkcs9AttributeObject
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs9LocalKeyId : Pkcs9AttributeObject
     {
         private byte[]? _lazyKeyId;
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
@@ -1,26 +1,31 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Formats.Asn1;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs9ContentType : Pkcs9AttributeObject
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs9MessageDigest : Pkcs9AttributeObject
     {
         //
         // Constructors.
         //
 
-        public Pkcs9ContentType()
-            : base(Oids.ContentTypeOid.CopyOid())
+        public Pkcs9MessageDigest()
+            : base(Oids.MessageDigestOid.CopyOid())
         {
         }
 
-        internal Pkcs9ContentType(ReadOnlySpan<byte> rawData)
-            : base(Oids.ContentTypeOid.CopyOid(), rawData)
+        internal Pkcs9MessageDigest(ReadOnlySpan<byte> rawData)
+            : base(Oids.MessageDigestOid.CopyOid(), rawData)
         {
         }
 
@@ -28,18 +33,18 @@ namespace System.Security.Cryptography.Pkcs
         // Public properties.
         //
 
-        public Oid ContentType
+        public byte[] MessageDigest
         {
             get
             {
-                return _lazyContentType ??= Decode(RawData);
+                return _lazyMessageDigest ??= Decode(RawData);
             }
         }
 
         public override void CopyFrom(AsnEncodedData asnEncodedData)
         {
             base.CopyFrom(asnEncodedData);
-            _lazyContentType = null;
+            _lazyMessageDigest = null;
         }
 
         //
@@ -47,15 +52,14 @@ namespace System.Security.Cryptography.Pkcs
         //
 
         [return: NotNullIfNotNull(nameof(rawData))]
-        private static Oid? Decode(byte[]? rawData)
+        private static byte[]? Decode(byte[]? rawData)
         {
             if (rawData == null)
                 return null;
 
-            string contentTypeValue = PkcsHelpers.DecodeOid(rawData);
-            return new Oid(contentTypeValue);
+            return PkcsHelpers.DecodeOctetString(rawData);
         }
 
-        private volatile Oid? _lazyContentType;
+        private volatile byte[]? _lazyMessageDigest;
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9SigningTime.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9SigningTime.cs
@@ -9,7 +9,13 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class Pkcs9SigningTime : Pkcs9AttributeObject
+#if BUILDING_PKCS
+    public
+#else
+    #pragma warning disable CA1510, CA1512
+    internal
+#endif
+    sealed class Pkcs9SigningTime : Pkcs9AttributeObject
     {
         //
         // Constructors.

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
@@ -50,7 +50,7 @@ namespace Internal.Cryptography.Pal.AnyOS
                 }
             }
 
-            unprotectedAttributes = SignerInfo.MakeAttributeCollection(data.UnprotectedAttributes);
+            unprotectedAttributes = PkcsHelpers.MakeAttributeCollection(data.UnprotectedAttributes);
 
             var recipientInfos = new List<RecipientInfo>();
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Encrypt.cs
@@ -78,7 +78,7 @@ namespace Internal.Cryptography.Pal.AnyOS
 
             if (unprotectedAttributes != null && unprotectedAttributes.Count > 0)
             {
-                List<AttributeAsn> attrList = CmsSigner.BuildAttributes(unprotectedAttributes);
+                List<AttributeAsn> attrList = PkcsHelpers.BuildAttributes(unprotectedAttributes);
 
                 envelopedData.UnprotectedAttributes = PkcsHelpers.NormalizeAttributeSet(attrList.ToArray());
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -19,23 +19,6 @@ namespace Internal.Cryptography
 {
     internal static partial class PkcsHelpers
     {
-        private static readonly bool s_oidIsInitOnceOnly = DetectInitOnlyOid();
-
-        private static bool DetectInitOnlyOid()
-        {
-            Oid testOid = new Oid(Oids.Sha256, null);
-
-            try
-            {
-                testOid.Value = Oids.Sha384;
-                return false;
-            }
-            catch (PlatformNotSupportedException)
-            {
-                return true;
-            }
-        }
-
 #if !NET && !NETSTANDARD2_1
         // Compatibility API.
         internal static void AppendData(this IncrementalHash hasher, ReadOnlySpan<byte> data)
@@ -83,30 +66,6 @@ namespace Internal.Cryptography
                 default:
                     throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, oidValue);
             }
-        }
-
-        internal static string GetOidFromHashAlgorithm(HashAlgorithmName algName)
-        {
-            if (algName == HashAlgorithmName.MD5)
-                return Oids.Md5;
-            if (algName == HashAlgorithmName.SHA1)
-                return Oids.Sha1;
-            if (algName == HashAlgorithmName.SHA256)
-                return Oids.Sha256;
-            if (algName == HashAlgorithmName.SHA384)
-                return Oids.Sha384;
-            if (algName == HashAlgorithmName.SHA512)
-                return Oids.Sha512;
-#if NET8_0_OR_GREATER
-            if (algName == HashAlgorithmName.SHA3_256)
-                return Oids.Sha3_256;
-            if (algName == HashAlgorithmName.SHA3_384)
-                return Oids.Sha3_384;
-            if (algName == HashAlgorithmName.SHA3_512)
-                return Oids.Sha3_512;
-#endif
-
-            throw new CryptographicException(SR.Cryptography_Cms_UnknownAlgorithm, algName.Name);
         }
 
         /// <summary>
@@ -229,35 +188,6 @@ namespace Internal.Cryptography
                 GC.KeepAlive(originalCert);
             }
             return recipientsCopy;
-        }
-
-        public static byte[] UnicodeToOctetString(this string s)
-        {
-            byte[] octets = new byte[2 * (s.Length + 1)];
-            Encoding.Unicode.GetBytes(s, 0, s.Length, octets, 0);
-            return octets;
-        }
-
-        public static string OctetStringToUnicode(this byte[] octets)
-        {
-            if (octets.Length < 2)
-                return string.Empty;   // .NET Framework compat: 0-length byte array maps to string.empty. 1-length byte array gets passed to Marshal.PtrToStringUni() with who knows what outcome.
-
-            int end = octets.Length;
-            int endMinusOne = end - 1;
-
-            // Truncate the string to before the first embedded \0 (probably the last two bytes).
-            for (int i = 0; i < endMinusOne; i += 2)
-            {
-                if (octets[i] == 0 && octets[i + 1] == 0)
-                {
-                    end = i;
-                    break;
-                }
-            }
-
-            string s = Encoding.Unicode.GetString(octets, 0, end);
-            return s;
         }
 
         public static X509Certificate2Collection GetStoreCertificates(StoreName storeName, StoreLocation storeLocation, bool openExistingOnly)
@@ -421,25 +351,6 @@ namespace Internal.Cryptography
             throw new CryptographicException();  // This just keeps the compiler happy. We don't expect to reach this.
         }
 
-        /// <summary>
-        /// Useful helper for "upgrading" well-known CMS attributes to type-specific objects such as Pkcs9DocumentName, Pkcs9DocumentDescription, etc.
-        /// </summary>
-        public static Pkcs9AttributeObject CreateBestPkcs9AttributeObjectAvailable(Oid oid, ReadOnlySpan<byte> encodedAttribute)
-        {
-            return oid.Value switch
-            {
-                Oids.DocumentName => new Pkcs9DocumentName(encodedAttribute),
-                Oids.DocumentDescription => new Pkcs9DocumentDescription(encodedAttribute),
-                Oids.SigningTime => new Pkcs9SigningTime(encodedAttribute),
-                Oids.ContentType => new Pkcs9ContentType(encodedAttribute),
-                Oids.MessageDigest => new Pkcs9MessageDigest(encodedAttribute),
-#if NET || NETSTANDARD2_1
-                Oids.LocalKeyId => new Pkcs9LocalKeyId() { RawData = encodedAttribute.ToArray() },
-#endif
-                _ => new Pkcs9AttributeObject(oid, encodedAttribute),
-            };
-        }
-
         internal static byte[] OneShot(this ICryptoTransform transform, byte[] data)
         {
             return OneShot(transform, data, 0, data.Length);
@@ -463,15 +374,6 @@ namespace Internal.Cryptography
             }
         }
 
-        public static void EnsureSingleBerValue(ReadOnlySpan<byte> source)
-        {
-            if (!AsnDecoder.TryReadEncodedValue(source, AsnEncodingRules.BER, out _, out _, out _, out int consumed) ||
-                consumed != source.Length)
-            {
-                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-            }
-        }
-
         public static int FirstBerValueLength(ReadOnlySpan<byte> source)
         {
             if (!AsnDecoder.TryReadEncodedValue(source, AsnEncodingRules.BER, out _, out _, out _, out int consumed))
@@ -480,155 +382,6 @@ namespace Internal.Cryptography
             }
 
             return consumed;
-        }
-
-        public static ReadOnlyMemory<byte> DecodeOctetStringAsMemory(ReadOnlyMemory<byte> encodedOctetString)
-        {
-            try
-            {
-                ReadOnlySpan<byte> input = encodedOctetString.Span;
-
-                if (AsnDecoder.TryReadPrimitiveOctetString(
-                    input,
-                    AsnEncodingRules.BER,
-                    out ReadOnlySpan<byte> primitive,
-                    out int consumed))
-                {
-                    if (consumed != input.Length)
-                    {
-                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                    }
-
-                    if (input.Overlaps(primitive, out int offset))
-                    {
-                        return encodedOctetString.Slice(offset, primitive.Length);
-                    }
-
-                    Debug.Fail("input.Overlaps(primitive) failed after TryReadPrimitiveOctetString succeeded");
-                }
-
-                byte[] ret = AsnDecoder.ReadOctetString(input, AsnEncodingRules.BER, out consumed);
-
-                if (consumed != input.Length)
-                {
-                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                }
-
-                return ret;
-            }
-            catch (AsnContentException e)
-            {
-                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
-            }
-        }
-
-        public static byte[] DecodeOctetString(ReadOnlyMemory<byte> encodedOctets)
-        {
-            try
-            {
-                // Read using BER because the CMS specification says the encoding is BER.
-                byte[] ret = AsnDecoder.ReadOctetString(encodedOctets.Span, AsnEncodingRules.BER, out int consumed);
-
-                if (consumed != encodedOctets.Length)
-                {
-                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                }
-
-                return ret;
-            }
-            catch (AsnContentException e)
-            {
-                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
-            }
-        }
-
-        public static byte[] EncodeOctetString(byte[] octets)
-        {
-            // Write using DER to support the most readers.
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.WriteOctetString(octets);
-            return writer.Encode();
-        }
-
-        public static byte[] EncodeUtcTime(DateTime utcTime)
-        {
-            const int maxLegalYear = 2049;
-            // Write using DER to support the most readers.
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-
-            try
-            {
-                // Sending the DateTime through ToLocalTime here will cause the right normalization
-                // of DateTimeKind.Unknown.
-                //
-                // Unknown => Local (adjust) => UTC (adjust "back", add Z marker; matches Windows)
-                if (utcTime.Kind == DateTimeKind.Unspecified)
-                {
-                    writer.WriteUtcTime(utcTime.ToLocalTime(), maxLegalYear);
-                }
-                else
-                {
-                    writer.WriteUtcTime(utcTime, maxLegalYear);
-                }
-
-                return writer.Encode();
-            }
-            catch (ArgumentException ex)
-            {
-                throw new CryptographicException(ex.Message, ex);
-            }
-        }
-
-        public static DateTime DecodeUtcTime(byte[] encodedUtcTime)
-        {
-            // Read using BER because the CMS specification says the encoding is BER.
-            try
-            {
-                DateTimeOffset value = AsnDecoder.ReadUtcTime(
-                    encodedUtcTime,
-                    AsnEncodingRules.BER,
-                    out int consumed);
-
-                if (consumed != encodedUtcTime.Length)
-                {
-                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                }
-
-                return value.UtcDateTime;
-            }
-            catch (AsnContentException e)
-            {
-                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
-            }
-        }
-
-        public static string DecodeOid(ReadOnlySpan<byte> encodedOid)
-        {
-            // Windows compat for a zero length OID.
-            if (encodedOid.Length == 2 && encodedOid[0] == 0x06 && encodedOid[1] == 0x00)
-            {
-                return string.Empty;
-            }
-
-            // Read using BER because the CMS specification says the encoding is BER.
-            try
-            {
-                string value = AsnDecoder.ReadObjectIdentifier(
-                    encodedOid,
-                    AsnEncodingRules.BER,
-                    out int consumed);
-
-                if (consumed != encodedOid.Length)
-                {
-                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                }
-
-                return value;
-            }
-            catch (AsnContentException e)
-            {
-                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
-            }
         }
 
         public static bool TryGetRsaOaepEncryptionPadding(
@@ -700,21 +453,6 @@ namespace Internal.Cryptography
             {
                 exception = e;
                 return false;
-            }
-        }
-
-        // Creates a defensive copy of an OID on platforms where OID
-        // is mutable. On platforms where OID is immutable, return the OID as-is.
-        [return: NotNullIfNotNull(nameof(oid))]
-        public static Oid? CopyOid(this Oid? oid)
-        {
-            if (s_oidIsInitOnceOnly)
-            {
-                return oid;
-            }
-            else
-            {
-                return oid is null ? null : new Oid(oid);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -28,9 +28,24 @@ System.Security.Cryptography.Pkcs.EnvelopedCms</PackageDescription>
 
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <!-- API types (platform independent) -->
-    <Compile Include="System\Security\Cryptography\CryptographicAttributeObject.cs" />
-    <Compile Include="System\Security\Cryptography\CryptographicAttributeObjectCollection.cs" />
-    <Compile Include="System\Security\Cryptography\CryptographicAttributeObjectEnumerator.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObject.cs"
+             Link="Common\System\Security\Cryptography\CryptographicAttributeObject.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObjectCollection.cs"
+             Link="Common\System\Security\Cryptography\CryptographicAttributeObjectCollection.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObjectEnumerator.cs"
+             Link="Common\System\Security\Cryptography\CryptographicAttributeObjectEnumerator.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9AttributeObject.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9AttributeObject.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9ContentType.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9ContentType.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9DocumentDescription.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9DocumentDescription.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9DocumentName.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9DocumentName.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9MessageDigest.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9MessageDigest.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9SigningTime.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9SigningTime.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\AlgorithmIdentifier.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\CmsRecipient.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\CmsRecipientCollection.cs" />
@@ -39,12 +54,6 @@ System.Security.Cryptography.Pkcs.EnvelopedCms</PackageDescription>
     <Compile Include="System\Security\Cryptography\Pkcs\EnvelopedCms.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\KeyAgreeRecipientInfo.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\KeyTransRecipientInfo.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs9AttributeObject.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs9ContentType.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs9DocumentDescription.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs9DocumentName.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs9MessageDigest.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs9SigningTime.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\PublicKeyInfo.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\RecipientInfo.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\RecipientInfoCollection.cs" />
@@ -66,6 +75,8 @@ System.Security.Cryptography.Pkcs.EnvelopedCms</PackageDescription>
     <Compile Include="Internal\Cryptography\RecipientInfoPal.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs"
              Link="Common\System\HexConverter.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\PkcsHelpers.cs"
+             Link="Common\Internal\Cryptography\PkcsHelpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Helpers.cs"
              Link="Common\System\Security\Cryptography\Helpers.cs" />
     <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml">
@@ -612,6 +623,13 @@ System.Security.Cryptography.Pkcs.EnvelopedCms</PackageDescription>
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml</DependentUpon>
     </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml</DependentUpon>
+    </Compile>
     <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml</Link>
     </AsnXml>
@@ -623,24 +641,30 @@ System.Security.Cryptography.Pkcs.EnvelopedCms</PackageDescription>
              Link="Common\System\Security\Cryptography\PasswordBasedEncryption.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs12Kdf.cs"
              Link="Common\System\Security\Cryptography\Pkcs12Kdf.cs" />
-    <AsnXml Include="System\Security\Cryptography\Pkcs\Asn1\SecretBagAsn.xml" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Asn1\SecretBagAsn.xml.cs">
-      <DependentUpon>System\Security\Cryptography\Pkcs\Asn1\SecretBagAsn.xml</DependentUpon>
-    </Compile>
     <Compile Include="System\Security\Cryptography\Pkcs\CmsSignature.DSA.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12Builder.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12CertBag.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12ConfidentialityMode.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12Builder.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12Builder.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12CertBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12CertBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12ConfidentialityMode.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12ConfidentialityMode.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12Info.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12IntegrityMode.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12KeyBag.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12SafeBag.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12SafeContents.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12SafeContentsBag.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12SecretBag.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs12ShroudedKeyBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12KeyBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12KeyBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SafeBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SafeBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SafeContents.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SafeContents.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SafeContentsBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SafeContentsBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SecretBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SecretBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12ShroudedKeyBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12ShroudedKeyBag.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Pkcs8PrivateKeyInfo.cs" />
-    <Compile Include="System\Security\Cryptography\Pkcs\Pkcs9LocalKeyId.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9LocalKeyId.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9LocalKeyId.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Rfc3161RequestResponseStatus.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Rfc3161TimestampRequest.cs" />
     <Compile Include="System\Security\Cryptography\Pkcs\Rfc3161TimestampToken.cs" />

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography.Pkcs
                 // If the content type is otherwise not-data we need to record it as the content-type attr.
                 if (SignedAttributes?.Count > 0 || contentTypeOid != Oids.Pkcs7Data)
                 {
-                    List<AttributeAsn> signedAttrs = BuildAttributes(SignedAttributes);
+                    List<AttributeAsn> signedAttrs = PkcsHelpers.BuildAttributes(SignedAttributes);
 
                     AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
                     writer.WriteOctetString(dataHash);
@@ -281,7 +281,7 @@ namespace System.Security.Cryptography.Pkcs
 
             if (UnsignedAttributes != null && UnsignedAttributes.Count > 0)
             {
-                List<AttributeAsn> attrs = BuildAttributes(UnsignedAttributes);
+                List<AttributeAsn> attrs = PkcsHelpers.BuildAttributes(UnsignedAttributes);
 
                 newSignerInfo.UnsignedAttributes = PkcsHelpers.NormalizeAttributeSet(attrs.ToArray());
             }
@@ -390,34 +390,6 @@ namespace System.Security.Cryptography.Pkcs
 
             chainCerts = certs;
             return newSignerInfo;
-        }
-
-        internal static List<AttributeAsn> BuildAttributes(CryptographicAttributeObjectCollection? attributes)
-        {
-            List<AttributeAsn> signedAttrs = new List<AttributeAsn>();
-
-            if (attributes == null || attributes.Count == 0)
-            {
-                return signedAttrs;
-            }
-
-            foreach (CryptographicAttributeObject attributeObject in attributes)
-            {
-                AttributeAsn newAttr = new AttributeAsn
-                {
-                    AttrType = attributeObject.Oid!.Value!,
-                    AttrValues = new ReadOnlyMemory<byte>[attributeObject.Values.Count],
-                };
-
-                for (int i = 0; i < attributeObject.Values.Count; i++)
-                {
-                    newAttr.AttrValues[i] = attributeObject.Values[i].RawData;
-                }
-
-                signedAttrs.Add(newAttr);
-            }
-
-            return signedAttrs;
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
@@ -84,7 +84,7 @@ namespace System.Security.Cryptography.Pkcs
                     new Oid(privateKeyInfo.PrivateKeyAlgorithm.Algorithm, null),
                     privateKeyInfo.PrivateKeyAlgorithm.Parameters,
                     privateKeyInfo.PrivateKey,
-                    SignerInfo.MakeAttributeCollection(privateKeyInfo.Attributes));
+                    PkcsHelpers.MakeAttributeCollection(privateKeyInfo.Attributes));
             }
             catch (AsnContentException e)
             {
@@ -262,7 +262,7 @@ namespace System.Security.Cryptography.Pkcs
 
             if (Attributes.Count > 0)
             {
-                info.Attributes = PkcsHelpers.NormalizeAttributeSet(CmsSigner.BuildAttributes(Attributes).ToArray());
+                info.Attributes = PkcsHelpers.NormalizeAttributeSet(PkcsHelpers.BuildAttributes(Attributes).ToArray());
             }
 
             // Write in BER in case any of the provided fields was BER.

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -59,10 +59,10 @@ namespace System.Security.Cryptography.Pkcs
         }
 
         public CryptographicAttributeObjectCollection SignedAttributes =>
-            _parsedSignedAttrs ??= MakeAttributeCollection(_signedAttributes);
+            _parsedSignedAttrs ??= PkcsHelpers.MakeAttributeCollection(_signedAttributes);
 
         public CryptographicAttributeObjectCollection UnsignedAttributes =>
-            _parsedUnsignedAttrs ??= MakeAttributeCollection(_unsignedAttributes);
+            _parsedUnsignedAttrs ??= PkcsHelpers.MakeAttributeCollection(_unsignedAttributes);
 
         internal ReadOnlyMemory<byte> GetSignatureMemory() => _signature;
 
@@ -623,7 +623,7 @@ namespace System.Security.Cryptography.Pkcs
 
                         if (attr.AttrType == Oids.MessageDigest)
                         {
-                            CryptographicAttributeObject obj = MakeAttribute(attr);
+                            CryptographicAttributeObject obj = PkcsHelpers.MakeAttribute(attr);
 
                             if (obj.Values.Count != 1)
                             {
@@ -798,34 +798,6 @@ namespace System.Security.Cryptography.Pkcs
         private HashAlgorithmName GetDigestAlgorithm()
         {
             return PkcsHelpers.GetDigestAlgorithm(DigestAlgorithm.Value!, forVerification: true);
-        }
-
-        internal static CryptographicAttributeObjectCollection MakeAttributeCollection(AttributeAsn[]? attributes)
-        {
-            var coll = new CryptographicAttributeObjectCollection();
-
-            if (attributes == null)
-                return coll;
-
-            foreach (AttributeAsn attribute in attributes)
-            {
-                coll.AddWithoutMerge(MakeAttribute(attribute));
-            }
-
-            return coll;
-        }
-
-        private static CryptographicAttributeObject MakeAttribute(AttributeAsn attribute)
-        {
-            Oid type = new Oid(attribute.AttrType);
-            AsnEncodedDataCollection valueColl = new AsnEncodedDataCollection();
-
-            foreach (ReadOnlyMemory<byte> attrValue in attribute.AttrValues)
-            {
-                valueColl.Add(PkcsHelpers.CreateBestPkcs9AttributeObjectAvailable(type, attrValue.ToArray()));
-            }
-
-            return new CryptographicAttributeObject(type, valueColl);
         }
 
         private static int FindAttributeIndexByOid(AttributeAsn[] attributes, Oid oid, int startIndex = 0)

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -66,6 +66,9 @@
   <data name="Arg_EmptyOrNullString" xml:space="preserve">
     <value>String cannot be empty or null.</value>
   </data>
+  <data name="Arg_EmptyOrNullString_Named" xml:space="preserve">
+    <value>The `{0}` string cannot be empty or null.</value>
+  </data>
   <data name="Arg_EmptySpan" xml:space="preserve">
     <value>Span may not be empty.</value>
   </data>
@@ -278,6 +281,9 @@
   </data>
   <data name="Cryptography_ConcurrentUseNotSupported" xml:space="preserve">
     <value>Concurrent operations from multiple threads on this type are not supported.</value>
+  </data>
+  <data name="Cryptography_Cms_UnknownAlgorithm" xml:space="preserve">
+    <value>Unknown algorithm '{0}'.</value>
   </data>
   <data name="Cryptography_CngKeyWrongAlgorithm" xml:space="preserve">
     <value>This key is for algorithm '{0}'. Expected '{1}'.</value>
@@ -573,8 +579,38 @@
   <data name="Cryptography_Pkcs_PssParametersSaltMismatch" xml:space="preserve">
     <value>PSS salt size {0} is not supported by this platform with hash algorithm {1}.</value>
   </data>
+  <data name="Cryptography_Pkcs12_CannotProcessEncryptedSafeContents" xml:space="preserve">
+    <value>This operation is not valid on an encrypted or enveloped Pkcs12SafeContents.</value>
+  </data>
+  <data name="Cryptography_Pkcs12_CertBagNotX509" xml:space="preserve">
+    <value>The Pkcs12CertBag contents are not an X.509 certificate.</value>
+  </data>
+  <data name="Cryptography_Pkcs12_PfxIsSealed" xml:space="preserve">
+    <value>The Pkcs12Builder can no longer be modified because one of the Seal methods was already invoked.</value>
+  </data>
+  <data name="Cryptography_Pkcs12_PfxMustBeSealed" xml:space="preserve">
+    <value>One of the Seal methods must be invoked on the Pkcs12Builder before invoking an Encode method.</value>
+  </data>
+  <data name="Cryptography_Pkcs12_SafeContentsIsEncrypted" xml:space="preserve">
+    <value>Cannot enumerate the contents of an encrypted or enveloped Pkcs12SafeContents.</value>
+  </data>
+  <data name="Cryptography_Pkcs12_SafeContentsIsReadOnly" xml:space="preserve">
+    <value>New Pkcs12SafeBag values cannot be added to a Pkcs12SafeContents that was read from existing data.</value>
+  </data>
+  <data name="Cryptography_Pkcs12_WrongModeForDecrypt" xml:space="preserve">
+    <value>This decryption operation applies to 'Pkcs12ConfidentialityMode.{0}', but the target object is in 'Pkcs12ConfidentialityMode.{1}'.</value>
+  </data>
+  <data name="Cryptography_Pkcs12_WrongModeForVerify" xml:space="preserve">
+    <value>This verification operation applies to 'Pkcs12IntegrityMode.{0}', but the target object is in 'Pkcs12IntegrityMode.{1}'.</value>
+  </data>
   <data name="Cryptography_Pkcs8_EncryptedReadFailed" xml:space="preserve">
     <value>The EncryptedPrivateKeyInfo structure was decoded but was not successfully interpreted, the password may be incorrect.</value>
+  </data>
+  <data name="Cryptography_Pkcs9_AttributeMismatch" xml:space="preserve">
+    <value>The parameter should be a PKCS 9 attribute.</value>
+  </data>
+  <data name="Cryptography_Pkcs9_MultipleSigningTimeNotAllowed" xml:space="preserve">
+    <value>Cannot add multiple PKCS 9 signing time attributes.</value>
   </data>
   <data name="Cryptography_PlaintextCiphertextLengthMismatch" xml:space="preserve">
     <value>Plaintext and ciphertext must have the same length.</value>
@@ -782,6 +818,12 @@
   </data>
   <data name="HashNameMultipleSetNotSupported" xml:space="preserve">
     <value>Setting the hashname after it's already been set is not supported on this platform.</value>
+  </data>
+  <data name="InvalidOperation_DuplicateItemNotAllowed" xml:space="preserve">
+    <value>Duplicate items are not allowed in the collection.</value>
+  </data>
+  <data name="InvalidOperation_WrongOidInAsnCollection" xml:space="preserve">
+    <value>AsnEncodedData element in the collection has wrong Oid value: expected = '{0}', actual = '{1}'.</value>
   </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
     <value>Enumeration has not started. Call MoveNext.</value>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -27,6 +27,8 @@
   <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' == ''">
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
              Link="Common\DisableRuntimeMarshalling.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\PkcsHelpers.cs"
+             Link="Common\Internal\Cryptography\PkcsHelpers.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs"
              Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeX509ChainHandle.cs"
@@ -268,6 +270,13 @@
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml</DependentUpon>
     </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\SecretBagAsn.xml</DependentUpon>
+    </Compile>
     <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml</Link>
     </AsnXml>
@@ -289,6 +298,12 @@
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml</DependentUpon>
     </Compile>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObject.cs"
+             Link="Common\System\Security\Cryptography\CryptographicAttributeObject.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObjectCollection.cs"
+             Link="Common\System\Security\Cryptography\CryptographicAttributeObjectCollection.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObjectEnumerator.cs"
+             Link="Common\System\Security\Cryptography\CryptographicAttributeObjectEnumerator.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"
              Link="Common\System\Security\Cryptography\CryptoPool.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\DSAKeyFormatHelper.cs"
@@ -329,6 +344,38 @@
              Link="Common\System\Security\Cryptography\SP800108HmacCounterKdfImplementationBase.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Utf8DataEncoding.cs"
              Link="Common\System\Security\Cryptography\Utf8DataEncoding.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9AttributeObject.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9AttributeObject.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9ContentType.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9ContentType.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9DocumentDescription.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9DocumentDescription.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9DocumentName.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9DocumentName.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9LocalKeyId.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9LocalKeyId.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9MessageDigest.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9MessageDigest.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs9SigningTime.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs9SigningTime.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12Builder.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12Builder.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12CertBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12CertBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12ConfidentialityMode.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12ConfidentialityMode.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12KeyBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12KeyBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SafeBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SafeBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SafeContents.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SafeContents.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SafeContentsBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SafeContentsBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12SecretBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12SecretBag.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs\Pkcs12ShroudedKeyBag.cs"
+             Link="Common\System\Security\Cryptography\Pkcs\Pkcs12ShroudedKeyBag.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\X509Certificates\Pkcs12LoaderLimits.cs"
              Link="Common\System\Security\Cryptography\X509Certificates\Pkcs12LoaderLimits.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\X509Certificates\Pkcs12LoadLimitExceededException.cs"

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixExportProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixExportProvider.cs
@@ -2,23 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Diagnostics;
-using System.Formats.Asn1;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.Asn1;
-using System.Security.Cryptography.Asn1.Pkcs12;
 using System.Security.Cryptography.Pkcs;
 using Microsoft.Win32.SafeHandles;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography.X509Certificates
 {
     internal abstract class UnixExportProvider : IExportPal
     {
-        private static readonly Asn1Tag s_contextSpecific0 =
-            new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true);
-
         internal static readonly PbeParameters s_windowsPbe =
             new PbeParameters(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 2000);
+
+        private static readonly Oid s_Pkcs12X509CertBagTypeOid = new Oid(Oids.Pkcs12X509CertBagType, null);
 
         protected ICertificatePalCore? _singleCertPal;
         protected X509Certificate2Collection? _certs;
@@ -84,22 +82,6 @@ namespace System.Security.Cryptography.X509Certificates
 
         private byte[] ExportPfx(SafePasswordHandle password)
         {
-            int certCount = 1;
-
-            if (_singleCertPal == null)
-            {
-                Debug.Assert(_certs != null);
-                certCount = _certs.Count;
-            }
-
-            CertBagAsn[] certBags = ArrayPool<CertBagAsn>.Shared.Rent(certCount);
-            SafeBagAsn[] keyBags = ArrayPool<SafeBagAsn>.Shared.Rent(certCount);
-            AttributeAsn[] certAttrs = ArrayPool<AttributeAsn>.Shared.Rent(certCount);
-            certAttrs.AsSpan(0, certCount).Clear();
-
-            AsnWriter tmpWriter = new AsnWriter(AsnEncodingRules.DER);
-            ArraySegment<byte> encodedAuthSafe = default;
-
             bool gotRef = false;
 
             try
@@ -107,47 +89,41 @@ namespace System.Security.Cryptography.X509Certificates
                 password.DangerousAddRef(ref gotRef);
                 ReadOnlySpan<char> passwordSpan = password.DangerousGetSpan();
 
-                int keyIdx = 0;
-                int certIdx = 0;
+                int localKeyIdCounter = 1;
+                Pkcs12Builder builder = new();
+                Pkcs12SafeContents certContainer = new();
+                Pkcs12SafeContents keyContainer = new();
 
-                if (_singleCertPal != null)
+                if (_singleCertPal is not null)
                 {
-                    BuildBags(
+                    AddCertPalToSafeContents(
+                        certContainer,
+                        keyContainer,
                         _singleCertPal,
                         passwordSpan,
-                        tmpWriter,
-                        certBags,
-                        certAttrs,
-                        keyBags,
-                        ref certIdx,
-                        ref keyIdx);
+                        ref localKeyIdCounter);
                 }
                 else
                 {
-                    foreach (X509Certificate2 cert in _certs!)
+                    Debug.Assert(_certs is not null);
+
+                    // Add the certificates in reverse order for compat.
+                    for (int i = _certs.Count - 1; i >= 0; i--)
                     {
-                        BuildBags(
+                        X509Certificate2 cert = _certs[i];
+                        AddCertPalToSafeContents(
+                            certContainer,
+                            keyContainer,
                             cert.Pal,
                             passwordSpan,
-                            tmpWriter,
-                            certBags,
-                            certAttrs,
-                            keyBags,
-                            ref certIdx,
-                            ref keyIdx);
+                            ref localKeyIdCounter);
                     }
                 }
 
-                encodedAuthSafe = EncodeAuthSafe(
-                    tmpWriter,
-                    keyBags,
-                    keyIdx,
-                    certBags,
-                    certAttrs,
-                    certIdx,
-                    passwordSpan);
-
-                return MacAndEncode(tmpWriter, encodedAuthSafe, passwordSpan);
+                builder.AddSafeContentsEncrypted(certContainer, passwordSpan, s_windowsPbe);
+                builder.AddSafeContentsUnencrypted(keyContainer);
+                builder.SealWithMac(passwordSpan, s_windowsPbe.HashAlgorithm, s_windowsPbe.IterationCount);
+                return builder.Encode();
             }
             finally
             {
@@ -155,411 +131,32 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     password.DangerousRelease();
                 }
-
-                certAttrs.AsSpan(0, certCount).Clear();
-                certBags.AsSpan(0, certCount).Clear();
-                keyBags.AsSpan(0, certCount).Clear();
-                ArrayPool<AttributeAsn>.Shared.Return(certAttrs);
-                ArrayPool<CertBagAsn>.Shared.Return(certBags);
-                ArrayPool<SafeBagAsn>.Shared.Return(keyBags);
-
-                if (encodedAuthSafe.Array != null)
-                {
-                    CryptoPool.Return(encodedAuthSafe);
-                }
-            }
-        }
-
-        private void BuildBags(
-            ICertificatePalCore certPal,
-            ReadOnlySpan<char> passwordSpan,
-            AsnWriter tmpWriter,
-            CertBagAsn[] certBags,
-            AttributeAsn[] certAttrs,
-            SafeBagAsn[] keyBags,
-            ref int certIdx,
-            ref int keyIdx)
-        {
-            tmpWriter.WriteOctetString(certPal.RawData);
-
-            certBags[certIdx] = new CertBagAsn
-            {
-                CertId = Oids.Pkcs12X509CertBagType,
-                CertValue = tmpWriter.Encode(),
-            };
-
-            tmpWriter.Reset();
-
-            if (certPal.HasPrivateKey)
-            {
-                byte[] attrBytes = new byte[6];
-                attrBytes[0] = (byte)UniversalTagNumber.OctetString;
-                attrBytes[1] = sizeof(int);
-                MemoryMarshal.Write(attrBytes.AsSpan(2), in keyIdx);
-
-                AttributeAsn attribute = new AttributeAsn
-                {
-                    AttrType = Oids.LocalKeyId,
-                    AttrValues = new ReadOnlyMemory<byte>[]
-                    {
-                        attrBytes,
-                    }
-                };
-                keyBags[keyIdx] = new SafeBagAsn
-                {
-                    BagId = Oids.Pkcs12ShroudedKeyBag,
-                    BagValue = ExportPkcs8(certPal, passwordSpan),
-                    BagAttributes = new[] { attribute }
-                };
-
-                // Reuse the attribute between the cert and the key.
-                certAttrs[certIdx] = attribute;
-                keyIdx++;
             }
 
-            certIdx++;
-        }
-
-        private static unsafe ArraySegment<byte> EncodeAuthSafe(
-            AsnWriter tmpWriter,
-            SafeBagAsn[] keyBags,
-            int keyCount,
-            CertBagAsn[] certBags,
-            AttributeAsn[] certAttrs,
-            int certIdx,
-            ReadOnlySpan<char> passwordSpan)
-        {
-            string? encryptionAlgorithmOid = null;
-            bool certsIsPkcs12Encryption = false;
-            string? certsHmacOid = null;
-
-            ArraySegment<byte> encodedKeyContents = default;
-            ArraySegment<byte> encodedCertContents = default;
-
-            try
+            void AddCertPalToSafeContents(
+                Pkcs12SafeContents certContainer,
+                Pkcs12SafeContents keyContainer,
+                ICertificatePalCore certificatePal,
+                ReadOnlySpan<char> password,
+                ref int localKeyIdCounter)
             {
-                if (keyCount > 0)
+                Pkcs12CertBag certBag = new(s_Pkcs12X509CertBagTypeOid, PkcsHelpers.EncodeOctetString(certificatePal.RawData));
+
+                if (certificatePal.HasPrivateKey)
                 {
-                    encodedKeyContents = EncodeKeys(tmpWriter, keyBags, keyCount);
+                    Span<byte> localKeyIdAttributeValue = stackalloc byte[sizeof(int)];
+                    BinaryPrimitives.WriteInt32LittleEndian(localKeyIdAttributeValue, localKeyIdCounter);
+                    Pkcs9LocalKeyId keyId = new(localKeyIdAttributeValue);
+                    Pkcs12ShroudedKeyBag keyBag = new(ExportPkcs8(certificatePal, password), skipCopy: true);
+
+                    certBag.Attributes.Add(keyId);
+                    keyBag.Attributes.Add(keyId);
+                    keyContainer.AddSafeBag(keyBag);
+                    localKeyIdCounter++;
                 }
 
-                Span<byte> salt = stackalloc byte[16];
-                RandomNumberGenerator.Fill(salt);
-                Span<byte> certContentsIv = stackalloc byte[8];
-
-                if (certIdx > 0)
-                {
-                    encodedCertContents = EncodeCerts(
-                        tmpWriter,
-                        certBags,
-                        certAttrs,
-                        certIdx,
-                        salt,
-                        passwordSpan,
-                        certContentsIv,
-                        out certsHmacOid,
-                        out encryptionAlgorithmOid,
-                        out certsIsPkcs12Encryption);
-                }
-
-                return EncodeAuthSafe(
-                    tmpWriter,
-                    encodedKeyContents,
-                    encodedCertContents,
-                    certsIsPkcs12Encryption,
-                    certsHmacOid!,
-                    encryptionAlgorithmOid!,
-                    salt,
-                    certContentsIv);
+                certContainer.AddSafeBag(certBag);
             }
-            finally
-            {
-                if (encodedCertContents.Array != null)
-                {
-                    CryptoPool.Return(encodedCertContents);
-                }
-
-                if (encodedKeyContents.Array != null)
-                {
-                    CryptoPool.Return(encodedKeyContents);
-                }
-            }
-        }
-
-        private static ArraySegment<byte> EncodeKeys(AsnWriter tmpWriter, SafeBagAsn[] keyBags, int keyCount)
-        {
-            Debug.Assert(tmpWriter.GetEncodedLength() == 0);
-
-            using (tmpWriter.PushSequence())
-            {
-                for (int i = 0; i < keyCount; i++)
-                {
-                    keyBags[i].Encode(tmpWriter);
-                }
-            }
-
-            int length = tmpWriter.GetEncodedLength();
-            byte[] keyBuf = CryptoPool.Rent(length);
-
-            if (!tmpWriter.TryEncode(keyBuf, out length))
-            {
-                Debug.Fail("TryEncode failed with a pre-allocated buffer");
-                throw new InvalidOperationException();
-            }
-
-            // Explicitly clear the internal buffer before it goes out of scope.
-            tmpWriter.Reset();
-
-            return new ArraySegment<byte>(keyBuf, 0, length);
-        }
-
-        private static ArraySegment<byte> EncodeCerts(
-            AsnWriter tmpWriter,
-            CertBagAsn[] certBags,
-            AttributeAsn[] certAttrs,
-            int certCount,
-            Span<byte> salt,
-            ReadOnlySpan<char> passwordSpan,
-            Span<byte> certContentsIv,
-            out string hmacOid,
-            out string encryptionAlgorithmOid,
-            out bool isPkcs12)
-        {
-            Debug.Assert(tmpWriter.GetEncodedLength() == 0);
-            tmpWriter.PushSequence();
-
-            PasswordBasedEncryption.InitiateEncryption(
-                s_windowsPbe,
-                out SymmetricAlgorithm cipher,
-                out hmacOid,
-                out encryptionAlgorithmOid,
-                out isPkcs12);
-
-            using (cipher)
-            {
-                Debug.Assert(certContentsIv.Length * 8 == cipher.BlockSize);
-
-                for (int i = certCount - 1; i >= 0; --i)
-                {
-                    // Manually write the SafeBagAsn
-                    // https://tools.ietf.org/html/rfc7292#section-4.2
-                    //
-                    // SafeBag ::= SEQUENCE {
-                    //   bagId          BAG-TYPE.&id ({PKCS12BagSet})
-                    //   bagValue       [0] EXPLICIT BAG-TYPE.&Type({PKCS12BagSet}{@bagId}),
-                    //   bagAttributes  SET OF PKCS12Attribute OPTIONAL
-                    // }
-                    tmpWriter.PushSequence();
-
-                    tmpWriter.WriteObjectIdentifierForCrypto(Oids.Pkcs12CertBag);
-
-                    tmpWriter.PushSequence(s_contextSpecific0);
-                    certBags[i].Encode(tmpWriter);
-                    tmpWriter.PopSequence(s_contextSpecific0);
-
-                    if (certAttrs[i].AttrType != null)
-                    {
-                        tmpWriter.PushSetOf();
-                        certAttrs[i].Encode(tmpWriter);
-                        tmpWriter.PopSetOf();
-                    }
-
-                    tmpWriter.PopSequence();
-                }
-
-                tmpWriter.PopSequence();
-
-                // The padding applied will add at most a block to the output,
-                // so ask for contentsSpan.Length + the number of bytes in a cipher block.
-                int cipherBlockBytes = cipher.BlockSize >> 3;
-                int requestedSize = checked(tmpWriter.GetEncodedLength() + cipherBlockBytes);
-                byte[] certContents = CryptoPool.Rent(requestedSize);
-
-                int encryptedLength = PasswordBasedEncryption.Encrypt(
-                    passwordSpan,
-                    ReadOnlySpan<byte>.Empty,
-                    cipher,
-                    isPkcs12,
-                    tmpWriter,
-                    s_windowsPbe,
-                    salt,
-                    certContents,
-                    certContentsIv);
-
-                Debug.Assert(encryptedLength <= requestedSize);
-                tmpWriter.Reset();
-
-                return new ArraySegment<byte>(certContents, 0, encryptedLength);
-            }
-        }
-
-        private static ArraySegment<byte> EncodeAuthSafe(
-            AsnWriter tmpWriter,
-            ReadOnlyMemory<byte> encodedKeyContents,
-            ReadOnlyMemory<byte> encodedCertContents,
-            bool isPkcs12,
-            string hmacOid,
-            string encryptionAlgorithmOid,
-            Span<byte> salt,
-            Span<byte> certContentsIv)
-        {
-            Debug.Assert(tmpWriter.GetEncodedLength() == 0);
-
-            tmpWriter.PushSequence();
-
-            if (!encodedKeyContents.IsEmpty)
-            {
-                tmpWriter.PushSequence();
-                tmpWriter.WriteObjectIdentifier(Oids.Pkcs7Data);
-                tmpWriter.PushSequence(s_contextSpecific0);
-
-                ReadOnlySpan<byte> keyContents = encodedKeyContents.Span;
-                tmpWriter.WriteOctetString(keyContents);
-
-                tmpWriter.PopSequence(s_contextSpecific0);
-                tmpWriter.PopSequence();
-            }
-
-            if (!encodedCertContents.IsEmpty)
-            {
-                tmpWriter.PushSequence();
-
-                {
-                    tmpWriter.WriteObjectIdentifier(Oids.Pkcs7Encrypted);
-
-                    tmpWriter.PushSequence(s_contextSpecific0);
-                    tmpWriter.PushSequence();
-
-                    {
-                        // No unprotected attributes: version 0 data
-                        tmpWriter.WriteInteger(0);
-
-                        tmpWriter.PushSequence();
-
-                        {
-                            tmpWriter.WriteObjectIdentifier(Oids.Pkcs7Data);
-
-                            PasswordBasedEncryption.WritePbeAlgorithmIdentifier(
-                                tmpWriter,
-                                isPkcs12,
-                                encryptionAlgorithmOid,
-                                salt,
-                                s_windowsPbe.IterationCount,
-                                hmacOid,
-                                certContentsIv);
-
-                            tmpWriter.WriteOctetString(encodedCertContents.Span, s_contextSpecific0);
-                            tmpWriter.PopSequence();
-                        }
-
-                        tmpWriter.PopSequence();
-                        tmpWriter.PopSequence(s_contextSpecific0);
-                    }
-
-                    tmpWriter.PopSequence();
-                }
-            }
-
-            tmpWriter.PopSequence();
-
-            int authSafeLength = tmpWriter.GetEncodedLength();
-            byte[] authSafe = CryptoPool.Rent(authSafeLength);
-
-            if (!tmpWriter.TryEncode(authSafe, out authSafeLength))
-            {
-                Debug.Fail("TryEncode failed with a pre-allocated buffer");
-                throw new InvalidOperationException();
-            }
-
-            tmpWriter.Reset();
-
-            return new ArraySegment<byte>(authSafe, 0, authSafeLength);
-        }
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "HMACSHA1 is required for compat with other platforms")]
-        private static unsafe byte[] MacAndEncode(
-            AsnWriter tmpWriter,
-            ReadOnlyMemory<byte> encodedAuthSafe,
-            ReadOnlySpan<char> passwordSpan)
-        {
-            Span<byte> macKey = stackalloc byte[HMACSHA1.HashSizeInBytes];
-            Span<byte> macSalt = stackalloc byte[HMACSHA1.HashSizeInBytes];
-            Span<byte> macSpan = stackalloc byte[HMACSHA1.HashSizeInBytes];
-            RandomNumberGenerator.Fill(macSalt);
-
-            Pkcs12Kdf.DeriveMacKey(
-                passwordSpan,
-                HashAlgorithmName.SHA1,
-                s_windowsPbe.IterationCount,
-                macSalt,
-                macKey);
-
-            int bytesWritten = HMACSHA1.HashData(macKey, encodedAuthSafe.Span, macSpan);
-
-            if (bytesWritten != HMACSHA1.HashSizeInBytes)
-            {
-                Debug.Fail($"HMACSHA1.HashData wrote {bytesWritten} of {HMACSHA1.HashSizeInBytes} bytes");
-                throw new CryptographicException();
-            }
-
-            CryptographicOperations.ZeroMemory(macKey);
-
-            // https://tools.ietf.org/html/rfc7292#section-4
-            //
-            // PFX ::= SEQUENCE {
-            //   version    INTEGER {v3(3)}(v3,...),
-            //   authSafe   ContentInfo,
-            //   macData    MacData OPTIONAL
-            // }
-            Debug.Assert(tmpWriter.GetEncodedLength() == 0);
-            tmpWriter.PushSequence();
-
-            tmpWriter.WriteInteger(3);
-
-            tmpWriter.PushSequence();
-            {
-                tmpWriter.WriteObjectIdentifier(Oids.Pkcs7Data);
-
-                tmpWriter.PushSequence(s_contextSpecific0);
-                {
-                    tmpWriter.WriteOctetString(encodedAuthSafe.Span);
-                    tmpWriter.PopSequence(s_contextSpecific0);
-                }
-
-                tmpWriter.PopSequence();
-            }
-
-            // https://tools.ietf.org/html/rfc7292#section-4
-            //
-            // MacData ::= SEQUENCE {
-            //   mac        DigestInfo,
-            //   macSalt    OCTET STRING,
-            //   iterations INTEGER DEFAULT 1
-            //   -- Note: The default is for historical reasons and its use is
-            //   -- deprecated.
-            // }
-            tmpWriter.PushSequence();
-            {
-                tmpWriter.PushSequence();
-                {
-                    tmpWriter.PushSequence();
-                    {
-                        tmpWriter.WriteObjectIdentifier(Oids.Sha1);
-                        tmpWriter.PopSequence();
-                    }
-
-                    tmpWriter.WriteOctetString(macSpan);
-                    tmpWriter.PopSequence();
-                }
-
-                tmpWriter.WriteOctetString(macSalt);
-                tmpWriter.WriteInteger(s_windowsPbe.IterationCount);
-
-                tmpWriter.PopSequence();
-            }
-
-            tmpWriter.PopSequence();
-            return tmpWriter.Encode();
         }
     }
 }


### PR DESCRIPTION
Currently, the `UnixExportProvider` is implemented by putting together ASN.1 data in a bit of an ad-hoc fashion using the serializers.

In order to support #80314 and #111560, we will soon want to offer the capability to export in PKCS12 with different configurations for PBES, like PBES2-AES256-SHA256.

Rather than try to tack on PBES2, PBKDF2, etc in to the ad-hoc encoder, this pulls in `Pkcs12Builder` in to System.Security.Cryptography. Because it is currently in `System.Security.Cryptography.Pkcs`, we can't use it directly because it is a package, and even if we ship the package, we have a circular reference problem.

To address that, this puts `Pkcs12Builder` and its dependencies in Common. This is, essentially:

1. Move the files. We use the existing `BUILDING_PKCS` define to change the visibility. If we are building the public API, its visibility is public, otherwise it is internal.
2. `PkcsHelpers` needed to be split.
3. Some things in `SignedCms` needed to be moved to `PkcsHelpers` because we don't want to pull in `SignedCms`.

Contributes to #80314.