### PR TITLE
Disable test

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -231,7 +231,6 @@ namespace System.Net.Http
         private static void OnRequestSendingRequest(WinHttpRequestState state)
         {
             Debug.Assert(state != null, "OnRequestSendingRequest: state is null");
-            Debug.Assert(state.RequestHandle != null, "OnRequestSendingRequest: state.RequestHandle is null");
             Debug.Assert(state.RequestMessage != null, "OnRequestSendingRequest: state.RequestMessage is null");
             Debug.Assert(state.RequestMessage.RequestUri != null, "OnRequestSendingRequest: state.RequestMessage.RequestUri is null");
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -96,6 +96,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         }
 
         [ConditionalFact(nameof(TestsEnabled))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/112700")]
         public async Task AfterReadResponseServerError_ClientWrite()
         {
             TaskCompletionSource<Stream> requestStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -96,7 +96,6 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         }
 
         [ConditionalFact(nameof(TestsEnabled))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/112700")]
         public async Task AfterReadResponseServerError_ClientWrite()
         {
             TaskCompletionSource<Stream> requestStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Disabling test failing on assert in https://github.com/dotnet/runtime/issues/112700.
This is already fixed in .NET 9.0+ by https://github.com/dotnet/runtime/pull/93984.

cc @wfurt @karelz 

## Customer Impact

- [ ] Customer reported
- [x] Found internally


## Regression

- [ ] Yes
- [X] No

## Testing

CI

## Risk

Very low - test only change.