### PR TITLE
JIT: fix local assertion prop error for partial local comparisons

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2223,17 +2223,17 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
     // If op1 is lcl and op2 is const or lcl, create assertion.
     if ((op1->gtOper == GT_LCL_VAR) && (op2->OperIsConst() || (op2->gtOper == GT_LCL_VAR))) // Fix for Dev10 851483
     {
-        // Watch out for cases where the local(s) are truncated.
+        // Watch out for cases where long local(s) are implicitly truncated.
         //
         LclVarDsc* const lcl1Dsc = lvaGetDesc(op1->AsLclVarCommon());
-        if (lcl1Dsc->TypeGet() != op1->TypeGet())
+        if ((lcl1Dsc->TypeGet() == TYP_LONG) && (op1->TypeGet() != TYP_LONG))
         {
             return NO_ASSERTION_INDEX;
         }
         if (op2->OperIs(GT_LCL_VAR))
         {
             LclVarDsc* const lcl2Dsc = lvaGetDesc(op2->AsLclVarCommon());
-            if (lcl2Dsc->TypeGet() != op2->TypeGet())
+            if ((lcl2Dsc->TypeGet() == TYP_LONG) && (op2->TypeGet() != TYP_LONG))
             {
                 return NO_ASSERTION_INDEX;
             }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2223,6 +2223,22 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
     // If op1 is lcl and op2 is const or lcl, create assertion.
     if ((op1->gtOper == GT_LCL_VAR) && (op2->OperIsConst() || (op2->gtOper == GT_LCL_VAR))) // Fix for Dev10 851483
     {
+        // Watch out for cases where the local(s) are truncated.
+        //
+        LclVarDsc* const lcl1Dsc = lvaGetDesc(op1->AsLclVarCommon());
+        if (lcl1Dsc->TypeGet() != op1->TypeGet())
+        {
+            return NO_ASSERTION_INDEX;
+        }
+        if (op2->OperIs(GT_LCL_VAR))
+        {
+            LclVarDsc* const lcl2Dsc = lvaGetDesc(op2->AsLclVarCommon());
+            if (lcl2Dsc->TypeGet() != op2->TypeGet())
+            {
+                return NO_ASSERTION_INDEX;
+            }
+        }
+
         return optCreateJtrueAssertions(op1, op2, assertionKind);
     }
     else if (!optLocalAssertionProp)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_111352/Runtime_111352.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_111352/Runtime_111352.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_111352
+{
+    [Fact]
+    public static int Test1() => Problem1(0x1_0000_0001L, 0x2_0000_0001L);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Problem1(long x, long y)
+    {
+        if ((uint)x == (uint)y)
+        {
+            if (x == y)
+            {
+                return -1;
+            }
+        }
+
+        return 100;
+    }
+
+    [Fact]
+    public static int Test2() => Problem2(0x1_0000_0000L);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Problem2(long x)
+    {
+        if ((uint)x == 0)
+        {
+            if (x == 0)
+            {
+                return -1;
+            }
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_111352/Runtime_111352.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_111352/Runtime_111352.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If a JTRUE comparison only involves part of a local value we cannot make assertions about the local as a whole.

Fixes #111352.