### PR TITLE
[release/9.0-staging][iOS][globalization] Fix IndexOf on empty strings on iOS to return -1

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -22,7 +22,10 @@ namespace System.Globalization.Tests
             yield return new object[] { s_germanCompare, "foo", "", 0, 3, CompareOptions.None, 0, 0 };
             yield return new object[] { s_germanCompare, "foo", "", 2, 1, CompareOptions.None, 2, 0 };
             yield return new object[] { s_germanCompare, "", "", 0, 0, CompareOptions.None, 0, 0 };
-            yield return new object[] { s_germanCompare, "", "foo", 0, 0, CompareOptions.None, -1, 0 };
+            if (!PlatformDetection.IsHybridGlobalizationOnBrowser)
+            {
+                yield return new object[] { s_germanCompare, "", "foo", 0, 0, CompareOptions.None, -1, 0 };
+            }
 
             // OrdinalIgnoreCase
             yield return new object[] { s_invariantCompare, "Hello", "l", 0, 5, CompareOptions.OrdinalIgnoreCase, 2, 1 };

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -12,10 +12,17 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> IndexOf_TestData()
         {
-            // Empty string
+            // Empty string, invariant
             yield return new object[] { s_invariantCompare, "foo", "", 0, 3, CompareOptions.None, 0, 0 };
             yield return new object[] { s_invariantCompare, "foo", "", 2, 1, CompareOptions.None, 2, 0 };
             yield return new object[] { s_invariantCompare, "", "", 0, 0, CompareOptions.None, 0, 0 };
+            yield return new object[] { s_invariantCompare, "", "foo", 0, 0, CompareOptions.None, -1, 0 };
+
+            // Empty string, non-invariant (s_germanCompare)
+            yield return new object[] { s_germanCompare, "foo", "", 0, 3, CompareOptions.None, 0, 0 };
+            yield return new object[] { s_germanCompare, "foo", "", 2, 1, CompareOptions.None, 2, 0 };
+            yield return new object[] { s_germanCompare, "", "", 0, 0, CompareOptions.None, 0, 0 };
+            yield return new object[] { s_germanCompare, "", "foo", 0, 0, CompareOptions.None, -1, 0 };
 
             // OrdinalIgnoreCase
             yield return new object[] { s_invariantCompare, "Hello", "l", 0, 5, CompareOptions.OrdinalIgnoreCase, 2, 1 };
@@ -166,7 +173,7 @@ namespace System.Globalization.Tests
         {
             bool useNls = PlatformDetection.IsNlsGlobalization;
             // Searches for the ligature \u00C6
-            string source1 = "Is AE or ae the same as \u00C6 or \u00E6?"; // 3 failures here
+            string source1 = "Is AE or ae the same as \u00C6 or \u00E6?";
             yield return new object[] { s_invariantCompare, source1, "AE", 8, 18, CompareOptions.None, useNls ? 24 : -1, useNls ? 1 : 0};
             yield return new object[] { s_invariantCompare, source1, "ae", 8, 18, CompareOptions.None, 9 , 2};
             yield return new object[] { s_invariantCompare, source1, "\u00C6", 8, 18, CompareOptions.None, 24, 1 };
@@ -184,7 +191,7 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> IndexOf_U_WithDiaeresis_TestData()
         {
             // Searches for the combining character sequence Latin capital letter U with diaeresis or Latin small letter u with diaeresis.
-            string source = "Is \u0055\u0308 or \u0075\u0308 the same as \u00DC or \u00FC?"; // 7 failures here
+            string source = "Is \u0055\u0308 or \u0075\u0308 the same as \u00DC or \u00FC?";
             yield return new object[] { s_invariantCompare, source, "U\u0308", 8, 18, CompareOptions.None, 24, 1 };
             yield return new object[] { s_invariantCompare, source, "u\u0308", 8, 18, CompareOptions.None, 9, 2 };
             yield return new object[] { s_invariantCompare, source, "\u00DC", 8, 18, CompareOptions.None, 24, 1 };

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -18,7 +18,7 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "", "", 0, 0, CompareOptions.None, 0, 0 };
             yield return new object[] { s_invariantCompare, "", "foo", 0, 0, CompareOptions.None, -1, 0 };
 
-            // Empty string, non-invariant (s_germanCompare)
+            // Empty string, using non-invariant (s_germanCompare) CompareInfo to test the ICU path
             yield return new object[] { s_germanCompare, "foo", "", 0, 3, CompareOptions.None, 0, 0 };
             yield return new object[] { s_germanCompare, "foo", "", 2, 1, CompareOptions.None, 2, 0 };
             yield return new object[] { s_germanCompare, "", "", 0, 0, CompareOptions.None, 0, 0 };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
@@ -210,6 +210,7 @@ namespace System.Tests
         [InlineData("Hello", 'e', StringComparison.CurrentCulture, true)]
         [InlineData("Hello", 'E', StringComparison.CurrentCulture, false)]
         [InlineData("", 'H', StringComparison.CurrentCulture, false)]
+        [InlineData("", '\u0301', StringComparison.CurrentCulture, false)]
         // CurrentCultureIgnoreCase
         [InlineData("Hello", 'H', StringComparison.CurrentCultureIgnoreCase, true)]
         [InlineData("Hello", 'Z', StringComparison.CurrentCultureIgnoreCase, false)]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
@@ -210,7 +210,7 @@ namespace System.Tests
         [InlineData("Hello", 'e', StringComparison.CurrentCulture, true)]
         [InlineData("Hello", 'E', StringComparison.CurrentCulture, false)]
         [InlineData("", 'H', StringComparison.CurrentCulture, false)]
-        [InlineData("", '\u0301', StringComparison.CurrentCulture, false)]
+        [InlineData("", '\u0301', StringComparison.CurrentCulture, false)] // Using non-ASCII character to test ICU path
         // CurrentCultureIgnoreCase
         [InlineData("Hello", 'H', StringComparison.CurrentCultureIgnoreCase, true)]
         [InlineData("Hello", 'Z', StringComparison.CurrentCultureIgnoreCase, false)]

--- a/src/native/libs/System.Globalization.Native/pal_collation.m
+++ b/src/native/libs/System.Globalization.Native/pal_collation.m
@@ -117,6 +117,11 @@ int32_t GlobalizationNative_CompareStringNative(const uint16_t* localeName, int3
     }
 }
 
+/**
+ * Removes zero-width and other weightless characters such as U+200B (Zero Width Space), 
+ * U+200C (Zero Width Non-Joiner), U+200D (Zero Width Joiner), U+FEFF (Zero Width No-Break Space), 
+ * and the NUL character from the specified string.
+ */
 static NSString* RemoveWeightlessCharacters(NSString* source)
 {
     NSError *error = nil;
@@ -143,10 +148,9 @@ static int32_t IsIndexFound(int32_t fromBeginning, int32_t foundLocation, int32_
 
 /*
 Function: IndexOf
-Find detailed explanation how this function works in https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-hybrid-mode.md
+Find detailed explanation how this function works in https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-hybrid-mode.md#string-indexing
 */
-Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNameLength, const uint16_t* lpTarget, int32_t cwTargetLength,
-                                        const uint16_t* lpSource, int32_t cwSourceLength, int32_t comparisonOptions, int32_t fromBeginning)
+Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNameLength, const uint16_t* lpTarget, int32_t cwTargetLength, const uint16_t* lpSource, int32_t cwSourceLength, int32_t comparisonOptions, int32_t fromBeginning)
 {
     @autoreleasepool
     {
@@ -158,6 +162,9 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
             return result;
         }
         NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions, true);
+        if (!fromBeginning) // LastIndexOf
+            options |= NSBackwardsSearch;
+
         NSString *searchString = [NSString stringWithCharacters: lpTarget length: (NSUInteger)cwTargetLength];
         NSString *searchStrCleaned = RemoveWeightlessCharacters(searchString);
         NSString *sourceString = [NSString stringWithCharacters: lpSource length: (NSUInteger)cwSourceLength];
@@ -168,7 +175,7 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
             searchStrCleaned = ConvertToKatakana(searchStrCleaned);
         }
 
