### PR TITLE
[LoongArch64] Fix some assertion failures for Debug ILC building Debug NativeAOT testcases.

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -7167,7 +7167,8 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
 
     if (leftFrameSize != 0)
     {
-        genStackPointerAdjustment(-leftFrameSize, initReg, pInitRegZeroed, /* reportUnwindData */ true);
+        // We've already established the frame pointer, so no need to report the stack pointer change to unwind info.
+        genStackPointerAdjustment(-leftFrameSize, initReg, pInitRegZeroed, /* reportUnwindData */ false);
     }
 }
 

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2504,8 +2504,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     //   else if (callType == EC_FUNC_TOKEN || callType == EC_FUNC_ADDR)
     //     if reloc:
     //             //pc + offset_38bits       # only when reloc.
-    //      pcaddu18i  t2, addr-hi20
-    //      jilr r0/1,t2,addr-lo18
+    //      pcaddu18i  t4, addr-hi20
+    //      jilr r0/1, t4, addr-lo18
     //
     //     else:
     //      lu12i_w  t2, dst_offset_lo32-hi
@@ -2634,7 +2634,7 @@ unsigned emitter::emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t 
         // pc + offset_38bits
         //
         //   pcaddu18i  t4, addr-hi20
-        //   jilr r0/1,t4,addr-lo18
+        //   jilr r0/1, t4, addr-lo18
 
         emitOutput_Instr(dst, 0x1e000000 | (int)REG_DEFAULT_HELPER_CALL_TARGET);
 
@@ -2643,7 +2643,6 @@ unsigned emitter::emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t 
         int reg2 = (int)addr & 1;
         addr     = addr ^ 1;
 
-        assert(isValidSimm38(addr - (ssize_t)dst));
         assert((addr & 3) == 0);
 
         dst += 4;

--- a/src/coreclr/jit/emitloongarch64.h
+++ b/src/coreclr/jit/emitloongarch64.h
@@ -170,40 +170,10 @@ static bool isValidSimm12(ssize_t value)
     return -(((int)1) << 11) <= value && value < (((int)1) << 11);
 };
 
-// Returns true if 'value' is a legal signed immediate 16 bit encoding.
-static bool isValidSimm16(ssize_t value)
-{
-    return -(((int)1) << 15) <= value && value < (((int)1) << 15);
-};
-
-// Returns true if 'value' is a legal unsigned immediate 16 bit encoding.
-static bool isValidUimm16(ssize_t value)
-{
-    return (0 == (value >> 16));
-};
-
-// Returns true if 'value' is a legal signed immediate 18 bit encoding.
-static bool isValidSimm18(ssize_t value)
-{
-    return -(((int)1) << 17) <= value && value < (((int)1) << 17);
-};
-
 // Returns true if 'value' is a legal signed immediate 20 bit encoding.
 static bool isValidSimm20(ssize_t value)
 {
     return -(((int)1) << 19) <= value && value < (((int)1) << 19);
-};
-
-// Returns true if 'value' is a legal signed immediate 28 bit encoding.
-static bool isValidSimm28(ssize_t value)
-{
-    return -(((int)1) << 27) <= value && value < (((int)1) << 27);
-};
-
-// Returns true if 'value' is a legal signed immediate 38 bit encoding.
-static bool isValidSimm38(ssize_t value)
-{
-    return -(((ssize_t)1) << 37) <= value && value < (((ssize_t)1) << 37);
 };
 
 // Returns the number of bits used by the given 'size'.

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -418,7 +418,7 @@ namespace ILCompiler.DependencyAnalysis
 
             uint pcInstr = *pCode;
 
-            Debug.Assert(pcInstr == 0x1e00000e);  // Must be pcaddu18i R14, 0
+            Debug.Assert(pcInstr == 0x1e000010);  // Must be pcaddu18i t4, 0
 
             long relOff = imm38 & 0x20000;
             long imm = imm38 + relOff;

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -2340,7 +2340,7 @@ void PutLoongArch64JIR(UINT32 * pCode, INT64 imm38)
 
     UINT32 pcInstr = *pCode;
 
-    _ASSERTE(pcInstr == 0x1e00000e); // Must be pcaddu18i R14, 0
+    _ASSERTE(pcInstr == 0x1e000010); // Must be pcaddu18i t4, 0
 
     INT64 relOff = imm38 & 0x20000;
     INT64 imm = imm38 + relOff;


### PR DESCRIPTION
* Fix some assertion failures for Debug ILC building Debug NativeAOT testcases.
* Fix the break of backtrace when already establish the frame pointer chain.
* Delete some unused codes.