### PR TITLE
Fix shimmed implementation of TryGetHashAndReset to handle HMAC.

### DIFF
--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
@@ -100,24 +100,13 @@ namespace System.Security.Cryptography
             Span<byte> destination,
             out int bytesWritten)
         {
-            int hashSize = hash.AlgorithmName.Name switch
-            {
-                nameof(HashAlgorithmName.MD5) or "HMACMD5" => 128 >> 3,
-                nameof(HashAlgorithmName.SHA1) or "HMACSHA1" => 160 >> 3,
-                nameof(HashAlgorithmName.SHA256) or "HMACSHA256" => 256 >> 3,
-                nameof(HashAlgorithmName.SHA384) or "HMACSHA384" => 384 >> 3,
-                nameof(HashAlgorithmName.SHA512) or "HMACSHA512" => 512 >> 3,
-                _ => throw new CryptographicException(),
-            };
+            byte[] actual = hash.GetHashAndReset();
 
-            if (destination.Length < hashSize)
+            if (destination.Length < actual.Length)
             {
                 bytesWritten = 0;
                 return false;
             }
-
-            byte[] actual = hash.GetHashAndReset();
-            Debug.Assert(actual.Length == hashSize);
 
             actual.AsSpan().CopyTo(destination);
             bytesWritten = actual.Length;

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
@@ -102,11 +102,11 @@ namespace System.Security.Cryptography
         {
             int hashSize = hash.AlgorithmName.Name switch
             {
-                nameof(HashAlgorithmName.MD5) => 128 >> 3,
-                nameof(HashAlgorithmName.SHA1) => 160 >> 3,
-                nameof(HashAlgorithmName.SHA256) => 256 >> 3,
-                nameof(HashAlgorithmName.SHA384) => 384 >> 3,
-                nameof(HashAlgorithmName.SHA512) => 512 >> 3,
+                nameof(HashAlgorithmName.MD5) or "HMACMD5" => 128 >> 3,
+                nameof(HashAlgorithmName.SHA1) or "HMACSHA1" => 160 >> 3,
+                nameof(HashAlgorithmName.SHA256) or "HMACSHA256" => 256 >> 3,
+                nameof(HashAlgorithmName.SHA384) or "HMACSHA384" => 384 >> 3,
+                nameof(HashAlgorithmName.SHA512) or "HMACSHA512" => 512 >> 3,
                 _ => throw new CryptographicException(),
             };
 


### PR DESCRIPTION
The TryGetHashAndReset in switches on the algorithm name of IncrementalHash. IncrementalHash prepends "HMAC" in front of the algorithm name, so the shim did not correctly handle the HMAC-prepended algorithm names.

Fixes #111926 