### PR TITLE
Update SVE instructions that writes to GC regs

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -1087,6 +1087,22 @@ bool emitter::emitInsMayWriteToGCReg(instrDesc* id)
         case IF_SR_1A: // SR_1A   ................ ...........ttttt      Rt       (dc zva, mrs)
             return ins == INS_mrs_tpid0;
 
+        // Below SVE instructions write to GPR and hence GC reg
+        case IF_SVE_CO_3A: // clasta, clastb
+        case IF_SVE_BM_1A: // decb, decd, dech, decw, incb, incd, inch, incw
+        case IF_SVE_BO_1A: // sqdecb, sqdecd, sqdech, sqdecw, sqincb, sqincd, sqinch, sqincw, uqdecb, uqdecd, uqdech,
+                           // uqdecw, uqincb, uqincd, uqinch, uqincw
+        case IF_SVE_CS_3A: // lasta, lastb
+        case IF_SVE_DK_3A: // cntp
+        case IF_SVE_DL_2A: // cntp
+        case IF_SVE_DM_2A: // decp, incp
+        case IF_SVE_DO_2A: // sqdecp, sqincp, uqdecp, uqincp
+        case IF_SVE_BB_2A: // addpl, addvl
+        case IF_SVE_BC_1A: // rdvl
+        case IF_SVE_BL_1A: // cntb, cntd, cnth, cntw
+        case IF_SVE_DS_2A: // ctermeq, ctermne
+            return true;
+
         default:
             return false;
     }


### PR DESCRIPTION
We didn't update the method `emitInsMayWriteToGCReg` when we added SVE instructions. This method keeps track if we will be writing into GPR registers and if so, need to remove that register from GC tracking.

Fixes: https://github.com/dotnet/runtime/issues/112362

@dotnet/arm64-contrib 