### PR TITLE
JIT: Fix cross crossgen comparison failures

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1195,15 +1195,9 @@ AGAIN:
 
     /* Check for an addition of a constant */
 
-    if (op2->IsIntCnsFitsInI32() && (op2->gtType != TYP_REF) && FitsIn<INT32>(cns + op2->AsIntConCommon()->IconValue()))
+    if (op2->IsIntCnsFitsInI32() && op2->AsIntConCommon()->ImmedValCanBeFolded(compiler, addr->OperGet()) &&
+        (op2->gtType != TYP_REF) && FitsIn<INT32>(cns + op2->AsIntConCommon()->IconValue()))
     {
-        // We should not be building address modes out of non-foldable constants
-        if (!op2->AsIntConCommon()->ImmedValCanBeFolded(compiler, addr->OperGet()))
-        {
-            assert(compiler->opts.compReloc);
-            return false;
-        }
-
         /* We're adding a constant */
 
         cns += op2->AsIntConCommon()->IconValue();

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -40,7 +40,8 @@ struct LikelyClassMethodHistogram
 {
     LikelyClassMethodHistogram(INT_PTR* histogramEntries, unsigned entryCount, bool int32Data = false);
 
-    template <typename ElemType> void LikelyClassMethodHistogramInner(ElemType* histogramEntries, unsigned entryCount);
+    template <typename ElemType>
+    void LikelyClassMethodHistogramInner(ElemType* histogramEntries, unsigned entryCount);
 
     // Sum of counts from all entries in the histogram. This includes "unknown" entries which are not captured in
     // m_histogram
@@ -77,7 +78,8 @@ LikelyClassMethodHistogram::LikelyClassMethodHistogram(INT_PTR* histogramEntries
     }
 }
 
-template <typename ElemType> void LikelyClassMethodHistogram::LikelyClassMethodHistogramInner(ElemType* histogramEntries, unsigned entryCount)
+template <typename ElemType>
+void LikelyClassMethodHistogram::LikelyClassMethodHistogramInner(ElemType* histogramEntries, unsigned entryCount)
 {
     m_unknownHandles               = 0;
     m_totalCount                   = 0;
@@ -91,7 +93,7 @@ template <typename ElemType> void LikelyClassMethodHistogram::LikelyClassMethodH
         }
 
         m_totalCount++;
-        INT_PTR currentEntry = (INT_PTR) histogramEntries[k];
+        INT_PTR currentEntry = (INT_PTR)histogramEntries[k];
 
         bool     found = false;
         unsigned h     = 0;
@@ -400,14 +402,17 @@ extern "C" DLLEXPORT UINT32 WINAPI getLikelyValues(LikelyValueRecord*           
 
         // We currently re-use existing infrastructure for type handles for simplicity.
         //
-        const bool isIntHistogramCount  = (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramIntCount);
-        const bool isLongHistogramCount = (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramLongCount);
-        const bool isHistogramCount     = isIntHistogramCount || isLongHistogramCount;
+        const bool isIntHistogramCount =
+            (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramIntCount);
+        const bool isLongHistogramCount =
+            (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramLongCount);
+        const bool isHistogramCount = isIntHistogramCount || isLongHistogramCount;
 
         if (isHistogramCount && (schema[i].Count == 1) && ((i + 1) < countSchemaItems) &&
             (schema[i + 1].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogram))
         {
-            LikelyClassMethodHistogram h((INT_PTR*)(pInstrumentationData + schema[i + 1].Offset), schema[i + 1].Count, isIntHistogramCount);
+            LikelyClassMethodHistogram h((INT_PTR*)(pInstrumentationData + schema[i + 1].Offset), schema[i + 1].Count,
+                                         isIntHistogramCount);
             LikelyClassMethodHistogramEntry sortedEntries[HISTOGRAM_MAX_SIZE_COUNT];
 
             if (h.countHistogramElements == 0)

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -38,7 +38,9 @@ struct LikelyClassMethodHistogramEntry
 //
 struct LikelyClassMethodHistogram
 {
-    LikelyClassMethodHistogram(INT_PTR* histogramEntries, unsigned entryCount);
+    LikelyClassMethodHistogram(INT_PTR* histogramEntries, unsigned entryCount, bool int32Data = false);
+
+    template <typename ElemType> void LikelyClassMethodHistogramInner(ElemType* histogramEntries, unsigned entryCount);
 
     // Sum of counts from all entries in the histogram. This includes "unknown" entries which are not captured in
     // m_histogram
@@ -61,8 +63,21 @@ struct LikelyClassMethodHistogram
 // Arguments:
 //    histogramEntries - pointer to the table portion of a ClassProfile* object (see corjit.h)
 //    entryCount - number of entries in the table to examine
+//    int32Data - true if table entries are 32 bits
 //
-LikelyClassMethodHistogram::LikelyClassMethodHistogram(INT_PTR* histogramEntries, unsigned entryCount)
+LikelyClassMethodHistogram::LikelyClassMethodHistogram(INT_PTR* histogramEntries, unsigned entryCount, bool int32Data)
+{
+    if (int32Data)
+    {
+        LikelyClassMethodHistogramInner<int>((int*)histogramEntries, entryCount);
+    }
+    else
+    {
+        LikelyClassMethodHistogramInner<INT_PTR>(histogramEntries, entryCount);
+    }
+}
+
+template <typename ElemType> void LikelyClassMethodHistogram::LikelyClassMethodHistogramInner(ElemType* histogramEntries, unsigned entryCount)
 {
     m_unknownHandles               = 0;
     m_totalCount                   = 0;
@@ -76,8 +91,7 @@ LikelyClassMethodHistogram::LikelyClassMethodHistogram(INT_PTR* histogramEntries
         }
 
         m_totalCount++;
-
-        INT_PTR currentEntry = histogramEntries[k];
+        INT_PTR currentEntry = (INT_PTR) histogramEntries[k];
 
         bool     found = false;
         unsigned h     = 0;
@@ -385,15 +399,15 @@ extern "C" DLLEXPORT UINT32 WINAPI getLikelyValues(LikelyValueRecord*           
             continue;
 
         // We currently re-use existing infrastructure for type handles for simplicity.
-
-        const bool isHistogramCount =
-            (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramIntCount) ||
-            (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramLongCount);
+        //
+        const bool isIntHistogramCount  = (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramIntCount);
+        const bool isLongHistogramCount = (schema[i].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogramLongCount);
+        const bool isHistogramCount     = isIntHistogramCount || isLongHistogramCount;
 
         if (isHistogramCount && (schema[i].Count == 1) && ((i + 1) < countSchemaItems) &&
             (schema[i + 1].InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::ValueHistogram))
         {
-            LikelyClassMethodHistogram h((INT_PTR*)(pInstrumentationData + schema[i + 1].Offset), schema[i + 1].Count);
+            LikelyClassMethodHistogram h((INT_PTR*)(pInstrumentationData + schema[i + 1].Offset), schema[i + 1].Count, isIntHistogramCount);
             LikelyClassMethodHistogramEntry sortedEntries[HISTOGRAM_MAX_SIZE_COUNT];
 
             if (h.countHistogramElements == 0)

--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -60,6 +60,19 @@
 
 #include "jitpch.h"
 
+ScevConstant::ScevConstant(var_types type, int64_t value)
+    : Scev(ScevOper::Constant, type)
+{
+    if (genTypeSize(type) == 4)
+    {
+        Value = (int32_t)value;
+    }
+    else
+    {
+        Value = value;
+    }
+}
+
 //------------------------------------------------------------------------
 // GetConstantValue: If this SSA use refers to a constant, then fetch that
 // constant.
@@ -1327,7 +1340,7 @@ bool ScalarEvolutionContext::Materialize(Scev* scev, bool createIR, GenTree** re
                 }
                 else
                 {
-                    *result = m_comp->gtNewIconNode((target_ssize_t)cns->Value, scev->Type);
+                    *result = m_comp->gtNewIconNode((ssize_t)cns->Value, scev->Type);
                 }
             }
 

--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -1327,7 +1327,7 @@ bool ScalarEvolutionContext::Materialize(Scev* scev, bool createIR, GenTree** re
                 }
                 else
                 {
-                    *result = m_comp->gtNewIconNode((ssize_t)cns->Value, scev->Type);
+                    *result = m_comp->gtNewIconNode((target_ssize_t)cns->Value, scev->Type);
                 }
             }
 

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -82,11 +82,7 @@ struct Scev
 
 struct ScevConstant : Scev
 {
-    ScevConstant(var_types type, int64_t value)
-        : Scev(ScevOper::Constant, type)
-        , Value(value)
-    {
-    }
+    ScevConstant(var_types type, int64_t value);
 
     int64_t Value;
 };


### PR DESCRIPTION
Fix a couple of issues that were causing cross-crossgen tests to fail
* address mode formation was sensitive to the size of a constant handle
* value histogram processing was always using 64 bit value sizes
* transformation for down-counted loops was using host-sized -1. 

Fixes the jit-related issues in #111972