### PR TITLE
JIT: Store padding information in ClassLayout/ClassLayoutBuilder

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -167,6 +167,7 @@ set( JIT_SOURCES
   regset.cpp
   scev.cpp
   scopeinfo.cpp
+  segmentlist.cpp
   sideeffects.cpp
   sm.cpp
   smdata.cpp
@@ -174,7 +175,6 @@ set( JIT_SOURCES
   ssabuilder.cpp
   ssarenamestate.cpp
   stacklevelsetter.cpp
-  structsegments.cpp
   switchrecognition.cpp
   treelifeupdater.cpp
   unwind.cpp
@@ -362,6 +362,7 @@ set( JIT_HEADERS
   register.h
   regset.h
   scev.h
+  segmentlist.h
   sideeffects.h
   simd.h
   sm.h
@@ -372,7 +373,6 @@ set( JIT_HEADERS
   ssaconfig.h
   ssarenamestate.h
   stacklevelsetter.h
-  structsegments.h
   target.h
   targetx86.h
   targetamd64.h

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -8269,67 +8269,6 @@ void Compiler::TransferTestDataToNode(GenTree* from, GenTree* to)
 
 #endif // DEBUG
 
-//------------------------------------------------------------------------
-// GetSignificantSegments:
-//   Compute a segment tree containing all significant (non-padding) segments
-//   for the specified class layout.
-//
-// Parameters:
-//   layout - The layout
-//
-// Returns:
-//   Segment tree containing all significant parts of the layout.
-//
-const StructSegments& Compiler::GetSignificantSegments(ClassLayout* layout)
-{
-    StructSegments* cached;
-    if ((m_significantSegmentsMap != nullptr) && m_significantSegmentsMap->Lookup(layout, &cached))
-    {
-        return *cached;
-    }
-
-    COMP_HANDLE compHnd = info.compCompHnd;
-
-    StructSegments* newSegments = new (this, CMK_Promotion) StructSegments(getAllocator(CMK_Promotion));
-
-    if (layout->IsCustomLayout())
-    {
-        newSegments->Add(StructSegments::Segment(0, layout->GetSize()));
-    }
-    else
-    {
-        CORINFO_TYPE_LAYOUT_NODE nodes[256];
-        size_t                   numNodes = ArrLen(nodes);
-        GetTypeLayoutResult      result   = compHnd->getTypeLayout(layout->GetClassHandle(), nodes, &numNodes);
-
-        if (result != GetTypeLayoutResult::Success)
-        {
-            newSegments->Add(StructSegments::Segment(0, layout->GetSize()));
-        }
-        else
-        {
-            for (size_t i = 0; i < numNodes; i++)
-            {
-                const CORINFO_TYPE_LAYOUT_NODE& node = nodes[i];
-                if ((node.type != CORINFO_TYPE_VALUECLASS) || (node.simdTypeHnd != NO_CLASS_HANDLE) ||
-                    node.hasSignificantPadding)
-                {
-                    newSegments->Add(StructSegments::Segment(node.offset, node.offset + node.size));
-                }
-            }
-        }
-    }
-
-    if (m_significantSegmentsMap == nullptr)
-    {
-        m_significantSegmentsMap = new (this, CMK_Promotion) ClassLayoutStructSegmentsMap(getAllocator(CMK_Promotion));
-    }
-
-    m_significantSegmentsMap->Set(layout, newSegments);
-
-    return *newSegments;
-}
-
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -43,7 +43,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "valuenum.h"
 #include "scev.h"
 #include "namedintrinsiclist.h"
-#include "structsegments.h"
+#include "segmentlist.h"
 #ifdef LATE_DISASM
 #include "disasm.h"
 #endif
@@ -5782,11 +5782,6 @@ public:
         }
         return m_signatureToLookupInfoMap;
     }
-
-    const StructSegments& GetSignificantSegments(ClassLayout* layout);
-
-    typedef JitHashTable<ClassLayout*, JitPtrKeyFuncs<ClassLayout>, class StructSegments*> ClassLayoutStructSegmentsMap;
-    ClassLayoutStructSegmentsMap* m_significantSegmentsMap = nullptr;
 
 #ifdef SWIFT_SUPPORT
     typedef JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<struct CORINFO_CLASS_STRUCT_>, CORINFO_SWIFT_LOWERING*> SwiftLoweringMap;

--- a/src/coreclr/jit/layout.cpp
+++ b/src/coreclr/jit/layout.cpp
@@ -595,13 +595,14 @@ const SegmentList& ClassLayout::GetNonPadding(Compiler* comp)
         return *m_nonPadding;
     }
 
-    assert(!IsCustomLayout() || (m_size == 0));
     m_nonPadding = new (comp, CMK_ClassLayout) SegmentList(comp->getAllocator(CMK_ClassLayout));
 
     if (m_size == 0)
     {
         return *m_nonPadding;
     }
+
+    assert(!IsCustomLayout());
 
     CORINFO_TYPE_LAYOUT_NODE nodes[256];
     size_t                   numNodes = ArrLen(nodes);
@@ -808,7 +809,7 @@ void ClassLayoutBuilder::SetGCPtrType(unsigned slot, var_types type)
 }
 
 //------------------------------------------------------------------------
