### PR TITLE
Include PDB for all TfmRuntimeSpecificPackageFile

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -122,7 +122,7 @@
       <TfmSpecificPackageFile Include="@(TfmRuntimeSpecificPackageFile)"
                               PackagePath="runtimes\$(_packageTargetRuntime)\$(BuildOutputTargetFolder)\$(_targetFrameworkWithoutSuffix)\" />
       <!-- Create the item and use its metadata separately to avoid MSB4120. See https://aka.ms/msbuild/metadata-self-ref for more info. -->
-      <_RuntimeSymbolPath Include="$(RuntimeSymbolPath)" />
+      <_RuntimeSymbolPath Include="@(TfmRuntimeSpecificPackageFile->'%(RootDir)%(Directory)%(FileName).pdb')" Condition="'%(TfmRuntimeSpecificPackageFile.Extension)' == '.dll'" KeepMetadata="None" />
       <TfmSpecificDebugSymbolsFile Include="@(_RuntimeSymbolPath)"
                                    TargetPath="/runtimes/$(_packageTargetRuntime)/$(BuildOutputTargetFolder)/$(_targetFrameworkWithoutSuffix)/%(_RuntimeSymbolPath.Filename)%(_RuntimeSymbolPath.Extension)"
                                    TargetFramework="$(_targetFrameworkWithoutSuffix)"


### PR DESCRIPTION
Previously this would only include the PDB for the primary output which missed any other additions to `TfmRuntimeSpecificPackageFile` - such as those from references or packages.

Currently the only place this is done is 
https://github.com/dotnet/runtime/blob/d4c7d865558316da4c135f519eb3dfc25b8a4367/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj#L135-L140