### PR TITLE
NativeAOT/Arm64: Do not overwrite gcinfo tracking registers for TLS

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -217,7 +217,6 @@ void emitter::emitInsSanityCheck(instrDesc* id)
         case IF_BR_1B: // BR_1B   ................ ......nnnnn.....         Rn
             if (emitComp->IsTargetAbi(CORINFO_NATIVEAOT_ABI) && id->idIsTlsGD())
             {
-                assert(isGeneralRegister(id->idReg1()));
                 assert(id->idAddr()->iiaAddr != nullptr);
             }
             else
@@ -9239,11 +9238,14 @@ void emitter::emitIns_Call(EmitCallType          callType,
         if (emitComp->IsTargetAbi(CORINFO_NATIVEAOT_ABI) && EA_IS_CNS_TLSGD_RELOC(retSize))
         {
             // For NativeAOT linux/arm64, we need to also record the relocation of methHnd.
-            // Since we do not have space to embed it in instrDesc, we store the register in
-            // reg1 and instead use the `iiaAdd` to store the method handle. Likewise, during
-            // emitOutputInstr, we retrieve the register from reg1 for this specific case.
+            // Since we do not have space to embed it in instrDesc, we use the `iiaAddr` to
+            // store the method handle.
+            // The target handle need to be always in R2 and hence the assert check.
+            // We cannot use reg1 and reg2 fields of instrDesc because they contain the gc
+            // registers (emitEncodeCallGCregs()) that are live across the call.
+
+            assert(ireg == REG_R2);
             id->idSetTlsGD();
-            id->idReg1(ireg);
             id->idAddr()->iiaAddr = (BYTE*)methHnd;
         }
         else
@@ -11045,12 +11047,13 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             {
                 emitRecordRelocation(odst, (CORINFO_METHOD_HANDLE)id->idAddr()->iiaAddr,
                                      IMAGE_REL_AARCH64_TLSDESC_CALL);
-                code |= insEncodeReg_Rn(id->idReg1()); // nnnnn
+                code |= insEncodeReg_Rn(REG_R2); // nnnnn
             }
             else
             {
                 code |= insEncodeReg_Rn(id->idReg3()); // nnnnn
             }
+
             dst += emitOutputCall(ig, dst, id, code);
             sz = id->idIsLargeCall() ? sizeof(instrDescCGCA) : sizeof(instrDesc);
             break;
@@ -13375,7 +13378,15 @@ void emitter::emitDispInsHelp(
         case IF_BR_1B: // BR_1B   ................ ......nnnnn.....         Rn
             // The size of a branch target is always EA_PTRSIZE
             assert(insOptsNone(id->idInsOpt()));
-            emitDispReg(id->idReg3(), EA_PTRSIZE, false);
+
+            if (emitComp->IsTargetAbi(CORINFO_NATIVEAOT_ABI) && id->idIsTlsGD())
+            {
+                emitDispReg(REG_R2, EA_PTRSIZE, false);
+            }
+            else
+            {
+                emitDispReg(id->idReg3(), EA_PTRSIZE, false);
+            }
             break;
 
         case IF_LS_1A: // LS_1A   XX...V..iiiiiiii iiiiiiiiiiittttt      Rt    PC imm(1MB)


### PR DESCRIPTION
Fields `reg1` and `reg2` of `instrDesc` were repurposed for saving live gc registers. However, this field was getting overwritten when we populate the register for the `blr` instruction that is needed for TLS access pattern. Since the pattern of the instructions including register requirements for them is very specific and has to be like following:

https://github.com/dotnet/runtime/blob/07f8ebdf5a703dc7f63b96202792dda6d05b1808/src/coreclr/jit/codegenarmarch.cpp#L3578-L3591

In LSRA, we already ensure that those requirements are met.

https://github.com/dotnet/runtime/blob/07f8ebdf5a703dc7f63b96202792dda6d05b1808/src/coreclr/jit/lsraarmarch.cpp#L265-L267

As such, there is no need to track the target handle register separately in a field but can just be used directly in codegen/emitter logic. Also, I noticed that the display was not using the right register, so fixed that as well.


Fixes: https://github.com/dotnet/runtime/issues/112351