### PR TITLE
Reapply "[browser][MT] move wasm MT CI legs to extra-platforms (#112712)"

### DIFF
--- a/eng/pipelines/common/templates/browser-wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/browser-wasm-build-tests.yml
@@ -42,11 +42,11 @@ jobs:
       jobParameters:
         dependsOn:
           - ${{ if eq(platform, 'browser_wasm') }}:
-            - ${{ if eq(includeMultiThreaded, true) }}:
+            - ${{ if eq(parameters.includeMultiThreaded, true) }}:
               - build_browser_wasm_linux_Release_MultiThreaded_BuildOnly
             - build_browser_wasm_linux_Release_SingleThreaded_BuildOnly
           - ${{ if eq(platform, 'browser_wasm_win') }}:
-            - ${{ if eq(includeMultiThreaded, true) }}:
+            - ${{ if eq(parameters.includeMultiThreaded, true) }}:
               - build_browser_wasm_windows_Release_MultiThreaded_BuildOnly
             - build_browser_wasm_windows_Release_SingleThreaded_BuildOnly
         isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
@@ -71,7 +71,7 @@ jobs:
               CleanTargetFolder: false
 
           # Download for multi-threaded
-          - ${{ if eq(includeMultiThreaded, true) }}:
+          - ${{ if eq(parameters.includeMultiThreaded, true) }}:
             - task: DownloadBuildArtifacts@0
               displayName: Download built nugets for multi-threaded runtime
               inputs:

--- a/eng/pipelines/common/templates/browser-wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/browser-wasm-build-tests.yml
@@ -7,6 +7,7 @@ parameters:
   platforms: []
   shouldContinueOnError: false
   extraBuildArgs: ''
+  includeMultiThreaded: false
 
 jobs:
 
@@ -41,10 +42,12 @@ jobs:
       jobParameters:
         dependsOn:
           - ${{ if eq(platform, 'browser_wasm') }}:
-            - build_browser_wasm_linux_Release_MultiThreaded_BuildOnly
+            - ${{ if eq(includeMultiThreaded, true) }}:
+              - build_browser_wasm_linux_Release_MultiThreaded_BuildOnly
             - build_browser_wasm_linux_Release_SingleThreaded_BuildOnly
           - ${{ if eq(platform, 'browser_wasm_win') }}:
-            - build_browser_wasm_windows_Release_MultiThreaded_BuildOnly
+            - ${{ if eq(includeMultiThreaded, true) }}:
+              - build_browser_wasm_windows_Release_MultiThreaded_BuildOnly
             - build_browser_wasm_windows_Release_SingleThreaded_BuildOnly
         isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
         testGroup: innerloop
@@ -68,21 +71,22 @@ jobs:
               CleanTargetFolder: false
 
           # Download for multi-threaded
-          - task: DownloadBuildArtifacts@0
-            displayName: Download built nugets for multi-threaded runtime
-            inputs:
-              buildType: current
-              artifactName: BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly
-              downloadType: single
-              downloadPath: '$(Build.SourcesDirectory)/artifacts'
+          - ${{ if eq(includeMultiThreaded, true) }}:
+            - task: DownloadBuildArtifacts@0
+              displayName: Download built nugets for multi-threaded runtime
+              inputs:
+                buildType: current
+                artifactName: BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly
+                downloadType: single
+                downloadPath: '$(Build.SourcesDirectory)/artifacts'
 
-          - task: CopyFiles@2
-            displayName: Copy multithreading runtime pack
-            inputs:
-              SourceFolder: '$(Build.SourcesDirectory)/artifacts/BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly'
-              Contents: packages/$(_BuildConfig)/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.*
-              TargetFolder: '$(Build.SourcesDirectory)/artifacts'
-              CleanTargetFolder: false
+            - task: CopyFiles@2
+              displayName: Copy multithreading runtime pack
+              inputs:
+                SourceFolder: '$(Build.SourcesDirectory)/artifacts/BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly'
+                Contents: packages/$(_BuildConfig)/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.*
+                TargetFolder: '$(Build.SourcesDirectory)/artifacts'
+                CleanTargetFolder: false
 
           # Download WBT
           - task: DownloadBuildArtifacts@0

--- a/eng/pipelines/common/templates/browser-wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/browser-wasm-build-tests.yml
@@ -7,7 +7,6 @@ parameters:
   platforms: []
   shouldContinueOnError: false
   extraBuildArgs: ''
-  includeMultiThreaded: false
 
 jobs:
 
@@ -42,12 +41,10 @@ jobs:
       jobParameters:
         dependsOn:
           - ${{ if eq(platform, 'browser_wasm') }}:
-            - ${{ if eq(parameters.includeMultiThreaded, true) }}:
-              - build_browser_wasm_linux_Release_MultiThreaded_BuildOnly
+            - build_browser_wasm_linux_Release_MultiThreaded_BuildOnly
             - build_browser_wasm_linux_Release_SingleThreaded_BuildOnly
           - ${{ if eq(platform, 'browser_wasm_win') }}:
-            - ${{ if eq(parameters.includeMultiThreaded, true) }}:
-              - build_browser_wasm_windows_Release_MultiThreaded_BuildOnly
+            - build_browser_wasm_windows_Release_MultiThreaded_BuildOnly
             - build_browser_wasm_windows_Release_SingleThreaded_BuildOnly
         isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
         testGroup: innerloop
