### PR TITLE
Workarounds for issue #104511

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -4168,23 +4168,9 @@ IS_VALUETYPE:
                 // It's not self-referential so try to load it
                 if (pByValueClass == NULL)
                 {
-                    // Loading a static valuetype field on a struct could be indirectly self-referential if one of the field type's
-                    //  generic arguments is the valuetype we're currently loading.
-                    BOOL fCouldBeSelfReferentialThroughGenerics = fIsStatic && IsValueClass();
-                    if (fCouldBeSelfReferentialThroughGenerics)
-                    {
-                        SigPointer sptr(pMemberSignature, cMemberSignature);
-                        uint32_t unused;
-                        sptr.GetCallingConvInfo(&unused); // Skip calling convention, we already know it
-                        CorElementType rawElementType;
-                        sptr.PeekElemType(&rawElementType);
-                        if (rawElementType != ELEMENT_TYPE_GENERICINST) // Determine whether this valuetype is a generic instance
-                            fCouldBeSelfReferentialThroughGenerics = FALSE;
-                    }
-
                     // Loading a non-self-ref valuetype field.
                     OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOAD_APPROXPARENTS);
-                    if ((isEnCField || fIsStatic) && !fCouldBeSelfReferentialThroughGenerics)
+                    if (isEnCField)
                     {
                         // EnCFieldDescs are not created at normal MethodTableBuilder time, and don't need to avoid recursive generic instantiation
                         pByValueClass = fsig.GetArgProps().GetTypeHandleThrowing(GetModule(),

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -3709,6 +3709,11 @@ BOOL MethodTableBuilder::IsSelfReferencingStaticValueTypeField(mdToken     dwByV
 {
     STANDARD_VM_CONTRACT;
 
+    if (this->IsInterface())
+    {
+        return TRUE;
+    }
+
     if (dwByValueClassToken != this->GetCl())
     {
         return FALSE;
@@ -4042,7 +4047,7 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
                 // By-value class
                 BAD_FORMAT_NOTHROW_ASSERT(dwByValueClassToken != 0);
 
-                if (this->IsValueClass() && (pTokenModule == GetModule()))
+                if ((this->IsValueClass() || this->IsInterface()) && (pTokenModule == GetModule()))
                 {
                     if (TypeFromToken(dwByValueClassToken) == mdtTypeRef)
                     {
@@ -4101,7 +4106,7 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
                             BuildMethodTableThrowException(IDS_CLASSLOAD_VALUEINSTANCEFIELD, mdMethodDefNil);
                         }
 
-                        if (!IsValueClass())
+                        if (!IsInterface() && !IsValueClass())
                         {
                             BuildMethodTableThrowException(COR_E_BADIMAGEFORMAT, IDS_CLASSLOAD_MUST_BE_BYVAL, mdTokenNil);
                         }
@@ -4118,9 +4123,23 @@ IS_VALUETYPE:
                 // It's not self-referential so try to load it
                 if (pByValueClass == NULL)
                 {
+                    // Loading a static valuetype field on a struct could be indirectly self-referential if one of the field type's
+                    //  generic arguments is the valuetype we're currently loading.
+                    BOOL fCouldBeSelfReferentialThroughGenerics = fIsStatic && IsValueClass();
+                    if (fCouldBeSelfReferentialThroughGenerics)
+                    {
+                        SigPointer sptr(pMemberSignature, cMemberSignature);
+                        uint32_t unused;
+                        sptr.GetCallingConvInfo(&unused); // Skip calling convention, we already know it
+                        CorElementType rawElementType;
+                        sptr.PeekElemType(&rawElementType);
+                        if (rawElementType != ELEMENT_TYPE_GENERICINST) // Determine whether this valuetype is a generic instance
+                            fCouldBeSelfReferentialThroughGenerics = FALSE;
+                    }
+
                     // Loading a non-self-ref valuetype field.
                     OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOAD_APPROXPARENTS);
-                    if (isEnCField || fIsStatic)
+                    if ((isEnCField || fIsStatic) && !fCouldBeSelfReferentialThroughGenerics)
                     {
                         // EnCFieldDescs are not created at normal MethodTableBuilder time, and don't need to avoid recursive generic instantiation
                         pByValueClass = fsig.GetArgProps().GetTypeHandleThrowing(GetModule(),


### PR DESCRIPTION
Draft to check for failures on CI
Alternative to https://github.com/dotnet/runtime/pull/111984

For two scenarios touched on in issue #104511, we can solve them through different paths in the same InitializeFieldDescs method:

__Static field *on a struct*, of a generic struct type that indirectly references the type hosting the field, i.e.__
```csharp
struct X { static ImmutableArray<X> F; }
```

We have existing infrastructure for doing cycle-avoidant type loads in cases like this - `tkTypeDefToAvoidIfPossible` - so we just need to sense that we've encountered a scenario where it might be necessary. We can do this by checking whether the field is:
1. static
2. of struct type
3. of a *generic* struct type
We already know 1 & 2, so I add a bit of signature decoding to determine 3. If all three conditions are met we use `tkTypeDefToAvoidIfPossible` to avoid loading ourselves when loading the field type. This feels like a decent compromise to fix this scenario and shouldn't impact the vast majority of fields in existing applications.

__Static field *on an interface*, of a struct type that implements said interface, i.e.__
```csharp
interface I { static Y F; }
struct Y : I { }
```

`tkTypeDefToAvoidIfPossible` can't save us here and flowing it through into the place where interfaces are loaded would require some significant code changes, so I decided to see if I could narrowly target a workaround based on our existing handling of self-referential static fields.
This PR's approach is to look up the type of each static struct field on an interface, and if it's a typedef (not a typeref, which means it's in the current module and can form a cycle), we scan the interfaceimpl table for that typedef to see if we're in it. If we are, treat the field type as if it's a reference to us. This taps into the existing logic for handling self-referential static fields and seems to work, though I had to tweak some code related to enums.

The cost of doing this could get prohibitive for large numbers of static struct type fields on an interface, though I'm having trouble imagining a scenario that would require that, and there are some fairly obvious ways to optimize it.