### PR TITLE
Optimize shift operations for BigInteger

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -15,6 +15,7 @@
     <Compile Include="System\Numerics\BigIntegerCalculator.GcdInv.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.PowMod.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.SquMul.cs" />
+    <Compile Include="System\Numerics\BigIntegerCalculator.ShiftRot.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.Utils.cs" />
     <Compile Include="System\Numerics\BigInteger.cs" />
     <Compile Include="System\Number.BigInteger.cs" />

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2533,8 +2533,7 @@ namespace System.Numerics
 
             bits.CopyTo(zd);
 
-            uint carry = 0;
-            BigIntegerCalculator.LeftShiftSelf(zd, smallShift, ref carry);
+            BigIntegerCalculator.LeftShiftSelf(zd, smallShift, out uint carry);
 
             Debug.Assert(carry == over);
             Debug.Assert(z[^1] != 0);
@@ -2612,8 +2611,7 @@ namespace System.Numerics
             zd[^1] = 0;
             bits.Slice(digitShift).CopyTo(zd);
 
-            uint carry = 0;
-            BigIntegerCalculator.RightShiftSelf(zd, smallShift, ref carry);
+            BigIntegerCalculator.RightShiftSelf(zd, smallShift, out uint carry);
 
             bool neg = value._sign < 0;
             if (neg && (carry != 0 || bits.Slice(0, digitShift).ContainsAnyExcept(0u)))
@@ -5088,8 +5086,7 @@ namespace System.Numerics
                 }
             }
 
-            uint carry = 0;
-            BigIntegerCalculator.RightShiftSelf(zd, smallShift, ref carry);
+            BigIntegerCalculator.RightShiftSelf(zd, smallShift, out _);
 
             BigInteger result = new BigInteger(zd, false);
 

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
@@ -39,8 +39,7 @@ namespace System.Numerics
         {
             Debug.Assert(bits.Length > 0);
 
-            uint carry = 0;
-            LeftShiftSelf(bits, smallShift, ref carry);
+            LeftShiftSelf(bits, smallShift, out uint carry);
             bits[0] |= carry;
 
             if (digitShift == 0)
@@ -53,8 +52,7 @@ namespace System.Numerics
         {
             Debug.Assert(bits.Length > 0);
 
-            uint carry = 0;
-            RightShiftSelf(bits, smallShift, ref carry);
+            RightShiftSelf(bits, smallShift, out uint carry);
             bits[^1] |= carry;
 
             if (digitShift == 0)
@@ -98,9 +96,11 @@ namespace System.Numerics
                 ArrayPool<uint>.Shared.Return(tmpFromPool);
         }
 
-        public static void LeftShiftSelf(Span<uint> bits, int shift, ref uint carry)
+        public static void LeftShiftSelf(Span<uint> bits, int shift, out uint carry)
         {
             Debug.Assert((uint)shift < 32);
+
+            carry = 0;
             if (shift == 0)
                 return;
 
@@ -112,9 +112,11 @@ namespace System.Numerics
                 bits[i] = value;
             }
         }
