### PR TITLE
JIT: Don't use `Compiler::compFloatingPointUsed` to check if FP kills are needed

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -741,15 +741,16 @@ public:
     void updateMaxSpill(RefPosition* refPosition);
     void recordMaxSpill();
 
+private:
     // max simultaneous spill locations used of every type
     unsigned int maxSpill[TYP_COUNT];
     unsigned int currentSpill[TYP_COUNT];
     bool         needFloatTmpForFPCall;
     bool         needDoubleTmpForFPCall;
     bool         needNonIntegerRegisters;
+    bool         needToKillFloatRegs;
 
 #ifdef DEBUG
-private:
     //------------------------------------------------------------------------
     // Should we stress lsra? This uses the DOTNET_JitStressRegs variable.
     //

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2413,6 +2413,7 @@ void LinearScan::buildIntervals()
         }
         else
         {
+            // If state isn't live across blocks, set FP register kill switch per block.
             needToKillFloatRegs = false;
         }
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -822,7 +822,7 @@ regMaskTP LinearScan::getKillSetForCall(GenTreeCall* call)
 {
     regMaskTP killMask = RBM_CALLEE_TRASH;
 #ifdef TARGET_X86
-    if (needToKillFloatRegs)
+    if (compiler->compFloatingPointUsed)
     {
         if (call->TypeGet() == TYP_DOUBLE)
         {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -822,7 +822,7 @@ regMaskTP LinearScan::getKillSetForCall(GenTreeCall* call)
 {
     regMaskTP killMask = RBM_CALLEE_TRASH;
 #ifdef TARGET_X86
-    if (compiler->compFloatingPointUsed)
+    if (needToKillFloatRegs)
     {
         if (call->TypeGet() == TYP_DOUBLE)
         {
@@ -841,8 +841,9 @@ regMaskTP LinearScan::getKillSetForCall(GenTreeCall* call)
     }
 
     // if there is no FP used, we can ignore the FP kills
-    if (!compiler->compFloatingPointUsed)
+    if (!needToKillFloatRegs)
     {
+        assert(!compiler->compFloatingPointUsed || !enregisterLocalVars);
 #if defined(TARGET_XARCH)
 
 #ifdef TARGET_AMD64
@@ -2332,7 +2333,6 @@ void LinearScan::buildIntervals()
     // live-in at the entry to each block (this will include the incoming args on
     // the first block).
     VarSetOps::AssignNoCopy(compiler, currentLiveVars, VarSetOps::MakeEmpty(compiler));
-    const bool floatingPointUsed = compiler->compFloatingPointUsed;
 
     for (block = startBlockSequence(); block != nullptr; block = moveToNextBlock())
     {
@@ -2341,6 +2341,7 @@ void LinearScan::buildIntervals()
 
         if (localVarsEnregistered)
         {
+            needToKillFloatRegs                    = compiler->compFloatingPointUsed;
             bool              predBlockIsAllocated = false;
             BasicBlock* const predBlock = findPredBlockForLiveIn(block, prevBlock DEBUGARG(&predBlockIsAllocated));
             if (predBlock != nullptr)
@@ -2412,8 +2413,7 @@ void LinearScan::buildIntervals()
         }
         else
         {
-            // If state isn't live across blocks, then reset any global Compiler state.
-            compiler->compFloatingPointUsed = floatingPointUsed;
+            needToKillFloatRegs = false;
         }
 
         // Add a dummy RefPosition to mark the block boundary.
@@ -3012,6 +3012,7 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, SingleTypeRegSet dstCandidates,
     if (!varTypeUsesIntReg(type))
     {
         compiler->compFloatingPointUsed = true;
+        needToKillFloatRegs             = true;
     }
 
     Interval* interval = newInterval(type);


### PR DESCRIPTION
Follow-up to #108147 ([comment](https://github.com/dotnet/runtime/pull/108147#discussion_r1960229577)). Add a flag for determining if `LinearScan::getKillSetForCall` can skip killing floating-point registers so that we can reduce dependencies on global `Compiler` state.