### PR TITLE
M.E.C.M. Add TryGetValue(ReadOnlySpan<char>) API

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
@@ -4,6 +4,9 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System;
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.Extensions.Caching.Distributed
 {
     public partial class MemoryDistributedCache : Microsoft.Extensions.Caching.Distributed.IDistributedCache
@@ -37,6 +40,13 @@ namespace Microsoft.Extensions.Caching.Memory
         public Microsoft.Extensions.Caching.Memory.MemoryCacheStatistics? GetCurrentStatistics() { throw null; }
         public void Remove(object key) { }
         public bool TryGetValue(object key, out object? result) { throw null; }
+
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+        public bool TryGetValue(ReadOnlySpan<char> key, out object? result) { throw null; }
+        [OverloadResolutionPriority(1)]
+        public bool TryGetValue<TItem>(ReadOnlySpan<char> key, out TItem? value) { throw null; }
+#endif
     }
     public partial class MemoryCacheOptions : Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions>
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
@@ -4,9 +4,6 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-using System;
-using System.Runtime.CompilerServices;
-
 namespace Microsoft.Extensions.Caching.Distributed
 {
     public partial class MemoryDistributedCache : Microsoft.Extensions.Caching.Distributed.IDistributedCache
@@ -42,10 +39,10 @@ namespace Microsoft.Extensions.Caching.Memory
         public bool TryGetValue(object key, out object? result) { throw null; }
 
 #if NET9_0_OR_GREATER
-        [OverloadResolutionPriority(1)]
-        public bool TryGetValue(ReadOnlySpan<char> key, out object? result) { throw null; }
-        [OverloadResolutionPriority(1)]
-        public bool TryGetValue<TItem>(ReadOnlySpan<char> key, out TItem? value) { throw null; }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public bool TryGetValue(System.ReadOnlySpan<char> key, out object? value) { throw null; }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public bool TryGetValue<TItem>(System.ReadOnlySpan<char> key, out TItem? value) { throw null; }
 #endif
     }
     public partial class MemoryCacheOptions : Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -207,12 +207,9 @@ namespace Microsoft.Extensions.Caching.Memory
             ThrowHelper.ThrowIfNull(key);
 
             CheckDisposed();
-
-            DateTime utcNow = UtcNow;
-
             CoherentState coherentState = _coherentState; // Clear() can update the reference in the meantime
             coherentState.TryGetValue(key, out CacheEntry? entry); // note we rely on documented "default when fails" contract re the out
-            return PostProcessTryGetValue(coherentState, utcNow, entry, out result);
+            return PostProcessTryGetValue(coherentState, entry, out result);
         }
 
 #if NET9_0_OR_GREATER
@@ -227,12 +224,9 @@ namespace Microsoft.Extensions.Caching.Memory
         public bool TryGetValue(ReadOnlySpan<char> key, out object? value)
         {
             CheckDisposed();
-
-            DateTime utcNow = UtcNow;
-
             CoherentState coherentState = _coherentState; // Clear() can update the reference in the meantime
             coherentState.TryGetValue(key, out CacheEntry? entry); // note we rely on documented "default when fails" contract re the out
-            return PostProcessTryGetValue(coherentState, utcNow, entry, out value);
+            return PostProcessTryGetValue(coherentState, entry, out value);
         }
 
         /// <summary>
@@ -267,10 +261,10 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 #endif
 
