### PR TITLE
`__ComObject` doesn't support dynamic interface map

### DIFF
--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -1090,9 +1090,12 @@ public:
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
-        // currently all ComObjects except
-        // for __ComObject have dynamic Interface maps
-        return GetNumInterfaces() > 0 && IsComObjectType() && !ParentEquals(g_pObjectClass);
+        // All ComObjects except for __ComObject
+        // have dynamic Interface maps
+        return GetNumInterfaces() > 0
+            && IsComObjectType()
+            && !ParentEquals(g_pObjectClass)
+            && this != g_pBaseCOMObject;
     }
 #endif // FEATURE_COMINTEROP
 

--- a/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
+++ b/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
@@ -79,6 +79,10 @@ namespace NetClient
             return 100;
         }
 
+        private class InterfaceImpl : Server.Contract.IInterface2
+        {
+        }
+
         private static void ValidationTests()
         {
             Console.WriteLine($"Running {nameof(ValidationTests)} ...");
@@ -208,6 +212,13 @@ namespace NetClient
             {
                 var expected = new Guid("{8EFAD956-B33D-46CB-90F4-45F55BA68A96}");
                 Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+
+            Console.WriteLine("-- Interfaces...");
+            {
+                var interfaceMaybe = miscTypeTesting.Marshal_Interface(new InterfaceImpl());
+                Assert.True(interfaceMaybe is Server.Contract.IInterface1);
+                Assert.True(interfaceMaybe is Server.Contract.IInterface2);
             }
         }
 

--- a/src/tests/Interop/COM/NETServer/MiscTypesTesting.cs
+++ b/src/tests/Interop/COM/NETServer/MiscTypesTesting.cs
@@ -45,4 +45,18 @@ public class MiscTypesTesting : Server.Contract.IMiscTypesTesting
     {
         result = value;
     }
+
+    private class InterfaceImpl : Server.Contract.IInterface2
+    {
+    }
+
+    Server.Contract.IInterface2 Server.Contract.IMiscTypesTesting.Marshal_Interface(object inst)
+    {
+        if (inst is not Server.Contract.IInterface2)
+        {
+            throw new InvalidCastException();
+        }
+
+        return new InterfaceImpl();
+    }
 }

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
@@ -331,6 +331,35 @@ void ValidationTests()
         HRESULT hr = miscTypesTesting->Marshal_Variant(args.Input, &args.Result);
         THROW_FAIL_IF_FALSE(hr == 0x80131531); // COR_E_INVALIDOLEVARIANTTYPE
     }
+
+    ::printf("-- Interfaces...\n");
+    {
+        struct InterfaceImpl : IInterface2
+        {
+            STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) override
+            {
+                if (riid == __uuidof(IInterface1) || riid == __uuidof(IInterface2))
+                {
+                    *ppvObject = static_cast<IInterface2*>(this);
+                }
+                else if (riid == __uuidof(IUnknown))
+                {
+                    *ppvObject = static_cast<IUnknown*>(this);
+                }
+                else
+                {
+                    *ppvObject = nullptr;
+                    return E_NOINTERFACE;
+                }
+                return S_OK;
+            }
+            STDMETHOD_(ULONG, AddRef)() override { return 1; }
+            STDMETHOD_(ULONG, Release)() override { return 1; }
+        } iface{};
+        ComSmartPtr<IInterface2> result;
+        HRESULT hr = miscTypesTesting->Marshal_Interface(&iface, &result);
+        THROW_IF_FAILED(hr);
+    }
 }
 
 void ValidationByRefTests()

