### PR TITLE
Add another set of debugging prints for stack overflow issue

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -260,6 +260,7 @@ CONFIG_DWORD_INFO(INTERNAL_SuppressLostExceptionTypeAssert, W("SuppressLostExcep
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_UseEntryPointFilter, W("UseEntryPointFilter"), 0, "")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_Corhost_Swallow_Uncaught_Exceptions, W("Corhost_Swallow_Uncaught_Exceptions"), 0, "")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_LegacyExceptionHandling, W("LegacyExceptionHandling"), 0, "Enable legacy exception handling.");
+CONFIG_DWORD_INFO(INTERNAL_LogStackOverflowExit, W("LogStackOverflowExit"), 0, "Temporary flag to log stack overflow exit process")
 
 ///
 /// Garbage collector

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -671,6 +671,9 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
             // Wait for the stack trace logging completion
             DWORD res = WaitForSingleObject(stackDumpThreadHandle, INFINITE);
             _ASSERTE(res == WAIT_OBJECT_0);
+ #ifdef _DEBUG
+            PrintToStdErrA("Stack trace printing helper thread exited.\n");
+ #endif    
         }
 
         g_stackOverflowCallStackLogged = 2;
@@ -701,6 +704,9 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
         if (pThread)
         {
             GCX_COOP();
+#ifdef _DEBUG
+            PrintToStdErrA("Setting throwable.\n");
+#endif    
             // If we had a SO before preallocated exception objects are initialized, we will AV here. This can happen
             // during the initialization of SystemDomain during EEStartup. Thus, setup the SO throwable only if its not
             // NULL.
@@ -734,10 +740,15 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
         }
 #endif // !TARGET_UNIX
 
+#ifdef _DEBUG
+        PrintToStdErrA("Calling WatsonLastChance.\n");
+#endif    
         WatsonLastChance(pThread, pExceptionInfo,
             (fTreatAsNativeUnhandledException == FALSE)? TypeOfReportedError::UnhandledException: TypeOfReportedError::NativeThreadUnhandledException);
     }
-
+#ifdef _DEBUG
+    PrintToStdErrA("Terminating the process.\n");
+#endif    
     CrashDumpAndTerminateProcess(COR_E_STACKOVERFLOW);
     UNREACHABLE();
 }

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -280,6 +280,12 @@ public:
     }
 };
 
+#ifdef _DEBUG
+// Temporarilly added flag to enable extra verbose printing of progress of stack overflow handling
+// to catch a bug that is not reproducible locally.
+static bool g_LogStackOverflowExit = false;
+#endif // _DEBUG
+
 //---------------------------------------------------------------------------------------
 //
 // A worker to save managed stack trace.
@@ -311,7 +317,10 @@ inline void LogCallstackForLogWorker(Thread* pThread, PEXCEPTION_POINTERS pExcep
     pThread->StackWalkFrames(&CallStackLogger::LogCallstackForLogCallback, &logger, QUICKUNWIND | FUNCTIONSONLY | ALLOW_ASYNC_STACK_WALK);
 
     logger.PrintStackTrace(WordAt.GetUnicode());
-
+#ifdef _DEBUG
+    if (g_LogStackOverflowExit)
+        PrintToStdErrA("@Exiting stack trace printing thread.\n");
+#endif
 }
 
 //---------------------------------------------------------------------------------------
@@ -663,6 +672,10 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
     // multiple stack traces together.
     if (InterlockedCompareExchange(&g_stackOverflowCallStackLogged, 1, 0) == 0)
     {
+#ifdef _DEBUG
+        g_LogStackOverflowExit = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_LogStackOverflowExit) != 0;
+#endif
+ 
         DisplayStackOverflowException();
 
         HandleHolder stackDumpThreadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, LogStackOverflowStackTraceThread, GetThreadNULLOk(), W(".NET Stack overflow trace logger"));
@@ -672,20 +685,30 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
             DWORD res = WaitForSingleObject(stackDumpThreadHandle, INFINITE);
             _ASSERTE(res == WAIT_OBJECT_0);
  #ifdef _DEBUG
-            PrintToStdErrA("Stack trace printing helper thread exited.\n");
- #endif    
+            if (g_LogStackOverflowExit)
+                PrintToStdErrA("@Stack trace printing helper thread exited.\n");
+ #endif
         }
 
         g_stackOverflowCallStackLogged = 2;
     }
     else
     {
+#ifdef _DEBUG
+        if (g_LogStackOverflowExit)
+            PrintToStdErrA("@Waiting for thread that's logging stack overflow.\n");
+#endif
         // Wait for the thread that is logging the stack trace to complete
         while (g_stackOverflowCallStackLogged != 2)
         {
             Sleep(50);
         }
     }
+
+#ifdef _DEBUG
+    if (g_LogStackOverflowExit)
+        PrintToStdErrA("@Proceeding with exit.\n");
+#endif
 
     if(ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context, FailFast))
     {
@@ -705,8 +728,9 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
         {
             GCX_COOP();
 #ifdef _DEBUG
-            PrintToStdErrA("Setting throwable.\n");
-#endif    
+            if (g_LogStackOverflowExit)
+                PrintToStdErrA("@Setting throwable.\n");
+#endif
             // If we had a SO before preallocated exception objects are initialized, we will AV here. This can happen
             // during the initialization of SystemDomain during EEStartup. Thus, setup the SO throwable only if its not
             // NULL.
@@ -741,14 +765,16 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
 #endif // !TARGET_UNIX
 
 #ifdef _DEBUG
-        PrintToStdErrA("Calling WatsonLastChance.\n");
-#endif    
+        if (g_LogStackOverflowExit)
+            PrintToStdErrA("@Calling WatsonLastChance.\n");
+#endif
         WatsonLastChance(pThread, pExceptionInfo,
             (fTreatAsNativeUnhandledException == FALSE)? TypeOfReportedError::UnhandledException: TypeOfReportedError::NativeThreadUnhandledException);
     }
 #ifdef _DEBUG
-    PrintToStdErrA("Terminating the process.\n");
-#endif    
+    if (g_LogStackOverflowExit)
+        PrintToStdErrA("@Terminating the process.\n");
+#endif
     CrashDumpAndTerminateProcess(COR_E_STACKOVERFLOW);
     UNREACHABLE();
 }

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -24,6 +24,7 @@ namespace TestStackOverflow
             testProcess.StartInfo.UseShellExecute = false;
             testProcess.StartInfo.RedirectStandardError = true;
             testProcess.StartInfo.Environment.Add("DOTNET_DbgEnableMiniDump", "0");
+            testProcess.StartInfo.Environment.Add("DOTNET_LogStackOverflowExit", "1");
             bool endOfStackTrace = false;
             
             testProcess.ErrorDataReceived += (sender, line) => 
@@ -40,7 +41,7 @@ namespace TestStackOverflow
                     {
                         lines.Add(line.Data);
                     }
-                    else
+                    else if (!line.Data.StartsWith("@"))
                     {
                         endOfStackTrace = true;
                     }


### PR DESCRIPTION
This adds more debugging output to help figure out the mysterious failure of the stack overflow tests that occur regularly in the lab, but that I am unable to repro locally.
Since I was unable to get it to repro even by manually triggering test runs from this PR over and over, I want to temporarily merge this change in to let the CI get me a repro.
The extra logging is under a temporarily added DOTNET_xxx env var to ensure that it is not visible outside of the stack overflow test.