### PR TITLE
JIT: Don't put cold blocks in RPO during layout

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4677,10 +4677,10 @@ void Compiler::fgDoReversePostOrderLayout()
 
     BasicBlock** const rpoSequence   = new (this, CMK_BasicBlock) BasicBlock*[m_dfsTree->GetPostOrderCount()];
     unsigned           numBlocks     = 0;
-    auto               addToSequence = [rpoSequence, &numBlocks](BasicBlock* block) {
-        // Exclude handler regions from being reordered.
+    auto               addToSequence = [this, rpoSequence, &numBlocks](BasicBlock* block) {
+        // Exclude handler regions and cold blocks from being reordered.
         //
-        if (!block->hasHndIndex())
+        if (!block->hasHndIndex() && !block->isBBWeightCold(this))
         {
             rpoSequence[numBlocks++] = block;
         }


### PR DESCRIPTION
Split off from #112004. Excluding cold blocks from the loop-aware RPO simplifies how we compute the initial layout to feed into 3-opt, as it eliminates the need to manually move cold blocks out-of-line, instead allowing them to sink to the end of the method. This has the consequence of changing -- most likely worsening -- the layout of cold sections. However, our current threshold for "cold" is low enough that I don't think this churn matters: While `BB_COLD_WEIGHT` is 0.01, we compare this to normalized weights scaled by `BB_UNITY_WEIGHT` (100), so normalized weights must be below 0.0001 to be considered cold. In other words, profile data must suggest a block executes less than 0.01% (not 1%) of the time to be excluded from reordering.