### PR TITLE
JIT: Compute `fgCalledCount` after synthesis

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5398,9 +5398,9 @@ public:
     // - Rationalization links all nodes into linear form which is kept until
     //   the end of compilation. The first and last nodes are stored in the block.
     NodeThreading fgNodeThreading = NodeThreading::None;
-    weight_t      fgCalledCount = BB_ZERO_WEIGHT;          // count of the number of times this method was called
-                                          // This is derived from the profile data
-                                          // or is BB_UNITY_WEIGHT when we don't have profile data
+    weight_t      fgCalledCount = BB_UNITY_WEIGHT; // count of the number of times this method was called
+                                                   // This is derived from the profile data
+                                                   // or is BB_UNITY_WEIGHT when we don't have profile data
 
     bool fgFuncletsCreated = false; // true if the funclet creation phase has been run
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4222,19 +4222,9 @@ PhaseStatus Compiler::fgComputeBlockWeights()
 
     if (fgIsUsingProfileWeights())
     {
-        // Compute fgCalledCount by subtracting any non-entry flow into fgFirstBB from its weight
-        fgCalledCount = fgFirstBB->bbWeight;
-        for (FlowEdge* const predEdge : fgFirstBB->PredEdges())
-        {
-            fgCalledCount = max(BB_ZERO_WEIGHT, fgCalledCount - predEdge->getLikelyWeight());
-        }
-
-        JITDUMP("We are using the profile weights and fgCalledCount is " FMT_WT "\n", fgCalledCount);
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
-    JITDUMP(" -- no profile data, so using default called count\n");
-    fgCalledCount = BB_UNITY_WEIGHT;
     return fgComputeMissingBlockWeights() ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 


### PR DESCRIPTION
Part of dotnet/runtime#107749. Follow-up to dotnet/runtime#111971 and dotnet/runtime#110693. For methods without profile data, ensure the default call count is available throughout compilation (this had no diffs for me locally). For methods with profile data, compute the call count after synthesis runs to ensure it is available early, and reasonably accurate.

I'm only seeing diffs in OSR methods locally, due to the logic in `fgFixEntryFlowForOSR` (which runs right after profile incorporation) no longer affecting `fgCalledCount`. This method guesses that the loop iterates about 100x the method call count, and scales the method entry block's weight down accordingly. This gives the impression later on that `fgCalledCount` is much lower than what we calculated using `fgEntryBB`.

The actual diffs seem to manifest largely in LSRA, which uses `fgCalledCount` to normalize block weights, though there are a few other phases that use `BasicBlock::getBBWeight` in lieu of the raw weight as well. I think we ought to consolidate our block weight strategy at some point, especially if we have newfound faith in `fgCalledCount`. For example, instead of this check in if conversion:
```
if (m_startBlock->getBBWeight(m_comp) > BB_UNITY_WEIGHT * 1.05)
```

Perhaps we could do:
```
if (m_startBlock->bbWeight > fgCalledCount * 1.05)
```

But that's for another PR.