### PR TITLE
Don't run RangeCheck if no GT_BOUNDS_CHECK were seen

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7578,6 +7578,7 @@ public:
 #define OMF_HAS_RECURSIVE_TAILCALL             0x00040000 // Method contains recursive tail call
 #define OMF_HAS_EXPANDABLE_CAST                0x00080000 // Method contains casts eligible for late expansion
 #define OMF_HAS_STACK_ARRAY                    0x00100000 // Method contains stack allocated arrays
+#define OMF_HAS_BOUND_CHECKS                   0x00200000 // Method contains bounds checks
 
     // clang-format on
 
@@ -7616,6 +7617,16 @@ public:
     void setMethodHasStaticInit()
     {
         optMethodFlags |= OMF_HAS_STATIC_INIT;
+    }
+
+    bool doesMethodHaveBoundChecks()
+    {
+        return (optMethodFlags & OMF_HAS_BOUND_CHECKS) != 0;
+    }
+
+    void setMethodHasBoundChecks()
+    {
+        optMethodFlags |= OMF_HAS_BOUND_CHECKS;
     }
 
     bool doesMethodHaveExpandableCasts()

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7578,7 +7578,7 @@ public:
 #define OMF_HAS_RECURSIVE_TAILCALL             0x00040000 // Method contains recursive tail call
 #define OMF_HAS_EXPANDABLE_CAST                0x00080000 // Method contains casts eligible for late expansion
 #define OMF_HAS_STACK_ARRAY                    0x00100000 // Method contains stack allocated arrays
-#define OMF_HAS_BOUND_CHECKS                   0x00200000 // Method contains bounds checks
+#define OMF_HAS_BOUNDS_CHECKS                  0x00200000 // Method contains bounds checks
 
     // clang-format on
 
@@ -7621,12 +7621,12 @@ public:
 
     bool doesMethodHaveBoundChecks()
     {
-        return (optMethodFlags & OMF_HAS_BOUND_CHECKS) != 0;
+        return (optMethodFlags & OMF_HAS_BOUNDS_CHECKS) != 0;
     }
 
     void setMethodHasBoundChecks()
     {
-        optMethodFlags |= OMF_HAS_BOUND_CHECKS;
+        optMethodFlags |= OMF_HAS_BOUNDS_CHECKS;
     }
 
     bool doesMethodHaveExpandableCasts()

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7619,12 +7619,12 @@ public:
         optMethodFlags |= OMF_HAS_STATIC_INIT;
     }
 
-    bool doesMethodHaveBoundChecks()
+    bool doesMethodHaveBoundsChecks()
     {
         return (optMethodFlags & OMF_HAS_BOUNDS_CHECKS) != 0;
     }
 
-    void setMethodHasBoundChecks()
+    void setMethodHasBoundsChecks()
     {
         optMethodFlags |= OMF_HAS_BOUNDS_CHECKS;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8693,7 +8693,7 @@ DONE_MORPHING_CHILDREN:
             break;
 
         case GT_BOUNDS_CHECK:
-            setMethodHasBoundChecks();
+            setMethodHasBoundsChecks();
             fgAddCodeRef(compCurBB, tree->AsBoundsChk()->gtThrowKind);
             break;
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8693,7 +8693,7 @@ DONE_MORPHING_CHILDREN:
             break;
 
         case GT_BOUNDS_CHECK:
-
+            setMethodHasBoundChecks();
             fgAddCodeRef(compCurBB, tree->AsBoundsChk()->gtThrowKind);
             break;
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -14,6 +14,11 @@
 //
 PhaseStatus Compiler::rangeCheckPhase()
 {
+    if (!doesMethodHaveBoundChecks() || (fgSsaPassesCompleted == 0))
+    {
+        return PhaseStatus::MODIFIED_NOTHING;
+    }
+
     RangeCheck rc(this);
     const bool madeChanges = rc.OptimizeRangeChecks();
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
@@ -1711,11 +1716,6 @@ void RangeCheck::MapMethodDefs()
 // Entry point to range check optimizations.
 bool RangeCheck::OptimizeRangeChecks()
 {
-    if (m_pCompiler->fgSsaPassesCompleted == 0)
-    {
-        return false;
-    }
-
     bool madeChanges = false;
 
     // Walk through trees looking for arrBndsChk node and check if it can be optimized.

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -14,7 +14,7 @@
 //
 PhaseStatus Compiler::rangeCheckPhase()
 {
-    if (!doesMethodHaveBoundChecks() || (fgSsaPassesCompleted == 0))
+    if (!doesMethodHaveBoundsChecks() || (fgSsaPassesCompleted == 0))
     {
         return PhaseStatus::MODIFIED_NOTHING;
     }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -15074,8 +15074,8 @@ void Compiler::vnPrint(ValueNum vn, unsigned level)
 
 // Methods of ValueNumPair.
 ValueNumPair::ValueNumPair()
-    : m_liberal(ValueNumStore::NoVN)
-    , m_conservative(ValueNumStore::NoVN)
+    : m_conservative(ValueNumStore::NoVN)
+    , m_liberal(ValueNumStore::NoVN)
 {
 }
 

--- a/src/coreclr/jit/valuenumtype.h
+++ b/src/coreclr/jit/valuenumtype.h
@@ -34,8 +34,8 @@ enum ValueNumKind
 struct ValueNumPair
 {
 private:
-    ValueNum m_liberal;
     ValueNum m_conservative;
+    ValueNum m_liberal;
 
 public:
     ValueNum GetLiberal() const
@@ -116,8 +116,8 @@ public:
     ValueNumPair();
 
     ValueNumPair(ValueNum lib, ValueNum cons)
-        : m_liberal(lib)
-        , m_conservative(cons)
+        : m_conservative(cons)
+        , m_liberal(lib)
     {
     }
 


### PR DESCRIPTION
Also, make `m_conservative` be the first field in `ValueNumPair` because we access it more frequently than `m_liberal`.

Improves JIT TP. [Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=950807&view=ms.vss-build-web.run-extensions-tab).