### PR TITLE
Do not run NAOT arm64 OSX testing on all PRs

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -609,7 +609,6 @@ extends:
           - osx_x64
           - linux_arm64
           - windows_arm64
-          - osx_arm64
           variables:
           - name: timeoutPerTestInMinutes
             value: 60


### PR DESCRIPTION
These legs have been constantly timing out since beginning of January because Helix is overloaded (e.g. #112073). In looking at why we don't see timeouts with CoreCLR, I found out we do not test ARM64 OSX with CoreCLR in these kinds of runs.

Cc @dotnet/ilc-contrib 