### PR TITLE
[QUIC] Observe exceptions from _connectionCloseTcs

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
@@ -215,26 +215,4 @@ internal static class ThrowHelper
             throw new ArgumentNullException(argumentName, SR.Format(resourceName, propertyName));
         }
     }
-
-    public static void ObserveException(this Task task)
-    {
-        if (task.IsCompleted)
-        {
-            ObserveExceptionCore(task);
-        }
-        else
-        {
-            task.ContinueWith(static (t) => ObserveExceptionCore(t), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-        }
-
-        static void ObserveExceptionCore(Task task)
-        {
-            Debug.Assert(task.IsCompleted);
-            if (task.IsFaulted)
-            {
-                // Access Exception to avoid TaskScheduler.UnobservedTaskException firing.
-                Exception? e = task.Exception!.InnerException;
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes #112094

Observing the exception the same way as channel does in:
https://github.com/dotnet/runtime/blob/ff604c23939bc59f856ef67f1f3d18dd685ff7a2/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs#L38-L45