### PR TITLE
Fixed Tensor Conversion Test

### DIFF
--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -84,7 +84,7 @@ namespace System.Numerics.Tensors.Tests
             ConvertCheckedImpl<Half, float>();
             ConvertCheckedImpl<Half, double>();
             ConvertCheckedImpl<float, double>();
-            ConvertCheckedImpl<double, float>();
+            ConvertCheckedImpl<double, double>();
 
             // Conversions that may overflow. This isn't an exhaustive list; just a sampling.
             ConvertCheckedImpl<float, int>(42f, float.MaxValue);


### PR DESCRIPTION
Fixes #112286.

We had a section of tests that should never overflow, but we had double -> float instead of double -> double. This was causing the issue when the randomly generated double wouldn't fit into the float. 