### PR TITLE
When generating Theory, wrap execution into try/catch

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -312,7 +312,17 @@ public sealed class MemberDataTest : ITestInfo
 
         using (builder.NewBracesScope())
         {
-            builder.Append(_innerTest.GenerateTestExecution(testReporterWrapper));
+            builder.AppendLine("try");
+            using (builder.NewBracesScope())
+            {
+                builder.Append(_innerTest.GenerateTestExecution(testReporterWrapper));
+            }
+            builder.AppendLine("catch (System.Exception ex)");
+
+            using (builder.NewBracesScope())
+            {
+                builder.AppendLine($@"throw new System.Exception(""Thrown during execution of the "" + {_innerTest.TestNameExpression}, ex);");
+            }
         }
         return builder;
     }


### PR DESCRIPTION
so in case of failure it's possible detect what specific data parameters trigger an error.

Sample output
```
BEGIN EXECUTION
 "c:\d\runtime\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root\corerun.exe" -p "System.Reflection.Metadata.MetadataUpdater.IsSupported=false" -p "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true"  ILVerificationTests.dll
System.Exception: Thrown during execution of the global::ILVerification.Tests.ILMethodTester.TestMethodsWithInvalidIL([FieldTests] LdsfldInitonlyInCtor (InitOnly))
 ---> Xunit.Sdk.EqualException: Assert.Equal() Failure: Values differ
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[T](T expected, T actual, IEqualityComparer`1 comparer) in /_/src/Microsoft.DotNet.XUnitAssert/src/EqualityAsserts.cs:line 174
   at ILVerification.Tests.ILMethodTester.TestMethodsWithInvalidIL(InvalidILTestCase invalidIL) in C:\d\runtime\src\tests\ilverify\ILMethodTester.cs:line 47
   at ILVerification.Tests.ILMethodTester.TestMethodsWithInvalidIL(InvalidILTestCase invalidIL) in C:\d\runtime\src\tests\ilverify\ILMethodTester.cs:line 31
   at __GeneratedMainWrapper.Main() in C:\d\runtime\artifacts\tests\coreclr\obj\windows.x64.Release\Managed\ilverify\ILVerificationTests\XUnitWrapperGenerator\XUnitWrapperGenerator.XUnitWrapperGenerator\SimpleRunner.g.cs:line 24
   --- End of inner exception stack trace ---
   at __GeneratedMainWrapper.Main() in C:\d\runtime\artifacts\tests\coreclr\obj\windows.x64.Release\Managed\ilverify\ILVerificationTests\XUnitWrapperGenerator\XUnitWrapperGenerator.XUnitWrapperGenerator\SimpleRunner.g.cs:line 28
Expected: 100
Actual: 101
END EXECUTION - FAILED
FAILED
```