### PR TITLE
Fix mistakes in net9 WorkloadManifest.json

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -197,10 +197,7 @@
     },
     "Microsoft.NET.Runtime.WebAssembly.Templates.${NetVersion}": {
       "kind": "template",
-      "version": "${PackageVersion}",
-      "alias-to": {
-        "any": "Microsoft.NET.Runtime.WebAssembly.Templates"
-      }
+      "version": "${PackageVersion}"
     },
     "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.android-arm": {
       "kind": "framework",

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -197,7 +197,10 @@
     },
     "Microsoft.NET.Runtime.WebAssembly.Templates.${NetVersion}": {
       "kind": "template",
-      "version": "${PackageVersion}"
+      "version": "${PackageVersion}",
+      "alias-to": {
+        "any": "Microsoft.NET.Runtime.WebAssembly.Templates"
+      }
     },
     "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.android-arm": {
       "kind": "framework",

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net9.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net9.Manifest/WorkloadManifest.json.in
@@ -197,10 +197,7 @@
     },
     "Microsoft.NET.Runtime.WebAssembly.Templates.net9": {
       "kind": "template",
-      "version": "${PackageVersionNet9}",
-      "alias-to": {
-        "any": "Microsoft.NET.Runtime.WebAssembly.Templates"
-      }
+      "version": "${PackageVersionNet9}"
     },
     "Microsoft.NETCore.App.Runtime.Mono.net9.android-arm": {
       "kind": "framework",

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net9.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net9.Manifest/WorkloadManifest.json.in
@@ -115,8 +115,8 @@
       "packs": [
         "Microsoft.NETCore.App.Runtime.Mono.net9.osx-arm64",
         "Microsoft.NETCore.App.Runtime.Mono.net9.osx-x64",
-        "Microsoft.NETCore.App.Runtime.osx-arm64",
-        "Microsoft.NETCore.App.Runtime.osx-x64"
+        "Microsoft.NETCore.App.Runtime.net9.osx-arm64",
+        "Microsoft.NETCore.App.Runtime.net9.osx-x64"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling-net9" ],
       "platforms": [ "osx-arm64", "osx-x64" ]
@@ -197,7 +197,10 @@
     },
     "Microsoft.NET.Runtime.WebAssembly.Templates.net9": {
       "kind": "template",
-      "version": "${PackageVersionNet9}"
+      "version": "${PackageVersionNet9}",
+      "alias-to": {
+        "any": "Microsoft.NET.Runtime.WebAssembly.Templates"
+      }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net9.android-arm": {
       "kind": "framework",


### PR DESCRIPTION
I noticed these while working on the workload manifest move to the sdk repo. We missed the net9 in the package id for microsoft-net-runtime-macos-net9.