### PR TITLE
Fix `Monitor.Wait` unregistration in CoreCLR upon a thread exiting

### DIFF
--- a/src/coreclr/vm/threaddebugblockinginfo.cpp
+++ b/src/coreclr/vm/threaddebugblockinginfo.cpp
@@ -14,13 +14,6 @@ ThreadDebugBlockingInfo::ThreadDebugBlockingInfo()
     m_firstBlockingItem = NULL;
 }
 
-//Destructor
-ThreadDebugBlockingInfo::~ThreadDebugBlockingInfo()
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(m_firstBlockingItem == NULL);
-}
-
 // Adds a new blocking item at the front of the list
 // The caller is responsible for allocating the memory this points to and keeping it alive until
 // after PopBlockingItem is called

--- a/src/coreclr/vm/threaddebugblockinginfo.h
+++ b/src/coreclr/vm/threaddebugblockinginfo.h
@@ -51,7 +51,6 @@ private:
 
 public:
     ThreadDebugBlockingInfo();
-    ~ThreadDebugBlockingInfo();
 
 #ifndef DACCESS_COMPILE
     // Adds a new blocking item at the front of the list

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -930,6 +930,7 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
         m_ThreadHandleForClose = hThread;
     }
 
+    UnregisterWaitEventLinks();
     CooperativeCleanup();
 
     // We need to make sure that TLS are touched last here.
@@ -2398,16 +2399,6 @@ Thread::~Thread()
 
     _ASSERTE(IsDead() || IsUnstarted() || IsAtProcessExit());
 
-    if (m_WaitEventLink.m_Next != NULL && !IsAtProcessExit())
-    {
-        WaitEventLink *walk = &m_WaitEventLink;
-        while (walk->m_Next) {
-            ThreadQueue::RemoveThread(this, (SyncBlock*)((DWORD_PTR)walk->m_Next->m_WaitSB & ~1));
-            StoreEventToEventStore (walk->m_Next->m_EventWait);
-        }
-        m_WaitEventLink.m_Next = NULL;
-    }
-
     if (m_StateNC & TSNC_ExistInThreadStore) {
         BOOL ret;
         ret = ThreadStore::RemoveThread(this);
@@ -2689,6 +2680,24 @@ void Thread::CleanupCOMState()
 }
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
+void Thread::UnregisterWaitEventLinks()
+{
+    _ASSERTE(this == GetThreadNULLOk());
+
+    if (m_WaitEventLink.m_Next != NULL && !IsAtProcessExit())
+    {
+        WaitEventLink *walk = &m_WaitEventLink;
+        while (walk->m_Next)
+        {
+            ThreadQueue::RemoveThread(this, (SyncBlock*)((DWORD_PTR)walk->m_Next->m_WaitSB & ~1));
+            StoreEventToEventStore(walk->m_Next->m_EventWait);
+            walk = walk->m_Next;
+        }
+
+        m_WaitEventLink.m_Next = NULL;
+    }
+}
+
 // Thread cleanup that must be run in cooperative mode before the thread is destroyed.
 void Thread::CooperativeCleanup()
 {
@@ -2777,6 +2786,7 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
 
     if (this == GetThreadNULLOk())
     {
+        UnregisterWaitEventLinks();
         CooperativeCleanup();
     }
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1180,8 +1180,11 @@ public:
     void            BaseWinRTUninitialize();
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
+private:
+    void        UnregisterWaitEventLinks();
     void        CooperativeCleanup();
 
+public:
     void        OnThreadTerminate(BOOL holdingLock);
 
     static void CleanupDetachedThreads();


### PR DESCRIPTION
Moved the Monitor wait unregistration to happen just before the thread exits, since the wait info is allocated on the stack. Monitor waits are not typically unregistered here, but there can be some odd cases.