### PR TITLE
JIT: Switch remainder of lowering to new ABI info

### DIFF
--- a/src/coreclr/jit/abi.h
+++ b/src/coreclr/jit/abi.h
@@ -8,8 +8,9 @@ enum class WellKnownArg : unsigned;
 
 class ABIPassingSegment
 {
-    regNumber m_register    = REG_NA;
-    unsigned  m_stackOffset = 0;
+    regNumberSmall m_register        = REG_NA;
+    bool           m_isFullStackSlot = true;
+    unsigned       m_stackOffset     = 0;
 
 public:
     bool IsPassedInRegister() const;
@@ -34,10 +35,16 @@ public:
     // offset, relative to the base of stack arguments.
     unsigned GetStackOffset() const;
 
+    // Get the size of stack consumed. Normally this is 'Size' rounded up to
+    // the pointer size, but for apple arm64 ABI some primitives do not consume
+    // full stack slots.
+    unsigned GetStackSize() const;
+
     var_types GetRegisterType() const;
 
     static ABIPassingSegment InRegister(regNumber reg, unsigned offset, unsigned size);
     static ABIPassingSegment OnStack(unsigned stackOffset, unsigned offset, unsigned size);
+    static ABIPassingSegment OnStackWithoutConsumingFullSlot(unsigned stackOffset, unsigned offset, unsigned size);
 
 #ifdef DEBUG
     void Dump() const;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1344,41 +1344,6 @@ bool CallArg::IsUserArg() const
     }
 }
 
-#ifdef DEBUG
-//---------------------------------------------------------------
-// CheckIsStruct: Verify that the struct ABI information is consistent with the IR node.
-//
-void CallArg::CheckIsStruct()
-{
-    GenTree* node = GetNode();
-    if (varTypeIsStruct(GetSignatureType()))
-    {
-        if (!varTypeIsStruct(node) && !node->OperIs(GT_FIELD_LIST))
-        {
-            // This is the case where we are passing a struct as a primitive type.
-            // On most targets, this is always a single register or slot.
-            // However, on ARM this could be two slots if it is TYP_DOUBLE.
-            bool isPassedAsPrimitiveType =
-                ((AbiInfo.NumRegs == 1) || ((AbiInfo.NumRegs == 0) && (AbiInfo.ByteSize <= TARGET_POINTER_SIZE)));
-#ifdef TARGET_ARM
-            if (!isPassedAsPrimitiveType)
-            {
-                if (node->TypeGet() == TYP_DOUBLE && AbiInfo.NumRegs == 0 && (AbiInfo.GetStackSlotsNumber() == 2))
-                {
-                    isPassedAsPrimitiveType = true;
-                }
-            }
-#endif // TARGET_ARM
-            assert(isPassedAsPrimitiveType);
-        }
-    }
-    else
-    {
-        assert(!varTypeIsStruct(node));
-    }
-}
-#endif
-
 CallArgs::CallArgs()
     : m_head(nullptr)
     , m_lateHead(nullptr)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4857,14 +4857,6 @@ public:
 
 #ifdef DEBUG
     void Dump(Compiler* comp);
-    // Check that the value of 'AbiInfo.IsStruct' is consistent.
-    // A struct arg must be one of the following:
-    // - A node of struct type,
-    // - A GT_FIELD_LIST, or
-    // - A node of a scalar type, passed in a single register or slot
-    //   (or two slots in the case of a struct pass on the stack as TYP_DOUBLE).
-    //
-    void CheckIsStruct();
 #endif
 };
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2159,10 +2159,6 @@ void CallArgs::AddFinalArgsAndDetermineABIInfo(Compiler* comp, GenTreeCall* call
                 }
 #endif
             }
