### PR TITLE
Remove unneeded DiagnosticSource content

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -25,7 +25,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
 
   <ItemGroup>
     <ILLinkSubstitutionsXmls Include="ILLink/ILLink.Substitutions.Shared.xml" />
-    <Content Include="ILLink\ILLink.Descriptors.LibraryBuild.xml" />
+    <None Include="ILLink\ILLink.Descriptors.LibraryBuild.xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The IL link file was getting included as unnecessary content in transitive dependent projects which caused confusion.

Fixes #112110


PTAL @tarekgh