### PR TITLE
Add workflow to prevent merging a PR when the `NO-MERGE` label is applied

### DIFF
--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
     - name: Check 'NO-MERGE' label
       run: |
-        echo "Merging permission is disabled when the `NO-MERGE` label is applied."
-        if [ "${{ contains(github.event.pull_request.labels.*.name, 'NO-MERGE') }}" = "true" ]; then
+        echo "Merging permission is disabled when the 'NO-MERGE' label is applied."
+        if [ "${{ contains(github.event.pull_request.labels.*.name, 'NO-MERGE') }}" = "false" ]; then
           exit 0
         else
           echo "::error:: The 'NO-MERGE' label was applied to the PR. Merging is disabled."

--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -1,0 +1,25 @@
+name: check-no-merge-label
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+    branches:
+      - 'main'
+      - 'release/**'
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check 'NO-MERGE' label
+      run: |
+        echo "Merging permission is disabled when the `NO-MERGE` label is applied."
+        if [ "${{ contains(github.event.pull_request.labels.*.name, 'NO-MERGE') }}" = "true" ]; then
+          exit 0
+        else
+          echo "::error:: The 'NO-MERGE' label was applied to the PR. Merging is disabled."
+          exit 1
+        fi

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Check 'Servicing-approved' label
       run: |
-        echo "Merging permission is enabled for servicing PRs when the `Servicing-approved` label is applied."
+        echo "Merging permission is enabled for servicing PRs when the 'Servicing-approved' label is applied."
         if [ "${{ contains(github.event.pull_request.labels.*.name, 'Servicing-approved') }}" = "true" ]; then
           exit 0
         else


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105452

We should backport to the servicing branches as well.