### PR TITLE
Make test `IUnknown` conforming

### DIFF
--- a/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
@@ -89,6 +89,23 @@ struct VariantMarshalTest
     }
 };
 
+class InterfaceImpl :
+    public UnknownImpl,
+    public IInterface2
+{
+public: // IInterface1
+public: // IInterface2
+public: // IUnknown
+    STDMETHOD(QueryInterface)(
+        /* [in] */ REFIID riid,
+        /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
+    {
+        return DoQueryInterface(riid, ppvObject, static_cast<IInterface1 *>(this), static_cast<IInterface2 *>(this));
+    }
+
+    DEFINE_REF_COUNTING();
+};
+
 void ValidationTests()
 {
     ::printf(__FUNCTION__ "() through CoCreateInstance...\n");
@@ -334,44 +351,6 @@ void ValidationTests()
 
     ::printf("-- Interfaces...\n");
     {
-        class InterfaceImpl : IInterface2
-        {
-            std::atomic<uint32_t> _refCount;
-        public:
-            InterfaceImpl() : _refCount{ 1 } {}
-
-            STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) override
-            {
-                if (riid == __uuidof(IInterface1) || riid == __uuidof(IInterface2))
-                {
-                    *ppvObject = static_cast<IInterface2*>(this);
-                }
-                else if (riid == __uuidof(IUnknown))
-                {
-                    *ppvObject = static_cast<IUnknown*>(this);
-                }
-                else
-                {
-                    *ppvObject = nullptr;
-                    return E_NOINTERFACE;
-                }
-                AddRef();
-                return S_OK;
-            }
-
-            STDMETHOD_(ULONG, AddRef)() override
-            {
-                return ++_refCount;
-            }
-
-            STDMETHOD_(ULONG, Release)() override
-            {
-                ULONG count = --_refCount;
-                if (count == 0)
-                    delete this;
-                return count;
-            }
-        };
         ComSmartPtr<InterfaceImpl> iface;
         iface.Attach(new InterfaceImpl());
 


### PR DESCRIPTION
The test was written quickly to validate basic interface marshalling. It was implemented on the stack to try and avoid fully implementing ref counting. This is an issue because of RCW clean-up, which can happen long after the native caller has returned.

Introduced in https://github.com/dotnet/runtime/pull/112375
Fixes #112545