### PR TITLE
Move generation of SuggestedBindingRedirects.targets to inner build

### DIFF
--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -97,7 +97,7 @@ System.Resources.Extensions.PreserializedResourceWriter</PackageDescription>
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(SuggestedBindingRedirectsPackageFile)"
           AfterTargets="CoreCompile"
-          Condition="'$(TargetFramework)' == '$(NetCoreAppMinimum)'">
+          Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)'">
     <PropertyGroup>
       <SuggestedBindingRedirectsPackageFileContent><![CDATA[<Project>
   <!-- ResolveAssemblyReferences will never see the assembly reference embedded in the resources type,

--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -9,7 +9,6 @@
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
     <SuggestedBindingRedirectsPackageFile>$(BaseIntermediateOutputPath)SuggestedBindingRedirects.targets</SuggestedBindingRedirectsPackageFile>
-    <BeforePack>$(BeforePack);GeneratePackageTargetsFile</BeforePack>
     <PackageDescription>Provides classes which read and write resources in a format that supports non-primitive objects.
 
 Commonly Used Types:
@@ -97,7 +96,8 @@ System.Resources.Extensions.PreserializedResourceWriter</PackageDescription>
   <Target Name="GeneratePackageTargetsFile" 
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(SuggestedBindingRedirectsPackageFile)"
-          Condition="'$(NetFrameworkMinimum)' != ''">
+          AfterTargets="CoreCompile"
+          Condition="'$(TargetFramework)' == '$(NetCoreAppMinimum)'">
     <PropertyGroup>
       <SuggestedBindingRedirectsPackageFileContent><![CDATA[<Project>
   <!-- ResolveAssemblyReferences will never see the assembly reference embedded in the resources type,
@@ -114,10 +114,11 @@ System.Resources.Extensions.PreserializedResourceWriter</PackageDescription>
                       Lines="$(SuggestedBindingRedirectsPackageFileContent)"
                       Overwrite="true" />
 
-    <ItemGroup>
-      <Content Include="$(SuggestedBindingRedirectsPackageFile)"
-               PackagePath="buildTransitive\$(NetFrameworkMinimum)\$(PackageId).targets" />
-    </ItemGroup>
   </Target>
+
+  <ItemGroup Condition="'$(NetFrameworkMinimum)' != ''">
+    <None Include="$(SuggestedBindingRedirectsPackageFile)" Pack="true"
+          PackagePath="buildTransitive\$(NetFrameworkMinimum)\$(PackageId).targets" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #111892 

These targets depend on the `AssemblyVersion` of the library which is specific to the inner-build of the library.  Generate them in the inner-build.

I tried including in the package as part of the inner-build as well but we also have other infrastructure in the outer build that observes targets added to the package, but can only do so if they're added in the outer build.
https://github.com/dotnet/runtime/blob/91bbb321494f4c274a5836226dc39105313859d0/eng/packaging.targets#L229-L230
I can't make that work so long as it runs in the outer build - since NuGet passes items out from inner-build only in a private item (`_PackageFiles`).  Probably I could refactor that to be part of the inner-build but it would be a larger change.
