### PR TITLE
Use FLS detach callback as a thread termination notification. Another try.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -157,7 +157,7 @@ void ThreadStore::DetachCurrentThread()
     }
 
     // Unregister from OS notifications
-    // This can return false if detach notification is spurious and does not belong to this thread.
+    // This can return false if a thread did not register for OS notification.
     if (!PalDetachThread(pDetachingThread))
     {
         return;

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1791,7 +1791,7 @@ void InitFlsSlot()
 //  thread        - thread to attach
 static void OsAttachThread(void* thread)
 {
-    if (flsState != FLS_STATE_INVOKED)
+    if (flsState == FLS_STATE_INVOKED)
     {
         _ASSERTE_ALL_BUILDS(!"Attempt to execute managed code after the .NET runtime thread state has been destroyed.");
     }

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1778,7 +1778,7 @@ static void OsAttachThread(void* thread)
 //  thread        - thread to detach
 // Return:
 //  true if the thread was detached, false if there was no attached thread
-bool OsDetachThread(void* thread)
+void OsDetachThread(void* thread)
 {
     ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);
     void* threadFromCurrentFiber = FlsGetValue(g_flsIndex);
@@ -1787,7 +1787,7 @@ bool OsDetachThread(void* thread)
     {
         // we've seen this thread, but not this fiber.  It must be a "foreign" fiber that was
         // borrowing this thread.
-        return false;
+        return;
     }
 
     if (threadFromCurrentFiber != thread)
@@ -1796,7 +1796,6 @@ bool OsDetachThread(void* thread)
     }
 
     FlsSetValue(g_flsIndex, NULL);
-    return true;
 }
 
 void EnsureTlsDestructionMonitor()

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1684,6 +1684,130 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
 
 #endif // !defined(CORECLR_EMBEDDED)
 
