### PR TITLE
System.Speech: Use intellisense xml from dotnet-api-docs

### DIFF
--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(NetCoreAppPrevious)' != ''">$(TargetFrameworks);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious)</TargetFrameworks>
+    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- CS0649: uninitialized interop type fields -->
     <!-- SA1129: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3277 -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/87711

The intellisense file that comes from Microsoft.Private.Intellisense, located in `C:\.tools\.nuget\packages\microsoft.private.intellisense\9.0.0-preview-20241010.1\IntellisenseFiles\net\1033\System.Speech.xml`, weighs 317KB.

But when building, the xml files under `C:\Users\calope\source\repos\runtime\artifacts\obj\System.Speech\$(Configuration)\` all weigh much less than that (varies depending on the OS/platform) and only contain resource strings (no actual docs).

This means we are using the xmls from the build, and almost none of the System.Speech have triple slash comments. I was able to confirm this by analyzing the binlog and finding that `UseCompilerGeneratedDocXmlFile` is set to `true` (the default value) so none of the logic from [intellisense.targets](https://github.com/dotnet/runtime/blob/7de730ad244e58626840e3617ca41349e5cf3720/eng/intellisense.targets#L7) is used.

The fix is to set this assembly's `UseCompilerGeneratedDocXmlFile` to explicitly to `false` in the csproj, exactly as @gewarren found in the original issue.

I was able to confirm with a rebuild of the csproj that the xml placed next to the built DLL is now the one coming from dotnet-api-docs: it weighs 317KB and contains all API docs, and can be found in all the target framework folders in the output folder.