### PR TITLE
Remove bounds checks for a[i+c1] followed by a[i+c2]

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2759,10 +2759,10 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
 
     // We canonicalize commutative operations.
     // (Perhaps should eventually handle associative/commutative [AC] ops -- but that gets complicated...)
-    if (VNFuncIsCommutative(func))
+    if (VNFuncIsCommutative(func) && !IsVNConstantNonHandle(arg1VN))
     {
-        // Order arg0 arg1 by numerical VN value.
-        if (arg0VN > arg1VN)
+        // Order arg0 arg1 by numerical VN value, but keep constant non-handle VNs on the right.
+        if ((arg0VN > arg1VN) || IsVNConstantNonHandle(arg0VN))
         {
             std::swap(arg0VN, arg1VN);
         }


### PR DESCRIPTION
Not entirely a proper fix for https://github.com/dotnet/runtime/issues/112524, but still helps. Basically, if we have an assertion that "(i + CNS1)" is within bounds, then any "(i + CNS2)" is within the same bounds if CNS2 is in [0..CNS1] range.
```cs
static void Test(int[] arr, int i)
{
    arr[i + 3] = 0;
    arr[i + 2] = 0;
    arr[i + 1] = 0;
}
```

Was:
```asm
; Method Proga:Test(int[],int) (FullOpts)
       sub      rsp, 40
       lea      eax, [rdx+0x03]
       mov      r8d, dword ptr [rcx+0x08]
       cmp      eax, r8d
       jae      SHORT G_M8086_IG06
       xor      r10d, r10d
       mov      dword ptr [rcx+4*rax+0x10], r10d
       lea      eax, [rdx+0x02]
       cmp      eax, r8d
       jae      SHORT G_M8086_IG06
       mov      dword ptr [rcx+4*rax+0x10], r10d
       inc      edx
       cmp      edx, r8d
       jae      SHORT G_M8086_IG06
       mov      eax, edx
       mov      dword ptr [rcx+4*rax+0x10], r10d
       add      rsp, 40
       ret      
G_M8086_IG06:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 62
```
Now:
```asm
; Method Proga:Test(int[],int) (FullOpts)
       sub      rsp, 40
       lea      eax, [rdx+0x03]
       mov      r8d, dword ptr [rcx+0x08]
       cmp      eax, r8d
       jae      SHORT G_M8086_IG06
       xor      r8d, r8d
       mov      dword ptr [rcx+4*rax+0x10], r8d
       lea      eax, [rdx+0x02]
       mov      dword ptr [rcx+4*rax+0x10], r8d
       inc      edx
       mov      eax, edx
       mov      dword ptr [rcx+4*rax+0x10], r8d
       add      rsp, 40
       ret      
G_M8086_IG06:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 52
```