### PR TITLE
[release/9.0] Skip NegotiateStream_StreamToStream_Authentication_EmptyCredentials_Fails on WinSrv 2025

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -26,6 +26,7 @@ namespace System
         public static bool IsWindows10OrLater => IsWindowsVersionOrLater(10, 0);
         public static bool IsWindowsServer2019 => IsWindows && IsNotWindowsNanoServer && GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildVersion() == 17763;
         public static bool IsWindowsServer2022 => IsWindows && IsNotWindowsNanoServer && GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildVersion() == 20348;
+        public static bool IsWindowsServer2025 => IsWindows && IsNotWindowsNanoServer && GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildVersion() == 26100;
         public static bool IsWindowsNanoServer => IsWindows && (IsNotWindowsIoTCore && GetWindowsInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         public static bool IsWindowsServerCore => IsWindows && GetWindowsInstallationType().Equals("Server Core", StringComparison.OrdinalIgnoreCase);
         public static int WindowsVersion => IsWindows ? (int)GetWindowsVersion() : -1;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -9,8 +9,9 @@ using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Security.Tests
 {
@@ -191,6 +192,11 @@ namespace System.Net.Security.Tests
         public async Task NegotiateStream_StreamToStream_Authentication_EmptyCredentials_Fails()
         {
             string targetName = "testTargetName";
+
+            if (PlatformDetection.IsWindowsServer2025)
+            {
+                throw new SkipTestException("Empty credentials not supported on Server 2025");
+            }
 
             // Ensure there is no confusion between DefaultCredentials / DefaultNetworkCredentials and a
             // NetworkCredential object with empty user, password and domain.


### PR DESCRIPTION
Manual port of https://github.com/dotnet/runtime/commit/92403f5bb07c8fd1def6abc8c2587b4a1d259610 which did not made it in release branches.

Fixes https://github.com/dotnet/runtime/issues/112312.

## Customer Impact

None, Test-only change

## Regression

No, new test failure occurred after adding new platform to test matrix.

## Testing

CI run succeeds

## Risk

Low, test-only change.