-        public static void RightShiftSelf(Span<uint> bits, int shift, ref uint carry)
+        public static void RightShiftSelf(Span<uint> bits, int shift, out uint carry)
         {
             Debug.Assert((uint)shift < 32);
+
+            carry = 0;
             if (shift == 0)
                 return;
 

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Numerics
+{
+    internal static partial class BigIntegerCalculator
+    {
+        public static void RotateLeft(Span<uint> bits, long rotateLeftAmount)
+        {
+            Debug.Assert(Math.Abs(rotateLeftAmount) <= 0x80000000);
+
+            const int digitShiftMax = (int)(0x80000000 / 32);
+
+            int digitShift = digitShiftMax;
+            int smallShift = 0;
+
+            if (rotateLeftAmount < 0)
+            {
+                if (rotateLeftAmount != -0x80000000)
+                    (digitShift, smallShift) = Math.DivRem(-(int)rotateLeftAmount, 32);
+
+                RotateRight(bits, digitShift % bits.Length, smallShift);
+            }
+            else
+            {
+                if (rotateLeftAmount != 0x80000000)
+                    (digitShift, smallShift) = Math.DivRem((int)rotateLeftAmount, 32);
+
+                RotateLeft(bits, digitShift % bits.Length, smallShift);
+            }
+        }
+
+        public static void RotateLeft(Span<uint> bits, int digitShift, int smallShift)
+        {
+            Debug.Assert(bits.Length > 0);
+
+            uint carry = 0;
+            LeftShiftSelf(bits, smallShift, ref carry);
+            bits[0] |= carry;
+
+            if (digitShift == 0)
+                return;
+
+            SwapUpperAndLower(bits, bits.Length - digitShift);
+        }
+
+        public static void RotateRight(Span<uint> bits, int digitShift, int smallShift)
+        {
+            Debug.Assert(bits.Length > 0);
+
+            uint carry = 0;
+            RightShiftSelf(bits, smallShift, ref carry);
+            bits[^1] |= carry;
+
+            if (digitShift == 0)
+                return;
+
+            SwapUpperAndLower(bits, digitShift);
+        }
+
+        private static void SwapUpperAndLower(Span<uint> bits, int lowerLength)
+        {
+            Debug.Assert(lowerLength > 0);
+            Debug.Assert(lowerLength < bits.Length);
+
+            int upperLength = bits.Length - lowerLength;
+
+            Span<uint> lower = bits.Slice(0, lowerLength);
+            Span<uint> upper = bits.Slice(lowerLength);
+
+            Span<uint> lowerDst = bits.Slice(upperLength);
+
+            int tmpLength = Math.Min(lowerLength, upperLength);
+            uint[]? tmpFromPool = null;
+            Span<uint> tmp = ((uint)tmpLength <= StackAllocThreshold ?
+                                  stackalloc uint[StackAllocThreshold]
+                                  : tmpFromPool = ArrayPool<uint>.Shared.Rent(tmpLength)).Slice(0, tmpLength);
+
+            if (upperLength < lowerLength)
+            {
+                upper.CopyTo(tmp);
+                lower.CopyTo(lowerDst);
+                tmp.CopyTo(bits);
+            }
+            else
+            {
+                lower.CopyTo(tmp);
+                upper.CopyTo(bits);
+                tmp.CopyTo(lowerDst);
+            }
+
+            if (tmpFromPool != null)
+                ArrayPool<uint>.Shared.Return(tmpFromPool);
+        }
+
+        public static void LeftShiftSelf(Span<uint> bits, int shift, ref uint carry)
+        {
+            Debug.Assert((uint)shift < 32);
+            if (shift == 0)
+                return;
+
+            int back = 32 - shift;
+            for (int i = 0; i < bits.Length; i++)
+            {
+                uint value = carry | bits[i] << shift;
+                carry = bits[i] >> back;
+                bits[i] = value;
+            }
+        }
+        public static void RightShiftSelf(Span<uint> bits, int shift, ref uint carry)
+        {
+            Debug.Assert((uint)shift < 32);
+            if (shift == 0)
+                return;
+
+            int back = 32 - shift;
+            for (int i = bits.Length - 1; i >= 0; i--)
+            {
+                uint value = carry | bits[i] >> shift;
+                carry = bits[i] << back;
+                bits[i] = value;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
@@ -107,23 +108,37 @@ namespace System.Numerics
             // where A = ~X and B = -Y
 
             // Trim trailing 0s (at the first in little endian array)
-            d = d.TrimStart(0u);
+            int i = d.IndexOfAnyExcept(0u);
+
+            if ((uint)i >= (uint)d.Length)
+            {
+                return;
+            }
 
             // Make the first non-zero element to be two's complement
-            if (d.Length > 0)
-            {
-                d[0] = (uint)(-(int)d[0]);
-                d = d.Slice(1);
-            }
+            d[i] = (uint)(-(int)d[i]);
+            d = d.Slice(i + 1);
 
             if (d.IsEmpty)
             {
                 return;
             }
 
-            // Make one's complement for other elements
-            int offset = 0;
+            DangerousMakeOnesComplement(d);
+        }
 
+        // Do an in-place one's complement. "Dangerous" because it causes
+        // a mutation and needs to be used with care for immutable types.
+        public static void DangerousMakeOnesComplement(Span<uint> d)
+        {
+            // Given a number:
+            //     XXXXXXXXXXX
+            // where Y is non-zero,
+            // The result of one's complement is
+            //     AAAAAAAAAAA
+            // where A = ~X
+
+            int offset = 0;
             ref uint start = ref MemoryMarshal.GetReference(d);
 
             while (Vector512.IsHardwareAccelerated && d.Length - offset >= Vector512<uint>.Count)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/MyBigInt.cs
@@ -108,8 +108,14 @@ namespace System.Numerics.Tests
                     return new BigInteger(Max(bytes1, bytes2).ToArray());
                 case "b>>":
                     return new BigInteger(ShiftLeft(bytes1, Negate(bytes2)).ToArray());
+                case "b>>>":
+                    return new BigInteger(ShiftRightUnsigned(bytes1, bytes2).ToArray());
                 case "b<<":
                     return new BigInteger(ShiftLeft(bytes1, bytes2).ToArray());
+                case "bRotateLeft":
+                    return new BigInteger(RotateLeft(bytes1, bytes2).ToArray());
+                case "bRotateRight":
+                    return new BigInteger(RotateLeft(bytes1, Negate(bytes2)).ToArray());
                 case "b^":
                     return new BigInteger(Xor(bytes1, bytes2).ToArray());
                 case "b|":
@@ -637,10 +643,66 @@ namespace System.Numerics.Tests
             return bnew;
         }
 
+        public static List<byte> ShiftRightUnsigned(List<byte> bytes1, List<byte> bytes2)
+        {
+            int byteShift = (int)new BigInteger(Divide(Copy(bytes2), new List<byte>(new byte[] { 8 })).ToArray());
+            sbyte bitShift = (sbyte)new BigInteger(Remainder(Copy(bytes2), new List<byte>(new byte[] { 8 })).ToArray());
+
+            if (byteShift == 0 && bitShift == 0)
+                return bytes1;
+
+            if (byteShift < 0 || bitShift < 0)
+                return ShiftLeft(bytes1, Negate(bytes2));
+
+            Trim(bytes1);
+
+            byte fill = (bytes1[bytes1.Count - 1] & 0x80) != 0 ? byte.MaxValue : (byte)0;
+
+            if (fill == byte.MaxValue)
+            {
+                while (bytes1.Count % 4 != 0)
+                {
+                    bytes1.Add(fill);
+                }
+                bytes1.Add(0);
+            }
+
+            for (int i = 0; i < bitShift; i++)
+            {
+                bytes1 = ShiftRight(bytes1);
+            }
+
+            if (byteShift >= bytes1.Count)
+            {
+                bytes1 = new List<byte>(new byte[] { fill });
+            }
+            else
+            {
+                List<byte> temp = new List<byte>();
+                for (int i = byteShift; i < bytes1.Count; i++)
+                {
+                    temp.Add(bytes1[i]);
+                }
+                bytes1 = temp;
+
+                Trim(bytes1);
+            }
+
+            if (bytes1.Count == 1 && bytes1[0] == 0)
+            {
+                // If value is a negative number, the operator returns MinusOne.
+                bytes1 = new List<byte>(new byte[] { fill });
+            }
+
+            return bytes1;
+        }
+
         public static List<byte> ShiftLeft(List<byte> bytes1, List<byte> bytes2)
         {
             int byteShift = (int)new BigInteger(Divide(Copy(bytes2), new List<byte>(new byte[] { 8 })).ToArray());
             sbyte bitShift = (sbyte)new BigInteger(Remainder(bytes2, new List<byte>(new byte[] { 8 })).ToArray());
+
+            Trim(bytes1);
 
             for (int i = 0; i < Math.Abs(bitShift); i++)
             {
@@ -772,6 +834,102 @@ namespace System.Numerics.Tests
             }
 
             return bresult;
+        }
+
+        public static List<byte> RotateRight(List<byte> bytes)
+        {
+            List<byte> bresult = new List<byte>();
+
+            byte bottom = (byte)(bytes[0] & 0x01);
+
+            for (int i = 0; i < bytes.Count; i++)
+            {
+                byte newbyte = bytes[i];
+
+                newbyte = (byte)(newbyte / 2);
+                if ((i != (bytes.Count - 1)) && ((bytes[i + 1] & 0x01) == 1))
+                {
+                    newbyte += 128;
+                }
+                if ((i == (bytes.Count - 1)) && (bottom != 0))
+                {
+                    newbyte += 128;
+                }
+                bresult.Add(newbyte);
+            }
+
+            return bresult;
+        }
+
+        public static List<byte> RotateLeft(List<byte> bytes)
+        {
+            List<byte> bresult = new List<byte>();
+
+            bool prevHead = (bytes[bytes.Count - 1] & 0x80) != 0;
+
+            for (int i = 0; i < bytes.Count; i++)
+            {
+                byte newbyte = bytes[i];
+
+                newbyte = (byte)(newbyte * 2);
+                if (prevHead)
+                {
+                    newbyte += 1;
+                }
+
+                bresult.Add(newbyte);
+
+                prevHead = (bytes[i] & 0x80) != 0;
+            }
+
+            return bresult;
+        }
+
+
+        public static List<byte> RotateLeft(List<byte> bytes1, List<byte> bytes2)
+        {
+            int byteShift = (int)new BigInteger(Divide(Copy(bytes2), new List<byte>(new byte[] { 8 })).ToArray());
+            sbyte bitShift = (sbyte)new BigInteger(Remainder(bytes2, new List<byte>(new byte[] { 8 })).ToArray());
+
+            Trim(bytes1);
+
+            byte fill = (bytes1[bytes1.Count - 1] & 0x80) != 0 ? byte.MaxValue : (byte)0;
+
+            if (fill == 0 && bytes1.Count > 1 && bytes1[bytes1.Count - 1] == 0)
+                bytes1.RemoveAt(bytes1.Count - 1);
+
+            while (bytes1.Count % 4 != 0)
+            {
+                bytes1.Add(fill);
+            }
+
+            for (int i = 0; i < Math.Abs(bitShift); i++)
+            {
+                if (bitShift < 0)
+                {
+                    bytes1 = RotateRight(bytes1);
+                }
+                else
+                {
+                    bytes1 = RotateLeft(bytes1);
+                }
+            }
+
+            byteShift %= bytes1.Count;
+
+            List<byte> temp = new List<byte>();
+            for (int i = 0; i < bytes1.Count; i++)
+            {
+                temp.Add(bytes1[(i - byteShift + bytes1.Count) % bytes1.Count]);
+            }
+            bytes1 = temp;
+
+            if (fill == 0)
+                bytes1.Add(0);
+
+            Trim(bytes1);
+
+            return bytes1;
         }
 
         public static List<byte> SetLength(List<byte> bytes, int size)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
@@ -5,146 +5,146 @@ using Xunit;
 
 namespace System.Numerics.Tests
 {
-    public abstract class op_rightshiftTestBase
+    public abstract class RotateTestBase
     {
         public abstract string opstring { get; }
         private static int s_samples = 10;
         private static Random s_random = new Random(100);
 
         [Fact]
-        public void RunRightShiftTests()
+        public void RunRotateTests()
         {
             byte[] tempByteArray1;
             byte[] tempByteArray2;
 
-            // RightShift Method - Large BigIntegers - large + Shift
+            // Rotate Method - Large BigIntegers - large + Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Large BigIntegers - small + Shift
+            // Rotate Method - Large BigIntegers - small + Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Large BigIntegers - 32 bit Shift
+            // Rotate Method - Large BigIntegers - 32 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)32 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - All One Uint Large BigIntegers - 32 bit Shift
+            // Rotate Method - All One Uint Large BigIntegers - 32 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomLengthAllOnesUIntByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)32 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Uint 0xffffffff 0x8000000 ... Large BigIntegers - 32 bit Shift
+            // Rotate Method - Uint 0xffffffff 0x8000000 ... Large BigIntegers - 32 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomLengthFirstUIntMaxSecondUIntMSBMaxArray(s_random);
                 tempByteArray2 = new byte[] { (byte)32 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Large BigIntegers - large - Shift
+            // Rotate Method - Large BigIntegers - large - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = GetRandomNegByteArray(s_random, 2);
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Large BigIntegers - small - Shift
+            // Rotate Method - Large BigIntegers - small - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { unchecked((byte)s_random.Next(-31, 0)) };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Large BigIntegers - -32 bit Shift
+            // Rotate Method - Large BigIntegers - -32 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)0xe0 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Large BigIntegers - 0 bit Shift
+            // Rotate Method - Large BigIntegers - 0 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random);
                 tempByteArray2 = new byte[] { (byte)0 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Small BigIntegers - large + Shift
+            // Rotate Method - Small BigIntegers - large + Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomPosByteArray(s_random, 2);
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Small BigIntegers - small + Shift
+            // Rotate Method - Small BigIntegers - small + Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Small BigIntegers - 32 bit Shift
+            // Rotate Method - Small BigIntegers - 32 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)32 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
-            // RightShift Method - Small BigIntegers - large - Shift
+            // Rotate Method - Small BigIntegers - large - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = GetRandomNegByteArray(s_random, 2);
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Small BigIntegers - small - Shift
+            // Rotate Method - Small BigIntegers - small - Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { unchecked((byte)s_random.Next(-31, 0)) };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Small BigIntegers - -32 bit Shift
+            // Rotate Method - Small BigIntegers - -32 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)0xe0 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Small BigIntegers - 0 bit Shift
+            // Rotate Method - Small BigIntegers - 0 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomByteArray(s_random, 2);
                 tempByteArray2 = new byte[] { (byte)0 };
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Positive BigIntegers - Shift to 0
+            // Rotate Method - Positive BigIntegers - Shift to 0
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomPosByteArray(s_random, 100);
@@ -153,10 +153,10 @@ namespace System.Numerics.Tests
                 {
                     Array.Reverse(tempByteArray2);
                 }
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
 
-            // RightShift Method - Negative BigIntegers - Shift to -1
+            // Rotate Method - Negative BigIntegers - Shift to -1
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomNegByteArray(s_random, 100);
@@ -165,7 +165,7 @@ namespace System.Numerics.Tests
                 {
                     Array.Reverse(tempByteArray2);
                 }
-                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
             }
         }
 
@@ -221,10 +221,10 @@ namespace System.Numerics.Tests
             byte[] tempByteArray1 = GetRandomSmallByteArray(value);
             byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
 
-            VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
         }
 
-        private static void VerifyRightShiftString(string opstring)
+        private static void VerifyRotateString(string opstring)
         {
             StackCalc sc = new StackCalc(opstring);
             while (sc.DoNextOperation())
@@ -306,80 +306,14 @@ namespace System.Numerics.Tests
             return MyBigIntImp.Print(bytes);
         }
     }
-    public class op_rightshiftTest : op_rightshiftTestBase
+
+    public class RotateRightTest : RotateTestBase
     {
-        public override string opstring => "b>>";
-
-        [Fact]
-        public static void BigShiftsTest()
-        {
-            BigInteger a = new BigInteger(1);
-            BigInteger b = new BigInteger(Math.Pow(2, 31));
-
-            for (int i = 0; i < 100; i++)
-            {
-                BigInteger a1 = (a << (i + 31));
-                BigInteger a2 = a1 >> i;
-
-                Assert.Equal(b, a2);
-            }
-        }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // May fail on 32-bit due to a large memory requirement
-        public static void LargeNegativeBigIntegerShiftTest()
-        {
-            // Create a very large negative BigInteger
-            int bitsPerElement = 8 * sizeof(uint);
-            int maxBitLength = ((Array.MaxLength / bitsPerElement) * bitsPerElement);
-            BigInteger bigInt = new BigInteger(-1) << (maxBitLength - 1);
-            Assert.Equal(maxBitLength - 1, bigInt.GetBitLength());
-            Assert.Equal(-1, bigInt.Sign);
-
-            // Validate internal representation.
-            // At this point, bigInt should be a 1 followed by maxBitLength - 1 zeros.
-            // Given this, bigInt._bits is expected to be structured as follows:
-            // - _bits.Length == ceil(maxBitLength / bitsPerElement)
-            // - First (_bits.Length - 1) elements: 0x00000000
-            // - Last element: 0x80000000
-            //                   ^------ (There's the leading '1')
-
-            Assert.Equal((maxBitLength + (bitsPerElement - 1)) / bitsPerElement, bigInt._bits.Length);
-
-            uint i = 0;
-            for (; i < (bigInt._bits.Length - 1); i++)
-            {
-                Assert.Equal(0x00000000u, bigInt._bits[i]);
-            }
-
-            Assert.Equal(0x80000000u, bigInt._bits[i]);
-
-            // Right shift the BigInteger
-            BigInteger shiftedBigInt = bigInt >> 1;
-            Assert.Equal(maxBitLength - 2, shiftedBigInt.GetBitLength());
-            Assert.Equal(-1, shiftedBigInt.Sign);
-
-            // Validate internal representation.
-            // At this point, shiftedBigInt should be a 1 followed by maxBitLength - 2 zeros.
-            // Given this, shiftedBigInt._bits is expected to be structured as follows:
-            // - _bits.Length == ceil((maxBitLength - 1) / bitsPerElement)
-            // - First (_bits.Length - 1) elements: 0x00000000
-            // - Last element: 0x40000000
-            //                   ^------ (the '1' is now one position to the right)
-
-            Assert.Equal(((maxBitLength - 1) + (bitsPerElement - 1)) / bitsPerElement, shiftedBigInt._bits.Length);
-
-            i = 0;
-            for (; i < (shiftedBigInt._bits.Length - 1); i++)
-            {
-                Assert.Equal(0x00000000u, shiftedBigInt._bits[i]);
-            }
-
-            Assert.Equal(0x40000000u, shiftedBigInt._bits[i]);
-        }
+        public override string opstring => "bRotateRight";
     }
 
-    public class op_UnsignedRightshiftTest : op_rightshiftTestBase
+    public class RotateLeftTest : RotateTestBase
     {
-        public override string opstring => "b>>>";
+        public override string opstring => "bRotateLeft";
     }
 }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
@@ -302,13 +302,39 @@ namespace System.Numerics.Tests
         }
     }
 
-    public class RotateRightTest : RotateTestBase
-    {
-        public override string opstring => "bRotateRight";
-    }
-
     public class RotateLeftTest : RotateTestBase
     {
         public override string opstring => "bRotateLeft";
+
+        [Fact]
+        public void PowerOfTwo()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                foreach (int k in new int[] { 1, 2, 10 })
+                {
+                    Assert.Equal(BigInteger.One << (32 * (k - 1) + i), BigInteger.RotateLeft(BigInteger.One << (32 * k + i), 32 * k));
+                    Assert.Equal((new BigInteger(uint.MaxValue << i)) << (32 * (k - 1)), BigInteger.RotateLeft(BigInteger.MinusOne << (32 * k + i), 32 * k));
+                }
+            }
+        }
+    }
+
+    public class RotateRightTest : RotateTestBase
+    {
+        public override string opstring => "bRotateRight";
+
+        [Fact]
+        public void PowerOfTwo()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                foreach (int k in new int[] { 1, 2, 10 })
+                {
+                    Assert.Equal(BigInteger.One << i, BigInteger.RotateRight(BigInteger.One << (32 * k + i), 32 * k));
+                    Assert.Equal(new BigInteger(uint.MaxValue << i), BigInteger.RotateRight(BigInteger.MinusOne << (32 * k + i), 32 * k));
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
@@ -169,7 +169,8 @@ namespace System.Numerics.Tests
             }
         }
 
