### PR TITLE
Allow using ldsflda on initonly fields outside of cctor

### DIFF
--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -2150,6 +2150,7 @@ namespace Internal.IL
         {
             var field = ResolveFieldToken(token);
             bool isPermanentHome = false;
+            bool isReadOnly = false;
 
             TypeDesc instance;
             if (isStatic)
@@ -2160,7 +2161,7 @@ namespace Internal.IL
                 instance = null;
 
                 if (field.IsInitOnly)
-                    Check(_method.IsStaticConstructor && field.OwningType == _method.OwningType, VerifierError.InitOnly);
+                    isReadOnly = true;
             }
             else
             {
@@ -2188,7 +2189,7 @@ namespace Internal.IL
 
             Check(_method.OwningType.CanAccess(field, instance), VerifierError.FieldAccess);
 
-            Push(StackValue.CreateByRef(field.FieldType, false, isPermanentHome));
+            Push(StackValue.CreateByRef(field.FieldType, isReadOnly, isPermanentHome));
         }
 
         void ImportStoreField(int token, bool isStatic)

--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -2161,6 +2161,7 @@ namespace Internal.IL
                 instance = null;
 
                 if (field.IsInitOnly)
+                    // TODO: verification of readonly references https://github.com/dotnet/runtime/issues/57444
                     isReadOnly = true;
             }
             else

--- a/src/coreclr/tools/ILVerify/ILVerify.sln
+++ b/src/coreclr/tools/ILVerify/ILVerify.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35617.110
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILVerify", "ILVerify.csproj", "{583EE755-61B5-EE65-D234-DD1B77EE869F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILVerification", "..\ILVerification\ILVerification.csproj", "{E2736A52-2B31-BFB1-D5B5-A8B16EAC6035}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{583EE755-61B5-EE65-D234-DD1B77EE869F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{583EE755-61B5-EE65-D234-DD1B77EE869F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{583EE755-61B5-EE65-D234-DD1B77EE869F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{583EE755-61B5-EE65-D234-DD1B77EE869F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2736A52-2B31-BFB1-D5B5-A8B16EAC6035}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2736A52-2B31-BFB1-D5B5-A8B16EAC6035}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2736A52-2B31-BFB1-D5B5-A8B16EAC6035}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2736A52-2B31-BFB1-D5B5-A8B16EAC6035}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {66E0EB07-EC2B-46D9-8B3F-EE2EF3AF8D3F}
+	EndGlobalSection
+EndGlobal

--- a/src/tests/ilverify/ILTests/FieldTests.il
+++ b/src/tests/ilverify/ILTests/FieldTests.il
@@ -128,7 +128,7 @@
         ret
     }
 
-    .method public hidebysig instance void 'special.LdsfldInitonlyInCtor..ctor_Invalid_InitOnly'(char) cil managed { ret }
+    .method public hidebysig instance void 'special.LdsfldaInitonlyInCtor..ctor_Valid'(char) cil managed { ret }
     .method public hidebysig specialname rtspecialname instance void .ctor(char) cil managed
     {
         ldarg.0
@@ -143,6 +143,20 @@
     {
         ldsflda int32 FieldTestsType::StaticInitonlyField
         pop
+        ldc.i4.0
+        stsfld  int32 FieldTestsType::StaticInitonlyField
+        ret
+    }
+
+    .method public instance void Ldsflda.InitonlyStructFieldOutsideCCtor_Valid() cil managed
+    {
+        ldsflda int32 FieldTestsType::StaticInitonlyField
+        pop
+        ret
+    }
+
+    .method public instance void Stfld.InitonlyStructFieldRegularMethod_Invalid_InitOnly() cil managed
+    {
         ldc.i4.0
         stsfld  int32 FieldTestsType::StaticInitonlyField
         ret


### PR DESCRIPTION
- Fixed incorect assumption that `ldsflda` cannot be used inside .ctor
- Add test cases which explicitly forbig storing static initonly field outside cctor

Fixes #94090