### PR TITLE
Workaround flaky ProcessName behavior during process startup

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2264,7 +2264,6 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/29330", TestPlatforms.OSX)]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52852", TestPlatforms.MacCatalyst)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/53095", TestPlatforms.Android)]
@@ -2294,6 +2293,10 @@ namespace System.Diagnostics.Tests
 
             using (Process px = Process.Start(sleepCommandPathFileName, "600"))
             {
+                // Reading of long process names is flaky during process startup and shutdown.
+                // Wait a bit to skip over the period where the ProcessName is not reliable.
+                Thread.Sleep(100);
+
                 Process[] runningProcesses = Process.GetProcesses();
                 try
                 {


### PR DESCRIPTION
Reenable long Process.Name test on OSX

Fixes #111460
Fixes #29330