### PR TITLE
JIT: Rework retbuf handling during inlining

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5210,7 +5210,7 @@ private:
                            InlineCandidateInfo**  ppInlineCandidateInfo,
                            InlineResult*          inlineResult);
 
-    void impInlineRecordArgInfo(InlineInfo* pInlineInfo, CallArg* arg, unsigned argNum, InlineResult* inlineResult);
+    void impInlineRecordArgInfo(InlineInfo* pInlineInfo, CallArg* arg, InlArgInfo* argInfo, InlineResult* inlineResult);
 
     void impInlineInitVars(InlineInfo* pInlineInfo);
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1874,7 +1874,8 @@ void Compiler::fgInsertInlineeArgument(
     else
     {
         // The argument is either not used or of a shape we allowed to be duplicated
-        noway_assert(!argInfo.argIsUsed || argInfo.argIsInvariant || argInfo.argIsLclVar || argInfo.argDuplicateComplex);
+        noway_assert(!argInfo.argIsUsed || argInfo.argIsInvariant || argInfo.argIsLclVar ||
+                     argInfo.argDuplicateComplex);
         noway_assert((argInfo.argIsLclVar == 0) ==
                      (argNode->gtOper != GT_LCL_VAR || (argNode->gtFlags & GTF_GLOB_REF)));
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1871,15 +1871,10 @@ void Compiler::fgInsertInlineeArgument(
             DISPSTMT(*afterStmt);
         }
     }
-    else if (argInfo.argIsByRefToStructLocal)
-    {
-        // Do nothing. Arg was directly substituted as we read
-        // the inlinee.
-    }
     else
     {
-        // The argument is either not used or a const or lcl var
-        noway_assert(!argInfo.argIsUsed || argInfo.argIsInvariant || argInfo.argIsLclVar);
+        // The argument is either not used or of a shape we allowed to be duplicated
+        noway_assert(!argInfo.argIsUsed || argInfo.argIsInvariant || argInfo.argIsLclVar || argInfo.argDuplicateComplex);
         noway_assert((argInfo.argIsLclVar == 0) ==
                      (argNode->gtOper != GT_LCL_VAR || (argNode->gtFlags & GTF_GLOB_REF)));
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1582,6 +1582,37 @@ unsigned CallArgs::GetIndex(CallArg* arg)
 }
 
 //---------------------------------------------------------------
+// GetIndex: Get the user arg index for the specified argument (IL index).
+//
+// Parameters:
+//   arg - The argument to obtain the index of.
+//
+// Returns:
+//   The user index.
+//
+unsigned CallArgs::GetUserIndex(CallArg* arg)
+{
+    unsigned i = 0;
+    for (CallArg& a : Args())
+    {
+        if (!a.IsUserArg())
+        {
+            continue;
+        }
+
+        if (&a == arg)
+        {
+            return i;
+        }
+
+        i++;
+    }
+
+    assert(!"Could not find argument in arg list");
+    return (unsigned)-1;
+}
+
+//---------------------------------------------------------------
 // Reverse: Reverse the specified subrange of arguments.
 //
 // Parameters:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4920,6 +4920,7 @@ public:
     CallArg* GetArgByIndex(unsigned index);
     CallArg* GetUserArgByIndex(unsigned index);
     unsigned GetIndex(CallArg* arg);
+    unsigned GetUserIndex(CallArg* arg);
 
     bool IsEmpty() const
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13599,27 +13599,26 @@ GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& l
              !argInfo.argHasSideEff && !argInfo.argHasGlobRef)
     {
         // Argument is a complex expression that we still prefer to duplicate.
-        // For example because it is an adress into a local in the caller. a
-        // by-ref address to a struct, a normed struct, or its field. In these
-        // cases, don't spill the byref to a local, simply clone the tree and
-        // use it.
+        // For example because it is an adress into a local in the caller. In
+        // these cases, don't spill the byref to a local, simply clone the tree
+        // and use it.
         //
         op1 = gtCloneExpr(argNode);
     }
     else
     {
-        /* Argument is a complex expression - it must be evaluated into a temp */
+        // Argument is a complex expression - it must be evaluated into a temp
 
         if (argInfo.argHasTmp)
         {
             assert(argInfo.argIsUsed);
             assert(argInfo.argTmpNum < lvaCount);
 
-            /* Create a new lcl var node - remember the argument lclNum */
+            // Create a new lcl var node - remember the argument lclNum
             op1 = gtNewLclvNode(argInfo.argTmpNum, genActualType(lclTyp));
 
-            /* This is the second or later use of the this argument,
-            so we have to use the temp (instead of the actual arg) */
+            // This is the second or later use of the this argument, so we have
+            // to use the temp (instead of the actual arg)
             argInfo.argBashTmpNode = nullptr;
         }
         else
@@ -13627,8 +13626,8 @@ GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& l
             /* First time use */
             assert(!argInfo.argIsUsed);
 
-            /* Reserve a temp for the expression.
-             * Use a large size node as we may change it later */
+            // Reserve a temp for the expression. Use a large size node as we
+            // may change it later
 
             const unsigned tmpNum = lvaGrabTemp(true DEBUGARG("Inlining Arg"));
 
@@ -13685,20 +13684,20 @@ GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& l
             if ((!varTypeIsStruct(lclTyp) && !argInfo.argHasSideEff && !argInfo.argHasGlobRef &&
                  !argInfo.argHasCallerLocalRef))
             {
-                /* Get a *LARGE* LCL_VAR node */
+                // Get a *LARGE* LCL_VAR node
                 op1 = gtNewLclLNode(tmpNum, genActualType(lclTyp));
 
-                /* Record op1 as the very first use of this argument.
-                If there are no further uses of the arg, we may be
-                able to use the actual arg node instead of the temp.
-                If we do see any further uses, we will clear this. */
+                // Record op1 as the very first use of this argument. If there
+                // are no further uses of the arg, we may be able to use the
+                // actual arg node instead of the temp. If we do see any
+                // further uses, we will clear this.
                 argInfo.argBashTmpNode = op1;
             }
             else
             {
-                /* Get a small LCL_VAR node */
+                // Get a small LCL_VAR node
                 op1 = gtNewLclvNode(tmpNum, genActualType(lclTyp));
-                /* No bashing of this argument */
+                // No bashing of this argument
                 argInfo.argBashTmpNode = nullptr;
             }
         }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11153,8 +11153,10 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
                 }
                 else // The struct was to be returned via a return buffer.
                 {
-                    assert(iciCall->gtArgs.HasRetBuffer());
-                    GenTree* dest = gtCloneExpr(iciCall->gtArgs.GetRetBufferArg()->GetEarlyNode());
+                    assert(iciCall->gtArgs.HasRetBuffer() && (impInlineInfo->inlRetBufferArgInfo != nullptr));
+                    InlLclVarInfo lclInfo = {};
+                    lclInfo.lclTypeInfo   = TYP_BYREF;
+                    GenTree* dest         = impInlineFetchArg(*impInlineInfo->inlRetBufferArgInfo, lclInfo);
 
                     if (fgNeedReturnSpillTemp())
                     {
@@ -12928,7 +12930,7 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE fncHandle,
 // Arguments:
 //   pInlineInfo - inline info for the inline candidate
 //   arg - the caller argument
-//   argNum - logical index of this argument
+//   argInfo - Structure to record information into
 //   inlineResult - result of ongoing inline evaluation
 //
 // Notes:
@@ -12940,12 +12942,10 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE fncHandle,
 
 void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
                                       CallArg*      arg,
-                                      unsigned      argNum,
+                                      InlArgInfo*   argInfo,
                                       InlineResult* inlineResult)
 {
-    InlArgInfo* inlCurArgInfo = &pInlineInfo->inlArgInfo[argNum];
-
-    inlCurArgInfo->arg = arg;
+    argInfo->arg       = arg;
     GenTree* curArgVal = arg->GetNode();
 
     assert(!curArgVal->OperIs(GT_RET_EXPR));
@@ -12958,7 +12958,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
 
         if (varTypeIsStruct(varDsc))
         {
-            inlCurArgInfo->argIsByRefToStructLocal = true;
+            argInfo->argIsByRefToStructLocal = true;
 #ifdef FEATURE_SIMD
             if (varTypeIsSIMD(varDsc))
             {
@@ -12967,28 +12967,27 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
 #endif // FEATURE_SIMD
         }
 
-        // Spilling code relies on correct aliasability annotations.
-        assert(varDsc->lvHasLdAddrOp || varDsc->IsAddressExposed());
+        // Spilling code relies on correct aliasability annotations, except for
+        // retbufs that are not actually exposed in IL.
+        assert(varDsc->lvHasLdAddrOp || varDsc->IsAddressExposed() ||
+               (arg->GetWellKnownArg() == WellKnownArg::RetBuffer));
     }
 
     if (curArgVal->gtFlags & GTF_ALL_EFFECT)
     {
-        inlCurArgInfo->argHasGlobRef = (curArgVal->gtFlags & GTF_GLOB_REF) != 0;
-        inlCurArgInfo->argHasSideEff = (curArgVal->gtFlags & (GTF_ALL_EFFECT & ~GTF_GLOB_REF)) != 0;
+        argInfo->argHasGlobRef = (curArgVal->gtFlags & GTF_GLOB_REF) != 0;
+        argInfo->argHasSideEff = (curArgVal->gtFlags & (GTF_ALL_EFFECT & ~GTF_GLOB_REF)) != 0;
     }
 
     if (curArgVal->gtOper == GT_LCL_VAR)
     {
-        inlCurArgInfo->argIsLclVar = true;
-
-        /* Remember the "original" argument number */
-        INDEBUG(curArgVal->AsLclVar()->gtLclILoffs = argNum;)
+        argInfo->argIsLclVar = true;
     }
 
     if (impIsInvariant(curArgVal))
     {
-        inlCurArgInfo->argIsInvariant = true;
-        if (inlCurArgInfo->argIsThis && (curArgVal->gtOper == GT_CNS_INT) && (curArgVal->AsIntCon()->gtIconVal == 0))
+        argInfo->argIsInvariant = true;
+        if (argInfo->argIsThis && (curArgVal->gtOper == GT_CNS_INT) && (curArgVal->AsIntCon()->gtIconVal == 0))
         {
             // Abort inlining at this call site
             inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_HAS_NULL_THIS);
@@ -12997,13 +12996,15 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
     }
     else if (gtIsTypeof(curArgVal))
     {
-        inlCurArgInfo->argIsInvariant = true;
-        inlCurArgInfo->argHasSideEff  = false;
+        argInfo->argIsInvariant = true;
+        argInfo->argHasSideEff  = false;
     }
 
-    bool isExact              = false;
-    bool isNonNull            = false;
-    inlCurArgInfo->argIsExact = (gtGetClassHandle(curArgVal, &isExact, &isNonNull) != NO_CLASS_HANDLE) && isExact;
+    argInfo->argIsThis = arg->GetWellKnownArg() == WellKnownArg::ThisPointer;
+
+    bool isExact        = false;
+    bool isNonNull      = false;
+    argInfo->argIsExact = (gtGetClassHandle(curArgVal, &isExact, &isNonNull) != NO_CLASS_HANDLE) && isExact;
 
     // If the arg is a local that is address-taken, we can't safely
     // directly substitute it into the inlinee.
@@ -13014,51 +13015,51 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
     // which is safe in this case.
     //
     // Instead mark the arg as having a caller local ref.
-    if (!inlCurArgInfo->argIsInvariant && gtHasLocalsWithAddrOp(curArgVal))
+    if (!argInfo->argIsInvariant && gtHasLocalsWithAddrOp(curArgVal))
     {
-        inlCurArgInfo->argHasCallerLocalRef = true;
+        argInfo->argHasCallerLocalRef = true;
     }
 
 #ifdef DEBUG
     if (verbose)
     {
-        if (inlCurArgInfo->argIsThis)
+        if (arg->GetWellKnownArg() != WellKnownArg::None)
         {
-            printf("thisArg:");
+            printf("%s:", getWellKnownArgName(arg->GetWellKnownArg()));
         }
         else
         {
-            printf("\nArgument #%u:", argNum);
+            printf("IL argument #%u:", pInlineInfo->iciCall->gtArgs.GetUserIndex(arg));
         }
-        if (inlCurArgInfo->argIsLclVar)
+        if (argInfo->argIsLclVar)
         {
             printf(" is a local var");
         }
-        if (inlCurArgInfo->argIsInvariant)
+        if (argInfo->argIsInvariant)
         {
             printf(" is a constant or invariant");
         }
-        if (inlCurArgInfo->argHasGlobRef)
+        if (argInfo->argHasGlobRef)
         {
             printf(" has global refs");
         }
-        if (inlCurArgInfo->argHasCallerLocalRef)
+        if (argInfo->argHasCallerLocalRef)
         {
             printf(" has caller local ref");
         }
-        if (inlCurArgInfo->argHasSideEff)
+        if (argInfo->argHasSideEff)
         {
             printf(" has side effects");
         }
-        if (inlCurArgInfo->argHasLdargaOp)
+        if (argInfo->argHasLdargaOp)
         {
             printf(" has ldarga effect");
         }
-        if (inlCurArgInfo->argHasStargOp)
+        if (argInfo->argHasStargOp)
         {
             printf(" has starg effect");
         }
-        if (inlCurArgInfo->argIsByRefToStructLocal)
+        if (argInfo->argIsByRefToStructLocal)
         {
             printf(" is byref to a struct local");
         }
@@ -13114,46 +13115,27 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
     unsigned ilArgCnt = 0;
     for (CallArg& arg : call->gtArgs.Args())
     {
+        InlArgInfo* argInfo = nullptr;
         switch (arg.GetWellKnownArg())
         {
-            case WellKnownArg::ThisPointer:
-                inlArgInfo[ilArgCnt].argIsThis = true;
-                break;
             case WellKnownArg::RetBuffer:
-                // This does not appear in the table of inline arg info; do not include them
-                continue;
+                pInlineInfo->inlRetBufferArgInfo = argInfo = new (this, CMK_Inlining) InlArgInfo{};
+                break;
             case WellKnownArg::InstParam:
-            {
-                InlArgInfo* ctxInfo  = new (this, CMK_Inlining) InlArgInfo{};
-                ctxInfo->arg         = &arg;
-                ctxInfo->argTmpNum   = BAD_VAR_NUM;
-                ctxInfo->argIsLclVar = arg.GetNode()->OperIs(GT_LCL_VAR);
-                if (arg.GetNode()->IsCnsIntOrI())
-                {
-                    ctxInfo->argIsInvariant = true;
-                }
-                else
-                {
-                    // Conservative approach
-                    ctxInfo->argHasSideEff = true;
-                    ctxInfo->argHasGlobRef = true;
-                }
-                pInlineInfo->inlInstParamArgInfo = ctxInfo;
-                continue;
-            }
+                pInlineInfo->inlInstParamArgInfo = argInfo = new (this, CMK_Inlining) InlArgInfo{};
+                break;
             default:
+                argInfo = &inlArgInfo[ilArgCnt++];
                 break;
         }
 
         arg.SetEarlyNode(gtFoldExpr(arg.GetEarlyNode()));
-        impInlineRecordArgInfo(pInlineInfo, &arg, ilArgCnt, inlineResult);
+        impInlineRecordArgInfo(pInlineInfo, &arg, argInfo, inlineResult);
 
         if (inlineResult->IsFailure())
         {
             return;
         }
-
-        ilArgCnt++;
     }
 
     /* Make sure we got the arg number right */

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13595,7 +13595,8 @@ GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& l
             }
         }
     }
