### PR TITLE
Fix case-insensitive JSON deserialization of enum member names

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -600,7 +600,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 Debug.Assert(JsonName.Equals(other.JsonName, StringComparison.OrdinalIgnoreCase), "The conflicting entry must be equal up to case insensitivity.");
 
-                if (MatchesSupersetOf(this, other))
+                if (ConflictsWith(this, other))
                 {
                     // Silently discard if the preceding entry is the default or has identical name.
                     return;
@@ -611,7 +611,7 @@ namespace System.Text.Json.Serialization.Converters
                 // Walk the existing list to ensure we do not add duplicates.
                 foreach (EnumFieldInfo conflictingField in conflictingFields)
                 {
-                    if (MatchesSupersetOf(conflictingField, other))
+                    if (ConflictsWith(conflictingField, other))
                     {
                         return;
                     }
@@ -621,23 +621,23 @@ namespace System.Text.Json.Serialization.Converters
 
                 // Determines whether the first field info matches everything that the second field info matches,
                 // in which case the second field info is redundant and doesn't need to be added to the list.
-                static bool MatchesSupersetOf(EnumFieldInfo field1, EnumFieldInfo field2)
+                static bool ConflictsWith(EnumFieldInfo current, EnumFieldInfo other)
                 {
                     // The default name matches everything case-insensitively.
-                    if (field1.Kind is EnumFieldNameKind.Default)
+                    if (current.Kind is EnumFieldNameKind.Default)
                     {
                         return true;
                     }
 
-                    // field1 matches case-sensitively since it's not the default name.
-                    // field2 matches case-insensitively, so it matches more than field1.
-                    if (field2.Kind is EnumFieldNameKind.Default)
+                    // current matches case-sensitively since it's not the default name.
+                    // other matches case-insensitively, so it matches more than current.
+                    if (other.Kind is EnumFieldNameKind.Default)
                     {
                         return false;
                     }
 
                     // Both are case-sensitive so they need to be identical.
-                    return field1.JsonName.Equals(field2.JsonName, StringComparison.Ordinal);
+                    return current.JsonName.Equals(other.JsonName, StringComparison.Ordinal);
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/EnumConverterTests.cs
@@ -1207,5 +1207,55 @@ namespace System.Text.Json.Serialization.Tests
             [JsonStringEnumMemberName("Comma separators not allowed, in flags enums")]
             Value
         }
+
+        [Theory]
+        [InlineData("\"cAmElCaSe\"", EnumWithVaryingNamingPolicies.camelCase, JsonKnownNamingPolicy.SnakeCaseUpper)]
+        [InlineData("\"cAmElCaSe\"", EnumWithVaryingNamingPolicies.camelCase, JsonKnownNamingPolicy.SnakeCaseLower)]
+        [InlineData("\"cAmElCaSe\"", EnumWithVaryingNamingPolicies.camelCase, JsonKnownNamingPolicy.KebabCaseUpper)]
+        [InlineData("\"cAmElCaSe\"", EnumWithVaryingNamingPolicies.camelCase, JsonKnownNamingPolicy.KebabCaseLower)]
+        [InlineData("\"pAsCaLcAsE\"", EnumWithVaryingNamingPolicies.PascalCase, JsonKnownNamingPolicy.SnakeCaseUpper)]
+        [InlineData("\"pAsCaLcAsE\"", EnumWithVaryingNamingPolicies.PascalCase, JsonKnownNamingPolicy.SnakeCaseLower)]
+        [InlineData("\"pAsCaLcAsE\"", EnumWithVaryingNamingPolicies.PascalCase, JsonKnownNamingPolicy.KebabCaseUpper)]
+        [InlineData("\"pAsCaLcAsE\"", EnumWithVaryingNamingPolicies.PascalCase, JsonKnownNamingPolicy.KebabCaseLower)]
+        [InlineData("\"sNaKe_CaSe_UpPeR\"", EnumWithVaryingNamingPolicies.SNAKE_CASE_UPPER, JsonKnownNamingPolicy.SnakeCaseUpper)]
+        [InlineData("\"sNaKe_CaSe_LoWeR\"", EnumWithVaryingNamingPolicies.snake_case_lower, JsonKnownNamingPolicy.SnakeCaseLower)]
+        [InlineData("\"cAmElCaSe\"", EnumWithVaryingNamingPolicies.camelCase, JsonKnownNamingPolicy.CamelCase)]
+        [InlineData("\"a\"", EnumWithVaryingNamingPolicies.A, JsonKnownNamingPolicy.CamelCase)]
+        [InlineData("\"a\"", EnumWithVaryingNamingPolicies.A, JsonKnownNamingPolicy.SnakeCaseUpper)]
+        [InlineData("\"a\"", EnumWithVaryingNamingPolicies.A, JsonKnownNamingPolicy.SnakeCaseLower)]
+        [InlineData("\"a\"", EnumWithVaryingNamingPolicies.A, JsonKnownNamingPolicy.KebabCaseUpper)]
+        [InlineData("\"a\"", EnumWithVaryingNamingPolicies.A, JsonKnownNamingPolicy.KebabCaseLower)]
+        [InlineData("\"B\"", EnumWithVaryingNamingPolicies.b, JsonKnownNamingPolicy.CamelCase)]
+        [InlineData("\"B\"", EnumWithVaryingNamingPolicies.b, JsonKnownNamingPolicy.SnakeCaseUpper)]
+        [InlineData("\"B\"", EnumWithVaryingNamingPolicies.b, JsonKnownNamingPolicy.SnakeCaseLower)]
+        [InlineData("\"B\"", EnumWithVaryingNamingPolicies.b, JsonKnownNamingPolicy.KebabCaseUpper)]
+        [InlineData("\"B\"", EnumWithVaryingNamingPolicies.b, JsonKnownNamingPolicy.KebabCaseLower)]
+        public static void StringConverterWithNamingPolicyIsCaseInsensitive(string json, EnumWithVaryingNamingPolicies expectedValue, JsonKnownNamingPolicy namingPolicy)
+        {
+            JsonNamingPolicy policy = namingPolicy switch
+            {
+                JsonKnownNamingPolicy.CamelCase => JsonNamingPolicy.CamelCase,
+                JsonKnownNamingPolicy.SnakeCaseLower => JsonNamingPolicy.SnakeCaseLower,
+                JsonKnownNamingPolicy.SnakeCaseUpper => JsonNamingPolicy.SnakeCaseUpper,
+                JsonKnownNamingPolicy.KebabCaseLower => JsonNamingPolicy.KebabCaseLower,
+                JsonKnownNamingPolicy.KebabCaseUpper => JsonNamingPolicy.KebabCaseUpper,
+                _ => throw new ArgumentOutOfRangeException(nameof(namingPolicy)),
+            };
+
+            JsonSerializerOptions options = new() { Converters = { new JsonStringEnumConverter(policy) } };
+
+            EnumWithVaryingNamingPolicies value = JsonSerializer.Deserialize<EnumWithVaryingNamingPolicies>(json, options);
+            Assert.Equal(expectedValue, value);
+        }
+
+        public enum EnumWithVaryingNamingPolicies
+        {
+            SNAKE_CASE_UPPER,
+            snake_case_lower,
+            camelCase,
+            PascalCase,
+            A,
+            b,
+        }
     }
 }


