### PR TITLE
JIT: fix try region cloning when try is nested in a handler

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2761,14 +2761,20 @@ BasicBlock* Compiler::fgCloneTryRegion(BasicBlock* tryEntry, CloneTryInfo& info,
     // this is cheaper than any other insertion point, as no existing regions get renumbered.
     //
     unsigned insertBeforeIndex = enclosingTryIndex;
-    if (insertBeforeIndex == EHblkDsc::NO_ENCLOSING_INDEX)
+    if ((enclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX) && (enclosingHndIndex == EHblkDsc::NO_ENCLOSING_INDEX))
     {
-        JITDUMP("Cloned EH clauses will go at the end of the EH table\n");
+        JITDUMP("No enclosing EH region; cloned EH clauses will go at the end of the EH table\n");
         insertBeforeIndex = compHndBBtabCount;
+    }
+    else if ((enclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX) || (enclosingHndIndex < enclosingTryIndex))
+    {
+        JITDUMP("Cloned EH clauses will go before enclosing handler region EH#%02u\n", enclosingHndIndex);
+        insertBeforeIndex = enclosingHndIndex;
     }
     else
     {
-        JITDUMP("Cloned EH clauses will go before enclosing region EH#%02u\n", enclosingTryIndex);
+        JITDUMP("Cloned EH clauses will go before enclosing try region EH#%02u\n", enclosingTryIndex);
+        assert(insertBeforeIndex == enclosingTryIndex);
     }
 
     // Once we call fgTryAddEHTableEntries with deferCloning = false,
@@ -2989,7 +2995,7 @@ BasicBlock* Compiler::fgCloneTryRegion(BasicBlock* tryEntry, CloneTryInfo& info,
             const unsigned originalTryIndex = block->getTryIndex();
             unsigned       cloneTryIndex    = originalTryIndex;
 
-            if (originalTryIndex <= outermostTryIndex)
+            if (originalTryIndex < enclosingTryIndex)
             {
                 cloneTryIndex += indexShift;
             }
@@ -3003,11 +3009,15 @@ BasicBlock* Compiler::fgCloneTryRegion(BasicBlock* tryEntry, CloneTryInfo& info,
         if (block->hasHndIndex())
         {
             const unsigned originalHndIndex = block->getHndIndex();
+            unsigned       cloneHndIndex    = originalHndIndex;
 
-            // if (originalHndIndex ==
-            const unsigned  cloneHndIndex = originalHndIndex + indexShift;
-            EHblkDsc* const originalEbd   = ehGetDsc(originalHndIndex);
-            EHblkDsc* const clonedEbd     = ehGetDsc(cloneHndIndex);
+            if (originalHndIndex < enclosingHndIndex)
+            {
+                cloneHndIndex += indexShift;
+            }
+
+            EHblkDsc* const originalEbd = ehGetDsc(originalHndIndex);
+            EHblkDsc* const clonedEbd   = ehGetDsc(cloneHndIndex);
             newBlock->setHndIndex(cloneHndIndex);
             updateBlockReferences(cloneHndIndex);
 

--- a/src/tests/JIT/opt/Cloning/loops_with_eh.cs
+++ b/src/tests/JIT/opt/Cloning/loops_with_eh.cs
@@ -5,7 +5,6 @@ using System;
 using System.Runtime.CompilerServices;
 using Xunit;
 
-
 // Cheat codes
 //
 // L   - loop
@@ -17,6 +16,7 @@ using Xunit;
 // m   - multiple try exits (TF will remain a try finally)
 // g   - giant finally (TF will remain try finally)
 // p   - regions are serial, not nested
+// TFi - try finally with what follows in the finally
 // 
 // x: we currently cannot clone loops where the try is the first thing
 // as the header and preheader are different regions
@@ -25,6 +25,9 @@ public class LoopsWithEH
 {
     static int[] data;
     static int n;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void SideEffect() { }
 
     static LoopsWithEH()
     {
@@ -178,7 +181,7 @@ public class LoopsWithEH
             {
                 return -1;
             }
-            catch(Exception)
+            catch (Exception)
             {
                 return -2;
             }
@@ -201,7 +204,7 @@ public class LoopsWithEH
             }
             catch (IndexOutOfRangeException)
             {
-                sum +=1;
+                sum += 1;
             }
             catch (Exception)
             {
@@ -536,7 +539,7 @@ public class LoopsWithEH
                 }
             }
         }
-        catch (Exception) 
+        catch (Exception)
         {
             return -1;
         }
@@ -642,7 +645,7 @@ public class LoopsWithEH
                 {
                     sum += data[i];
                 }
-                finally 
+                finally
                 {
                     sum += 1;
                 }
@@ -807,7 +810,7 @@ public class LoopsWithEH
 
     [Fact]
     public static int Test_LxTFxTF() => Sum_LxTFTF(data, n) - 110;
-    
+
     public static int Sum_TFLxTF(int[] data, int n)
     {
         int sum = 0;
@@ -896,7 +899,7 @@ public class LoopsWithEH
                 sum += 1;
             }
         }
-        catch(Exception)
+        catch (Exception)
         {
             return -1;
         }
@@ -935,6 +938,193 @@ public class LoopsWithEH
         {
             sum += 1;
         }
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_TFiL() => Sum_TFiL(data, n) - 91;
+
+    public static int Sum_TFiL(int[] data, int n)
+    {
+        int sum = 0;
+        try
+        {
+            SideEffect();
+        }
+        finally
+        {
+            sum += 1;
+            for (int i = 0; i < n; i++)
+            {
+                sum += data[i];
+            }
+        }
+
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_TFiLxTF() => Sum_TFiLxTF(data, n) - 131;
+
+    public static int Sum_TFiLxTF(int[] data, int n)
+    {
+        int sum = 0;
+        try
+        {
+            SideEffect();
+        }
+        finally
+        {
+            sum += 1;
+            for (int i = 0; i < n; i++)
+            {
+                sum += 1;
+                try
+                {
+                    sum += data[i];
+                }
+                finally
+                {
+                    sum += 1;
+                }
+            }
+        }
+
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_TFiLxTCc() => Sum_TFiLxTCc(data, n) - 111;
+
+    public static int Sum_TFiLxTCc(int[] data, int n)
+    {
+        int sum = 0;
+        try
+        {
+            SideEffect();
+        }
+        finally
+        {
+            sum += 1;
+            for (int i = 0; i < n; i++)
+            {
+                sum += 1;
+                try
+                {
+                    sum += data[i];
+                }
+                catch (Exception)
+                {
+                    sum += 1;
+                }
+            }
+        }
+
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_TFiLxTC() => Sum_TFiLxTC(data, n) - 112;
+
+    public static int Sum_TFiLxTC(int[] data, int n)
+    {
+        int sum = 0;
+        try
+        {
+            SideEffect();
+        }
+        finally
+        {
+            sum += 1;
+            for (int i = 0; i < n; i++)
+            {
+                sum += 1;
+                try
+                {
+                    sum += data[i];
+                }
+                catch (Exception)
+                {
+                    goto after_loop;
+                }
+            }
+
+        after_loop:
+            sum += 1;
+
+        }
+
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_TFTFiLxTC() => Sum_TFTFiLxTC(data, n) - 113;
+
+    public static int Sum_TFTFiLxTC(int[] data, int n)
+    {
+        int sum = 0;
+        try
+        {
+            try
+            {
+                SideEffect();
+            }
+            finally
+            {
+                sum += 1;
+                for (int i = 0; i < n; i++)
+                {
+                    sum += 1;
+                    try
+                    {
+                        sum += data[i];
+                    }
+                    catch (Exception)
+                    {
+                        goto after_loop;
+                    }
+                }
+
+            after_loop:
+                sum += 1;
+            }
+        }
+        finally
+        {
+            sum += 1;
+        }
+
+        return sum;
+    }
+
+
+    [Fact]
+    public static int Test_TFiTFxL() => Sum_TFiTFxL(data, n) - 92;
+
+    public static int Sum_TFiTFxL(int[] data, int n)
+    {
+        int sum = 0;
+
+        try
+        {
+            SideEffect();
+        }
+        finally
+        {
+            try
+            {
+                sum += 1;
+                for (int i = 0; i < n; i++)
+                {
+                    sum += data[i];
+                }
+            }
+            finally
+            {
+                sum += 1;
+            }
+        }
+
         return sum;
     }
 }


### PR DESCRIPTION
We were not placing the new EH region in the table properly, and not correctly updating the handler indexes of cloned blocks.

Add some test cases where we have cloneable loops with EH inside of finallies.

Fixes some issues that came up testing #111473