### PR TITLE
Fix side-effect order for COMMA in impStoreStruct

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -970,9 +970,9 @@ GenTree* Compiler::impStoreStruct(GenTree*         store,
         GenTree* sideEffectAddressStore = nullptr;
         if (store->OperIs(GT_STORE_BLK, GT_STOREIND) && ((store->AsIndir()->Addr()->gtFlags & GTF_ALL_EFFECT) != 0))
         {
-            TempInfo addrikTmp       = fgMakeTemp(store->AsIndir()->Addr());
-            sideEffectAddressStore   = addrikTmp.store;
-            store->AsIndir()->Addr() = addrikTmp.load;
+            TempInfo addrTmp         = fgMakeTemp(store->AsIndir()->Addr());
+            sideEffectAddressStore   = addrTmp.store;
+            store->AsIndir()->Addr() = addrTmp.load;
         }
 
         if (pAfterStmt)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -967,9 +967,31 @@ GenTree* Compiler::impStoreStruct(GenTree*         store,
     }
     else if (src->OperIs(GT_COMMA))
     {
+        GenTree* sideEffectAddressStore = nullptr;
+        if (store->OperIs(GT_STORE_BLK, GT_STOREIND))
+        {
+            GenTree* addr = store->AsIndir()->Addr();
+            if ((addr->gtFlags & GTF_ALL_EFFECT) != 0)
+            {
+                if (!addr->OperIs(GT_FIELD_ADDR) || (addr->gtGetOp1()->gtFlags & GTF_ALL_EFFECT) != 0)
+                {
+                    TempInfo addrikTmp       = fgMakeTemp(addr);
+                    sideEffectAddressStore   = addrikTmp.store;
+                    store->AsIndir()->Addr() = addrikTmp.load;
+                }
+            }
+        }
+
         if (pAfterStmt)
         {
             // Insert op1 after '*pAfterStmt'
+            if (sideEffectAddressStore != nullptr)
+            {
+                Statement* addrStmt = gtNewStmt(sideEffectAddressStore, usedDI);
+                fgInsertStmtAfter(block, *pAfterStmt, addrStmt);
+                *pAfterStmt = addrStmt;
+            }
+
             Statement* newStmt = gtNewStmt(src->AsOp()->gtOp1, usedDI);
             fgInsertStmtAfter(block, *pAfterStmt, newStmt);
             *pAfterStmt = newStmt;
@@ -977,6 +999,10 @@ GenTree* Compiler::impStoreStruct(GenTree*         store,
         else if (impLastStmt != nullptr)
         {
             // Do the side-effect as a separate statement.
+            if (sideEffectAddressStore != nullptr)
+            {
+                impAppendTree(sideEffectAddressStore, curLevel, usedDI);
+            }
             impAppendTree(src->AsOp()->gtOp1, curLevel, usedDI);
         }
         else
@@ -989,6 +1015,10 @@ GenTree* Compiler::impStoreStruct(GenTree*         store,
             gtUpdateNodeSideEffects(store);
             src->SetAllEffectsFlags(src->AsOp()->gtOp1, src->AsOp()->gtOp2);
 
+            if (sideEffectAddressStore != nullptr)
+            {
+                src = gtNewOperNode(GT_COMMA, src->TypeGet(), sideEffectAddressStore, src);
+            }
             return src;
         }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -968,18 +968,12 @@ GenTree* Compiler::impStoreStruct(GenTree*         store,
     else if (src->OperIs(GT_COMMA))
     {
         GenTree* sideEffectAddressStore = nullptr;
-        if (store->OperIs(GT_STORE_BLK, GT_STOREIND))
+        if (store->OperIs(GT_STORE_BLK, GT_STOREIND) &&
+            ((store->AsIndir()->Addr()->gtFlags & GTF_ALL_EFFECT) != 0))
         {
-            GenTree* addr = store->AsIndir()->Addr();
-            if ((addr->gtFlags & GTF_ALL_EFFECT) != 0)
-            {
-                if (!addr->OperIs(GT_FIELD_ADDR) || (addr->gtGetOp1()->gtFlags & GTF_ALL_EFFECT) != 0)
-                {
-                    TempInfo addrikTmp       = fgMakeTemp(addr);
-                    sideEffectAddressStore   = addrikTmp.store;
-                    store->AsIndir()->Addr() = addrikTmp.load;
-                }
-            }
+            TempInfo addrikTmp       = fgMakeTemp(store->AsIndir()->Addr());
+            sideEffectAddressStore   = addrikTmp.store;
+            store->AsIndir()->Addr() = addrikTmp.load;
         }
 
         if (pAfterStmt)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -968,8 +968,7 @@ GenTree* Compiler::impStoreStruct(GenTree*         store,
     else if (src->OperIs(GT_COMMA))
     {
         GenTree* sideEffectAddressStore = nullptr;
-        if (store->OperIs(GT_STORE_BLK, GT_STOREIND) &&
-            ((store->AsIndir()->Addr()->gtFlags & GTF_ALL_EFFECT) != 0))
+        if (store->OperIs(GT_STORE_BLK, GT_STOREIND) && ((store->AsIndir()->Addr()->gtFlags & GTF_ALL_EFFECT) != 0))
         {
             TempInfo addrikTmp       = fgMakeTemp(store->AsIndir()->Addr());
             sideEffectAddressStore   = addrikTmp.store;


### PR DESCRIPTION
Fix an issue @jakobbotsch noticed.

`impStoreStruct` could evaluate Data before Address 