### PR TITLE
Update container image used for wasm to Azure Linux 3.0

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -98,12 +98,12 @@ extends:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
 
       browser_wasm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly-20230913040940-1edc1c6
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-webassembly-amd64
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
       wasi_wasm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly-20230913040940-1edc1c6
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-webassembly-amd64
         env:
           ROOTFS_DIR: /crossrootfs/x64
 


### PR DESCRIPTION
The current referenced image is way out of date because of the datestamp tag it's using. Updating it to use Azure Linux 3.0.