### PR TITLE
R2RDump: normalize GC info totalInterruptibleLength

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -537,6 +537,9 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 }
             }
 
+            if (SlotTable.NumTracked == 0)
+                return new Dictionary<int, List<BaseGcTransition>>();
+
             int numChunks = (totalInterruptibleLength + _gcInfoTypes.NUM_NORM_CODE_OFFSETS_PER_CHUNK - 1) / _gcInfoTypes.NUM_NORM_CODE_OFFSETS_PER_CHUNK;
             int numBitsPerPointer = (int)NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.POINTER_SIZE_ENCBASE, ref bitOffset);
             if (numBitsPerPointer == 0)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -525,13 +525,15 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             int totalInterruptibleLength = 0;
             if (NumInterruptibleRanges == 0)
             {
-                totalInterruptibleLength = CodeLength;
+                totalInterruptibleLength = _gcInfoTypes.NormalizeCodeLength(CodeLength);
             }
             else
             {
                 foreach (InterruptibleRange range in InterruptibleRanges)
                 {
-                    totalInterruptibleLength += (int)(range.StopOffset - range.StartOffset);
+                    uint normStart = _gcInfoTypes.NormalizeCodeOffset(range.StartOffset);
+                    uint normStop  = _gcInfoTypes.NormalizeCodeOffset(range.StopOffset);
+                    totalInterruptibleLength += (int)(normStop - normStart);
                 }
             }
 
@@ -629,6 +631,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                     fSkip = !fSkip;
                     fReport = !fReport;
                 }
+                Debug.Assert(readSlots == numTracked);
             }
             else
             {
@@ -642,6 +645,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                         numCouldBeLiveSlots++;
                 }
             }
+            Debug.Assert(numCouldBeLiveSlots > 0);
             return numCouldBeLiveSlots;
         }
 


### PR DESCRIPTION
One more from #110845. Without it sees too many numChunks and decoding transitions goes south.

Plus some checks like gcinfodecoder.cpp.

Part of #84834, cc @dotnet/samsung @VSadov