### PR TITLE
Update breaking change rules regarding byref/objref fields.

### DIFF
--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -169,6 +169,8 @@ Breaking Change Rules
 
 * Changing a `struct` type to a `ref struct` type and vice versa
 
+* Adding a `ref` or object reference field to a value type that didn't previously have either a `ref` or object reference field before (recursively)
+
 * Changing the underlying type of an enum
 
     This is a compile-time and behavioral breaking change as well as a binary breaking change which can make attribute arguments unparsable.

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -236,7 +236,7 @@ successfully bind to that overload, if simply passing an `int` value. However, i
 
     Definite assignment rules allow use of uninitialized variables so long as the variable type is a stateless struct. If the struct is made stateful, code could now end up with uninitialized data. This is both potentially a source breaking and binary breaking change.
 
-* Adding a reference type field, a `ref` field, or a field involving a generic type parameter without the `unmanaged` constraint, to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking. This rule applies recursively to new fields that contain value type that may also introduce a new field kind.
+* Adding a reference type field, a `ref` field, or a field involving a generic type parameter without the `unmanaged` constraint, to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking. This rule applies recursively to new fields that contain value types that may also introduce a new field kind.
 
 ### Signatures
 &#10003; **Allowed**

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -236,7 +236,7 @@ successfully bind to that overload, if simply passing an `int` value. However, i
 
     Definite assignment rules allow use of uninitialized variables so long as the variable type is a stateless struct. If the struct is made stateful, code could now end up with uninitialized data. This is both potentially a source breaking and binary breaking change.
 
-* Adding a `ref` (byref), object reference, or generic type parameter-based field to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking.
+* Adding a `ref` (byref), object reference, or generic type parameter without an `unmanaged` constraint field to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking.
 
 ### Signatures
 &#10003; **Allowed**

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -236,7 +236,7 @@ successfully bind to that overload, if simply passing an `int` value. However, i
 
     Definite assignment rules allow use of uninitialized variables so long as the variable type is a stateless struct. If the struct is made stateful, code could now end up with uninitialized data. This is both potentially a source breaking and binary breaking change.
 
-* Adding a reference type field, a `ref` field, or a field involving a generic type parameter without the `unmanaged` constraint, to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking.
+* Adding a reference type field, a `ref` field, or a field involving a generic type parameter without the `unmanaged` constraint, to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking. This rule applies recursively to new fields that contain value type that may also introduce a new field kind.
 
 ### Signatures
 &#10003; **Allowed**

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -236,7 +236,7 @@ successfully bind to that overload, if simply passing an `int` value. However, i
 
     Definite assignment rules allow use of uninitialized variables so long as the variable type is a stateless struct. If the struct is made stateful, code could now end up with uninitialized data. This is both potentially a source breaking and binary breaking change.
 
-* Adding a `ref` (byref), object reference, or generic type parameter without an `unmanaged` constraint field to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking.
+* Adding a reference type field, a `ref` field, or a field involving a generic type parameter without the `unmanaged` constraint, to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking.
 
 ### Signatures
 &#10003; **Allowed**

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -169,8 +169,6 @@ Breaking Change Rules
 
 * Changing a `struct` type to a `ref struct` type and vice versa
 
-* Adding a `ref` or object reference field to a value type that didn't previously have either a `ref` or object reference field before (recursively)
-
 * Changing the underlying type of an enum
 
     This is a compile-time and behavioral breaking change as well as a binary breaking change which can make attribute arguments unparsable.
@@ -237,6 +235,8 @@ successfully bind to that overload, if simply passing an `int` value. However, i
 * Adding a field to a struct that previously had no state
 
     Definite assignment rules allow use of uninitialized variables so long as the variable type is a stateless struct. If the struct is made stateful, code could now end up with uninitialized data. This is both potentially a source breaking and binary breaking change.
+
+* Adding a `ref`, object reference, or generic parameter based field to a value type that didn't previously have any of these field kinds (recursively)
 
 ### Signatures
 &#10003; **Allowed**

--- a/docs/coding-guidelines/breaking-change-rules.md
+++ b/docs/coding-guidelines/breaking-change-rules.md
@@ -236,7 +236,7 @@ successfully bind to that overload, if simply passing an `int` value. However, i
 
     Definite assignment rules allow use of uninitialized variables so long as the variable type is a stateless struct. If the struct is made stateful, code could now end up with uninitialized data. This is both potentially a source breaking and binary breaking change.
 
-* Adding a `ref`, object reference, or generic parameter based field to a value type that didn't previously have any of these field kinds (recursively)
+* Adding a `ref` (byref), object reference, or generic type parameter-based field to a value type that formerly had none of those field kinds. If the value type already contains at least one such field, adding another is non-breaking.
 
 ### Signatures
 &#10003; **Allowed**


### PR DESCRIPTION
New rule based on https://github.com/dotnet/runtime/pull/111584

Fixes #112033