### PR TITLE
[NO MERGE] See if it's possible to build stress tests

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -42,7 +42,7 @@ namespace HttpStress
 
         private static bool TryParseCli(string[] args, [NotNullWhen(true)] out Configuration? config)
         {
-            var cmd = new RootCommand();
+            RootCommand cmd = new RootCommand();
             cmd.AddOption(new Option("-n", "Max number of requests to make concurrently.") { Argument = new Argument<int>("numWorkers", Environment.ProcessorCount) });
             cmd.AddOption(new Option("-serverUri", "Stress suite server uri.") { Argument = new Argument<string>("serverUri", "https://localhost:5001") });
             cmd.AddOption(new Option("-runMode", "Stress suite execution mode. Defaults to Both.") { Argument = new Argument<RunMode>("runMode", RunMode.both) });


### PR DESCRIPTION
These two stress builds are failing in my other PR (#111864), while I can build them with no problem locally. I just want to check if it's my fault.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=930627&view=logs&j=0bc77094-9fcd-5c38-f6e4-27d2ae131589&t=17686723-e01f-55c9-b447-aba4418d28eb