### PR TITLE
[release/8.0] Fix compilation of runtime with Xcode 16

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
@@ -16,15 +16,6 @@
 
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
-#if defined(__APPLE__)
-        .set LOCAL_LABEL(\Name\()_Size), . - C_FUNC(\Name)
-        .section __LD,__compact_unwind,regular,debug
-        .quad C_FUNC(\Name)
-        .long LOCAL_LABEL(\Name\()_Size)
-        .long 0x04000000 # DWARF
-        .quad 0
-        .quad 0
-#endif
 .endm
 
 .macro PATCH_LABEL Name

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
@@ -33,7 +33,12 @@ C_FUNC(\Name):
 .endm
 
 .macro ALTERNATE_ENTRY Name
+#if defined(__APPLE__)
+        .alt_entry C_FUNC(\Name)
+        .private_extern C_FUNC(\Name)
+#else
         .global C_FUNC(\Name)
+#endif
 C_FUNC(\Name):
 .endm
 

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
@@ -24,8 +24,11 @@ C_FUNC(\Name):
 .endm
 
 .macro ALTERNATE_ENTRY Name
+#if defined(__APPLE__)
+        .alt_entry C_FUNC(\Name)
+        .private_extern C_FUNC(\Name)
+#else
         .global C_FUNC(\Name)
-#if !defined(__APPLE__)
         .hidden C_FUNC(\Name)
 #endif
 C_FUNC(\Name):

--- a/src/coreclr/pal/inc/unixasmmacrosamd64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosamd64.inc
@@ -14,15 +14,6 @@
 
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
-#if defined(__APPLE__)
-        .set LOCAL_LABEL(\Name\()_Size), . - C_FUNC(\Name)
-        .section __LD,__compact_unwind,regular,debug
-        .quad C_FUNC(\Name)
-        .long LOCAL_LABEL(\Name\()_Size)
-        .long 0x04000000 # DWARF
-        .quad 0
-        .quad 0
-#endif
 .endm
 
 .macro PATCH_LABEL Name

--- a/src/coreclr/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm64.inc
@@ -17,7 +17,12 @@
 .endm
 
 .macro PATCH_LABEL Name
+#if defined(__APPLE__)
+        .alt_entry C_FUNC(\Name)
+        .private_extern C_FUNC(\Name)
+#else
         .global C_FUNC(\Name)
+#endif
 C_FUNC(\Name):
 .endm
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -169,8 +169,7 @@ NESTED_END ThePreStub, _TEXT
 
 LEAF_ENTRY ThePreStubPatch, _TEXT
     nop
-.globl C_FUNC(ThePreStubPatchLabel)
-C_FUNC(ThePreStubPatchLabel):
+PATCH_LABEL ThePreStubPatchLabel
     ret lr
 LEAF_END ThePreStubPatch, _TEXT
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -818,8 +818,12 @@ NESTED_END ResolveWorkerAsmStub, _TEXT
 #ifdef FEATURE_READYTORUN
 
 NESTED_ENTRY DelayLoad_MethodCall_FakeProlog, _TEXT, NoHandler
-C_FUNC(DelayLoad_MethodCall):
+#if defined(__APPLE__)
+    .alt_entry C_FUNC(DelayLoad_MethodCall)
+#endif
     .global C_FUNC(DelayLoad_MethodCall)
+C_FUNC(DelayLoad_MethodCall):
+
     PROLOG_WITH_TRANSITION_BLOCK
 
     add x0, sp, #__PWTB_TransitionBlock // pTransitionBlock
@@ -838,8 +842,11 @@ NESTED_END DelayLoad_MethodCall_FakeProlog, _TEXT
 
 .macro DynamicHelper frameFlags, suffix
 NESTED_ENTRY DelayLoad_Helper\suffix\()_FakeProlog, _TEXT, NoHandler
-C_FUNC(DelayLoad_Helper\suffix):
+#if defined(__APPLE__)
+    .alt_entry C_FUNC(DelayLoad_Helper\suffix)
+#endif
     .global C_FUNC(DelayLoad_Helper\suffix)
+C_FUNC(DelayLoad_Helper\suffix):
 
     PROLOG_WITH_TRANSITION_BLOCK
 


### PR DESCRIPTION
Backport of #106744, #106442, and #111530 to release/8.0

Ref: https://github.com/dotnet/sdk/issues/46006#issuecomment-2636016972

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Apple build tools (Xcode) are updated annually. Customers are expected to use up to date version to build applications, which is often enforced through policies on Apple systems and tooling (eg. uploading to App Store or signing and notarizing may enforce minimum Xcode version necessary for building apps). Xcode 16 started enforcing restriction on correct layout of unwinding information in relation to publicly exported symbols. In order to allow compilation with the new tooling we need to mark some of the runtime symbols with .alt_entry to signify they are not function entrypoints but rather just labels pointing at specific instruction in a given function.

## Regression

- [ ] Yes
- [x] No

## Testing

The runtime repository was built on Apple machine with Xcode 16.2 and it no longer produces compilation errors and linker warning. NativeAOT smoke tests were used to verify that the code still links and runs as it should.

## Risk

Low