### PR TITLE
Fix exception handling in the prestub worker

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -3053,14 +3053,17 @@ void StackTraceInfo::AppendElement(OBJECTHANDLE hThrowable, UINT_PTR currentIP, 
     // This is a workaround to fix the generation of stack traces from exception objects so that
     // they point to the line that actually generated the exception instead of the line
     // following.
-    if (pCf->IsIPadjusted())
+    if (pCf != NULL)
     {
-        stackTraceElem.flags |= STEF_IP_ADJUSTED;
-    }
-    else if (!pCf->HasFaulted() && stackTraceElem.ip != 0)
-    {
-        stackTraceElem.ip -= STACKWALK_CONTROLPC_ADJUST_OFFSET;
-        stackTraceElem.flags |= STEF_IP_ADJUSTED;
+        if (pCf->IsIPadjusted())
+        {
+            stackTraceElem.flags |= STEF_IP_ADJUSTED;
+        }
+        else if (!pCf->HasFaulted() && stackTraceElem.ip != 0)
+        {
+            stackTraceElem.ip -= STACKWALK_CONTROLPC_ADJUST_OFFSET;
+            stackTraceElem.flags |= STEF_IP_ADJUSTED;
+        }
     }
 
 #ifndef TARGET_UNIX // Watson is supported on Windows only

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -932,7 +932,12 @@ ProcessCLRExceptionNew(IN     PEXCEPTION_RECORD   pExceptionRecord,
 
     Thread* pThread         = GetThread();
 
-    if (pThread->HasThreadStateNC(Thread::TSNC_ProcessedUnhandledException))
+    // Skip native frames of asm helpers that have the ProcessCLRException set as their personality routine.
+    // There is nothing to do for those with the new exception handling.
+    // Also skip all frames when processing unhandled exceptions. That allows them to reach the host app
+    // level and let 3rd party the chance to handle them.
+    if (!ExecutionManager::IsManagedCode((PCODE)pDispatcherContext->ControlPc) ||
+        pThread->HasThreadStateNC(Thread::TSNC_ProcessedUnhandledException))
     {
         if ((pExceptionRecord->ExceptionFlags & EXCEPTION_UNWINDING))
         {
@@ -8520,7 +8525,7 @@ static StackWalkAction MoveToNextNonSkippedFrame(StackFrameIterator* pStackFrame
     return retVal;
 }
 
-extern "C" size_t CallDescrWorkerInternalReturnAddressOffset;
+bool IsCallDescrWorkerInternalReturnAddress(PCODE pCode);
 
 extern "C" bool QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollideClauseIdx, bool* fUnwoundReversePInvoke, bool* pfIsExceptionIntercepted)
 {
@@ -8575,8 +8580,7 @@ extern "C" bool QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollideCla
         }
         else
         {
-            size_t CallDescrWorkerInternalReturnAddress = (size_t)CallDescrWorkerInternal + CallDescrWorkerInternalReturnAddressOffset;
-            if (GetIP(pThis->m_crawl.GetRegisterSet()->pCallerContext) == CallDescrWorkerInternalReturnAddress)
+            if (IsCallDescrWorkerInternalReturnAddress(GetIP(pThis->m_crawl.GetRegisterSet()->pCallerContext)))
             {
                 invalidRevPInvoke = true;
             }

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2570,33 +2570,17 @@ static PCODE PreStubWorker_Preemptive(
     // No GC frame is needed here since there should be no OBJECTREFs involved
     // in this call due to UnmanagedCallersOnlyAttribute semantics.
 
-    EX_TRY
-    {
-        bool propagateExceptionToNativeCode = IsCallDescrWorkerInternalReturnAddress(pTransitionBlock->m_ReturnAddress);
-        INSTALL_MANAGED_EXCEPTION_DISPATCHER_EX;
-        INSTALL_UNWIND_AND_CONTINUE_HANDLER_EX;
+    INSTALL_MANAGED_EXCEPTION_DISPATCHER;
+    INSTALL_UNWIND_AND_CONTINUE_HANDLER;
 
-        // Make sure the method table is restored, and method instantiation if present
-        pMD->CheckRestore();
-        CONSISTENCY_CHECK(GetAppDomain()->CheckCanExecuteManagedCode(pMD));
+    // Make sure the method table is restored, and method instantiation if present
+    pMD->CheckRestore();
+    CONSISTENCY_CHECK(GetAppDomain()->CheckCanExecuteManagedCode(pMD));
 
-        pbRetVal = pMD->DoPrestub(NULL, CallerGCMode::Preemptive);
+    pbRetVal = pMD->DoPrestub(NULL, CallerGCMode::Preemptive);
 
-        UNINSTALL_UNWIND_AND_CONTINUE_HANDLER_EX(propagateExceptionToNativeCode);
-        UNINSTALL_MANAGED_EXCEPTION_DISPATCHER_EX(propagateExceptionToNativeCode);
-    }
-    EX_CATCH
-    {
-        GCX_COOP();
-        if (g_isNewExceptionHandlingEnabled)
-        {
-            OBJECTHANDLE ohThrowable = currentThread->LastThrownObjectHandle();
-            _ASSERTE(ohThrowable);
-            StackTraceInfo::AppendElement(ohThrowable, 0, (UINT_PTR)pTransitionBlock, pMD, NULL);
-        }
-        EX_RETHROW;
-    }
-    EX_END_CATCH(SwallowAllExceptions)
+    UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
+    UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
 
     {
         HardwareExceptionHolder;

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -1262,6 +1262,8 @@ ResolveCacheElem* __fastcall VirtualCallStubManager::PromoteChainEntry(ResolveCa
 }
 #endif // CHAIN_LOOKUP
 
+bool IsCallDescrWorkerInternalReturnAddress(PCODE pCode);
+
 /* Resolve to a method and return its address or NULL if there is none.
    Our return value is the target address that control should continue to.  Our caller will
    enter the target address as if a direct call with the original stack frame had been made from
@@ -1309,14 +1311,16 @@ PCODE VSD_ResolveWorker(TransitionBlock * pTransitionBlock,
 
     PCODE target = (PCODE)NULL;
 
+    bool propagateExceptionToNativeCode = IsCallDescrWorkerInternalReturnAddress(pTransitionBlock->m_ReturnAddress);
+
     if (pObj == NULL) {
         pSDFrame->SetForNullReferenceException();
         pSDFrame->Push(CURRENT_THREAD);
-        INSTALL_MANAGED_EXCEPTION_DISPATCHER;
-        INSTALL_UNWIND_AND_CONTINUE_HANDLER;
+        INSTALL_MANAGED_EXCEPTION_DISPATCHER_EX;
+        INSTALL_UNWIND_AND_CONTINUE_HANDLER_EX;
         COMPlusThrow(kNullReferenceException);
-        UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
-        UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
+        UNINSTALL_UNWIND_AND_CONTINUE_HANDLER_EX(propagateExceptionToNativeCode);
+        UNINSTALL_MANAGED_EXCEPTION_DISPATCHER_EX(propagateExceptionToNativeCode);
         _ASSERTE(!"Throw returned");
     }
 
@@ -1351,8 +1355,9 @@ PCODE VSD_ResolveWorker(TransitionBlock * pTransitionBlock,
 
     pSDFrame->SetRepresentativeSlot(pRepresentativeMT, representativeToken.GetSlotNumber());
     pSDFrame->Push(CURRENT_THREAD);
-    INSTALL_MANAGED_EXCEPTION_DISPATCHER;
-    INSTALL_UNWIND_AND_CONTINUE_HANDLER;
+
+    INSTALL_MANAGED_EXCEPTION_DISPATCHER_EX;
+    INSTALL_UNWIND_AND_CONTINUE_HANDLER_EX;
 
     // For Virtual Delegates the m_siteAddr is a field of a managed object
     // Thus we have to report it as an interior pointer,
@@ -1388,8 +1393,8 @@ PCODE VSD_ResolveWorker(TransitionBlock * pTransitionBlock,
 
     GCPROTECT_END();
 
-    UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
-    UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
+    UNINSTALL_UNWIND_AND_CONTINUE_HANDLER_EX(propagateExceptionToNativeCode);
+    UNINSTALL_MANAGED_EXCEPTION_DISPATCHER_EX(propagateExceptionToNativeCode);
     pSDFrame->Pop(CURRENT_THREAD);
 
     return target;

--- a/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.cs
+++ b/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.cs
@@ -4,5 +4,8 @@ namespace Dependency
 {
     public class DependencyClass
     {
+        public static void Test()
+        {
+        }
     }
 }

--- a/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.cs
+++ b/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Dependency
+{
+    public class DependencyClass
+    {
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.cs
+++ b/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 
 namespace Dependency

--- a/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/dependencytodelete.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="dependencytodelete.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_76531/tailcallinvoker.il
+++ b/src/tests/Regressions/coreclr/GitHub_76531/tailcallinvoker.il
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern legacy library mscorlib {}
+.assembly extern dependencytodelete {}
+.assembly 'lowlevel' {}
+
+.class public sequential ansi sealed beforefieldinit TailCallInvoker
+       extends [mscorlib]System.Object
+{
+  .method public static void Test() cil managed noinlining
+  {
+    .maxstack  1
+    tail. call void [dependencytodelete]Dependency.DependencyClass::Test()
+    ret
+  } // end of method TailCallInvoker.Test
+} // end of class TailCallInvoker

--- a/src/tests/Regressions/coreclr/GitHub_76531/tailcallinvoker.il
+++ b/src/tests/Regressions/coreclr/GitHub_76531/tailcallinvoker.il
@@ -3,7 +3,7 @@
 
 .assembly extern legacy library mscorlib {}
 .assembly extern dependencytodelete {}
-.assembly 'lowlevel' {}
+.assembly 'tailcallinvoker' {}
 
 .class public sequential ansi sealed beforefieldinit TailCallInvoker
        extends [mscorlib]System.Object

--- a/src/tests/Regressions/coreclr/GitHub_76531/tailcallinvoker.ilproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/tailcallinvoker.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="tailcallinvoker.il" />
+    <ProjectReference Include="dependencytodelete.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.cs
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Reflection;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Test76531
+{
+    internal class Test
+    {
+        private static Dependency.DependencyClass? value;
+
+        static Test()
+        {
+            value = new Dependency.DependencyClass();
+        }
+    }
+
+    public class Program
+    {
+	[MethodImpl(MethodImplOptions.NoInlining)]
+        static void TestMethod()
+        {
+            try
+            {
+                Test test = new ();
+            }
+            catch (TypeInitializationException)
+            {
+                // This catch fails with issue #76531
+            }
+        }
+
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            File.Delete(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "dependencytodelete.dll"));
+            TestMethod();
+        }
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Required for the ability to disable the test for WASM via issues.targets  -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- This test removes one of its dependencies at runtime, so it is not compatible with AOT  -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
@@ -8,5 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="dependencytodelete.csproj" />
+    <ProjectReference Include="tailcallinvoker.ilproj" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- This test removes one of its dependencies at runtime, so it is not compatible with AOT  -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This test removes one of its dependencies at runtime, so it is not compatible with AOT  -->
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test76531.cs" />

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test76531.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="dependencytodelete.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3227,7 +3227,7 @@
         <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/unhandled/unhandled/**">
             <Issue>System.Diagnostics.Process is not supported</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/Regressions/coreclr/GitHub_76531/**">
+        <ExcludeList Include = "$(XunitTestBinBase)/Regressions/coreclr/GitHub_76531/test76531/**">
             <Issue>Assembly.GetExecutingAssembly().Location returns NULL on WASM</Issue>
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventcounter/incrementingeventcounter/**">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3227,6 +3227,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/unhandled/unhandled/**">
             <Issue>System.Diagnostics.Process is not supported</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/Regressions/coreclr/GitHub_76531/**">
+            <Issue>Assembly.GetExecutingAssembly().Location returns NULL on WASM</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventcounter/incrementingeventcounter/**">
             <Issue>System.Threading.Thread.UnsafeStart not supported</Issue>
         </ExcludeList>


### PR DESCRIPTION
There is a bug in the new exception handling when `ThePreStub` is called
from `CallDescrWorkerInternal` and the exception is propagated through
that. One of such cases is when a managed class is being initialized
during JITting and the constructor is in an assembly that's not found.
The bug results in skipping all the native frames upto a managed frame
that called that native chain that lead to the exception.
The effect is that some lock holders are skipped and the exception is
not converted to `TypeInitializationException`.

The fix is to ensure that when `ThePreStub` is called by
`CallDescrWorkerInternal`, the exception is not caught in the
`PreStubWorker`. It is left flowing into the native calling code instead.

On Windows, we also need to prevent the `ProcessCLRException` invocation
to call into the managed exception handling code for the case when the 
`ProcessCLRException` personality routine was on one of our asm helpers.

Close https://github.com/dotnet/runtime/issues/112502