### PR TITLE
Fix an edge case in the Tarjan GC bridge that leads to losing xref information

### DIFF
--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -785,8 +785,11 @@ create_scc (ScanData *data)
 
 		// Maybe we should make sure we are not adding duplicates here. It is not really a problem
 		// since we will get rid of duplicates before submitting the SCCs to the client in gather_xrefs
-		if (color_data)
+		if (color_data) {
 			add_other_colors (color_data, &other->xrefs);
+		} else {
+			g_assert (dyn_array_ptr_size (&other->xrefs) == 0);
+		}
 		dyn_array_ptr_uninit (&other->xrefs);
 
 		if (other == data) {

--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -736,10 +736,16 @@ create_scc (ScanData *data)
 	gboolean found = FALSE;
 	gboolean found_bridge = FALSE;
 	ColorData *color_data = NULL;
+	gboolean can_reduce_color = TRUE;
 
 	for (i = dyn_array_ptr_size (&loop_stack) - 1; i >= 0; --i) {
 		ScanData *other = (ScanData *)dyn_array_ptr_get (&loop_stack, i);
-		found_bridge |= other->is_bridge || dyn_array_ptr_size (&other->xrefs) > 0;
+		found_bridge |= other->is_bridge;
+		if (dyn_array_ptr_size (&other->xrefs) > 0) {
+			// This scc will have more xrefs than the ones from the color_merge_array,
+			// we will need to create a new color to store this information.
+			can_reduce_color = FALSE;
+		}
 		if (found_bridge || other == data)
 			break;
 	}
@@ -747,8 +753,10 @@ create_scc (ScanData *data)
 	if (found_bridge) {
 		color_data = new_color (TRUE);
 		++num_colors_with_bridges;
-	} else {
+	} else if (can_reduce_color) {
 		color_data = reduce_color ();
+	} else {
+		color_data = new_color (FALSE);
 	}
 #if DUMP_GRAPH
 	printf ("|SCC %p rooted in %s (%p) has bridge %d\n", color_data, safe_name_bridge (data->obj), data->obj, found_bridge);

--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -739,7 +739,7 @@ create_scc (ScanData *data)
 
 	for (i = dyn_array_ptr_size (&loop_stack) - 1; i >= 0; --i) {
 		ScanData *other = (ScanData *)dyn_array_ptr_get (&loop_stack, i);
-		found_bridge |= other->is_bridge;
+		found_bridge |= other->is_bridge || dyn_array_ptr_size (&other->xrefs) > 0;
 		if (found_bridge || other == data)
 			break;
 	}

--- a/src/mono/mono/tests/sgen-bridge-pathologies.cs
+++ b/src/mono/mono/tests/sgen-bridge-pathologies.cs
@@ -18,11 +18,6 @@ public class NonBridge
 	public object Link;
 }
 
