### PR TITLE
Allow the NativeAOT runtime pack to be specified as the ILC runtime package

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -67,10 +67,9 @@
     <PropertyGroup>
       <IlcHostPackagePath Condition="'@(ResolvedILCompilerPack)' == '$(_hostPackageName)'">@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcHostPackagePath>
       <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == ''">@(ResolvedILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
-      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == '$(_targetPackageName)'">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
-      <!-- Also allow referencing the NativeAOT Runtime Pack as the target runtime package and set a property to specify which package layout later targets should expect. -->
-      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == '$(_targetRuntimePackName)'">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
+      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' != ''">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
       <IlcUseNativeAOTRuntimePackLayout Condition="'@(ResolvedTargetILCompilerPack)' == '$(_targetRuntimePackName)'">true</IlcUseNativeAOTRuntimePackLayout>
+      <IlcUseNativeAOTRuntimePackLayout Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == ''">$(PublishAotUsingRuntimePack)</IlcUseNativeAOTRuntimePackLayout>
     </PropertyGroup>
 
   </Target>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -24,6 +24,8 @@
     <_hostPackageName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">runtime.$(RuntimeIdentifier).Microsoft.DotNet.ILCompiler</_hostPackageName>
     <_targetPackageName>runtime.$(_originalTargetOS)-$(_targetArchitecture).Microsoft.DotNet.ILCompiler</_targetPackageName>
     <_targetPackageName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">runtime.$(RuntimeIdentifier).Microsoft.DotNet.ILCompiler</_targetPackageName>
+    <_targetRuntimePackName>Microsoft.NETCore.App.Runtime.NativeAOT.$(_originalTargetOS)-$(_targetArchitecture)</_targetRuntimePackName>
+    <_targetRuntimePackName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">Microsoft.NETCore.App.Runtime.NativeAOT.$(RuntimeIdentifier)</_targetRuntimePackName>
 
     <!-- Treat linux-musl and linux-bionic etc. as linux -->
     <_targetOS>$(_originalTargetOS)</_targetOS>
@@ -64,8 +66,11 @@
 
     <PropertyGroup>
       <IlcHostPackagePath Condition="'@(ResolvedILCompilerPack)' == '$(_hostPackageName)'">@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcHostPackagePath>
-      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == '$(_targetPackageName)'">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
       <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == ''">@(ResolvedILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
+      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == '$(_targetPackageName)'">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
+      <!-- Also allow referencing the NativeAOT Runtime Pack as the target runtime package and set a property to specify which package layout later targets should expect. -->
+      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == '$(_targetRuntimePackName)'">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
+      <IlcUseNativeAOTRuntimePackLayout Condition="'@(ResolvedTargetILCompilerPack)' == '$(_targetRuntimePackName)'">true</IlcUseNativeAOTRuntimePackLayout>
     </PropertyGroup>
 
   </Target>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -68,8 +68,8 @@
       Text="Add a PackageReference for '$(_hostPackageName)' to allow cross-compilation for $(_targetArchitecture)" />
 
     <!-- NativeAOT runtime pack assemblies need to be defined to avoid the default CoreCLR implementations being set as compiler inputs -->
-    <Error Condition="'@(PrivateSdkAssemblies)' == '' and '$(PublishAotUsingRuntimePack)' != 'true'" Text="The PrivateSdkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
-    <Error Condition="'@(FrameworkAssemblies)' == '' and '$(PublishAotUsingRuntimePack)' != 'true'" Text="The FrameworkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
+    <Error Condition="'@(PrivateSdkAssemblies)' == '' and '$(IlcUseNativeAOTRuntimePackLayout)' != 'true'" Text="The PrivateSdkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
+    <Error Condition="'@(FrameworkAssemblies)' == '' and '$(IlcUseNativeAOTRuntimePackLayout)' != 'true'" Text="The FrameworkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
 
     <ComputeManagedAssembliesToCompileToNative
       Assemblies="@(_ResolvedCopyLocalPublishAssets)"

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -138,7 +138,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">
       <!--
         If we're actually using the runtime pack from the ResolvedFrameworkReference, pull the path from there.
-        Otherwise pull it from
+        Otherwise pull it from the RuntimePackagePath.
       -->
       <_NETCoreAppRuntimePackPath Condition="'$(PublishAotUsingRuntimePack)' == 'true'">%(_NETCoreAppFrameworkReference.RuntimePackPath)/runtimes/$(RuntimeIdentifier)/</_NETCoreAppRuntimePackPath>
       <_NETCoreAppRuntimePackPath Condition="'$(PublishAotUsingRuntimePack)' != 'true'">$(RuntimePackagePath)/runtimes/$(RuntimeIdentifier)/</_NETCoreAppRuntimePackPath>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -131,10 +131,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_NETCoreAppFrameworkReference Include="@(ResolvedFrameworkReference)" Condition="'%(ResolvedFrameworkReference.RuntimePackName)' == 'Microsoft.NETCore.App.Runtime.NativeAOT.$(RuntimeIdentifier)'" />
     </ItemGroup>
 
