### PR TITLE
Remove unnecessary _DARWIN_C_SOURCE definition in CMake files

### DIFF
--- a/src/tests/Exceptions/ForeignThread/CMakeLists.txt
+++ b/src/tests/Exceptions/ForeignThread/CMakeLists.txt
@@ -2,11 +2,6 @@ project (ForeignThreadExceptionsNative)
 
 include_directories(${INC_PLATFORM_DIR})
 
-if(CLR_CMAKE_HOST_OSX)
-  # Enable non-POSIX pthreads APIs, which by default are not included in the pthreads header
-  add_definitions(-D_DARWIN_C_SOURCE)
-endif(CLR_CMAKE_HOST_OSX)
-
 set(SOURCES ForeignThreadExceptionsNative.cpp)
 
 if(NOT CLR_CMAKE_HOST_WIN32)

--- a/src/tests/baseservices/exceptions/UnhandledExceptionHandler/ForeignThreadRevPInvokeUnhandled/CMakeLists.txt
+++ b/src/tests/baseservices/exceptions/UnhandledExceptionHandler/ForeignThreadRevPInvokeUnhandled/CMakeLists.txt
@@ -2,11 +2,6 @@ project (ForeignThreadRevPInvokeUnhandledNative)
 
 include_directories(${INC_PLATFORM_DIR})
 
-if(CLR_CMAKE_HOST_OSX)
-  # Enable non-POSIX pthreads APIs, which by default are not included in the pthreads header
-  add_definitions(-D_DARWIN_C_SOURCE)
-endif(CLR_CMAKE_HOST_OSX)
-
 set(SOURCES ForeignThreadRevPInvokeUnhandledNative.cpp)
 
 if(NOT CLR_CMAKE_HOST_WIN32)

--- a/src/tests/baseservices/exceptions/UnhandledExceptionHandler/PInvokeRevPInvokeUnhandled/CMakeLists.txt
+++ b/src/tests/baseservices/exceptions/UnhandledExceptionHandler/PInvokeRevPInvokeUnhandled/CMakeLists.txt
@@ -2,11 +2,6 @@ project (PInvokeRevPInvokeUnhandledNative)
 
 include_directories(${INC_PLATFORM_DIR})
 
-if(CLR_CMAKE_HOST_OSX)
-  # Enable non-POSIX pthreads APIs, which by default are not included in the pthreads header
-  add_definitions(-D_DARWIN_C_SOURCE)
-endif(CLR_CMAKE_HOST_OSX)
-
 set(SOURCES PInvokeRevPInvokeUnhandledNative.cpp)
 
 if(NOT CLR_CMAKE_HOST_WIN32)

--- a/src/tests/baseservices/exceptions/unhandled/CMakeLists.txt
+++ b/src/tests/baseservices/exceptions/unhandled/CMakeLists.txt
@@ -2,11 +2,6 @@ project (foreignunhandled)
 
 include_directories(${INC_PLATFORM_DIR})
 
-if(CLR_CMAKE_HOST_OSX)
-  # Enable non-POSIX pthreads APIs, which by default are not included in the pthreads header
-  add_definitions(-D_DARWIN_C_SOURCE)
-endif(CLR_CMAKE_HOST_OSX)
-
 set(SOURCES foreignunhandled.cpp)
 
 if(NOT CLR_CMAKE_HOST_WIN32)


### PR DESCRIPTION
We define this globally:
https://github.com/dotnet/runtime/blob/d44116e0dc18ffd94b910bd03cdcf2c8219a59bd/eng/native/configurecompiler.cmake#L301-L304