### PR TITLE
Remove fstream usage from corehost

### DIFF
--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <vector>
-#include <fstream>
 #include <sstream>
 #include <iostream>
 #include <cstring>
@@ -118,14 +117,6 @@ namespace pal
     typedef wchar_t char_t;
     typedef std::wstring string_t;
     typedef std::wstringstream stringstream_t;
-    // TODO: Agree on the correct encoding of the files: The PoR for now is to
-    // temporarily wchar for Windows and char for Unix. Current implementation
-    // implicitly expects the contents on both Windows and Unix as char and
-    // converts them to wchar in code for Windows. This line should become:
-    // typedef std::basic_ifstream<char_t> ifstream_t.
-    typedef std::basic_ifstream<char> ifstream_t;
-    typedef std::istreambuf_iterator<ifstream_t::char_type> istreambuf_iterator_t;
-    typedef std::basic_istream<char> istream_t;
     typedef HRESULT hresult_t;
     typedef HMODULE dll_t;
     typedef FARPROC proc_t;
@@ -207,9 +198,6 @@ namespace pal
     typedef char char_t;
     typedef std::string string_t;
     typedef std::stringstream stringstream_t;
-    typedef std::basic_ifstream<char> ifstream_t;
-    typedef std::istreambuf_iterator<ifstream_t::char_type> istreambuf_iterator_t;
-    typedef std::basic_istream<char> istream_t;
     typedef int hresult_t;
     typedef void* dll_t;
     typedef void* proc_t;

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -456,7 +456,7 @@ bool get_install_location_from_file(const pal::string_t& file_path, bool& file_f
 {
     file_found = true;
     bool install_location_found = false;
-    FILE* install_location_file = pal::file_open(file_path, "r");
+    FILE* install_location_file = pal::file_open(file_path, _X("r"));
     if (install_location_file != nullptr)
     {
         if (!get_line_from_file(install_location_file, install_location))
@@ -819,12 +819,10 @@ pal::string_t pal::get_current_os_rid_platform()
     {
         // Read the file to get ID and VERSION_ID data that will be used
         // to construct the RID.
-        std::fstream fsVersionFile;
-
-        fsVersionFile.open(versionFile, std::fstream::in);
+        FILE* fsVersionFile = pal::file_open(versionFile, _X("r"));
 
         // Proceed only if we were able to open the file
-        if (fsVersionFile.good())
+        if (fsVersionFile != nullptr)
         {
             pal::string_t line;
             pal::string_t strID(_X("ID="));
@@ -834,11 +832,8 @@ pal::string_t pal::get_current_os_rid_platform()
 
             bool fFoundID = false, fFoundVersion = false;
 
-            // Read the first line
-            std::getline(fsVersionFile, line);
-
             // Loop until we are at the end of file
-            while (!fsVersionFile.eof())
+            while (get_line_from_file(fsVersionFile, line))
             {
                 // Look for ID if we have not found it already
                 if (!fFoundID)
@@ -872,13 +867,10 @@ pal::string_t pal::get_current_os_rid_platform()
                     // We have everything we need to form the RID - break out of the loop.
                     break;
                 }
-
-                // Read the next line
-                std::getline(fsVersionFile, line);
             }
 
             // Close the file now that we are done with it.
-            fsVersionFile.close();
+            fclose(fsVersionFile);
 
             if (fFoundID)
             {

--- a/src/native/corehost/json_parser.cpp
+++ b/src/native/corehost/json_parser.cpp
@@ -104,9 +104,9 @@ bool json_parser_t::parse_file(const pal::string_t& path)
     if (m_data == nullptr)
     {
 #ifdef _WIN32
-        // Since we can't use in-situ parsing on Windows, as JSON data is encoded in
+        // We can't use in-situ parsing on Windows, as JSON data is encoded in
         // UTF-8 and the host expects wide strings.
-        // We do not need COW and read-only mapping will be enough.
+        // We do not need copy-on-write, so read-only mapping will be enough.
         m_data = (char*)pal::mmap_read(path, &m_size);
 #else // _WIN32
         m_data = (char*)pal::mmap_copy_on_write(path, &m_size);

--- a/src/native/corehost/json_parser.cpp
+++ b/src/native/corehost/json_parser.cpp
@@ -94,7 +94,11 @@ bool json_parser_t::parse_file(const pal::string_t& path)
         //  * The json file is mapped as copy-on-write.
         //  * The mapping cannot be immediately released, and will be unmapped by the json_parser destructor.
         m_data = bundle::info_t::config_t::map(path, m_bundle_location);
-        m_size = (size_t)m_bundle_location->size;
+
+        if (m_data != nullptr)
+        {
+            m_size = (size_t)m_bundle_location->size;
+        }
     }
 
     if (m_data == nullptr)
@@ -119,7 +123,7 @@ bool json_parser_t::parse_file(const pal::string_t& path)
     size_t size = m_size;
 
     // Skip over UTF-8 BOM, if present
-    if (size >= 3 && m_data[0] == 0xEF && m_data[1] == 0xBB && m_data[1] == 0xBF)
+    if (size >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[1] == 0xBF)
     {
         size -= 3;
         data += 3;

--- a/src/native/corehost/json_parser.cpp
+++ b/src/native/corehost/json_parser.cpp
@@ -19,7 +19,7 @@ namespace {
 
 void get_line_column_from_offset(const char* data, uint64_t size, size_t offset, int *line, int *column)
 {
-    assert(offset < size);
+    assert(offset <= size);
 
     *line = *column = 1;
 

--- a/src/native/corehost/json_parser.h
+++ b/src/native/corehost/json_parser.h
@@ -40,24 +40,22 @@ class json_parser_t {
         bool parse_file(const pal::string_t& path);
 
         json_parser_t()
-            : m_bundle_data(nullptr)
+            : m_data(nullptr)
             , m_bundle_location(nullptr) {}
 
         ~json_parser_t();
 
     private:
-        // This is a vector of char and not pal::char_t because JSON data
-        // parsed by this class is always encoded in UTF-8.  On Windows,
-        // where wide strings are used, m_json is kept in UTF-8, but converted
+        char* m_data; // The memory mapped bytes of the file
+        size_t m_size; // Size of the mapped memory
+
+        // On Windows, where wide strings are used, m_data is kept in UTF-8, but converted
         // to UTF-16 by m_document during load.
-        std::vector<char> m_json;
         document_t m_document;
 
-        // If a json file is parsed from a single-file bundle, the following two fields represent:
-        char* m_bundle_data; // The memory mapped bytes of the application bundle.
-        const bundle::location_t* m_bundle_location; // Location of this json file within the bundle.
-
-        void realloc_buffer(size_t size);
+        // If a json file is parsed from a single-file bundle, the following two fields represents
+        // the location of this json file within the bundle.
+        const bundle::location_t* m_bundle_location;
 };
 
 #endif // __JSON_PARSER_H__

--- a/src/native/corehost/json_parser.h
+++ b/src/native/corehost/json_parser.h
@@ -53,7 +53,7 @@ class json_parser_t {
         // to UTF-16 by m_document during load.
         document_t m_document;
 
-        // If a json file is parsed from a single-file bundle, the following two fields represents
+        // If a json file is parsed from a single-file bundle, the following fields represents
         // the location of this json file within the bundle.
         const bundle::location_t* m_bundle_location;
 };

--- a/src/native/corehost/test/nativehost/host_context_test.cpp
+++ b/src/native/corehost/test/nativehost/host_context_test.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <iostream>
+#include <fstream>
 #include <pal.h>
 #include <error_codes.h>
 #include <future>


### PR DESCRIPTION
Contributes to #111665

There's still fstream usage in corerun, so this alone doesn't resolve the Android build errors.