### PR TITLE
Reduce TP for targets with more than 64 Registers Part 1

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1110,6 +1110,31 @@ inline regNumber genFirstRegNumFromMaskAndToggle(SingleTypeRegSet& mask, var_typ
     return regNum;
 }
 
+//------------------------------------------------------------------------------
+// genFirstRegNumFromMaskAndToggle : Maps first bit set in the register mask to a
+//          register number and also toggle the bit in the `mask`.
+// Arguments:
+//    mask               - the register mask
+//    type               - type of the register mask
+//
+// Return Value:
+//    The number of the first register contained in the mask and updates the `mask` to toggle
+//    the bit.
+//
+
+inline regNumber genFirstRegNumFromMaskAndToggle(SingleTypeRegSet& mask)
+{
+    assert(mask != RBM_NONE); // Must have one bit set, so can't have a mask of zero
+
+    /* Convert the mask to a register number */
+
+    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
+
+    mask ^= genSingleTypeRegMask(regNum);
+
+    return regNum;
+}
+
 /*****************************************************************************
  *
  *  Return the size in bytes of the given type.

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -3856,9 +3856,37 @@ void LinearScan::processKills(RefPosition* killRefPosition)
     RefPosition* nextKill = killRefPosition->nextRefPosition;
 
     regMaskTP killedRegs = killRefPosition->getKilledRegisters();
-    while (killedRegs.IsNonEmpty())
+
+    freeKilledRegs(killRefPosition, killedRegs.getLow(), nextKill, REG_LOW_BASE);
+
+#ifdef HAS_MORE_THAN_64_REGISTERS
+    freeKilledRegs(killRefPosition, killedRegs.getHigh(), nextKill, REG_HIGH_BASE);
+#endif
+
+    regsBusyUntilKill &= ~killRefPosition->getKilledRegisters();
+    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_KILL_REGS, nullptr, REG_NA, nullptr, NONE,
+                                    killRefPosition->getKilledRegisters()));
+}
+
+//------------------------------------------------------------------------
+// freeKilledRegs: Handle  registers that are being killed.
+//
+// Arguments:
+//   killRefPosition - The RefPosition for the kill
+//   killedRegs - Registers to kill
+//   nextKill - The RefPosition for next kill
+//   regBase - `0` or `64` based on the `killedRegs` being processed
+//
+void LinearScan::freeKilledRegs(RefPosition* killRefPosition,
+                                regMaskSmall killedRegs,
+                                RefPosition* nextKill,
+                                int          regBase)
+{
+
+    while (killedRegs != RBM_NONE)
     {
-        regNumber  killedReg        = genFirstRegNumFromMaskAndToggle(killedRegs);
+        regNumber killedReg = (regNumber)(BitOperations::BitScanForward(killedRegs) + regBase);
+        killedRegs ^= genSingleTypeRegMask(killedReg);
         RegRecord* regRecord        = getRegisterRecord(killedReg);
         Interval*  assignedInterval = regRecord->assignedInterval;
         if (assignedInterval != nullptr)
@@ -3874,10 +3902,6 @@ void LinearScan::processKills(RefPosition* killRefPosition)
                                          : regRecord->recentRefPosition->nextRefPosition;
         updateNextFixedRef(regRecord, regNextRefPos, nextKill);
     }
-
-    regsBusyUntilKill &= ~killRefPosition->getKilledRegisters();
-    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_KILL_REGS, nullptr, REG_NA, nullptr, NONE,
-                                    killRefPosition->getKilledRegisters()));
 }
 
 //------------------------------------------------------------------------
@@ -4555,14 +4579,35 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
         }
     }
 #else
+
     regMaskTP deadCandidates = ~liveRegs;
 
     // Only focus on actual registers present
     deadCandidates &= actualRegistersMask;
+    handleDeadCandidates(deadCandidates.getLow(), REG_LOW_BASE, inVarToRegMap);
+#ifdef HAS_MORE_THAN_64_REGISTERS
+    handleDeadCandidates(deadCandidates.getHigh(), REG_HIGH_BASE, inVarToRegMap);
+#endif // HAS_MORE_THAN_64_REGISTERS
+#endif // TARGET_ARM
+}
 
-    while (deadCandidates.IsNonEmpty())
+//------------------------------------------------------------------------
+// handleDeadCandidates: Handle registers thata re assigned to local variables.
+//
+// Arguments:
+//    deadCandidates - mask of registers.
+//    regBase - base register number.
+//    inVarToRegMap - variable to register map.
+//
+// Return Value:
+//    None
+//
+void LinearScan::handleDeadCandidates(regMaskSmall deadCandidates, int regBase, VarToRegMap inVarToRegMap)
+{
+    while (deadCandidates != RBM_NONE)
     {
-        regNumber  reg           = genFirstRegNumFromMaskAndToggle(deadCandidates);
+        regNumber reg = (regNumber)(BitOperations::BitScanForward(deadCandidates) + regBase);
+        deadCandidates ^= genSingleTypeRegMask(reg);
         RegRecord* physRegRecord = getRegisterRecord(reg);
 
         makeRegAvailable(reg, physRegRecord->registerType);
@@ -4592,7 +4637,6 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
             }
         }
     }
-#endif // TARGET_ARM
 }
 
 //------------------------------------------------------------------------
@@ -4745,6 +4789,24 @@ void LinearScan::freeRegister(RegRecord* physRegRecord)
 // LinearScan::freeRegisters: Free the registers in 'regsToFree'
 //
 // Arguments:
+//    regsToFree         - the mask of registers to free, separated into low and high parts.
+//    regBase            - `0` or `64` depending on if the registers to be freed are in the lower or higher bank.
+//
+void LinearScan::freeRegistersNoMask(SingleTypeRegSet regsToFree, int regBase)
+{
+    while (regsToFree != RBM_NONE)
+    {
+        regNumber nextReg = (regNumber)(BitOperations::BitScanForward(regsToFree) + regBase);
+        regsToFree ^= genSingleTypeRegMask(nextReg);
+
+        RegRecord* regRecord = getRegisterRecord(nextReg);
+        freeRegister(regRecord);
+    }
+}
+//------------------------------------------------------------------------
+// LinearScan::freeRegisters: Free the registers in 'regsToFree'
+//
+// Arguments:
 //    regsToFree         - the mask of registers to free
 //
 void LinearScan::freeRegisters(regMaskTP regsToFree)
@@ -4756,20 +4818,26 @@ void LinearScan::freeRegisters(regMaskTP regsToFree)
 
     INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_FREE_REGS));
     makeRegsAvailable(regsToFree);
+#ifdef TARGET_ARM
     while (regsToFree.IsNonEmpty())
     {
         regNumber nextReg = genFirstRegNumFromMaskAndToggle(regsToFree);
 
         RegRecord* regRecord = getRegisterRecord(nextReg);
-#ifdef TARGET_ARM
         if (regRecord->assignedInterval != nullptr && (regRecord->assignedInterval->registerType == TYP_DOUBLE))
         {
             assert(genIsValidDoubleReg(nextReg));
             regsToFree.RemoveRegNumFromMask(regNumber(nextReg + 1));
         }
-#endif
         freeRegister(regRecord);
     }
+#else
+    freeRegistersNoMask(regsToFree.getLow(), REG_LOW_BASE);
+#ifdef HAS_MORE_THAN_64_REGISTERS
+    freeRegistersNoMask(regsToFree.getHigh(), REG_HIGH_BASE);
+#endif
+
+#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -3877,15 +3877,15 @@ void LinearScan::processKills(RefPosition* killRefPosition)
 //   nextKill - The RefPosition for next kill
 //   regBase - `0` or `64` based on the `killedRegs` being processed
 //
-void LinearScan::freeKilledRegs(RefPosition* killRefPosition,
+void LinearScan::freeKilledRegs(RefPosition*     killRefPosition,
                                 SingleTypeRegSet killedRegs,
-                                RefPosition* nextKill,
-                                int          regBase)
+                                RefPosition*     nextKill,
+                                int              regBase)
 {
 
     while (killedRegs != RBM_NONE)
     {
-        regNumber killedReg = (regNumber)(genFirstRegNumFromMaskAndToggle(killedRegs) + regBase);
+        regNumber  killedReg        = (regNumber)(genFirstRegNumFromMaskAndToggle(killedRegs) + regBase);
         RegRecord* regRecord        = getRegisterRecord(killedReg);
         Interval*  assignedInterval = regRecord->assignedInterval;
         if (assignedInterval != nullptr)
@@ -4605,7 +4605,7 @@ void LinearScan::handleDeadCandidates(SingleTypeRegSet deadCandidates, int regBa
 {
     while (deadCandidates != RBM_NONE)
     {
-        regNumber reg = (regNumber)(genFirstRegNumFromMaskAndToggle(deadCandidates) + regBase);
+        regNumber  reg           = (regNumber)(genFirstRegNumFromMaskAndToggle(deadCandidates) + regBase);
         RegRecord* physRegRecord = getRegisterRecord(reg);
 
         makeRegAvailable(reg, physRegRecord->registerType);
@@ -4794,7 +4794,7 @@ void LinearScan::freeRegistersSingleType(SingleTypeRegSet regsToFree, int regBas
 {
     while (regsToFree != RBM_NONE)
     {
-        regNumber nextReg = (regNumber)(genFirstRegNumFromMaskAndToggle(regsToFree) + regBase);
+        regNumber  nextReg   = (regNumber)(genFirstRegNumFromMaskAndToggle(regsToFree) + regBase);
         RegRecord* regRecord = getRegisterRecord(nextReg);
         freeRegister(regRecord);
     }

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1006,7 +1006,7 @@ private:
     // Record variable locations at start/end of block
     void processBlockStartLocations(BasicBlock* current);
 
-    FORCEINLINE void handleDeadCandidates(regMaskSmall deadCandidates, int regBase, VarToRegMap inVarToRegMap);
+    FORCEINLINE void handleDeadCandidates(SingleTypeRegSet deadCandidates, int regBase, VarToRegMap inVarToRegMap);
     void             processBlockEndLocations(BasicBlock* current);
     void             resetAllRegistersState();
 
@@ -1084,7 +1084,7 @@ private:
     void             makeRegisterInactive(RegRecord* physRegRecord);
     void             freeRegister(RegRecord* physRegRecord);
     void             freeRegisters(regMaskTP regsToFree);
-    FORCEINLINE void freeRegistersNoMask(SingleTypeRegSet regsToFree, int regBase);
+    FORCEINLINE void freeRegistersSingleType(SingleTypeRegSet regsToFree, int regBase);
 
     // Get the type that this tree defines.
     var_types getDefType(GenTree* tree)
@@ -1197,7 +1197,7 @@ private:
 
     void             processKills(RefPosition* killRefPosition);
     FORCEINLINE void freeKilledRegs(RefPosition* killRefPosition,
-                                    regMaskSmall killedRegs,
+                                    SingleTypeRegSet killedRegs,
                                     RefPosition* nextKill,
                                     int          regBase);
     void             spillGCRefs(RefPosition* killRefPosition);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -849,7 +849,7 @@ private:
     {
         return (LsraBlockBoundaryLocations)(lsraStressMask & LSRA_BLOCK_BOUNDARY_MASK);
     }
-    regNumber rotateBlockStartLocation(Interval* interval, regNumber targetReg, regMaskTP availableRegs);
+    regNumber rotateBlockStartLocation(Interval* interval, regNumber targetReg, SingleTypeRegSet availableRegs);
 
     // This controls whether we always insert a GT_RELOAD instruction after a spill
     // Note that this can be combined with LSRA_SPILL_ALWAYS (or not)

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1005,8 +1005,10 @@ private:
 
     // Record variable locations at start/end of block
     void processBlockStartLocations(BasicBlock* current);
-    void processBlockEndLocations(BasicBlock* current);
-    void resetAllRegistersState();
+
+    FORCEINLINE void handleDeadCandidates(regMaskSmall deadCandidates, int regBase, VarToRegMap inVarToRegMap);
+    void             processBlockEndLocations(BasicBlock* current);
+    void             resetAllRegistersState();
 
 #ifdef TARGET_ARM
     bool       isSecondHalfReg(RegRecord* regRec, Interval* interval);
@@ -1079,9 +1081,10 @@ private:
     SingleTypeRegSet lowSIMDRegs();
     SingleTypeRegSet internalFloatRegCandidates();
 
-    void makeRegisterInactive(RegRecord* physRegRecord);
-    void freeRegister(RegRecord* physRegRecord);
-    void freeRegisters(regMaskTP regsToFree);
+    void             makeRegisterInactive(RegRecord* physRegRecord);
+    void             freeRegister(RegRecord* physRegRecord);
+    void             freeRegisters(regMaskTP regsToFree);
+    FORCEINLINE void freeRegistersNoMask(SingleTypeRegSet regsToFree, int regBase);
 
     // Get the type that this tree defines.
     var_types getDefType(GenTree* tree)
@@ -1192,8 +1195,12 @@ private:
     void setIntervalAsSplit(Interval* interval);
     void spillInterval(Interval* interval, RefPosition* fromRefPosition DEBUGARG(RefPosition* toRefPosition));
 
-    void processKills(RefPosition* killRefPosition);
-    void spillGCRefs(RefPosition* killRefPosition);
+    void             processKills(RefPosition* killRefPosition);
+    FORCEINLINE void freeKilledRegs(RefPosition* killRefPosition,
+                                    regMaskSmall killedRegs,
+                                    RefPosition* nextKill,
+                                    int          regBase);
+    void             spillGCRefs(RefPosition* killRefPosition);
 
     /*****************************************************************************
      * Register selection

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -849,7 +849,7 @@ private:
     {
         return (LsraBlockBoundaryLocations)(lsraStressMask & LSRA_BLOCK_BOUNDARY_MASK);
     }
-    regNumber rotateBlockStartLocation(Interval* interval, regNumber targetReg, SingleTypeRegSet availableRegs);
+    regNumber rotateBlockStartLocation(Interval* interval, regNumber targetReg, regMaskTP availableRegs);
 
     // This controls whether we always insert a GT_RELOAD instruction after a spill
     // Note that this can be combined with LSRA_SPILL_ALWAYS (or not)

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1196,10 +1196,10 @@ private:
     void spillInterval(Interval* interval, RefPosition* fromRefPosition DEBUGARG(RefPosition* toRefPosition));
 
     void             processKills(RefPosition* killRefPosition);
-    FORCEINLINE void freeKilledRegs(RefPosition* killRefPosition,
+    FORCEINLINE void freeKilledRegs(RefPosition*     killRefPosition,
                                     SingleTypeRegSet killedRegs,
-                                    RefPosition* nextKill,
-                                    int          regBase);
+                                    RefPosition*     nextKill,
+                                    int              regBase);
     void             spillGCRefs(RefPosition* killRefPosition);
 
     /*****************************************************************************

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -239,6 +239,10 @@ typedef uint64_t regMaskSmall;
 #define HAS_MORE_THAN_64_REGISTERS 1
 #endif // TARGET_ARM64
 
+#define REG_LOW_BASE 0
+#ifdef HAS_MORE_THAN_64_REGISTERS
+#define REG_HIGH_BASE 64
+#endif
 // TODO: Rename regMaskSmall as RegSet64 (at least for 64-bit)
 typedef regMaskSmall    SingleTypeRegSet;
 inline SingleTypeRegSet genSingleTypeRegMask(regNumber reg);


### PR DESCRIPTION
## Theory:
 My profiling shows among others 3 methods whose tpdiff spikes when we have more than 64 registers – `processKills()`, `freeRegisters()`, `processBlockStartLocations()`. These 3 iterate over a `regMaskTP` and modifies it. The idea here is to work on 2`regMaskSmall`s separately  instead of `regMaskTP`


## Expectation:
Targets with less than 64 registers will not see any impact. Targets with more than 64 registers(currently only arm64) will see tpdiff improvement.


## Relevant issue:

#113670

## Result

Using arm64 as proxy for target with more than 64 registers, from [CI](https://dev.azure.com/dnceng-public/public/_build/results?buildId=983866&view=logs&j=913ce52b-8ad3-5a93-c0fe-123235d07c67&t=b8277af6-3c57-5db6-91e7-5bc6c9977a8e)

### linux arm64


<details>
<summary>Overall (<span style="color:green">-0.87%</span> to <span style="color:green">-0.61%</span>)</summary>
<div style="margin-left:1em">

|Collection|PDIFF|
|---|--:|
|benchmarks.run.linux.arm64.checked.mch|<span style="color:green">-0.71%</span>|
|benchmarks.run_pgo.linux.arm64.checked.mch|<span style="color:green">-0.75%</span>|
|benchmarks.run_tiered.linux.arm64.checked.mch|<span style="color:green">-0.87%</span>|
|coreclr_tests.run.linux.arm64.checked.mch|<span style="color:green">-0.78%</span>|
|libraries.crossgen2.linux.arm64.checked.mch|<span style="color:green">-0.68%</span>|
|libraries.pmi.linux.arm64.checked.mch|<span style="color:green">-0.67%</span>|
|libraries_tests.run.linux.arm64.Release.mch|<span style="color:green">-0.80%</span>|
|libraries_tests_no_tiered_compilation.run.linux.arm64.Release.mch|<span style="color:green">-0.61%</span>|
|realworld.run.linux.arm64.checked.mch|<span style="color:green">-0.64%</span>|
|smoke_tests.nativeaot.linux.arm64.checked.mch|<span style="color:green">-0.72%</span>

</div></details>

<details>
<summary>MinOpts (<span style="color:green">-1.39%</span> to <span style="color:green">-0.88%</span>)</summary>
<div style="margin-left:1em">

|Collection|PDIFF|
|---|--:|
|benchmarks.run.linux.arm64.checked.mch|<span style="color:green">-0.99%</span>|
|benchmarks.run_pgo.linux.arm64.checked.mch|<span style="color:green">-1.13%</span>|
|benchmarks.run_tiered.linux.arm64.checked.mch|<span style="color:green">-1.12%</span>|
|coreclr_tests.run.linux.arm64.checked.mch|<span style="color:green">-0.88%</span>|
|libraries.crossgen2.linux.arm64.checked.mch|<span style="color:green">-0.89%</span>|
|libraries.pmi.linux.arm64.checked.mch|<span style="color:green">-0.98%</span>|
|libraries_tests.run.linux.arm64.Release.mch|<span style="color:green">-1.12%</span>|
|libraries_tests_no_tiered_compilation.run.linux.arm64.Release.mch|<span style="color:green">-0.89%</span>|
|realworld.run.linux.arm64.checked.mch|<span style="color:green">-1.25%</span>|
|smoke_tests.nativeaot.linux.arm64.checked.mch|<span style="color:green">-1.39%</span>|


</div></details>

<details>
<summary>FullOpts (<span style="color:green">-0.72%</span> to <span style="color:green">-0.60%</span>)</summary>
<div style="margin-left:1em">

|Collection|PDIFF|
|---|--:|
|benchmarks.run.linux.arm64.checked.mch|<span style="color:green">-0.70%</span>|
|benchmarks.run_pgo.linux.arm64.checked.mch|<span style="color:green">-0.71%</span>|
|benchmarks.run_tiered.linux.arm64.checked.mch|<span style="color:green">-0.63%</span>|
|coreclr_tests.run.linux.arm64.checked.mch|<span style="color:green">-0.71%</span>|
|libraries.crossgen2.linux.arm64.checked.mch|<span style="color:green">-0.68%</span>|
|libraries.pmi.linux.arm64.checked.mch|<span style="color:green">-0.67%</span>|
|libraries_tests.run.linux.arm64.Release.mch|<span style="color:green">-0.70%</span>|
|libraries_tests_no_tiered_compilation.run.linux.arm64.Release.mch|<span style="color:green">-0.60%</span>|
|realworld.run.linux.arm64.checked.mch|<span style="color:green">-0.63%</span>|
|smoke_tests.nativeaot.linux.arm64.checked.mch|<span style="color:green">-0.72%</span>|


</div></details>





### Local tests done:
I added some temporary changes locally so that x64 has more than 64 registers and ran superpmi tpdiff with/without the optimization to simulate impact with more than 64 registers

The results from local testing is below





<details>
<summary>Overall (<span style="color:green">-0.66%</span> to <span style="color:green">-0.47%</span>)</summary>
<div style="margin-left:1em">

|Collection|PDIFF|
|---|--:|
|aspnet.run.windows.x64.checked.mch|<span style="color:green">-0.66%</span>|
|benchmarks.run.windows.x64.checked.mch|<span style="color:green">-0.51%</span>|
|benchmarks.run_pgo.windows.x64.checked.mch|<span style="color:green">-0.64%</span>|
|benchmarks.run_pgo_optrepeat.windows.x64.checked.mch|<span style="color:green">-0.51%</span>|
|benchmarks.run_tiered.windows.x64.checked.mch|<span style="color:green">-0.59%</span>|
|coreclr_tests.run.windows.x64.checked.mch|<span style="color:green">-0.63%</span>|
|libraries.crossgen2.windows.x64.checked.mch|<span style="color:green">-0.49%</span>|
|libraries.pmi.windows.x64.checked.mch|<span style="color:green">-0.57%</span>|
|libraries_tests.run.windows.x64.Release.mch|<span style="color:green">-0.66%</span>|
|libraries_tests_no_tiered_compilation.run.windows.x64.Release.mch|<span style="color:green">-0.54%</span>|
|realworld.run.windows.x64.checked.mch|<span style="color:green">-0.54%</span>|
|smoke_tests.nativeaot.windows.x64.checked.mch|<span style="color:green">-0.47%</span>|


</div></details>

<details>
<summary>MinOpts (<span style="color:green">-1.14%</span> to <span style="color:green">-0.65%</span>)</summary>
<div style="margin-left:1em">

|Collection|PDIFF|
|---|--:|
|aspnet.run.windows.x64.checked.mch|<span style="color:green">-0.87%</span>|
|benchmarks.run.windows.x64.checked.mch|<span style="color:green">-0.75%</span>|
|benchmarks.run_pgo.windows.x64.checked.mch|<span style="color:green">-0.86%</span>|
|benchmarks.run_pgo_optrepeat.windows.x64.checked.mch|<span style="color:green">-0.75%</span>|
|benchmarks.run_tiered.windows.x64.checked.mch|<span style="color:green">-0.82%</span>|
|coreclr_tests.run.windows.x64.checked.mch|<span style="color:green">-0.69%</span>|
|libraries.crossgen2.windows.x64.checked.mch|<span style="color:green">-0.65%</span>|
|libraries.pmi.windows.x64.checked.mch|<span style="color:green">-0.71%</span>|
|libraries_tests.run.windows.x64.Release.mch|<span style="color:green">-0.92%</span>|
|libraries_tests_no_tiered_compilation.run.windows.x64.Release.mch|<span style="color:green">-0.75%</span>|
|realworld.run.windows.x64.checked.mch|<span style="color:green">-1.14%</span>|
|smoke_tests.nativeaot.windows.x64.checked.mch|<span style="color:green">-0.93%</span>|


</div></details>

<details>
<summary>FullOpts (<span style="color:green">-0.62%</span> to <span style="color:green">-0.43%</span>)</summary>
<div style="margin-left:1em">

|Collection|PDIFF|
|---|--:|
|aspnet.run.windows.x64.checked.mch|<span style="color:green">-0.62%</span>|
|benchmarks.run.windows.x64.checked.mch|<span style="color:green">-0.51%</span>|
|benchmarks.run_pgo.windows.x64.checked.mch|<span style="color:green">-0.60%</span>|
|benchmarks.run_pgo_optrepeat.windows.x64.checked.mch|<span style="color:green">-0.51%</span>|
|benchmarks.run_tiered.windows.x64.checked.mch|<span style="color:green">-0.43%</span>|
|coreclr_tests.run.windows.x64.checked.mch|<span style="color:green">-0.59%</span>|
|libraries.crossgen2.windows.x64.checked.mch|<span style="color:green">-0.49%</span>|
|libraries.pmi.windows.x64.checked.mch|<span style="color:green">-0.57%</span>|
|libraries_tests.run.windows.x64.Release.mch|<span style="color:green">-0.57%</span>|
|libraries_tests_no_tiered_compilation.run.windows.x64.Release.mch|<span style="color:green">-0.53%</span>|
|realworld.run.windows.x64.checked.mch|<span style="color:green">-0.53%</span>|
|smoke_tests.nativeaot.windows.x64.checked.mch|<span style="color:green">-0.47%</span>|


</div></details>


