### PR TITLE
Remove broken link of Reflection In AOT file

### DIFF
--- a/src/coreclr/nativeaot/docs/README.md
+++ b/src/coreclr/nativeaot/docs/README.md
@@ -5,7 +5,6 @@
 - [Building native AOT apps in containers](containers.md)
 - [Debugging applications](debugging.md)
 - [Optimizing applications](optimizing.md)
-- [Reflection In AOT](reflection-in-aot-mode.md)
 - [Troubleshooting](troubleshooting.md)
 - [RD.xml Documentation](rd-xml-format.md)
 - [Using Native AOT on Android-Bionic](android-bionic.md)


### PR DESCRIPTION
In #109857 the `reflection-in-aot-mode.md` file was removed but its link in the readme file still exists and it gets 404.