@@ -71,22 +68,21 @@ jobs:
               CleanTargetFolder: false
 
           # Download for multi-threaded
-          - ${{ if eq(parameters.includeMultiThreaded, true) }}:
-            - task: DownloadBuildArtifacts@0
-              displayName: Download built nugets for multi-threaded runtime
-              inputs:
-                buildType: current
-                artifactName: BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly
-                downloadType: single
-                downloadPath: '$(Build.SourcesDirectory)/artifacts'
+          - task: DownloadBuildArtifacts@0
+            displayName: Download built nugets for multi-threaded runtime
+            inputs:
+              buildType: current
+              artifactName: BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly
+              downloadType: single
+              downloadPath: '$(Build.SourcesDirectory)/artifacts'
 
-            - task: CopyFiles@2
-              displayName: Copy multithreading runtime pack
-              inputs:
-                SourceFolder: '$(Build.SourcesDirectory)/artifacts/BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly'
-                Contents: packages/$(_BuildConfig)/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.*
-                TargetFolder: '$(Build.SourcesDirectory)/artifacts'
-                CleanTargetFolder: false
+          - task: CopyFiles@2
+            displayName: Copy multithreading runtime pack
+            inputs:
+              SourceFolder: '$(Build.SourcesDirectory)/artifacts/BuildArtifacts_browser_wasm_$(_hostedOs)_Release_MultiThreaded_BuildOnly'
+              Contents: packages/$(_BuildConfig)/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.*
+              TargetFolder: '$(Build.SourcesDirectory)/artifacts'
+              CleanTargetFolder: false
 
           # Download WBT
           - task: DownloadBuildArtifacts@0

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -74,6 +74,22 @@ jobs:
       scenarios:
         - WasmTestOnChrome
 
+  # Library tests with full threading
+  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+    parameters:
+      platforms:
+        - browser_wasm
+        #- browser_wasm_win
+      nameSuffix: _Threading
+      extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      extraHelixArguments: /p:WasmEnableThreads=true
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      shouldRunSmokeOnly: onLibrariesAndIllinkChanges
+      scenarios:
+        - WasmTestOnChrome
+
   # EAT Library tests - only run on linux
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
     parameters:
@@ -162,7 +178,6 @@ jobs:
         - browser_wasm_win
       nameSuffix: MultiThreaded
       extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      condition: ne(variables['wasmMultiThreadedBuildOnlyNeededOnDefaultPipeline'], true)
       publishArtifactsForWorkload: true
       publishWBT: false
 

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -188,7 +188,6 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      includeMultiThreaded: true
 
   - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
     parameters:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -188,6 +188,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      includeMultiThreaded: true
 
   - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
     parameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -822,20 +822,6 @@ extends:
           scenarios:
             - WasmTestOnChrome
 
-      # Library tests with full threading
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            #- browser_wasm_win
-          nameSuffix: _Threading
-          extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          extraHelixArguments: /p:WasmEnableThreads=true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          shouldRunSmokeOnly: onLibrariesAndIllinkChanges
-          scenarios:
-            - WasmTestOnChrome
-
       # EAT Library tests - only run on linux
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
         parameters:
@@ -870,17 +856,6 @@ extends:
           extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           publishArtifactsForWorkload: true
           publishWBT: true
-
-      - template: /eng/pipelines/common/templates/wasm-build-only.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
-          nameSuffix: MultiThreaded
-          extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          publishArtifactsForWorkload: true
-          publishWBT: false
 
       # Browser Wasm.Build.Tests
       - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -857,6 +857,17 @@ extends:
           publishArtifactsForWorkload: true
           publishWBT: true
 
+      - template: /eng/pipelines/common/templates/wasm-build-only.yml
+        parameters:
+          platforms:
+            - browser_wasm
+            - browser_wasm_win
+          condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
+          nameSuffix: MultiThreaded
+          extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          publishArtifactsForWorkload: true
+          publishWBT: false
+
       # Browser Wasm.Build.Tests
       - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml
         parameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -876,18 +876,6 @@ extends:
 
       # WASI/WASM
 
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - wasi_wasm
-            - wasi_wasm_win
-          nameSuffix: '_Smoke'
-          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          scenarios:
-            - WasmTestOnWasmtime
-
       - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
         parameters:
           platforms:

--- a/src/mono/wasm/features.md
+++ b/src/mono/wasm/features.md
@@ -23,7 +23,7 @@ Some of these properties require a unique build of the runtime, which means that
 
 ### Multi-threading
 
-Multi-threading support is enabled by `<WasmEnableThreads>true</WasmEnableThreads>`, and is currently disabled by default. It requires a unique build of the runtime.
+Multi-threading experiment is enabled by `<WasmEnableThreads>true</WasmEnableThreads>`, and is currently disabled by default. It requires a unique build of the runtime.
 
 Your HTTPS server and/or proxy must be configured to send HTTP headers similar to `Cross-Origin-Embedder-Policy:require-corp` and `Cross-Origin-Opener-Policy:same-origin` in order to enable multi-threading support in end-user web browsers for security reasons.
 


### PR DESCRIPTION
With the fix that caused the runtime pipeline to not get triggered.