### PR TITLE
Use a unified cache for SSL_CTX objects

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -31,15 +31,17 @@ internal static partial class Interop
 
         private sealed class SafeSslContextCache : SafeHandleCache<SslContextCacheKey, SafeSslContextHandle> { }
 
-        private static readonly SafeSslContextCache s_clientSslContexts = new();
+        private static readonly SafeSslContextCache s_sslContexts = new();
 
         internal readonly struct SslContextCacheKey : IEquatable<SslContextCacheKey>
         {
+            public readonly bool IsClient;
             public readonly byte[]? CertificateThumbprint;
             public readonly SslProtocols SslProtocols;
 
-            public SslContextCacheKey(SslProtocols sslProtocols, byte[]? certificateThumbprint)
+            public SslContextCacheKey(bool isClient, SslProtocols sslProtocols, byte[]? certificateThumbprint)
             {
+                IsClient = isClient;
                 SslProtocols = sslProtocols;
                 CertificateThumbprint = certificateThumbprint;
             }
@@ -47,6 +49,7 @@ internal static partial class Interop
             public override bool Equals(object? obj) => obj is SslContextCacheKey key && Equals(key);
 
             public bool Equals(SslContextCacheKey other) =>
+                IsClient == other.IsClient &&
                 SslProtocols == other.SslProtocols &&
                 (CertificateThumbprint == null && other.CertificateThumbprint == null ||
                  CertificateThumbprint != null && other.CertificateThumbprint != null && CertificateThumbprint.AsSpan().SequenceEqual(other.CertificateThumbprint));
@@ -55,6 +58,7 @@ internal static partial class Interop
             {
                 HashCode hash = default;
 
+                hash.Add(IsClient);
                 hash.Add(SslProtocols);
                 if (CertificateThumbprint != null)
                 {
@@ -161,41 +165,19 @@ internal static partial class Interop
                 return AllocateSslContext(sslAuthenticationOptions, protocols, allowCached);
             }
 
-            if (sslAuthenticationOptions.IsClient)
-            {
-                var key = new SslContextCacheKey(protocols, sslAuthenticationOptions.CertificateContext?.TargetCertificate.GetCertHash(HashAlgorithmName.SHA512));
-                return s_clientSslContexts.GetOrCreate(key, static (args) =>
-                {
-                    var (sslAuthOptions, protocols, allowCached) = args;
-                    return AllocateSslContext(sslAuthOptions, protocols, allowCached);
-                }, (sslAuthenticationOptions, protocols, allowCached));
-            }
-
-            // cache in SslStreamCertificateContext is bounded and there is no eviction
-            // so the handle should always be valid,
-
             bool hasAlpn = sslAuthenticationOptions.ApplicationProtocols != null && sslAuthenticationOptions.ApplicationProtocols.Count != 0;
 
-            SslProtocols serverCacheKey = protocols | (hasAlpn ? FakeAlpnSslProtocol : SslProtocols.None);
-            if (!sslAuthenticationOptions.CertificateContext!.SslContexts!.TryGetValue(serverCacheKey, out SafeSslContextHandle? handle))
+            SslProtocols serverProtocolCacheKey = protocols | (hasAlpn ? FakeAlpnSslProtocol : SslProtocols.None);
+
+            var key = new SslContextCacheKey(
+                sslAuthenticationOptions.IsClient,
+                sslAuthenticationOptions.IsClient ? protocols : serverProtocolCacheKey,
+                sslAuthenticationOptions.CertificateContext?.TargetCertificate.GetCertHash(HashAlgorithmName.SHA512));
+            return s_sslContexts.GetOrCreate(key, static (args) =>
             {
-                // not found in cache, create and insert
-                handle = AllocateSslContext(sslAuthenticationOptions, protocols, allowCached);
-
-                SafeSslContextHandle cached = sslAuthenticationOptions.CertificateContext!.SslContexts!.GetOrAdd(serverCacheKey, handle);
-
-                if (handle != cached)
-                {
-                    // lost the race, another thread created the SSL_CTX meanwhile, prefer the cached one
-                    handle.Dispose();
-                    Debug.Assert(handle.IsClosed);
-                    handle = cached;
-                }
-            }
-
-            Debug.Assert(!handle.IsClosed);
-            handle.TryAddRentCount();
-            return handle;
+                var (sslAuthOptions, protocols, allowCached) = args;
+                return AllocateSslContext(sslAuthOptions, protocols, allowCached);
+            }, (sslAuthenticationOptions, protocols, allowCached));
         }
 
         // This essentially wraps SSL_CTX* aka SSL_CTX_new + setting
