### PR TITLE
Don't build host tools when building the cross-os DACs

### DIFF
--- a/src/coreclr/.nuget/Microsoft.CrossOsDiag.Private.CoreCLR/Microsoft.CrossOsDiag.Private.CoreCLR.proj
+++ b/src/coreclr/.nuget/Microsoft.CrossOsDiag.Private.CoreCLR/Microsoft.CrossOsDiag.Private.CoreCLR.proj
@@ -32,7 +32,8 @@
       <_CrossOSDacProject Include="@(SupportedRid->'$(RepoRoot)Build.proj')"
                           AdditionalProperties="TargetOS=%(TargetOS);
                                                 TargetArchitecture=%(TargetArchitecture);
-                                                Subset=linuxdac+alpinedac" />
+                                                Subset=linuxdac+alpinedac
+                                                BuildHostTools=false" />
       <_RuntimePrereqsProject Include="$(CoreClrProjectRoot)runtime-prereqs.proj" />
     </ItemGroup>
 

--- a/src/coreclr/.nuget/Microsoft.CrossOsDiag.Private.CoreCLR/Microsoft.CrossOsDiag.Private.CoreCLR.proj
+++ b/src/coreclr/.nuget/Microsoft.CrossOsDiag.Private.CoreCLR/Microsoft.CrossOsDiag.Private.CoreCLR.proj
@@ -32,7 +32,7 @@
       <_CrossOSDacProject Include="@(SupportedRid->'$(RepoRoot)Build.proj')"
                           AdditionalProperties="TargetOS=%(TargetOS);
                                                 TargetArchitecture=%(TargetArchitecture);
-                                                Subset=linuxdac+alpinedac
+                                                Subset=linuxdac+alpinedac;
                                                 BuildHostTools=false" />
       <_RuntimePrereqsProject Include="$(CoreClrProjectRoot)runtime-prereqs.proj" />
     </ItemGroup>


### PR DESCRIPTION
In the VMR, we're building the cross-os DAC tools on (technically) a Win-x86 build. This is causing some confusion in the build scripts thats trying to build the IL host tools in an unsupported way. We will never need to build the il tools here, so explicitly make sure we don't trigger that build.