-public class NonBridge2 : NonBridge
-{
-	public object Link2;
-}
-
 class Driver {
 	const int OBJ_COUNT = 200 * 1000;
 	const int LINK_COUNT = 2;
@@ -212,32 +207,6 @@ class Driver {
 		c.Links.Add (last_level);
 	}
 
-	/*
-	 * Simulates a graph with two nested cycles that is produces by
-	 * the async state machine when `async Task M()` method gets its
-	 * continuation rooted by an Action held by RunnableImplementor
-	 * (ie. the task continuation is hooked through the SynchronizationContext
-	 * implentation and rooted only by Android bridge objects).
-	 */
-	static void NestedCycles ()
-	{ 
-		Bridge runnableImplementor = new Bridge ();
-		Bridge byteArrayOutputStream = new Bridge ();
-		NonBridge2 action = new NonBridge2 ();
-		NonBridge displayClass = new NonBridge ();
-		NonBridge2 asyncStateMachineBox = new NonBridge2 ();
-		NonBridge2 asyncStreamWriter = new NonBridge2 ();
-
-		runnableImplementor.Links.Add(action);
-		action.Link = displayClass;
-		action.Link2 = asyncStateMachineBox;
-		displayClass.Link = action;
-		asyncStateMachineBox.Link = asyncStreamWriter;
-		asyncStateMachineBox.Link2 = action;
-		asyncStreamWriter.Link = byteArrayOutputStream;
-		asyncStreamWriter.Link2 = asyncStateMachineBox;
-	}
-
 	static void RunTest (ThreadStart setup)
 	{
 		var t = new Thread (setup);
@@ -262,7 +231,6 @@ class Driver {
 		RunTest (SetupDeadList);
 		RunTest (SetupSelfLinks);
 		RunTest (Spider);
-		RunTest (NestedCycles);
 
 		for (int i = 0; i < 0; ++i) {
 			GC.Collect ();

--- a/src/mono/mono/tests/sgen-bridge-pathologies.cs
+++ b/src/mono/mono/tests/sgen-bridge-pathologies.cs
@@ -18,6 +18,11 @@ public class NonBridge
 	public object Link;
 }
 
+public class NonBridge2 : NonBridge
+{
+	public object Link2;
+}
+
 class Driver {
 	const int OBJ_COUNT = 200 * 1000;
 	const int LINK_COUNT = 2;
@@ -207,6 +212,32 @@ class Driver {
 		c.Links.Add (last_level);
 	}
 
+	/*
+	 * Simulates a graph with two nested cycles that is produces by
+	 * the async state machine when `async Task M()` method gets its
+	 * continuation rooted by an Action held by RunnableImplementor
+	 * (ie. the task continuation is hooked through the SynchronizationContext
+	 * implentation and rooted only by Android bridge objects).
+	 */
+	static void NestedCycles ()
+	{ 
+		Bridge runnableImplementor = new Bridge ();
+		Bridge byteArrayOutputStream = new Bridge ();
+		NonBridge2 action = new NonBridge2 ();
+		NonBridge displayClass = new NonBridge ();
+		NonBridge2 asyncStateMachineBox = new NonBridge2 ();
+		NonBridge2 asyncStreamWriter = new NonBridge2 ();
+
+		runnableImplementor.Links.Add(action);
+		action.Link = displayClass;
+		action.Link2 = asyncStateMachineBox;
+		displayClass.Link = action;
+		asyncStateMachineBox.Link = asyncStreamWriter;
+		asyncStateMachineBox.Link2 = action;
+		asyncStreamWriter.Link = byteArrayOutputStream;
+		asyncStreamWriter.Link2 = asyncStateMachineBox;
+	}
+
 	static void RunTest (ThreadStart setup)
 	{
 		var t = new Thread (setup);
@@ -231,6 +262,7 @@ class Driver {
 		RunTest (SetupDeadList);
 		RunTest (SetupSelfLinks);
 		RunTest (Spider);
+		RunTest (NestedCycles);
 
 		for (int i = 0; i < 0; ++i) {
 			GC.Collect ();

--- a/src/tests/GC/Features/Bridge/Bridge.cs
+++ b/src/tests/GC/Features/Bridge/Bridge.cs
@@ -385,7 +385,7 @@ public class BridgeTest
 
         RunGraphTest(SetupDeadList);
         RunGraphTest(SetupSelfLinks);
-//        RunGraphTest(NestedCycles); // Fixed by Filip
+        RunGraphTest(NestedCycles);
 //        RunGraphTest(Spider); // Crashes
         return 100;
     }


### PR DESCRIPTION
In the Tarjan SCC bridge processing there's a color graph used to find out connections between SCCs. There was a rare case which only manifested when a cycle in the object graph points to another cycle that points to a bridge object. We only recognized direct bridge pointers but not pointers to other non-bridge SCCs that in turn point to bridges and where we already calculated the xrefs. These xrefs were then lost.

Consider the following object graph:
```mermaid
flowchart TB
    subgraph InnerSCC["Inner SCC"]
        AsyncStreamWriter["&lt;AsyncStreamWriter&gt;d__2"]
        AsyncStateMachineBox["AsyncStateMachineBox`1"]
    end
    subgraph OuterSCC["Outer SCC"]
        c__DisplayClass2_0["&lt;&gt;c__DisplayClass2_0"]
        Action
        InnerSCC
    end
    RunnableImplementor --> Action
    Action --> c__DisplayClass2_0 & AsyncStateMachineBox
    c__DisplayClass2_0 --> Action
    AsyncStateMachineBox --> Action & AsyncStreamWriter
    AsyncStreamWriter --> AsyncStateMachineBox & ByteArrayOutputStream
    
    style RunnableImplementor stroke-dasharray:2
    style ByteArrayOutputStream stroke-dasharray:2
```

`RunnableImplementor` and `ByteArrayOutputStream` are bridge objects that are eligible for collection on the .NET side. 

`ByteArrayOutputStream` is assigned a color in the color graph. We start traversing the graph through depth first search from `RunnableImplementor` to find the strongly connected components using the Tarjan algorithm. Once we discover the link from `<>c__DisplayClass2_0` to `ByteArrayOutputStream` we make a note of the color that needs to be recorded in the color graph to produce an xref. We then exit the recursion and find that `Inner SCC` forms a strongly connected component and we merge all the recorded colors into `[AsyncStateMachineBox'1]->xref` array. Then we proceed to continue with the Tarjan algorithm which eventually finds the `Outer SCC`. Once again we want to merge all the colors of the nodes in the outer SCC. The implementation assumes that there could be any links in the color graph only if any objects in the SCC point to a bridge object. However, it failed to consider that `Inner SCC`'s nodes were already processed and contain the summary information in `node->xref` field. If there were any other links to bridge objects it would still allocate a color for the `Outer SCC` and behave correctly. However, if there are no other links to bridge objects in the reminder of `Outer SCC` it would fail to allocate a color and silently drop the `node->xref` list on any contained node.

Fixes https://github.com/dotnet/runtime/issues/115611
Ref https://github.com/dotnet/android/pull/9789 for discussion on the root cause