### PR TITLE
JIT: Use `fgCalledCount` in inlinee weight computation

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12878,7 +12878,7 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
     if ((pInlineInfo != nullptr) && rootCompiler->fgHaveSufficientProfileWeights())
     {
         const weight_t callSiteWeight = pInlineInfo->iciBlock->bbWeight;
-        const weight_t entryWeight    = rootCompiler->fgFirstBB->bbWeight;
+        const weight_t entryWeight    = rootCompiler->fgCalledCount;
         profileFreq                   = fgProfileWeightsEqual(entryWeight, 0.0) ? 0.0 : callSiteWeight / entryWeight;
         hasProfile                    = true;
 


### PR DESCRIPTION
I noticed that tweaking the computation of the entry weight for OSR methods (in service of #111915) incurred large inlining diffs. This is due to the fact that we use the entry block's weight to compute the normalized weight of a call site. This means we will get the wrong normalized weight for call sites when the entry block's weight diverges from the method's call count. This is currently possible only when the entry block is part of a loop, or when we compute a weight for the OSR entry fixup block that differs from `fgCalledCount` (which we [almost always do](https://github.com/dotnet/runtime/blob/751acdef8e947ab5bd602721ea0cd7884c5a3e4a/src/coreclr/jit/fgbasic.cpp#L4060)). The correct thing to do is to use the root method's call count to normalize the call site's weight.