+static void RuntimeThreadShutdown(void* thread)
+{
+    Thread* pThread = (Thread*)thread;
+    _ASSERTE(pThread == GetThreadNULLOk());
+
+    if (pThread)
+    {
+#ifdef FEATURE_COMINTEROP
+        // reset the CoInitialize state
+        // so we don't call CoUninitialize during thread detach
+        pThread->ResetCoInitialized();
+#endif // FEATURE_COMINTEROP
+        // For case where thread calls ExitThread directly, we need to reset the
+        // frame pointer. Otherwise stackwalk would AV. We need to do it in cooperative mode.
+        // We need to set m_GCOnTransitionsOK so this thread won't trigger GC when toggle GC mode
+        if (pThread->m_pFrame != FRAME_TOP)
+        {
+#ifdef _DEBUG
+            pThread->m_GCOnTransitionsOK = FALSE;
+#endif
+            GCX_COOP_NO_DTOR();
+            pThread->m_pFrame = FRAME_TOP;
+            GCX_COOP_NO_DTOR_END();
+        }
+
+        pThread->DetachThread(TRUE);
+    }
+    else
+    {
+        // Since we don't actually cleanup the TLS data along this path, verify that it is already cleaned up
+        AssertThreadStaticDataFreed();
+    }
+
+    ThreadDetaching();
+}
+
+#ifdef TARGET_WINDOWS
+
+// Index for the fiber local storage of the attached thread pointer
+static uint32_t g_flsIndex = FLS_OUT_OF_INDEXES;
+
+// This is called when each *fiber* is destroyed. When the home fiber of a thread is destroyed,
+// it means that the thread itself is destroyed.
+// Since we receive that notification outside of the Loader Lock, it allows us to safely acquire
+// the ThreadStore lock in the RuntimeThreadShutdown.
+static void __stdcall FiberDetachCallback(void* lpFlsData)
+{
+    ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);
+    ASSERT(lpFlsData == FlsGetValue(g_flsIndex));
+
+    if (lpFlsData != NULL)
+    {
+        // The current fiber is the home fiber of a thread, so the thread is shutting down
+        RuntimeThreadShutdown(lpFlsData);
+    }
+}
+
+bool InitFlsSlot()
+{
+    // We use fiber detach callbacks to run our thread shutdown code because the fiber detach
+    // callback is made without the OS loader lock
+    g_flsIndex = FlsAlloc(FiberDetachCallback);
+    if (g_flsIndex == FLS_OUT_OF_INDEXES)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+// Register the thread with OS to be notified when thread is about to be destroyed
+// It fails fast if a different thread was already registered with the current fiber.
+// Parameters:
+//  thread        - thread to attach
+static void OsAttachThread(void* thread)
+{
+    void* threadFromCurrentFiber = FlsGetValue(g_flsIndex);
+
+    if (threadFromCurrentFiber != NULL)
+    {
+        _ASSERTE(!"Multiple threads encountered from a single fiber");
+        COMPlusThrowWin32();
+    }
+
+    // Associate the current fiber with the current thread.  This makes the current fiber the thread's "home"
+    // fiber.  This fiber is the only fiber allowed to execute managed code on this thread.  When this fiber
+    // is destroyed, we consider the thread to be destroyed.
+    FlsSetValue(g_flsIndex, thread);
+}
+
+// Detach thread from OS notifications.
+// It fails fast if some other thread value was attached to the current fiber.
+// Parameters:
+//  thread        - thread to detach
+// Return:
+//  true if the thread was detached, false if there was no attached thread
+bool OsDetachThread(void* thread)
+{
+    ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);
+    void* threadFromCurrentFiber = FlsGetValue(g_flsIndex);
+
+    if (threadFromCurrentFiber == NULL)
+    {
+        // we've seen this thread, but not this fiber.  It must be a "foreign" fiber that was
+        // borrowing this thread.
+        return false;
+    }
+
+    if (threadFromCurrentFiber != thread)
+    {
+        _ASSERTE(!"Detaching a thread from the wrong fiber");
+        COMPlusThrowWin32();
+    }
+
+    FlsSetValue(g_flsIndex, NULL);
+    return true;
+}
+
+void EnsureTlsDestructionMonitor()
+{
+    OsAttachThread(GetThread());
+}
+
+#else
 struct TlsDestructionMonitor
 {
     bool m_activated = false;
@@ -1697,36 +1821,7 @@ struct TlsDestructionMonitor
     {
         if (m_activated)
         {
-            Thread* thread = GetThreadNULLOk();
-            if (thread)
-            {
-#ifdef FEATURE_COMINTEROP
-                // reset the CoInitialize state
-                // so we don't call CoUninitialize during thread detach
-                thread->ResetCoInitialized();
-#endif // FEATURE_COMINTEROP
-                // For case where thread calls ExitThread directly, we need to reset the
-                // frame pointer. Otherwise stackwalk would AV. We need to do it in cooperative mode.
-                // We need to set m_GCOnTransitionsOK so this thread won't trigger GC when toggle GC mode
-                if (thread->m_pFrame != FRAME_TOP)
-                {
-#ifdef _DEBUG
-                    thread->m_GCOnTransitionsOK = FALSE;
-#endif
-                    GCX_COOP_NO_DTOR();
-                    thread->m_pFrame = FRAME_TOP;
-                    GCX_COOP_NO_DTOR_END();
-                }
-
-                thread->DetachThread(TRUE);
-            }
-            else
-            {
-                // Since we don't actually cleanup the TLS data along this path, verify that it is already cleaned up
-                AssertThreadStaticDataFreed();
-            }
-
-            ThreadDetaching();
+            RuntimeThreadShutdown(GetThreadNULLOk());
         }
     }
 };
@@ -1739,6 +1834,8 @@ void EnsureTlsDestructionMonitor()
 {
     tls_destructionMonitor.Activate();
 }
+
+#endif
 
 #ifdef DEBUGGING_SUPPORTED
 //

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1755,7 +1755,7 @@ static uint32_t g_flsIndex = FLS_OUT_OF_INDEXES;
 #define FLS_STATE_ARMED 1
 #define FLS_STATE_INVOKED 2
 
-static __declspec(thread) int flsState;
+static __declspec(thread) byte flsState;
 
 // This is called when each *fiber* is destroyed. When the home fiber of a thread is destroyed,
 // it means that the thread itself is destroyed.
@@ -1791,7 +1791,10 @@ void InitFlsSlot()
 //  thread        - thread to attach
 static void OsAttachThread(void* thread)
 {
-    _ASSERTE_ALL_BUILDS((flsState != FLS_STATE_INVOKED) && "Initializing thread after termination callback has run.");
+    if (flsState != FLS_STATE_INVOKED)
+    {
+        _ASSERTE_ALL_BUILDS(!"Attempt to execute managed code after the .NET runtime thread state has been destroyed.");
+    }
 
     flsState = FLS_STATE_ARMED;
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1741,17 +1741,16 @@ static void __stdcall FiberDetachCallback(void* lpFlsData)
     }
 }
 
