### PR TITLE
Refactor `CertFreeCRLContext`

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertFreeCRLContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertFreeCRLContext.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Crypt32
+    {
+        // https://learn.microsoft.com/windows/win32/api/wincrypt/nf-wincrypt-certfreecrlcontext
+        [LibraryImport(Libraries.Crypt32)]
+        public static partial int CertFreeCRLContext(IntPtr certContext);
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ldap.cs
@@ -190,9 +190,6 @@ internal static partial class Interop
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
         public static partial int ldap_control_free(IntPtr control);
 
-        [LibraryImport("Crypt32.dll", EntryPoint = "CertFreeCRLContext")]
-        public static partial int CertFreeCRLContext(IntPtr certContext);
-
         [LibraryImport(Libraries.Wldap32, EntryPoint = "ldap_result2error")]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
         public static partial int ldap_result2error(ConnectionHandle ldapHandle, IntPtr result, int freeIt);

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -69,6 +69,7 @@
     <Compile Include="System\DirectoryServices\Protocols\Interop\SafeHandles.Windows.cs" />
 
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertFreeCRLContext.cs" Link="Common\Interop\Windows\Crypt32\Interop.CertFreeCRLContext.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Wldap32\Interop.Ldap.cs" Link="Common\Interop\Windows\Wldap32\Interop.Ldap.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Wldap32\Interop.Ber.cs" Link="Common\Interop\Windows\Wldap32\Interop.Ber.cs" />
   </ItemGroup>

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
@@ -8,7 +8,7 @@ namespace System.DirectoryServices.Protocols
 {
     public partial class LdapSessionOptions
     {
-        private static void PALCertFreeCRLContext(IntPtr certPtr) => Interop.Ldap.CertFreeCRLContext(certPtr);
+        private static void PALCertFreeCRLContext(IntPtr certPtr) => Interop.Crypt32.CertFreeCRLContext(certPtr);
 
         public bool SecureSocketLayer
         {


### PR DESCRIPTION
Move `CertFreeCRLContext` to `Interop/Windows/Crypt32/Interop.CertFreeCRLContext.cs` as it is provided by the `Crypt32` library.