### PR TITLE
MemoryCache: use net9.cs file rather than #if for TFM limits

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
@@ -37,13 +37,6 @@ namespace Microsoft.Extensions.Caching.Memory
         public Microsoft.Extensions.Caching.Memory.MemoryCacheStatistics? GetCurrentStatistics() { throw null; }
         public void Remove(object key) { }
         public bool TryGetValue(object key, out object? result) { throw null; }
-
-#if NET9_0_OR_GREATER
-        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-        public bool TryGetValue(System.ReadOnlySpan<char> key, out object? value) { throw null; }
-        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-        public bool TryGetValue<TItem>(System.ReadOnlySpan<char> key, out TItem? value) { throw null; }
-#endif
     }
     public partial class MemoryCacheOptions : Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions>
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.csproj
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.csproj
@@ -1,10 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>
     <Compile Include="Microsoft.Extensions.Caching.Memory.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <Compile Include="Microsoft.Extensions.Caching.Memory.net9.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.net9.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.net9.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Extensions.Caching.Memory
+{
+    public partial class MemoryCache
+    {
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public bool TryGetValue(System.ReadOnlySpan<char> key, out object? value) { throw null; }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public bool TryGetValue<TItem>(System.ReadOnlySpan<char> key, out TItem? value) { throw null; }
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/112695, addressing `#if` usage in `/ref/` files

/cc @stephentoub 