### PR TITLE
Support generic type parameter when created with TypeBuilder

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3599,7 +3599,7 @@ namespace System
             bool foundNonRuntimeType = false;
             for (int i = 0; i < typeArguments.Length; i++)
             {
-                Type instantiationElem = typeArguments[i] ?? throw new ArgumentNullException(nameof(typeArguments));
+                Type instantiationElem = typeArguments[i] ?? throw new ArgumentNullException();
                 RuntimeType? rtInstantiationElem = instantiationElem as RuntimeType;
 
                 if (rtInstantiationElem == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3568,18 +3568,18 @@ namespace System
         }
 
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
-        public override Type MakeGenericType(Type[] instantiation)
+        public override Type MakeGenericType(Type[] typeArguments)
         {
-            ArgumentNullException.ThrowIfNull(instantiation);
+            ArgumentNullException.ThrowIfNull(typeArguments);
 
             if (!IsGenericTypeDefinition)
                 throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this));
 
             RuntimeType[] genericParameters = GetGenericArgumentsInternal();
-            if (genericParameters.Length != instantiation.Length)
-                throw new ArgumentException(SR.Argument_GenericArgsCount, nameof(instantiation));
+            if (genericParameters.Length != typeArguments.Length)
+                throw new ArgumentException(SR.Argument_GenericArgsCount, nameof(typeArguments));
 
-            if (instantiation.Length == 1 && instantiation[0] is RuntimeType rt)
+            if (typeArguments.Length == 1 && typeArguments[0] is RuntimeType rt)
             {
                 ThrowIfTypeNeverValidGenericArgument(rt);
                 try
@@ -3593,13 +3593,13 @@ namespace System
                 }
             }
 
-            RuntimeType[] instantiationRuntimeType = new RuntimeType[instantiation.Length];
+            RuntimeType[] instantiationRuntimeType = new RuntimeType[typeArguments.Length];
 
             bool foundSigType = false;
             bool foundNonRuntimeType = false;
-            for (int i = 0; i < instantiation.Length; i++)
+            for (int i = 0; i < typeArguments.Length; i++)
             {
-                Type instantiationElem = instantiation[i] ?? throw new ArgumentNullException();
+                Type instantiationElem = typeArguments[i] ?? throw new ArgumentNullException(nameof(typeArguments));
                 RuntimeType? rtInstantiationElem = instantiationElem as RuntimeType;
 
                 if (rtInstantiationElem == null)
@@ -3617,9 +3617,9 @@ namespace System
             if (foundNonRuntimeType)
             {
                 if (foundSigType)
-                    return new SignatureConstructedGenericType(this, instantiation);
+                    return new SignatureConstructedGenericType(this, typeArguments);
 
-                return Reflection.Emit.TypeBuilderInstantiation.MakeGenericType(this, (Type[])(instantiation.Clone()));
+                return Reflection.Emit.TypeBuilderInstantiation.MakeGenericType(this, (Type[])(typeArguments.Clone()));
             }
 
             SanityCheckGenericArguments(instantiationRuntimeType, genericParameters);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -441,7 +441,7 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 Type typeArgument = typeArguments[i];
                 if (typeArgument == null)
-                    throw new ArgumentNullException(nameof(typeArguments));
+                    throw new ArgumentNullException();
 
                 if (typeArgument is RuntimeType typeArgumentAsRuntimeType)
                 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -441,7 +441,7 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 Type typeArgument = typeArguments[i];
                 if (typeArgument == null)
-                    throw new ArgumentNullException();
+                    throw new ArgumentNullException(nameof(typeArguments));
 
                 if (typeArgument is RuntimeType typeArgumentAsRuntimeType)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Text;
 
 namespace System.Reflection
@@ -11,8 +12,9 @@ namespace System.Reflection
         // intended user of this constructor.
         internal SignatureConstructedGenericType(Type genericTypeDefinition, Type[] typeArguments)
         {
-            ArgumentNullException.ThrowIfNull(genericTypeDefinition);
-            ArgumentNullException.ThrowIfNull(typeArguments);
+            Debug.Assert(genericTypeDefinition != null);
+            Debug.Assert(typeArguments != null);
+            Debug.Assert(genericTypeDefinition.IsGenericTypeDefinition);
 
             typeArguments = (Type[])(typeArguments.Clone());
             for (int i = 0; i < typeArguments.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
@@ -32,7 +32,7 @@ namespace System.Reflection
         protected sealed override bool IsArrayImpl() => false;
         protected sealed override bool IsByRefImpl() => false;
         public sealed override bool IsByRefLike => _genericTypeDefinition.IsByRefLike;
-        public sealed override bool IsEnum => false;
+        public sealed override bool IsEnum => _genericTypeDefinition.IsEnum;
         protected sealed override bool IsPointerImpl() => false;
         public sealed override bool IsSZArray => false;
         public sealed override bool IsVariableBoundArray => false;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
@@ -30,7 +30,7 @@ namespace System.Reflection
         protected sealed override bool IsArrayImpl() => false;
         protected sealed override bool IsByRefImpl() => false;
         public sealed override bool IsByRefLike => _genericTypeDefinition.IsByRefLike;
-        public sealed override bool IsEnum => _genericTypeDefinition.IsEnum;
+        public sealed override bool IsEnum => false;
         protected sealed override bool IsPointerImpl() => false;
         public sealed override bool IsSZArray => false;
         public sealed override bool IsVariableBoundArray => false;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
@@ -50,6 +50,7 @@ namespace System.Reflection
             }
         }
 
+        protected sealed override bool IsValueTypeImpl() => _genericTypeDefinition.IsValueType;
         internal sealed override SignatureType? ElementType => null;
         public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);
         public sealed override Type GetGenericTypeDefinition() => _genericTypeDefinition;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureConstructedGenericType.cs