-    <PropertyGroup>
-      <IlcUseNativeAOTRuntimePackLayout Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == ''">$(PublishAotUsingRuntimePack)</IlcUseNativeAOTRuntimePackLayout>
-    </PropertyGroup>
-
     <PropertyGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">
       <!--
         If we're actually using the runtime pack from the ResolvedFrameworkReference, pull the path from there.
@@ -155,8 +151,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <!-- Define paths used in build targets to point to the runtime-specific ILCompiler implementation -->
       <IlcToolsPath Condition="'$(IlcToolsPath)' == ''">$(IlcHostPackagePath)\tools\</IlcToolsPath>
-      <IlcMibcPath Condition="'$(IlcMibcPath)' == '' and Exists('$(RuntimePackagePath)\mibc\')">$(RuntimePackagePath)\mibc\</IlcMibcPath>
-      <IlcMibcPath Condition="'$(IlcMibcPath)' == '' and !Exists('$(RuntimePackagePath)\mibc\')">$(IlcHostPackagePath)\mibc\</IlcMibcPath>
+      <IlcMibcPath Condition="'$(IlcMibcPath)' == ''">$(RuntimePackagePath)\mibc\</IlcMibcPath>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -129,27 +129,40 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Target Name="SetupProperties" DependsOnTargets="$(IlcSetupPropertiesDependsOn)" BeforeTargets="Publish">
     <ItemGroup>
       <_NETCoreAppFrameworkReference Include="@(ResolvedFrameworkReference)" Condition="'%(ResolvedFrameworkReference.RuntimePackName)' == 'Microsoft.NETCore.App.Runtime.NativeAOT.$(RuntimeIdentifier)'" />
+      <IlcUseNativeAOTRuntimePackLayout Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == ''">$(PublishAotUsingRuntimePack)</IlcUseNativeAOTRuntimePackLayout>
     </ItemGroup>
+
+    <PropertyGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">
+      <!--
+        If we're actually using the runtime pack from the ResolvedFrameworkReference, pull the path from there.
+        Otherwise pull it from
+      -->
+      <_NETCoreAppRuntimePackPath Condition="'$(PublishAotUsingRuntimePack)' == 'true'">%(_NETCoreAppFrameworkReference.RuntimePackPath)/runtimes/$(RuntimeIdentifier)/</_NETCoreAppRuntimePackPath>
+      <_NETCoreAppRuntimePackPath Condition="'$(PublishAotUsingRuntimePack)' != 'true'">$(RuntimePackagePath)/runtimes/$(RuntimeIdentifier)/</_NETCoreAppRuntimePackPath>
+      <IlcFrameworkNativePath Condition="'$(IlcFrameworkNativePath)' == ''">$(_NETCoreAppRuntimePackPath)\native\</IlcFrameworkNativePath>
+      <IlcSdkPath Condition="'$(IlcSdkPath)' == ''">$(IlcFrameworkNativePath)</IlcSdkPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' != 'true'">
+      <IlcFrameworkPath Condition="'$(IlcFrameworkPath)' == ''">$(RuntimePackagePath)\framework\</IlcFrameworkPath>
+      <IlcFrameworkNativePath Condition="'$(IlcFrameworkNativePath)' == ''">$(RuntimePackagePath)\framework\</IlcFrameworkNativePath>
+      <IlcSdkPath Condition="'$(IlcSdkPath)' == ''">$(RuntimePackagePath)\sdk\</IlcSdkPath>
+    </PropertyGroup>
 
     <PropertyGroup>
       <!-- Define paths used in build targets to point to the runtime-specific ILCompiler implementation -->
       <IlcToolsPath Condition="'$(IlcToolsPath)' == ''">$(IlcHostPackagePath)\tools\</IlcToolsPath>