-bool InitFlsSlot()
+void InitFlsSlot()
 {
     // We use fiber detach callbacks to run our thread shutdown code because the fiber detach
     // callback is made without the OS loader lock
     g_flsIndex = FlsAlloc(FiberDetachCallback);
     if (g_flsIndex == FLS_OUT_OF_INDEXES)
     {
-        return false;
+        _ASSERTE(!"Initialization of an FLS slot failed.");
+        COMPlusThrowWin32();
     }
-
-    return true;
 }
 
 // Register the thread with OS to be notified when thread is about to be destroyed

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1748,7 +1748,6 @@ void InitFlsSlot()
     g_flsIndex = FlsAlloc(FiberDetachCallback);
     if (g_flsIndex == FLS_OUT_OF_INDEXES)
     {
-        _ASSERTE(!"Initialization of an FLS slot failed.");
         COMPlusThrowWin32();
     }
 }

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1789,8 +1789,6 @@ static void OsAttachThread(void* thread)
 // It fails fast if some other thread value was attached to the current fiber.
 // Parameters:
 //  thread        - thread to detach
-// Return:
-//  true if the thread was detached, false if there was no attached thread
 void OsDetachThread(void* thread)
 {
     ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1751,20 +1751,27 @@ static void RuntimeThreadShutdown(void* thread)
 // Index for the fiber local storage of the attached thread pointer
 static uint32_t g_flsIndex = FLS_OUT_OF_INDEXES;
 
+#define FLS_STATE_CLEAR 0
+#define FLS_STATE_ARMED 1
+#define FLS_STATE_INVOKED 2
+
+static __declspec(thread) int flsState;
+
 // This is called when each *fiber* is destroyed. When the home fiber of a thread is destroyed,
 // it means that the thread itself is destroyed.
 // Since we receive that notification outside of the Loader Lock, it allows us to safely acquire
 // the ThreadStore lock in the RuntimeThreadShutdown.
 static void __stdcall FiberDetachCallback(void* lpFlsData)
 {
-    ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);
-    ASSERT(lpFlsData == FlsGetValue(g_flsIndex));
+    _ASSERTE(g_flsIndex != FLS_OUT_OF_INDEXES);
+    _ASSERTE(lpFlsData);
 
-    if (lpFlsData != NULL)
+    if (flsState == FLS_STATE_ARMED)
     {
-        // The current fiber is the home fiber of a thread, so the thread is shutting down
         RuntimeThreadShutdown(lpFlsData);
     }
+
+    flsState = FLS_STATE_INVOKED;
 }
 
 void InitFlsSlot()
@@ -1784,12 +1791,9 @@ void InitFlsSlot()
 //  thread        - thread to attach
 static void OsAttachThread(void* thread)
 {
-    void* threadFromCurrentFiber = FlsGetValue(g_flsIndex);
+    _ASSERTE_ALL_BUILDS((flsState != FLS_STATE_INVOKED) && "Initializing thread after termination callback has run.");
 
-    if (threadFromCurrentFiber != NULL)
-    {
-        _ASSERTE_ALL_BUILDS(!"Multiple threads encountered from a single fiber");
-    }
+    flsState = FLS_STATE_ARMED;
 
     // Associate the current fiber with the current thread.  This makes the current fiber the thread's "home"
     // fiber.  This fiber is the only fiber allowed to execute managed code on this thread.  When this fiber
@@ -1808,19 +1812,12 @@ void OsDetachThread(void* thread)
     ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);
     void* threadFromCurrentFiber = FlsGetValue(g_flsIndex);
 
-    if (threadFromCurrentFiber == NULL)
-    {
-        // we've seen this thread, but not this fiber.  It must be a "foreign" fiber that was
-        // borrowing this thread.
-        return;
-    }
-
     if (threadFromCurrentFiber != thread)
     {
         _ASSERTE_ALL_BUILDS(!"Detaching a thread from the wrong fiber");
     }
 
-    FlsSetValue(g_flsIndex, NULL);
+    flsState = FLS_STATE_CLEAR;
 }
 
 void EnsureTlsDestructionMonitor()

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1764,8 +1764,7 @@ static void OsAttachThread(void* thread)
 
     if (threadFromCurrentFiber != NULL)
     {
-        _ASSERTE(!"Multiple threads encountered from a single fiber");
-        COMPlusThrowWin32();
+        _ASSERTE_ALL_BUILDS(!"Multiple threads encountered from a single fiber");
     }
 
     // Associate the current fiber with the current thread.  This makes the current fiber the thread's "home"