-        public static IEnumerable<object[]> RunSmallTestsData()
+        [Fact]
+        public void RunSmallTests()
         {
             foreach (int i in new int[] {
                     0,
@@ -207,21 +208,15 @@ namespace System.Numerics.Tests
                         foreach (int sign in new int[] { -1, +1 })
                         {
                             Int128 value128 = sign * (num + k);
-                            yield return [value128, shift];
+
+                            byte[] tempByteArray1 = GetRandomSmallByteArray(value128);
+                            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
+
+                            VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
                         }
                     }
                 }
             }
-        }
-
-        [Theory]
-        [MemberData(nameof(RunSmallTestsData))]
-        public void RunSmallTests(Int128 value, int shift)
-        {
-            byte[] tempByteArray1 = GetRandomSmallByteArray(value);
-            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
-
-            VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
         }
 
         private static void VerifyRotateString(string opstring)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
@@ -151,6 +151,61 @@ namespace System.Numerics.Tests
             }
         }
 
+        public static IEnumerable<object[]> RunSmallTestsData()
+        {
+            foreach (int i in new int[] {
+                    0,
+                    1,
+                    16,
+                    31,
+                    32,
+                    33,
+                    63,
+                    64,
+                    65,
+                    100,
+                    127,
+                    128,
+            })
+            {
+                foreach (int shift in new int[] {
+                    0,
+                    -1, 1,
+                    -16, 16,
+                    -31, 31,
+                    -32, 32,
+                    -33, 33,
+                    -63, 63,
+                    -64, 64,
+                    -65, 65,
+                    -100, 100,
+                    -127, 127,
+                    -128, 128,
+                })
+                {
+                    var num = Int128.One << i;
+                    for (int k = -1; k <= 1; k++)
+                    {
+                        foreach (int sign in new int[] { -1, +1 })
+                        {
+                            Int128 value128 = sign * (num + k);
+                            yield return [value128, shift];
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RunSmallTestsData))]
+        public void RunSmallTests(Int128 value, int shift)
+        {
+            byte[] tempByteArray1 = GetRandomSmallByteArray(value);
+            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
+
+            VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
+        }
+
         private static void VerifyLeftShiftString(string opstring)
         {
             StackCalc sc = new StackCalc(opstring);
@@ -158,6 +213,19 @@ namespace System.Numerics.Tests
             {
                 Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
             }
+        }
+
+        private static byte[] GetRandomSmallByteArray(Int128 num)
+        {
+            byte[] value = new byte[16];
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                value[i] = (byte)num;
+                num >>= 8;
+            }
+
+            return value;
         }
 
         private static byte[] GetRandomByteArray(Random random)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_leftshift.cs
@@ -151,7 +151,8 @@ namespace System.Numerics.Tests
             }
         }
 
