### PR TITLE
Native AOT Pri-1 test tree bring up (Loader test tree)

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -25,6 +25,8 @@ namespace TestLibrary
 
         public static bool IsRareEnumsSupported => !Utilities.IsNativeAot;
 
+        public static bool IsCollectibleAssembliesSupported => !Utilities.IsNativeAot;
+
         private static volatile Tuple<bool> s_lazyNonZeroLowerBoundArraySupported;
         public static bool IsNonZeroLowerBoundArraySupported
         {

--- a/src/tests/Loader/AssemblyDependencyResolver/MissingHostPolicyTests/MissingHostPolicyTests.csproj
+++ b/src/tests/Loader/AssemblyDependencyResolver/MissingHostPolicyTests/MissingHostPolicyTests.csproj
@@ -3,6 +3,8 @@
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- AssemblyDependencyResolver is not supported -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvalidHostingTest.cs" />

--- a/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/ResolvedFromDifferentContext.cs
+++ b/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/ResolvedFromDifferentContext.cs
@@ -14,6 +14,7 @@ using System.Runtime.Loader;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.IO;
+using TestLibrary;
 using Xunit;
 
 class TestAssemblyLoadContext : AssemblyLoadContext
@@ -207,7 +208,7 @@ public class Test
         return 100;
     }
 
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsCollectibleAssembliesSupported))]
     public static int TestEntryPoint()
     {
         int status = 100;

--- a/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/ResolvedFromDifferentContext.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/ResolvedFromDifferentContext.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="TestInterface.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="TestClass.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/tests/Loader/NativeLibs/FromNativePaths.csproj
+++ b/src/tests/Loader/NativeLibs/FromNativePaths.csproj
@@ -4,6 +4,8 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- Test expects a CORE_ROOT -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FromNativePaths.cs" />

--- a/src/tests/Loader/classloader/MethodImpl/generics_override1.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/generics_override1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for NativeAotIncompatible -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-
     <!-- Testing TypeLoad/MissingMethod exceptions in situations that are expensive to detect -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>

--- a/src/tests/Loader/classloader/MethodImpl/override_override1.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/override_override1.ilproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Testing TypeLoad exceptions in situations that are expensive to detect -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="override_override1.il" />

--- a/src/tests/Loader/classloader/MethodImpl/self_override1.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/self_override1.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/Loader/classloader/MethodImpl/self_override2.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/self_override2.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/MethodImpl/self_override3.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/self_override3.ilproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Testing TypeLoad exceptions in situations that are expensive to detect -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="self_override3.il" />

--- a/src/tests/Loader/classloader/MethodImpl/self_override5.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/self_override5.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/methodoverriding/regressions/576621/VSW576621.csproj
+++ b/src/tests/Loader/classloader/methodoverriding/regressions/576621/VSW576621.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -653,6 +653,15 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/DiamondShape/svm_diamondshape_r/*">
             <Issue>https://github.com/dotnet/runtime/issues/72589</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/MethodImpl/self_override2/*">
+            <Issue>https://github.com/dotnet/runtime/issues/111991</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/MethodImpl/self_override5/*">
+            <Issue>https://github.com/dotnet/runtime/issues/111991</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/methodoverriding/regressions/576621/VSW576621/*">
+            <Issue>https://github.com/dotnet/runtime/issues/111991</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/NegativeTestCases/**">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Compatible TypeLoadException for invalid inputs</Issue>
         </ExcludeList>


### PR DESCRIPTION
I've also dropped `RequiresProcessIsolation` from tests while I was looking at them.

Cc @dotnet/ilc-contrib 