### PR TITLE
JIT: Fix illegal instruction encoding for float->float casts

### DIFF
--- a/eng/pipelines/coreclr/jitstress-isas-avx512.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-avx512.yml
@@ -1,20 +1,6 @@
 # This pipeline only runs on GitHub PRs, not on merges.
 trigger: none
 
-# Only run on specific changes to the JIT directory that are likely to affect AVX-512.
-pr:
-  branches:
-    include:
-    - main
-  paths:
-    include:
-    - src/coreclr/jit/hwintrinsiccodegenxarch.cpp
-    - src/coreclr/jit/hwintrinsiclistxarch.h
-    - src/coreclr/jit/hwintrinsicxarch.cpp
-    - src/coreclr/jit/instrsxarch.h
-    - src/coreclr/jit/emitxarch.cpp
-    - src/coreclr/jit/emitxarch.h
-
 schedules:
 - cron: "30 19 * * 6"
   displayName: Sat at 11:30 AM (UTC-8:00)

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -7234,11 +7234,16 @@ void CodeGen::genFloatToFloatCast(GenTree* treeNode)
     assert(varTypeIsFloating(srcType) && varTypeIsFloating(dstType));
 
     genConsumeOperands(treeNode->AsOp());
-    if (srcType == dstType && (op1->isUsedFromReg() && (targetReg == op1->GetRegNum())))
+    if (srcType == dstType)
     {
-        // source and destinations types are the same and also reside in the same register.
-        // we just need to consume and produce the reg in this case.
-        ;
+        if (op1->isUsedFromReg())
+        {
+            GetEmitter()->emitIns_Mov(INS_movaps, EA_16BYTE, targetReg, op1->GetRegNum(), /* canSkip */ true);
+        }
+        else
+        {
+            inst_RV_TT(ins_Move_Extend(dstType, /* srcInReg */ false), emitTypeSize(dstType), targetReg, op1);
+        }
     }
     else
     {

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2477,8 +2477,6 @@ instruction CodeGen::ins_FloatConv(var_types to, var_types from)
                     return INS_cvttss2si32;
                 case TYP_LONG:
                     return INS_cvttss2si64;
-                case TYP_FLOAT:
-                    return ins_Move_Extend(TYP_FLOAT, false);
                 case TYP_DOUBLE:
                     return INS_cvtss2sd;
                 case TYP_ULONG:
@@ -2499,8 +2497,6 @@ instruction CodeGen::ins_FloatConv(var_types to, var_types from)
                     return INS_cvttsd2si64;
                 case TYP_FLOAT:
                     return INS_cvtsd2ss;
-                case TYP_DOUBLE:
-                    return ins_Move_Extend(TYP_DOUBLE, false);
                 case TYP_ULONG:
                     return INS_vcvttsd2usi64;
                 case TYP_UINT:


### PR DESCRIPTION
Fixes #112163 

This resolves the illegal instruction encoding by no longer pretending that `movss` and `movsd` are 'conversion' instructions, which have different encoding forms.

There's a minor codegen improvement ([diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=941905&view=ms.vss-build-web.run-extensions-tab)) when a no-op cast has different source and target registers, where we now emit `movaps` instead of `movss`/`movsd`. Previously we would elide the cast only if source and target reg were the same.

```diff
-       vmovss   xmm1, xmm1, xmm2
+       vmovaps  xmm1, xmm2
        vbroadcastss xmm1, xmm1
```