### PR TITLE
Fix ICustomQueryInterface implementation in CrossApartmentQueryInterface_NoDeadlock

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1121,7 +1121,7 @@ namespace ComWrappersTests
                     }
                 }
 
-                return CustomQueryInterfaceResult.Failed;
+                return CustomQueryInterfaceResult.NotHandled;
             }
         }
     }


### PR DESCRIPTION
Try changing the ICustomQueryInterface implementation to always return NotHandled instead of Failed to defer back to the ComWrappers impl instead of failing every QI (which I suspect is what is leading to the failures).

Fixes https://github.com/dotnet/runtime/issues/111264