### PR TITLE
[9.0] Backport labeling workflow changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,3 +113,4 @@
 /docs/area-owners.*                                 @jeffhandley
 /docs/issue*.md                                     @jeffhandley
 /.github/policies/                                  @jeffhandley @mkArtakMSFT
+/.github/workflows/                                 @dotnet/runtime-infrastructure

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,4 +113,4 @@
 /docs/area-owners.*                                 @jeffhandley
 /docs/issue*.md                                     @jeffhandley
 /.github/policies/                                  @jeffhandley @mkArtakMSFT
-/.github/workflows/                                 @dotnet/runtime-infrastructure
+/.github/workflows/                                 @jeffhandley @dotnet/runtime-infrastructure

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,6 @@
+# Workflows
+
+General guidance:
+
+- Please make sure to include the @dotnet/runtime-infrastructure group as a reviewer of your PRs.
+- Do not use the `pull_request` event. Use `pull_request_target` instead, as documented in [Workflows in forked repositories](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories) and [pull_request_target](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,5 +2,21 @@
 
 General guidance:
 
-- Please make sure to include the @dotnet/runtime-infrastructure group as a reviewer of your PRs.
-- Do not use the `pull_request` event. Use `pull_request_target` instead, as documented in [Workflows in forked repositories](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories) and [pull_request_target](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target).
+Please make sure to include the @dotnet/runtime-infrastructure group as a reviewer of your PRs.
+
+For workflows that are triggered by pull requests, refer to GitHub's documentation for the `pull_request` and `pull_request_target` events. The `pull_request_target` event is the more common use case in this repository as it runs the workflow in the context of the target branch instead of in the context of the pull request's fork or branch. However, workflows that need to consume the contents of the pull request need to use the `pull_request` event. There are security considerations with each of the events though.
+
+Most workflows are intended to run only in the `dotnet/runtime` repository and not in forks. To force workflow jobs to be skipped in forks, each job should apply an `if` statement that checks the repository name or owner. Either approach works, but checking only the repository owner allows the workflow to run in copies or forks withing the dotnet org.
+
+```yaml
+jobs:
+  job-1:
+    # Do not run this job in forks
+    if: github.repository == 'dotnet/runtime'
+
+  job-2:
+    # Do not run this job in forks outside the dotnet org
+    if: github.repository_owner == 'dotnet'
+```
+
+Refer to GitHub's [Workflows in forked repositories](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories) and [pull_request_target](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) documentation for more information.

--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   check-labels:
+    if: github.repository == 'dotnet/runtime'
     runs-on: ubuntu-latest
     steps:
     - name: Check 'NO-MERGE' label

--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -1,0 +1,25 @@
+name: check-no-merge-label
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled]
+    branches:
+      - 'main'
+      - 'release/**'
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check 'NO-MERGE' label
+      run: |
+        echo "Merging permission is disabled when the 'NO-MERGE' label is applied."
+        if [ "${{ contains(github.event.pull_request.labels.*.name, 'NO-MERGE') }}" = "false" ]; then
+          exit 0
+        else
+          echo "::error:: The 'NO-MERGE' label was applied to the PR. Merging is disabled."
+          exit 1
+        fi

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   check-labels:
+    if: github.repository == 'dotnet/runtime'
     runs-on: ubuntu-latest
     steps:
     - name: Check 'Servicing-approved' label

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -4,8 +4,8 @@ permissions:
   pull-requests: read
 
 on:
-  pull_request:
-    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+  pull_request_target:
+    types: [labeled, unlabeled]
     branches:
       - 'release/**'
 

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled]
+    types: [opened, reopened, labeled, unlabeled]
     branches:
       - 'release/**'
 


### PR DESCRIPTION
cc @jeffhandley 

Backporting https://github.com/dotnet/runtime/pull/112169 and https://github.com/dotnet/runtime/pull/112161

Infra only, tell-mode.

Backporting to the release/9.0 branch so it can flow to release/9.0-staging automatically at any time.

I discussed the functionality with @jeffhandley via chat, and we should _not_ expect the pull_request_target change to work in this PR at the moment. It will start working after this is merged.