### PR TITLE
[8.0] Make CPU utilization checks in the thread pool configurable

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -27,10 +27,26 @@ namespace System.Threading
                 bool debuggerBreakOnWorkStarvation =
                     AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.DebugBreakOnWorkerStarvation", false);
 
+                // CPU utilization is updated when the gate thread performs periodic activities (GateActivitiesPeriodMs), so
+                // that would also affect the actual interval. Set to 0 to disable using CPU utilization and have components
+                // behave as though CPU utilization is low. The default value of 1 causes CPU utilization to be updated whenever
+                // the gate thread performs periodic activities.
+                int cpuUtilizationIntervalMs =
+                    AppContextConfigHelper.GetInt32Config(
+                        "System.Threading.ThreadPool.CpuUtilizationIntervalMs",
+                        "DOTNET_ThreadPool_CpuUtilizationIntervalMs",
+                        defaultValue: 1,
+                        allowNegative: false);
+
                 // The first reading is over a time range other than what we are focusing on, so we do not use the read other
                 // than to send it to any runtime-specific implementation that may also use the CPU utilization.
                 CpuUtilizationReader cpuUtilizationReader = default;
-                _ = cpuUtilizationReader.CurrentUtilization;
+                int lastCpuUtilizationRefreshTimeMs = 0;
+                if (cpuUtilizationIntervalMs > 0)
+                {
+                    lastCpuUtilizationRefreshTimeMs = Environment.TickCount;
+                    _ = cpuUtilizationReader.CurrentUtilization;
+                }
 
                 PortableThreadPool threadPoolInstance = ThreadPoolInstance;
                 LowLevelLock threadAdjustmentLock = threadPoolInstance._threadAdjustmentLock;
@@ -102,8 +118,17 @@ namespace System.Threading
                                 (uint)threadPoolInstance.GetAndResetHighWatermarkCountOfThreadsProcessingUserCallbacks());
                         }
 
-                        int cpuUtilization = (int)cpuUtilizationReader.CurrentUtilization;
-                        threadPoolInstance._cpuUtilization = cpuUtilization;
+                        // Determine whether CPU utilization should be updated. CPU utilization is only used by the starvation
+                        // heuristic and hill climbing, and neither of those are active when there is a pending blocking
+                        // adjustment.
+                        if (cpuUtilizationIntervalMs > 0 &&
+                            threadPoolInstance._pendingBlockingAdjustment == PendingBlockingAdjustment.None &&
+                            (uint)(currentTimeMs - lastCpuUtilizationRefreshTimeMs) >= (uint)cpuUtilizationIntervalMs)
+                        {
+                            lastCpuUtilizationRefreshTimeMs = currentTimeMs;
+                            int cpuUtilization = (int)cpuUtilizationReader.CurrentUtilization;
+                            threadPoolInstance._cpuUtilization = cpuUtilization;
+                        }
 
                         if (!disableStarvationDetection &&
                             threadPoolInstance._pendingBlockingAdjustment == PendingBlockingAdjustment.None &&


### PR DESCRIPTION
- Port of https://github.com/dotnet/runtime/pull/112789 to 8.0
- On Windows, checking CPU utilization seems to involve a small amount of overhead, which can become noticeable or even significant in some scenarios. This change makes the intervals of time over which CPU utilization is computed configurable. Increasing the interval increases the period at which CPU utilization is updated. The same config var can also be used to disable CPU utilization checks and have features that use it behave as though CPU utilization is low.
- CPU utilization is used by the starvation heuristic and hill climbing. When CPU utilization is very high, the starvation heuristic reduces the rate of thread injection in starved cases. When CPU utilization is high, hill climbing avoids settling on higher thread count control values.
- CPU utilization is currently updated when the gate thread performs periodic activities, which happens typically every 500 ms when a worker thread is active. There is one gate thread per .NET process.
- In scenarios where there are many .NET processes running, and where many of them frequently but lightly use the thread pool, overall CPU usage may be relatively low, but the overhead from CPU utilization checks can bubble up to a noticeable portion of overall CPU usage. In a scenario involving 100s of .NET processes, it was seen that CPU utilization checks amount to 0.5-1% of overall CPU usage on the machine, which was considered significant.

## Customer Impact

A 1p customer running a large number of .NET services on a system with a large number of processors is seeing about 0.5-1% of total CPU time on the system being spent doing CPU utilization checks in the .NET thread pool. Due to other controls on usage, the positive impact of the CPU utilization checks is likely negligible, and the customer would like to reduce CPU usage from these checks, or to even eliminate the checks.

## Regression?

No

## Testing

Validated on a small test case that CPU usage from CPU utilization checks is reduced when the interval is increased, and eliminated when the checks are disabled.

## Risk

Low, the change is under an opt-in config setting