### PR TITLE
Check for an empty string for the TimeZoneDirectory environment variable

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -613,7 +613,7 @@ namespace System
         {
             string? tzDirectory = Environment.GetEnvironmentVariable(TimeZoneDirectoryEnvironmentVariable);
 
-            if (tzDirectory == null)
+            if (tzDirectory == null || srting.IsNullOrEmpty(tzDirectory))
             {
                 tzDirectory = DefaultTimeZoneDirectory;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -613,7 +613,7 @@ namespace System
         {
             string? tzDirectory = Environment.GetEnvironmentVariable(TimeZoneDirectoryEnvironmentVariable);
 
-            if (tzDirectory == null || srting.IsNullOrEmpty(tzDirectory))
+            if (string.IsNullOrEmpty(tzDirectory))
             {
                 tzDirectory = DefaultTimeZoneDirectory;
             }


### PR DESCRIPTION
If the value of ```tzDirectory``` is an empty string, it may cause a problem where the root path is searched with ```/``` appended. Therefore, this PR changes it to set a default value when the value of ```tzDirectory``` is an empty string.