### PR TITLE
[android] Fix java runner to not assume zip format when unzipping

### DIFF
--- a/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -146,33 +146,33 @@ public class MonoRunner extends Instrumentation
 
     static void unzipAssets(Context context, String toPath, String zipName) {
         AssetManager assetManager = context.getAssets();
-        try {
-            InputStream inputStream = assetManager.open(zipName);
-            ZipInputStream zipInputStream = new ZipInputStream(new BufferedInputStream(inputStream));
+        try (InputStream inputStream = assetManager.open(zipName);
+            ZipInputStream zipInputStream = new ZipInputStream(new BufferedInputStream(inputStream))) {
+
             ZipEntry zipEntry;
             byte[] buffer = new byte[4096];
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                 String fileOrDirectory = zipEntry.getName();
-                Uri.Builder builder = new Uri.Builder();
-                builder.scheme("file");
-                builder.appendPath(toPath);
-                builder.appendPath(fileOrDirectory);
-                String fullToPath = builder.build().getPath();
-                if (zipEntry.isDirectory()) {
-                    File directory = new File(fullToPath);
-                    directory.mkdirs();
-                    continue;
+                File file = new File(toPath, fileOrDirectory);
+                File parent = new File(file.getParent());
+
+                if (file.isDirectory()) {
+                    file.mkdirs();
                 }
+                else if (!parent.exists()) {
+                    parent.mkdirs();
+                }
+
+                String fullToPath = file.getAbsolutePath();
                 Log.i("DOTNET", "Extracting asset to " + fullToPath);
+
                 int count = 0;
                 FileOutputStream fileOutputStream = new FileOutputStream(fullToPath);
                 while ((count = zipInputStream.read(buffer)) != -1) {
                     fileOutputStream.write(buffer, 0, count);
                 }
-                fileOutputStream.close();
                 zipInputStream.closeEntry();
             }
-            zipInputStream.close();
         } catch (IOException e) {
             Log.e("DOTNET", e.getLocalizedMessage());
         }

--- a/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -158,6 +158,7 @@ public class MonoRunner extends Instrumentation
 
                 if (zipEntry.isDirectory()) {
                     file.mkdirs();
+                    continue;
                 }
                 else if (!parent.exists()) {
                     parent.mkdirs();

--- a/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -156,7 +156,7 @@ public class MonoRunner extends Instrumentation
                 File file = new File(toPath, fileOrDirectory);
                 File parent = new File(file.getParent());
 
-                if (file.isDirectory()) {
+                if (zipEntry.isDirectory()) {
                     file.mkdirs();
                 }
                 else if (!parent.exists()) {


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/112256 landed, there was a change to zip the test assets using `ZipFile.CreateFromDirectory` for cross platform support. This regressed `unzipAssets` in `MonoRunner.java` because it naivley assumed that directories would come before files in the zip archive.

This change fixes the problem by making sure directories are created first before writing files to disk.

Fixes https://github.com/dotnet/runtime/issues/112558