### PR DESCRIPTION
Fixes #110745

The JSON serializer supports deserializing an enum case-insensitively from the C# enum member name even when a naming policy is used. For example, consider the following enum:

```cs
enum MyEnum { EnumValue }
```

If `JsonNamingPolicy.SnakeCaseLower` is specified, then `"enum_value"` will be deserialized to `MyEnum.EnumValue` (this is case-sensitive, so deserializion of `"Enum_value"` will throw). In addition, `"EnumValue"` also will be deserialized to `MyEnum.EnumValue` because it is the name of the member (this is case-insensitive so `"enumValue"` will also be deserialized).

However, there is a regression in .NET 9.0 when the enum member name is the same as the name from the naming policy:

```cs
var options = new JsonSerializerOptions();
options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower));

// Both work in .NET 8.0 but throw in .NET 9.0
Console.WriteLine(JsonSerializer.Deserialize<MyEnum>("\"Example\"", options));
Console.WriteLine(JsonSerializer.Deserialize<MyEnum>("\"Another_Example\"", options));

enum MyEnum
{
  // C# name: "example"
  // lower snake-case: "example"
  example,

  // C# name: "another_example"
  // lower snake-case: "another_example"
  another_example
}
```

Note that the enum member name for both members is the same as the lower snake casing.

The regression was introduced in #105032 which added the `JsonStringEnumMemberName` attribute allowing custom names to be specified for enum members. That change added a new design for the converter which essentially uses the custom name, the naming policy derived name, and/or the C# member name as the key to figure out which C# enum value to deserialize to. This edge case was not covered because the C# member name and the naming-policy derived name both would have the same key and thus the C# member name was not inserted into the lookup.

The change in this PR fixes this by always adding both the naming-policy key and the C# member name key regardless of whether they are the same. There were no tests for this specific code path, so new tests have been added to cover this case now.