### PR TITLE
Improve Enumerable.Skip and Enumerable.Take performance

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
@@ -148,6 +149,17 @@ namespace System.Linq
 
             private static void Fill(IList<TSource> source, Span<TSource> destination, int sourceIndex)
             {
+                if (source is TSource[] sourceArray)
+                {
+                    sourceArray.AsSpan(sourceIndex, destination.Length).CopyTo(destination);
+                    return;
+                }
+                else if (source is List<TSource> sourceList)
+                {
+                    CollectionsMarshal.AsSpan(sourceList).Slice(sourceIndex, destination.Length).CopyTo(destination);
+                    return;
+                }
+
                 for (int i = 0; i < destination.Length; i++, sourceIndex++)
                 {
                     destination[i] = source[sourceIndex];

--- a/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
@@ -166,6 +166,11 @@ namespace System.Linq
             {
                 IList<TSource> source = _source;
 
+                if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
+                {
+                    return span.Slice(_minIndexInclusive, Count).IndexOf(item);
+                }
+
                 int end = _minIndexInclusive + Count;
                 for (int i = _minIndexInclusive; i < end; i++)
                 {

--- a/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
@@ -149,14 +148,9 @@ namespace System.Linq
 
             private static void Fill(IList<TSource> source, Span<TSource> destination, int sourceIndex)
             {
-                if (source is TSource[] sourceArray)
+                if (source.TryGetSpan(out ReadOnlySpan<TSource> sourceSpan))
                 {
-                    sourceArray.AsSpan(sourceIndex, destination.Length).CopyTo(destination);
-                    return;
-                }
-                else if (source is List<TSource> sourceList)
-                {
-                    CollectionsMarshal.AsSpan(sourceList).Slice(sourceIndex, destination.Length).CopyTo(destination);
+                    sourceSpan.Slice(sourceIndex, destination.Length).CopyTo(destination);
                     return;
                 }
 


### PR DESCRIPTION
## Summary

`CopyTo` is now used in `ToArray` and `ToList` after `Skip` and `Take` when source is `List<T>` or `T[]`.

## Benchmark

```
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.26100.3037)
12th Gen Intel Core i7-12700F, 1 CPU, 20 logical and 12 physical cores
.NET SDK=8.0.300
  [Host]     : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2


|         Method |      Mean |     Error |    StdDev |   Gen0 |   Gen1 | Allocated |
|--------------- |----------:|----------:|----------:|-------:|-------:|----------:|
|    SkipAndTake | 533.98 ns | 10.388 ns | 10.203 ns | 0.1335 |      - |   1.71 KB |
| SkipAndTake_PR | 118.56 ns |  1.430 ns |  1.194 ns | 0.1340 | 0.0007 |   1.71 KB |
|       GetRange |  77.37 ns |  0.815 ns |  0.723 ns | 0.1267 | 0.0007 |   1.62 KB |
```

```cs
[MemoryDiagnoser]
public class Benchmark
{
    private readonly List<string> _list = Enumerable.Range(0, 1000).Select(i => i.ToString()).ToList();

    [Benchmark]
    public List<string> SkipAndTake() =>
        _list.Skip(200).Take(200).ToList();

    [Benchmark]
    public List<string> SkipAndTake_PR() =>
        _list.Skip_PR(200).Take_PR(200).ToList();

    [Benchmark]
    public List<string> GetRange() =>
        _list.GetRange(200, 200);
}
```