### PR TITLE
Re-enable HKDF-SHA3 on Azure Linux

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
@@ -207,7 +207,6 @@ namespace System.Security.Cryptography.Tests
 
         [Theory]
         [MemberData(nameof(Sha3TestCases))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/106489", typeof(PlatformDetection), nameof(PlatformDetection.IsAzureLinux))]
         public void Sha3Tests(HkdfTestCase test)
         {
             if (PlatformDetection.SupportsSha3)


### PR DESCRIPTION
HKDF-SHA3 did not work with SymCrypt correctly, but was fixed in 103.4.2. Recent versions of Azure Linux have 103.6.0.