### PR TITLE
fix for possible Null Reference Exception

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
@@ -82,7 +82,8 @@ namespace System.Xml
             }
             if (reader.ReadState == ReadState.Interactive)
             {
-                XmlNode n = LoadNode(true)!;
+                XmlNode? n = LoadNode(true);
+                Debug.Assert(n != null);
 
                 // Move to the next node
                 if (n != null && n.NodeType != XmlNodeType.Attribute)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
@@ -86,7 +86,7 @@ namespace System.Xml
                 Debug.Assert(n != null);
 
                 // Move to the next node
-                if (n != null && n.NodeType != XmlNodeType.Attribute)
+                if (n.NodeType != XmlNodeType.Attribute)
                     reader.Read();
 
                 return n;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlLoader.cs
@@ -85,7 +85,7 @@ namespace System.Xml
                 XmlNode n = LoadNode(true)!;
 
                 // Move to the next node
-                if (n.NodeType != XmlNodeType.Attribute)
+                if (n != null && n.NodeType != XmlNodeType.Attribute)
                     reader.Read();
 
                 return n;


### PR DESCRIPTION
Method "LoadNode" returns the nullable type "XmlNode?". So, maybe we need to check "n" for "null" here?

Found by Linux Verification Center (linuxtesting.org) with SVACE.