@@ -30,6 +30,7 @@ namespace System.Reflection
         protected sealed override bool IsArrayImpl() => false;
         protected sealed override bool IsByRefImpl() => false;
         public sealed override bool IsByRefLike => _genericTypeDefinition.IsByRefLike;
+        public sealed override bool IsEnum => _genericTypeDefinition.IsEnum;
         protected sealed override bool IsPointerImpl() => false;
         public sealed override bool IsSZArray => false;
         public sealed override bool IsVariableBoundArray => false;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
@@ -26,6 +26,7 @@ namespace System.Reflection
         public sealed override bool IsGenericParameter => true;
         public abstract override bool IsGenericMethodParameter { get; }
         public sealed override bool ContainsGenericParameters => true;
+        protected sealed override bool IsValueTypeImpl() => false;
 
         internal sealed override SignatureType? ElementType => null;
         public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
@@ -26,7 +26,7 @@ namespace System.Reflection
         public sealed override bool IsGenericParameter => true;
         public abstract override bool IsGenericMethodParameter { get; }
         public sealed override bool ContainsGenericParameters => true;
-        protected sealed override bool IsValueTypeImpl() => false;
+        protected sealed override bool IsValueTypeImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
 
         internal sealed override SignatureType? ElementType => null;
         public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
@@ -19,6 +19,7 @@ namespace System.Reflection
         protected sealed override bool IsArrayImpl() => false;
         protected sealed override bool IsByRefImpl() => false;
         public sealed override bool IsByRefLike => false;
+        public sealed override bool IsEnum => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override bool IsPointerImpl() => false;
         public sealed override bool IsSZArray => false;
         public sealed override bool IsVariableBoundArray => false;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
@@ -27,7 +27,7 @@ namespace System.Reflection
         public sealed override bool IsGenericTypeParameter => false;
         public sealed override bool IsGenericMethodParameter => false;
         public sealed override bool ContainsGenericParameters => _elementType.ContainsGenericParameters;
-        protected sealed override bool IsValueTypeImpl() => _elementType.IsValueType;
+        protected sealed override bool IsValueTypeImpl() => false;
 
         internal sealed override SignatureType? ElementType => _elementType;
         public abstract override int GetArrayRank();

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
@@ -27,6 +27,7 @@ namespace System.Reflection
         public sealed override bool IsGenericTypeParameter => false;
         public sealed override bool IsGenericMethodParameter => false;
         public sealed override bool ContainsGenericParameters => _elementType.ContainsGenericParameters;
