### PR TITLE
[browser][ST] avoid thread interruption checkpoint

### DIFF
--- a/src/mono/mono/metadata/marshal-shared.c
+++ b/src/mono/mono/metadata/marshal-shared.c
@@ -12,6 +12,7 @@
 #include "mono/metadata/class-internals.h"
 #include "metadata/reflection-internals.h"
 #include "mono/metadata/handle.h"
+#include <mono/utils/options.h>
 
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
@@ -962,6 +963,10 @@ mono_marshal_shared_emit_struct_conv (MonoMethodBuilder *mb, MonoClass *klass, g
 void
 mono_marshal_shared_emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, MonoJitICallId checkpoint_icall_id)
 {
+	if(mono_opt_wasm_disable_threads) {
+		return;
+	}
+
 	int pos_noabort, pos_noex;
 
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);

--- a/src/mono/mono/metadata/monitor.c
+++ b/src/mono/mono/metadata/monitor.c
@@ -1160,8 +1160,11 @@ mono_monitor_try_enter_loop_if_interrupted (MonoObject *obj, guint32 ms,
 		res = mono_monitor_try_enter_internal (obj, ms, allow_interruption);
 		if (res == -1) {
 			// The wait was interrupted and the monitor was not acquired.
+#ifndef DISABLE_THREADS
 			MonoException *exc;
+#endif
 			HANDLE_FUNCTION_ENTER ();
+#ifndef DISABLE_THREADS
 			exc = mono_thread_interruption_checkpoint ();
 			if (exc) {
 				MONO_HANDLE_NEW (MonoException, exc);
@@ -1170,9 +1173,12 @@ mono_monitor_try_enter_loop_if_interrupted (MonoObject *obj, guint32 ms,
 				else
 					mono_set_pending_exception (exc);
 			}
+#endif
 			HANDLE_FUNCTION_RETURN ();
+#ifndef DISABLE_THREADS
 			if (exc)
 				return FALSE;
+#endif
 			// The interrupt was a false positive. Ignore it from now on.
 			// This feels like a hack.
 			// threads.c should give us less confusing directions.

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -605,8 +605,12 @@ retry_top:
 		 * throw tie for the type.
 		 */
 		if (exc && mono_object_class (exc) == mono_defaults.threadabortexception_class) {
+#ifndef DISABLE_THREADS
 			pending_tae = TRUE;
 			mono_thread_resume_interruption (FALSE);
+#else // DISABLE_THREADS
+			g_assert_not_reached ();
+#endif // DISABLE_THREADS
 		}
 	} else {
 		/* this just blocks until the initializing thread is done */

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1132,6 +1132,7 @@ interp_throw_ex_general (
 		THROW_EX (interp_get_exception_null_reference (frame, ip), ip); \
 	} while (0)
 
+#ifndef DISABLE_THREADS
 #define EXCEPTION_CHECKPOINT	\
 	do {										\
 		if (mono_thread_interruption_request_flag && !mono_threads_is_critical_method (frame->imethod->method)) { \
@@ -1140,6 +1141,9 @@ interp_throw_ex_general (
 				THROW_EX_GENERAL (exc, ip, TRUE);					\
 		}									\
 	} while (0)
+#else
+#define EXCEPTION_CHECKPOINT do { } while (0);
+#endif
 
 // Reduce duplicate code in mono_interp_exec_method
 static MONO_NEVER_INLINE void

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2422,8 +2422,12 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 							}
 						}
 						if (is_outside) {
+#ifndef DISABLE_THREADS
 							jit_tls->handler_block = NULL;
 							mono_thread_resume_interruption (TRUE); /*We ignore the exception here, it will be raised later*/
+#else // DISABLE_THREADS
+							g_assert_not_reached ();
+#endif // DISABLE_THREADS
 						}
 					}
 

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2995,7 +2995,7 @@ mini_safepoints_enabled (void)
 	#ifndef DISABLE_THREADS
 		return TRUE;
 	#else
-		return mono_opt_wasm_gc_safepoints;
+		return !mono_opt_wasm_disable_threads;
 	#endif
 #else
 	return TRUE;

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -64,7 +64,7 @@ DEFINE_BOOL(aot_lazy_assembly_load, "aot-lazy-assembly-load", FALSE, "Load assem
 DEFINE_BOOL(interp_pgo_recording, "interp-pgo-recording", FALSE, "Record interpreter tiering information for automatic PGO")
 #else
 DEFINE_BOOL(interp_pgo_recording, "interp-pgo-recording", FALSE, "Record interpreter tiering information for automatic PGO")
-DEFINE_BOOL(wasm_gc_safepoints, "wasm-gc-safepoints", FALSE, "Use GC safepoints on WASM")
+DEFINE_BOOL(wasm_disable_threads, "wasm-disable-threads", FALSE, "Disable threads on WASM")
 #endif
 DEFINE_BOOL(interp_pgo_logging, "interp-pgo-logging", FALSE, "Log messages when interpreter PGO optimizes a method or updates its table")
 DEFINE_BOOL(interp_codegen_timing, "interp-codegen-timing", FALSE, "Measure time spent generating interpreter code and log it periodically")
@@ -80,7 +80,7 @@ DEFINE_BOOL(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry-enabled"
 // jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
 DEFINE_BOOL(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", TRUE, "JIT specialized WASM do_jit_call trampolines")
 
-DEFINE_BOOL(wasm_gc_safepoints, "wasm-gc-safepoints", FALSE, "Use GC safepoints on WASM")
+DEFINE_BOOL(wasm_disable_threads, "wasm-disable-threads", TRUE, "Disable threads on WASM")
 #else
 // traces_enabled controls whether the jiterpreter will JIT individual interpreter opcode traces
 DEFINE_BOOL(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", TRUE, "JIT interpreter opcode traces into WASM")
@@ -89,7 +89,7 @@ DEFINE_BOOL_READONLY(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry
 // jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
 DEFINE_BOOL_READONLY(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", FALSE, "JIT specialized WASM do_jit_call trampolines")
 
-DEFINE_BOOL_READONLY(wasm_gc_safepoints, "wasm-gc-safepoints", TRUE, "Use GC safepoints on WASM")
+DEFINE_BOOL(wasm_disable_threads, "wasm-disable-threads", FALSE, "Disable threads on WASM")
 #endif // DISABLE_THREADS
 
 // enables using WASM try/catch_all instructions where appropriate (currently only do_jit_call),

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -639,7 +639,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="mattr=simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="-v" Condition="'$(WasmAOTCompilerVerbose)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="--wasm-exceptions" Condition="'$(WasmEnableExceptionHandling)' == 'true'" />
-      <MonoAOTCompilerDefaultProcessArguments Include="--wasm-gc-safepoints" Condition="'$(WasmEnableThreads)' == 'true'" />
+      <MonoAOTCompilerDefaultProcessArguments Include="--wasm-disable-threads" Condition="'$(WasmEnableThreads)' != 'true' and '$(RuntimeIdentifier)' == 'browser-wasm'" />
       <AotProfilePath Include="$(WasmAotProfilePath)"/>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
This should make AOT smaller and everything faster in ST.

- rename `mono_opt_wasm_gc_safepoints` to `mono_opt_wasm_disable_threads` and negate it
- `mono_marshal_shared_emit_thread_interrupt_checkpoint_call` and `emit_thread_interrupt_checkpoint` used only then threads are not disabled
- avoid `mono_thread_interruption_checkpoint` in ST `monitor.c`
- ifdef `threads.c`
- empty `EXCEPTION_CHECKPOINT` for ST

Fixes https://github.com/dotnet/runtime/issues/112631