-
-#if defined(UNIX_AMD64_ABI) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-            INDEBUG(arg.CheckIsStruct());
-#endif
         }
         else
         {

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -345,7 +345,15 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
     {
         for (CallArg& arg : call->gtArgs.Args())
         {
-            const unsigned slotCount = arg.AbiInfo.GetStackSlotsNumber();
+            unsigned slotCount = 0;
+            for (const ABIPassingSegment& segment : arg.NewAbiInfo.Segments())
+            {
+                if (segment.IsPassedOnStack())
+                {
+                    slotCount += segment.GetStackSize() / TARGET_POINTER_SIZE;
+                }
+            }
+
             if (slotCount != 0)
             {
                 GenTree* node = arg.GetNode();

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -350,7 +350,7 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
             {
                 if (segment.IsPassedOnStack())
                 {
-                    slotCount += segment.GetStackSize() / TARGET_POINTER_SIZE;
+                    slotCount += (segment.GetStackSize() + (TARGET_POINTER_SIZE - 1)) / TARGET_POINTER_SIZE;
                 }
             }
 

--- a/src/coreclr/jit/targetarm64.cpp
+++ b/src/coreclr/jit/targetarm64.cpp
@@ -182,17 +182,11 @@ ABIPassingInformation Arm64Classifier::Classify(Compiler*    comp,
             unsigned          alignment;
             if (compAppleArm64Abi())
             {
-                if (varTypeIsStruct(type))
-                {
-                    alignment = TARGET_POINTER_SIZE;
-                }
-                else
-                {
-                    alignment = genTypeSize(type);
-                }
-
+                alignment      = varTypeIsStruct(type) ? TARGET_POINTER_SIZE : genTypeSize(type);
                 m_stackArgSize = roundUp(m_stackArgSize, alignment);
-                segment        = ABIPassingSegment::OnStackWithoutConsumingFullSlot(m_stackArgSize, 0, passedSize);
+                segment        = alignment < TARGET_POINTER_SIZE
+                                     ? ABIPassingSegment::OnStackWithoutConsumingFullSlot(m_stackArgSize, 0, passedSize)
+                                     : ABIPassingSegment::OnStack(m_stackArgSize, 0, passedSize);
             }
             else
             {

--- a/src/coreclr/jit/targetarm64.cpp
+++ b/src/coreclr/jit/targetarm64.cpp
@@ -87,9 +87,12 @@ ABIPassingInformation Arm64Classifier::Classify(Compiler*    comp,
             {
                 unsigned alignment =
                     compAppleArm64Abi() ? min(elemSize, (unsigned)TARGET_POINTER_SIZE) : TARGET_POINTER_SIZE;
-                m_stackArgSize            = roundUp(m_stackArgSize, alignment);
-                ABIPassingSegment segment = ABIPassingSegment::OnStack(m_stackArgSize, 0, structLayout->GetSize());
-                info                      = ABIPassingInformation::FromSegmentByValue(comp, segment);
+                m_stackArgSize = roundUp(m_stackArgSize, alignment);
+                ABIPassingSegment segment =
+                    alignment < TARGET_POINTER_SIZE
+                        ? ABIPassingSegment::OnStackWithoutConsumingFullSlot(m_stackArgSize, 0, structLayout->GetSize())
+                        : ABIPassingSegment::OnStack(m_stackArgSize, 0, structLayout->GetSize());
+                info = ABIPassingInformation::FromSegmentByValue(comp, segment);
                 m_stackArgSize += roundUp(structLayout->GetSize(), alignment);
                 // After passing any float value on the stack, we should not enregister more float values.
                 m_floatRegs.Clear();

--- a/src/coreclr/jit/targetarm64.cpp
+++ b/src/coreclr/jit/targetarm64.cpp
@@ -175,7 +175,8 @@ ABIPassingInformation Arm64Classifier::Classify(Compiler*    comp,
         }
         else
         {
-            unsigned alignment;
+            ABIPassingSegment segment;
+            unsigned          alignment;
             if (compAppleArm64Abi())
             {
                 if (varTypeIsStruct(type))
@@ -188,15 +189,16 @@ ABIPassingInformation Arm64Classifier::Classify(Compiler*    comp,
                 }
 
                 m_stackArgSize = roundUp(m_stackArgSize, alignment);
+                segment        = ABIPassingSegment::OnStackWithoutConsumingFullSlot(m_stackArgSize, 0, passedSize);
             }
             else
             {
                 alignment = TARGET_POINTER_SIZE;
                 assert((m_stackArgSize % TARGET_POINTER_SIZE) == 0);
+                segment = ABIPassingSegment::OnStack(m_stackArgSize, 0, passedSize);
             }
 
-            info = ABIPassingInformation::FromSegment(comp, passedByRef,
-                                                      ABIPassingSegment::OnStack(m_stackArgSize, 0, passedSize));
+            info = ABIPassingInformation::FromSegment(comp, passedByRef, segment);
 
             m_stackArgSize += roundUp(passedSize, alignment);
 


### PR DESCRIPTION
This required introducing some new information in `ABIPassingSegment` for stack-passed segments about whether they own the full stack slot or not. Apple arm64 notoriously has cases where multiple parameters are packed in the same stack slot.