### PR TITLE
Change the Unix cert store to store certificates with AES256+SHA256 PBES2

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslDirectoryBasedStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslDirectoryBasedStoreProvider.cs
@@ -23,6 +23,10 @@ namespace System.Security.Cryptography.X509Certificates
         private const string PfxOrdinalWildcard = "." + PfxWildcard;
 
         private static string? s_userStoreRoot;
+        private static readonly PbeParameters s_storePbeParameters = new PbeParameters(
+            PbeEncryptionAlgorithm.Aes256Cbc,
+            HashAlgorithmName.SHA256,
+            iterationCount: 1);
 
         private readonly string _storePath;
 
@@ -212,7 +216,7 @@ namespace System.Security.Cryptography.X509Certificates
                         throw new CryptographicException(SR.Format(SR.Cryptography_InvalidFilePermissions, stream.Name));
                     }
 
-                    byte[] pkcs12 = copy.Export(X509ContentType.Pkcs12)!;
+                    byte[] pkcs12 = copy.ExportPkcs12(s_storePbeParameters, null);
                     stream.Write(pkcs12, 0, pkcs12.Length);
                 }
             }


### PR DESCRIPTION
Today, we store certificates on-disk with Linux that result in 3DES and SHA1 being used. If you are on a FIPS-constrained environment, OpenSSL will fail to be able to read and write to a certificate store.

This changes the Unix stores to use AES256+SHA256 using the new `ExportPkcs12` API. Since we have more control over the export now, this also allows using a single round for the KDFs. We don't need 2000 rounds since a `null` password is used.

Fixes #111560