-        private bool PostProcessTryGetValue(CoherentState coherentState, DateTime utcNow, CacheEntry? entry, out object? result)
+        private bool PostProcessTryGetValue(CoherentState coherentState, CacheEntry? entry, out object? result)
         {
             // shared "get value" logic
-
+            DateTime utcNow = UtcNow;
             if (entry is not null)
             {
                 // Check if expired due to expiration tokens, timers, etc. and if so, remove it.

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -220,11 +220,11 @@ namespace Microsoft.Extensions.Caching.Memory
         /// Gets the item associated with this key if present.
         /// </summary>
         /// <param name="key">A character span corresponding to a <see cref="string"/> identifying the requested entry.</param>
-        /// <param name="result">The located value or null.</param>
+        /// <param name="value">The located value or null.</param>
         /// <returns>True if the key was found.</returns>
         /// <remarks>This method allows values with <see cref="string"/> keys to be queried by content without allocating a new <see cref="string"/> instance.</remarks>
         [OverloadResolutionPriority(1)]
-        public bool TryGetValue(ReadOnlySpan<char> key, out object? result)
+        public bool TryGetValue(ReadOnlySpan<char> key, out object? value)
         {
             CheckDisposed();
 
@@ -232,36 +232,36 @@ namespace Microsoft.Extensions.Caching.Memory
 
             CoherentState coherentState = _coherentState; // Clear() can update the reference in the meantime
             coherentState.TryGetValue(key, out CacheEntry? entry); // note we rely on documented "default when fails" contract re the out
-            return PostProcessTryGetValue(coherentState, utcNow, entry, out result);
+            return PostProcessTryGetValue(coherentState, utcNow, entry, out value);
         }
 
         /// <summary>
         /// Gets the item associated with this key if present.
         /// </summary>
         /// <param name="key">A character span corresponding to a <see cref="string"/> identifying the requested entry.</param>
-        /// <param name="result">The located value or null.</param>
+        /// <param name="value">The located value or null.</param>
         /// <returns>True if the key was found.</returns>
         /// <remarks>This method allows values with <see cref="string"/> keys to be queried by content without allocating a new <see cref="string"/> instance.</remarks>
         [OverloadResolutionPriority(1)]
-        public bool TryGetValue<TItem>(ReadOnlySpan<char> key, out TItem? result)
+        public bool TryGetValue<TItem>(ReadOnlySpan<char> key, out TItem? value)
         {
             // this implementation intentionally based on (and consistent with) CacheExtensions.TryGetValue<TItem>
             if (TryGetValue(key, out object? untyped))
             {
                 if (untyped == null)
                 {
-                    result = default;
+                    value = default;
                     return true;
                 }
 
                 if (untyped is TItem item)
                 {
-                    result = item;
+                    value = item;
                     return true;
                 }
             }
 
-            result = default;
+            value = default;
             return false;
 
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AltLookupTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AltLookupTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Xunit;
+
+namespace Microsoft.Extensions.Caching.Memory.Tests
+{
+    public class AltLookupTests
+    {
+        [Fact]
+        public void SimpleStringAccess()
+        {
+            // create a cache with unrelated other values
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            cache.Set("unrelated key", new object());
+            cache.Set(Guid.NewGuid(), new object());
+
+            // our key, in various disguises
+            string stringKey = "my_key";
+            object objKey = stringKey;
+            ReadOnlySpan<char> stringSpanKey = stringKey.AsSpan();
+            // in the case of span, just to be super rigorous, we
+            // will also check an isolated span that isn't an interior pointer to a string
+            Span<char> isolated = stackalloc char[stringKey.Length];
+            stringKey.AsSpan().CopyTo(isolated);
+            ReadOnlySpan<char> isolatedSpanKey = isolated;
+
+            // not found initially (before added)
+            Assert.False(cache.TryGetValue(stringKey, out object? result));
+            Assert.Null(result);
+
+            Assert.False(cache.TryGetValue(objKey, out result));
+            Assert.Null(result);
+
+#if NET9_0_OR_GREATER
+            Assert.False(cache.TryGetValue(stringSpanKey, out result));
+            Assert.Null(result);
+
+            Assert.False(cache.TryGetValue(isolatedSpanKey, out result));
+            Assert.Null(result);
+#endif
+
+            // found after adding
+            object cachedValue = new();
+            cache.Set(stringKey, cachedValue);
+
+            Assert.True(cache.TryGetValue(stringKey, out result));
+            Assert.Same(cachedValue, result);
+
+            Assert.True(cache.TryGetValue(objKey, out result));
+            Assert.Same(cachedValue, result);
+
+#if NET9_0_OR_GREATER
+            Assert.True(cache.TryGetValue(stringSpanKey, out result));
+            Assert.Same(cachedValue, result);
+
+            Assert.True(cache.TryGetValue(isolatedSpanKey, out result));
+            Assert.Same(cachedValue, result);
+#endif
+
+            // not found after removing
+            cache.Remove(stringKey);
+            cache.Set(stringKey, cachedValue);
+
+            Assert.False(cache.TryGetValue(stringKey, out result));
+            Assert.Null(result);
+
+            Assert.False(cache.TryGetValue(objKey, out result));
+            Assert.Null(result);
+
+#if NET9_0_OR_GREATER
+            Assert.False(cache.TryGetValue(stringSpanKey, out result));
+            Assert.Null(result);
+
+            Assert.False(cache.TryGetValue(isolatedSpanKey, out result));
+            Assert.Null(result);
+#endif
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AltLookupTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AltLookupTests.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Extensions.Caching.Memory.Tests
 
             // not found after removing
             cache.Remove(stringKey);
-            cache.Set(stringKey, cachedValue);
 
             Assert.False(cache.TryGetValue(stringKey, out result));
             Assert.Null(result);


### PR DESCRIPTION
Implement `MemoryCache.TryGetValue` APIs taking `ReadOnlySpan<char>`, as approved in #110504

fix #110504