### PR TITLE
Wait to complete the test before releasing the agile reference.

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1084,6 +1084,7 @@ namespace ComWrappersTests
 
                 staThread.Start();
                 mtaThread.Start();
+                testCompleted.WaitOne();
             }
             finally
             {
@@ -1092,8 +1093,6 @@ namespace ComWrappersTests
                     Marshal.Release(agileReference);
                 }
             }
-
-            testCompleted.WaitOne();
         }
 
         [DllImport("ole32.dll")]


### PR DESCRIPTION
Otherwise we can end up with a use-after-free of the agile reference if the cleanup runs before the MTA thread calls Resolve.

I believe this fixes #112305 and fixes https://github.com/dotnet/runtime/issues/112386