### PR TITLE
Our "mono variant" check doesn't work on non-desktop platforms, so explicitly skip on Browser and Wasi

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635_1.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635_1.il
@@ -31,6 +31,10 @@
         type([TestLibrary]TestLibrary.PlatformDetection)
         string[1] ('IsMonoInterpreter')
     }
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.TestPlatforms) = {
+        string('https://github.com/dotnet/runtime/issues/74687')
+        int32(0x2400) // Browser | Wasi
+    }
 
     .entrypoint
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/112244