-// CopyInfoFrom: Copy GC pointers from another layout.
+// CopyInfoFrom: Copy GC pointers and padding information from another layout.
 //
 // Arguments:
 //   offset - Offset in this builder to start copy information into.

--- a/src/coreclr/jit/layout.cpp
+++ b/src/coreclr/jit/layout.cpp
@@ -595,8 +595,13 @@ const SegmentList& ClassLayout::GetNonPadding(Compiler* comp)
         return *m_nonPadding;
     }
 
-    assert(!IsCustomLayout());
+    assert(!IsCustomLayout() || (m_size == 0));
     m_nonPadding = new (comp, CMK_ClassLayout) SegmentList(comp->getAllocator(CMK_ClassLayout));
+
+    if (m_size == 0)
+    {
+        return *m_nonPadding;
+    }
 
     CORINFO_TYPE_LAYOUT_NODE nodes[256];
     size_t                   numNodes = ArrLen(nodes);

--- a/src/coreclr/jit/layout.cpp
+++ b/src/coreclr/jit/layout.cpp
@@ -833,7 +833,7 @@ void ClassLayoutBuilder::CopyInfoFrom(unsigned offset, ClassLayout* layout)
 
     for (const SegmentList::Segment& nonPadding : layout->GetNonPadding(m_compiler))
     {
-        RemovePadding(nonPadding);
+        RemovePadding(SegmentList::Segment(offset + nonPadding.Start, offset + nonPadding.End));
     }
 }
 

--- a/src/coreclr/jit/layout.h
+++ b/src/coreclr/jit/layout.h
@@ -19,21 +19,22 @@ class ClassLayoutBuilder
     BYTE*        m_gcPtrs = nullptr;
     unsigned     m_size;
     unsigned     m_gcPtrCount = 0;
-    SegmentList* m_nonPadding;
+    SegmentList* m_nonPadding = nullptr;
 #ifdef DEBUG
     const char* m_name      = "UNNAMED";
     const char* m_shortName = "UNNAMED";
 #endif
 
-    BYTE* GetOrCreateGCPtrs();
-    void  SetGCPtr(unsigned slot, CorInfoGCType type);
+    BYTE*        GetOrCreateGCPtrs();
+    void         SetGCPtr(unsigned slot, CorInfoGCType type);
+    SegmentList* GetOrCreateNonPadding();
 public:
     // Create a class layout builder.
     //
     ClassLayoutBuilder(Compiler* compiler, unsigned size);
 
     void SetGCPtrType(unsigned slot, var_types type);
-    void CopyInfoFrom(unsigned offset, ClassLayout* layout);
+    void CopyInfoFrom(unsigned offset, ClassLayout* layout, bool copyPadding);
     void AddPadding(const SegmentList::Segment& padding);
     void RemovePadding(const SegmentList::Segment& nonPadding);
 

--- a/src/coreclr/jit/layout.h
+++ b/src/coreclr/jit/layout.h
@@ -5,6 +5,7 @@
 #define LAYOUT_H
 
 #include "jit.h"
+#include "segmentlist.h"
 
 // Builder for class layouts
 //
@@ -14,10 +15,11 @@ class ClassLayoutBuilder
     friend class ClassLayoutTable;
     friend struct CustomLayoutKey;
 
-    Compiler* m_compiler;
-    BYTE*     m_gcPtrs = nullptr;
-    unsigned  m_size;
-    unsigned  m_gcPtrCount = 0;
+    Compiler*    m_compiler;
+    BYTE*        m_gcPtrs = nullptr;
+    unsigned     m_size;
+    unsigned     m_gcPtrCount = 0;
+    SegmentList* m_nonPadding;
 #ifdef DEBUG
     const char* m_name      = "UNNAMED";
     const char* m_shortName = "UNNAMED";
@@ -32,6 +34,8 @@ public:
 
     void SetGCPtrType(unsigned slot, var_types type);
     void CopyInfoFrom(unsigned offset, ClassLayout* layout);
