### PR TITLE
JIT: Remove `LclVarDsc::GetArgReg` and `LclVarDsc::GetOtherArgReg` uses

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -521,7 +521,7 @@ public:
     var_types lvType : 5; // TYP_INT/LONG/FLOAT/DOUBLE/REF
 
     unsigned char lvIsParam           : 1; // is this a parameter?
-    unsigned char lvIsRegArg          : 1; // is this an argument that was passed by register?
+    unsigned char lvIsRegArg          : 1; // is any part of this parameter passed in a register?
     unsigned char lvIsParamRegTarget  : 1; // is this the target of a param reg to local mapping?
     unsigned char lvFramePointerBased : 1; // 0 = off of REG_SPBASE (e.g., ESP), 1 = off of REG_FPBASE (e.g., EBP)
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -6619,7 +6619,8 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
 #ifdef TARGET_ARM64
                 if (info.compIsVarArgs && varDsc->lvIsRegArg && (lclNum != info.compRetBuffArg))
                 {
-                    const ABIPassingInformation& abiInfo = lvaGetParameterABIInfo(varDsc->lvIsStructField ? varDsc->lvParentLcl : lclNum);
+                    const ABIPassingInformation& abiInfo =
+                        lvaGetParameterABIInfo(varDsc->lvIsStructField ? varDsc->lvParentLcl : lclNum);
                     bool found = false;
                     for (const ABIPassingSegment& segment : abiInfo.Segments())
                     {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -5842,8 +5842,21 @@ void Compiler::lvaFixVirtualFrameOffsets()
 #ifdef TARGET_ARM
 bool Compiler::lvaIsPreSpilled(unsigned lclNum, regMaskTP preSpillMask)
 {
-    const LclVarDsc& desc = lvaTable[lclNum];
-    return desc.lvIsRegArg && (preSpillMask & genRegMask(desc.GetArgReg()));
+    LclVarDsc* dsc = lvaGetDesc(lclNum);
+    if (dsc->lvIsStructField)
+    {
+        lclNum = dsc->lvParentLcl;
+    }
+    const ABIPassingInformation& abiInfo = lvaGetParameterABIInfo(lclNum);
+    for (const ABIPassingSegment& segment : abiInfo.Segments())
+    {
+        if (segment.IsPassedInRegister() && ((preSpillMask & segment.GetRegisterMask()) != RBM_NONE))
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 #endif // TARGET_ARM
 
@@ -6604,12 +6617,30 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
             if (varDsc->lvIsParam)
             {
 #ifdef TARGET_ARM64
-                if (info.compIsVarArgs && varDsc->lvIsRegArg &&
-                    (varDsc->GetArgReg() != theFixedRetBuffReg(info.compCallConv)))
+                if (info.compIsVarArgs && varDsc->lvIsRegArg && (lclNum != info.compRetBuffArg))
                 {
-                    // Stack offset to varargs (parameters) should point to home area which will be preallocated.
-                    const unsigned regArgNum = genMapIntRegNumToRegArgNum(varDsc->GetArgReg(), info.compCallConv);
-                    varDsc->SetStackOffset(-initialStkOffs + regArgNum * REGSIZE_BYTES);
+                    const ABIPassingInformation& abiInfo = lvaGetParameterABIInfo(varDsc->lvIsStructField ? varDsc->lvParentLcl : lclNum);
+                    bool found = false;
+                    for (const ABIPassingSegment& segment : abiInfo.Segments())
+                    {
+                        if (!segment.IsPassedInRegister())
+                        {
+                            continue;
+                        }
+
+                        if (varDsc->lvIsStructField && (segment.Offset != varDsc->lvFldOffset))
+                        {
+                            continue;
+                        }
+
+                        found = true;
+                        // Stack offset to varargs (parameters) should point to home area which will be preallocated.
+                        const unsigned regArgNum = genMapIntRegNumToRegArgNum(segment.GetRegister(), info.compCallConv);
+                        varDsc->SetStackOffset(-initialStkOffs + regArgNum * REGSIZE_BYTES);
+                        break;
+                    }
+
+                    assert(found);
                     continue;
                 }
 #endif
@@ -6916,7 +6947,7 @@ bool Compiler::lvaParamHasLocalStackSpace(unsigned lclNum)
     // On ARM we spill the registers in codeGen->regSet.rsMaskPreSpillRegArg
     // in the prolog, thus they don't need stack frame space.
     //
-    if ((codeGen->regSet.rsMaskPreSpillRegs(false) & genRegMask(varDsc->GetArgReg())) != 0)
+    if (lvaIsPreSpilled(lclNum, codeGen->regSet.rsMaskPreSpillRegs(false)))
     {
         assert(varDsc->GetStackOffset() != BAD_STK_OFFS);
         return false;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1619,13 +1619,7 @@ bool LinearScan::isRegCandidate(LclVarDsc* varDsc)
             // vars will have `lvMustInit` set, because emitter has poor support for struct liveness,
             // but if the variable is tracked the prolog generator would expect it to be in liveIn set,
             // so an assert in `genFnProlog` will fire.
-            bool isRegCandidate = compiler->compEnregStructLocals() && !varDsc->HasGCPtr();
-#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-            // The LoongArch64's ABI which the float args within a struct maybe passed by integer register
-            // when no float register left but free integer register.
-            isRegCandidate &= !genIsValidFloatReg(varDsc->GetOtherArgReg());
-#endif
-            return isRegCandidate;
+            return compiler->compEnregStructLocals() && !varDsc->HasGCPtr();
         }
 
         case TYP_UNDEF:

--- a/src/coreclr/jit/scopeinfo.cpp
+++ b/src/coreclr/jit/scopeinfo.cpp
@@ -1702,85 +1702,39 @@ void CodeGen::psiBegProlog()
         }
         siVarLoc varLocation;
 
-        if (lclVarDsc->lvIsRegArg)
+        regNumber reg1 = REG_NA;
+        regNumber reg2 = REG_NA;
+
+        const ABIPassingInformation& abiInfo = compiler->lvaGetParameterABIInfo(varScope->vsdVarNum);
+        for (const ABIPassingSegment& segment : abiInfo.Segments())
         {
-            bool isStructHandled = false;
-#if defined(UNIX_AMD64_ABI)
-            SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
-            if (varTypeIsStruct(lclVarDsc))
+            if (segment.IsPassedInRegister())
             {
-                CORINFO_CLASS_HANDLE typeHnd = lclVarDsc->GetLayout()->GetClassHandle();
-                assert(typeHnd != nullptr);
-                compiler->eeGetSystemVAmd64PassStructInRegisterDescriptor(typeHnd, &structDesc);
-                if (structDesc.passedInRegisters)
+                if (reg1 == REG_NA)
                 {
-                    regNumber regNum      = REG_NA;
-                    regNumber otherRegNum = REG_NA;
-                    for (unsigned nCnt = 0; nCnt < structDesc.eightByteCount; nCnt++)
-                    {
-                        if (nCnt == 0)
-                        {
-                            regNum = lclVarDsc->GetArgReg();
-                        }
-                        else if (nCnt == 1)
-                        {
-                            otherRegNum = lclVarDsc->GetOtherArgReg();
-                        }
-                        else
-                        {
-                            assert(false && "Invalid eightbyte number.");
-                        }
-                    }
-
-                    varLocation.storeVariableInRegisters(regNum, otherRegNum);
+                    reg1 = segment.GetRegister();
                 }
                 else
                 {
-                    // Stack passed argument. Get the offset from the  caller's frame.
-                    varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
+                    reg2 = segment.GetRegister();
+                    break;
                 }
-
-                isStructHandled = true;
             }
-#endif // !defined(UNIX_AMD64_ABI)
-            if (!isStructHandled)
+            else
             {
-#ifdef DEBUG
-#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-                var_types regType;
-                if (varTypeIsStruct(lclVarDsc))
-                {
-                    // Must be <= 16 bytes or else it wouldn't be passed in registers,
-                    // which can be bigger (and is handled above).
-                    noway_assert(EA_SIZE_IN_BYTES(lclVarDsc->lvSize()) <= 16);
-                    if (emitter::isFloatReg(lclVarDsc->GetArgReg()))
-                    {
-                        regType = TYP_DOUBLE;
-                    }
-                    else
-                    {
-                        regType = lclVarDsc->GetLayout()->GetGCPtrType(0);
-                    }
-                }
-                else
-                {
-                    regType = compiler->mangleVarArgsType(lclVarDsc->TypeGet());
-                    if (emitter::isGeneralRegisterOrR0(lclVarDsc->GetArgReg()) && isFloatRegType(regType))
-                    {
-                        // For LoongArch64 and RISCV64's ABI, the float args may be passed by integer register.
-                        regType = TYP_LONG;
-                    }
-                }
-#else
-                var_types regType = compiler->mangleVarArgsType(lclVarDsc->TypeGet());
-                if (lclVarDsc->lvIsHfaRegArg())
-                {
-                    regType = lclVarDsc->GetHfaType();
-                }
-#endif // defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-#endif // DEBUG
-                varLocation.storeVariableInRegisters(lclVarDsc->GetArgReg(), REG_NA);
+                break;
             }
+        }
+
+        // We only report multiple registers on SysV ABI. On other ABIs we
+        // report only the first register.
+#ifndef UNIX_AMD64_ABI
+        reg2 = REG_NA;
+#endif
+
+        if (reg1 != REG_NA)
+        {
+            varLocation.storeVariableInRegisters(reg1, reg2);
         }
         else
         {


### PR DESCRIPTION
Switch these to use new ABI info.

The only uses left are in logging and in the old ABI classification happening during `lvaInitUserArgs`. Once we remove uses of all the information stored there we can get rid of the fields entirely.