### PR TITLE
fix the regression in regions when handling heavily pinning scenarios

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -32551,10 +32551,9 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
         }
 
 #ifdef SIMPLE_DPRINTF
-        dprintf (REGIONS_LOG, ("h%d ad_p_d: PL: %zd, SL: %zd, pfr: %.3f, psr: %.3f, prmoote gen1 %d. gen1_pins_left %Id, total surv %Id (p:%Id), total_space %Id(%Id)",
-            heap_number, gen1_pins_left, total_space_to_skip, pin_frag_ratio, pin_surv_ratio, actual_promote_gen1_pins_p,
-            gen1_pins_left, dd_survived_size (dynamic_data_of (max_generation - 1)), dd_pinned_survived_size (dynamic_data_of (max_generation - 1)),
-            total_space_to_skip, total_space_no_es));
+        dprintf (REGIONS_LOG, ("h%d ad_p_d: PL: %zd, SL: %zd, pfr: %.3f, psr: %.3f, prmoote gen1 %d. gen1_pins_left %Id, total surv %Id (p:%Id), total_space %Id",
+            heap_number, gen1_pins_left, total_space_to_skip, pin_frag_ratio, pin_surv_ratio, actual_promote_gen1_pins_p, gen1_pins_left,
+            dd_survived_size (dynamic_data_of (max_generation - 1)), dd_pinned_survived_size (dynamic_data_of (max_generation - 1)), total_space_to_skip));
 #endif
     }
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -106,16 +106,14 @@ BOOL bgc_heap_walk_for_etw_p = FALSE;
 #define num_partial_refs 32
 #endif //SERVER_GC
 
+#define demotion_plug_len_th (6*1024*1024)
+
 #ifdef USE_REGIONS
-// If the pinned survived is 1+% of the region size, we don't demote.
-#define demotion_pinned_ratio_th (1)
 // If the survived / region_size is 90+%, we don't compact this region.
 #define sip_surv_ratio_th (90)
 // If the survived due to cards from old generations / region_size is 90+%,
 // we don't compact this region, also we immediately promote it to gen2.
 #define sip_old_card_surv_ratio_th (90)
-#else
-#define demotion_plug_len_th (6*1024*1024)
 #endif //USE_REGIONS
 
 #ifdef HOST_64BIT
@@ -2566,6 +2564,8 @@ BOOL        gc_heap::last_gc_before_oom = FALSE;
 
 BOOL        gc_heap::sufficient_gen0_space_p = FALSE;
 
+BOOL        gc_heap::decide_promote_gen1_pins_p = TRUE;
+
 #ifdef BACKGROUND_GC
 uint8_t*    gc_heap::background_saved_lowest_address = 0;
 uint8_t*    gc_heap::background_saved_highest_address = 0;
@@ -2616,8 +2616,6 @@ uint8_t*    gc_heap::gc_high = 0;
 uint8_t*    gc_heap::demotion_low;
 
 uint8_t*    gc_heap::demotion_high;
-
-BOOL        gc_heap::demote_gen1_p = TRUE;
 
 uint8_t*    gc_heap::last_gen1_pin_end;
 #endif //!USE_REGIONS
