### PR TITLE
Fix flags in EarlyProp after nullcheck is removed

### DIFF
--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -459,7 +459,6 @@ bool Compiler::optFoldNullCheck(GenTree* tree, LocalNumberToNullCheckTreeMap* nu
 
         // The current indir is no longer non-faulting.
         tree->gtFlags &= ~GTF_IND_NONFAULTING;
-        tree->SetIndirExceptionFlags(this);
 
         if (nullCheckParent != nullptr)
         {

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -457,6 +457,10 @@ bool Compiler::optFoldNullCheck(GenTree* tree, LocalNumberToNullCheckTreeMap* nu
         nullCheckTree->SetHasOrderingSideEffect();
         nullCheckTree->gtFlags |= GTF_IND_NONFAULTING;
 
+        // The current indir is no longer non-faulting.
+        tree->gtFlags &= ~GTF_IND_NONFAULTING;
+        tree->SetIndirExceptionFlags(this);
+
         if (nullCheckParent != nullptr)
         {
             nullCheckParent->gtFlags &= ~GTF_DONT_CSE;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/112333

When we have:
```
NULLCHECK(addr)
IND(addr)
```
if we decide to remove the nullcheck (when it is followed by an indirect which is recognized as an implicit nullcheck for the same address), we should update the flags in that indirect as it's no longer non-faulting.