### PR TITLE
Update HelloAndroid App output path and PerfBDN dotnet-install.sh url.

### DIFF
--- a/eng/pipelines/performance/templates/build-perf-bdn-app.yml
+++ b/eng/pipelines/performance/templates/build-perf-bdn-app.yml
@@ -85,9 +85,8 @@ steps:
   - script: |
       echo '{ }' > ./global.json
       curl -o NuGet.config 'https://raw.githubusercontent.com/dotnet/maui/${{parameters.framework}}/NuGet.config'
-      curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'
-      curl -Lo performance-version-details.xml 'https://raw.githubusercontent.com/dotnet/performance/${{parameters.perfBranch}}/eng/Version.Details.xml'
-      version=$(sed -nr 's/[[:space:]]*<Dependency Name="Microsoft.NET.Sdk" Version="(.*)"[[:space:]].*/\1/p' ./performance-version-details.xml)
+      curl -o dotnet-install.sh 'https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh'
+      version=$(sed -nr 's/[[:space:]]*<Dependency Name="Microsoft.NET.Sdk" Version="([^"]*)"[[:space:]]?.*/\1/p' ./performance/eng/Version.Details.xml)
       echo dotnet-version: $version
       chmod -R a+rx .
       ./dotnet-install.sh --version $version --install-dir .

--- a/eng/pipelines/performance/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/performance/templates/build-perf-sample-apps.yml
@@ -26,7 +26,7 @@ steps:
       displayName: Build HelloAndroid sample app
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
-        rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/publish/apk/bin/HelloAndroid.apk
+        rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/Bundle/bin/HelloAndroid.apk
         includeRootFolder: true
         displayName: Android Mono Artifacts
         artifactName: AndroidMonoarm64


### PR DESCRIPTION
Update the folder used for the runtime HelloAndroid app and update the perfBDN app dotnet-install.sh version retrieval and URL.

Partial test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2640497&view=results. This test run included some fixes to later perfBDN issues but demonstrates the work AndroidMono build and working install Maui workload that this PR addresses. 