### PR TITLE
Include datas in GCSettingsEvent

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -52945,6 +52945,15 @@ void GCHeap::DiagGetGCSettings(EtwGCSettingsInfo* etw_settings)
 #else
         true;
 #endif //MULTIPLE_HEAPS
+#if BUILD_AS_STANDALONE
+    if (g_runtimeSupportedVersion.MajorVersion >= 4)
+#endif //BUILD_AS_STANDALONE
+        etw_settings->dynamic_heap_count_p = 
+#ifdef DYNAMIC_HEAP_COUNT
+            gc_heap::dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes;
+#else
+            false;
+#endif //DYNAMIC_HEAP_COUNT
 #endif //FEATURE_EVENT_TRACE
 }
 

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -15,7 +15,7 @@
 
 // The major version of the IGCToCLR interface. Breaking changes to this interface
 // require bumps in the major version number.
-#define EE_INTERFACE_MAJOR_VERSION 3
+#define EE_INTERFACE_MAJOR_VERSION 4
 
 struct ScanContext;
 struct gc_alloc_context;
@@ -141,6 +141,7 @@ struct EtwGCSettingsInfo
     // If this is false, it means the hardlimit was set implicitly by the container.
     bool hard_limit_config_p;
     bool no_affinitize_p;
+    bool dynamic_heap_count_p;
 };
 
 // Opaque type for tracking object pointers

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -66,11 +66,12 @@ enum EtwThreadFlags
 
 enum EtwGCSettingFlags
 {
-    kEtwGCFlagConcurrent =      0x00000001,
-    kEtwGCFlagLargePages =      0x00000002,
-    kEtwGCFlagFrozenSegs =      0x00000004,
-    kEtwGCFlagHardLimitConfig = 0x00000008,
-    kEtwGCFlagNoAffinitize =    0x00000010,
+    kEtwGCFlagConcurrent       = 0x00000001,
+    kEtwGCFlagLargePages       = 0x00000002,
+    kEtwGCFlagFrozenSegs       = 0x00000004,
+    kEtwGCFlagHardLimitConfig  = 0x00000008,
+    kEtwGCFlagNoAffinitize     = 0x00000010,
+    kEtwGCFlagDynamicHeapCount = 0x00000020,
 };
 
 #ifndef FEATURE_NATIVEAOT

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -4117,6 +4117,9 @@ VOID ETW::EnumerationLog::SendGCRundownEvent()
         if (gcSettingsInfo.no_affinitize_p)
             dwEtwGCSettingFlags |= kEtwGCFlagNoAffinitize;
 
+        if (gcSettingsInfo.dynamic_heap_count_p)
+            dwEtwGCSettingFlags |= kEtwGCFlagDynamicHeapCount;
+
         FireEtwGCSettingsRundown (
             gcSettingsInfo.heap_hard_limit,
             gcSettingsInfo.loh_threshold,


### PR DESCRIPTION
This allow us to know if DATAS is enabled through the trace when the `GCSettingsRundown` event is enabled.

PerfView support is [here](https://github.com/microsoft/perfview/pull/2157)