### PR TITLE
Special-case empty enumerables in AsyncEnumerable

### DIFF
--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateBy.cs
@@ -42,7 +42,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(func);
 
-            return Impl(source, keySelector, seed, func, keyComparer, default);
+            return
+                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                Impl(source, keySelector, seed, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -117,7 +119,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(func);
 
-            return Impl(source, keySelector, seed, func, keyComparer, default);
+            return
+                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                Impl(source, keySelector, seed, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -188,7 +192,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(seedSelector);
             ThrowHelper.ThrowIfNull(func);
 
-            return Impl(source, keySelector, seedSelector, func, keyComparer, default);
+            return
+                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                Impl(source, keySelector, seedSelector, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -264,7 +270,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(seedSelector);
             ThrowHelper.ThrowIfNull(func);
 
-            return Impl(source, keySelector, seedSelector, func, keyComparer, default);
+            return
+                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                Impl(source, keySelector, seedSelector, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -277,28 +285,26 @@ namespace System.Linq
                 IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
                 try
                 {
-                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    if (await enumerator.MoveNextAsync().ConfigureAwait(false))
                     {
-                        yield break;
-                    }
+                        Dictionary<TKey, TAccumulate> dict = new(keyComparer);
 
-                    Dictionary<TKey, TAccumulate> dict = new(keyComparer);
+                        do
+                        {
+                            TSource value = enumerator.Current;
+                            TKey key = await keySelector(value, cancellationToken).ConfigureAwait(false);
 
-                    do
-                    {
-                        TSource value = enumerator.Current;
-                        TKey key = await keySelector(value, cancellationToken).ConfigureAwait(false);
+                            dict[key] = await func(
+                                dict.TryGetValue(key, out TAccumulate? acc) ? acc : await seedSelector(key, cancellationToken).ConfigureAwait(false),
+                                value,
+                                cancellationToken).ConfigureAwait(false);
+                        }
+                        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
 
-                        dict[key] = await func(
-                            dict.TryGetValue(key, out TAccumulate? acc) ? acc : await seedSelector(key, cancellationToken).ConfigureAwait(false),
-                            value,
-                            cancellationToken).ConfigureAwait(false);
-                    }
-                    while (await enumerator.MoveNextAsync().ConfigureAwait(false));
-
-                    foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
-                    {
-                        yield return countBy;
+                        foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
+                        {
+                            yield return countBy;
+                        }
                     }
                 }
                 finally

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateBy.cs
@@ -43,7 +43,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(func);
 
             return
-                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                source.IsKnownEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
                 Impl(source, keySelector, seed, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(
@@ -120,7 +120,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(func);
 
             return
-                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                source.IsKnownEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
                 Impl(source, keySelector, seed, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(
@@ -193,7 +193,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(func);
 
             return
-                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                source.IsKnownEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
                 Impl(source, keySelector, seedSelector, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(
@@ -271,7 +271,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(func);
 
             return
-                source.IsEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
+                source.IsKnownEmpty() ? Empty<KeyValuePair<TKey, TAccumulate>>() :
                 Impl(source, keySelector, seedSelector, func, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, TAccumulate>> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Cast.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Cast.cs
@@ -27,7 +27,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 source as IAsyncEnumerable<TResult> ??
                 Impl(source, default);
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Cast.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Cast.cs
@@ -26,8 +26,9 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return source is IAsyncEnumerable<TResult> result ?
-                result :
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                source as IAsyncEnumerable<TResult> ??
                 Impl(source, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Chunk.cs
@@ -30,7 +30,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNegativeOrZero(size);
 
-            return Chunk(source, size, default);
+            return
+                source.IsEmpty() ? Empty<TSource[]>() :
+                Chunk(source, size, default);
 
             async static IAsyncEnumerable<TSource[]> Chunk(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Chunk.cs
@@ -31,7 +31,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNegativeOrZero(size);
 
             return
-                source.IsEmpty() ? Empty<TSource[]>() :
+                source.IsKnownEmpty() ? Empty<TSource[]>() :
                 Chunk(source, size, default);
 
             async static IAsyncEnumerable<TSource[]> Chunk(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Concat.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Concat.cs
@@ -23,7 +23,10 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(first);
             ThrowHelper.ThrowIfNull(second);
 
-            return Impl(first, second, default);
+            return
+                first.IsEmpty() ? second :
+                second.IsEmpty() ? first :
+                Impl(first, second, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Concat.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Concat.cs
@@ -24,8 +24,8 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
 
             return
-                first.IsEmpty() ? second :
-                second.IsEmpty() ? first :
+                first.IsKnownEmpty() ? second :
+                second.IsKnownEmpty() ? first :
                 Impl(first, second, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountBy.cs
@@ -28,7 +28,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, keyComparer, default);
+            return
+                source.IsEmpty() ? Empty<KeyValuePair<TKey, int>>() :
+                Impl(source, keySelector, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, int>> Impl(
                 IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? keyComparer, [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -83,7 +85,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, keyComparer, default);
+            return
+                source.IsEmpty() ? Empty<KeyValuePair<TKey, int>>() :
+                Impl(source, keySelector, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, int>> Impl(
                 IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, IEqualityComparer<TKey>? keyComparer, [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountBy.cs
@@ -29,7 +29,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? Empty<KeyValuePair<TKey, int>>() :
+                source.IsKnownEmpty() ? Empty<KeyValuePair<TKey, int>>() :
                 Impl(source, keySelector, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, int>> Impl(
@@ -86,7 +86,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? Empty<KeyValuePair<TKey, int>>() :
+                source.IsKnownEmpty() ? Empty<KeyValuePair<TKey, int>>() :
                 Impl(source, keySelector, keyComparer, default);
 
             static async IAsyncEnumerable<KeyValuePair<TKey, int>> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Distinct.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Distinct.cs
@@ -21,7 +21,9 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source, comparer, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Distinct.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Distinct.cs
@@ -22,7 +22,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DistinctBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DistinctBy.cs
@@ -33,7 +33,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -89,7 +89,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DistinctBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DistinctBy.cs
@@ -32,7 +32,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -86,7 +88,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Empty.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Empty.cs
@@ -17,12 +17,13 @@ namespace System.Linq
         public static IAsyncEnumerable<TResult> Empty<TResult>() => EmptyAsyncEnumerable<TResult>.Instance;
 
         /// <summary>Determines whether <paramref name="source"/> is known to be an always-empty enumerable.</summary>
-        private static bool IsEmpty<TResult>(this IAsyncEnumerable<TResult> source) => source is EmptyAsyncEnumerable<TResult>;
+        private static bool IsEmpty<TResult>(this IAsyncEnumerable<TResult> source) =>
+            ReferenceEquals(source, EmptyAsyncEnumerable<TResult>.Instance);
 
         private sealed class EmptyAsyncEnumerable<TResult> :
             IAsyncEnumerable<TResult>, IAsyncEnumerator<TResult>, IOrderedAsyncEnumerable<TResult>
         {
-            public static EmptyAsyncEnumerable<TResult> Instance { get; } = new EmptyAsyncEnumerable<TResult>();
+            public static readonly EmptyAsyncEnumerable<TResult> Instance = new();
 
             public IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default) => this;
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Empty.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Empty.cs
@@ -16,7 +16,11 @@ namespace System.Linq
         /// <returns>An empty <see cref="IAsyncEnumerable{T}"/> whose type argument is <typeparamref name="TResult"/>.</returns>
         public static IAsyncEnumerable<TResult> Empty<TResult>() => EmptyAsyncEnumerable<TResult>.Instance;
 
-        private sealed class EmptyAsyncEnumerable<TResult> : IAsyncEnumerable<TResult>, IAsyncEnumerator<TResult>
+        /// <summary>Determines whether <paramref name="source"/> is known to be an always-empty enumerable.</summary>
+        private static bool IsEmpty<TResult>(this IAsyncEnumerable<TResult> source) => source is EmptyAsyncEnumerable<TResult>;
+
+        private sealed class EmptyAsyncEnumerable<TResult> :
+            IAsyncEnumerable<TResult>, IAsyncEnumerator<TResult>, IOrderedAsyncEnumerable<TResult>
         {
             public static EmptyAsyncEnumerable<TResult> Instance { get; } = new EmptyAsyncEnumerable<TResult>();
 
@@ -27,6 +31,18 @@ namespace System.Linq
             public TResult Current => default!;
 
             public ValueTask DisposeAsync() => default;
+
+            public IOrderedAsyncEnumerable<TResult> CreateOrderedAsyncEnumerable<TKey>(Func<TResult, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
+            {
+                ThrowHelper.ThrowIfNull(keySelector);
+                return this;
+            }
+
+            public IOrderedAsyncEnumerable<TResult> CreateOrderedAsyncEnumerable<TKey>(Func<TResult, CancellationToken, ValueTask<TKey>> keySelector, IComparer<TKey>? comparer, bool descending)
+            {
+                ThrowHelper.ThrowIfNull(keySelector);
+                return this;
+            }
         }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Empty.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Empty.cs
@@ -17,7 +17,7 @@ namespace System.Linq
         public static IAsyncEnumerable<TResult> Empty<TResult>() => EmptyAsyncEnumerable<TResult>.Instance;
 
         /// <summary>Determines whether <paramref name="source"/> is known to be an always-empty enumerable.</summary>
-        private static bool IsEmpty<TResult>(this IAsyncEnumerable<TResult> source) =>
+        private static bool IsKnownEmpty<TResult>(this IAsyncEnumerable<TResult> source) =>
             ReferenceEquals(source, EmptyAsyncEnumerable<TResult>.Instance);
 
         private sealed class EmptyAsyncEnumerable<TResult> :

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Except.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Except.cs
@@ -26,7 +26,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(first);
             ThrowHelper.ThrowIfNull(second);
 
-            return Impl(first, second, comparer, default);
+            return
+                first.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, comparer, default);
 
             async static IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,
@@ -34,19 +36,34 @@ namespace System.Linq
                 IEqualityComparer<TSource>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                HashSet<TSource> set = new(comparer);
-
-                await foreach (TSource element in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                IAsyncEnumerator<TSource> firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+                try
                 {
-                    set.Add(element);
-                }
-
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
-                {
-                    if (set.Add(element))
+                    if (!await firstEnumerator.MoveNextAsync().ConfigureAwait(false))
                     {
-                        yield return element;
+                        yield break;
                     }
+
+                    HashSet<TSource> set = new(comparer);
+
+                    await foreach (TSource element in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                    {
+                        set.Add(element);
+                    }
+
+                    do
+                    {
+                        TSource firstElement = firstEnumerator.Current;
+                        if (set.Add(firstElement))
+                        {
+                            yield return firstElement;
+                        }
+                    }
+                    while (await firstEnumerator.MoveNextAsync().ConfigureAwait(false));
+                }
+                finally
+                {
+                    await firstEnumerator.DisposeAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Except.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Except.cs
@@ -27,7 +27,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
 
             return
-                first.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, comparer, default);
 
             async static IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ExceptBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ExceptBy.cs
@@ -33,7 +33,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(first, second, keySelector, comparer, default);
+            return
+                first.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,
@@ -42,19 +44,34 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                HashSet<TKey> set = new(comparer);
-
-                await foreach (TKey key in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                IAsyncEnumerator<TSource> firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+                try
                 {
-                    set.Add(key);
-                }
-
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
-                {
-                    if (set.Add(keySelector(element)))
+                    if (!await firstEnumerator.MoveNextAsync().ConfigureAwait(false))
                     {
-                        yield return element;
+                        yield break;
                     }
+
+                    HashSet<TKey> set = new(comparer);
+
+                    await foreach (TKey key in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                    {
+                        set.Add(key);
+                    }
+
+                    do
+                    {
+                        TSource firstElement = firstEnumerator.Current;
+                        if (set.Add(keySelector(firstElement)))
+                        {
+                            yield return firstElement;
+                        }
+                    }
+                    while (await firstEnumerator.MoveNextAsync().ConfigureAwait(false));
+                }
+                finally
+                {
+                    await firstEnumerator.DisposeAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -82,7 +99,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(first, second, keySelector, comparer, default);
+            return
+                first.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,
@@ -91,19 +110,34 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                HashSet<TKey> set = new(comparer);
-
-                await foreach (TKey key in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                IAsyncEnumerator<TSource> firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+                try
                 {
-                    set.Add(key);
-                }
-
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
-                {
-                    if (set.Add(await keySelector(element, cancellationToken).ConfigureAwait(false)))
+                    if (!await firstEnumerator.MoveNextAsync().ConfigureAwait(false))
                     {
-                        yield return element;
+                        yield break;
                     }
+
+                    HashSet<TKey> set = new(comparer);
+
+                    await foreach (TKey key in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                    {
+                        set.Add(key);
+                    }
+
+                    do
+                    {
+                        TSource firstElement = firstEnumerator.Current;
+                        if (set.Add(await keySelector(firstElement, cancellationToken).ConfigureAwait(false)))
+                        {
+                            yield return firstElement;
+                        }
+                    }
+                    while (await firstEnumerator.MoveNextAsync().ConfigureAwait(false));
+                }
+                finally
+                {
+                    await firstEnumerator.DisposeAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ExceptBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ExceptBy.cs
@@ -34,7 +34,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                first.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -100,7 +100,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                first.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupBy.cs
@@ -33,7 +33,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? Empty<IGrouping<TKey, TSource>>() :
+                source.IsKnownEmpty() ? Empty<IGrouping<TKey, TSource>>() :
                 Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TSource>> Impl(
@@ -70,7 +70,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? Empty<IGrouping<TKey, TSource>>() :
+                source.IsKnownEmpty() ? Empty<IGrouping<TKey, TSource>>() :
                 Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TSource>> Impl(
@@ -116,7 +116,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(elementSelector);
 
             return
-                source.IsEmpty() ? Empty<IGrouping<TKey, TElement>>() :
+                source.IsKnownEmpty() ? Empty<IGrouping<TKey, TElement>>() :
                 Impl(source, keySelector, elementSelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TElement>> Impl(
@@ -163,7 +163,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(elementSelector);
 
             return
-                source.IsEmpty() ? Empty<IGrouping<TKey, TElement>>() :
+                source.IsKnownEmpty() ? Empty<IGrouping<TKey, TElement>>() :
                 Impl(source, keySelector, elementSelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TElement>> Impl(
@@ -209,7 +209,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, keySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -258,7 +258,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, keySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -311,7 +311,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, keySelector, elementSelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -365,7 +365,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, keySelector, elementSelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupBy.cs
@@ -32,7 +32,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<IGrouping<TKey, TSource>>() :
+                Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TSource>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -67,7 +69,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<IGrouping<TKey, TSource>>() :
+                Impl(source, keySelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TSource>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -111,7 +115,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(elementSelector);
 
-            return Impl(source, keySelector, elementSelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<IGrouping<TKey, TElement>>() :
+                Impl(source, keySelector, elementSelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TElement>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -156,7 +162,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(elementSelector);
 
-            return Impl(source, keySelector, elementSelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<IGrouping<TKey, TElement>>() :
+                Impl(source, keySelector, elementSelector, comparer, default);
 
             static async IAsyncEnumerable<IGrouping<TKey, TElement>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -200,7 +208,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, keySelector, resultSelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, keySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -209,10 +219,12 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                var lookup = (AsyncLookup<TKey, TSource>)await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false);
-                foreach (TResult item in lookup.ApplyResultSelector(resultSelector))
+                if (await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TSource> lookup)
                 {
-                    yield return item;
+                    foreach (TResult item in lookup.ApplyResultSelector(resultSelector))
+                    {
+                        yield return item;
+                    }
                 }
             }
         }
@@ -245,7 +257,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, keySelector, resultSelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, keySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -254,10 +268,12 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                var lookup = (AsyncLookup<TKey, TSource>)await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false);
-                await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken).ConfigureAwait(false))
+                if (await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TSource> lookup)
                 {
-                    yield return item;
+                    await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken).ConfigureAwait(false))
+                    {
+                        yield return item;
+                    }
                 }
             }
         }
@@ -294,7 +310,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(elementSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, keySelector, elementSelector, resultSelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, keySelector, elementSelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -304,10 +322,12 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                var lookup = (AsyncLookup<TKey, TElement>)await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false);
-                foreach (TResult item in lookup.ApplyResultSelector(resultSelector))
+                if (await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TElement> lookup)
                 {
-                    yield return item;
+                    foreach (TResult item in lookup.ApplyResultSelector(resultSelector))
+                    {
+                        yield return item;
+                    }
                 }
             }
         }
@@ -344,7 +364,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(elementSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, keySelector, elementSelector, resultSelector, comparer, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, keySelector, elementSelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -354,10 +376,12 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                var lookup = (AsyncLookup<TKey, TElement>)await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false);
-                await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken).ConfigureAwait(false))
+                if (await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TElement> lookup)
                 {
-                    yield return item;
+                    await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken).ConfigureAwait(false))
+                    {
+                        yield return item;
+                    }
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupJoin.cs
@@ -47,7 +47,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                outer.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer,
@@ -116,7 +118,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                outer.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupJoin.cs
@@ -48,7 +48,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                outer.IsEmpty() ? Empty<TResult>() :
+                outer.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -119,7 +119,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                outer.IsEmpty() ? Empty<TResult>() :
+                outer.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Index.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Index.cs
@@ -20,7 +20,9 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source, default);
+            return
+                source.IsEmpty() ? Empty<(int Index, TSource Item)>() :
+                Impl(source, default);
 
             static async IAsyncEnumerable<(int Index, TSource Item)> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Index.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Index.cs
@@ -21,7 +21,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<(int Index, TSource Item)>() :
+                source.IsKnownEmpty() ? Empty<(int Index, TSource Item)>() :
                 Impl(source, default);
 
             static async IAsyncEnumerable<(int Index, TSource Item)> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Intersect.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Intersect.cs
@@ -26,7 +26,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(first);
             ThrowHelper.ThrowIfNull(second);
 
-            return Impl(first, second, comparer, default);
+            return
+                first.IsEmpty() || second.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Intersect.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Intersect.cs
@@ -27,7 +27,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
 
             return
-                first.IsEmpty() || second.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() || second.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/IntersectBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/IntersectBy.cs
@@ -38,7 +38,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(first, second, keySelector, comparer, default);
+            return
+                first.IsEmpty() || second.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,
@@ -106,7 +108,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(first, second, keySelector, comparer, default);
+            return
+                first.IsEmpty() || second.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/IntersectBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/IntersectBy.cs
@@ -39,7 +39,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                first.IsEmpty() || second.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() || second.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -109,7 +109,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                first.IsEmpty() || second.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() || second.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Join.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Join.cs
@@ -44,7 +44,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                outer.IsEmpty() || inner.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer, IAsyncEnumerable<TInner> inner,
@@ -121,7 +123,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                outer.IsEmpty() || inner.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Join.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Join.cs
@@ -45,7 +45,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                outer.IsEmpty() || inner.IsEmpty() ? Empty<TResult>() :
+                outer.IsKnownEmpty() || inner.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -124,7 +124,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                outer.IsEmpty() || inner.IsEmpty() ? Empty<TResult>() :
+                outer.IsKnownEmpty() || inner.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LeftJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LeftJoin.cs
@@ -41,7 +41,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                outer.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer, IAsyncEnumerable<TInner> inner,
@@ -116,7 +118,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                outer.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LeftJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LeftJoin.cs
@@ -42,7 +42,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                outer.IsEmpty() ? Empty<TResult>() :
+                outer.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -119,7 +119,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                outer.IsEmpty() ? Empty<TResult>() :
+                outer.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OfType.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OfType.cs
@@ -26,7 +26,9 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<object?> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OfType.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OfType.cs
@@ -27,7 +27,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
@@ -33,8 +33,15 @@ namespace System.Linq
         public static IOrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>( // satisfies the C# query-expression pattern
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey>? comparer = null) =>
-            new OrderedIterator<TSource, TKey>(source, keySelector, comparer, false, null);
+            IComparer<TKey>? comparer = null)
+        {
+            ThrowHelper.ThrowIfNull(source);
+            ThrowHelper.ThrowIfNull(keySelector);
+
+            return
+                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                new OrderedIterator<TSource, TKey>(source, keySelector, comparer, false, null);
+        }
 
         /// <summary>Sorts the elements of a sequence in ascending order.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
@@ -48,8 +55,15 @@ namespace System.Linq
         public static IOrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
-            IComparer<TKey>? comparer = null) =>
-            new OrderedIterator<TSource, TKey>(source, keySelector, comparer, false, null);
+            IComparer<TKey>? comparer = null)
+        {
+            ThrowHelper.ThrowIfNull(source);
+            ThrowHelper.ThrowIfNull(keySelector);
+
+            return
+                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                new OrderedIterator<TSource, TKey>(source, keySelector, comparer, false, null);
+        }
 
         /// <summary>Sorts the elements of a sequence in descending order.</summary>
         /// <typeparam name="T">The type of the elements of <paramref name="source"/>.</typeparam>
@@ -74,8 +88,15 @@ namespace System.Linq
         public static IOrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>( // satisfies the C# query-expression pattern
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey>? comparer = null) =>
-            new OrderedIterator<TSource, TKey>(source, keySelector, comparer, true, null);
+            IComparer<TKey>? comparer = null)
+        {
+            ThrowHelper.ThrowIfNull(source);
+            ThrowHelper.ThrowIfNull(keySelector);
+
+            return
+                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                new OrderedIterator<TSource, TKey>(source, keySelector, comparer, true, null);
+        }
 
         /// <summary>Sorts the elements of a sequence in descending order.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
@@ -89,8 +110,15 @@ namespace System.Linq
         public static IOrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
-            IComparer<TKey>? comparer = null) =>
-            new OrderedIterator<TSource, TKey>(source, keySelector, comparer, true, null);
+            IComparer<TKey>? comparer = null)
+        {
+            ThrowHelper.ThrowIfNull(source);
+            ThrowHelper.ThrowIfNull(keySelector);
+
+            return
+                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                new OrderedIterator<TSource, TKey>(source, keySelector, comparer, true, null);
+        }
 
         /// <summary>Performs a subsequent ordering of the elements in a sequence in ascending order.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
@@ -198,9 +226,6 @@ namespace System.Linq
             internal OrderedIterator(IAsyncEnumerable<TElement> source, object keySelector, IComparer<TKey>? comparer, bool descending, OrderedIterator<TElement>? parent) :
                 base(source)
             {
-                ThrowHelper.ThrowIfNull(source);
-                ThrowHelper.ThrowIfNull(keySelector);
-
                 Debug.Assert(keySelector is Func<TElement, TKey> or Func<TElement, CancellationToken, ValueTask<TKey>>);
 
                 _parent = parent;

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
@@ -39,7 +39,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                source.IsKnownEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
                 new OrderedIterator<TSource, TKey>(source, keySelector, comparer, false, null);
         }
 
@@ -61,7 +61,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                source.IsKnownEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
                 new OrderedIterator<TSource, TKey>(source, keySelector, comparer, false, null);
         }
 
@@ -94,7 +94,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                source.IsKnownEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
                 new OrderedIterator<TSource, TKey>(source, keySelector, comparer, true, null);
         }
 
@@ -116,7 +116,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                source.IsEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
+                source.IsKnownEmpty() ? EmptyAsyncEnumerable<TSource>.Instance :
                 new OrderedIterator<TSource, TKey>(source, keySelector, comparer, true, null);
         }
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Reverse.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Reverse.cs
@@ -19,7 +19,9 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Reverse.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Reverse.cs
@@ -20,7 +20,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/RightJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/RightJoin.cs
@@ -42,7 +42,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                inner.IsEmpty() ? Empty<TResult>() :
+                inner.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -120,7 +120,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                inner.IsEmpty() ? Empty<TResult>() :
+                inner.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/RightJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/RightJoin.cs
@@ -41,7 +41,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                inner.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer,
@@ -117,7 +119,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(innerKeySelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
+            return
+                inner.IsEmpty() ? Empty<TResult>() :
+                Impl(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TOuter> outer,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Select.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Select.cs
@@ -29,7 +29,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -63,7 +63,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -100,7 +100,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -138,7 +138,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Select.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Select.cs
@@ -28,7 +28,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -60,7 +62,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -95,7 +99,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -131,7 +137,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SelectMany.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SelectMany.cs
@@ -32,7 +32,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -72,7 +72,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -112,7 +112,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -153,7 +153,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -195,7 +195,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -237,7 +237,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(selector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -287,7 +287,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -337,7 +337,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -387,7 +387,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -437,7 +437,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
@@ -486,7 +486,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, collectionSelector, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -536,7 +536,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, collectionSelector, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -586,7 +586,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                source.IsEmpty() ? Empty<TResult>() :
+                source.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(source, collectionSelector, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SelectMany.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SelectMany.cs
@@ -31,7 +31,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -69,7 +71,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -107,7 +111,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -146,7 +152,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -186,7 +194,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -226,7 +236,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(selector);
 
-            return Impl(source, selector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, selector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -274,7 +286,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(collectionSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, collectionSelector, resultSelector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -322,7 +336,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(collectionSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, collectionSelector, resultSelector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -370,7 +386,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(collectionSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, collectionSelector, resultSelector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -418,7 +436,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(collectionSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, collectionSelector, resultSelector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, collectionSelector, resultSelector, default);
 
             async static IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -465,7 +485,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(collectionSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, collectionSelector, resultSelector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, collectionSelector, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -513,7 +535,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(collectionSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, collectionSelector, resultSelector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, collectionSelector, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -561,7 +585,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(collectionSelector);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(source, collectionSelector, resultSelector, default);
+            return
+                source.IsEmpty() ? Empty<TResult>() :
+                Impl(source, collectionSelector, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Shuffle.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Shuffle.cs
@@ -24,7 +24,9 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Shuffle.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Shuffle.cs
@@ -25,7 +25,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Skip.cs
@@ -21,8 +21,9 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return count <= 0 ?
-                source :
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                count <= 0 ? source :
                 Impl(source, count, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Skip.cs
@@ -22,7 +22,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 count <= 0 ? source :
                 Impl(source, count, default);
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipLast.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipLast.cs
@@ -26,7 +26,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 count <= 0 ? source :
                 TakeRangeFromEndIterator(source, isStartIndexFromEnd: false, startIndex: 0, isEndIndexFromEnd: true, endIndex: count, default);
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipLast.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipLast.cs
@@ -26,6 +26,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
+                source.IsEmpty() ? Empty<TSource>() :
                 count <= 0 ? source :
                 TakeRangeFromEndIterator(source, isStartIndexFromEnd: false, startIndex: 0, isEndIndexFromEnd: true, endIndex: count, default);
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipWhile.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipWhile.cs
@@ -31,7 +31,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -84,7 +86,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -141,7 +145,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -199,7 +205,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipWhile.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipWhile.cs
@@ -32,7 +32,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -87,7 +87,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -146,7 +146,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -206,7 +206,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Take.cs
@@ -26,8 +26,8 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return count <= 0 ?
-                Empty<TSource>() :
+            return
+                source.IsEmpty() || count <= 0 ? Empty<TSource>() :
                 Impl(source, count, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -63,6 +63,11 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
+            if (source.IsEmpty())
+            {
+                return Empty<TSource>();
+            }
+
             Index start = range.Start, end = range.End;
             bool isStartIndexFromEnd = start.IsFromEnd, isEndIndexFromEnd = end.IsFromEnd;
             int startIndex = start.Value, endIndex = end.Value;
@@ -78,8 +83,8 @@ namespace System.Linq
             }
             else if (!isEndIndexFromEnd)
             {
-                return startIndex >= endIndex ?
-                    Empty<TSource>() :
+                return
+                    startIndex >= endIndex ? Empty<TSource>() :
                     Impl(source, startIndex, endIndex, default);
             }
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Take.cs
@@ -27,7 +27,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() || count <= 0 ? Empty<TSource>() :
+                source.IsKnownEmpty() || count <= 0 ? Empty<TSource>() :
                 Impl(source, count, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -63,7 +63,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            if (source.IsEmpty())
+            if (source.IsKnownEmpty())
             {
                 return Empty<TSource>();
             }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeLast.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeLast.cs
@@ -19,7 +19,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
 
             return
-                source.IsEmpty() || count <= 0 ? Empty<TSource>() :
+                source.IsKnownEmpty() || count <= 0 ? Empty<TSource>() :
                 TakeRangeFromEndIterator(source, isStartIndexFromEnd: true, startIndex: count, isEndIndexFromEnd: true, endIndex: 0, default);
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeLast.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeLast.cs
@@ -18,8 +18,8 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return count <= 0 ?
-                Empty<TSource>() :
+            return
+                source.IsEmpty() || count <= 0 ? Empty<TSource>() :
                 TakeRangeFromEndIterator(source, isStartIndexFromEnd: true, startIndex: count, isEndIndexFromEnd: true, endIndex: 0, default);
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeWhile.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeWhile.cs
@@ -27,7 +27,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate,
@@ -62,7 +64,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -101,7 +105,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -141,7 +147,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeWhile.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeWhile.cs
@@ -28,7 +28,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -65,7 +65,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -106,7 +106,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -148,7 +148,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToArrayAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToArrayAsync.cs
@@ -27,13 +27,27 @@ namespace System.Linq
             static async ValueTask<TSource[]> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source)
             {
-                List<TSource> list = [];
-                await foreach (TSource element in source)
+                ConfiguredCancelableAsyncEnumerable<TSource>.Enumerator e = source.GetAsyncEnumerator();
+                try
                 {
-                    list.Add(element);
-                }
+                    if (await e.MoveNextAsync())
+                    {
+                        List<TSource> list = [];
+                        do
+                        {
+                            list.Add(e.Current);
+                        }
+                        while (await e.MoveNextAsync());
 
-                return list.ToArray();
+                        return list.ToArray();
+                    }
+
+                    return [];
+                }
+                finally
+                {
+                    await e.DisposeAsync();
+                }
             }
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToAsyncEnumerable.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToAsyncEnumerable.cs
@@ -22,9 +22,10 @@ namespace System.Linq
 
             return source switch
             {
-                TSource[] array => FromArray(array),
+                TSource[] array => array.Length == 0 ? Empty<TSource>() : FromArray(array),
                 List<TSource> list => FromList(list),
                 IList<TSource> list => FromIList(list),
+                _ when source == Enumerable.Empty<TSource>() => Empty<TSource>(),
                 _ => FromIterator(source),
             };
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Union.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Union.cs
@@ -27,7 +27,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
 
             return
-                first.IsEmpty() && second.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() && second.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Union.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Union.cs
@@ -26,7 +26,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(first);
             ThrowHelper.ThrowIfNull(second);
 
-            return Impl(first, second, comparer, default);
+            return
+                first.IsEmpty() && second.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/UnionBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/UnionBy.cs
@@ -31,7 +31,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                first.IsEmpty() && second.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() && second.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -82,7 +82,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
 
             return
-                first.IsEmpty() && second.IsEmpty() ? Empty<TSource>() :
+                first.IsKnownEmpty() && second.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/UnionBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/UnionBy.cs
@@ -30,7 +30,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(first, second, keySelector, comparer, default);
+            return
+                first.IsEmpty() && second.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,
@@ -79,7 +81,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(first, second, keySelector, comparer, default);
+            return
+                first.IsEmpty() && second.IsEmpty() ? Empty<TSource>() :
+                Impl(first, second, keySelector, comparer, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> first,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Where.cs
@@ -25,7 +25,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -58,7 +58,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -97,7 +97,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
@@ -137,7 +137,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(predicate);
 
             return
-                source.IsEmpty() ? Empty<TSource>() :
+                source.IsKnownEmpty() ? Empty<TSource>() :
                 Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Where.cs
@@ -24,7 +24,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -55,7 +57,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -92,7 +96,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -130,7 +136,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, default);
+            return
+                source.IsEmpty() ? Empty<TSource>() :
+                Impl(source, predicate, default);
 
             static async IAsyncEnumerable<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Zip.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Zip.cs
@@ -34,7 +34,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                first.IsEmpty() || second.IsEmpty() ? Empty<TResult>() :
+                first.IsKnownEmpty() || second.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(first, second, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -91,7 +91,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(resultSelector);
 
             return
-                first.IsEmpty() || second.IsEmpty() ? Empty<TResult>() :
+                first.IsKnownEmpty() || second.IsKnownEmpty() ? Empty<TResult>() :
                 Impl(first, second, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
@@ -140,7 +140,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
 
             return
-                first.IsEmpty() || second.IsEmpty() ? Empty<(TFirst, TSecond)>() :
+                first.IsKnownEmpty() || second.IsKnownEmpty() ? Empty<(TFirst, TSecond)>() :
                 Impl(first, second, default);
 
             static async IAsyncEnumerable<(TFirst First, TSecond Second)> Impl(
@@ -193,7 +193,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(third);
 
             return
-                first.IsEmpty() || second.IsEmpty() || third.IsEmpty() ? Empty<(TFirst, TSecond, TThird)>() :
+                first.IsKnownEmpty() || second.IsKnownEmpty() || third.IsKnownEmpty() ? Empty<(TFirst, TSecond, TThird)>() :
                 Impl(first, second, third, default);
 
             static async IAsyncEnumerable<(TFirst First, TSecond Second, TThird)> Impl(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Zip.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Zip.cs
@@ -33,7 +33,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(first, second, resultSelector, default);
+            return
+                first.IsEmpty() || second.IsEmpty() ? Empty<TResult>() :
+                Impl(first, second, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TFirst> first,
@@ -88,7 +90,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(resultSelector);
 
-            return Impl(first, second, resultSelector, default);
+            return
+                first.IsEmpty() || second.IsEmpty() ? Empty<TResult>() :
+                Impl(first, second, resultSelector, default);
 
             static async IAsyncEnumerable<TResult> Impl(
                 IAsyncEnumerable<TFirst> first,
@@ -135,7 +139,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(first);
             ThrowHelper.ThrowIfNull(second);
 
-            return Impl(first, second, default);
+            return
+                first.IsEmpty() || second.IsEmpty() ? Empty<(TFirst, TSecond)>() :
+                Impl(first, second, default);
 
             static async IAsyncEnumerable<(TFirst First, TSecond Second)> Impl(
                 IAsyncEnumerable<TFirst> first,
@@ -186,7 +192,9 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(second);
             ThrowHelper.ThrowIfNull(third);
 
-            return Impl(first, second, third, default);
+            return
+                first.IsEmpty() || second.IsEmpty() || third.IsEmpty() ? Empty<(TFirst, TSecond, TThird)>() :
+                Impl(first, second, third, default);
 
             static async IAsyncEnumerable<(TFirst First, TSecond Second, TThird)> Impl(
                 IAsyncEnumerable<TFirst> first, IAsyncEnumerable<TSecond> second, IAsyncEnumerable<TThird> third, [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AggregateByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AggregateByTests.cs
@@ -32,6 +32,15 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("func", () => AsyncEnumerable.AggregateBy(AsyncEnumerable.Empty<int>(), async (x, ct) => x, async (x, ct) => x, (Func<int, int, CancellationToken, ValueTask<int>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<KeyValuePair<int, int>>(), AsyncEnumerable.Empty<int>().AggregateBy(x => x, x => x, (x, y) => x + y));
+            Assert.Same(AsyncEnumerable.Empty<KeyValuePair<int, int>>(), AsyncEnumerable.Empty<int>().AggregateBy(x => x, 42, (x, y) => x + y));
+            Assert.Same(AsyncEnumerable.Empty<KeyValuePair<int, int>>(), AsyncEnumerable.Empty<int>().AggregateBy(async (x, ct) => x, async (x, ct) => x, async (x, y, ct) => x + y));
+            Assert.Same(AsyncEnumerable.Empty<KeyValuePair<int, int>>(), AsyncEnumerable.Empty<int>().AggregateBy(async (x, ct) => x, 42, async (x, y, ct) => x + y));
+        }
+
         public static IEnumerable<object[]> VariousValues_MatchesEnumerable_String_MemberData()
         {
             yield return new object[] { new string[0] };

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AsyncEnumerableTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AsyncEnumerableTests.cs
@@ -16,6 +16,12 @@ namespace System.Linq.Tests
 
         protected static IEnumerable<IAsyncEnumerable<T>> CreateSources<T>(params T[] items)
         {
+            if (items.Length == 0)
+            {
+                yield return Enumerable.Empty<T>().ToAsyncEnumerable();
+                yield return AsyncEnumerable.Empty<T>();
+            }
+
             yield return items.ToAsyncEnumerable();
             yield return items.ToAsyncEnumerable().Yield();
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/CastTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/CastTests.cs
@@ -17,10 +17,10 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public async Task Empty_ProducesEmpty()
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
         {
-            await AssertEqual(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<object>().Cast<string>());
-            await AssertEqual(AsyncEnumerable.Empty<double>(), AsyncEnumerable.Empty<object>().Cast<double>());
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<object>().Cast<string>());
+            Assert.Same(AsyncEnumerable.Empty<double>(), AsyncEnumerable.Empty<object>().Cast<double>());
         }
 
         [Fact]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ChunkTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ChunkTests.cs
@@ -20,6 +20,12 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("size", () => AsyncEnumerable.Chunk(AsyncEnumerable.Empty<int>(), -1));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int[]>(), AsyncEnumerable.Empty<int>().Chunk(1));
+        }
+
 #if NET
         [Fact]
         public async Task VariousValues_MatchesEnumerable()

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ConcatTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ConcatTests.cs
@@ -17,6 +17,17 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("second", () => AsyncEnumerable.Concat(AsyncEnumerable.Empty<int>(), null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<int> empty = AsyncEnumerable.Empty<int>();
+            IAsyncEnumerable<int> nonEmpty = CreateSource(1, 3, 5);
+
+            Assert.Same(empty, empty.Concat(empty));
+            Assert.Same(nonEmpty, nonEmpty.Concat(empty));
+            Assert.Same(nonEmpty, empty.Concat(nonEmpty));
+        }
+
         [Theory]
         [InlineData(new int[0], new int[0])]
         [InlineData(new int[0], new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/CountByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/CountByTests.cs
@@ -18,6 +18,13 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => AsyncEnumerable.CountBy(AsyncEnumerable.Empty<string>(), (Func<string, CancellationToken, ValueTask<int>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<KeyValuePair<object, int>>(), AsyncEnumerable.Empty<object>().CountBy(i => i));
+            Assert.Same(AsyncEnumerable.Empty<KeyValuePair<object, int>>(), AsyncEnumerable.Empty<object>().CountBy(async (i, ct) => i));
+        }
+
 #if NET
         [Fact]
         public async Task VariousValues_MatchesEnumerable_Strings()

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/DistinctByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/DistinctByTests.cs
@@ -20,6 +20,13 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => AsyncEnumerable.DistinctBy(AsyncEnumerable.Empty<int>(), (Func<int, CancellationToken, ValueTask<int>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().DistinctBy(i => i));
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().DistinctBy(async (i, ct) => i));
+        }
+
 #if NET
         [Theory]
         [InlineData(new int[0])]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/DistinctTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/DistinctTests.cs
@@ -16,6 +16,13 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.Distinct<int>(null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().Distinct());
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().Distinct());
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 1 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ExceptByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ExceptByTests.cs
@@ -22,6 +22,13 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => AsyncEnumerable.ExceptBy(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<int>(), (Func<string, CancellationToken, ValueTask<int>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().ExceptBy(CreateSource(1, 2, 3), i => i));
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().ExceptBy(CreateSource(1, 2, 3), async (i, ct) => i));
+        }
+
 #if NET
         [Theory]
         [InlineData(new int[0], new int[0])]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ExceptTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ExceptTests.cs
@@ -17,6 +17,12 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("second", () => AsyncEnumerable.Except(AsyncEnumerable.Empty<int>(), null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().Except(CreateSource(1, 2, 3)));
+        }
+
         [Theory]
         [InlineData(new int[0], new int[0])]
         [InlineData(new int[0], new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/GroupByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/GroupByTests.cs
@@ -43,6 +43,22 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<IGrouping<string, string>>(), AsyncEnumerable.Empty<string>().GroupBy(i => i));
+            Assert.Same(AsyncEnumerable.Empty<IGrouping<string, string>>(), AsyncEnumerable.Empty<string>().GroupBy(async (i, ct) => i));
+
+            Assert.Same(AsyncEnumerable.Empty<IGrouping<string, int>>(), AsyncEnumerable.Empty<string>().GroupBy(i => i, i => i.Length));
+            Assert.Same(AsyncEnumerable.Empty<IGrouping<string, int>>(), AsyncEnumerable.Empty<string>().GroupBy(async (i, ct) => i, async (i, ct) => i.Length));
+
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<string>().GroupBy(i => i, (i, elements) => i.Length));
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<string>().GroupBy(async (i, ct) => i, async (i, elements, ct) => i.Length));
+
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<string>().GroupBy(i => i, i => i.Length, (i, elements) => i.Length));
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<string>().GroupBy(async (i, ct) => i, async (i, ct) => i.Length, async (i, elements, ct) => i.Length));
+        }
+
+        [Fact]
         public async Task VariousValues_MatchesEnumerable_String()
         {
             Random rand = new(42);

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/GroupJoinTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/GroupJoinTests.cs
@@ -27,6 +27,13 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().GroupJoin(CreateSource(1, 2, 3), s => s, i => i.ToString(), (s, e) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().GroupJoin(CreateSource(1, 2, 3), async (s, ct) => s, async (i, ct) => i.ToString(), async (s, e, ct) => s));
+        }
+
+        [Fact]
         public async Task VariousValues_MatchesEnumerable_String()
         {
             Random rand = new(42);

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/IndexTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/IndexTests.cs
@@ -16,6 +16,12 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.Index<int>(null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<(int, string)>(), AsyncEnumerable.Empty<string>().Index());
+        }
+
 #if NET
         [Theory]
         [InlineData(new int[0])]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/IntersectByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/IntersectByTests.cs
@@ -22,6 +22,19 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => AsyncEnumerable.IntersectBy(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<int>(), (Func<string, CancellationToken, ValueTask<int>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<int> empty = AsyncEnumerable.Empty<int>();
+            IAsyncEnumerable<int> nonEmpty = CreateSource(1, 2, 3);
+
+            Assert.Same(empty, empty.IntersectBy(nonEmpty, x => x));
+            Assert.Same(empty, empty.IntersectBy(nonEmpty, async (x, ct) => x));
+
+            Assert.Same(empty, nonEmpty.IntersectBy(empty, x => x));
+            Assert.Same(empty, nonEmpty.IntersectBy(empty, async (x, ct) => x));
+        }
+
 #if NET
         [Theory]
         [InlineData(new int[0], new int[0])]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/IntersectTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/IntersectTests.cs
@@ -17,6 +17,16 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("second", () => AsyncEnumerable.Intersect(AsyncEnumerable.Empty<int>(), null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<int> empty = AsyncEnumerable.Empty<int>();
+            IAsyncEnumerable<int> nonEmpty = CreateSource(1, 2, 3);
+
+            Assert.Same(empty, empty.Intersect(nonEmpty));
+            Assert.Same(empty, nonEmpty.Intersect(empty));
+        }
+
         [Theory]
         [InlineData(new int[0], new int[0])]
         [InlineData(new int[0], new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/JoinTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/JoinTests.cs
@@ -27,6 +27,22 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<string> empty = AsyncEnumerable.Empty<string>();
+            IAsyncEnumerable<string> nonEmpty = CreateSource("1", "2", "3");
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.Join(empty, s => s, s => s, (s1, s2) => s1));
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.Join(empty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), nonEmpty.Join(empty, s => s, s => s, (s1, s2) => s1));
+            Assert.Same(AsyncEnumerable.Empty<string>(), nonEmpty.Join(empty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.Join(nonEmpty, s => s, s => s, (s1, s2) => s1));
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.Join(nonEmpty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+        }
+
+        [Fact]
         public async Task VariousValues_MatchesEnumerable_String()
         {
             Random rand = new(42);

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/LeftJoinTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/LeftJoinTests.cs
@@ -26,6 +26,22 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("resultSelector", () => AsyncEnumerable.LeftJoin(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>(), async (outer, ct) => outer, async (inner, ct) => inner, (Func<string, string, CancellationToken, ValueTask<string>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<string> empty = AsyncEnumerable.Empty<string>();
+            IAsyncEnumerable<string> nonEmpty = CreateSource("1", "2", "3");
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.LeftJoin(empty, s => s, s => s, (s1, s2) => s1));
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.LeftJoin(empty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+
+            Assert.NotSame(AsyncEnumerable.Empty<string>(), nonEmpty.LeftJoin(empty, s => s, s => s, (s1, s2) => s1));
+            Assert.NotSame(AsyncEnumerable.Empty<string>(), nonEmpty.LeftJoin(empty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.LeftJoin(nonEmpty, s => s, s => s, (s1, s2) => s1));
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.LeftJoin(nonEmpty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+        }
+
 #if NET
         [Fact]
         public async Task VariousValues_MatchesEnumerable_String()

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/OfTypeTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/OfTypeTests.cs
@@ -18,10 +18,10 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public async Task Empty_ProducesEmpty()
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
         {
-            await AssertEqual(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<object>().OfType<string>());
-            await AssertEqual(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<object>().OfType<int>());
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<object>().OfType<string>());
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<object>().OfType<int>());
         }
 
         [Fact]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/OrderByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/OrderByTests.cs
@@ -38,6 +38,22 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderBy(i => i));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderBy(async (i, ct) => i));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderByDescending(i => i));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderByDescending(async (i, ct) => i));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderBy(i => i).ThenBy(i => i));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderBy(async (i, ct) => i).ThenBy(async (i, ct) => i));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderByDescending(i => i).ThenByDescending(i => i));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().OrderByDescending(async (i, ct) => i).ThenByDescending(async (i, ct) => i));
+        }
+
+        [Fact]
         public async Task VariousValues_MatchesEnumerable_Int32()
         {
             Random rand = new(42);

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/RangeTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/RangeTests.cs
@@ -17,6 +17,12 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Range(42, 0));
+        }
+
+        [Fact]
         public async Task VariousValues_MatchesEnumerable()
         {
             foreach (int start in new[] { int.MinValue, -1, 0, 1, 1_000_000 })

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/RepeatTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/RepeatTests.cs
@@ -15,6 +15,12 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Repeat("42", 0));
+        }
+
+        [Fact]
         public async Task VariousValues_MatchesEnumerable()
         {
             foreach (int count in new[] { 0, 1, 10 })

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ReverseTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ReverseTests.cs
@@ -16,6 +16,12 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.Reverse<int>(null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().Reverse());
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 1 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/RightJoinTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/RightJoinTests.cs
@@ -26,6 +26,22 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("resultSelector", () => AsyncEnumerable.RightJoin(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>(), async (outer, ct) => outer, async (inner, ct) => inner, (Func<string, string, CancellationToken, ValueTask<string>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<string> empty = AsyncEnumerable.Empty<string>();
+            IAsyncEnumerable<string> nonEmpty = CreateSource("1", "2", "3");
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.RightJoin(empty, s => s, s => s, (s1, s2) => s1));
+            Assert.Same(AsyncEnumerable.Empty<string>(), empty.RightJoin(empty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), nonEmpty.RightJoin(empty, s => s, s => s, (s1, s2) => s1));
+            Assert.Same(AsyncEnumerable.Empty<string>(), nonEmpty.RightJoin(empty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+
+            Assert.NotSame(AsyncEnumerable.Empty<string>(), empty.RightJoin(nonEmpty, s => s, s => s, (s1, s2) => s1));
+            Assert.NotSame(AsyncEnumerable.Empty<string>(), empty.RightJoin(nonEmpty, async (s, ct) => s, async (s, ct) => s, async (s1, s2, ct) => s1));
+        }
+
 #if NET
         [Fact]
         public async Task VariousValues_MatchesEnumerable_String()

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SelectManyTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SelectManyTests.cs
@@ -58,6 +58,27 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<char>(), AsyncEnumerable.Empty<string>().SelectMany(s => s.ToCharArray()));
+            Assert.Same(AsyncEnumerable.Empty<char>(), AsyncEnumerable.Empty<string>().SelectMany(async (s, ct) => (IEnumerable<char>)s.ToCharArray()));
+            Assert.Same(AsyncEnumerable.Empty<char>(), AsyncEnumerable.Empty<string>().SelectMany(s => s.ToAsyncEnumerable()));
+
+            Assert.Same(AsyncEnumerable.Empty<char>(), AsyncEnumerable.Empty<string>().SelectMany((s, i) => s.ToCharArray()));
+            Assert.Same(AsyncEnumerable.Empty<char>(), AsyncEnumerable.Empty<string>().SelectMany(async (s, i, ct) => (IEnumerable<char>)s.ToCharArray()));
+            Assert.Same(AsyncEnumerable.Empty<char>(), AsyncEnumerable.Empty<string>().SelectMany((s, i) => s.ToAsyncEnumerable()));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SelectMany(s => s.ToCharArray(), (s, c) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SelectMany(async (s, ct) => (IEnumerable<char>)s.ToCharArray(), async (s, c, ct) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SelectMany(s => s.ToAsyncEnumerable(), (s, c) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SelectMany(s => s.ToAsyncEnumerable(), async (s, c, ct) => s));
+
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SelectMany((s, i) => s.ToCharArray(), (s, c) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SelectMany(async (s, i, ct) => (IEnumerable<char>)s.ToCharArray(), async (s, c, ct) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SelectMany((s, i) => s.ToAsyncEnumerable(), async (s, c, ct) => s));
+        }
+
+        [Fact]
         public async Task VariousValues_MatchesEnumerable()
         {
             Random rand = new(42);

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SelectTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SelectTests.cs
@@ -24,6 +24,15 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("selector", () => AsyncEnumerable.Select(AsyncEnumerable.Empty<int>(), (Func<int, int, CancellationToken, ValueTask<string>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().Select(s => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().Select((s, index) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().Select(async (string s, CancellationToken ct) => s));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().Select(async (string s, int index, CancellationToken ct) => s));
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ShuffleTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ShuffleTests.cs
@@ -16,6 +16,12 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.Shuffle<int>(null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().Shuffle());
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 1 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SkipLastTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SkipLastTests.cs
@@ -16,6 +16,16 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.SkipLast((IAsyncEnumerable<int>)null, 42));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SkipLast(42));
+
+            IAsyncEnumerable<int> source = CreateSource(2, 4, 8, 16);
+            Assert.Same(source, source.SkipLast(0));
+            Assert.Same(source, source.SkipLast(-1));
+        }
+
 #if NET
         [Theory]
         [InlineData(new int[0])]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SkipTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SkipTests.cs
@@ -16,6 +16,16 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.Skip((IAsyncEnumerable<int>)null, 42));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().Skip(42));
+
+            IAsyncEnumerable<int> source = CreateSource(2, 4, 8, 16);
+            Assert.Same(source, source.Skip(0));
+            Assert.Same(source, source.Skip(-1));
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SkipWhileTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SkipWhileTests.cs
@@ -24,6 +24,15 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("predicate", () => AsyncEnumerable.SkipWhile(AsyncEnumerable.Empty<int>(), (Func<int, int, CancellationToken, ValueTask<bool>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SkipWhile(i => true));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SkipWhile((i, index) => true));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SkipWhile(async (i, ct) => true));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().SkipWhile(async (i, index, ct) => true));
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/TakeLastTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/TakeLastTests.cs
@@ -16,6 +16,14 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.TakeLast((IAsyncEnumerable<int>)null, 42));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().TakeLast(42));
+            Assert.Same(AsyncEnumerable.Empty<int>(), CreateSource(1, 2, 3).TakeLast(0));
+            Assert.Same(AsyncEnumerable.Empty<int>(), CreateSource(1, 2, 3).TakeLast(-1));
+        }
+
 #if NET
         [Theory]
         [InlineData(new int[0])]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/TakeTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/TakeTests.cs
@@ -18,8 +18,10 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void TakeNothing_ReturnsEmpty()
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
         {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().TakeLast(42));
+
             Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Take(new int[] { 1, 2, 3 }.ToAsyncEnumerable(), 0));
             Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Take(new int[] { 1, 2, 3 }.ToAsyncEnumerable(), -1));
             Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Take(new int[] { 1, 2, 3 }.ToAsyncEnumerable(), new Range(new(0), new(0))));

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/TakeWhileTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/TakeWhileTests.cs
@@ -24,6 +24,15 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("predicate", () => AsyncEnumerable.TakeWhile(AsyncEnumerable.Empty<int>(), (Func<int, int, CancellationToken, ValueTask<bool>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().TakeWhile(i => true));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().TakeWhile((i, index) => true));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().TakeWhile(async (i, ct) => true));
+            Assert.Same(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>().TakeWhile(async (i, index, ct) => true));
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ToAsyncEnumerableTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ToAsyncEnumerableTests.cs
@@ -16,6 +16,18 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", () => AsyncEnumerable.ToAsyncEnumerable<int>(null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int>(), Enumerable.Empty<int>().ToAsyncEnumerable());
+            Assert.Same(AsyncEnumerable.Empty<int>(), Array.Empty<int>().ToAsyncEnumerable());
+            Assert.Same(AsyncEnumerable.Empty<int>(), new int[0].ToAsyncEnumerable());
+
+            Assert.NotSame(AsyncEnumerable.Empty<int>(), new List<int>().ToAsyncEnumerable());
+            Assert.NotSame(AsyncEnumerable.Empty<int>(), new HashSet<int>().ToAsyncEnumerable());
+            Assert.NotSame(AsyncEnumerable.Empty<int>(), new ReadOnlyCollection<int>([]).ToAsyncEnumerable());
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 1 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/UnionByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/UnionByTests.cs
@@ -23,6 +23,23 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("keySelector", () => AsyncEnumerable.UnionBy(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<string>(), (Func<string, CancellationToken, ValueTask<int>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<int> empty = AsyncEnumerable.Empty<int>();
+            IAsyncEnumerable<int> nonEmpty = CreateSource(1, 2, 3);
+
+            Assert.Same(empty, empty.UnionBy(empty, i => i));
+            Assert.NotSame(empty, empty.UnionBy(nonEmpty, i => i));
+            Assert.NotSame(empty, nonEmpty.UnionBy(empty, i => i));
+            Assert.NotSame(empty, nonEmpty.UnionBy(nonEmpty, i => i));
+
+            Assert.Same(empty, empty.UnionBy(empty, async (i, ct) => i));
+            Assert.NotSame(empty, empty.UnionBy(nonEmpty, async (i, ct) => i));
+            Assert.NotSame(empty, nonEmpty.UnionBy(empty, async (i, ct) => i));
+            Assert.NotSame(empty, nonEmpty.UnionBy(nonEmpty, async (i, ct) => i));
+        }
+
         [Theory]
         [InlineData(new int[0], new int[0])]
         [InlineData(new int[0], new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/UnionTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/UnionTests.cs
@@ -17,6 +17,18 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("second", () => AsyncEnumerable.Union(AsyncEnumerable.Empty<int>(), null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<int> empty = AsyncEnumerable.Empty<int>();
+            IAsyncEnumerable<int> nonEmpty = CreateSource(1, 2, 3);
+
+            Assert.Same(empty, empty.Union(empty));
+            Assert.NotSame(empty, empty.Union(nonEmpty));
+            Assert.NotSame(empty, nonEmpty.Union(empty));
+            Assert.NotSame(empty, nonEmpty.Union(nonEmpty));
+        }
+
         [Theory]
         [InlineData(new int[0], new int[0])]
         [InlineData(new int[0], new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/WhereTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/WhereTests.cs
@@ -24,6 +24,15 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("predicate", () => AsyncEnumerable.Where(AsyncEnumerable.Empty<int>(), (Func<int, int, CancellationToken, ValueTask<bool>>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().Where(i => true));
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().Where((i, index) => true));
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().Where(async (i, ct) => true));
+            Assert.Same(AsyncEnumerable.Empty<int>(), AsyncEnumerable.Empty<int>().Where(async (i, index, ct) => true));
+        }
+
         [Theory]
         [InlineData(new int[0])]
         [InlineData(new int[] { 42 })]

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ZipTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ZipTests.cs
@@ -29,6 +29,37 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("third", () => AsyncEnumerable.Zip(AsyncEnumerable.Empty<string>(), AsyncEnumerable.Empty<int>(), (IAsyncEnumerable<DateTime>)null));
         }
 
+        [Fact]
+        public void Empty_ProducesEmpty() // validating an optimization / implementation detail
+        {
+            IAsyncEnumerable<int> empty = AsyncEnumerable.Empty<int>();
+            IAsyncEnumerable<int> nonEmpty = CreateSource(1, 2, 3);
+
+            Assert.Same(AsyncEnumerable.Empty<(int, int)>(), empty.Zip(empty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int)>(), empty.Zip(nonEmpty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int)>(), nonEmpty.Zip(empty));
+            Assert.NotSame(AsyncEnumerable.Empty<(int, int)>(), nonEmpty.Zip(nonEmpty));
+
+            Assert.Same(AsyncEnumerable.Empty<int>(), empty.Zip(empty, (i1, i2) => i1 + i2));
+            Assert.Same(AsyncEnumerable.Empty<int>(), nonEmpty.Zip(empty, (i1, i2) => i1 + i2));
+            Assert.Same(AsyncEnumerable.Empty<int>(), empty.Zip(nonEmpty, (i1, i2) => i1 + i2));
+            Assert.NotSame(AsyncEnumerable.Empty<int>(), nonEmpty.Zip(nonEmpty, (i1, i2) => i1 + i2));
+
+            Assert.Same(AsyncEnumerable.Empty<int>(), empty.Zip(empty, async (i1, i2, ct) => i1 + i2));
+            Assert.Same(AsyncEnumerable.Empty<int>(), nonEmpty.Zip(empty, async (i1, i2, ct) => i1 + i2));
+            Assert.Same(AsyncEnumerable.Empty<int>(), empty.Zip(nonEmpty, async (i1, i2, ct) => i1 + i2));
+            Assert.NotSame(AsyncEnumerable.Empty<int>(), nonEmpty.Zip(nonEmpty, async (i1, i2, ct) => i1 + i2));
+
+            Assert.Same(AsyncEnumerable.Empty<(int, int, int)>(), empty.Zip(empty, empty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int, int)>(), nonEmpty.Zip(empty, empty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int, int)>(), empty.Zip(nonEmpty, empty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int, int)>(), empty.Zip(empty, nonEmpty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int, int)>(), nonEmpty.Zip(nonEmpty, empty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int, int)>(), nonEmpty.Zip(empty, nonEmpty));
+            Assert.Same(AsyncEnumerable.Empty<(int, int, int)>(), empty.Zip(nonEmpty, nonEmpty));
+            Assert.NotSame(AsyncEnumerable.Empty<(int, int, int)>(), nonEmpty.Zip(nonEmpty, nonEmpty));
+        }
+
         [Theory]
         [InlineData(new int[0], new int[0])]
         [InlineData(new int[0], new int[] { 42 })]


### PR DESCRIPTION
The goal here is to handle known empty inputs in a way that reduces unnecessary allocation, e.g. avoiding an iterator allocation or avoiding an intermediate collection. This does not modify operators where there isn't such overhead.