### PR TITLE
[DAC] ClrDataAccess::GetFrameName support Frames using identifier instead of vptr

### DIFF
--- a/src/coreclr/debug/daccess/dacfn.cpp
+++ b/src/coreclr/debug/daccess/dacfn.cpp
@@ -24,14 +24,6 @@ struct DacHostVtPtrs
 #undef VPTR_CLASS
 };
 
-
-const WCHAR *g_dacVtStrings[] =
-{
-#define VPTR_CLASS(name) W(#name),
-#include <vptr_list.h>
-#undef VPTR_CLASS
-};
-
 DacHostVtPtrs g_dacHostVtPtrs;
 
 HRESULT
@@ -1139,25 +1131,6 @@ DacGetTargetAddrForHostInteriorAddr(LPCVOID ptr, bool throwEx)
         return addr;
     }
 #endif // !_PREFIX_
-}
-
-PWSTR    DacGetVtNameW(TADDR targetVtable)
-{
-    PWSTR pszRet = NULL;
-
-    TADDR *targ = &DacGlobalValues()->EEJitManager__vtAddr;
-    TADDR *targStart = targ;
-    for (ULONG i = 0; i < sizeof(g_dacHostVtPtrs) / sizeof(PVOID); i++)
-    {
-        if (targetVtable == (*targ))
-        {
-            pszRet = (PWSTR) *(g_dacVtStrings + (targ - targStart));
-            break;
-        }
-
-        targ++;
-    }
-    return pszRet;
 }
 
 PWSTR    DacGetFrameNameW(TADDR frameIdentifier)

--- a/src/coreclr/debug/daccess/dacfn.cpp
+++ b/src/coreclr/debug/daccess/dacfn.cpp
@@ -32,6 +32,13 @@ const WCHAR *g_dacVtStrings[] =
 #undef VPTR_CLASS
 };
 
+const WCHAR *g_dacFrameStrings[] =
+{
+#define FRAME_TYPE_NAME(name) W(#name),
+#include "FrameTypes.h"
+#undef FRAME_TYPE_NAME
+};
+
 DacHostVtPtrs g_dacHostVtPtrs;
 
 HRESULT
@@ -1150,6 +1157,20 @@ PWSTR    DacGetVtNameW(TADDR targetVtable)
 
         targ++;
     }
+    return pszRet;
+}
+
+PWSTR    DacGetFrameNameW(TADDR frameIdentifier)
+{
+    PWSTR pszRet = NULL;
+
+    FrameIdentifier frameId = static_cast<FrameIdentifier>(frameIdentifier);
+
+    if (!(frameId == FrameIdentifier::None || frameId >= FrameIdentifier::CountPlusOne))
+    {
+        pszRet = (PWSTR) g_dacFrameStrings[(int)frameId - 1];
+    }
+
     return pszRet;
 }
 

--- a/src/coreclr/debug/daccess/dacfn.cpp
+++ b/src/coreclr/debug/daccess/dacfn.cpp
@@ -32,13 +32,6 @@ const WCHAR *g_dacVtStrings[] =
 #undef VPTR_CLASS
 };
 
-const WCHAR *g_dacFrameStrings[] =
-{
-#define FRAME_TYPE_NAME(name) W(#name),
-#include "FrameTypes.h"
-#undef FRAME_TYPE_NAME
-};
-
 DacHostVtPtrs g_dacHostVtPtrs;
 
 HRESULT
@@ -51,6 +44,13 @@ DacGetHostVtPtrs(void)
 
     return S_OK;
 }
+
+const WCHAR *g_dacFrameStrings[] =
+{
+#define FRAME_TYPE_NAME(name) W(#name),
+#include "FrameTypes.h"
+#undef FRAME_TYPE_NAME
+};
 
 bool
 DacExceptionFilter(Exception* ex, ClrDataAccess* access,

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2143,7 +2143,7 @@ ClrDataAccess::GetFrameName(CLRDATA_ADDRESS vtable, unsigned int count, _Inout_u
 
     SOSDacEnter();
 
-    PWSTR pszName = DacGetVtNameW(CLRDATA_ADDRESS_TO_TADDR(vtable));
+    PWSTR pszName = DacGetFrameNameW(CLRDATA_ADDRESS_TO_TADDR(vtable));
     if (pszName == NULL)
     {
         hr = E_INVALIDARG;
@@ -2921,7 +2921,7 @@ ClrDataAccess::GetGCDynamicAdaptationMode(int* pDynamicAdaptationMode)
     {
         *pDynamicAdaptationMode = -1;
         hr = S_FALSE;
-    }    
+    }
     SOSDacLeave();
     return hr;
 }

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -700,6 +700,7 @@ TADDR   DacGetTargetAddrForHostAddr(LPCVOID ptr, bool throwEx);
 TADDR   DacGetTargetAddrForHostInteriorAddr(LPCVOID ptr, bool throwEx);
 TADDR   DacGetTargetVtForHostVt(LPCVOID vtHost, bool throwEx);
 PWSTR   DacGetVtNameW(TADDR targetVtable);
+PWSTR   DacGetFrameNameW(TADDR frameIdentifier);
 
 // Report a region of memory to the debugger
 bool    DacEnumMemoryRegion(TADDR addr, TSIZE_T size, bool fExpectSuccess = true);

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -699,7 +699,6 @@ PWSTR   DacInstantiateStringW(TADDR addr, ULONG32 maxChars, bool throwEx);
 TADDR   DacGetTargetAddrForHostAddr(LPCVOID ptr, bool throwEx);
 TADDR   DacGetTargetAddrForHostInteriorAddr(LPCVOID ptr, bool throwEx);
 TADDR   DacGetTargetVtForHostVt(LPCVOID vtHost, bool throwEx);
-PWSTR   DacGetVtNameW(TADDR targetVtable);
 PWSTR   DacGetFrameNameW(TADDR frameIdentifier);
 
 // Report a region of memory to the debugger


### PR DESCRIPTION
#112166 converted Frames to use a `FrameIdentifier` value instead of a VPtr to differentiate types, removing all Frame types from the list of `VPTR_CLASS`'s. `ClrDataAccess::GetFrameName` previously searched for the Frame name from the list of `VPTR_CLASS`'s, this PR converts the logic to use the `FrameIdentifier` value instead.

Note, there is `Frame::GetFrameTypeName` which could be reused but would require refactoring as it is only compiled in `DEBUG`, non-DAC builds. 