### PR TITLE
JIT: Re-enable acceleration of Vector512<long>.op_Multiply

### DIFF
--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -3335,7 +3335,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                 {
                     // Emulate NI_AVX512DQ_VL_MultiplyLow with SSE41 for SIMD16
                 }
-                else
+                else if (simdSize != 64)
                 {
                     // Software fallback
                     break;
@@ -3393,7 +3393,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                 {
                     // Emulate NI_AVX512DQ_VL_MultiplyLow with SSE41 for SIMD16
                 }
-                else
+                else if (simdSize != 64)
                 {
                     // Software fallback
                     break;


### PR DESCRIPTION
This was a regression in 9.0, from #103555

https://godbolt.org/z/11hs3Kqdd