+        protected sealed override bool IsValueTypeImpl() => _elementType.IsValueType;
 
         internal sealed override SignatureType? ElementType => _elementType;
         public abstract override int GetArrayRank();

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
@@ -19,6 +19,7 @@ namespace System.Reflection
         protected abstract override bool IsArrayImpl();
         protected abstract override bool IsByRefImpl();
         public sealed override bool IsByRefLike => false;
+        public sealed override bool IsEnum => false;
         protected abstract override bool IsPointerImpl();
         public abstract override bool IsSZArray { get; }
         public abstract override bool IsVariableBoundArray { get; }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
@@ -188,7 +188,7 @@ namespace System.Reflection
         public sealed override Type[] FindInterfaces(TypeFilter filter, object? filterCriteria) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override InterfaceMapping GetInterfaceMap([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type interfaceType) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override bool IsContextfulImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
-        public sealed override bool IsEnum => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public abstract override bool IsEnum { get; }
         public sealed override bool IsEquivalentTo([NotNullWhen(true)] Type? other) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override bool IsInstanceOfType([NotNullWhen(true)] object? o) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override bool IsMarshalByRefImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
@@ -198,7 +198,7 @@ namespace System.Reflection
         [Obsolete(Obsoletions.LegacyFormatterMessage, DiagnosticId = Obsoletions.LegacyFormatterDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public sealed override bool IsSerializable => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override bool IsSubclassOf(Type c) => throw new NotSupportedException(SR.NotSupported_SignatureType);
-        protected sealed override bool IsValueTypeImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected abstract override bool IsValueTypeImpl();
 
         public sealed override StructLayoutAttribute StructLayoutAttribute => throw new NotSupportedException(SR.NotSupported_SignatureType);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeDelegator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeDelegator.cs
@@ -57,6 +57,8 @@ namespace System.Reflection
         public override string? AssemblyQualifiedName => typeImpl.AssemblyQualifiedName;
         public override Type? BaseType => typeImpl.BaseType;
 
+        public override int GetArrayRank() => typeImpl.GetArrayRank();
+
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder? binder,
                 CallingConventions callConvention, Type[] types, ParameterModifier[]? modifiers)

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -651,7 +651,16 @@ namespace System
 
         public virtual Type MakePointerType() => throw new NotSupportedException();
 
-        public static Type MakeGenericSignatureType(Type genericTypeDefinition, params Type[] typeArguments) => new SignatureConstructedGenericType(genericTypeDefinition, typeArguments);
+        public static Type MakeGenericSignatureType(Type genericTypeDefinition, params Type[] typeArguments)
+        {
+            ArgumentNullException.ThrowIfNull(genericTypeDefinition);
+            ArgumentNullException.ThrowIfNull(typeArguments);
+
+            if (!genericTypeDefinition.IsGenericTypeDefinition)
+                throw new ArgumentException(SR.Format(SR.Arg_NotGenericTypeDefinition, genericTypeDefinition), nameof(genericTypeDefinition));
+
+            return new SignatureConstructedGenericType(genericTypeDefinition, typeArguments);
+        }
 
         public static Type MakeGenericMethodParameter(int position)
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
@@ -329,9 +329,16 @@ namespace System.Reflection.Tests
         [Fact]
         public static void MakeGenericSignatureTypeValidation()
         {
-            AssertExtensions.Throws<ArgumentNullException>("genericTypeDefinition", () => Type.MakeGenericSignatureType(null));
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(typeof(IList<>), typeArguments: null));
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(typeof(IList<>), new Type[] { null }));
+            // Standard reflection used as baseline.
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: null));
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: new Type[] { null }));
+            AssertExtensions.Throws<ArgumentException>("genericTypeDefinition", () => typeof(int).MakeGenericType(typeArguments: new Type[] { typeof(int) }));
+
+            // SignatureTypes.
+            AssertExtensions.Throws<ArgumentNullException>("genericTypeDefinition", () => Type.MakeGenericSignatureType(genericTypeDefinition: null));
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: null));
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: new Type[] { null }));
+            AssertExtensions.Throws<ArgumentException>("genericTypeDefinition", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(int), typeArguments: new Type[] { typeof(int) }));
         }
 
         private static Type ToSignatureType(this Type type)
