### PR TITLE
JIT: generalize ParseArrayAddress a bit more

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -19887,14 +19887,39 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
     ValueNum  vn = comp->GetValueNumStore()->VNLiberalNormalValue(tree->gtVNPair);
     VNFuncApp vnf;
 
+    bool treeIsArrayRef = false;
+
     if (tree->TypeIs(TYP_REF) || comp->GetValueNumStore()->IsVNNewArr(vn, &vnf))
     {
         // This must be the array pointer.
         assert(*pArr == nullptr);
         *pArr = tree;
         assert(inputMul == 1); // Can't multiply the array pointer by anything.
+        treeIsArrayRef = true;
     }
-    else
+    else if (tree->OperIs(GT_LCL_VAR) && tree->TypeIs(TYP_BYREF, TYP_I_IMPL))
+    {
+        // This is sort of like gtGetClassHandle, but that requires TYP_REF
+        //
+        const unsigned       lclNum = tree->AsLclVar()->GetLclNum();
+        CORINFO_CLASS_HANDLE hnd    = comp->lvaTable[lclNum].lvClassHnd;
+
+        if (hnd != NO_CLASS_HANDLE)
+        {
+            DWORD attribs  = comp->info.compCompHnd->getClassAttribs(hnd);
+            treeIsArrayRef = (attribs & CORINFO_FLG_ARRAY) != 0;
+
+            if (treeIsArrayRef)
+            {
+                // This must be the array pointer.
+                assert(*pArr == nullptr);
+                *pArr = tree;
+                assert(inputMul == 1); // Can't multiply the array pointer by anything.
+            }
+        }
+    }
+
+    if (!treeIsArrayRef)
     {
         switch (tree->OperGet())
         {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -19901,8 +19901,7 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
     {
         // This is sort of like gtGetClassHandle, but that requires TYP_REF
         //
-        const unsigned       lclNum = tree->AsLclVar()->GetLclNum();
-        CORINFO_CLASS_HANDLE hnd    = comp->lvaTable[lclNum].lvClassHnd;
+        CORINFO_CLASS_HANDLE hnd = comp->lvaGetDesc(tree->AsLclVar())->lvClassHnd;
 
         if (hnd != NO_CLASS_HANDLE)
         {


### PR DESCRIPTION
Now that we are stack allocating arrays, the array reference may be either TYP_BYREF or TYP_I_IMPL, so try and recognize those cases when possible. In particular for OSR methods the array allocation may "disappear" once we redirect flow to the OSR entry, so relying on VN is insufficient.

Fixes #112429 (benchmark regression where we're measuring OSR code)