@@ -367,8 +349,7 @@ internal static partial class Interop
                 {
                     // Server should always have certificate
                     Debug.Assert(sslAuthenticationOptions.CertificateContext != null);
-                    if (sslAuthenticationOptions.CertificateContext == null ||
-                       sslAuthenticationOptions.CertificateContext.SslContexts == null)
+                    if (sslAuthenticationOptions.CertificateContext == null)
                     {
                         cacheSslContext = false;
                     }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -352,6 +352,8 @@ namespace Microsoft.Win32.SafeHandles
         private bool _handshakeCompleted;
 
         public GCHandle AlpnHandle;
+        // Reference to the parent SSL_CTX handle in the SSL_CTX is being cached. Only used for
+        // refcount management.
         public SafeSslContextHandle? SslContextHandle;
 
         public bool IsServer
@@ -445,8 +447,6 @@ namespace Microsoft.Win32.SafeHandles
                 Disconnect();
             }
 
-            // drop reference to any SSL_CTX handle, any handle present here is being
-            // rented from (client) SSL_CTX cache.
             SslContextHandle?.Dispose();
 
             if (AlpnHandle.IsAllocated)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -130,8 +130,8 @@ namespace Microsoft.Win32.SafeHandles
             if (_sslSessions != null)
             {
                 // The SSL_CTX is ref counted and may not immediately die when we call SslCtxDestroy()
-                // Since there is no relation between SafeSslContextHandle and SafeSslHandle `this` can be release
-                // while we still have SSL session using it.
+                // Since there is no relation between SafeSslContextHandle and SafeSslHandle `this`
+                // can be released while we still have SSL session using it.
                 Interop.Ssl.SslCtxSetData(handle, IntPtr.Zero);
 
                 lock (_sslSessions)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -28,7 +28,7 @@ namespace System.Net.Security
         internal readonly SafeX509Handle CertificateHandle;
         internal readonly SafeEvpPKeyHandle KeyHandle;
 
-        internal object SyncObject => KeyHandle;
+        private object SyncObject => KeyHandle;
 
         private bool _staplingForbidden;
         private byte[]? _ocspResponse;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -25,24 +25,10 @@ namespace System.Net.Security
 
         private const bool TrimRootCertificate = true;
         private const bool ChainBuildNeedsTrustedRoot = false;
-        internal ConcurrentDictionary<SslProtocols, SafeSslContextHandle> SslContexts
-        {
-            get
-            {
-                ConcurrentDictionary<SslProtocols, SafeSslContextHandle>? sslContexts = _sslContexts;
-                if (sslContexts is null)
-                {
-                    Interlocked.CompareExchange(ref _sslContexts, new(), null);
-                    sslContexts = _sslContexts;
-                }
-
-                return sslContexts;
-            }
-        }
-
-        private ConcurrentDictionary<SslProtocols, SafeSslContextHandle>? _sslContexts;
         internal readonly SafeX509Handle CertificateHandle;
         internal readonly SafeEvpPKeyHandle KeyHandle;
+
+        internal object SyncObject => KeyHandle;
 
         private bool _staplingForbidden;
         private byte[]? _ocspResponse;
@@ -239,7 +225,7 @@ namespace System.Net.Security
                 return new ValueTask<byte[]?>((byte[]?)null);
             }
 
-            lock (SslContexts)
+            lock (SyncObject)
             {
                 pending = _pendingDownload;
 


### PR DESCRIPTION
Fixes #110803.

Regression from https://github.com/dotnet/runtime/pull/102656, This also simplifies the internal code a bit and removes the requirement to always use SslStreamCertificateContext on server side to benefit from TLS Resumption.