### PR TITLE
JIT: Fix stack allocated arrays for NativeAOT

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -419,7 +419,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
                 {
                     allocType = OAT_NEWOBJ;
                 }
-                else if (!comp->opts.IsReadyToRun() && data->IsHelperCall())
+                else if (data->IsHelperCall())
                 {
                     switch (data->AsCall()->GetHelperNum())
                     {
@@ -468,10 +468,6 @@ bool ObjectAllocator::MorphAllocObjNodes()
                     if (allocType == OAT_NEWARR)
                     {
                         assert(basicBlockHasNewArr);
-
-                        // R2R not yet supported
-                        //
-                        assert(!comp->opts.IsReadyToRun());
 
                         //------------------------------------------------------------------------
                         // We expect the following expression tree at this point

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -469,6 +469,11 @@ bool ObjectAllocator::MorphAllocObjNodes()
                     {
                         assert(basicBlockHasNewArr);
 
+                        // R2R not yet supported
+                        //
+                        const bool isNativeAot = comp->IsTargetAbi(CORINFO_NATIVEAOT_ABI);
+                        assert(isNativeAot || !comp->opts.IsReadyToRun());
+
                         //------------------------------------------------------------------------
                         // We expect the following expression tree at this point
                         // For non-ReadyToRun:

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -472,7 +472,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
 
                         // R2R not yet supported
                         //
-                        assert(isReadyToRun);
+                        assert(!isReadyToRun);
 
                         //------------------------------------------------------------------------
                         // We expect the following expression tree at this point

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -392,6 +392,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
     bool didStackAllocate             = false;
     m_PossiblyStackPointingPointers   = BitVecOps::MakeEmpty(&m_bitVecTraits);
     m_DefinitelyStackPointingPointers = BitVecOps::MakeEmpty(&m_bitVecTraits);
+    const bool isReadyToRun           = comp->opts.IsReadyToRun() && !comp->IsTargetAbi(CORINFO_NATIVEAOT_ABI);
 
     for (BasicBlock* const block : comp->Blocks())
     {
@@ -419,7 +420,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
                 {
                     allocType = OAT_NEWOBJ;
                 }
-                else if (data->IsHelperCall())
+                else if (!isReadyToRun && data->IsHelperCall())
                 {
                     switch (data->AsCall()->GetHelperNum())
                     {
@@ -471,8 +472,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
 
                         // R2R not yet supported
                         //
-                        const bool isNativeAot = comp->IsTargetAbi(CORINFO_NATIVEAOT_ABI);
-                        assert(isNativeAot || !comp->opts.IsReadyToRun());
+                        assert(isReadyToRun);
 
                         //------------------------------------------------------------------------
                         // We expect the following expression tree at this point


### PR DESCRIPTION
In R2R we use a separate helper so we don't need the `opts.IsReadyToRun()` check. Otherwise the optimization will be blocked under NativeAOT.

Fixes #111822 