### PR TITLE
Remove `RequiresProcessIsolation` on InterfaceFolding tests

### DIFF
--- a/src/tests/Loader/classloader/InterfaceFolding/Ambiguous.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/Ambiguous.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase0.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase0.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_I_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_I_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_J_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase0_Nested_J_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase1.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase1.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_I_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_I_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_J_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase1_Nested_J_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase2.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase2.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_I_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_I_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_J_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase2_Nested_J_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase3.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase3.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_I_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_I_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_J_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase3_Nested_J_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase4.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase4.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_I_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_I_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_J_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase4_Nested_J_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase5.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase5.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_I_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_I_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_J_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase5_Nested_J_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase6.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase6.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_I_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_I_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_J.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_J.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_J_Nested_I.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase6_Nested_J_Nested_I.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/InterfaceFolding/TestCase7.ilproj
+++ b/src/tests/Loader/classloader/InterfaceFolding/TestCase7.ilproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Was looking at these and saw there's no need for isolation here.