-        public static IEnumerable<object[]> RunSmallTestsData()
+        [Fact]
+        public void RunSmallTests()
         {
             foreach (int i in new int[] {
                     0,
@@ -189,21 +190,15 @@ namespace System.Numerics.Tests
                         foreach (int sign in new int[] { -1, +1 })
                         {
                             Int128 value128 = sign * (num + k);
-                            yield return [value128, shift];
+
+                            byte[] tempByteArray1 = GetRandomSmallByteArray(value128);
+                            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
+
+                            VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
                         }
                     }
                 }
             }
-        }
-
-        [Theory]
-        [MemberData(nameof(RunSmallTestsData))]
-        public void RunSmallTests(Int128 value, int shift)
-        {
-            byte[] tempByteArray1 = GetRandomSmallByteArray(value);
-            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
-
-            VerifyLeftShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b<<");
         }
 
         private static void VerifyLeftShiftString(string opstring)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -376,5 +376,18 @@ namespace System.Numerics.Tests
     public class op_UnsignedRightshiftTest : op_rightshiftTestBase
     {
         public override string opstring => "b>>>";
+
+        [Fact]
+        public void PowerOfTwo()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                foreach (int k in new int[] { 1, 2, 10 })
+                {
+                    Assert.Equal(BigInteger.One << i, (BigInteger.One << (32 * k + i)) >>> (32 * k));
+                    Assert.Equal(new BigInteger(uint.MaxValue << i), (BigInteger.MinusOne << (32 * k + i)) >>> (32 * k));
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -169,7 +169,8 @@ namespace System.Numerics.Tests
             }
         }
 
