### PR TITLE
fix #112163

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -7247,7 +7247,15 @@ void CodeGen::genFloatToFloatCast(GenTree* treeNode)
         // floating-point conversions all have RMW semantics if VEX support is not available
 
         bool isRMW = !compiler->canUseVexEncoding();
-        inst_RV_RV_TT(ins, emitTypeSize(dstType), targetReg, targetReg, op1, isRMW, INS_OPTS_NONE);
+        if (ins == INS_movss)
+        {
+            //Specially, movss does not have equivalent form of ins src1, src1, src2
+            inst_RV_TT(ins, emitTypeSize(dstType), targetReg, op1);
+        }
+        else
+        {
+            inst_RV_RV_TT(ins, emitTypeSize(dstType), targetReg, targetReg, op1, isRMW, INS_OPTS_NONE);
+        }
     }
 
     genProduceReg(treeNode);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -7249,7 +7249,7 @@ void CodeGen::genFloatToFloatCast(GenTree* treeNode)
         bool isRMW = !compiler->canUseVexEncoding();
         if (ins == INS_movss)
         {
-            //Specially, movss does not have equivalent form of ins src1, src1, src2
+            // Specially, movss does not have equivalent form of ins src1, src1, src2
             inst_RV_TT(ins, emitTypeSize(dstType), targetReg, op1);
         }
         else


### PR DESCRIPTION
More details in https://github.com/dotnet/runtime/issues/112163#issuecomment-2637988122

I'm not so sure if simply isolating the case for `vmovss` will be a proper fix, but I will run through the CI first to check if there is any other problem.