### PR TITLE
Avoid `Unsafe.As` in `BitConverter`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -54,7 +54,8 @@ namespace System
         public static byte[] GetBytes(char value)
         {
             byte[] bytes = new byte[sizeof(char)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -81,7 +82,8 @@ namespace System
         public static byte[] GetBytes(short value)
         {
             byte[] bytes = new byte[sizeof(short)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -108,7 +110,8 @@ namespace System
         public static byte[] GetBytes(int value)
         {
             byte[] bytes = new byte[sizeof(int)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -135,7 +138,8 @@ namespace System
         public static byte[] GetBytes(long value)
         {
             byte[] bytes = new byte[sizeof(long)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -162,7 +166,8 @@ namespace System
         public static byte[] GetBytes(Int128 value)
         {
             byte[] bytes = new byte[Int128.Size];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -190,7 +195,8 @@ namespace System
         public static byte[] GetBytes(ushort value)
         {
             byte[] bytes = new byte[sizeof(ushort)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -219,7 +225,8 @@ namespace System
         public static byte[] GetBytes(uint value)
         {
             byte[] bytes = new byte[sizeof(uint)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -248,7 +255,8 @@ namespace System
         public static byte[] GetBytes(ulong value)
         {
             byte[] bytes = new byte[sizeof(ulong)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -277,7 +285,8 @@ namespace System
         public static byte[] GetBytes(UInt128 value)
         {
             byte[] bytes = new byte[UInt128.Size];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -305,7 +314,8 @@ namespace System
         public static unsafe byte[] GetBytes(Half value)
         {
             byte[] bytes = new byte[sizeof(Half)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -332,7 +342,8 @@ namespace System
         public static byte[] GetBytes(float value)
         {
             byte[] bytes = new byte[sizeof(float)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 
@@ -359,7 +370,8 @@ namespace System
         public static byte[] GetBytes(double value)
         {
             byte[] bytes = new byte[sizeof(double)];
-            MemoryMarshal.Write(bytes, value);
+            bool success = TryWriteBytes(bytes, value);
+            Debug.Assert(success);
             return bytes;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -54,7 +54,7 @@ namespace System
         public static byte[] GetBytes(char value)
         {
             byte[] bytes = new byte[sizeof(char)];
-            Unsafe.As<byte, char>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -81,7 +81,7 @@ namespace System
         public static byte[] GetBytes(short value)
         {
             byte[] bytes = new byte[sizeof(short)];
-            Unsafe.As<byte, short>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -108,7 +108,7 @@ namespace System
         public static byte[] GetBytes(int value)
         {
             byte[] bytes = new byte[sizeof(int)];
-            Unsafe.As<byte, int>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -135,7 +135,7 @@ namespace System
         public static byte[] GetBytes(long value)
         {
             byte[] bytes = new byte[sizeof(long)];
-            Unsafe.As<byte, long>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -162,7 +162,7 @@ namespace System
         public static byte[] GetBytes(Int128 value)
         {
             byte[] bytes = new byte[Int128.Size];
-            Unsafe.As<byte, Int128>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -190,7 +190,7 @@ namespace System
         public static byte[] GetBytes(ushort value)
         {
             byte[] bytes = new byte[sizeof(ushort)];
-            Unsafe.As<byte, ushort>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -219,7 +219,7 @@ namespace System
         public static byte[] GetBytes(uint value)
         {
             byte[] bytes = new byte[sizeof(uint)];
-            Unsafe.As<byte, uint>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -248,7 +248,7 @@ namespace System
         public static byte[] GetBytes(ulong value)
         {
             byte[] bytes = new byte[sizeof(ulong)];
-            Unsafe.As<byte, ulong>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -277,7 +277,7 @@ namespace System
         public static byte[] GetBytes(UInt128 value)
         {
             byte[] bytes = new byte[UInt128.Size];
-            Unsafe.As<byte, UInt128>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -305,7 +305,7 @@ namespace System
         public static unsafe byte[] GetBytes(Half value)
         {
             byte[] bytes = new byte[sizeof(Half)];
-            Unsafe.As<byte, Half>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -332,7 +332,7 @@ namespace System
         public static byte[] GetBytes(float value)
         {
             byte[] bytes = new byte[sizeof(float)];
-            Unsafe.As<byte, float>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 
@@ -359,7 +359,7 @@ namespace System
         public static byte[] GetBytes(double value)
         {
             byte[] bytes = new byte[sizeof(double)];
-            Unsafe.As<byte, double>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref bytes[0], value);
             return bytes;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -54,7 +54,7 @@ namespace System
         public static byte[] GetBytes(char value)
         {
             byte[] bytes = new byte[sizeof(char)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -81,7 +81,7 @@ namespace System
         public static byte[] GetBytes(short value)
         {
             byte[] bytes = new byte[sizeof(short)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -108,7 +108,7 @@ namespace System
         public static byte[] GetBytes(int value)
         {
             byte[] bytes = new byte[sizeof(int)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -135,7 +135,7 @@ namespace System
         public static byte[] GetBytes(long value)
         {
             byte[] bytes = new byte[sizeof(long)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -162,7 +162,7 @@ namespace System
         public static byte[] GetBytes(Int128 value)
         {
             byte[] bytes = new byte[Int128.Size];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -190,7 +190,7 @@ namespace System
         public static byte[] GetBytes(ushort value)
         {
             byte[] bytes = new byte[sizeof(ushort)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -219,7 +219,7 @@ namespace System
         public static byte[] GetBytes(uint value)
         {
             byte[] bytes = new byte[sizeof(uint)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -248,7 +248,7 @@ namespace System
         public static byte[] GetBytes(ulong value)
         {
             byte[] bytes = new byte[sizeof(ulong)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -277,7 +277,7 @@ namespace System
         public static byte[] GetBytes(UInt128 value)
         {
             byte[] bytes = new byte[UInt128.Size];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -305,7 +305,7 @@ namespace System
         public static unsafe byte[] GetBytes(Half value)
         {
             byte[] bytes = new byte[sizeof(Half)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -332,7 +332,7 @@ namespace System
         public static byte[] GetBytes(float value)
         {
             byte[] bytes = new byte[sizeof(float)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 
@@ -359,7 +359,7 @@ namespace System
         public static byte[] GetBytes(double value)
         {
             byte[] bytes = new byte[sizeof(double)];
-            Unsafe.WriteUnaligned(ref bytes[0], value);
+            MemoryMarshal.Write(bytes, value);
             return bytes;
         }
 


### PR DESCRIPTION
Doesn't depend upon implementation specific behaviour, i.e. that the array data is properly aligned.