+    void AddPadding(const SegmentList::Segment& padding);
+    void RemovePadding(const SegmentList::Segment& nonPadding);
 
 #ifdef DEBUG
     void SetName(const char* name, const char* shortName);
@@ -67,6 +71,8 @@ private:
         BYTE* m_gcPtrs;
         BYTE  m_gcPtrsArray[sizeof(BYTE*)];
     };
+
+    class SegmentList* m_nonPadding = nullptr;
 
     // The normalized type to use in IR for block nodes with this layout.
     const var_types m_type;
@@ -246,6 +252,8 @@ public:
     }
 
     bool IntersectsGCPtr(unsigned offset, unsigned size) const;
+
+    const SegmentList& GetNonPadding(Compiler* comp);
 
     static bool AreCompatible(const ClassLayout* layout1, const ClassLayout* layout2);
 

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -720,9 +720,9 @@ public:
                         return true;
                     }
 
-                    const StructSegments& significantSegments = comp->GetSignificantSegments(otherAccess.Layout);
+                    const SegmentList& significantSegments = otherAccess.Layout->GetNonPadding(comp);
                     if (!significantSegments.Intersects(
-                            StructSegments::Segment(layoutOffset + accessSize, layoutOffset + TARGET_POINTER_SIZE)))
+                            SegmentList::Segment(layoutOffset + accessSize, layoutOffset + TARGET_POINTER_SIZE)))
                     {
                         return true;
                     }
@@ -1296,17 +1296,17 @@ public:
             }
 #endif
 
-            agg->Unpromoted = m_compiler->GetSignificantSegments(m_compiler->lvaGetDesc(agg->LclNum)->GetLayout());
+            agg->Unpromoted = m_compiler->lvaGetDesc(agg->LclNum)->GetLayout()->GetNonPadding(m_compiler);
             for (Replacement& rep : reps)
             {
-                agg->Unpromoted.Subtract(StructSegments::Segment(rep.Offset, rep.Offset + genTypeSize(rep.AccessType)));
+                agg->Unpromoted.Subtract(SegmentList::Segment(rep.Offset, rep.Offset + genTypeSize(rep.AccessType)));
             }
 
             JITDUMP("  Unpromoted remainder: ");
             DBEXEC(m_compiler->verbose, agg->Unpromoted.Dump());
             JITDUMP("\n\n");
 
