### PR TITLE
Make `CalculateAssemblyAction` virtual.

### DIFF
--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -386,7 +386,7 @@ namespace Mono.Linker
 			Annotations.SetAction (assembly, action);
 		}
 #endif
-		public AssemblyAction CalculateAssemblyAction (AssemblyDefinition assembly)
+		public virtual AssemblyAction CalculateAssemblyAction (AssemblyDefinition assembly)
 		{
 			if (_actions.TryGetValue (assembly.Name.Name, out AssemblyAction action)) {
 				if (IsCPPCLIAssembly (assembly.MainModule) && action != AssemblyAction.Copy && action != AssemblyAction.Skip) {


### PR DESCRIPTION
We need to override this in UnityLinker