### PR TITLE
Support disassembling single file bundle for ILSpy

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -483,17 +483,8 @@ namespace ILCompiler.Reflection.ReadyToRun
 
             if (CompositeReader == null)
             {
-                byte[] image = null;
-                if (Image == null)
-                {
-                    image = File.ReadAllBytes(Filename);
-                    Image = image;
-                }
-                else
-                {
-                    image = Image;
-                }
-
+                Image ??= File.ReadAllBytes(Filename);
+                byte[] image = Image;
                 ImagePin = new PinningReference(image);
                 CompositeReader = new PEReader(Unsafe.As<byte[], ImmutableArray<byte>>(ref image));
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -438,14 +438,11 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private unsafe byte[] ConvertToArray(ReadOnlyMemory<byte> content)
         {
-            if (MemoryMarshal.TryGetArray(content, out ArraySegment<byte> segment))
+            if (MemoryMarshal.TryGetArray(content, out ArraySegment<byte> segment) && (segment.Offset == 0) && (segment.Count == content.Length))
             {
                 return segment.Array;
             }
-            else
-            {
-                return content.ToArray();
-            }
+            return content.ToArray();
         }
 
         public static bool IsReadyToRunImage(PEReader peReader)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -406,7 +406,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             _assemblyResolver = assemblyResolver;
             CompositeReader = peReader;
             Filename = filename;
-            Image = Unsafe.As<ImmutableArray<byte>, byte[]>(ref content);
+            Image = ImmutableCollectionsMarshal.AsArray<byte>(content);
             Initialize(metadata);
         }
 
@@ -432,7 +432,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             _assemblyResolver = assemblyResolver;
             Filename = filename;
-            Image = Unsafe.As<ImmutableArray<byte>, byte[]>(ref content);
+            Image = ImmutableCollectionsMarshal.AsArray<byte>(content);
             Initialize(metadata: null);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -489,7 +489,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 byte[] image = null;
                 if (Image == null)
                 {
-                    File.ReadAllBytes(Filename);
+                    image = File.ReadAllBytes(Filename);
                     Image = image;
                 }
                 else


### PR DESCRIPTION
ILSpy support decompiling single file bundle by keeping the PE images in a single file bundle in memory.

To support disassembling the ready to run code embedded in it, this change accept the PE image content as an immutable byte array. That allow us to disassemble the content without having to save the file on disk.

- https://github.com/icsharpcode/ILSpy/issues/3397
- https://github.com/icsharpcode/ILSpy/pull/3398