### PR TITLE
Fix doc typo

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -24,7 +24,7 @@ namespace System.DirectoryServices.Protocols
         /// which can be done by using <code>openssl rehash .</code> or <code>c_rehash .</code> in the directory
         /// containing the certificate files.
         /// </remarks>
-        /// <exception cref="DirectoryNotFoundException">The directory not exist.</exception>
+        /// <exception cref="DirectoryNotFoundException">The directory does not exist.</exception>
         [UnsupportedOSPlatform("windows")]
         public string TrustedCertificatesDirectory
         {


### PR DESCRIPTION
Fix recently introduced typo in https://github.com/dotnet/runtime/pull/111877. Found by copilot.