-    else if (argInfo.argDuplicateComplex && !argCanBeModified && !argInfo.argHasCallerLocalRef && !argInfo.argHasSideEff && !argInfo.argHasGlobRef)
+    else if (argInfo.argDuplicateComplex && !argCanBeModified && !argInfo.argHasCallerLocalRef &&
+             !argInfo.argHasSideEff && !argInfo.argHasGlobRef)
     {
         // Argument is a complex expression that we still prefer to duplicate.
         // For example because it is an adress into a local in the caller. a

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13599,7 +13599,7 @@ GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& l
              !argInfo.argHasSideEff && !argInfo.argHasGlobRef)
     {
         // Argument is a complex expression that we still prefer to duplicate.
-        // For example because it is an adress into a local in the caller. In
+        // For example because it is an address into a local in the caller. In
         // these cases, don't spill the byref to a local, simply clone the tree
         // and use it.
         //

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -653,8 +653,7 @@ struct InlArgInfo
     unsigned argHasTmp               : 1; // the argument will be evaluated to a temp
     unsigned argHasLdargaOp          : 1; // Is there LDARGA(s) operation on this argument?
     unsigned argHasStargOp           : 1; // Is there STARG(s) operation on this argument?
-    unsigned argIsByRefToStructLocal : 1; // Is this arg an address of a struct local or a normed struct local or a
-                                          // field in them?
+    unsigned argDuplicateComplex     : 1; // Is this an argument whose tree we prefer to duplicate regardless of complexity (provided it is safe)?
     unsigned argIsExact : 1;              // Is this arg of an exact class?
 };
 

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -693,6 +693,7 @@ struct InlineInfo
     unsigned      argCnt;
     InlArgInfo    inlArgInfo[MAX_INL_ARGS + 1];
     InlArgInfo*   inlInstParamArgInfo;
