### PR TITLE
Disable interpreter test on native AOT

### DIFF
--- a/src/tests/JIT/interpreter/InterpreterTester.csproj
+++ b/src/tests/JIT/interpreter/InterpreterTester.csproj
@@ -3,6 +3,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
     <DisableProjectBuild Condition="'$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64'">true</DisableProjectBuild>
+    <!-- Interpreter is CoreCLR-VM specific -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InterpreterTester.cs" />


### PR DESCRIPTION
Test is broken in native AOT testing.