### PR TITLE
Coretestlib: Add information of parent process id during test failure for Windows

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -801,6 +801,9 @@ namespace CoreclrTestLib
                             Console.WriteLine($"\t{activeProcess.Id,-6} {activeProcess.ProcessName}");
                         }
 
+                        Console.WriteLine("Snapshot of processes currently running (using wmic):");
+                        Console.WriteLine(GetAllProcessNames_wmic());
+
                         if (collectCrashDumps)
                         {
                             if (crashDumpFolder != null)
@@ -832,6 +835,28 @@ namespace CoreclrTestLib
             }
 
             return exitCode;
+        }
+
+        private static string GetAllProcessNames_wmic()
+        {
+            // The command to execute
+            string command = "wmic process get Name, ProcessId, ParentProcessId";
+            
+            // Start the process and capture the output
+            Process process = new Process();
+            process.StartInfo.FileName = "cmd.exe";
+            process.StartInfo.Arguments = $"/c {command}";
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+
+            // Start the process and read the output
+            process.Start();
+            string output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(100); // wait for 100 ms
+
+            // Output the result
+            return output;
         }
     }
 }

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -801,8 +801,11 @@ namespace CoreclrTestLib
                             Console.WriteLine($"\t{activeProcess.Id,-6} {activeProcess.ProcessName}");
                         }
 
-                        Console.WriteLine("Snapshot of processes currently running (using wmic):");
-                        Console.WriteLine(GetAllProcessNames_wmic());
+                        if (OperatingSystem.IsWindows())
+                        {
+                            Console.WriteLine("Snapshot of processes currently running (using wmic):");
+                            Console.WriteLine(GetAllProcessNames_wmic());
+                        }
 
                         if (collectCrashDumps)
                         {


### PR DESCRIPTION
Over past week, we have seen multiple hangs in windows/arm64 configuration, that doesn't repro locally. We want to understand why the dump of the hung process is not getting created. The parent process tries to iterate over the child processes but doesn't find the desired `corerun` child process and hence no dump is created. To make sure that the logic around that is correct, this PR adds logging of parent process id as well to make sure our dump collection logic gets triggered at right place.

Reference:
- https://github.com/dotnet/runtime/issues/112619
- https://github.com/dotnet/runtime/issues/112546
- https://github.com/dotnet/runtime/issues/112332