### PR TITLE
JIT: Don't show code bytes for loongarch64 disasm unless it was told to do so

### DIFF
--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -3988,9 +3988,13 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
 
     printf("  ");
 
-    if (!emitComp->opts.disDiffable)
+    if (emitComp->opts.disCodeBytes)
     {
         printf("%08X  ", code);
+    }
+    else
+    {
+        printf("          ");
     }
 #else
     printf("            ");

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -3988,7 +3988,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
 
     printf("  ");
 
-    if (emitComp->opts.disCodeBytes)
+    if (emitComp->opts.disCodeBytes && !emitComp->opts.disDiffable)
     {
         printf("%08X  ", code);
     }


### PR DESCRIPTION
Keep the same behavior with other architectures. We were using the incorrect knob.