@@ -1794,8 +1793,7 @@ bool OsDetachThread(void* thread)
 
     if (threadFromCurrentFiber != thread)
     {
-        _ASSERTE(!"Detaching a thread from the wrong fiber");
-        COMPlusThrowWin32();
+        _ASSERTE_ALL_BUILDS(!"Detaching a thread from the wrong fiber");
     }
 
     FlsSetValue(g_flsIndex, NULL);

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1677,26 +1677,6 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
                 }
                 break;
             }
-
-            case DLL_THREAD_DETACH:
-            {
-#ifdef TARGET_WINDOWS
-                // Make sure that we do not have an attached Thread object.
-                // We can end up here with live Thread if some kind of thread termination callback initializes
-                // the Thread by entering managed code or by calling APIs that set up Thread, after the point where
-                // the OS premortem callback for the thread could have run.
-                // There will be no further clean up at this point and we will likely crash in GC once OS clears the native TLS.
-                //
-                // NB: It is ok for the Thread to be reinitialized before the premortem OS callback runs.
-                //     That historically may happen in rare cases when a thread cleans upon returning, but then FlsDataCleanup for COM
-                //     ends up releasing objects and calling APIs in the runtime that require Thread, or sends messages to the thread's
-                //     managed message loop. That is ok, as long as initialization happens prior to our thread termination
-                //     callback from OS. We guarantee that by ensuring our FlsSlot is initializad after COM has already been
-                //     initialized.
-                _ASSERTE_ALL_BUILDS(!GetThreadNULLOk() && "Thread initialized after final clean up could have run.");
-#endif
-                break;
-            }
         }
 
     }

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1680,20 +1680,22 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
 
             case DLL_THREAD_DETACH:
             {
+#ifdef TARGET_WINDOWS
                 // Make sure that we do not have an attached Thread object.
-                // We can end up here with live Thread if some kind of thread termination callback reinitializes
-                // the Thread by entering managed code or by calling APIs that set up Thread, after we have already
-                // seen the OS premortem callback for the thread.
-                // The callback runs only once. There will be no further clean up and we will likely crash in GC
-                // once OS clears the native TLS.
+                // We can end up here with live Thread if some kind of thread termination callback initializes
+                // the Thread by entering managed code or by calling APIs that set up Thread, after the point where
+                // the OS premortem callback for the thread could have run.
+                // There will be no further clean up at this point and we will likely crash in GC once OS clears the native TLS.
                 //
                 // NB: It is ok for the Thread to be reinitialized before the premortem OS callback runs.
                 //     That historically may happen in rare cases when a thread cleans upon returning, but then FlsDataCleanup for COM
                 //     ends up releasing objects and calling APIs in the runtime that require Thread, or sends messages to the thread's
-                //     managed message loop. That is ok, as long as reinitialization happens prior to our thread termination
+                //     managed message loop. That is ok, as long as initialization happens prior to our thread termination
                 //     callback from OS. We guarantee that by ensuring our FlsSlot is initializad after COM has already been
                 //     initialized.
-                _ASSERTE_ALL_BUILDS(!GetThreadNULLOk() && "Thread reinitialized after final clean up?");
+                _ASSERTE_ALL_BUILDS(!GetThreadNULLOk() && "Thread initialized after final clean up could have run.");
+#endif
+                break;
             }
         }
 

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -48,7 +48,7 @@ void ThreadDetaching();
 void EnsureTlsDestructionMonitor();
 #ifdef TARGET_WINDOWS
 void InitFlsSlot();
-bool OsDetachThread(void* thread);
+void OsDetachThread(void* thread);
 #endif
 
 void SetLatchedExitCode (INT32 code);

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -47,7 +47,7 @@ void ThreadDetaching();
 
 void EnsureTlsDestructionMonitor();
 #ifdef TARGET_WINDOWS
