### PR TITLE
Factor positive lookaheads better into find optimizations

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -940,7 +940,7 @@ namespace System.Text.RegularExpressions
                         node = ExtractCommonPrefixText(node);
                         if (node.Kind == RegexNodeKind.Alternate)
                         {
-                            node = ExtractCommonPrefixOneNotoneSet(node);
+                            node = ExtractCommonPrefixNode(node);
                             if (node.Kind == RegexNodeKind.Alternate)
                             {
                                 node = RemoveRedundantEmptiesAndNothings(node);
@@ -1072,7 +1072,7 @@ namespace System.Text.RegularExpressions
             // This function optimizes out prefix nodes from alternation branches that are
             // the same across multiple contiguous branches.
             // e.g. \w12|\d34|\d56|\w78|\w90 => \w12|\d(?:34|56)|\w(?:78|90)
-            static RegexNode ExtractCommonPrefixOneNotoneSet(RegexNode alternation)
+            static RegexNode ExtractCommonPrefixNode(RegexNode alternation)
             {
                 Debug.Assert(alternation.Kind == RegexNodeKind.Alternate);
                 Debug.Assert(alternation.Children is List<RegexNode> { Count: >= 2 });
@@ -1097,7 +1097,7 @@ namespace System.Text.RegularExpressions
                 {
                     Debug.Assert(children[startingIndex].Children is List<RegexNode> { Count: >= 2 });
 
-                    // Only handle the case where each branch begins with the same One, Notone, or Set (individual or loop).
+                    // Only handle the case where each branch begins with the same One, Notone, Set (individual or loop), or Anchor.
                     // Note that while we can do this for individual characters, fixed length loops, and atomic loops, doing
                     // it for non-atomic variable length loops could change behavior as each branch could otherwise have a
                     // different number of characters consumed by the loop based on what's after it.
@@ -1107,6 +1107,10 @@ namespace System.Text.RegularExpressions
                         case RegexNodeKind.One or RegexNodeKind.Notone or RegexNodeKind.Set:
                         case RegexNodeKind.Oneloopatomic or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Setloopatomic:
                         case RegexNodeKind.Oneloop or RegexNodeKind.Notoneloop or RegexNodeKind.Setloop or RegexNodeKind.Onelazy or RegexNodeKind.Notonelazy or RegexNodeKind.Setlazy when required.M == required.N:
+                        case RegexNodeKind.Beginning or RegexNodeKind.Bol or RegexNodeKind.Start
+                             or RegexNodeKind.End or RegexNodeKind.EndZ
+                             or RegexNodeKind.Boundary or RegexNodeKind.ECMABoundary
+                             or RegexNodeKind.NonBoundary or RegexNodeKind.NonECMABoundary:
                             break;
 
                         default:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1107,8 +1107,8 @@ namespace System.Text.RegularExpressions
                         case RegexNodeKind.One or RegexNodeKind.Notone or RegexNodeKind.Set:
                         case RegexNodeKind.Oneloopatomic or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Setloopatomic:
                         case RegexNodeKind.Oneloop or RegexNodeKind.Notoneloop or RegexNodeKind.Setloop or RegexNodeKind.Onelazy or RegexNodeKind.Notonelazy or RegexNodeKind.Setlazy when required.M == required.N:
-                        case RegexNodeKind.Beginning or RegexNodeKind.Bol or RegexNodeKind.Start
-                             or RegexNodeKind.End or RegexNodeKind.EndZ
+                        case RegexNodeKind.Beginning or RegexNodeKind.Start or RegexNodeKind.Bol
+                             or RegexNodeKind.End or RegexNodeKind.EndZ or RegexNodeKind.Eol
                              or RegexNodeKind.Boundary or RegexNodeKind.ECMABoundary
                              or RegexNodeKind.NonBoundary or RegexNodeKind.NonECMABoundary:
                             break;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -1311,7 +1311,6 @@ namespace System.Text.RegularExpressions
             FindLeadingOrTrailingAnchor(node, leading: false);
 
         /// <summary>Computes the leading or trailing anchor of a node.</summary>
-        /// <summary>Computes the leading or trailing anchor of a node.</summary>
         private static RegexNodeKind FindLeadingOrTrailingAnchor(RegexNode node, bool leading)
         {
             if (!StackHelper.TryEnsureSufficientExecutionStack())

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -1228,6 +1228,80 @@ namespace System.Text.RegularExpressions
             return null;
         }
 
+        /// <summary>Finds a positive lookahead node that can be considered to start the pattern.</summary>
+        public static RegexNode? FindLeadingPositiveLookahead(RegexNode node)
+        {
+            RegexNode? positiveLookahead = null;
+            FindLeadingPositiveLookahead(node, ref positiveLookahead);
+            return positiveLookahead;
+
+            // Returns whether to keep examining subsequent nodes in a concatenation.
+            static bool FindLeadingPositiveLookahead(RegexNode node, ref RegexNode? positiveLookahead)
+            {
+                if (!StackHelper.TryEnsureSufficientExecutionStack())
+                {
+                    return false;
+                }
+
+                while (true)
+                {
+                    if ((node.Options & RegexOptions.RightToLeft) != 0)
+                    {
+                        return false;
+                    }
+
+                    switch (node.Kind)
+                    {
+                        case RegexNodeKind.PositiveLookaround:
+                            // Got one.
+                            positiveLookahead = node;
+                            return false;
+
+                        case RegexNodeKind.Bol:
+                        case RegexNodeKind.Eol:
+                        case RegexNodeKind.Beginning:
+                        case RegexNodeKind.Start:
+                        case RegexNodeKind.EndZ:
+                        case RegexNodeKind.End:
+                        case RegexNodeKind.Boundary:
+                        case RegexNodeKind.ECMABoundary:
+                        case RegexNodeKind.NegativeLookaround:
+                        case RegexNodeKind.Empty:
+                            // Skip past zero-width nodes.
+                            return true;
+
+                        case RegexNodeKind.Atomic:
+                        case RegexNodeKind.Capture:
+                            // Process the child instead of the group, which adds no semantics for this purpose.
+                            node = node.Child(0);
+                            continue;
+
+                        case RegexNodeKind.Loop or RegexNodeKind.Lazyloop when node.M >= 1:
+                            // Process the child and then stop. We don't know how many times the
+                            // loop will actually repeat, only that it must execute at least once.
+                            FindLeadingPositiveLookahead(node.Child(0), ref positiveLookahead);
+                            return false;
+
+                        case RegexNodeKind.Concatenate:
+                            // Check each child, stopping the search if processing it says we can't process further.
+                            int childCount = node.ChildCount();
+                            for (int i = 0; i < childCount; i++)
+                            {
+                                if (!FindLeadingPositiveLookahead(node.Child(i), ref positiveLookahead))
+                                {
+                                    return false;
+                                }
+                            }
+
+                            return true;
+
+                        default:
+                            return false;
+                    }
+                }
+            }
+        }
+
         /// <summary>Computes the leading anchor of a node.</summary>
         public static RegexNodeKind FindLeadingAnchor(RegexNode node) =>
             FindLeadingOrTrailingAnchor(node, leading: true);
@@ -1236,6 +1310,7 @@ namespace System.Text.RegularExpressions
         public static RegexNodeKind FindTrailingAnchor(RegexNode node) =>
             FindLeadingOrTrailingAnchor(node, leading: false);
 
+        /// <summary>Computes the leading or trailing anchor of a node.</summary>
         /// <summary>Computes the leading or trailing anchor of a node.</summary>
         private static RegexNodeKind FindLeadingOrTrailingAnchor(RegexNode node, bool leading)
         {
@@ -1263,7 +1338,14 @@ namespace System.Text.RegularExpressions
 
                     case RegexNodeKind.Atomic:
                     case RegexNodeKind.Capture:
-                        // For groups, continue exploring the sole child.
+                    case RegexNodeKind.Loop or RegexNodeKind.Lazyloop when leading && node.M >= 1:
+                    case RegexNodeKind.PositiveLookaround when leading && (node.Options & RegexOptions.RightToLeft) == 0:
+                        // For atomic and capture groups, for the purposes of finding anchors they add no semantics around the child.
+                        // Loops are like atomic and captures for the purposes of finding leading anchors, as long as the loop has
+                        // at least one guaranteed iteration (if its min is 0, any anchors inside might not apply).
+                        // Positive lookaheads are also relevant as long as we're looking for leading anchors, as an anchor
+                        // at the beginning of a starting positive lookahead has the same semantics as the same anchor at the
+                        // beginning of the pattern.
                         node = node.Child(0);
                         continue;
 
@@ -1274,15 +1356,35 @@ namespace System.Text.RegularExpressions
                         {
                             int childCount = node.ChildCount();
                             RegexNode? child = null;
+                            RegexNodeKind bestAnchorFound = RegexNodeKind.Unknown;
                             if (leading)
                             {
                                 for (int i = 0; i < childCount; i++)
                                 {
-                                    if (node.Child(i).Kind is not (RegexNodeKind.Empty or RegexNodeKind.PositiveLookaround or RegexNodeKind.NegativeLookaround))
+                                    RegexNode tmpChild = node.Child(i);
+                                    switch (tmpChild.Kind)
                                     {
-                                        child = node.Child(i);
-                                        break;
+                                        case RegexNodeKind.Empty or RegexNodeKind.NegativeLookaround:
+                                        case RegexNodeKind.PositiveLookaround when ((node.Options | tmpChild.Options) & RegexOptions.RightToLeft) != 0:
+                                            // Skip over zero-width assertions.
+                                            continue;
+
+                                        case RegexNodeKind.PositiveLookaround:
+                                            // Except for positive lookaheads at the beginning of the pattern, as any anchor it has at
+                                            // its beginning can also be used.
+                                            bestAnchorFound = ChooseBetterAnchor(bestAnchorFound, FindLeadingOrTrailingAnchor(tmpChild, leading));
+                                            if (IsBestAnchor(bestAnchorFound))
+                                            {
+                                                return bestAnchorFound;
+                                            }
+
+                                            // Now that we know what anchor might be in the lookahead, skip the zero-width assertion
+                                            // and continue examining subsequent nodes of the concatenation.
+                                            continue;
                                     }
+
+                                    child = tmpChild;
+                                    break;
                                 }
                             }
                             else
@@ -1297,13 +1399,57 @@ namespace System.Text.RegularExpressions
                                 }
                             }
 
-                            if (child is not null)
+                            if (bestAnchorFound is not RegexNodeKind.Unknown)
                             {
+                                // We found a leading anchor in a positive lookahead. If we don't have a child node, then
+                                // just return the anchor we got. If we do have a child node, recur into it to find any anchor
+                                // it has, and then choose the best between that and the lookahead.
+                                Debug.Assert(leading);
+                                return child is not null ?
+                                    ChooseBetterAnchor(bestAnchorFound, FindLeadingAnchor(child)) :
+                                    bestAnchorFound;
+                            }
+                            else if (child is not null)
+                            {
+                                // Loop around to process the child node.
                                 node = child;
                                 continue;
                             }
 
                             goto default;
+
+                            // Decide which of two anchors we'd rather search for, based on which yields the fastest
+                            // search, e.g. Beginning means we only have one place to search, whereas worse Bol could be at the
+                            // start of any line, and even worse Boundary could be at the start or end of any word.
+                            static RegexNodeKind ChooseBetterAnchor(RegexNodeKind anchor1, RegexNodeKind anchor2)
+                            {
+                                return
+                                    anchor1 == RegexNodeKind.Unknown ? anchor2 :
+                                    anchor2 == RegexNodeKind.Unknown ? anchor1 :
+                                    RankAnchorQuality(anchor1) >= RankAnchorQuality(anchor2) ? anchor1 :
+                                    anchor2;
+
+                                static int RankAnchorQuality(RegexNodeKind node) =>
+                                    node switch
+                                    {
+                                        RegexNodeKind.Beginning => 3,
+                                        RegexNodeKind.Start => 3,
+                                        RegexNodeKind.End => 3,
+                                        RegexNodeKind.EndZ => 3,
+
+                                        RegexNodeKind.Bol => 2,
+                                        RegexNodeKind.Eol => 2,
+
+                                        RegexNodeKind.Boundary => 1,
+                                        RegexNodeKind.ECMABoundary => 1,
+
+                                        _ => 0
+                                    };
+                            }
+
+                            static bool IsBestAnchor(RegexNodeKind anchor) =>
+                                // Keep in sync with ChooseBetterAnchor
+                                anchor is RegexNodeKind.Beginning or RegexNodeKind.Start or RegexNodeKind.End or RegexNodeKind.EndZ;
                         }
 
                     case RegexNodeKind.Alternate:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -77,7 +77,7 @@ namespace System.Text.RegularExpressions
             CaptureNameToNumberMapping = captureNameToNumberMapping;
             CaptureNames = captureNames;
             Options = options;
-            FindOptimizations = new RegexFindOptimizations(root, options);
+            FindOptimizations = RegexFindOptimizations.Create(root, options);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
@@ -30,6 +30,23 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"\zhello$", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_End)]
         [InlineData(@"\zhi|\zhello", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_End)]
 
+        [InlineData(@"(?=^abc)", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?=^)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?=.*$)abc", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight)]
+        [InlineData(@"(?=^)abc", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft)]
+        [InlineData(@"abc(?=^)", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft)]
+        [InlineData(@"(?<!42)(?=^)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?<=^)abc", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight)]
+        [InlineData(@"(?<=^)(?=^)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?=^)+abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?=^\w+)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?=\b)^abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?=\b)(?=^.*$)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        [InlineData(@"(?=\b)(?=\B)^abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
+        // The next two could be improved slightly to be LeadingString_LeftToRight.
+        [InlineData(@"(?=^.*def)?abc", 0, (int)FindNextStartingPositionMode.FixedDistanceChar_LeftToRight)] 
+        [InlineData(@"(?=^)?(?=^)abc", 0, (int)FindNextStartingPositionMode.FixedDistanceChar_LeftToRight)]
+
         [InlineData(@"^", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning)]
         [InlineData(@"hello^", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning)]
         [InlineData(@"$hello^", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning)]
@@ -89,7 +106,19 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"(ab){2,4}(de){4,}", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "de")]
         [InlineData(@"ab|(abc)|(abcd)", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
         [InlineData(@"ab(?=cd)", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
+        [InlineData(@"ab(?=cd)ef", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "abef")]
+        [InlineData(@"ab(?=cd){2}ef", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "abef")]
+        [InlineData(@"(?=)ab", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
+        [InlineData(@"(?=a)bc", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "bc")]
+        [InlineData(@"(?=ab)cd", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "cd")]
+        [InlineData(@"(?=ab)", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
+        [InlineData(@"(?<=ab)cd", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "cd")]
+        [InlineData(@"(?!ab)cd", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "cd")]
+        [InlineData(@"(?<!ab)cd", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "cd")]
         [InlineData(@"ab(?=cd)", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
+        [InlineData(@"ab(?<=cd)", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
+        [InlineData(@"(?=cd)ab", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
+        [InlineData(@"(?<=cd)ab", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
         [InlineData(@"\bab(?=\w)(?!=\d)c\b", 0, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "abc")]
         [InlineData(@"\bab(?=\w)(?!=\d)c\b", (int)RegexOptions.IgnoreCase, (int)FindNextStartingPositionMode.LeadingString_OrdinalIgnoreCase_LeftToRight, "abc")]
         public void LeadingPrefix(string pattern, int options, int expectedMode, string expectedPrefix)
@@ -159,7 +188,7 @@ namespace System.Text.RegularExpressions.Tests
         private static RegexFindOptimizations ComputeOptimizations(string pattern, RegexOptions options)
         {
             RegexTree tree = RegexParser.Parse(pattern, options, CultureInfo.InvariantCulture);
-            return new RegexFindOptimizations(tree.Root, options);
+            return RegexFindOptimizations.Create(tree.Root, options);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
@@ -261,12 +261,15 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("a|b|c|d|e|g|h|z", "[a-eghz]")]
         [InlineData("a|b|c|def|g|h", "(?>[a-c]|def|[gh])")]
         [InlineData("this|that|there|then|those", "th(?>is|at|ere|en|ose)")]
+        [InlineData("^this|^that|^there|^then|^those", "^th(?>is|at|ere|en|ose)")]
+        [InlineData("\bthis|\bthat|\bthere|\bthen|\bthose", "\bth(?>is|at|ere|en|ose)")]
         [InlineData("it's (?>this|that|there|then|those)", "it's (?>th(?>is|at|e(?>re|n)|ose))")]
         [InlineData("it's (?>this|that|there|then|those)!", "it's (?>th(?>is|at|e(?>re|n)|ose))!")]
         [InlineData("abcd|abce", "abc[de]")]
         [InlineData("abcd|abef", "ab(?>cd|ef)")]
         [InlineData("abcd|aefg", "a(?>bcd|efg)")]
         [InlineData("abcd|abc|ab|a", "a(?>bcd|bc|b|)")]
+        [InlineData("^abcd|^abce", "^(?:abc[de])")]
         // [InlineData("abcde|abcdef", "abcde(?>|f)")] // TODO https://github.com/dotnet/runtime/issues/66031: Need to reorganize optimizations to avoid an extra Empty being left at the end of the tree
         [InlineData("abcdef|abcde", "abcde(?>f|)")]
         [InlineData("abcdef|abcdeg|abcdeh|abcdei|abcdej|abcdek|abcdel", "abcde[f-l]")]
@@ -495,6 +498,8 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("a*(?(xyz)acd|efg)", "(?>a*)(?(xyz)acd|efg)")]
         [InlineData("a*(?(xyz)bcd|afg)", "(?>a*)(?(xyz)bcd|afg)")]
         [InlineData("a*(?(xyz)bcd)", "(?>a*)(?(xyz)bcd)")]
+        // Different prefixes on alternation branches
+        [InlineData("^abcd|$abce", "^abcd|^abce")]
         public void PatternsReduceDifferently(string actual, string expected)
         {
             // NOTE: RegexNode.ToString is only compiled into debug builds, so DEBUG is currently set on the unit tests project.


### PR DESCRIPTION
A positive lookahead at the start of a pattern can be used for determining find optimizations even when the non-zero-width portions of the pattern aren't. This helps particularly in cases where the positive lookahead contains an anchor or a literal.

Also extends the existing alternation reduction optimization to factor out anchors that begin every branch of an alternation.

As an example of how this applies, this is one of the expressions in our list:
```regex
(?=^\bset\b.*;\s*\bselect\b|^\bselect\b).*?\s+from\s+(?:[\s\(\[`\"]*([^,;\[\s\]\(\)`\"\.]*)[\s\)\]`\"]*)(?:\.[\s\(\[`\"]*([^,;\[\s\]\(\)`\"\.]*)[\s\)\]`\"]*)*
```
Note that the pattern begins with a positive lookahead and that what comes after it isn't particularly searchable. This leads to the following generated TryFindNextPossibleStartingPosition routine:
```C#
                private bool TryFindNextPossibleStartingPosition(ReadOnlySpan<char> inputSpan)
                {
                    int pos = base.runtextpos;
                    
                    // Any possible match is at least 6 characters.
                    if (pos <= inputSpan.Length - 6)
                    {
                        return true;
                    }
                    
                    // No match found.
                    base.runtextpos = inputSpan.Length;
                    return false;
                }
```
which effectively always just returns true (as long as the input is long enough), which means we end up trying to match at most positions.

Now with the change, we get this:
```C#
                private bool TryFindNextPossibleStartingPosition(ReadOnlySpan<char> inputSpan)
                {
                    int pos = base.runtextpos;
                    
                    // Any possible match is at least 6 characters.
                    if (pos <= inputSpan.Length - 6)
                    {
                        // The pattern leads with a beginning (\A) anchor.
                        if (pos == 0)
                        {
                            return true;
                        }
                    }
                    
                    // No match found.
                    base.runtextpos = inputSpan.Length;
                    return false;
                }
```
Note the new `pos == 0` check. That happens because we will now factor in the ^ from the positive lookahead's alternation.