### PR TITLE
FileSystem: guard against stack overflow in recursive delete (#84344)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -472,7 +472,7 @@ namespace System.IO
             {
                 Debug.Assert(recursive);
 
-                RemoveDirectoryRecursive(fullPath, 0);
+                RemoveDirectoryRecursive(fullPath, depth: 0);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.Enumeration;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
 
@@ -471,11 +472,11 @@ namespace System.IO
             {
                 Debug.Assert(recursive);
 
-                RemoveDirectoryRecursive(fullPath);
+                RemoveDirectoryRecursive(fullPath, 0);
             }
         }
 
-        private static void RemoveDirectoryRecursive(string fullPath)
+        private static void RemoveDirectoryRecursive(string fullPath, int depth)
         {
             Exception? firstException = null;
 
@@ -496,7 +497,11 @@ namespace System.IO
                     {
                         if (isDirectory)
                         {
-                            RemoveDirectoryRecursive(childPath);
+                            if (depth > DirectoryRemoveUncheckedRecursion)
+                            {
+                                RuntimeHelpers.EnsureSufficientExecutionStack();
+                            }
+                            RemoveDirectoryRecursive(childPath, depth + 1);
                         }
                         else
                         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
@@ -19,6 +19,8 @@ namespace System.IO
             UnixFileMode.SetGroup |
             UnixFileMode.SetUser;
 
+        private const int DirectoryRemoveUncheckedRecursion = 32; // 32 arbitrarily chosen
+
         internal static void VerifyValidPath(string path, string argName)
         {
             ArgumentException.ThrowIfNullOrEmpty(path, argName);

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/Delete.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/Delete.cs
@@ -293,6 +293,34 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [OuterLoop]
+        public void RecursiveDelete_ShouldThrowExceptionIfNestingTooDeep()
+        {
+            // Create a 6000 level deep directory and recursively delete from the root.
+
+            string rootDirectory = GetTestFilePath();
+            StringBuilder sb = new StringBuilder(15000);
+            sb.Append(rootDirectory);
+            for (int i = 0; i < 3000; i++)
+            {
+                sb.Append(@"\a");
+            }
+            string cleanupRoot = sb.ToString();
+            for (int i = 0; i < 3000; i++)
+            {
+                sb.Append(@"\a");
+            }
+            string path = sb.ToString();
+            Directory.CreateDirectory(path);
+            Assert.Throws<InsufficientExecutionStackException>(() => Delete(rootDirectory, recursive: true));
+
+            // Cleanup
+            Directory.Delete(cleanupRoot, true);
+            Directory.Delete(path, true);
+        }
+
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Recursive delete throws IOException if directory contains in-use file
         public void RecursiveDelete_ShouldThrowIOExceptionIfContainedFileInUse()
         {


### PR DESCRIPTION
Fixes #84344. This guards large recursive deletes with a 
sufficient execution stack check.