### PR TITLE
SPMI: Include JIT-EE GUID changes in JIT baseline detection

### DIFF
--- a/src/coreclr/scripts/jitrollingbuild.py
+++ b/src/coreclr/scripts/jitrollingbuild.py
@@ -208,8 +208,8 @@ def process_git_hash_arg(coreclr_args, return_first_hash=False):
         baseline_hash = stdout_git_merge_base.decode('utf-8').strip()
         logging.info("Baseline hash: %s", baseline_hash)
 
-        # Enumerate the last 20 changes, starting with the baseline, that included JIT changes.
-        command = [ "git", "log", "--pretty=format:%H", baseline_hash, "-20", "--", "src/coreclr/jit/*" ]
+        # Enumerate the last 20 changes, starting with the baseline, that included JIT and JIT-EE GUID changes.
+        command = [ "git", "log", "--pretty=format:%H", baseline_hash, "-20", "--", "src/coreclr/jit/*", "src/coreclr/inc/jiteeversionguid.h" ]
         logging.debug("Invoking: {}".format(" ".join(command)))
         proc = subprocess.Popen(command, stdout=subprocess.PIPE)
         stdout_change_list, _ = proc.communicate()
@@ -435,8 +435,8 @@ def upload_command(coreclr_args):
         # from the root of the runtime repo.
 
         with ChangeDir(coreclr_args.runtime_repo_location):
-            # Enumerate the last change, starting with the jit_git_hash, that included JIT changes.
-            command = [ "git", "log", "--pretty=format:%H", jit_git_hash, "-1", "--", "src/coreclr/jit/*" ]
+            # Enumerate the last change, starting with the jit_git_hash, that included JIT and JIT-EE GUID changes.
+            command = [ "git", "log", "--pretty=format:%H", jit_git_hash, "-1", "--", "src/coreclr/jit/*", "src/coreclr/inc/jiteeversionguid.h" ]
             logging.info("Invoking: {}".format(" ".join(command)))
             proc = subprocess.Popen(command, stdout=subprocess.PIPE)
             stdout_change_list, _ = proc.communicate()

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -4357,8 +4357,8 @@ def process_base_jit_path_arg(coreclr_args):
             baseline_hash = coreclr_args.base_git_hash
 
         if coreclr_args.base_git_hash is None:
-            # Enumerate the last 20 changes, starting with the baseline, that included JIT changes.
-            command = [ "git", "log", "--pretty=format:%H", baseline_hash, "-20", "--", "src/coreclr/jit/*" ]
+            # Enumerate the last 20 changes, starting with the baseline, that included JIT and JIT-EE GUID changes.
+            command = [ "git", "log", "--pretty=format:%H", baseline_hash, "-20", "--", "src/coreclr/jit/*", "src/coreclr/inc/jiteeversionguid.h" ]
             logging.debug("Invoking: %s", " ".join(command))
             proc = subprocess.Popen(command, stdout=subprocess.PIPE)
             stdout_change_list, _ = proc.communicate()

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -222,7 +222,16 @@ HRESULT JitInstance::StartUp(char* PathToJit, bool copyJit, bool breakOnDebugBre
         // Mismatched version ID. Fail the load.
         pJitInstance = NULL;
 
-        LogError("Jit Compiler has wrong version identifier");
+        GUID expected = JITEEVersionIdentifier;
+        GUID actual = versionId;
+        LogError("Jit Compiler has wrong version identifier. Expected: %08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x. Actual: %08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x.",
+                 expected.Data1, expected.Data2, expected.Data3, 
+                 expected.Data4[0], expected.Data4[1], expected.Data4[2], expected.Data4[3],
+                 expected.Data4[4], expected.Data4[5], expected.Data4[6], expected.Data4[7],
+                 actual.Data1, actual.Data2, actual.Data3, 
+                 actual.Data4[0], actual.Data4[1], actual.Data4[2], actual.Data4[3],
+                 actual.Data4[4], actual.Data4[5], actual.Data4[6], actual.Data4[7]);
+                 
         return -1;
     }
 


### PR DESCRIPTION
fb67dbab4f50402a92a0a42a6c4254df304b4bbb changed the JIT-EE GUID, but it includes no changes under src/coreclr/jit/*. The result is that jitrollingbuild built a JIT on that version but overrode the JIT on the parent commit 7060c62203d056f074e7d43f96fd43c37a19d4a2 with it. That means the JIT for 7060c62203d056f074e7d43f96fd43c37a19d4a2 now has a wrong JIT-EE GUID.

Fix the baseline detection so that it includes changes in the JIT-EE GUID. Also log the GUIDs when there is a mismatch in SPMI.