### PR TITLE
JIT: Skip `fgComputeMissingBlockWeights` when we have profile data

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6308,8 +6308,7 @@ public:
     void fgPrintEdgeWeights();
 #endif
     PhaseStatus fgComputeBlockWeights();
-    bool fgComputeMissingBlockWeights(weight_t* returnWeight);
-    bool fgComputeCalledCount(weight_t returnWeight);
+    bool fgComputeMissingBlockWeights();
 
     bool fgReorderBlocks(bool useProfile);
     void fgDoReversePostOrderLayout();

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13524,7 +13524,7 @@ PhaseStatus Compiler::fgMorphBlocks()
             if (!fgProfileWeightsConsistent(incomingWeight, fgEntryBB->bbWeight))
             {
                 JITDUMP("OSR: Original method entry " FMT_BB " has inconsistent weight. Data %s inconsistent.\n",
-                        fgPgoConsistent ? "is now" : "was already");
+                        fgEntryBB->bbNum, fgPgoConsistent ? "is now" : "was already");
                 fgPgoConsistent = false;
             }
         }


### PR DESCRIPTION
Part of #107749. Follow-up to #111764. `fgComputeMissingBlockWeights` doesn't modify anything when we have profile data, and `fgCalledCount` can be derived from the entry block's weight quite simply.