### PR TITLE
Fix `BigInteger.Rotate{Left,Right}`

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -15,6 +15,7 @@
     <Compile Include="System\Numerics\BigIntegerCalculator.GcdInv.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.PowMod.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.SquMul.cs" />
+    <Compile Include="System\Numerics\BigIntegerCalculator.ShiftRot.cs" />
     <Compile Include="System\Numerics\BigIntegerCalculator.Utils.cs" />
     <Compile Include="System\Numerics\BigInteger.cs" />
     <Compile Include="System\Number.BigInteger.cs" />

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Numerics
+{
+    internal static partial class BigIntegerCalculator
+    {
+        public static void RotateLeft(Span<uint> bits, long rotateLeftAmount)
+        {
+            Debug.Assert(Math.Abs(rotateLeftAmount) <= 0x80000000);
+
+            const int digitShiftMax = (int)(0x80000000 / 32);
+
+            int digitShift = digitShiftMax;
+            int smallShift = 0;
+
+            if (rotateLeftAmount < 0)
+            {
+                if (rotateLeftAmount != -0x80000000)
+                    (digitShift, smallShift) = Math.DivRem(-(int)rotateLeftAmount, 32);
+
+                RotateRight(bits, digitShift % bits.Length, smallShift);
+            }
+            else
+            {
+                if (rotateLeftAmount != 0x80000000)
+                    (digitShift, smallShift) = Math.DivRem((int)rotateLeftAmount, 32);
+
+                RotateLeft(bits, digitShift % bits.Length, smallShift);
+            }
+        }
+
+        public static void RotateLeft(Span<uint> bits, int digitShift, int smallShift)
+        {
+            Debug.Assert(bits.Length > 0);
+
+            LeftShiftSelf(bits, smallShift, out uint carry);
+            bits[0] |= carry;
+
+            if (digitShift == 0)
+                return;
+
+            SwapUpperAndLower(bits, bits.Length - digitShift);
+        }
+
+        public static void RotateRight(Span<uint> bits, int digitShift, int smallShift)
+        {
+            Debug.Assert(bits.Length > 0);
+
+            RightShiftSelf(bits, smallShift, out uint carry);
+            bits[^1] |= carry;
+
+            if (digitShift == 0)
+                return;
+
+            SwapUpperAndLower(bits, digitShift);
+        }
+
+        private static void SwapUpperAndLower(Span<uint> bits, int lowerLength)
+        {
+            Debug.Assert(lowerLength > 0);
+            Debug.Assert(lowerLength < bits.Length);
+
+            int upperLength = bits.Length - lowerLength;
+
+            Span<uint> lower = bits.Slice(0, lowerLength);
+            Span<uint> upper = bits.Slice(lowerLength);
+
+            Span<uint> lowerDst = bits.Slice(upperLength);
+
+            int tmpLength = Math.Min(lowerLength, upperLength);
+            uint[]? tmpFromPool = null;
+            Span<uint> tmp = ((uint)tmpLength <= StackAllocThreshold ?
+                                  stackalloc uint[StackAllocThreshold]
+                                  : tmpFromPool = ArrayPool<uint>.Shared.Rent(tmpLength)).Slice(0, tmpLength);
+
+            if (upperLength < lowerLength)
+            {
+                upper.CopyTo(tmp);
+                lower.CopyTo(lowerDst);
+                tmp.CopyTo(bits);
+            }
+            else
+            {
+                lower.CopyTo(tmp);
+                upper.CopyTo(bits);
+                tmp.CopyTo(lowerDst);
+            }
+
+            if (tmpFromPool != null)
+                ArrayPool<uint>.Shared.Return(tmpFromPool);
+        }
+
+        public static void LeftShiftSelf(Span<uint> bits, int shift, out uint carry)
+        {
+            Debug.Assert((uint)shift < 32);
+
+            carry = 0;
+            if (shift == 0)
+                return;
+
+            int back = 32 - shift;
+            for (int i = 0; i < bits.Length; i++)
+            {
+                uint value = carry | bits[i] << shift;
+                carry = bits[i] >> back;
+                bits[i] = value;
+            }
+        }
+        public static void RightShiftSelf(Span<uint> bits, int shift, out uint carry)
+        {
+            Debug.Assert((uint)shift < 32);
+
+            carry = 0;
+            if (shift == 0)
+                return;
+
+            int back = 32 - shift;
+            for (int i = bits.Length - 1; i >= 0; i--)
+            {
+                uint value = carry | bits[i] >> shift;
+                carry = bits[i] << back;
+                bits[i] = value;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
@@ -107,23 +108,37 @@ namespace System.Numerics
             // where A = ~X and B = -Y
 
             // Trim trailing 0s (at the first in little endian array)
-            d = d.TrimStart(0u);
+            int i = d.IndexOfAnyExcept(0u);
+
+            if ((uint)i >= (uint)d.Length)
+            {
+                return;
+            }
 
             // Make the first non-zero element to be two's complement
-            if (d.Length > 0)
-            {
-                d[0] = (uint)(-(int)d[0]);
-                d = d.Slice(1);
-            }
+            d[i] = (uint)(-(int)d[i]);
+            d = d.Slice(i + 1);
 
             if (d.IsEmpty)
             {
                 return;
             }
 
-            // Make one's complement for other elements
-            int offset = 0;
+            DangerousMakeOnesComplement(d);
+        }
 
+        // Do an in-place one's complement. "Dangerous" because it causes
+        // a mutation and needs to be used with care for immutable types.
+        public static void DangerousMakeOnesComplement(Span<uint> d)
+        {
+            // Given a number:
+            //     XXXXXXXXXXX
+            // where Y is non-zero,
+            // The result of one's complement is
+            //     AAAAAAAAAAA
+            // where A = ~X
+
+            int offset = 0;
             ref uint start = ref MemoryMarshal.GetReference(d);
 
             while (Vector512.IsHardwareAccelerated && d.Length - offset >= Vector512<uint>.Count)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/Rotate.cs
@@ -1,0 +1,629 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Numerics.Tests
+{
+    public abstract class RotateTestBase
+    {
+        public abstract string opstring { get; }
+        private static int s_samples = 10;
+        private static Random s_random = new Random(100);
+
+        [Fact]
+        public void RunRotateTests()
+        {
+            byte[] tempByteArray1;
+            byte[] tempByteArray2;
+
+            // Rotate Method - Large BigIntegers - large + Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = GetRandomPosByteArray(s_random, 2);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Large BigIntegers - small + Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Large BigIntegers - 32 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = new byte[] { (byte)32 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - All One Uint Large BigIntegers - 32 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomLengthAllOnesUIntByteArray(s_random);
+                tempByteArray2 = new byte[] { (byte)32 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Uint 0xffffffff 0x8000000 ... Large BigIntegers - 32 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomLengthFirstUIntMaxSecondUIntMSBMaxArray(s_random);
+                tempByteArray2 = new byte[] { (byte)32 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Large BigIntegers - large - Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = GetRandomNegByteArray(s_random, 2);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Large BigIntegers - small - Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = new byte[] { unchecked((byte)s_random.Next(-31, 0)) };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Large BigIntegers - -32 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = new byte[] { (byte)0xe0 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Large BigIntegers - 0 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random);
+                tempByteArray2 = new byte[] { (byte)0 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Small BigIntegers - large + Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = GetRandomPosByteArray(s_random, 2);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Small BigIntegers - small + Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = new byte[] { (byte)s_random.Next(1, 32) };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Small BigIntegers - 32 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = new byte[] { (byte)32 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+            // Rotate Method - Small BigIntegers - large - Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = GetRandomNegByteArray(s_random, 2);
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Small BigIntegers - small - Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = new byte[] { unchecked((byte)s_random.Next(-31, 0)) };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Small BigIntegers - -32 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = new byte[] { (byte)0xe0 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Small BigIntegers - 0 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomByteArray(s_random, 2);
+                tempByteArray2 = new byte[] { (byte)0 };
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Positive BigIntegers - Shift to 0
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomPosByteArray(s_random, 100);
+                tempByteArray2 = BitConverter.GetBytes(s_random.Next(8 * tempByteArray1.Length, 1000));
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray2);
+                }
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+
+            // Rotate Method - Negative BigIntegers - Shift to -1
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomNegByteArray(s_random, 100);
+                tempByteArray2 = BitConverter.GetBytes(s_random.Next(8 * tempByteArray1.Length, 1000));
+                if (!BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempByteArray2);
+                }
+                VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+            }
+        }
+
+        [Fact]
+        public void RunSmallTests()
+        {
+            foreach (int i in new int[] {
+                    0,
+                    1,
+                    16,
+                    31,
+                    32,
+                    33,
+                    63,
+                    64,
+                    65,
+                    100,
+                    127,
+                    128,
+            })
+            {
+                foreach (int shift in new int[] {
+                    0,
+                    -1, 1,
+                    -16, 16,
+                    -31, 31,
+                    -32, 32,
+                    -33, 33,
+                    -63, 63,
+                    -64, 64,
+                    -65, 65,
+                    -100, 100,
+                    -127, 127,
+                    -128, 128,
+                })
+                {
+                    var num = Int128.One << i;
+                    for (int k = -1; k <= 1; k++)
+                    {
+                        foreach (int sign in new int[] { -1, +1 })
+                        {
+                            Int128 value128 = sign * (num + k);
+
+                            byte[] tempByteArray1 = GetRandomSmallByteArray(value128);
+                            byte[] tempByteArray2 = GetRandomSmallByteArray(shift);
+
+                            VerifyRotateString(Print(tempByteArray2) + Print(tempByteArray1) + opstring);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void VerifyRotateString(string opstring)
+        {
+            StackCalc sc = new StackCalc(opstring);
+            while (sc.DoNextOperation())
+            {
+                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
+            }
+        }
+
+        private static byte[] GetRandomSmallByteArray(Int128 num)
+        {
+            byte[] value = new byte[16];
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                value[i] = (byte)num;
+                num >>= 8;
+            }
+
+            return value;
+        }
+
+        private static byte[] GetRandomByteArray(Random random)
+        {
+            return GetRandomByteArray(random, random.Next(0, 1024));
+        }
+
+        private static byte[] GetRandomByteArray(Random random, int size)
+        {
+            return MyBigIntImp.GetRandomByteArray(random, size);
+        }
+
+        private static byte[] GetRandomPosByteArray(Random random, int size)
+        {
+            byte[] value = new byte[size];
+
+            for (int i = 0; i < value.Length; ++i)
+            {
+                value[i] = (byte)random.Next(0, 256);
+            }
+            value[value.Length - 1] &= 0x7F;
+
+            return value;
+        }
+
+        private static byte[] GetRandomNegByteArray(Random random, int size)
+        {
+            byte[] value = new byte[size];
+
+            for (int i = 0; i < value.Length; ++i)
+            {
+                value[i] = (byte)random.Next(0, 256);
+            }
+            value[value.Length - 1] |= 0x80;
+
+            return value;
+        }
+
+        private static byte[] GetRandomLengthAllOnesUIntByteArray(Random random)
+        {
+            int gap = random.Next(0, 128);
+            int byteLength = 4 + gap * 4 + 1;
+            byte[] array = new byte[byteLength];
+            array[0] = 1;
+            array[^1] = 0xFF;
+            return array;
+        }
+        private static byte[] GetRandomLengthFirstUIntMaxSecondUIntMSBMaxArray(Random random)
+        {
+            int gap = random.Next(0, 128);
+            int byteLength = 4 + gap * 4 + 1;
+            byte[] array = new byte[byteLength];
+            array[^5] = 0x80;
+            array[^1] = 0xFF;
+            return array;
+        }
+
+        private static string Print(byte[] bytes)
+        {
+            return MyBigIntImp.Print(bytes);
+        }
+    }
+
+    public class RotateLeftTest : RotateTestBase
+    {
+        public override string opstring => "bRotateLeft";
+
+
+        public static TheoryData<BigInteger, int, BigInteger> NegativeNumber_TestData = new TheoryData<BigInteger, int, BigInteger>
+        {
+
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0000)),
+                1,
+                new BigInteger(unchecked((long)0xFFFF_FFFE_0000_0001))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0000)),
+                2,
+                new BigInteger(unchecked((long)0xFFFF_FFFC_0000_0003))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0001)),
+                1,
+                new BigInteger(unchecked((long)0xFFFF_FFFE_0000_0003))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0001)),
+                2,
+                new BigInteger(unchecked((long)0xFFFF_FFFC_0000_0007))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0002)),
+                1,
+                new BigInteger(unchecked((long)0xFFFF_FFFE_0000_0005))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0002)),
+                2,
+                new BigInteger(unchecked((long)0xFFFF_FFFC_0000_000B))
+            },
+
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0000)),
+                1,
+                new BigInteger(0x1)
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0000)),
+                2,
+                new BigInteger(0x2)
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0001)),
+                1,
+                new BigInteger(0x3)
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0001)),
+                2,
+                new BigInteger(0x6)
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0002)),
+                1,
+                new BigInteger(0x5)
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0002)),
+                2,
+                new BigInteger(0xA)
+            },
+
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                new BigInteger(0x1)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                new BigInteger(0x2)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                new BigInteger(0x3)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                new BigInteger(0x6)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                new BigInteger(0x5)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                new BigInteger(0xA)
+            },
+
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("________E_0000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("________C_0000_0000_0000_0000_0000_0003".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("________E_0000_0000_0000_0000_0000_0003".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("________C_0000_0000_0000_0000_0000_0007".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("________E_0000_0000_0000_0000_0000_0005".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("________C_0000_0000_0000_0000_0000_000B".Replace("_", ""), NumberStyles.HexNumber)
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(NegativeNumber_TestData))]
+        public void NegativeNumber(BigInteger input, int rotateAmount, BigInteger expected)
+        {
+            Assert.Equal(expected, BigInteger.RotateLeft(input, rotateAmount));
+        }
+
+        [Fact]
+        public void PowerOfTwo()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                foreach (int k in new int[] { 1, 2, 3, 10 })
+                {
+                    BigInteger plus = BigInteger.One << (32 * k + i);
+                    BigInteger minus = BigInteger.MinusOne << (32 * k + i);
+
+                    Assert.Equal(BigInteger.One << (i == 31 ? 0 : (32 * k + i + 1)), BigInteger.RotateLeft(plus, 1));
+                    Assert.Equal(BigInteger.One << i, BigInteger.RotateLeft(plus, 32));
+                    Assert.Equal(BigInteger.One << (32 * (k - 1) + i), BigInteger.RotateLeft(plus, 32 * k));
+
+                    Assert.Equal(i == 31 ? BigInteger.One : (new BigInteger(-1 << (i + 1)) << 32 * k) + 1,
+                        BigInteger.RotateLeft(minus, 1));
+                    Assert.Equal(new BigInteger(uint.MaxValue << i), BigInteger.RotateLeft(minus, 32));
+                    Assert.Equal(new BigInteger(uint.MaxValue << i) << (32 * (k - 1)), BigInteger.RotateLeft(minus, 32 * k));
+                }
+            }
+        }
+    }
+
+    public class RotateRightTest : RotateTestBase
+    {
+        public override string opstring => "bRotateRight";
+
+        public static TheoryData<BigInteger, int, BigInteger> NegativeNumber_TestData = new TheoryData<BigInteger, int, BigInteger>
+        {
+
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0000)),
+                1,
+                new BigInteger(unchecked((long)0x7FFF_FFFF_8000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0000)),
+                2,
+                new BigInteger(unchecked((long)0x3FFF_FFFF_C000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0001)),
+                1,
+                new BigInteger(unchecked((int)0x8000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0001)),
+                2,
+                new BigInteger(unchecked((long)0x7FFF_FFFF_C000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0002)),
+                1,
+                new BigInteger(unchecked((long)0x7FFF_FFFF_8000_0001))
+            },
+            {
+                new BigInteger(unchecked((long)0xFFFF_FFFF_0000_0002)),
+                2,
+                new BigInteger(unchecked((long)0xBFFF_FFFF_C000_0000))
+            },
+
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0000)),
+                1,
+                new BigInteger(unchecked((long)0x4000_0000_0000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0000)),
+                2,
+                new BigInteger(unchecked((long)0x2000_0000_0000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0001)),
+                1,
+                new BigInteger(unchecked((long)0xC000_0000_0000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0001)),
+                2,
+                new BigInteger(unchecked((long)0x6000_0000_0000_0000))
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0002)),
+                1,
+                new BigInteger(unchecked((long)0x4000_0000_0000_0001))
+            },
+            {
+                new BigInteger(unchecked((long)0x8000_0000_0000_0002)),
+                2,
+                new BigInteger(unchecked((long)0xA000_0000_0000_0000))
+            },
+
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("4000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("2000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("C000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("6000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("4000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("8000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("A000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("7FFF_FFFF_8000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("3FFF_FFFF_C000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("__________8000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("7FFF_FFFF_C000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                1,
+                BigInteger.Parse("7FFF_FFFF_8000_0000_0000_0000_0000_0001".Replace("_", ""), NumberStyles.HexNumber)
+            },
+            {
+                BigInteger.Parse("________F_0000_0000_0000_0000_0000_0002".Replace("_", ""), NumberStyles.HexNumber),
+                2,
+                BigInteger.Parse("BFFF_FFFF_C000_0000_0000_0000_0000_0000".Replace("_", ""), NumberStyles.HexNumber)
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(NegativeNumber_TestData))]
+        public void NegativeNumber(BigInteger input, int rotateAmount, BigInteger expected)
+        {
+            Assert.Equal(expected, BigInteger.RotateRight(input, rotateAmount));
+        }
+
+        [Fact]
+        public void PowerOfTwo()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                foreach (int k in new int[] { 1, 2, 3, 10 })
+                {
+                    BigInteger plus = BigInteger.One << (32 * k + i);
+                    BigInteger minus = BigInteger.MinusOne << (32 * k + i);
+
+                    Assert.Equal(BigInteger.One << (32 * k + i - 1), BigInteger.RotateRight(plus, 1));
+                    Assert.Equal(BigInteger.One << (32 * (k - 1) + i), BigInteger.RotateRight(plus, 32));
+                    Assert.Equal(BigInteger.One << i, BigInteger.RotateRight(plus, 32 * k));
+
+                    Assert.Equal(new BigInteger(uint.MaxValue << i) << (32 * k - 1), BigInteger.RotateRight(minus, 1));
+                    Assert.Equal(new BigInteger(uint.MaxValue << i) << (32 * (k - 1)), BigInteger.RotateRight(minus, 32));
+                    Assert.Equal(new BigInteger(uint.MaxValue << i), BigInteger.RotateRight(minus, 32 * k));
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/stackcalculator.cs
@@ -193,6 +193,10 @@ namespace System.Numerics.Tests
                     return num1 >> (int)num2;
                 case "b<<":
                     return num1 << (int)num2;
+                case "bRotateLeft":
+                    return BigInteger.RotateLeft(num1, (int)num2);
+                case "bRotateRight":
+                    return BigInteger.RotateRight(num1, (int)num2);
                 case "b^":
                     return num1 ^ num2;
                 case "b|":
@@ -254,7 +258,7 @@ namespace System.Numerics.Tests
 
         private static string Print(byte[] bytes)
         {
-           return MyBigIntImp.PrintFormatX(bytes);
+            return MyBigIntImp.PrintFormatX(bytes);
         }
     }
 }

--- a/src/libraries/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/libraries/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="BigInteger\op_multiply.cs" />
     <Compile Include="BigInteger\op_not.cs" />
     <Compile Include="BigInteger\op_or.cs" />
+    <Compile Include="BigInteger\Rotate.cs" />
     <Compile Include="BigInteger\op_rightshift.cs" />
     <Compile Include="BigInteger\op_xor.cs" />
     <Compile Include="BigInteger\parse.cs" />


### PR DESCRIPTION
Fix #112854

- Fixed the logic of RotateRight.
- Fixed a bug that caused incorrect two’s complement computation for negative numbers with the most significant bit set in RotateRight and RotateLeft. 

I reused the code from #112632.

## Benchmark

<details>

<summary>Code</summary>

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using System.Numerics;

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class RotateTest
{
    const int shiftSize = (1 << 23) + 13;
    BigInteger positive, negative;

    [GlobalSetup]
    public void Setup()
    {
        var bytes = new byte[1 << 25];
        new Random(227).NextBytes(bytes);
        positive = new BigInteger(bytes, isUnsigned: true);
        negative = -positive;
    }

    [Benchmark] public BigInteger PositiveRotateLeft() => BigInteger.RotateLeft(positive, shiftSize);
    [Benchmark] public BigInteger NegativeRotateLeft() => BigInteger.RotateLeft(negative, shiftSize);

    [Benchmark] public BigInteger PositiveRotateRight() => BigInteger.RotateRight(positive, shiftSize);
    [Benchmark] public BigInteger NegativeRotateRight() => BigInteger.RotateRight(negative, shiftSize);
}
```
</details>

```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3194)
13th Gen Intel Core i5-13500, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.100-alpha.1.25077.2
  [Host]     : .NET 10.0.0 (10.0.25.7313), X64 RyuJIT AVX2
  Job-JFZQTT : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-RFISUH : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2


```
| Method              | Toolchain         | Mean     | Ratio | Gen0     | Gen1     | Gen2     | Allocated | Alloc Ratio |
|-------------------- |------------------ |---------:|------:|---------:|---------:|---------:|----------:|------------:|
| PositiveRotateLeft  | \main\corerun.exe | 19.15 ms |  1.00 | 156.2500 | 156.2500 | 156.2500 |     33 MB |        1.00 |
| PositiveRotateLeft  | \pr\corerun.exe   | 14.10 ms |  0.61 | 218.7500 | 218.7500 | 218.7500 |  32.69 MB |        0.99 |
|                     |                   |          |       |          |          |          |           |             |
| NegativeRotateLeft  | \main\corerun.exe | 19.35 ms |  1.00 | 156.2500 | 156.2500 | 156.2500 |     33 MB |        1.00 |
| NegativeRotateLeft  | \pr\corerun.exe   | 18.59 ms |  0.96 | 218.7500 | 218.7500 | 218.7500 |  33.25 MB |        1.01 |
|                     |                   |          |       |          |          |          |           |             |
| PositiveRotateRight | \main\corerun.exe | 14.93 ms |  1.00 | 156.2500 | 156.2500 | 156.2500 |   32.5 MB |        1.00 |
| PositiveRotateRight | \pr\corerun.exe   | 14.07 ms |  0.94 | 234.3750 | 234.3750 | 234.3750 |  32.73 MB |        1.01 |
|                     |                   |          |       |          |          |          |           |             |
| NegativeRotateRight | \main\corerun.exe | 16.92 ms |  1.00 | 156.2500 | 156.2500 | 156.2500 |     33 MB |        1.00 |
| NegativeRotateRight | \pr\corerun.exe   | 16.43 ms |  0.97 | 218.7500 | 218.7500 | 218.7500 |  33.25 MB |        1.01 |
