### PR TITLE
Fix assertion when capturing dump on ARM64

### DIFF
--- a/src/coreclr/debug/createdump/memoryregion.h
+++ b/src/coreclr/debug/createdump/memoryregion.h
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#include "specialdiaginfo.h"
+
 #if !defined(PAGE_SIZE) && (defined(__arm__) || defined(__aarch64__) || defined(__loongarch64)) || defined(__riscv)
 extern long g_pageSize;
 #define PAGE_SIZE g_pageSize
@@ -44,8 +46,15 @@ public:
         m_endAddress(end),
         m_offset(0)
     {
-        assert((start & ~PAGE_MASK) == 0);
-        assert((end & ~PAGE_MASK) == 0);
+        if (start == SpecialDiagInfoAddress)
+        {
+            assert(end == (SpecialDiagInfoAddress + SpecialDiagInfoSize));
+        }
+        else
+        {
+            assert((start & ~PAGE_MASK) == 0);
+            assert((end & ~PAGE_MASK) == 0);
+        }
     }
 
     // copy with new flags constructor. The file name is not copied.

--- a/src/coreclr/debug/createdump/specialdiaginfo.h
+++ b/src/coreclr/debug/createdump/specialdiaginfo.h
@@ -11,6 +11,8 @@
 // information like the exception record address for a NativeAOT app crash or the runtime module
 // base address. The exception record contains the pointer to the JSON formatted crash info.
 
+#pragma once
+
 #define SPECIAL_DIAGINFO_SIGNATURE "DIAGINFOHEADER"
 #define SPECIAL_DIAGINFO_VERSION 2
 


### PR DESCRIPTION
This change fixes an assertion fired on OSX/ARM64 while capturing a heap dump.

The problem is that on OSX/ARM64, the page size is 16k (instead of the usual 4k), so `SpecialDiagInfoSize` is not a multiple of the page size, the `end` will not be page aligned.

And by the time this special region get to `CombineMemoryRegions`, it won't usually get combined with any existing region, but it itself is not page aligned, and so triggering the assertion.

We aren't really writing the actual page to the dump anyway, might as well just assert the exact size for this particular region instead.

This change is only tested for OSX/ARM64, and it should have no retail impact (just failing for check/debug builds)