### PR TITLE
Enable Mono tests

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
@@ -4,8 +4,6 @@
 using System.Runtime.InteropServices;
 using Xunit;
 
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35912", TestRuntimes.Mono)]
-
 namespace System.DirectoryServices.Protocols.Tests
 {
     public static class DirectoryServicesTestHelpers


### PR DESCRIPTION
The Mono tests do not appear to be failing anymore in CI. This could be because Mono desktop is no longer used as the case when this issue was created in v5, or because of the LibraryImportGenerator used since v7 that may have fixed interop bugs.

Fixes https://github.com/dotnet/runtime/issues/35912