@@ -416,8 +423,6 @@ namespace System.Reflection.Tests
 
         private class NoOneSubclasses { }
         private class NoOneSubclassesThisEither { }
-
-        private enum MyEnum { }
 
         private static void TestSignatureTypeInvariants(Type type)
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
@@ -329,16 +329,18 @@ namespace System.Reflection.Tests
         [Fact]
         public static void MakeGenericSignatureTypeValidation()
         {
-            // Standard reflection used as baseline.
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: null));
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: new Type[] { null }));
-            AssertExtensions.Throws<ArgumentException>("genericTypeDefinition", () => typeof(int).MakeGenericType(typeArguments: new Type[] { typeof(int) }));
+            // Calls to MakeGenericSignatureType() should have consistent validation with MakeGenericType().
 
-            // SignatureTypes.
             AssertExtensions.Throws<ArgumentNullException>("genericTypeDefinition", () => Type.MakeGenericSignatureType(genericTypeDefinition: null));
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: null));
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: new Type[] { null }));
+
             AssertExtensions.Throws<ArgumentException>("genericTypeDefinition", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(int), typeArguments: new Type[] { typeof(int) }));
+            AssertExtensions.Throws<InvalidOperationException>(() => typeof(int).MakeGenericType(typeArguments: new Type[] { typeof(int) }));
+
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: null));
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: null));
+
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: new Type[] { null }));
+            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: new Type[] { null }));
         }
 
         private static Type ToSignatureType(this Type type)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
@@ -266,14 +266,14 @@ namespace System.Reflection.Tests
             Assert.True(t.IsArray);
             Assert.True(t.IsSZArray);
             Assert.Equal(1, t.GetArrayRank());
+            Assert.False(t.IsValueType);
+            Assert.False(t.IsEnum);
 
             Type et = t.GetElementType();
             Assert.True(et.IsSignatureType);
             Assert.True(et.IsGenericParameter);
             Assert.False(et.IsGenericTypeParameter);
             Assert.True(et.IsGenericMethodParameter);
-            Assert.Throws<NotSupportedException>(() => et.IsValueType);
-            Assert.Throws<NotSupportedException>(() => et.IsEnum);
             Assert.Equal(5, et.GenericParameterPosition);
 
             TestSignatureTypeInvariants(t);
@@ -302,6 +302,8 @@ namespace System.Reflection.Tests
             Type t = Type.MakeGenericMethodParameter(5);
             t = t.MakeByRefType();
             Assert.True(t.IsByRef);
+            Assert.False(t.IsValueType);
+            Assert.False(t.IsEnum);
 
             Type et = t.GetElementType();
             Assert.True(et.IsSignatureType);
@@ -309,8 +311,6 @@ namespace System.Reflection.Tests
             Assert.False(et.IsGenericTypeParameter);
             Assert.True(et.IsGenericMethodParameter);
             Assert.Equal(5, et.GenericParameterPosition);
-            Assert.False(t.IsValueType);
-            Assert.False(t.IsEnum);
 
             TestSignatureTypeInvariants(t);
         }
@@ -321,6 +321,8 @@ namespace System.Reflection.Tests
             Type t = Type.MakeGenericMethodParameter(5);
             t = t.MakePointerType();
             Assert.True(t.IsPointer);
+            Assert.False(t.IsValueType);
+            Assert.False(t.IsEnum);
 
             Type et = t.GetElementType();
             Assert.True(et.IsSignatureType);
@@ -328,8 +330,6 @@ namespace System.Reflection.Tests
             Assert.False(et.IsGenericTypeParameter);
             Assert.True(et.IsGenericMethodParameter);
             Assert.Equal(5, et.GenericParameterPosition);
