### PR TITLE
Enable `SA1015`: Closing generic bracket should not be followed by a space

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1178,7 +1178,7 @@ dotnet_diagnostic.SA1013.severity = none
 dotnet_diagnostic.SA1014.severity = warning
 
 # SA1015: Closing generic bracket should not be followed by a space
-dotnet_diagnostic.SA1015.severity = none
+dotnet_diagnostic.SA1015.severity = warning
 
 # SA1018: Nullable type symbol should not be preceded by a space
 dotnet_diagnostic.SA1018.severity = warning

--- a/src/tasks/MonoTargetsTasks/JsonToItemsTaskFactory/JsonToItemsTaskFactory.cs
+++ b/src/tasks/MonoTargetsTasks/JsonToItemsTaskFactory/JsonToItemsTaskFactory.cs
@@ -370,7 +370,7 @@ namespace JsonToItemsTaskFactory
                         var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
                         if (dict == null)
                             return null!;
-                        var idict = new Dictionary<string, string> (dict, StringComparer.OrdinalIgnoreCase);
+                        var idict = new Dictionary<string, string>(dict, StringComparer.OrdinalIgnoreCase);
                         if  (!idict.TryGetValue("Identity", out var identity) || string.IsNullOrEmpty(identity))
                             throw new JsonException ("deserialized json dictionary item did not have a non-empty Identity metadata");
                         else

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Workload.Build.Tasks
                                                     Path.Combine(req.TargetPath, "dotnet"),
                                                     $"workload install --skip-manifest-update --skip-sign-check --configfile \"{nugetConfigPath}\" --temp-dir \"{_tempDir}/workload-install-temp\" {ExtraWorkloadInstallCommandArguments} {req.WorkloadId}",
                                                     workingDir: _tempDir,
-                                                    envVars: new Dictionary<string, string> () {
+                                                    envVars: new Dictionary<string, string>() {
                                                         ["NUGET_PACKAGES"] = _nugetCachePath
                                                     },
                                                     logStdErrAsMessage: req.IgnoreErrors,

--- a/src/tools/illink/.editorconfig
+++ b/src/tools/illink/.editorconfig
@@ -42,6 +42,9 @@ file_header_template = Copyright (c) .NET Foundation and contributors. All right
 # Spacing around keywords
 dotnet_diagnostic.SA1000.severity = none
 
+# Closing generic bracket should not be followed by a space
+dotnet_diagnostic.SA1015.severity = none
+
 # Access modifier must be declared
 dotnet_diagnostic.SA1400.severity = none
 


### PR DESCRIPTION
Do not enable for `src/tools/illink/` due to different code style.

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
