### PR TITLE
Pin web assembly server 2025 docker image

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -177,6 +177,6 @@ jobs:
     # Browser WebAssembly windows
     - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:
       - (Windows.Amd64.Server2022.Open)windows.amd64.server2022.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-webassembly
-      - (Windows.Server2025.Amd64.Open)windows.server2025.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2025-helix-webassembly-amd64
+      - (Windows.Server2025.Amd64.Open)windows.server2025.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:146a5bd53f9325f6f58f56ff1f084bb9fed6db0783f92e1c56f4025f9aea6515
 
     ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Latest builds of docker images are broken with latest VMs.

@dotnet/dnceng is working on a fix, temporarily pinning.