### PR TITLE
System.Configuration.ConfigurationManager.Tests: use Assembly.Location to determine ThisApplicationPath.

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
@@ -132,15 +132,6 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/21319", TargetFrameworkMonikers.NetFramework)]
-        public void exePath_UserLevelNone()
-        {
-            string name = TestUtil.ThisApplicationPath;
-            SysConfig config = ConfigurationManager.OpenExeConfiguration(name);
-            Assert.Equal(TestUtil.ThisApplicationPath + ".config", config.FilePath);
-        }
-
-        [Fact]
         public void exePath_UserLevelPerRoaming()
         {
             string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
@@ -54,17 +54,6 @@ namespace MonoTests.System.Configuration.Util
             }
         }
 
-        public static string ThisApplicationPath
-        {
-            get
-            {
-                Assembly assembly = Assembly.GetEntryAssembly();
-                string directory = Path.GetDirectoryName(assembly.Location);
-                string fileName = assembly.ManifestModule.Name;
-                return Path.Combine(directory, fileName);
-            }
-        }
-
         public static string ThisConfigFileName
         {
             get

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
@@ -58,8 +58,10 @@ namespace MonoTests.System.Configuration.Util
         {
             get
             {
-                return Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
-                    Assembly.GetEntryAssembly().ManifestModule.Name);
+                Assembly assembly = Assembly.GetEntryAssembly();
+                string directory = Path.GetDirectoryName(assembly.Location);
+                string fileName = assembly.ManifestModule.Name;
+                return Path.Combine(directory, fileName);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/108476.

@ViktorHofer @steveharter ptal.