-            StructSegments::Segment unpromotedSegment;
+            SegmentList::Segment unpromotedSegment;
             if (agg->Unpromoted.CoveringSegment(&unpromotedSegment))
             {
                 agg->UnpromotedMin = unpromotedSegment.Start;
@@ -2281,7 +2281,7 @@ bool ReplaceVisitor::CanReplaceCallArgWithFieldListOfReplacements(GenTreeCall*  
             // the remainder is a different promotion we will return false when
             // the replacement is visited in this callback.
             if ((repSize < seg.Size) &&
-                agg->Unpromoted.Intersects(StructSegments::Segment(rep.Offset + repSize, rep.Offset + seg.Size)))
+                agg->Unpromoted.Intersects(SegmentList::Segment(rep.Offset + repSize, rep.Offset + seg.Size)))
             {
                 return false;
             }

--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -46,7 +46,7 @@ struct AggregateInfo
     jitstd::vector<Replacement> Replacements;
     unsigned                    LclNum;
     // Unpromoted parts of the struct local.
-    StructSegments Unpromoted;
+    SegmentList Unpromoted;
     // Min offset in the struct local of the unpromoted part.
     unsigned UnpromotedMin = 0;
     // Max offset in the struct local of the unpromoted part.
@@ -98,7 +98,7 @@ class Promotion
     friend class PromotionLiveness;
     friend class ReplaceVisitor;
     friend class DecompositionPlan;
-    friend class StructSegments;
+    friend class SegmentList;
 
     void            ExplicitlyZeroInitReplacementLocals(unsigned                           lclNum,
                                                         const jitstd::vector<Replacement>& replacements,

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -234,17 +234,17 @@ private:
     //   need to be considered part of the remainder. For example, the last 4
     //   bytes of Span<T> on 64-bit are not returned as the remainder.
     //
-    StructSegments ComputeRemainder()
+    SegmentList ComputeRemainder()
     {
         ClassLayout* dstLayout = m_store->GetLayout(m_compiler);
 
-        StructSegments segments = m_compiler->GetSignificantSegments(dstLayout);
+        SegmentList segments(dstLayout->GetNonPadding(m_compiler));
 
         for (int i = 0; i < m_entries.Height(); i++)
         {
             const Entry& entry = m_entries.BottomRef(i);
 
-            segments.Subtract(StructSegments::Segment(entry.Offset, entry.Offset + genTypeSize(entry.Type)));
+            segments.Subtract(SegmentList::Segment(entry.Offset, entry.Offset + genTypeSize(entry.Type)));
         }
 
 #ifdef DEBUG
@@ -301,14 +301,14 @@ private:
             return RemainderStrategy(RemainderStrategy::NoRemainder);
         }
 
-        StructSegments remainder = ComputeRemainder();
+        SegmentList remainder = ComputeRemainder();
         if (remainder.IsEmpty())
         {
             JITDUMP("  => Remainder strategy: do nothing (no remainder)\n");
             return RemainderStrategy(RemainderStrategy::NoRemainder);
         }
 
-        StructSegments::Segment segment;
+        SegmentList::Segment segment;
         // See if we can "plug the hole" with a single primitive.
         if (remainder.CoveringSegment(&segment))
         {

--- a/src/coreclr/jit/promotionliveness.cpp
+++ b/src/coreclr/jit/promotionliveness.cpp
@@ -234,7 +234,7 @@ void PromotionLiveness::MarkUseDef(Statement* stmt, GenTreeLclVarCommon* lcl, Bi
             }
 
             bool isFullDefOfRemainder = isDef && (agg->UnpromotedMin >= offs) && (agg->UnpromotedMax <= (offs + size));
-            bool isUseOfRemainder     = isUse && agg->Unpromoted.Intersects(StructSegments::Segment(offs, offs + size));
+            bool isUseOfRemainder     = isUse && agg->Unpromoted.Intersects(SegmentList::Segment(offs, offs + size));
             MarkIndex(baseIndex, isUseOfRemainder, isFullDefOfRemainder, useSet, defSet);
         }
     }
@@ -580,7 +580,7 @@ void PromotionLiveness::FillInLiveness(BitVec& life, BitVec volatileVars, Statem
             {
                 BitVecOps::AddElemD(&aggTraits, aggDeaths, 0);
 
-                if (isUse && agg->Unpromoted.Intersects(StructSegments::Segment(offs, offs + size)))
+                if (isUse && agg->Unpromoted.Intersects(SegmentList::Segment(offs, offs + size)))
                 {
                     BitVecOps::AddElemD(m_bvTraits, life, baseIndex);
                 }

--- a/src/coreclr/jit/segmentlist.h
+++ b/src/coreclr/jit/segmentlist.h
@@ -6,12 +6,14 @@
 #include "alloc.h"
 #include "jitstd/vector.h"
 
-// Represents significant segments of a struct operation.
+// Represents a list of segments.
 //
 // Essentially a segment tree (but not stored as a tree) that supports boolean
 // Add/Subtract operations of segments. Used to compute the remainder after
-// replacements have been handled as part of a decomposed block operation.
-class StructSegments
+// replacements have been handled as part of a decomposed block operation in
+// physical promotion. Also used to store non-padding of class layouts.
+//
+class SegmentList
 {
 public:
     struct Segment
@@ -38,8 +40,9 @@ public:
 private:
     jitstd::vector<Segment> m_segments;
 
+    size_t BinarySearchEnd(unsigned offset) const;
 public:
-    explicit StructSegments(CompAllocator allocator)
+    explicit SegmentList(CompAllocator allocator)
         : m_segments(allocator)
     {
     }
@@ -49,6 +52,26 @@ public:
     bool IsEmpty() const;
     bool CoveringSegment(Segment* result) const;
     bool Intersects(const Segment& segment) const;
+
+    jitstd::vector<Segment>::iterator begin()
+    {
+        return m_segments.begin();
+    }
+
+    jitstd::vector<Segment>::iterator end()
+    {
+        return m_segments.end();
+    }
+
+    jitstd::vector<Segment>::const_iterator begin() const
+    {
+        return m_segments.begin();
+    }
+
+    jitstd::vector<Segment>::const_iterator end() const
+    {
+        return m_segments.end();
+    }
 
 #ifdef DEBUG
     void Dump();


### PR DESCRIPTION
* Rename `StructSegments` -> `SegmentList`
* Add `ClassLayout::GetNonPadding` to get the non-padding of a class layout. Computed lazily for `CORINFO_CLASS_HANDLE` backed layouts and saved ahead of time for custom layouts.
* Add `ClassLayoutBuilder::AddPadding` and `ClassLayoutBuilder::RemovePadding`
* Remove `Compiler::GetSignificantSegments` and switch uses to `ClassLayout->GetNonPadding()`