### PR TITLE
Move local thread pool work items to global by default when blocking on a task

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -3060,26 +3060,21 @@ namespace System.Threading.Tasks
             bool returnValue = SpinWait(millisecondsTimeout);
             if (!returnValue)
             {
-#if CORECLR
-                if (ThreadPoolWorkQueue.s_prioritizationExperiment)
-                {
-                    // We're about to block waiting for the task to complete, which is expensive, and if
-                    // the task being waited on depends on some other work to run, this thread could end up
-                    // waiting for some other thread to do work. If the two threads are part of the same scheduler,
-                    // such as the thread pool, that could lead to a (temporary) deadlock. This is made worse by
-                    // it also leading to a possible priority inversion on previously queued work. Each thread in
-                    // the thread pool has a local queue. A key motivator for this local queue is it allows this
-                    // thread to create work items that it will then prioritize above all other work in the
-                    // pool. However, while this thread makes its own local queue the top priority, that queue is
-                    // every other thread's lowest priority. If this thread blocks, all of its created work that's
-                    // supposed to be high priority becomes low priority, and work that's typically part of a
-                    // currently in-flight operation gets deprioritized relative to new requests coming into the
-                    // pool, which can lead to the whole system slowing down or even deadlocking. To address that,
-                    // just before we block, we move all local work into a global queue, so that it's at least
-                    // prioritized by other threads more fairly with respect to other work.
-                    ThreadPoolWorkQueue.TransferAllLocalWorkItemsToHighPriorityGlobalQueue();
-                }
-#endif
+                // We're about to block waiting for the task to complete, which is expensive, and if
+                // the task being waited on depends on some other work to run, this thread could end up
+                // waiting for some other thread to do work. If the two threads are part of the same scheduler,
+                // such as the thread pool, that could lead to a (temporary) deadlock. This is made worse by
+                // it also leading to a possible priority inversion on previously queued work. Each thread in
+                // the thread pool has a local queue. A key motivator for this local queue is it allows this
+                // thread to create work items that it will then prioritize above all other work in the
+                // pool. However, while this thread makes its own local queue the top priority, that queue is
+                // every other thread's lowest priority. If this thread blocks, all of its created work that's
+                // supposed to be high priority becomes low priority, and work that's typically part of a
+                // currently in-flight operation gets deprioritized relative to new requests coming into the
+                // pool, which can lead to the whole system slowing down or even deadlocking. To address that,
+                // just before we block, we move all local work into a global queue, so that it's at least
+                // prioritized by other threads more fairly with respect to other work.
+                ThreadPoolWorkQueue.TransferAllLocalWorkItemsToHighPriorityGlobalQueue();
 
                 var mres = new SetOnInvokeMres();
                 try


### PR DESCRIPTION
- Enables the change in https://github.com/dotnet/runtime/pull/109841 by default
- A worker thread blocking on a task while having pending local work items can lead to priority inversion and deadlock-like issues, as local work items are stolen with the lowest priority by other threads. In a situation where all worker threads are blocked on tasks and new ones continue to block on tasks similarly, the global queues may not deplete for a long time and any local work items of blocked threads may not run meanwhile. There have been some reports of issues like this occurring while coinciding with other external issues that aggravate the problem.
- When a worker thread blocks on a task, the change moves any local work items to the high-priority global queue. Using the normal-priority queues can lead to other priority inversion issues in worst-case scenarios like above, where the normal-priority queues may consist of a number of new requests, and local work items typically represent already in-flight work.