### PR TITLE
Fix for possible handle leaks

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
@@ -66,8 +66,8 @@ namespace System.Security.Cryptography.Xml
 
         private static void MarkInclusionStateForNodes(XmlNodeList nodeList, XmlDocument inputRoot, XmlDocument root)
         {
-            CanonicalXmlNodeList elementList = new CanonicalXmlNodeList();
-            CanonicalXmlNodeList elementListCanonical = new CanonicalXmlNodeList();
+            using CanonicalXmlNodeList elementList = new CanonicalXmlNodeList();
+            using CanonicalXmlNodeList elementListCanonical = new CanonicalXmlNodeList();
             elementList.Add(inputRoot);
             elementListCanonical.Add(root);
             int index = 0;

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
@@ -76,8 +76,8 @@ namespace System.Security.Cryptography.Xml
 
         private static void MarkInclusionStateForNodes(XmlNodeList nodeList, XmlDocument inputRoot, XmlDocument root)
         {
-            CanonicalXmlNodeList elementList = new CanonicalXmlNodeList();
-            CanonicalXmlNodeList elementListCanonical = new CanonicalXmlNodeList();
+            using CanonicalXmlNodeList elementList = new CanonicalXmlNodeList();
+            using CanonicalXmlNodeList elementListCanonical = new CanonicalXmlNodeList();
             elementList.Add(inputRoot);
             elementListCanonical.Add(root);
             int index = 0;


### PR DESCRIPTION
Fix for possible handle leaks because of new CanonicalXmlNodeList() is not disposed.

Found by Linux Verification Center (linuxtesting.org) with SVACE.