### PR TITLE
JIT: Keep small-typedness information for return temps introduced by GDV

### DIFF
--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -827,6 +827,16 @@ private:
                 {
                     returnTemp = compiler->lvaGrabTemp(false DEBUGARG("guarded devirt return temp"));
                     JITDUMP("Reworking call(s) to return value via a new temp V%02u\n", returnTemp);
+
+                    // Keep the information about small typedness to avoid
+                    // inserting unnecessary casts for normalization, which can
+                    // make tailcall invariants unhappy. This is the same logic
+                    // that impImportCall uses when it introduces call temps.
+                    if (varTypeIsSmall(origCall->gtReturnType))
+                    {
+                        assert(origCall->NormalizesSmallTypesOnReturn());
+                        compiler->lvaGetDesc(returnTemp)->lvType = origCall->gtReturnType;
+                    }
                 }
 
                 if (varTypeIsStruct(origCall))


### PR DESCRIPTION
Fix #112635

I tried for a while to create a reduced test case, but getting this IR requires a very specific tree of GDVs and inlines that I had a hard time creating.