### PR TITLE
JIT: Merge store/loads for return buffers

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9439,8 +9439,15 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeIndir* ind)
         //
         // IND<byte> is always fine (and all IND<X> created here from such)
         // IND<simd> is not required to be atomic per our Memory Model
-        const bool allowsNonAtomic =
+        bool allowsNonAtomic =
             ((ind->gtFlags & GTF_IND_ALLOW_NON_ATOMIC) != 0) && ((prevInd->gtFlags & GTF_IND_ALLOW_NON_ATOMIC) != 0);
+
+        if (!allowsNonAtomic && currData.baseAddr->OperIs(GT_LCL_VAR) &&
+            (currData.baseAddr->AsLclVar()->GetLclNum() == comp->info.compRetBuffArg))
+        {
+            // RetBuf is a private stack memory, so we don't need to worry about atomicity.
+            allowsNonAtomic = true;
+        }
 
         if (!allowsNonAtomic && (genTypeSize(ind) > 1) && !varTypeIsSIMD(ind))
         {


### PR DESCRIPTION
A follow up to https://github.com/dotnet/runtime/pull/112060

Previously, we were conservative about return buffers and couldn't really merge loads/store due to unknown alignment & unknown atomicity requirements.

```cs
(int,int,int,int) Test => (1, 2, 3, 4);
```
```diff
; Method Proga:get_Test():System.ValueTuple`4[int,int,int,int]:this
-      mov      dword ptr [rdx], 1
-      mov      dword ptr [rdx+0x04], 2
-      mov      dword ptr [rdx+0x08], 3
-      mov      dword ptr [rdx+0x0C], 4
+      vmovups  xmm0, xmmword ptr [reloc @RWD00]
+      vmovups  xmmword ptr [rdx], xmm0
       mov      rax, rdx
       ret   
+RWD00  	dq	0000000200000001h, 0000000400000003h   
+; Total bytes of code: 31
-; Total bytes of code: 16
```