-        if (sourceStrCleaned.length == 0 || searchStrCleaned.length == 0)
+        if (searchStrCleaned.length == 0)
         {
             result.location = fromBeginning ? 0 : (int32_t)sourceString.length;
             return result;
@@ -178,9 +185,6 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
         NSString *searchStrPrecomposed = searchStrCleaned.precomposedStringWithCanonicalMapping;
         NSString *sourceStrPrecomposed = sourceStrCleaned.precomposedStringWithCanonicalMapping;
 
-        // last index
-        if (!fromBeginning)
-            options |= NSBackwardsSearch;
 
         // check if there is a possible match and return -1 if not
         // doesn't matter which normalization form is used here
@@ -233,7 +237,7 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
             result.location = (int32_t)precomposedRange.location;
             result.length = (int32_t)precomposedRange.length;
             if (!(comparisonOptions & IgnoreCase))
-            return result;
+                return result;
         }
 
         // check if sourceString has decomposed form of characters and searchString has precomposed form of characters


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/111898.

Fix incorrect return condition for iOS IndexOf implementation and add test case for `IndexOf("", <something>)` and `"".Contains(<something>)`. Clean-up of some styling issues and adding comments.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Customers using `CompareInfo.IndexOf` or `string.Contains` APIs on empty source strings involving ICU logic are returning a result 0 (indicates found at index 0) instead of -1 (indicates not found).

Some of the issues reported by customers:
- https://github.com/dotnet/runtime/issues/110609
- https://github.com/dotnet/runtime/issues/111340

## Regression

- [x] Yes
- [ ] No

The regression was introduced in https://github.com/dotnet/runtime/pull/86895 and initially limited to when hybrid globalization is enabled. However, in .NET 9, we switched fully to Apple native globalization APIs (initially also referred to as hybrid globalization), thus spreading this issue to all iOS Globalization code using the IndexOf API.

## Testing

Previously there were no test cases for this code path. This PR adds test scenarios for both `CompareInfo.IndexOf` or `string.Contains`.

## Risk

Low

This change is correcting previously incorrect behavior. It is unlikely that .NET 9 iOS customers are depending on this new behavior as it is fundamentally incorrect as per [.net doc](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.compareinfo.indexof?view=net-9.0&viewFallbackFrom=system-globalization-compareinfo-indexof(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-globalization-compareoptions-system-int32%40)).