### PR TITLE
Fix getting resource when `ResourceResolve` returns assembly with resource that is an assembly ref

### DIFF
--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -508,7 +508,6 @@ BOOL PEAssembly::GetResource(LPCSTR szName, DWORD *cbResource,
     }
     CONTRACTL_END;
 
-
     mdToken            mdLinkRef;
     DWORD              dwResourceFlags;
     DWORD              dwOffset;
@@ -557,14 +556,15 @@ BOOL PEAssembly::GetResource(LPCSTR szName, DWORD *cbResource,
     }
 
 
-    switch(TypeFromToken(mdLinkRef)) {
+    switch(TypeFromToken(mdLinkRef))
+    {
     case mdtAssemblyRef:
         {
             if (pAssembly == NULL)
                 return FALSE;
 
             AssemblySpec spec;
-            spec.InitializeSpec(mdLinkRef, GetMDImport(), pAssembly);
+            spec.InitializeSpec(mdLinkRef, pAssembly->GetMDImport(), pAssembly);
             Assembly* pLoadedAssembly = spec.LoadAssembly(FILE_LOADED);
 
             if (dwLocation) {
@@ -574,13 +574,13 @@ BOOL PEAssembly::GetResource(LPCSTR szName, DWORD *cbResource,
                 *dwLocation = *dwLocation | 2; // ResourceLocation.containedInAnotherAssembly
             }
 
-            return GetResource(szName,
-                                cbResource,
-                                pbInMemoryResource,
-                                pAssemblyRef,
-                                szFileName,
-                                dwLocation,
-                                pLoadedAssembly);
+            return pLoadedAssembly->GetResource(
+                        szName,
+                        cbResource,
+                        pbInMemoryResource,
+                        pAssemblyRef,
+                        szFileName,
+                        dwLocation);
         }
 
     case mdtFile:

--- a/src/tests/Loader/ResourceResolve/ManifestResourceAssemblyRef.il
+++ b/src/tests/Loader/ResourceResolve/ManifestResourceAssemblyRef.il
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+}
+
+.assembly extern ResourceAssembly
+{
+  .publickeytoken = (00 00 00 00 00 00 00 00)
+}
+
+.assembly ManifestResourceAssemblyRef { }
+
+.mresource public 'MyResource'
+{
+  .assembly extern 'ResourceAssembly'
+}

--- a/src/tests/Loader/ResourceResolve/ManifestResourceAssemblyRef.ilproj
+++ b/src/tests/Loader/ResourceResolve/ManifestResourceAssemblyRef.ilproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ManifestResourceAssemblyRef.il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/ResourceResolve/ResourceAssembly.csproj
+++ b/src/tests/Loader/ResourceResolve/ResourceAssembly.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource LogicalName="MyResource" Include="$(MSBuildProjectFile)" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/ResourceResolve/ResourceResolve.cs
+++ b/src/tests/Loader/ResourceResolve/ResourceResolve.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+[ConditionalClass(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
+public unsafe class ResourceResolve
+{
+    [Fact]
+    [SkipOnMono("AssemblyRef manifest resource is not supported")]
+    public static void AssemblyRef()
+    {
+        string resourceName = "MyResource";
+        Assembly assembly = typeof(ResourceResolve).Assembly;
+
+        // Manifest resource is not in the current assembly
+        Stream stream = assembly.GetManifestResourceStream(resourceName);
+        Assert.Null(stream);
+
+        // Handler returns assembly with a manifest resource assembly ref that
+        // points to another assembly with the resource
+        ResolveEventHandler handler = (sender, args) =>
+        {
+            if (args.Name == resourceName && args.RequestingAssembly == assembly)
+                return Assembly.Load("ManifestResourceAssemblyRef");
+
+            return null;
+        };
+        AppDomain.CurrentDomain.ResourceResolve += handler;
+        stream = assembly.GetManifestResourceStream(resourceName);
+        AppDomain.CurrentDomain.ResourceResolve -= handler;
+        Assert.NotNull(stream);
+
+        // Verify that the stream matches the expected one in the resource assembly
+        Assembly resourceAssembly = Assembly.Load("ResourceAssembly");
+        Stream expected = resourceAssembly.GetManifestResourceStream(resourceName);
+        Assert.Equal(expected.Length, stream.Length);
+        Span<byte> expectedBytes = new byte[expected.Length];
+        expected.Read(expectedBytes);
+        Span<byte> streamBytes = new byte[stream.Length];
+        stream.Read(streamBytes);
+        Assert.Equal(expectedBytes, streamBytes);
+    }
+}

--- a/src/tests/Loader/ResourceResolve/ResourceResolve.csproj
+++ b/src/tests/Loader/ResourceResolve/ResourceResolve.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="ResourceResolve.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <ProjectReference Include="ManifestResourceAssemblyRef.ilproj" />
+    <ProjectReference Include="ResourceAssembly.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When getting a resource where `ResourceResolve` handler returns an assembly with a manifest resource that is an assembly ref, we incorrectly resolved the reference on the original assembly instead of the assembly returned by the handler and then also looked for the resource on the original assembly again instead of using the referenced assembly.

Added a test for this case using IL. The manifest resource file (as opposed to assembly ref) case is already [covered in libraries tests](https://github.com/dotnet/runtime/blob/6dcd8d192a7998c50e8194e3b4eb9f447c4077fc/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/AppDomainTests.cs#L749).

As called out in #111537, this is a regression in .NET 9 from https://github.com/dotnet/runtime/commit/eae15423f361719fe57e206edc9aea6582357cee.