### PR TITLE
Reduce allocations in XmlWriterApiTests.TCFullEndElement

### DIFF
--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
@@ -5296,11 +5296,14 @@ namespace System.Xml.XmlWriterApiTests
                 [XmlWriterInlineData(4096)]
                 public void Base64_1(XmlWriterUtils utils, int strBase64Len)
                 {
-                    string strBase64 = string.Empty;
+                    StringBuilder strBase64Builder = new StringBuilder(strBase64Len);
+
                     for (int i = 0; i < strBase64Len; i++)
                     {
-                        strBase64 += "A";
+                        strBase64Builder.Append("A");
                     }
+
+                    string strBase64 = strBase64Builder.ToString();
 
                     byte[] Wbase64 = new byte[strBase64Len * 2];
                     int Wbase64len = 0;
@@ -5325,11 +5328,14 @@ namespace System.Xml.XmlWriterApiTests
 
                     CError.Compare(nRead, strBase64Len * 2, "Read count");
 
-                    string strRes = string.Empty;
+                    StringBuilder strResBuilder = new StringBuilder(strBase64Len);
+
                     for (int i = 0; i < nRead; i += 2)
                     {
-                        strRes += BitConverter.ToChar(buffer, i);
+                        strResBuilder.Append(BitConverter.ToChar(buffer, i));
                     }
+
+                    string strRes = strResBuilder.ToString();
                     CError.Compare(strRes, strBase64, "Base64 value");
 
                     return;
@@ -6306,15 +6312,22 @@ namespace System.Xml.XmlWriterApiTests
                 [XmlWriterInlineData]
                 public void var_1(XmlWriterUtils utils)
                 {
-                    string UniStr = "";
-                    using (XmlWriter w = utils.CreateWriter())
+                    int charCount = (int)('\ufffe' - '\ue000');
+                    StringBuilder uniStrBuilder = new StringBuilder(charCount);
+
+                    for (char ch = '\ue000'; ch < '\ufffe'; ch++)
                     {
-                        for (char ch = '\ue000'; ch < '\ufffe'; ch++)
-                            UniStr += ch;
-                        w.WriteElementString("root", UniStr);
+                        uniStrBuilder.Append(ch);
                     }
 
-                    Assert.True(utils.CompareReader("<root>" + UniStr + "</root>"));
+                    string uniStr = uniStrBuilder.ToString();
+
+                    using (XmlWriter w = utils.CreateWriter())
+                    {
+                        w.WriteElementString("root", uniStr);
+                    }
+
+                    Assert.True(utils.CompareReader("<root>" + uniStr + "</root>"));
                 }
 
                 [Fact]

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
@@ -5296,15 +5296,7 @@ namespace System.Xml.XmlWriterApiTests
                 [XmlWriterInlineData(4096)]
                 public void Base64_1(XmlWriterUtils utils, int strBase64Len)
                 {
-                    StringBuilder strBase64Builder = new StringBuilder(strBase64Len);
-
-                    for (int i = 0; i < strBase64Len; i++)
-                    {
-                        strBase64Builder.Append("A");
-                    }
-
-                    string strBase64 = strBase64Builder.ToString();
-
+                    string strBase64 = new string('A', strBase64Len);
                     byte[] Wbase64 = new byte[strBase64Len * 2];
                     int Wbase64len = 0;
 
@@ -6312,10 +6304,12 @@ namespace System.Xml.XmlWriterApiTests
                 [XmlWriterInlineData]
                 public void var_1(XmlWriterUtils utils)
                 {
-                    int charCount = (int)('\ufffe' - '\ue000');
+                    char startChar = '\ue000';
+                    char endChar = '\ufffe';
+                    int charCount = endChar - startChar;
                     StringBuilder uniStrBuilder = new StringBuilder(charCount);
 
-                    for (char ch = '\ue000'; ch < '\ufffe'; ch++)
+                    for (char ch = startChar; ch < endChar; ch++)
                     {
                         uniStrBuilder.Append(ch);
                     }


### PR DESCRIPTION
Attempt to improve https://github.com/dotnet/runtime/issues/110090 without disabling tests.