### PR TITLE
Fix inheritdoc warnings in docs repo

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
@@ -45,19 +45,19 @@ namespace Microsoft.Extensions.DependencyInjection
             _descriptors.Clear();
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains(T)"/>
         public bool Contains(ServiceDescriptor item)
         {
             return _descriptors.Contains(item);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo(T[], int)"/>
         public void CopyTo(ServiceDescriptor[] array, int arrayIndex)
         {
             _descriptors.CopyTo(array, arrayIndex);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove(T)"/>
         public bool Remove(ServiceDescriptor item)
         {
             CheckReadOnly();
@@ -81,13 +81,13 @@ namespace Microsoft.Extensions.DependencyInjection
             return GetEnumerator();
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IndexOf(T)"/>
         public int IndexOf(ServiceDescriptor item)
         {
             return _descriptors.IndexOf(item);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Insert(int, T)"/>
         public void Insert(int index, ServiceDescriptor item)
         {
             CheckReadOnly();

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/DefaultServiceProviderFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/DefaultServiceProviderFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="IServiceProviderFactory{TContainerBuilder}.CreateServiceProvider(TContainerBuilder)"/>
         public IServiceProvider CreateServiceProvider(IServiceCollection containerBuilder)
         {
             return containerBuilder.BuildServiceProvider(_options);


### PR DESCRIPTION
Fixes these warnings in the dotnet-api-docs repo. This might be a shortcoming of the docs system, but if it doesn't hurt to add these crefs to the inheritdoc tags, then this seems easier.

![image](https://github.com/user-attachments/assets/c54909e9-03a0-4ab8-bc13-15d06f66a92a)
