### PR TITLE
[9.0] Move release/9.0 localization back to main too

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -41,11 +41,11 @@ extends:
       # Localization build
       #
 
-      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/9.0') }}:
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml
           parameters:
             MirrorRepo: runtime
-            MirrorBranch: release/9.0
+            MirrorBranch: main
             LclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 
@@ -661,7 +661,7 @@ extends:
                 flattenFolders: true
 
             buildArgs: -s mono.workloads -c $(_BuildConfig) /p:PackageSource=$(Build.SourcesDirectory)/artifacts/workloadPackages /p:WorkloadOutputPath=$(Build.SourcesDirectory)/artifacts/workloads
-            
+
             postBuildSteps:
             # Upload packages wrapping msis
             - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml


### PR DESCRIPTION
Switching main localization to point back to main was not enough (https://github.com/dotnet/runtime/pull/111872/files), we also need to switch the release/9.0 branch back to main.