### PR TITLE
Native DLLs: only load imported DLLs from System32

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -70,6 +70,9 @@ if (MSVC)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:CLR_EH_OPTION>>)
   add_link_options($<$<BOOL:$<TARGET_PROPERTY:CLR_CONTROL_FLOW_GUARD>>:/guard:cf>)
 
+  # Load all imported DLLs from the System32 directory.
+  add_linker_flag(/DEPENDENTLOADFLAG:0x800)
+
   # Linker flags
   #
   set (WINDOWS_SUBSYSTEM_VERSION 6.01)

--- a/eng/native/ijw/IJW.cmake
+++ b/eng/native/ijw/IJW.cmake
@@ -64,6 +64,10 @@ if (CLR_CMAKE_HOST_WIN32)
   remove_ijw_incompatible_options("${dirCompileOptions}" dirCompileOptions)
   set_directory_properties(PROPERTIES COMPILE_OPTIONS "${dirCompileOptions}")
 
+  # IJW tests needs to load DLLs from somewhere other than System32
+  string(REPLACE "/DEPENDENTLOADFLAG:0x800" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+  string(REPLACE "/DEPENDENTLOADFLAG:0x800" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+
   set(CLR_SDK_REF_PACK_OUTPUT "")
   set(CLR_SDK_REF_PACK_DISCOVERY_ERROR "")
   set(CLR_SDK_REF_PACK_DISCOVERY_RESULT 0)


### PR DESCRIPTION
By using the [/DEPENDENTLOADFLAG](https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag) link.exe flag, we can tell the Windows loader to only look for referenced DLLs in the System32 directory. This prevents [DLL injection](https://en.wikipedia.org/wiki/DLL_injection), like https://github.com/dotnet/runtime/pull/87495 fixed in 2023. This is a defense-in-depth change; it does not solve any known security problem.

This PR is a new version of #89311 which was merged in 2023 but reverted by #95540 shortly after. The reason the original PR was reverted is that `link.exe` did not support changing `/DEPENDENTLOADFLAG` when consuming PGO data ( [internal Microsoft issue link](https://devdiv.visualstudio.com/DevDiv/_queries/edit/1924842/) ). It appears that issue has been fixed in the version of `link.exe` used to build .NET.