-            Assert.False(t.IsValueType);
-            Assert.False(t.IsEnum);
 
             TestSignatureTypeInvariants(t);
         }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
@@ -301,6 +301,7 @@ namespace System.Reflection.Tests
         [Theory]
         [InlineData(typeof(List<>))]
         [InlineData(typeof(Span<>))]
+        [InlineData(typeof(GenericType<>.GenericEnum))]
         public static void MakeSignatureConstructedGenericType(Type genericTypeDefinition)
         {
             Type gmp = Type.MakeGenericMethodParameter(5);
@@ -313,7 +314,7 @@ namespace System.Reflection.Tests
                     Assert.Equal(genericTypeDefinition, t.GetGenericTypeDefinition());
                     Assert.Equal(1, t.GenericTypeArguments.Length);
                     Assert.Equal(genericTypeDefinition.IsValueType, t.IsValueType);
-                    Assert.False(t.IsEnum);
+                    Assert.Equal(genericTypeDefinition.IsEnum, t.IsEnum);
 
                     Type et = t.GenericTypeArguments[0];
                     Assert.True(et.IsSignatureType);
@@ -425,6 +426,13 @@ namespace System.Reflection.Tests
 
         private class NoOneSubclasses { }
         private class NoOneSubclassesThisEither { }
+
+        private class GenericType<T>
+        {
+            public enum GenericEnum
+            {
+            }
+        }
 
         private static void TestSignatureTypeInvariants(Type type)
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
@@ -49,42 +49,6 @@ namespace System.Reflection.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(IsValueTypeTestData))]
-        public static void IsValueType(Type type, bool expected)
-        {
-            Assert.Equal(expected, type.IsValueType);
-        }
-
-        public static IEnumerable<object[]> IsValueTypeTestData
-        {
-            get
-            {
-                // These have normal generic argument types, not SignatureTypes. Using a SignatureType from MakeGenericMethodParameter()
-                // as the generic type argument throws NotSupportedException which is verified in MakeSignatureConstructedGenericType().
-                yield return new object[] { Type.MakeGenericSignatureType(typeof(List<>), typeof(int)).GetGenericArguments()[0], true };
-                yield return new object[] { Type.MakeGenericSignatureType(typeof(List<>), typeof(object)).GetGenericArguments()[0], false };
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(IsEnumTestData))]
-        public static void IsEnum(Type type, bool expected)
-        {
-            Assert.Equal(expected, type.IsEnum);
-        }
-
-        public static IEnumerable<object[]> IsEnumTestData
-        {
-            get
-            {
-                // These have normal generic argument types, not SignatureTypes. Using a SignatureType from MakeGenericMethodParameter()
-                // as the generic type argument throws NotSupportedException which is verified in MakeSignatureConstructedGenericType().
-                yield return new object[] { Type.MakeGenericSignatureType(typeof(List<>), typeof(MyEnum)).GetGenericArguments()[0], true };
-                yield return new object[] { Type.MakeGenericSignatureType(typeof(List<>), typeof(object)).GetGenericArguments()[0], false };
-            }
-        }
-
         [Fact]
         public static void GetMethodWithGenericParameterCount()
         {
@@ -348,6 +312,8 @@ namespace System.Reflection.Tests
                     Assert.True(t.IsConstructedGenericType);
                     Assert.Equal(genericTypeDefinition, t.GetGenericTypeDefinition());
                     Assert.Equal(1, t.GenericTypeArguments.Length);
+                    Assert.Equal(genericTypeDefinition.IsValueType, t.IsValueType);
+                    Assert.False(t.IsEnum);
 
                     Type et = t.GenericTypeArguments[0];
                     Assert.True(et.IsSignatureType);
@@ -355,8 +321,6 @@ namespace System.Reflection.Tests
                     Assert.False(et.IsGenericTypeParameter);
                     Assert.True(et.IsGenericMethodParameter);
                     Assert.Equal(5, et.GenericParameterPosition);
-                    Assert.Throws<NotSupportedException>(() => et.IsValueType);
-                    Assert.Throws<NotSupportedException>(() => et.IsEnum);
 
                     TestSignatureTypeInvariants(t);
                 });

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/SignatureTypes.cs
@@ -340,8 +340,8 @@ namespace System.Reflection.Tests
             AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: null));
             AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: null));
 
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: new Type[] { null }));
-            AssertExtensions.Throws<ArgumentNullException>("typeArguments", () => typeof(IList<>).MakeGenericType(typeArguments: new Type[] { null }));
+            AssertExtensions.Throws<ArgumentNullException>(() => Type.MakeGenericSignatureType(genericTypeDefinition: typeof(IList<>), typeArguments: new Type[] { null }));
+            AssertExtensions.Throws<ArgumentNullException>(() => typeof(IList<>).MakeGenericType(typeArguments: new Type[] { null }));
         }
 
         private static Type ToSignatureType(this Type type)

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1413,39 +1413,39 @@ namespace System
         }
 
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
-        public override Type MakeGenericType(Type[] instantiation)
+        public override Type MakeGenericType(Type[] typeArguments)
         {
-            ArgumentNullException.ThrowIfNull(instantiation);
+            ArgumentNullException.ThrowIfNull(typeArguments);
 
-            RuntimeType[] instantiationRuntimeType = new RuntimeType[instantiation.Length];
+            RuntimeType[] instantiationRuntimeType = new RuntimeType[typeArguments.Length];
 
             if (!IsGenericTypeDefinition)
                 throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this));
 
             RuntimeType[] genericParameters = GetGenericArgumentsInternal();
 
