### PR TITLE
WasmAppBuilder: Remove double computation of a value

### DIFF
--- a/src/tasks/WasmAppBuilder/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeCollector.cs
@@ -204,8 +204,6 @@ internal sealed class PInvokeCollector {
                 .Any(d => d.AttributeType.Name == "DisableRuntimeMarshallingAttribute");
         }
 
-       value = assembly.GetCustomAttributesData().Any(d => d.AttributeType.Name == "DisableRuntimeMarshallingAttribute");
-
         return value;
     }
 }


### PR DESCRIPTION
Credit goes to https://pvs-studio.com/en/blog/posts/csharp/1216/