### PR TITLE
Enable building projects during BuildPass=2 in dotnet/runtime

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -5,5 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectToBuild Include="$(RepoRoot)Build.proj" />
+    <!-- dotnet/runtime controls which projects run in which passes through our DefaultSubsets settings in eng/Subsets.props -->
+    <ProjectToBuild Include="$(RepoRoot)Build.proj" BuildPass="2" />
   </ItemGroup>
 </Project>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -6,6 +6,6 @@
   <ItemGroup>
     <ProjectToBuild Include="$(RepoRoot)Build.proj" />
     <!-- dotnet/runtime controls which projects run in which passes through our DefaultSubsets settings in eng/Subsets.props -->
-    <ProjectToBuild Include="$(RepoRoot)Build.proj" BuildPass="2" />
+    <ProjectToBuild Include="$(RepoRoot)Build.proj" DotNetBuildPass="2" Condition="'$(DotNetBuildPass)' == '2'" />
   </ItemGroup>
 </Project>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -69,7 +69,7 @@
     <DefaultSubsets Condition="'$(DotNetBuildMonoCrossAOT)' == 'true'">mono+packs</DefaultSubsets>
 
     <!-- In the Win-x86 BuildPass2 job in the VMR, we want to build the cross-OS DACs and pack them. -->
-    <DefaultSubsets Condition="'$(DotNetBuildPass)' == '2' and '$(TargetRid)' == 'win-x86'">crossdacpack</DefaultSubsets>
+    <DefaultSubsets Condition="'$(DotNetBuildPass)' == '2' and '$(TargetOS)' == 'windows' and '$(TargetArchitecture)' == 'x86'">crossdacpack</DefaultSubsets>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We control all BuildPass filtering in eng/Subsets.props, so we need to manually say "Use Build.proj for BuildPass 2 as well".