-        public static IEnumerable<object[]> RunSmallTestsData()
+        [Fact]
+        public void RunSmallTests()
         {
             foreach (int i in new int[] {
                     0,
@@ -207,21 +208,15 @@ namespace System.Numerics.Tests
                         foreach (int sign in new int[] { -1, +1 })
                         {
                             Int128 value128 = sign * (num + k);
-                            yield return [value128, shift];
+
+                            byte[] tempByteArray1 = GetRandomSmallByteArray(value128);
+                            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
+
+                            VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
                         }
                     }
                 }
             }
-        }
-
-        [Theory]
-        [MemberData(nameof(RunSmallTestsData))]
-        public void RunSmallTests(Int128 value, int shift)
-        {
-            byte[] tempByteArray1 = GetRandomSmallByteArray(value);
-            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
-
-            VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
         }
 
         private static void VerifyRightShiftString(string opstring)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
@@ -191,8 +191,14 @@ namespace System.Numerics.Tests
                     return BigInteger.Max(num1, num2);
                 case "b>>":
                     return num1 >> (int)num2;
+                case "b>>>":
+                    return num1 >>> (int)num2;
                 case "b<<":
                     return num1 << (int)num2;
+                case "bRotateLeft":
+                    return BigInteger.RotateLeft(num1, (int)num2);
+                case "bRotateRight":
+                    return BigInteger.RotateRight(num1, (int)num2);
                 case "b^":
                     return num1 ^ num2;
                 case "b|":
