### PR TITLE
Remove unnecessary Unsafe.As call from StringValues

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 if (Count == 1)
                 {
-                    return Unsafe.As<string>(this[0])?.GetHashCode() ?? Count.GetHashCode();
+                    return this[0]?.GetHashCode() ?? Count.GetHashCode();
                 }
                 int hashCode = 0;
                 for (int i = 0; i < values.Length; i++)


### PR DESCRIPTION
(Caught by static analysis.)

This is essentially calling `Unsafe.As<string>(string)`, which is a no-op. Remove the call to `Unsafe.As`.