### PR TITLE
Relax encrypted cert requirement for Windows with Pkcs12Export tests

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -834,9 +834,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         AssertEncryptionAlgorithm(epki.EncryptionAlgorithm);
                         keys++;
                     }
-                    else if (safeBag is Pkcs12CertBag && (wasEncryptedSafe || PlatformDetection.IsWindows))
+                    else if (safeBag is Pkcs12CertBag)
                     {
-                        certs++;
+                        if (wasEncryptedSafe)
+                        {
+                            certs++;
+                        }
+                        else if (PlatformDetection.IsWindows10OrLater && !PlatformDetection.IsWindows10Version1703OrGreater)
+                        {
+                            // Windows 10 before RS2 / 1703 did not encrypt certs, but count them anyway.
+                            certs++;
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -834,7 +834,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         AssertEncryptionAlgorithm(epki.EncryptionAlgorithm);
                         keys++;
                     }
-                    else if (safeBag is Pkcs12CertBag && wasEncryptedSafe)
+                    else if (safeBag is Pkcs12CertBag && (wasEncryptedSafe || PlatformDetection.IsWindows))
                     {
                         certs++;
                     }


### PR DESCRIPTION
Older Windowses do not encrypt certificates in PKCS#12 exports, only keys. This change relaxes the counting of certificates in unit tests to include unencrypted certificates on Windows.

Contributes to #112738 