### PR TITLE
[browser] Leave the fingerprint pattern in relative path

### DIFF
--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
@@ -340,7 +340,6 @@ public class ComputeWasmPublishAssets : Task
             if (newAssetFingerprintedFileName != assetFileNameToFingerprint)
             {
                 newAssetItemSpec = $"{assetDirectory}/{newAssetFingerprintedFileName}";
-                newAssetRelativePath = newAssetRelativePath.Replace(assetFileNameToFingerprint, newAssetFingerprintedFileName);
             }
         }
 


### PR DESCRIPTION
Uncovered in https://github.com/dotnet/sdk/pull/46233. We do hard fingerprinting on wasm generated assets during build. On disk the files already contain the fingerprint. During publish we upgrade those build assets to publish assets, so the item spec contains the fingerprint, but we want to treat the asset as "fingerprintable" for further processing during publish (eg. when generating import maps), so that there is still the link between unfingerprinted (eg. `dotnet.js`) and fingerprinted (eg. `dotnet.abcd.js`) even though the file on disk exists only as fingerprinted.

#### Previous behavior
```
..../bin/wwwroot/_framework/dotnet.abcd.js
  RelativePath = _framework/dotnet.abcd.js
  Fingerprint = abcd
```

#### New behavior
```
..../bin/wwwroot/_framework/dotnet.abcd.js
  RelativePath = _framework/dotnet.#[{.fingerprint}]!.js
  Fingerprint = abcd
```