--- a/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
+++ b/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
@@ -8,6 +8,20 @@
 
 class MiscTypesTesting : public UnknownImpl, public IMiscTypesTesting
 {
+    struct InterfaceImpl : public UnknownImpl, public IInterface2
+    {
+        public: // IInterface1
+        public: // IInterface2
+        public: // IUnknown
+            STDMETHOD(QueryInterface)(
+                /* [in] */ REFIID riid,
+                /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
+            {
+                return DoQueryInterface(riid, ppvObject, static_cast<IInterface1 *>(this), static_cast<IInterface2 *>(this));
+            }
+
+        DEFINE_REF_COUNTING();
+    };
 public: // IMiscTypesTesting
     DEF_FUNC(Marshal_Variant)(_In_ VARIANT obj, _Out_ VARIANT* result)
     {
@@ -22,6 +36,22 @@ public: // IMiscTypesTesting
     DEF_FUNC(Marshal_ByRefVariant)(_Inout_ VARIANT* result, _In_ VARIANT value)
     {
         return E_NOTIMPL;
+    }
+
+    DEF_FUNC(Marshal_Interface)(_In_ IUnknown* input, _Outptr_ IInterface2** value)
+    {
+        HRESULT hr;
+
+        IInterface2* ifaceMaybe = nullptr;
+        hr = input->QueryInterface(__uuidof(IInterface2), (void**)&ifaceMaybe);
+        if (FAILED(hr))
+            return hr;
+        (void)ifaceMaybe->Release();
+
+        InterfaceImpl* inst = new InterfaceImpl();
+        hr = inst->QueryInterface(__uuidof(IInterface2), (void**)value);
+        (void)inst->Release();
+        return hr;
     }
 
 public: // IUnknown

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -185,6 +185,20 @@ namespace Server.Contract
     }
 
     [ComVisible(true)]
+    [Guid("4242A2F9-995D-4302-A722-02058CF58158")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IInterface1
+    {
+    }
+
+    [ComVisible(true)]
+    [Guid("7AC820FE-E227-4C4D-A8B0-FCA68C459B43")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IInterface2 : IInterface1
+    {
+    }
+
+    [ComVisible(true)]
     [Guid("7FBB8677-BDD0-4E5A-B38B-CA92A4555466")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface IMiscTypesTesting
@@ -195,6 +209,9 @@ namespace Server.Contract
         object Marshal_Instance_Variant([MarshalAs(UnmanagedType.LPWStr)] string init);
 
         void Marshal_ByRefVariant(ref object result, object value);
+
+        [return: MarshalAs(UnmanagedType.Interface)]
+        IInterface2 Marshal_Interface([MarshalAs(UnmanagedType.Interface)] object inst);
     }
 
     public struct HResult

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -366,6 +366,16 @@ IStringTesting : IUnknown
         /*[out]*/ LCID* outLcid) = 0;
 };
 
+struct __declspec(uuid("4242A2F9-995D-4302-A722-02058CF58158"))
+IInterface1 : IUnknown
+{
+};
+
+struct __declspec(uuid("7AC820FE-E227-4C4D-A8B0-FCA68C459B43"))
+IInterface2 : public IInterface1
+{
+};
+
 struct __declspec(uuid("7FBB8677-BDD0-4E5A-B38B-CA92A4555466"))
 IMiscTypesTesting : IUnknown
 {
@@ -380,6 +390,10 @@ IMiscTypesTesting : IUnknown
       virtual HRESULT STDMETHODCALLTYPE Marshal_ByRefVariant (
         /*[inout]*/ VARIANT* result,
         /*[in]*/ VARIANT value) = 0;
+
+      virtual HRESULT STDMETHODCALLTYPE Marshal_Interface (
+        /*[in]*/ IUnknown* value,
+        /*[out,ret]*/ IInterface2** iface) = 0;
 };
 
 struct __declspec(uuid("592386a5-6837-444d-9de3-250815d18556"))


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/105965, an interface was added to `__ComObject`. This made some previous checks fail as they were written assuming `__ComObject` didn't have any interfaces. This change makes an explicit check that the `MethodTable` being queried isn't `__ComObject` as opposed to relying on some indirect reasoning.

Fixes #112371