### PR TITLE
[release/9.0] Remove explicit __compact_unwind entries from x64 assembler

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
@@ -16,15 +16,6 @@
 
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
-#if defined(__APPLE__)
-        .set LOCAL_LABEL(\Name\()_Size), . - C_FUNC(\Name)
-        .section __LD,__compact_unwind,regular,debug
-        .quad C_FUNC(\Name)
-        .long LOCAL_LABEL(\Name\()_Size)
-        .long 0x04000000 # DWARF
-        .quad 0
-        .quad 0
-#endif
 .endm
 
 .macro PATCH_LABEL Name

--- a/src/coreclr/pal/inc/unixasmmacrosamd64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosamd64.inc
@@ -16,15 +16,6 @@
 
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
-#if defined(__APPLE__)
-        .set LOCAL_LABEL(\Name\()_Size), . - C_FUNC(\Name)
-        .section __LD,__compact_unwind,regular,debug
-        .quad C_FUNC(\Name)
-        .long LOCAL_LABEL(\Name\()_Size)
-        .long 0x04000000 # DWARF
-        .quad 0
-        .quad 0
-#endif
 .endm
 
 .macro PATCH_LABEL Name


### PR DESCRIPTION
Backport of #111530 to release/9.0

Ref: https://github.com/dotnet/sdk/issues/46006#issuecomment-2636016972

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Update of Apple build tools to Xcode 16 started producing a warning on some builds in native linker invocation. This affects NativeAOT application builds on macOS machines where Xcode 16 or newer is used. The warnings are suppressed but they indicate a long-standing issue in the code base that surfaced with updated build tooling. We should aim to produce no warning with up-to-date tooling, both on CI pipeline (such as those in dotnet/sdk) and users' machines.

## Regression

- [ ] Yes
- [x] No

## Testing

The fix was applied on .NET 10 for a while and ingested by various CI pipelines. The object files produced by the native tooling were manually verified. Previously they contained duplicated - identical - records in the compact unwinding section, now the duplicates are no longer produced.

## Risk

Low