-            if (genericParameters.Length != instantiation.Length)
-                throw new ArgumentException(SR.Argument_GenericArgsCount, nameof(instantiation));
+            if (genericParameters.Length != typeArguments.Length)
+                throw new ArgumentException(SR.Argument_GenericArgsCount, nameof(typeArguments));
 
-            for (int i = 0; i < instantiation.Length; i++)
+            for (int i = 0; i < typeArguments.Length; i++)
             {
-                Type instantiationElem = instantiation[i];
+                Type instantiationElem = typeArguments[i];
                 if (instantiationElem == null)
-                    throw new ArgumentNullException();
+                    throw new ArgumentNullException(nameof(typeArguments));
 
                 RuntimeType? rtInstantiationElem = instantiationElem as RuntimeType;
 
                 if (rtInstantiationElem == null)
                 {
                     if (instantiationElem.IsSignatureType)
-                        return MakeGenericSignatureType(this, instantiation);
-                    Type[] instantiationCopy = new Type[instantiation.Length];
-                    for (int iCopy = 0; iCopy < instantiation.Length; iCopy++)
-                        instantiationCopy[iCopy] = instantiation[iCopy];
-                    instantiation = instantiationCopy;
+                        return MakeGenericSignatureType(this, typeArguments);
+                    Type[] instantiationCopy = new Type[typeArguments.Length];
+                    for (int iCopy = 0; iCopy < typeArguments.Length; iCopy++)
+                        instantiationCopy[iCopy] = typeArguments[iCopy];
+                    typeArguments = instantiationCopy;
                     if (!RuntimeFeature.IsDynamicCodeSupported)
                         throw new PlatformNotSupportedException();
-                    return System.Reflection.Emit.TypeBuilderInstantiation.MakeGenericType(this, instantiation);
+                    return System.Reflection.Emit.TypeBuilderInstantiation.MakeGenericType(this, typeArguments);
                 }
 
                 instantiationRuntimeType[i] = rtInstantiationElem;

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1431,7 +1431,7 @@ namespace System
             {
                 Type instantiationElem = typeArguments[i];
                 if (instantiationElem == null)
-                    throw new ArgumentNullException(nameof(typeArguments));
+                    throw new ArgumentNullException();
 
                 RuntimeType? rtInstantiationElem = instantiationElem as RuntimeType;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/112155

There may be other related edge cases related to "signature types"; this PR only fixes the case mentioned.
