### PR TITLE
[EventPipe] Add ThreadSessionState cleanup to GetEvent path

### DIFF
--- a/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
@@ -279,7 +279,7 @@ test_buffer_manager_write_event (void)
 	ep_raise_error_if_nok (write_events (buffer_manager, thread_handle, session, ep_event, 1, NULL) == true);
 
 	EP_LOCK_ENTER (section1)
-		ep_buffer_manager_suspend_write_event (buffer_manager, ep_session_get_index (session));
+		ep_buffer_manager_suspend_write_event (buffer_manager);
 	EP_LOCK_EXIT (section1)
 
 ep_on_exit:
@@ -318,7 +318,7 @@ test_buffer_manager_read_event (void)
 	ep_raise_error_if_nok (write_events (buffer_manager, thread_handle, session, ep_event, 1, NULL) == true);
 
 	EP_LOCK_ENTER (section1)
-		ep_buffer_manager_suspend_write_event (buffer_manager, ep_session_get_index (session));
+		ep_buffer_manager_suspend_write_event (buffer_manager);
 	EP_LOCK_EXIT (section1)
 
 	ep_event_instance = ep_buffer_manager_get_next_event (buffer_manager);
@@ -371,7 +371,7 @@ test_buffer_manager_deallocate_buffers (void)
 	ep_raise_error_if_nok (write_events (buffer_manager, thread_handle, session, ep_event, 1, NULL) == true);
 
 	EP_LOCK_ENTER (section1)
-		ep_buffer_manager_suspend_write_event (buffer_manager, ep_session_get_index (session));
+		ep_buffer_manager_suspend_write_event (buffer_manager);
 	EP_LOCK_EXIT (section1)
 
 	ep_buffer_manager_deallocate_buffers (buffer_manager);
@@ -472,7 +472,7 @@ test_buffer_manager_oom (void)
 	ep_raise_error_if_nok (write_events (buffer_manager, thread_handle, session, ep_event, 1000 * 1000, NULL) == false);
 
 	EP_LOCK_ENTER (section1)
-		ep_buffer_manager_suspend_write_event (buffer_manager, ep_session_get_index (session));
+		ep_buffer_manager_suspend_write_event (buffer_manager);
 	EP_LOCK_EXIT (section1)
 
 ep_on_exit:
@@ -543,7 +543,7 @@ test_buffer_manager_perf (void)
 	}
 
 	EP_LOCK_ENTER (section1)
-		ep_buffer_manager_suspend_write_event (buffer_manager, ep_session_get_index (session));
+		ep_buffer_manager_suspend_write_event (buffer_manager);
 	EP_LOCK_EXIT (section1)
 
 	test_location = 4;

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -1049,9 +1049,7 @@ ep_on_error:
 }
 
 void