-      <IlcFrameworkPath Condition="'$(IlcFrameworkPath)' == '' and '$(PublishAotUsingRuntimePack)' != 'true'">$(RuntimePackagePath)\framework\</IlcFrameworkPath>
-      <_NETCoreAppRuntimePackPath>%(_NETCoreAppFrameworkReference.RuntimePackPath)/runtimes/$(RuntimeIdentifier)/</_NETCoreAppRuntimePackPath>
-      <IlcFrameworkNativePath Condition="'$(IlcFrameworkNativePath)' == '' and '$(PublishAotUsingRuntimePack)' == 'true'">$(_NETCoreAppRuntimePackPath)\native\</IlcFrameworkNativePath>
-      <IlcFrameworkNativePath Condition="'$(IlcFrameworkNativePath)' == '' and '$(PublishAotUsingRuntimePack)' != 'true'">$(RuntimePackagePath)\framework\</IlcFrameworkNativePath>
-      <IlcSdkPath Condition="'$(IlcSdkPath)' == '' and '$(PublishAotUsingRuntimePack)' == 'true'">$(IlcFrameworkNativePath)</IlcSdkPath>
-      <IlcSdkPath Condition="'$(IlcSdkPath)' == '' and '$(PublishAotUsingRuntimePack)' != 'true'">$(RuntimePackagePath)\sdk\</IlcSdkPath>
-      <IlcMibcPath Condition="'$(IlcMibcPath)' == ''">$(RuntimePackagePath)\mibc\</IlcMibcPath>
+      <IlcMibcPath Condition="'$(IlcMibcPath)' == '' and Exists('$(RuntimePackagePath)\mibc\')">$(RuntimePackagePath)\mibc\</IlcMibcPath>
+      <IlcMibcPath Condition="'$(IlcMibcPath)' == '' and !Exists('$(RuntimePackagePath)\mibc\')">$(IlcHostPackagePath)\mibc\</IlcMibcPath>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(PublishAotUsingRuntimePack)' == 'true'">
+    <ItemGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">
       <PrivateSdkAssemblies Include="$(IlcSdkPath)*.dll"/>
       <FrameworkAssemblies Include="@(RuntimePackAsset)" Condition="'%(Extension)' == '.dll'" />
       <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(PublishAotUsingRuntimePack)' != 'true'">
+    <ItemGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' != 'true'">
       <PrivateSdkAssemblies Include="$(IlcSdkPath)*.dll"/>
       <!-- Exclude unmanaged dlls -->
       <FrameworkAssemblies Include="$(IlcFrameworkPath)*.dll" Exclude="$(IlcFrameworkPath)*.Native.dll;$(IlcFrameworkPath)msquic.dll" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -129,8 +129,11 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Target Name="SetupProperties" DependsOnTargets="$(IlcSetupPropertiesDependsOn)" BeforeTargets="Publish">
     <ItemGroup>
       <_NETCoreAppFrameworkReference Include="@(ResolvedFrameworkReference)" Condition="'%(ResolvedFrameworkReference.RuntimePackName)' == 'Microsoft.NETCore.App.Runtime.NativeAOT.$(RuntimeIdentifier)'" />
-      <IlcUseNativeAOTRuntimePackLayout Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == ''">$(PublishAotUsingRuntimePack)</IlcUseNativeAOTRuntimePackLayout>
     </ItemGroup>
+
+    <PropertyGroup>
+      <IlcUseNativeAOTRuntimePackLayout Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == ''">$(PublishAotUsingRuntimePack)</IlcUseNativeAOTRuntimePackLayout>
+    </PropertyGroup>
 
     <PropertyGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">
       <!--

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.NativeAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.NativeAOT.sfxproj
@@ -20,7 +20,10 @@
 
   <ItemGroup>
     <IgnoredDuplicateType Include="Internal.Runtime.CompilerHelpers.LibraryInitializer" />
+    <FilesToPackage Include="$(CoreCLRArtifactsPath)StandardOptimizationData.mibc"
+                    Condition="Exists('$(CoreCLRArtifactsPath)StandardOptimizationData.mibc')" />
   </ItemGroup>
+
 
   <Import Project="Microsoft.NETCore.App.Runtime.props" />
 


### PR DESCRIPTION
Allow specifying the NativeAOT runtime pack as the "runtime package" for ILC to enable us to exclusively ship the NativeAOT runtime through the NativeAOT runtime pack packages without further breaking the in-box `dotnet build /t:Publish` scenario any more than it already is.

This change also helps move us towards less confusion in VMR/Source-Build scenarios. Today, we have to build a "host ILC" package that targets the SDK's RID with only ILC. If this one is accidentally picked up by any testing in the VMR for runtime assets, things fail with a pretty inscrutable error.
In the future, we'll still have to build the "host ILC" package, but if we move the SDK to only use the NativeAOT runtime pack for "target" assets in .NET 10+, we can ensure that the "host ILC" package doesn't have a shape that differs from the actually shipping ILC package.