@@ -254,7 +260,7 @@ namespace System.Numerics.Tests
 
         private static string Print(byte[] bytes)
         {
-           return MyBigIntImp.PrintFormatX(bytes);
+            return MyBigIntImp.PrintFormatX(bytes);
         }
     }
 }

--- a/src/libraries/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/libraries/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="BigInteger\op_multiply.cs" />
     <Compile Include="BigInteger\op_not.cs" />
     <Compile Include="BigInteger\op_or.cs" />
+    <Compile Include="BigInteger\Rotate.cs" />
     <Compile Include="BigInteger\op_rightshift.cs" />
     <Compile Include="BigInteger\op_xor.cs" />
     <Compile Include="BigInteger\parse.cs" />


### PR DESCRIPTION
Fix #112564

This pull request includes the following changes:

- Added tests for `RotateLeft`, `RotateRight` and  the unsigned right shift(`>>>`).
- Fixed shifting for negative numbers (#112564)
- Optimized performance

## Benchmark



```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3194)
13th Gen Intel Core i5-13500, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.100-alpha.1.25077.2
  [Host]     : .NET 10.0.0 (10.0.25.7313), X64 RyuJIT AVX2
  Job-XLUTTB : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-KGFXGU : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2


```
| Method                     | Toolchain         | Mean      | Ratio | Gen0     | Gen1     | Gen2     | Allocated | Alloc Ratio |
|--------------------------- |------------------ |----------:|------:|---------:|---------:|---------:|----------:|------------:|
| PositiveLeftShift          | \main\corerun.exe | 13.920 ms |  1.00 |  62.5000 |  62.5000 |  62.5000 |     33 MB |        1.00 |
| PositiveLeftShift          | \pr\corerun.exe   |  9.485 ms |  0.68 | 156.2500 | 156.2500 | 156.2500 |     33 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| NegativeLeftShift          | \main\corerun.exe | 13.567 ms |  1.00 |  78.1250 |  78.1250 |  78.1250 |     33 MB |        1.00 |
| NegativeLeftShift          | \pr\corerun.exe   |  9.134 ms |  0.67 | 156.2500 | 156.2500 | 156.2500 |     33 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| PositiveRightShift         | \main\corerun.exe | 16.709 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     31 MB |        1.00 |
| PositiveRightShift         | \pr\corerun.exe   | 12.411 ms |  0.74 | 187.5000 | 187.5000 | 187.5000 |     31 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| NegativeRightShift         | \main\corerun.exe | 21.708 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     31 MB |        1.00 |
| NegativeRightShift         | \pr\corerun.exe   | 12.291 ms |  0.57 | 187.5000 | 187.5000 | 187.5000 |     31 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| PositiveUnsignedRightShift | \main\corerun.exe | 15.083 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     31 MB |        1.00 |
| PositiveUnsignedRightShift | \pr\corerun.exe   | 12.585 ms |  0.84 | 187.5000 | 187.5000 | 187.5000 |     31 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| NegativeUnsignedRightShift | \main\corerun.exe | 18.347 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     31 MB |        1.00 |
| NegativeUnsignedRightShift | \pr\corerun.exe   | 14.719 ms |  0.81 | 187.5000 | 187.5000 | 187.5000 |     31 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| PositiveRotateLeft         | \main\corerun.exe | 15.150 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     32 MB |        1.00 |
| PositiveRotateLeft         | \pr\corerun.exe   | 13.825 ms |  0.90 | 187.5000 | 187.5000 | 187.5000 |     32 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| NegativeRotateLeft         | \main\corerun.exe | 19.346 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     32 MB |        1.00 |
| NegativeRotateLeft         | \pr\corerun.exe   | 18.920 ms |  0.97 | 187.5000 | 187.5000 | 187.5000 |     32 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| PositiveRotateRight        | \main\corerun.exe | 14.727 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     32 MB |        1.00 |
| PositiveRotateRight        | \pr\corerun.exe   | 14.222 ms |  0.97 | 187.5000 | 187.5000 | 187.5000 |     32 MB |        1.00 |
|                            |                   |           |       |          |          |          |           |             |
| NegativeRotateRight        | \main\corerun.exe | 16.936 ms |  1.00 | 125.0000 | 125.0000 | 125.0000 |     32 MB |        1.00 |
| NegativeRotateRight        | \pr\corerun.exe   | 16.650 ms |  0.98 | 187.5000 | 187.5000 | 187.5000 |     32 MB |        1.00 |


<details>

<summary>benchmark code</summary>

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using System.Numerics;

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class ShiftTest
{
    const int shiftSize = (1 << 23) + 13;
    BigInteger positive, negative;

    [GlobalSetup]
    public void Setup()
    {
        var bytes = new byte[1 << 25];
        new Random(227).NextBytes(bytes);
        positive = new BigInteger(bytes, isUnsigned: true);
        negative = -positive;
    }

    [Benchmark] public BigInteger PositiveLeftShift() => positive << shiftSize;
    [Benchmark] public BigInteger NegativeLeftShift() => negative << shiftSize;

    [Benchmark] public BigInteger PositiveRightShift() => positive >> shiftSize;
    [Benchmark] public BigInteger NegativeRightShift() => negative >> shiftSize;

    [Benchmark] public BigInteger PositiveUnsignedRightShift() => positive >>> shiftSize;
    [Benchmark] public BigInteger NegativeUnsignedRightShift() => negative >>> shiftSize;

    [Benchmark] public BigInteger PositiveRotateLeft() => BigInteger.RotateLeft(positive, shiftSize);
    [Benchmark] public BigInteger NegativeRotateLeft() => BigInteger.RotateLeft(negative, shiftSize);

    [Benchmark] public BigInteger PositiveRotateRight() => BigInteger.RotateRight(positive, shiftSize);
    [Benchmark] public BigInteger NegativeRotateRight() => BigInteger.RotateRight(negative, shiftSize);
}
```

</details>
