### PR TITLE
[Swift Interop] Enabled TestSelfIsFrozenNonEnregisteredStructWithExtraArgs on mono

### DIFF
--- a/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.cs
+++ b/src/tests/Interop/Swift/SwiftSelfContext/SwiftSelfContext.cs
@@ -98,7 +98,6 @@ public class SelfContextTests
     }
 
     [Fact]
-    [SkipOnMono("https://github.com/dotnet/runtime/issues/108855")]
     public unsafe static void TestSelfIsFrozenNonEnregisteredStructWithExtraArgs()
     {
         float sum = SumFrozenNonEnregisteredStructWithExtraArgs(3f, 4f, new SwiftSelf<FrozenNonEnregisteredStruct>(new FrozenNonEnregisteredStruct { A = 10, B = 20, C = 30, D = 40, E = 50 }));


### PR DESCRIPTION
In the past we disabled `TestSelfIsFrozenNonEnregisteredStructWithExtraArgs` as it was failing on the CI. The failures might have been caused by outdated hardware. This PR should run the CI and verify the current status.

EDIT:
The CI passes, we should enable the test

https://github.com/dotnet/runtime/issues/108855