-ep_buffer_manager_suspend_write_event (
-	EventPipeBufferManager *buffer_manager,
-	uint32_t session_index)
+ep_buffer_manager_suspend_write_event (EventPipeBufferManager *buffer_manager)
 {
 	EP_ASSERT (buffer_manager != NULL);
 

--- a/src/native/eventpipe/ep-buffer-manager.h
+++ b/src/native/eventpipe/ep-buffer-manager.h
@@ -200,9 +200,7 @@ ep_buffer_manager_write_event (
 // finish or cancel. After that all BufferLists and Buffers can be safely drained and/or deleted.
 // _Requires_lock_held (ep)
 void
-ep_buffer_manager_suspend_write_event (
-	EventPipeBufferManager *buffer_manager,
-	uint32_t session_index);
+ep_buffer_manager_suspend_write_event (EventPipeBufferManager *buffer_manager);
 
 // Write the contents of the managed buffers to the specified file.
 // The stop_timeStamp is used to determine when tracing was stopped to ensure that we

--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -392,7 +392,7 @@ ep_session_suspend_write_event (EventPipeSession *session)
 
 	if (session->buffer_manager)
 		// Convert all buffers to read only to ensure they get flushed
-		ep_buffer_manager_suspend_write_event (session->buffer_manager, session->index);
+		ep_buffer_manager_suspend_write_event (session->buffer_manager);
 }
 
 void

--- a/src/tests/tracing/eventpipe/eventsvalidation/threadstress.cs
+++ b/src/tests/tracing/eventpipe/eventsvalidation/threadstress.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Diagnostics.Tracing;
+using Tracing.Tests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
+using Xunit;
+
+namespace Tracing.Tests.ThreadStress
+{
+    internal sealed class ThreadStressEventListener : EventListener
+    {
+        public bool GCEventObserved { get; private set; } = false;
+        public int ExceptionEventCount { get; private set; } = 0;
+
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name.Equals("Microsoft-Windows-DotNETRuntime"))
+            {
+                EnableEvents(source, EventLevel.Informational, (EventKeywords)0x8001);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName == "ExceptionThrown_V1")
+            {
+                ExceptionEventCount++;
+            }
+            else if (!GCEventObserved && eventData.EventName == "GCTriggered")
+            {
+                GCEventObserved = true;
+            }
+        }
+    }
+
+    public class ThreadStressValidation
+    {
+        [Fact]
+        public static int TestEntryPoint()
+        {
+            Console.WriteLine("Starting ThreadStressValidation test...");
+            using (var listener = new ThreadStressEventListener())
+            {
+                // Start stressing NativeRuntimeEventSource EventPipe Session's
+                // Buffer Manager's ThreadSessionStateList
+                Console.WriteLine("Spawning short-lived threads to populate the EP Session's Buffer Manager's ThreadSessionStateList...");
+                for (int i = 0; i < 1000; i++)
+                {
+                    var thread = new Thread(() => { int[] array = new int[1000]; });
+                    thread.Start();
+                    thread.Join();
+                }
+                if (!listener.GCEventObserved)
+                {
+                    Console.WriteLine("GC event not observed. Expected threads to stress EP Session's Buffer Manager's ThreadSessionStateList. ThreadStressValidation test failed!");
+                    return -1;
+                }
+
+                Console.WriteLine("Begin throwing exceptions to trigger GetNextEvent...");
+                for (int i = 0; i < 500000; i++)
+                {
+                    try
+                    {
+                        throw new Exception();
+                    }
+                    catch {}
+                }
+
+                Console.WriteLine($"\tEventListener received {listener.ExceptionEventCount} exception event(s)\n");
+                bool pass = listener.ExceptionEventCount >= 495000 && listener.ExceptionEventCount <= 500000;
+                if (pass)
+                {
+                    Console.WriteLine("Dropped less than 1% of events. ThreadStressValidation test passed!");
+                    return 100;
+                }
+                else
+                {
+                    Console.WriteLine("Dropped more than 1% of events. ThreadStressValidation test failed!");
+                    return -1;
+                }
+            }
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/eventsvalidation/threadstress.csproj
+++ b/src/tests/tracing/eventpipe/eventsvalidation/threadstress.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for GCStressIncompatible, UnloadabilityIncompatible, JitOptimizationSensitive -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/eventpipe_common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/111368

This PR does the following:
- Adds the ThreadSessionState cleanup logic from [`ep_buffer_manager_write_all_buffers_to_file_v4`](https://github.com/dotnet/runtime/blob/1da2ea4983bb5cc3d17a3806eebc435df4cd27dd/src/native/eventpipe/ep-buffer-manager.c#L1265-L1298) excluding the Sequence point specific logic that [does not apply](https://github.com/dotnet/runtime/blob/1da2ea4983bb5cc3d17a3806eebc435df4cd27dd/src/native/eventpipe/ep-session.c#L174) to Listener EventPipe Sessions.
- Removes the unused arg `session_index` from `ep_buffer_manager_suspend_write_event`, as it was removed in https://github.com/dotnet/runtime/pull/46220


## Testing

On Windows, ran repro in the description of https://github.com/dotnet/runtime/issues/111368 with the ThreadSessionState cleanup logic and observed 
```
Threads: 10000
Enabling CLR EventPipe

Throwing and catching 1000 exceptions (warm up JIT)

Throwing and catching 500000 exceptions
RSS: 33MiB, user CPU: 117.19219619373295%
2000000 EventPipe events received, 500000 exceptions thrown

Spawning 10000 short-lived threads
RSS: 42MiB, user CPU: 56.8904339307025%
35966 EventPipe events received, 10000 exceptions thrown

Throwing and catching 500000 exceptions
RSS: 41MiB, user CPU: 106.8586502739847%
2000000 EventPipe events received, 500000 exceptions thrown

Reconfiguring EventPipe with identical settings

Throwing and catching 500000 exceptions
RSS: 42MiB, user CPU: 109.8092124268282%
2000000 EventPipe events received, 500000 exceptions thrown
```