### PR TITLE
Remove one usage of `Unsafe.AsPointer`.

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.Mono.cs
@@ -18,7 +18,7 @@ namespace System.Reflection
         private Func<Assembly?, string, bool, Type?>? _typeResolver;
         private bool _throwOnError;
         private bool _ignoreCase;
-        private void* _stackMark;
+        private ref StackCrawlMark _stackMark;
 
         [RequiresUnreferencedCode("The type might be removed")]
         internal static Type? GetType(
@@ -52,7 +52,7 @@ namespace System.Reflection
                 _typeResolver = typeResolver,
                 _throwOnError = throwOnError,
                 _ignoreCase = ignoreCase,
-                _stackMark = Unsafe.AsPointer(ref stackMark)
+                _stackMark = ref stackMark
             }.Resolve(parsed);
         }
 
@@ -69,11 +69,9 @@ namespace System.Reflection
             }
             else
             {
-                ref StackCrawlMark stackMark = ref Unsafe.AsRef<StackCrawlMark>(_stackMark);
-
                 if (_throwOnError)
                 {
-                    assembly = Assembly.Load(name, ref stackMark, null);
+                    assembly = Assembly.Load(name, ref _stackMark, null);
                 }
                 else
                 {
@@ -81,7 +79,7 @@ namespace System.Reflection
                     // Other exceptions like BadImangeFormatException should still fly.
                     try
                     {
-                        assembly = Assembly.Load(name, ref stackMark, null);
+                        assembly = Assembly.Load(name, ref _stackMark, null);
                     }
                     catch (FileNotFoundException)
                     {
@@ -123,9 +121,7 @@ namespace System.Reflection
             {
                 if (assembly is null)
                 {
-                    ref StackCrawlMark stackMark = ref Unsafe.AsRef<StackCrawlMark>(_stackMark);
-
-                    type = RuntimeType.GetType(escapedTypeName, _throwOnError, _ignoreCase, ref stackMark);
+                    type = RuntimeType.GetType(escapedTypeName, _throwOnError, _ignoreCase, ref _stackMark);
                 }
                 else
                 {


### PR DESCRIPTION
Related to #94941.