### PR TITLE
[8.0] Update Android and Linux-Bionic images (#102928)

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -573,7 +573,7 @@ jobs:
       targetRid: android-x64
       platform: android_x64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
+      container: android
       jobParameters:
         runtimeFlavor: mono
         buildConfig: ${{ parameters.buildConfig }}
@@ -613,7 +613,7 @@ jobs:
       targetRid: android-x86
       platform: android_x86
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
+      container: android
       jobParameters:
         runtimeFlavor: mono
         buildConfig: ${{ parameters.buildConfig }}
@@ -633,7 +633,7 @@ jobs:
       targetRid: android-arm
       platform: android_arm
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
+      container: android
       jobParameters:
         runtimeFlavor: mono
         buildConfig: ${{ parameters.buildConfig }}
@@ -653,7 +653,7 @@ jobs:
       targetRid: android-arm64
       platform: android_arm64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
+      container: android
       jobParameters:
         runtimeFlavor: mono
         buildConfig: ${{ parameters.buildConfig }}

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -48,8 +48,12 @@ extends:
           ROOTFS_DIR: /crossrootfs/arm64
 
       # This container contains all required toolsets to build for Android and for Linux with bionic libc.
-      linux_bionic:
+      android:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-android-amd64
+
+      # This container contains all required toolsets to build for Android and for Linux with bionic libc and a special layout of OpenSSL.
+      linux_bionic:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-android-openssl
 
       # This container contains all required toolsets to build for Android as well as tooling to build docker images.
       android_docker:

--- a/src/native/libs/System.Security.Cryptography.Native/extra_libs.cmake
+++ b/src/native/libs/System.Security.Cryptography.Native/extra_libs.cmake
@@ -4,26 +4,27 @@ macro(append_extra_cryptography_libs NativeLibsExtra)
        set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
     endif(CMAKE_STATIC_LIB_LINK)
 
+    find_package(OpenSSL)
     # This is bad and wrong, but good enough to satisfy the build
     # We only care about having "enough" OpenSSL to get the native lib built
     # here, and it's on the end user to ship libssl/libcrypto from Google
-    if(FORCE_ANDROID_OPENSSL)
-        set(OPENSSL_CRYPTO_LIBRARY /usr/lib/x86_64-linux-gnu/libcrypto.so)
-        set(OPENSSL_SSL_LIBRARY /usr/lib/x86_64-linux-gnu/libssl.so)
+    if(FORCE_ANDROID_OPENSSL AND NOT OPENSSL_FOUND)
+        set(OPENSSL_CRYPTO_LIBRARY /usr/lib/x86_64-linux-gnu/libcrypto.so CACHE PATH "libcrypto.so" FORCE)
+        set(OPENSSL_SSL_LIBRARY /usr/lib/x86_64-linux-gnu/libssl.so CACHE PATH "libcrypto.so" FORCE)
         # Things get more wrong. We need Desktop OpenSSL headers, but
         # /usr/include is special cased and forbidden. We need to copy
         # the headers to a different location and use them
-        if(NOT DEFINED OPENSSL_INCLUDE_DIR)
+        if(NOT OPENSSL_INCLUDE_DIR)
             string(RANDOM LENGTH 24 _s)
-            set(OPENSSL_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${_s}/opensslheaders CACHE PATH "temporary directory")
+            set(OPENSSL_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${_s}/opensslheaders CACHE PATH "temporary directory" FORCE)
             file(MAKE_DIRECTORY ${OPENSSL_INCLUDE_DIR})
             file(COPY /usr/include/openssl DESTINATION ${OPENSSL_INCLUDE_DIR})
             file(GLOB_RECURSE opensslconf /usr/include/*/openssl/*conf*.h)
             file(COPY ${opensslconf} DESTINATION ${OPENSSL_INCLUDE_DIR}/openssl/)
         endif()
+        set(OPENSSL_FOUND TRUE CACHE BOOL "OpenSSL found" FORCE)
     endif()
 
-    find_package(OpenSSL)
 
     if(NOT OPENSSL_FOUND)
         message(FATAL_ERROR "!!! Cannot find libssl and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (on Linux, but this may vary by distro) or openssl (on macOS) !!!. See the requirements document for your specific operating system: https://github.com/dotnet/runtime/tree/main/docs/workflow/requirements.")


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/102928 to 8.0.

This is necessary to fix the linux-bionic-arm64 runtime-official build that got broken after https://github.com/dotnet/runtime/pull/110199