-bool InitFlsSlot();
+void InitFlsSlot();
 bool OsDetachThread(void* thread);
 #endif
 

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -46,6 +46,10 @@ void ForceEEShutdown(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownCom
 void ThreadDetaching();
 
 void EnsureTlsDestructionMonitor();
+#ifdef TARGET_WINDOWS
+bool InitFlsSlot();
+bool OsDetachThread(void* thread);
+#endif
 
 void SetLatchedExitCode (INT32 code);
 INT32 GetLatchedExitCode (void);

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -470,10 +470,6 @@ void FinalizerThread::FinalizerThreadCreate()
     _ASSERTE(g_pFinalizerThread == 0);
     g_pFinalizerThread = SetupUnstartedThread();
 
-#ifdef FEATURE_COMINTEROP
-    g_pFinalizerThread->SetApartmentOfUnstartedThread(Thread::AS_InMTA);
-#endif
-
     // We don't want the thread block disappearing under us -- even if the
     // actual thread terminates.
     GetFinalizerThread()->IncExternalCount();

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -385,6 +385,7 @@ DWORD WINAPI FinalizerThread::FinalizerThreadStart(void *args)
     // Making finalizer thread MTA early ensures that COM is initialized before we initialize our thread
     // termination callback.
     ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    g_fComStarted = true;
 #endif
 
     InitFlsSlot();

--- a/src/coreclr/vm/finalizerthread.h
+++ b/src/coreclr/vm/finalizerthread.h
@@ -65,6 +65,8 @@ public:
         }
     }
 
+    static void WaitForFinalizerThreadStart();
+
     static void FinalizerThreadWait();
 
     static void SignalFinalizationDone(int observedFullGcCount);

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -1400,12 +1400,14 @@ VOID EnsureComStarted(BOOL fCoInitCurrentThread)
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(GetThreadNULLOk() || !fCoInitCurrentThread);
-        PRECONDITION(g_fEEStarted || IsFinalizerThread());
+        PRECONDITION(g_fEEStarted);
     }
     CONTRACTL_END;
 
     if (g_fComStarted == FALSE)
     {
+        FinalizerThread::GetFinalizerThread()->SetRequiresCoInitialize();
+
         // Attempt to set the thread's apartment model (to MTA by default). May not
         // succeed (if someone beat us to the punch). That doesn't matter (since
         // CLR objects are now apartment agile), we only care that a CoInitializeEx
@@ -1413,12 +1415,8 @@ VOID EnsureComStarted(BOOL fCoInitCurrentThread)
         if (fCoInitCurrentThread)
             GetThread()->SetApartment(Thread::AS_InMTA);
 
-        if (!IsFinalizerThread())
-        {
-            FinalizerThread::GetFinalizerThread()->SetRequiresCoInitialize();
-            // set the finalizer event
-            FinalizerThread::EnableFinalization();
-        }
+        // set the finalizer event
+        FinalizerThread::EnableFinalization();
 
         g_fComStarted = TRUE;
     }

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -1404,7 +1404,7 @@ VOID EnsureComStarted(BOOL fCoInitCurrentThread)
     }
     CONTRACTL_END;
 
-    // COM should have been stated as soon as we start finalizer thread.
+    // COM is expected to be started on finalizer thread during startup
     _ASSERTE(g_fComStarted);
 }
 
@@ -1422,7 +1422,7 @@ HRESULT EnsureComStartedNoThrow(BOOL fCoInitCurrentThread)
 
     HRESULT hr = S_OK;
 
-    // COM should have been stated as soon as we start finalizer thread.
+    // COM is expected to be started on finalizer thread during startup
     _ASSERTE(g_fComStarted);
 
     return hr;

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -1404,22 +1404,8 @@ VOID EnsureComStarted(BOOL fCoInitCurrentThread)
     }
     CONTRACTL_END;
 
-    if (g_fComStarted == FALSE)
-    {
-        FinalizerThread::GetFinalizerThread()->SetRequiresCoInitialize();
-
-        // Attempt to set the thread's apartment model (to MTA by default). May not
-        // succeed (if someone beat us to the punch). That doesn't matter (since
-        // CLR objects are now apartment agile), we only care that a CoInitializeEx
-        // has been performed on this thread by us.
-        if (fCoInitCurrentThread)
-            GetThread()->SetApartment(Thread::AS_InMTA);
-
-        // set the finalizer event
-        FinalizerThread::EnableFinalization();
-
-        g_fComStarted = TRUE;
-    }
+    // COM should have been stated as soon as we start finalizer thread.
+    _ASSERTE(g_fComStarted);
 }
 
 HRESULT EnsureComStartedNoThrow(BOOL fCoInitCurrentThread)
@@ -1436,15 +1422,8 @@ HRESULT EnsureComStartedNoThrow(BOOL fCoInitCurrentThread)
 
     HRESULT hr = S_OK;
 
