### PR TITLE
[release/8.0-staging] Move generation of SuggestedBindingRedirects.targets to inner build

### DIFF
--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -7,7 +7,6 @@
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
     <SuggestedBindingRedirectsPackageFile>$(BaseIntermediateOutputPath)SuggestedBindingRedirects.targets</SuggestedBindingRedirectsPackageFile>
-    <BeforePack>$(BeforePack);GeneratePackageTargetsFile</BeforePack>
     <PackageDescription>Provides classes which read and write resources in a format that supports non-primitive objects.
 
 Commonly Used Types:
@@ -41,7 +40,7 @@ System.Resources.Extensions.PreserializedResourceWriter</PackageDescription>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" 
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs"
              Link="System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs"
              Link="System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
@@ -51,10 +50,11 @@ System.Resources.Extensions.PreserializedResourceWriter</PackageDescription>
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
-  <Target Name="GeneratePackageTargetsFile" 
+  <Target Name="GeneratePackageTargetsFile"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(SuggestedBindingRedirectsPackageFile)"
-          Condition="'$(NetFrameworkMinimum)' != ''">
+          AfterTargets="CoreCompile"
+          Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)'">
     <PropertyGroup>
       <SuggestedBindingRedirectsPackageFileContent><![CDATA[<Project>
   <!-- ResolveAssemblyReferences will never see the assembly reference embedded in the resources type,
@@ -71,9 +71,11 @@ System.Resources.Extensions.PreserializedResourceWriter</PackageDescription>
                       Lines="$(SuggestedBindingRedirectsPackageFileContent)"
                       Overwrite="true" />
 
-    <ItemGroup>
-      <Content Include="$(SuggestedBindingRedirectsPackageFile)"
-               PackagePath="buildTransitive\$(NetFrameworkMinimum)\$(PackageId).targets" />
-    </ItemGroup>
   </Target>
+
+  <ItemGroup Condition="'$(NetFrameworkMinimum)' != ''">
+    <None Include="$(SuggestedBindingRedirectsPackageFile)" Pack="true"
+          PackagePath="buildTransitive\$(NetFrameworkMinimum)\$(PackageId).targets" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Backport of #112379 to release/9.0-staging
Fixes https://github.com/dotnet/runtime/issues/111892

/cc @ericstj

In 8.0 we don't need to actually ship this, since we haven't shipped a patch in 8.0 there is nothing to fix.  We just want to proactively port this fix so that it's ready should we need to patch in the future.

## Customer Impact

- [X] Customer reported
- [ ] Found internally

.NETFramework project using the latest System.Resources.Extensions package fails to load resources with `FileLoadException`.

## Regression

- [x] Yes
- [ ] No

9.0.1 - this is the first time we've serviced this package.  The package didn't account for the serviced assembly version correctly.

## Testing

Build / package / inspect redirects.  Manually test consuming package in .NETFramework project.

Automated tests here are difficult with current infrastructure as we don't consume the built packages, nor rely on auto-generated bindingRedirects in the same way a customer project does.

## Risk

Low - updating target in a single project that only impacts that library's generation of a targets file.  If it builds its good.

