### PR TITLE
[8.0] Wrap the OneLocBuild yml section with a SourceBranch check

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -44,12 +44,13 @@ extends:
       # Localization build
       #
 
-      - template: /eng/common/templates-official/job/onelocbuild.yml
-        parameters:
-          MirrorRepo: runtime
-          MirrorBranch: main
-          LclSource: lclFilesfromPackage
-          LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml
+          parameters:
+            MirrorRepo: runtime
+            MirrorBranch: main
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 
       #
       # Source Index Build


### PR DESCRIPTION
Tell-mode, infra only.

From a conversation with @cristianosuzuki77 , the OneLocBuild yaml section in 9.0 and main is protected with a SourceBranch check. We can add the same to release/8.0 to prevent the build from running and also to reduce confusion when the Loc team has to troubleshoot issues in runtime.

https://github.com/dotnet/runtime/blob/release/9.0/eng/pipelines/runtime-official.yml#L40-L50
https://github.com/dotnet/runtime/blob/main/eng/pipelines/runtime-official.yml#L40-L50

Sending this directly to release/8.0 as we still have runway to merge to that branch. Ideally we want this to flow to internal right away, and it will automatically flow to staging with the autogenerated PRs.