-    if (!g_fComStarted)
-    {
-        GCX_COOP();
-        EX_TRY
-        {
-            EnsureComStarted(fCoInitCurrentThread);
-        }
-        EX_CATCH_HRESULT(hr);
-    }
+    // COM should have been stated as soon as we start finalizer thread.
+    _ASSERTE(g_fComStarted);
 
     return hr;
 }

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1051,8 +1051,7 @@ void InitThreadManager()
 #ifdef TARGET_WINDOWS
     if (!InitFlsSlot())
     {
-        _ASSERTE(!"Initialization of a FLS slot failed.");
-        COMPlusThrowWin32();
+        _ASSERTE_ALL_BUILDS(!"Initialization of a FLS slot failed.");
     }
 #endif
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1049,10 +1049,7 @@ void InitThreadManager()
     CONTRACTL_END;
 
 #ifdef TARGET_WINDOWS
-    if (!InitFlsSlot())
-    {
-        _ASSERTE_ALL_BUILDS(!"Initialization of a FLS slot failed.");
-    }
+    InitFlsSlot();
 #endif
 
     // All patched helpers should fit into one page.

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -353,6 +353,7 @@ void SetThread(Thread* t)
 {
     LIMITED_METHOD_CONTRACT
 
+    Thread* origThread = gCurrentThreadInfo.m_pThread;
     gCurrentThreadInfo.m_pThread = t;
     if (t != NULL)
     {
@@ -360,6 +361,14 @@ void SetThread(Thread* t)
         EnsureTlsDestructionMonitor();
         t->InitRuntimeThreadLocals();
     }
+#ifdef TARGET_WINDOWS
+    else if (origThread != NULL)
+    {
+        // Unregister from OS notifications
+        // This can return false if a thread did not register for OS notification.
+        OsDetachThread(origThread);
+    }
+#endif
 
     // Clear or set the app domain to the one domain based on if the thread is being nulled out or set
     gCurrentThreadInfo.m_pAppDomain = t == NULL ? NULL : AppDomain::GetCurrentDomain();
@@ -1038,6 +1047,14 @@ void InitThreadManager()
         GC_TRIGGERS;
     }
     CONTRACTL_END;
+
+#ifdef TARGET_WINDOWS
+    if (!InitFlsSlot())
+    {
+        _ASSERTE(!"Initialization of a FLS slot failed.");
+        COMPlusThrowWin32();
+    }
+#endif
 
     // All patched helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -357,6 +357,7 @@ void SetThread(Thread* t)
     gCurrentThreadInfo.m_pThread = t;
     if (t != NULL)
     {
+        _ASSERTE(origThread == NULL);
         InitializeCurrentThreadsStaticData(t);
         EnsureTlsDestructionMonitor();
         t->InitRuntimeThreadLocals();

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -875,7 +875,7 @@ void DestroyThread(Thread *th)
 // Public function: DetachThread()
 // Marks the thread as needing to be destroyed, but doesn't destroy it yet.
 //-------------------------------------------------------------------------
-HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
+HRESULT Thread::DetachThread(BOOL inTerminationCallback)
 {
     // !!! Can not use contract here.
     // !!! Contract depends on Thread object for GC_TRIGGERS.
@@ -900,9 +900,9 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
         pErrorInfo->Release();
     }
 
-    // Revoke our IInitializeSpy registration only if we are not in DLL_THREAD_DETACH
+    // Revoke our IInitializeSpy registration only if we are not in a thread termination callback
     // (COM will do it or may have already done it automatically in that case).
-    if (!fDLLThreadDetach)
+    if (!inTerminationCallback)
     {
         RevokeApartmentSpy();
     }

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1048,10 +1048,6 @@ void InitThreadManager()
     }
     CONTRACTL_END;
 
-#ifdef TARGET_WINDOWS
-    InitFlsSlot();
-#endif
-
     // All patched helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
     _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart > (ptrdiff_t)0);

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -678,7 +678,7 @@ public:
     };
 
 public:
-    HRESULT DetachThread(BOOL fDLLThreadDetach);
+    HRESULT DetachThread(BOOL inTerminationCallback);
 
     void SetThreadState(ThreadState ts)
     {


### PR DESCRIPTION
Fixes: #110350

Switches the mechanism for OS notification about thread termination to use FLS (Fiber Local Storage) - the same mechanism as used on NativeAOT.

The advantage of FLS notification is that it does not run while holding the Loader Lock, thus it does not require that the termination callback never calls or waits for an OS call that may need to acquire that same Loader Lock. (It is hard for us to guarantee the latter)

This PR is similar to #110589 with additional mitigation for scenario where COM thread cleanups reinitialize the Thread object after we had our last chance to clean it up. 
The mitigation is basically ensuring that COM is initialized and sets up its FLS slot before we set up ours.