+    InlArgInfo*   inlRetBufferArgInfo;
     int           lclTmpNum[MAX_INL_LCLS];                     // map local# -> temp# (-1 if unused)
     InlLclVarInfo lclVarInfo[MAX_INL_LCLS + MAX_INL_ARGS + 1]; // type information from local sig
 

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -640,21 +640,22 @@ struct LateDevirtualizationInfo
 
 struct InlArgInfo
 {
-    CallArg* arg;                         // the caller argument
-    GenTree* argBashTmpNode;              // tmp node created, if it may be replaced with actual arg
-    unsigned argTmpNum;                   // the argument tmp number
-    unsigned argIsUsed               : 1; // is this arg used at all?
-    unsigned argIsInvariant          : 1; // the argument is a constant or a local variable address
-    unsigned argIsLclVar             : 1; // the argument is a local variable
-    unsigned argIsThis               : 1; // the argument is the 'this' pointer
-    unsigned argHasSideEff           : 1; // the argument has side effects
-    unsigned argHasGlobRef           : 1; // the argument has a global ref
-    unsigned argHasCallerLocalRef    : 1; // the argument value depends on an aliased caller local
-    unsigned argHasTmp               : 1; // the argument will be evaluated to a temp
-    unsigned argHasLdargaOp          : 1; // Is there LDARGA(s) operation on this argument?
-    unsigned argHasStargOp           : 1; // Is there STARG(s) operation on this argument?
-    unsigned argDuplicateComplex     : 1; // Is this an argument whose tree we prefer to duplicate regardless of complexity (provided it is safe)?
-    unsigned argIsExact : 1;              // Is this arg of an exact class?
+    CallArg* arg;                      // the caller argument
+    GenTree* argBashTmpNode;           // tmp node created, if it may be replaced with actual arg
+    unsigned argTmpNum;                // the argument tmp number
+    unsigned argIsUsed            : 1; // is this arg used at all?
+    unsigned argIsInvariant       : 1; // the argument is a constant or a local variable address
+    unsigned argIsLclVar          : 1; // the argument is a local variable
+    unsigned argIsThis            : 1; // the argument is the 'this' pointer
+    unsigned argHasSideEff        : 1; // the argument has side effects
+    unsigned argHasGlobRef        : 1; // the argument has a global ref
+    unsigned argHasCallerLocalRef : 1; // the argument value depends on an aliased caller local
+    unsigned argHasTmp            : 1; // the argument will be evaluated to a temp
+    unsigned argHasLdargaOp       : 1; // Is there LDARGA(s) operation on this argument?
+    unsigned argHasStargOp        : 1; // Is there STARG(s) operation on this argument?
+    unsigned argDuplicateComplex  : 1; // Is this an argument whose tree we prefer to duplicate regardless of complexity
+                                       // (provided it is safe)?
+    unsigned argIsExact : 1;           // Is this arg of an exact class?
 };
 
 // InlLclVarInfo describes inline candidate argument and local variable properties.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_112053/Runtime_112053.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_112053/Runtime_112053.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_112053
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Throws<NullReferenceException>(() => Foo(null, 0));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Foo(C c, int x)
+    {
+        c.G = Test(1 / x);
+    }
+
+    static Guid Test(int x)
+    {
+        return new Guid(x, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    class C
+    {
+        public Guid G;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_112053/Runtime_112053.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_112053/Runtime_112053.cs
@@ -19,13 +19,18 @@ public class Runtime_112053
         c.G = Test(1 / x);
     }
 
-    static Guid Test(int x)
+    static RetBuf Test(int x)
     {
-        return new Guid(x, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        return new RetBuf();
     }
 
     class C
     {
-        public Guid G;
+        public RetBuf G;
+    }
+
+    struct RetBuf
+    {
+        public nint A, B, C, D, E, F, G, H;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_112053/Runtime_112053.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_112053/Runtime_112053.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Avoid directly capturing the return buffer from the call in the inliner; instead record an actual `InlArgInfo` entry for the retbuffer. This unifies the handling with how the generic context and other arguments are handled.

Fix #112053