### PR TITLE
Disable newly added test on native AOT and drop RequiresProcessIsolation

### DIFF
--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CMakeProjectReference -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'windows'">true</CLRTestTargetUnsupported>
+    <!-- Testing a backwards compatibility quirk we don't officially support -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'windows'">true</CLRTestTargetUnsupported>


### PR DESCRIPTION
CMakeProjectReference is not a reason to add RequiresProcessIsolation, I've been deleting those for a while (e.g. #111406).