### PR TITLE
Prevent returning disposed HTTP/1.1 connections to the pool

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -2102,6 +2102,7 @@ namespace System.Net.Http
 
         private void ReturnConnectionToPool()
         {
+            Debug.Assert(!_disposed, "Connection should not be disposed.");
             Debug.Assert(_currentRequest == null, "Connection should no longer be associated with a request.");
             Debug.Assert(_readAheadTask == default, "Expected a previous initial read to already be consumed.");
             Debug.Assert(_readAheadTaskStatus == ReadAheadTask_NotStarted, "Expected SendAsync to reset the read-ahead task status.");


### PR DESCRIPTION
Fixes #31254
Fixes #110577

There are race conditions in HTTP 1.1 response stream reading methods that may prevent the exceptional termination of those methods despite cancellation callbacks firing and disposing the connection, see the discussion starting with https://github.com/dotnet/runtime/issues/31254#issuecomment-2648840680.

As a result, these methods may call `CompleteResponse` returning the disposed connection to the pool.

This is a minimal fix for the mentioned issue, but I agree with @MihaZupan that we should rework the HTTP/1.1 cancellation, making sure to forward the CancellationTokens down to the underlying stream instead of relying on CancellationTokenRegistration + Dispose. In case we take this PR, I'm planning to open a new issue to track that work.