@@ -3378,61 +3376,61 @@ gc_heap::dt_low_ephemeral_space_p (gc_tuning_point tp)
 
 BOOL
 gc_heap::dt_high_frag_p (gc_tuning_point tp,
-                         int gen_number,
-                         BOOL elevate_p)
+    int gen_number,
+    BOOL elevate_p)
 {
     BOOL ret = FALSE;
 
     switch (tp)
     {
-        case tuning_deciding_condemned_gen:
-        {
-            dynamic_data* dd = dynamic_data_of (gen_number);
-            float fragmentation_burden = 0;
+    case tuning_deciding_condemned_gen:
+    {
+        dynamic_data* dd = dynamic_data_of (gen_number);
+        float fragmentation_burden = 0;
 
-            if (elevate_p)
+        if (elevate_p)
+        {
+            ret = (dd_fragmentation (dynamic_data_of (max_generation)) >= dd_max_size(dd));
+            if (ret)
             {
-                ret = (dd_fragmentation (dynamic_data_of (max_generation)) >= dd_max_size(dd));
-                if (ret)
-                {
-                    dprintf (6666, ("h%d: frag is %zd, max size is %zd",
-                        heap_number, dd_fragmentation (dd), dd_max_size(dd)));
-                }
+                dprintf (6666, ("h%d: frag is %zd, max size is %zd",
+                    heap_number, dd_fragmentation (dd), dd_max_size(dd)));
             }
-            else
-            {
-#ifndef MULTIPLE_HEAPS
-                if (gen_number == max_generation)
-                {
-                    size_t maxgen_size = generation_size (max_generation);
-                    float frag_ratio = (maxgen_size ? ((float)dd_fragmentation (dynamic_data_of (max_generation)) / (float)maxgen_size) : 0.0f);
-                    if (frag_ratio > 0.65)
-                    {
-                        dprintf (GTC_LOG, ("g2 FR: %d%%", (int)(frag_ratio*100)));
-                        return TRUE;
-                    }
-                }
-#endif //!MULTIPLE_HEAPS
-                size_t fr = generation_unusable_fragmentation (generation_of (gen_number), heap_number);
-                ret = (fr > dd_fragmentation_limit(dd));
-                if (ret)
-                {
-                    size_t gen_size = generation_size (gen_number);
-                    fragmentation_burden = (gen_size ? ((float)fr / (float)gen_size) : 0.0f);
-                    ret = (fragmentation_burden > dd_v_fragmentation_burden_limit (dd));
-                }
-                if (ret)
-                {
-                    dprintf (6666, ("h%d: gen%d, frag is %zd, alloc effi: %zu%%, unusable frag is %zd, ratio is %d",
-                        heap_number, gen_number, dd_fragmentation (dd),
-                        generation_allocator_efficiency_percent (generation_of (gen_number)),
-                        fr, (int)(fragmentation_burden * 100)));
-                }
-            }
-            break;
         }
-        default:
-            break;
+        else
+        {
+#ifndef MULTIPLE_HEAPS
+            if (gen_number == max_generation)
+            {
+                size_t maxgen_size = generation_size (max_generation);
+                float frag_ratio = (maxgen_size ? ((float)dd_fragmentation (dynamic_data_of (max_generation)) / (float)maxgen_size) : 0.0f);
+                if (frag_ratio > 0.65)
+                {
+                    dprintf (GTC_LOG, ("g2 FR: %d%%", (int)(frag_ratio*100)));
+                    return TRUE;
+                }
+            }
+#endif //!MULTIPLE_HEAPS
+            size_t fr = generation_unusable_fragmentation (generation_of (gen_number), heap_number);
+            ret = (fr > dd_fragmentation_limit(dd));
+            if (ret)
+            {
+                size_t gen_size = generation_size (gen_number);
+                fragmentation_burden = (gen_size ? ((float)fr / (float)gen_size) : 0.0f);
+                ret = (fragmentation_burden > dd_v_fragmentation_burden_limit (dd));
+            }
+            if (ret)
+            {
+                dprintf (6666, ("h%d: gen%d, frag is %zd, alloc effi: %zu%%, unusable frag is %zd, ratio is %d",
+                    heap_number, gen_number, dd_fragmentation (dd),
+                    generation_allocator_efficiency_percent (generation_of (gen_number)),
+                    fr, (int)(fragmentation_burden * 100)));
+            }
+        }
+        break;
+    }
+    default:
+        break;
     }
 
     return ret;
@@ -20754,6 +20752,55 @@ heap_segment* gc_heap::get_next_alloc_seg (generation* gen)
 #endif //USE_REGIONS
 }
 
+bool gc_heap::decide_on_gen1_pin_promotion (float pin_frag_ratio, float pin_surv_ratio)
+{
+    return ((pin_frag_ratio > 0.15) && (pin_surv_ratio > 0.30));
+}
+
+// Add the size of the pinned plug to the higher generation's pinned allocations.
+void gc_heap::attribute_pin_higher_gen_alloc (
+#ifdef USE_REGIONS
+                                              heap_segment* seg, int to_gen_number,
+#endif
+                                              uint8_t* plug, size_t len)
+{
+    //find out which gen this pinned plug came from
+    int frgn = object_gennum (plug);
+    if ((frgn != (int)max_generation) && settings.promotion)
+    {
+        generation_pinned_allocation_sweep_size (generation_of (frgn + 1)) += len;
+
+#ifdef USE_REGIONS
+        // With regions it's a bit more complicated since we only set the plan_gen_num
+        // of a region after we've planned it. This means if the pinning plug is in the
+        // the same seg we are planning, we haven't set its plan_gen_num yet. So we
+        // need to check for that first.
+        int togn = (in_range_for_segment (plug, seg) ? to_gen_number : object_gennum_plan (plug));
+#else
+        int togn = object_gennum_plan (plug);
+#endif //USE_REGIONS
+        if (frgn < togn)
+        {
+            generation_pinned_allocation_compact_size (generation_of (togn)) += len;
+        }
+    }
+}
+
+#ifdef USE_REGIONS
+void gc_heap::attribute_pin_higher_gen_alloc (int frgn, int togn, size_t len)
+{
+    if ((frgn != (int)max_generation) && settings.promotion)
+    {
+        generation_pinned_allocation_sweep_size (generation_of (frgn + 1)) += len;
+
+        if (frgn < togn)
+        {
+            generation_pinned_allocation_compact_size (generation_of (togn)) += len;
+        }
+    }
+}
+#endif //USE_REGIONS
+
 uint8_t* gc_heap::allocate_in_condemned_generations (generation* gen,
                                                   size_t size,
                                                   int from_gen_number,
@@ -20841,28 +20888,12 @@ retry:
                 generation_allocation_context_start_region (gen) = generation_allocation_pointer (gen);
                 generation_allocation_limit (gen) = heap_segment_plan_allocated (seg);
                 set_allocator_next_pin (gen);
-
-                //Add the size of the pinned plug to the right pinned allocations
-                //find out which gen this pinned plug came from
-                int frgn = object_gennum (plug);
-                if ((frgn != (int)max_generation) && settings.promotion)
-                {
-                    generation_pinned_allocation_sweep_size (generation_of (frgn + 1)) += len;
-
+                attribute_pin_higher_gen_alloc (
 #ifdef USE_REGIONS
-                    // With regions it's a bit more complicated since we only set the plan_gen_num
-                    // of a region after we've planned it. This means if the pinning plug is in the
-                    // the same seg we are planning, we haven't set its plan_gen_num yet. So we
-                    // need to check for that first.
-                    int togn = (in_range_for_segment (plug, seg) ? to_gen_number : object_gennum_plan (plug));
-#else
-                    int togn = object_gennum_plan (plug);
-#endif //USE_REGIONS
-                    if (frgn < togn)
-                    {
-                        generation_pinned_allocation_compact_size (generation_of (togn)) += len;
-                    }
-                }
+                                                seg, to_gen_number,
+#endif
+                                                plug, len);
+
                 goto retry;
             }
 
@@ -31125,7 +31156,8 @@ void gc_heap::advance_pins_for_demotion (generation* gen)
         size_t total_space_to_skip = last_gen1_pin_end - generation_allocation_pointer (gen);
         float pin_frag_ratio = (float)gen1_pins_left / (float)total_space_to_skip;
         float pin_surv_ratio = (float)gen1_pins_left / (float)(dd_survived_size (dynamic_data_of (max_generation - 1)));
-        if ((pin_frag_ratio > 0.15) && (pin_surv_ratio > 0.30))
+        bool actual_promote_gen1_pins_p = decide_on_gen1_pin_promotion (pin_frag_ratio, pin_surv_ratio);
+        if (actual_promote_gen1_pins_p)
         {
             while (!pinned_plug_que_empty_p() &&
                     (pinned_plug (oldest_pin()) < original_youngest_start))
@@ -31139,19 +31171,7 @@ void gc_heap::advance_pins_for_demotion (generation* gen)
                 generation_allocation_pointer (gen) = plug + len;
                 generation_allocation_limit (gen) = heap_segment_plan_allocated (seg);
                 set_allocator_next_pin (gen);
-
-                //Add the size of the pinned plug to the right pinned allocations
-                //find out which gen this pinned plug came from
-                int frgn = object_gennum (plug);
-                if ((frgn != (int)max_generation) && settings.promotion)
-                {
-                    int togn = object_gennum_plan (plug);
-                    generation_pinned_allocation_sweep_size ((generation_of (frgn +1))) += len;
-                    if (frgn < togn)
-                    {
-                        generation_pinned_allocation_compact_size (generation_of (togn)) += len;
-                    }
-                }
+                attribute_pin_higher_gen_alloc (plug, len);
 
                 dprintf (2, ("skipping gap %zu, pin %p (%zd)",
                     pinned_len (pinned_plug_of (entry)), plug, len));
@@ -31280,7 +31300,7 @@ retry:
             if (active_new_gen_number == (max_generation - 1))
             {
                 maxgen_pinned_compact_before_advance = generation_pinned_allocation_compact_size (generation_of (max_generation));
-                if (!demote_gen1_p)
+                if (decide_promote_gen1_pins_p)
                     advance_pins_for_demotion (consing_gen);
             }
 
@@ -32214,6 +32234,7 @@ void gc_heap::record_interesting_data_point (interesting_data_point idp)
 void gc_heap::skip_pins_in_alloc_region (generation* consing_gen, int plan_gen_num)
 {
     heap_segment* alloc_region = generation_allocation_segment (consing_gen);
+    size_t skipped_pins_len = 0;
     while (!pinned_plug_que_empty_p())
     {
         uint8_t* oldest_plug = pinned_plug (oldest_pin());
@@ -32225,6 +32246,7 @@ void gc_heap::skip_pins_in_alloc_region (generation* consing_gen, int plan_gen_n
             uint8_t* plug = pinned_plug (m);
             size_t len =    pinned_len (m);
 
+            skipped_pins_len += len;
             set_new_pin_info (m, generation_allocation_pointer (consing_gen));
             dprintf (REGIONS_LOG, ("pin %p b: %zx->%zx", plug, brick_of (plug),
                 (size_t)(brick_table[brick_of (plug)])));
@@ -32243,36 +32265,42 @@ void gc_heap::skip_pins_in_alloc_region (generation* consing_gen, int plan_gen_n
         (heap_segment_swept_in_plan (alloc_region) ? "SIP" : "non SIP"),
         (heap_segment_swept_in_plan (alloc_region) ?
             heap_segment_plan_gen_num (alloc_region) : plan_gen_num)));
+
+    attribute_pin_higher_gen_alloc (heap_segment_gen_num (alloc_region), plan_gen_num, skipped_pins_len);
+
     set_region_plan_gen_num_sip (alloc_region, plan_gen_num);
     heap_segment_plan_allocated (alloc_region) = generation_allocation_pointer (consing_gen);
 }
 
-void gc_heap::decide_on_demotion_pin_surv (heap_segment* region, int* no_pinned_surv_region_count)
+void gc_heap::decide_on_demotion_pin_surv (heap_segment* region, int* no_pinned_surv_region_count, bool promote_gen1_pins_p, bool large_pins_p)
 {
+    int gen_num = heap_segment_gen_num (region);
     int new_gen_num = 0;
     int pinned_surv = heap_segment_pinned_survived (region);
+    int promote_pins_p = large_pins_p;
 
     if (pinned_surv == 0)
     {
         (*no_pinned_surv_region_count)++;
-        dprintf (REGIONS_LOG, ("region %Ix will be empty", heap_segment_mem (region)));
+        dprintf (REGIONS_LOG, ("h%d gen%d region %Ix will be empty", heap_number, heap_segment_gen_num (region), heap_segment_mem (region)));
     }
-
-    // If this region doesn't have much pinned surv left, we demote it; otherwise the region
-    // will be promoted like normal.
-    size_t basic_region_size = (size_t)1 << min_segment_size_shr;
-    int pinned_ratio = (int)(((double)pinned_surv * 100.0) / (double)basic_region_size);
-    dprintf (REGIONS_LOG, ("h%d g%d region %Ix(%Ix) ps: %d (%d) (%s)", heap_number,
-        heap_segment_gen_num (region), (size_t)region, heap_segment_mem (region), pinned_surv, pinned_ratio,
-        ((pinned_ratio >= demotion_pinned_ratio_th) ? "ND" : "D")));
-
-    if (pinned_ratio >= demotion_pinned_ratio_th)
+    else
     {
-        if (settings.promotion)
+        if (!promote_pins_p && (gen_num == (max_generation - 1)) && promote_gen1_pins_p)
+        {
+            promote_pins_p = true;
+        }
+
+        if (promote_pins_p)
         {
             new_gen_num = get_plan_gen_num (heap_segment_gen_num (region));
         }
+
+        attribute_pin_higher_gen_alloc (gen_num, new_gen_num, pinned_surv);
     }
+
+    dprintf (REGIONS_LOG, ("h%d gen%d region pinned surv %d %s -> g%d",
+        heap_number, gen_num, pinned_surv, (promote_pins_p ? "PROMOTE" : "DEMOTE"), new_gen_num));
 
     set_region_plan_gen_num (region, new_gen_num);
 }
@@ -32425,6 +32453,9 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
 
                 // Instead of checking for this condition we just set the alloc region to 0 so it's easier to check
                 // later.
+                //
+                // set generation_allocation_segment to 0, we know we don't have pins so we will not be going through the while loop below
+                // 
                 generation_allocation_segment (consing_gen) = 0;
                 generation_allocation_pointer (consing_gen) = 0;
                 generation_allocation_limit (consing_gen) = 0;
@@ -32435,13 +32466,12 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
     // What has been planned doesn't change at this point. So at this point we know exactly which generation still doesn't
     // have any regions planned and this method is responsible to attempt to plan at least one region in each of those gens.
     // So we look at each of the remaining regions (that are non SIP, since SIP regions have already been planned) and decide
-    // which generation it should be planned in. We used the following rules to decide -
+    // which generation it should be planned in.
     //
-    // + if the pinned surv of a region is >= demotion_pinned_ratio_th (this will be dynamically tuned based on memory load),
-    //   it will be promoted to its normal planned generation unconditionally.
+    // + if we are in a gen1 GC due to cards, we will decide if we need to promote based on the same criteria as segments. And
+    //   we never demote large pins to gen0.
     //
-    // + if the pinned surv is < demotion_pinned_ratio_th, we will always demote it to gen0. We will record how many regions
-    //   have no survival at all - those will be empty and can be used to plan any non gen0 generation if needed.
+    // + we will record how many regions have no survival at all - those will be empty and can be used to plan any non gen0 generation if needed.
     //
     //   Note! We could actually promote a region with non zero pinned survivors to whichever generation we'd like (eg, we could
     //   promote a gen0 region to gen2). However it means we'd need to set cards on those objects because we will not have a chance
@@ -32458,7 +32488,7 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
     // + if we don't have enough in regions that will be empty, we'll need to ask for new regions and if we can't, we fall back
     //   to the special sweep mode.
     //
-    dprintf (REGIONS_LOG, ("h%d regions in g2: %d, g1: %d, g0: %d, before processing remaining regions",
+    dprintf (REGIONS_LOG, ("h%d planned regions in g2: %d, g1: %d, g0: %d, before processing remaining regions",
         heap_number, planned_regions_per_gen[2], planned_regions_per_gen[1], planned_regions_per_gen[0]));
 
     dprintf (REGIONS_LOG, ("h%d g2: surv %Id(p: %Id, %.2f%%), g1: surv %Id(p: %Id, %.2f%%), g0: surv %Id(p: %Id, %.2f%%)",
@@ -32472,11 +32502,67 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
 
     int to_be_empty_regions = 0;
 
+    // If decide_promote_gen1_pins_p is true, We need to see if we should promote what's left in gen1 pins. We either promote
+    // or demote all that's left. As a future performance improvement, we could sort these regions by the amount of
+    // pinned survival and only promote the ones with excessive amounts of survival.
+    //
+    // First go through the remaining gen1 regions to see if we should demote the remaining pins
+    heap_segment* current_region = generation_allocation_segment (consing_gen);
+    bool actual_promote_gen1_pins_p = false;
+
+    if (decide_promote_gen1_pins_p)
+    {
+        size_t gen1_pins_left = 0;
+        size_t total_space_to_skip = 0;
+
+        // just need to go through each remaining gen1 regions (heap_segment_non_sip regions, the SIP regions's pinned surv should be 0 anyway because pinned_survived_region
+        // simply doesn't get updated and remains 0) and get their pinned surv.
+        //
+        while (current_region)
+        {
+            int gen_num = heap_segment_gen_num (current_region);
+            if (gen_num != 0)
+            {
+                assert (gen_num == (max_generation - 1));
+
+                gen1_pins_left += heap_segment_pinned_survived (current_region);
+                total_space_to_skip += get_region_size (current_region);
+            }
+            else
+            {
+                break;
+            }
+
+            current_region = heap_segment_next (current_region);
+        }
+
+        // note total_space_to_skip can be 0 because we could have already consumed all the pins before current_region.
+        float pin_frag_ratio = 0.0;
+        float pin_no_es_frag_ratio = 0.0;
+        float pin_surv_ratio = (float)gen1_pins_left / (float)(dd_survived_size (dynamic_data_of (max_generation - 1)));
+
+        if (total_space_to_skip)
+        {
+            pin_frag_ratio = (float)gen1_pins_left / (float)total_space_to_skip;
+            actual_promote_gen1_pins_p = decide_on_gen1_pin_promotion (pin_frag_ratio, pin_surv_ratio);
+        }
+
+#ifdef SIMPLE_DPRINTF
+        dprintf (REGIONS_LOG, ("h%d ad_p_d: PL: %zd, SL: %zd, pfr: %.3f, psr: %.3f, prmoote gen1 %d. gen1_pins_left %Id, total surv %Id (p:%Id), total_space %Id(%Id)",
+            heap_number, gen1_pins_left, total_space_to_skip, pin_frag_ratio, pin_surv_ratio, actual_promote_gen1_pins_p,
+            gen1_pins_left, dd_survived_size (dynamic_data_of (max_generation - 1)), dd_pinned_survived_size (dynamic_data_of (max_generation - 1)),
+            total_space_to_skip, total_space_no_es));
+#endif
+    }
+
+    maxgen_pinned_compact_before_advance = generation_pinned_allocation_compact_size (generation_of (max_generation));
+
+    bool large_pins_p = false;
+
     while (!pinned_plug_que_empty_p())
     {
         uint8_t* oldest_plug = pinned_plug (oldest_pin());
 
-        // detect pinned block in segments without pins
         heap_segment* nseg = heap_segment_rw (generation_allocation_segment (consing_gen));
         dprintf (3, ("h%d oldest pin: %p, consing alloc %p, ptr %p, limit %p",
             heap_number, oldest_plug, heap_segment_mem (nseg),
@@ -32486,12 +32572,10 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
         while ((oldest_plug < generation_allocation_pointer (consing_gen)) ||
                (oldest_plug >= heap_segment_allocated (nseg)))
         {
-            assert ((oldest_plug < heap_segment_mem (nseg)) ||
-                    (oldest_plug > heap_segment_reserved (nseg)));
-            assert (generation_allocation_pointer (consing_gen)>=
-                    heap_segment_mem (nseg));
-            assert (generation_allocation_pointer (consing_gen)<=
-                    heap_segment_committed (nseg));
+            assert ((oldest_plug < heap_segment_mem (nseg)) || (oldest_plug > heap_segment_reserved (nseg)));
+            assert (generation_allocation_pointer (consing_gen)>= heap_segment_mem (nseg));
+            assert (generation_allocation_pointer (consing_gen)<= heap_segment_committed (nseg));
+            assert (!heap_segment_swept_in_plan (nseg));
 
             dprintf (3, ("h%d PRR: in loop, seg %p pa %p -> alloc ptr %p, plan gen %d->%d",
                 heap_number, heap_segment_mem (nseg),
@@ -32500,10 +32584,8 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
                 heap_segment_plan_gen_num (nseg),
                 current_plan_gen_num));
 
-            assert (!heap_segment_swept_in_plan (nseg));
-
             heap_segment_plan_allocated (nseg) = generation_allocation_pointer (consing_gen);
-            decide_on_demotion_pin_surv (nseg, &to_be_empty_regions);
+            decide_on_demotion_pin_surv (nseg, &to_be_empty_regions, actual_promote_gen1_pins_p, large_pins_p);
 
             heap_segment* next_seg = heap_segment_next_non_sip (nseg);
 
@@ -32516,6 +32598,7 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
 
             assert (next_seg != 0);
             nseg = next_seg;
+            large_pins_p = false;
 
             generation_allocation_segment (consing_gen) = nseg;
             generation_allocation_pointer (consing_gen) = heap_segment_mem (nseg);
@@ -32524,6 +32607,11 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
         mark* m = pinned_plug_of (deque_pinned_plug());
         uint8_t* plug = pinned_plug (m);
         size_t len = pinned_len (m);
+
+        if (!large_pins_p)
+        {
+            large_pins_p = (len >= demotion_plug_len_th);
+        }
 
         set_new_pin_info (m, generation_allocation_pointer (consing_gen));
         size_t free_size = pinned_len (m);
@@ -32537,7 +32625,7 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
             generation_allocation_pointer (consing_gen);
     }
 
-    heap_segment* current_region = generation_allocation_segment (consing_gen);
+    current_region = generation_allocation_segment (consing_gen);
 
     if (special_sweep_p)
     {
@@ -32556,7 +32644,7 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
 
     if (current_region)
     {
-        decide_on_demotion_pin_surv (current_region, &to_be_empty_regions);
+        decide_on_demotion_pin_surv (current_region, &to_be_empty_regions, actual_promote_gen1_pins_p, large_pins_p);
 
         if (!heap_segment_swept_in_plan (current_region))
         {
@@ -33295,6 +33383,12 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
     dprintf(3,( " From %zx to %zx", (size_t)x, (size_t)end));
 
+    // Normally we always demote pins left after plan allocation, but if we are doing a gen1 only because of cards, it means
+    // we need to decide if we will promote these pins from gen1.
+    decide_promote_gen1_pins_p = (settings.promotion &&
+        (settings.condemned_generation == (max_generation - 1)) &&
+        gen_to_condemn_reasons.is_only_condition(gen_low_card_p));
+
 #ifdef USE_REGIONS
     if (should_sweep_in_plan (seg1))
     {
@@ -33304,11 +33398,6 @@ void gc_heap::plan_phase (int condemned_gen_number)
 #else
     demotion_low = MAX_PTR;
     demotion_high = heap_segment_allocated (ephemeral_heap_segment);
-    // If we are doing a gen1 only because of cards, it means we should not demote any pinned plugs
-    // from gen1. They should get promoted to gen2.
-    demote_gen1_p = !(settings.promotion &&
-        (settings.condemned_generation == (max_generation - 1)) &&
-        gen_to_condemn_reasons.is_only_condition(gen_low_card_p));
 
     total_ephemeral_size = 0;
 #endif //!USE_REGIONS
@@ -33789,7 +33878,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                 dd_artificial_pinned_survived_size (dd_active_old) += artificial_pinned_size;
 
 #ifndef USE_REGIONS
-                if (!demote_gen1_p && (active_old_gen_number == (max_generation - 1)))
+                if (decide_promote_gen1_pins_p && (active_old_gen_number == (max_generation - 1)))
                 {
                     last_gen1_pin_end = plug_end;
                 }
@@ -33886,7 +33975,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                     if (active_new_gen_number == (max_generation - 1))
                     {
                         maxgen_pinned_compact_before_advance = generation_pinned_allocation_compact_size (generation_of (max_generation));
-                        if (!demote_gen1_p)
+                        if (decide_promote_gen1_pins_p)
                             advance_pins_for_demotion (consing_gen);
                     }
 
@@ -34032,9 +34121,9 @@ void gc_heap::plan_phase (int condemned_gen_number)
         }
 
         dprintf (2, ("older gen's free alloc: %zd->%zd, seg alloc: %zd->%zd, condemned alloc: %zd->%zd",
-                    r_older_gen_free_list_allocated, generation_free_list_allocated (older_gen),
-                    r_older_gen_end_seg_allocated, generation_end_seg_allocated (older_gen),
-                    r_older_gen_condemned_allocated, generation_condemned_allocated (older_gen)));
+            r_older_gen_free_list_allocated, generation_free_list_allocated (older_gen),
+            r_older_gen_end_seg_allocated, generation_end_seg_allocated (older_gen),
+            r_older_gen_condemned_allocated, generation_condemned_allocated (older_gen)));
 
         dprintf (2, ("this GC did %zd free list alloc(%zd bytes free space rejected)",
             free_list_allocated, rejected_free_space));


### PR DESCRIPTION
this is to make regions behave very similarly to segments for heavily pinning scenarios. previously we observed regression in heap size due to regions not being aggressively demoted. changes included in this PR -

1) use the same policy for demotion of pinned plugs as much as possible for regions. since objects in a region can only belong to one generation, for pins observed `skip_pins_in_alloc_region` they will not use the same policy as they must belong to what's already allocated in that region. this policy is only applicable for regions with only pins left.

2) attribute the pins to the higher generation's `generation_allocation_size` when appropriate.

3) update data for events correctly for these pins.

testing methodology -

I used the following GCPerfSim cmdline -

`-tc 2 -tagb 50 -tlgb 2 -lohpi 0 -sohsi 50 -ramb 20 -rlmb 2`

and 4 scenarios with varying pinning -

```
NOPIN:
-sohpi 0 

PIN_NO_DEMOTE:
-sohpi 50

PIN_SOME_DEMOTE:
-sohpi 8

PIN_LOTS_DEMOTE:
-sohpi 5
```

and 2 heaps for both regions and segments to show the difference -

![image](https://github.com/user-attachments/assets/84a4ac7c-fa04-43ba-9f69-b7e1c5b607a0)
![image](https://github.com/user-attachments/assets/9606a652-4b29-49fd-b267-0a7b125c4ad0)

regions recovered almost all of the regression with a bit of sacrifice in throughput (by design since we now have to process more in ephemeral GCs). but with the throughput drop it's still consistently faster than segments.

with DATAS it's also showing heap size reduction. 
![image](https://github.com/user-attachments/assets/80e519d8-259e-448d-b80e-f6c410e890ec)
![image](https://github.com/user-attachments/assets/e046815a-01e1-490d-882b-ba34fa31375a)
