### PR TITLE
Clean up Stopwatch a bit

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
@@ -14,8 +14,7 @@ namespace System.Diagnostics
         public static readonly bool IsHighResolution = true;
 
         // performance-counter frequency, in counts per ticks.
-        // This can speed up conversion from high frequency performance-counter
-        // to ticks.
+        // This can speed up conversion to ticks.
         private static readonly double s_tickFrequency = (double)TimeSpan.TicksPerSecond / Frequency;
 
         public Stopwatch()
@@ -34,7 +33,7 @@ namespace System.Diagnostics
 
         public static Stopwatch StartNew()
         {
-            Stopwatch s = new Stopwatch();
+            Stopwatch s = new();
             s.Start();
             return s;
         }
@@ -72,31 +71,29 @@ namespace System.Diagnostics
         /// </returns>
         public override string ToString() => Elapsed.ToString();
 
-        public bool IsRunning
-        {
-            get { return _isRunning; }
-        }
+        public bool IsRunning => _isRunning;
 
-        public TimeSpan Elapsed
-        {
-            get { return new TimeSpan(GetElapsedDateTimeTicks()); }
-        }
+        public TimeSpan Elapsed => new(ElapsedTimeSpanTicks);
 
-        public long ElapsedMilliseconds
-        {
-            get { return GetElapsedDateTimeTicks() / TimeSpan.TicksPerMillisecond; }
-        }
+        public long ElapsedMilliseconds => ElapsedTimeSpanTicks / TimeSpan.TicksPerMillisecond;
 
         public long ElapsedTicks
         {
-            get { return GetRawElapsedTicks(); }
+            get
+            {
+                long timeElapsed = _elapsed;
+
+                // If the Stopwatch is running, add elapsed time since the Stopwatch is started last time.
+                if (_isRunning)
+                {
+                    timeElapsed += GetTimestamp() - _startTimeStamp;
+                }
+
+                return timeElapsed;
+            }
         }
 
-        public static long GetTimestamp()
-        {
-            Debug.Assert(IsHighResolution);
-            return QueryPerformanceCounter();
-        }
+        public static long GetTimestamp() => QueryPerformanceCounter();
 
         /// <summary>Gets the elapsed time since the <paramref name="startingTimestamp"/> value retrieved using <see cref="GetTimestamp"/>.</summary>
         /// <param name="startingTimestamp">The timestamp marking the beginning of the time period.</param>
@@ -109,31 +106,9 @@ namespace System.Diagnostics
         /// <param name="endingTimestamp">The timestamp marking the end of the time period.</param>
         /// <returns>A <see cref="TimeSpan"/> for the elapsed time between the starting and ending timestamps.</returns>
         public static TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp) =>
-            new TimeSpan((long)((endingTimestamp - startingTimestamp) * s_tickFrequency));
+            new((long)((endingTimestamp - startingTimestamp) * s_tickFrequency));
 
-        // Get the elapsed ticks.
-        private long GetRawElapsedTicks()
-        {
-            long timeElapsed = _elapsed;
-
-            if (_isRunning)
-            {
-                // If the Stopwatch is running, add elapsed time since
-                // the Stopwatch is started last time.
-                long currentTimeStamp = GetTimestamp();
-                long elapsedUntilNow = currentTimeStamp - _startTimeStamp;
-                timeElapsed += elapsedUntilNow;
-            }
-            return timeElapsed;
-        }
-
-        // Get the elapsed ticks.
-        private long GetElapsedDateTimeTicks()
-        {
-            Debug.Assert(IsHighResolution);
-            // convert high resolution perf counter to DateTime ticks
-            return unchecked((long)(GetRawElapsedTicks() * s_tickFrequency));
-        }
+        private long ElapsedTimeSpanTicks => (long)(ElapsedTicks * s_tickFrequency);
 
         private string DebuggerDisplay => $"{Elapsed} (IsRunning = {_isRunning})";
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
@@ -3,10 +3,6 @@
 
 namespace System.Diagnostics
 {
-    // This class uses high-resolution performance counter if the installed
-    // hardware supports it. Otherwise, the class will fall back to DateTime
-    // and uses ticks as a measurement.
-
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public partial class Stopwatch
     {
@@ -14,10 +10,6 @@ namespace System.Diagnostics
         private long _startTimeStamp;
         private bool _isRunning;
 
-        // "Frequency" stores the frequency of the high-resolution performance counter,
-        // if one exists. Otherwise it will store TicksPerSecond.
-        // The frequency cannot change while the system is running,
-        // so we only need to initialize it once.
         public static readonly long Frequency = QueryPerformanceFrequency();
         public static readonly bool IsHighResolution = true;
 
@@ -28,7 +20,6 @@ namespace System.Diagnostics
 
         public Stopwatch()
         {
-            Reset();
         }
 
         public void Start()
@@ -53,29 +44,16 @@ namespace System.Diagnostics
             // Calling stop on a stopped Stopwatch is a no-op.
             if (_isRunning)
             {
-                long endTimeStamp = GetTimestamp();
-                long elapsedThisPeriod = endTimeStamp - _startTimeStamp;
-                _elapsed += elapsedThisPeriod;
+                _elapsed += GetTimestamp() - _startTimeStamp;
                 _isRunning = false;
-
-                if (_elapsed < 0)
-                {
-                    // When measuring small time periods the Stopwatch.Elapsed*
-                    // properties can return negative values.  This is due to
-                    // bugs in the basic input/output system (BIOS) or the hardware
-                    // abstraction layer (HAL) on machines with variable-speed CPUs
-                    // (e.g. Intel SpeedStep).
-
-                    _elapsed = 0;
-                }
             }
         }
 
         public void Reset()
         {
             _elapsed = 0;
-            _isRunning = false;
             _startTimeStamp = 0;
+            _isRunning = false;
         }
 
         // Convenience method for replacing {sw.Reset(); sw.Start();} with a single sw.Restart()


### PR DESCRIPTION
- Remove unnecessary Reset call from ctor
- Remove unnecessary branch for _elapsed < 0 (Stop is now more inlineable)
- Remove some defunct comments
- Clean up style of Stop to match that of Start

Closes https://github.com/dotnet/runtime/issues/66734
Related to https://github.com/dotnet/runtime/issues/111829


| Method | Toolchain         | Mean     | Ratio | Code Size | Allocated | Alloc Ratio |
|------- |------------------ |---------:|------:|----------:|----------:|------------:|
| Time   | \main\corerun.exe | 38.51 ns |  1.00 |     363 B |      40 B |        1.00 |
| Time   | \pr\corerun.exe   | 30.35 ns |  0.79 |     156 B |         - |        0.00 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Diagnostics;
using System.Runtime.CompilerServices;

BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

[DisassemblyDiagnoser]
[MemoryDiagnoser(false)]
public partial class Tests
{
    [Benchmark]
    public TimeSpan Time()
    {
        Stopwatch sw = Stopwatch.StartNew();
        Nop();
        sw.Stop();
        return sw.Elapsed;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    public static void Nop() { }
}
```