### PR TITLE
Seed in the skeleton of ML-DSA based on current prototyping

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -314,3 +314,4 @@ Diagnostic id values for experimental APIs must not be recycled, as that could s
 |  __`SYSLIB5003`__ |     .NET 9 |     TBD | `System.Runtime.Intrinsics.Arm.Sve` is experimental |
 |  __`SYSLIB5004`__ |     .NET 9 |     TBD | `X86Base.DivRem` is experimental since performance is not as optimized as `T.DivRem` |
 |  __`SYSLIB5005`__ |     .NET 9 |     TBD | `System.Formats.Nrbf` is experimental |
+|  __`SYSLIB5006`__ |    .NET 10 |     TBD | Types for Post-Quantum Cryptography (PQC) are experimental. |

--- a/src/libraries/Common/src/System/Experimentals.cs
+++ b/src/libraries/Common/src/System/Experimentals.cs
@@ -31,6 +31,9 @@ namespace System
         // System.Formats.Nrbf is experimental
         internal const string NrbfDecoderDiagId = "SYSLIB5005";
 
+        // Types for Post-Quantum Cryptography (PQC) are experimental.
+        internal const string PostQuantumCryptographyDiagId = "SYSLIB5006";
+
         // When adding a new diagnostic ID, add it to the table in docs\project\list-of-diagnostics.md as well.
         // Keep new const identifiers above this comment.
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/IImportExportShape.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/IImportExportShape.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Security.Cryptography
+{
+#if DESIGNTIMEINTERFACES
+    internal interface IImportExportShape<TSelf> where TSelf : class, IImportExportShape<TSelf>
+    {
+        static abstract bool TryImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
+        static abstract bool TryImportPkcs8PrivateKey(ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
+        static abstract bool TryImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
+        static abstract bool TryImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password, ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
+
+        static abstract TSelf ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source);
+        static abstract TSelf ImportPkcs8PrivateKey(ReadOnlySpan<byte> source);
+        static abstract TSelf ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source);
+        static abstract TSelf ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source);
+
+        static abstract bool TryImportFromPem(
+            ReadOnlySpan<char> source, [NotNullWhen(true)] out TSelf? imported);
+        static abstract bool TryImportFromEncryptedPem(
+            ReadOnlySpan<char> source, ReadOnlySpan<char> password, [NotNullWhen(true)] out TSelf? imported);
+        static abstract bool TryImportFromEncryptedPem(
+            ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes, [NotNullWhen(true)] out TSelf? imported);
+
+        static abstract TSelf ImportFromPem(ReadOnlySpan<char> source);
+        static abstract TSelf ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password);
+        static abstract TSelf ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes);
+
+        byte[] ExportSubjectPublicKeyInfo();
+        bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten);
+        string ExportSubjectPublicKeyInfoPem();
+
+        byte[] ExportPkcs8PrivateKey();
+        bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten);
+        string ExportPkcs8PrivateKeyPem();
+
+        byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters);
+        bool TryExportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten);
+        string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters);
+
+        byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters);
+        bool TryExportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten);
+        string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters);
+    }
+#endif
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/IImportExportShape.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/IImportExportShape.cs
@@ -1,31 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Security.Cryptography
 {
 #if DESIGNTIMEINTERFACES
     internal interface IImportExportShape<TSelf> where TSelf : class, IImportExportShape<TSelf>
     {
-        static abstract bool TryImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
-        static abstract bool TryImportPkcs8PrivateKey(ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
-        static abstract bool TryImportEncryptedPkcs8PrivateKey(
-            ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
-        static abstract bool TryImportEncryptedPkcs8PrivateKey(
-            ReadOnlySpan<char> password, ReadOnlySpan<byte> source, [NotNullWhen(true)] out TSelf? imported);
-
         static abstract TSelf ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source);
         static abstract TSelf ImportPkcs8PrivateKey(ReadOnlySpan<byte> source);
         static abstract TSelf ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source);
         static abstract TSelf ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source);
-
-        static abstract bool TryImportFromPem(
-            ReadOnlySpan<char> source, [NotNullWhen(true)] out TSelf? imported);
-        static abstract bool TryImportFromEncryptedPem(
-            ReadOnlySpan<char> source, ReadOnlySpan<char> password, [NotNullWhen(true)] out TSelf? imported);
-        static abstract bool TryImportFromEncryptedPem(
-            ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes, [NotNullWhen(true)] out TSelf? imported);
 
         static abstract TSelf ImportFromPem(ReadOnlySpan<char> source);
         static abstract TSelf ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password);

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -284,12 +284,12 @@ namespace System.Security.Cryptography
             {
                 using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
                 {
-                    ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(password, manager.Memory, out bytesRead);
-                    AsnValueReader reader = new(decrypted, AsnEncodingRules.BER);
-                    reader.ReadEncodedValue();
+                    ArraySegment<byte> decrypted = DecryptPkcs8(password, manager.Memory, out bytesRead);
 
                     try
                     {
+                        AsnValueReader reader = new(decrypted, AsnEncodingRules.BER);
+                        reader.ReadEncodedValue();
                         reader.ThrowIfNotEmpty();
                         return keyReader(decrypted);
                     }

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -12,6 +12,8 @@ namespace System.Security.Cryptography
 {
     internal static partial class KeyFormatHelper
     {
+        internal delegate TRet ReadOnlySpanFunc<TIn, TRet>(ReadOnlySpan<TIn> span);
+
         internal static unsafe void ReadEncryptedPkcs8<TRet>(
             string[] validOids,
             ReadOnlySpan<byte> source,
@@ -275,7 +277,7 @@ namespace System.Security.Cryptography
         internal static unsafe T DecryptPkcs8<T>(
             ReadOnlySpan<char> password,
             ReadOnlySpan<byte> source,
-            Func<ReadOnlySpan<byte>, T> keyReader,
+            ReadOnlySpanFunc<byte, T> keyReader,
             out int bytesRead)
         {
             fixed (byte* pointer = source)
@@ -306,7 +308,7 @@ namespace System.Security.Cryptography
         internal static unsafe T DecryptPkcs8<T>(
             ReadOnlySpan<byte> passwordBytes,
             ReadOnlySpan<byte> source,
-            Func<ReadOnlySpan<byte>, T> keyReader,
+            ReadOnlySpanFunc<byte, T> keyReader,
             out int bytesRead)
         {
             fixed (byte* pointer = source)

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -315,7 +315,7 @@ namespace System.Security.Cryptography
             ThrowIfDisposed();
 
             AsnWriter writer = ExportSubjectPublicKeyInfoCore();
-            return writer.Encode(static span => PemEncoding.WriteString("PUBLIC KEY", span));
+            return writer.Encode(static span => PemEncoding.WriteString(PemLabels.SpkiPublicKey, span));
         }
 
         /// <summary>
@@ -422,6 +422,8 @@ namespace System.Security.Cryptography
         {
             ThrowIfDisposed();
 
+            // TODO: Validation on pbeParameters.
+
             AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore(password, pbeParameters);
 
             try
@@ -461,6 +463,8 @@ namespace System.Security.Cryptography
         public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters)
         {
             ThrowIfDisposed();
+
+            // TODO: Validation on pbeParameters.
 
             AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore(passwordBytes, pbeParameters);
 
@@ -605,11 +609,13 @@ namespace System.Security.Cryptography
         {
             ThrowIfDisposed();
 
+            // TODO: Validation on pbeParameters.
+
             AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore(password, pbeParameters);
 
             try
             {
-                return writer.Encode(static span => PemEncoding.WriteString("ENCRYPTED PRIVATE KEY", span));
+                return writer.Encode(static span => PemEncoding.WriteString(PemLabels.EncryptedPkcs8PrivateKey, span));
             }
             finally
             {
@@ -648,11 +654,13 @@ namespace System.Security.Cryptography
         {
             ThrowIfDisposed();
 
+            // TODO: Validation on pbeParameters.
+
             AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore(passwordBytes, pbeParameters);
 
             try
             {
-                return writer.Encode(static span => PemEncoding.WriteString("ENCRYPTED PRIVATE KEY", span));
+                return writer.Encode(static span => PemEncoding.WriteString(PemLabels.EncryptedPkcs8PrivateKey, span));
             }
             finally
             {
@@ -1621,6 +1629,7 @@ namespace System.Security.Cryptography
                             {
                                 AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
                                 pki.PrivateKeyAlgorithm.Encode(writer);
+                                // TODO: Use callback and span support for this in .NET 9.
                                 algorithmId = Convert.ToHexString(writer.Encode());
                             }
                         }
@@ -1765,6 +1774,10 @@ namespace System.Security.Cryptography
                 Algorithm = algorithm;
                 Oid = oid;
             }
+
+            // ML-DSA parameter sets, and the sizes associated with them,
+            // are defined in FIPS 204, section 4 "Parameter Sets".
+            // particularly Table 2 "Sizes (in bytes) of keys and signatures of ML-DSA"
 
             internal static readonly ParameterSetInfo MLDsa44 =
                 new ParameterSetInfo(2560, 1312, 2420, MLDsaAlgorithm.MLDsa44, Oids.MLDsa44);

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
 using System.Security.Cryptography.Asn1;
-using System.Security.Cryptography.X509Certificates;
 
 // The type being internal is making unused parameter warnings fire for
 // not-implemented methods. Suppress those warnings.
@@ -789,185 +788,6 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Attempts to import an ML-DSA public key from an X.509 SubjectPublicKeyInfo structure.
-        /// </summary>
-        /// <param name="source">
-        ///   The bytes of an X.509 SubjectPublicKeyInfo structure in the ASN.1-DER encoding.
-        /// </param>
-        /// <param name="imported">
-        ///   When this method returns, contains a value that represents the imported key, or <see langword="null"/>
-        ///   if the SubjectPublicKeyInfo value did not represent an ML-DSA key.
-        /// </param>
-        /// <returns>
-        ///   <see langword="false" /> if the SubjectPublicKeyInfo value indicates an algorithm other than a known ML-DSA algorithm;
-        ///   <see langword="true" /> if the value indicates an ML-DSA key and it was successfully imported;
-        ///   otherwise, an exception is thrown.
-        /// </returns>
-        /// <exception cref="CryptographicException">
-        ///   <para>
-        ///     The contents of <paramref name="source"/> do not represent an ASN.1-DER-encoded X.509 SubjectPublicKeyInfo structure.
-        ///   </para>
-        ///   <para>-or-</para>
-        ///   <para>
-        ///     The algorithm-specific import failed.
-        ///   </para>
-        /// </exception>
-        public static bool TryImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source, [NotNullWhen(true)] out MLDsa? imported)
-        {
-            ThrowIfNotSupported();
-
-            return TryImportSubjectPublicKeyInfo(source, out imported, out _);
-        }
-
-        /// <summary>
-        ///   Attempts to import an ML-DSA private key from a PKCS#8 PrivateKeyInfo structure.
-        /// </summary>
-        /// <param name="source">
-        ///   The bytes of a PKCS#8 PrivateKeyInfo structure in the ASN.1-BER encoding.
-        /// </param>
-        /// <param name="imported">
-        ///   When this method returns, contains a value that represents the imported key, or <see langword="null"/>
-        ///   if the PrivateKeyInfo value did not represent an ML-DSA key.
-        /// </param>
-        /// <returns>
-        ///   <see langword="false" /> if the PrivateKeyInfo value indicates an algorithm other than a known ML-DSA algorithm;
-        ///   <see langword="true" /> if the value indicates an ML-DSA key and it was successfully imported;
-        ///   otherwise, an exception is thrown.
-        /// </returns>
-        /// <exception cref="CryptographicException">
-        ///   <para>
-        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 PrivateKeyInfo structure.
-        ///   </para>
-        ///   <para>-or-</para>
-        ///   <para>
-        ///     The algorithm-specific import failed.
-        ///   </para>
-        /// </exception>
-        public static bool TryImportPkcs8PrivateKey(ReadOnlySpan<byte> source, [NotNullWhen(true)] out MLDsa? imported)
-        {
-            ThrowIfNotSupported();
-
-            return TryImportPkcs8PrivateKey(source, out imported, out _);
-        }
-
-        /// <summary>
-        ///   Attempts to import an ML-DSA private key from a PKCS#8 EncryptedPrivateKeyInfo structure.
-        /// </summary>
-        /// <param name="passwordBytes">
-        ///   The bytes to use as a password when decrypting the key material.
-        /// </param>
-        /// <param name="source">
-        ///   The bytes of a PKCS#8 EncryptedPrivateKeyInfo structure in the ASN.1-BER encoding.
-        /// </param>
-        /// <param name="imported">
-        ///   When this method returns, contains a value that represents the imported key, or <see langword="null"/>
-        ///   if the decrypted PrivateKeyInfo value did not represent an ML-DSA key.
-        /// </param>
-        /// <returns>
-        ///   <see langword="false" /> if the decrypted PrivateKeyInfo value indicates an algorithm other than a known ML-DSA algorithm;
-        ///   <see langword="true" /> if the value indicates an ML-DSA key and it was successfully imported;
-        ///   otherwise, an exception is thrown.
-        /// </returns>
-        /// <exception cref="CryptographicException">
-        ///   <para>
-        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
-        ///   </para>
-        ///   <para>-or-</para>
-        ///   <para>
-        ///     The specified password is incorrect.
-        ///   </para>
-        ///   <para>-or-</para>
-        ///   <para>
-        ///     The EncryptedPrivateKeyInfo indicates the Key Derivation Function (KDF) to apply is the legacy PKCS#12 KDF,
-        ///     which requires <see cref="char"/>-based passwords.
-        ///   </para>
-        ///   <para>-or-</para>
-        ///   <para>
-        ///     The algorithm-specific import failed.
-        ///   </para>
-        /// </exception>
-        public static bool TryImportEncryptedPkcs8PrivateKey(
-            ReadOnlySpan<byte> passwordBytes,
-            ReadOnlySpan<byte> source,
-            [NotNullWhen(true)] out MLDsa? imported)
-        {
-            ThrowIfNotSupported();
-
-            MLDsa? tmp = KeyFormatHelper.DecryptPkcs8(
-                passwordBytes,
-                source,
-                static span =>
-                {
-                    if (!TryImportPkcs8PrivateKey(span, out MLDsa? imported))
-                    {
-                        imported = null;
-                    }
-
-                    return imported;
-                },
-                out _);
-
-            imported = tmp;
-            return tmp is not null;
-        }
-
-        /// <summary>
-        ///   Attempts to import an ML-DSA private key from a PKCS#8 EncryptedPrivateKeyInfo structure.
-        /// </summary>
-        /// <param name="password">
-        ///   The password to use when decrypting the key material.
-        /// </param>
-        /// <param name="source">
-        ///   The bytes of a PKCS#8 EncryptedPrivateKeyInfo structure in the ASN.1-BER encoding.
-        /// </param>
-        /// <param name="imported">
-        ///   When this method returns, contains a value that represents the imported key, or <see langword="null"/>
-        ///   if the decrypted PrivateKeyInfo value did not represent an ML-DSA key.
-        /// </param>
-        /// <returns>
-        ///   <see langword="false" /> if the decrypted PrivateKeyInfo value indicates an algorithm other than a known ML-DSA algorithm;
-        ///   <see langword="true" /> if the value indicates an ML-DSA key and it was successfully imported;
-        ///   otherwise, an exception is thrown.
-        /// </returns>
-        /// <exception cref="CryptographicException">
-        ///   <para>
-        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
-        ///   </para>
-        ///   <para>-or-</para>
-        ///   <para>
-        ///     The specified password is incorrect.
-        ///   </para>
-        ///   <para>-or-</para>
-        ///   <para>
-        ///     The algorithm-specific import failed.
-        ///   </para>
-        /// </exception>
-        public static bool TryImportEncryptedPkcs8PrivateKey(
-            ReadOnlySpan<char> password,
-            ReadOnlySpan<byte> source,
-            [NotNullWhen(true)] out MLDsa? imported)
-        {
-            ThrowIfNotSupported();
-
-            MLDsa? tmp = KeyFormatHelper.DecryptPkcs8(
-                password,
-                source,
-                static span =>
-                {
-                    if (!TryImportPkcs8PrivateKey(span, out MLDsa? imported))
-                    {
-                        imported = null;
-                    }
-
-                    return imported;
-                },
-                out _);
-
-            imported = tmp;
-            return tmp is not null;
-        }
-
-        /// <summary>
         ///  Imports an ML-DSA public key from an X.509 SubjectPublicKeyInfo structure.
         /// </summary>
         /// <param name="source">
@@ -993,14 +813,29 @@ namespace System.Security.Cryptography
         {
             ThrowIfNotSupported();
 
-            if (!TryImportSubjectPublicKeyInfo(source, out MLDsa? imported, out string? algorithmId, computeAlgorithmId: true))
+            unsafe
             {
-                Debug.Assert(algorithmId is not null);
-                ThrowAlgorithmUnknown(algorithmId);
-            }
+                fixed (byte* pointer = source)
+                {
+                    using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
+                    {
+                        AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
+                        SubjectPublicKeyInfoAsn.Decode(ref reader, manager.Memory, out SubjectPublicKeyInfoAsn spki);
 
-            Debug.Assert(imported is not null);
-            return imported;
+                        ParameterSetInfo info = ParameterSetInfo.GetParameterSetInfoFromOid(spki.Algorithm.Algorithm);
+
+                        if (spki.Algorithm.Parameters.HasValue)
+                        {
+                            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+                            spki.Algorithm.Encode(writer);
+                            ThrowAlgorithmUnknown(writer);
+                            Debug.Fail("Execution should have halted in the throw-helper.");
+                        }
+
+                        return MLDsaImplementation.ImportPublicKey(info, spki.SubjectPublicKey.Span);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -1029,14 +864,29 @@ namespace System.Security.Cryptography
         {
             ThrowIfNotSupported();
 
-            if (!TryImportPkcs8PrivateKey(source, out MLDsa? imported, out string? algorithmId, computeAlgorithmId: true))
+            unsafe
             {
-                Debug.Assert(algorithmId is not null);
-                ThrowAlgorithmUnknown(algorithmId);
-            }
+                fixed (byte* pointer = source)
+                {
+                    using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
+                    {
+                        AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
+                        PrivateKeyInfoAsn.Decode(ref reader, manager.Memory, out PrivateKeyInfoAsn pki);
 
-            Debug.Assert(imported is not null);
-            return imported;
+                        ParameterSetInfo info = ParameterSetInfo.GetParameterSetInfoFromOid(pki.PrivateKeyAlgorithm.Algorithm);
+
+                        if (pki.PrivateKeyAlgorithm.Parameters.HasValue)
+                        {
+                            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+                            pki.PrivateKeyAlgorithm.Encode(writer);
+                            ThrowAlgorithmUnknown(writer);
+                            Debug.Fail("Execution should have halted in the throw-helper.");
+                        }
+
+                        return MLDsaImplementation.ImportPkcs8PrivateKeyValue(info, pki.PrivateKey.Span);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -1125,50 +975,6 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Attempts to import an ML-DSA key from an RFC 7468 PEM-encoded string.
-        /// </summary>
-        /// <param name="source">
-        ///   The text of the PEM key to import.
-        /// </param>
-        /// <param name="imported">
-        ///   When this method returns, contains a value that represents the imported key, or <see langword="null"/>
-        ///   if the input did not contain a PEM-encoded ML-DSA key.
-        /// </param>
-        /// <returns>
-        ///   <see langword="false" /> if the source did not contain a PEM-encoded ML-DSA key;
-        ///   <see langword="true" /> if the source contains an ML-DSA key and it was successfully imported;
-        ///   otherwise, an exception is thrown.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///   <para><paramref name="source" /> contains an encrypted PEM-encoded key.</para>
-        ///   <para>-or-</para>
-        ///   <para><paramref name="source" /> contains multiple PEM-encoded ML-DSA keys.</para>
-        /// </exception>
-        /// <exception cref="CryptographicException">
-        ///   An error occurred while importing the key.
-        /// </exception>
-        public static bool TryImportFromPem(ReadOnlySpan<char> source, [NotNullWhen(true)] out MLDsa? imported)
-        {
-            ThrowIfNotSupported();
-
-            // TODO, probably in PemKeyHelper.
-            // * If the PEM ever contains a valid envelope with the label "ENCRYPTED PUBLIC KEY", throw ArgumentException.
-            // * Otherwise
-            //   * for each known label, send it to the TryImport method.
-            //     * If only one returns true, emit the imported key and return true
-            //     * If a second one returns true, dispose the first (without ever assigning it to the public out) and throw
-            //     * Be aware
-            //       * Subsequent TryImport calls may throw, so dispose the first import if that happens.
-            //       * The TryImport methods ignore trailing data.  This must not.
-            //         * Maybe we want both the no-out (lax?) import and an out bytesRead version?
-            // * If nothing returned true (or threw), return false.
-
-            // Alternatively, if we feel this method is to loosey-goosey, we can cut it.
-
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         ///  Imports an ML-DSA key from an RFC 7468 PEM-encoded string.
         /// </summary>
         /// <param name="source">
@@ -1191,99 +997,8 @@ namespace System.Security.Cryptography
         {
             ThrowIfNotSupported();
 
-            // TODO: Decide if we want different exceptions for "no known PEM labels" and
-            // "there were known PEM labels, but none of them matched"
-            // Since the Try won't make a distinction, we probably don't want to here.
-            if (!TryImportFromPem(source, out MLDsa? imported))
-            {
-                // TODO: Give this a string and bind it to the source parameter.
-                throw new ArgumentException();
-            }
-
-            return imported;
-        }
-
-        /// <summary>
-        ///   Attempts to import an ML-DSA key from an RFC 7468 PEM-encoded string.
-        /// </summary>
-        /// <param name="source">
-        ///   The text of the PEM key to import.
-        /// </param>
-        /// <param name="password">
-        ///  The password to use when decrypting the key material.
-        /// </param>
-        /// <param name="imported">
-        ///   When this method returns, contains a value that represents the imported key, or <see langword="null"/>
-        ///   if the input did not contain a PEM-encoded ML-DSA key.
-        /// </param>
-        /// <returns>
-        ///   <see langword="false" /> if the source did not contain a PEM-encoded ML-DSA key;
-        ///   <see langword="true" /> if the source contains an ML-DSA key and it was successfully imported;
-        ///   otherwise, an exception is thrown.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///   <para><paramref name="source" /> contains an encrypted PEM-encoded key.</para>
-        ///   <para>-or-</para>
-        ///   <para><paramref name="source" /> contains multiple PEM-encoded ML-DSA keys.</para>
-        /// </exception>
-        /// <exception cref="CryptographicException">
-        ///   An error occurred while importing the key.
-        /// </exception>
-        public static bool TryImportFromEncryptedPem(
-            ReadOnlySpan<char> source,
-            ReadOnlySpan<char> password,
-            [NotNullWhen(true)] out MLDsa? imported)
-        {
-            ThrowIfNotSupported();
-
-            // TODO (probably in PemKeyHelper)
-            // * Ignore any PEM values that are not ENCRYPTED PRIVATE KEY
-            // * If exactly one TryImportEncryptedPkcs8PrivateKey succeeds, emit that key and return true.
-            // * Throw exceptions similar to the non-encrypted version.
-            // * return false when necessary.
-
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        ///   Attempts to import an ML-DSA key from an RFC 7468 PEM-encoded string.
-        /// </summary>
-        /// <param name="source">
-        ///   The text of the PEM key to import.
-        /// </param>
-        /// <param name="passwordBytes">
-        ///  The bytes to use as a password when decrypting the key material.
-        /// </param>
-        /// <param name="imported">
-        ///   When this method returns, contains a value that represents the imported key, or <see langword="null"/>
-        ///   if the input did not contain a PEM-encoded ML-DSA key.
-        /// </param>
-        /// <returns>
-        ///   <see langword="false" /> if the source did not contain a PEM-encoded ML-DSA key;
-        ///   <see langword="true" /> if the source contains an ML-DSA key and it was successfully imported;
-        ///   otherwise, an exception is thrown.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///   <para><paramref name="source" /> contains an encrypted PEM-encoded key.</para>
-        ///   <para>-or-</para>
-        ///   <para><paramref name="source" /> contains multiple PEM-encoded ML-DSA keys.</para>
-        /// </exception>
-        /// <exception cref="CryptographicException">
-        ///   An error occurred while importing the key.
-        /// </exception>
-        public static bool TryImportFromEncryptedPem(
-            ReadOnlySpan<char> source,
-            ReadOnlySpan<byte> passwordBytes,
-            [NotNullWhen(true)] out MLDsa? imported)
-        {
-            ThrowIfNotSupported();
-
-            // TODO (probably in PemKeyHelper)
-            // * Ignore any PEM values that are not ENCRYPTED PRIVATE KEY
-            // * If exactly one TryImportEncryptedPkcs8PrivateKey succeeds, emit that key and return true.
-            // * Throw exceptions similar to the non-encrypted version.
-            // * return false when necessary.
-
+            // TODO: Match the behavior of ECDsa.ImportFromPem.
+            // Double-check that the base64-decoded data has no trailing contents.
             throw new NotImplementedException();
         }
 
@@ -1313,16 +1028,10 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password)
         {
-            // TODO: Decide if we want different exceptions for "no known PEM labels" and
-            // "there were known PEM labels, but none of them matched"
-            // Since the Try won't make a distinction, we probably don't want to here.
-            if (!TryImportFromEncryptedPem(source, password, out MLDsa? imported))
-            {
-                // TODO: Give this a string and bind it to the source parameter.
-                throw new ArgumentException();
-            }
+            ThrowIfNotSupported();
 
-            return imported;
+            // TODO: Match the behavior of ECDsa.ImportFromEncryptedPem.
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -1351,16 +1060,10 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes)
         {
-            // TODO: Decide if we want different exceptions for "no known PEM labels" and
-            // "there were known PEM labels, but none of them matched"
-            // Since the Try won't make a distinction, we probably don't want to here.
-            if (!TryImportFromEncryptedPem(source, passwordBytes, out MLDsa? imported))
-            {
-                // TODO: Give this a string and bind it to the source parameter.
-                throw new ArgumentException();
-            }
+            ThrowIfNotSupported();
 
-            return imported;
+            // TODO: Match the behavior of ECDsa.ImportFromEncryptedPem.
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -1554,97 +1257,6 @@ namespace System.Security.Cryptography
         /// </param>
         protected abstract void ExportMLDsaPrivateSeedCore(Span<byte> destination);
 
-        private static bool TryImportSubjectPublicKeyInfo(
-            ReadOnlySpan<byte> source,
-            [NotNullWhen(true)] out MLDsa? imported,
-            out string? algorithmId,
-            bool computeAlgorithmId = false)
-        {
-            ThrowIfNotSupported();
-            algorithmId = null;
-
-            unsafe
-            {
-                fixed (byte* pointer = source)
-                {
-                    using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
-                    {
-                        AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
-                        SubjectPublicKeyInfoAsn.Decode(ref reader, manager.Memory, out SubjectPublicKeyInfoAsn spki);
-
-                        if (ParameterSetInfo.TryGetParameterSetInfo(spki.Algorithm.Algorithm, out ParameterSetInfo? info))
-                        {
-                            if (!spki.Algorithm.Parameters.HasValue)
-                            {
-                                imported = MLDsaImplementation.ImportPublicKey(info, spki.SubjectPublicKey.Span);
-                                return true;
-                            }
-
-                            if (computeAlgorithmId)
-                            {
-                                AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-                                spki.Algorithm.Encode(writer);
-                                algorithmId = Convert.ToHexString(writer.Encode());
-                            }
-                        }
-                        else
-                        {
-                            algorithmId = spki.Algorithm.Algorithm;
-                        }
-
-                        imported = null;
-                        return false;
-                    }
-                }
-            }
-        }
-
-        private static bool TryImportPkcs8PrivateKey(
-            ReadOnlySpan<byte> source,
-            [NotNullWhen(true)] out MLDsa? imported,
-            out string? algorithmId,
-            bool computeAlgorithmId = false)
-        {
-            ThrowIfNotSupported();
-            algorithmId = null;
-
-            unsafe
-            {
-                fixed (byte* pointer = source)
-                {
-                    using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
-                    {
-                        AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
-                        PrivateKeyInfoAsn.Decode(ref reader, manager.Memory, out PrivateKeyInfoAsn pki);
-
-                        if (ParameterSetInfo.TryGetParameterSetInfo(pki.PrivateKeyAlgorithm.Algorithm, out ParameterSetInfo? info))
-                        {
-                            if (!pki.PrivateKeyAlgorithm.Parameters.HasValue)
-                            {
-                                imported = MLDsaImplementation.ImportPkcs8PrivateKeyValue(info, pki.PrivateKey.Span);
-                                return true;
-                            }
-
-                            if (computeAlgorithmId)
-                            {
-                                AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-                                pki.PrivateKeyAlgorithm.Encode(writer);
-                                // TODO: Use callback and span support for this in .NET 9.
-                                algorithmId = Convert.ToHexString(writer.Encode());
-                            }
-                        }
-                        else
-                        {
-                            algorithmId = pki.PrivateKeyAlgorithm.Algorithm;
-                        }
-
-                        imported = null;
-                        return false;
-                    }
-                }
-            }
-        }
-
         private AsnWriter ExportSubjectPublicKeyInfoCore()
         {
             ThrowIfDisposed();
@@ -1747,6 +1359,20 @@ namespace System.Security.Cryptography
             }
         }
 
+        [DoesNotReturn]
+        private static void ThrowAlgorithmUnknown(AsnWriter encodedId)
+        {
+#if NET9_0_OR_GREATER
+            throw encodedId.Encode(static encoded =>
+                new CryptographicException(
+                    SR.Format(SR.Cryptography_UnknownAlgorithmIdentifier, Convert.ToHexString(encoded))));
+#else
+            throw new CryptographicException(
+                SR.Format(SR.Cryptography_UnknownAlgorithmIdentifier, Convert.ToHexString(encodedId.Encode())));
+#endif
+        }
+
+        [DoesNotReturn]
         private static ParameterSetInfo ThrowAlgorithmUnknown(string algorithmId)
         {
             throw new CryptographicException(
@@ -1799,17 +1425,15 @@ namespace System.Security.Cryptography
                 };
             }
 
-            internal static bool TryGetParameterSetInfo(string oid, [NotNullWhen(true)] out ParameterSetInfo? info)
+            internal static ParameterSetInfo GetParameterSetInfoFromOid(string oid)
             {
-                info = oid switch
+                return oid switch
                 {
                     Oids.MLDsa44 => MLDsa44,
                     Oids.MLDsa65 => MLDsa65,
                     Oids.MLDsa87 => MLDsa87,
-                    _ => default,
+                    _ => ThrowAlgorithmUnknown(oid),
                 };
-
-                return info != null;
             }
         }
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -1098,6 +1098,7 @@ namespace System.Security.Cryptography
         public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             ThrowIfNotSupported();
+            ArgumentNullException.ThrowIfNull(algorithm);
 
             ParameterSetInfo info = ParameterSetInfo.GetParameterSetInfo(algorithm);
 
@@ -1137,6 +1138,7 @@ namespace System.Security.Cryptography
         public static MLDsa ImportMLDsaSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             ThrowIfNotSupported();
+            ArgumentNullException.ThrowIfNull(algorithm);
 
             ParameterSetInfo info = ParameterSetInfo.GetParameterSetInfo(algorithm);
 
@@ -1385,6 +1387,9 @@ namespace System.Security.Cryptography
 
         internal sealed class ParameterSetInfo
         {
+            // TODO: If MLDsaAlgorithm is a class, this class can be merged into it.
+            // TODO: Some of the information maybe then becomes public on MLDsaAlgorithm, rather than MLDsa?
+
             internal int SecretKeySizeInBytes { get; }
             internal int PublicKeySizeInBytes { get; }
             internal int SignatureSizeInBytes { get; }
@@ -1420,6 +1425,8 @@ namespace System.Security.Cryptography
 
             internal static ParameterSetInfo GetParameterSetInfo(MLDsaAlgorithm algorithm)
             {
+                ArgumentNullException.ThrowIfNull(algorithm);
+
                 return algorithm.Name switch
                 {
                     "ML-DSA-44" => MLDsa44,

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -198,6 +198,8 @@ namespace System.Security.Cryptography
             return SignatureSizeInBytes;
         }
 
+        // TODO: SignPreHash
+
         /// <summary>
         ///   Verifies that the specified signature is valid for this key and the provided data.
         /// </summary>
@@ -245,6 +247,8 @@ namespace System.Security.Cryptography
 
             return VerifyDataCore(data, context, signature);
         }
+
+        // TODO: VerifyPreHash
 
         /// <summary>
         ///  Exports the public-key portion of the current key in the X.509 SubjectPublicKeyInfo format.

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -8,6 +8,10 @@ using System.Formats.Asn1;
 using System.Security.Cryptography.Asn1;
 using System.Security.Cryptography.X509Certificates;
 
+// The type being internal is making unused parameter warnings fire for
+// not-implemented methods. Suppress those warnings.
+#pragma warning disable IDE0060
+
 namespace System.Security.Cryptography
 {
     /// <summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -1300,16 +1300,17 @@ namespace System.Security.Cryptography
             ThrowIfDisposed();
 
             // TODO: Determine a more appropriate maximum size once the format is actually known.
-            int initialSize = _parameterSetInfo.SecretKeySizeInBytes * 2;
+            int size = _parameterSetInfo.SecretKeySizeInBytes * 2;
             // The buffer is only being passed out as a span, so the derived type can't meaningfully
             // hold on to it without being malicious.
-            byte[] rented = CryptoPool.Rent(initialSize);
+            byte[] rented = CryptoPool.Rent(size);
             int written;
 
             while (!TryExportPkcs8PrivateKey(rented, out written))
             {
+                size = rented.Length;
                 CryptoPool.Return(rented, 0);
-                rented = CryptoPool.Rent(rented.Length * 2);
+                rented = CryptoPool.Rent(size * 2);
             }
 
             AsnWriter tmp = new AsnWriter(AsnEncodingRules.BER);

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Security.Cryptography
+{
+    /// <summary>
+    ///   Represents a specific algorithm within the ML-DSA family.
+    /// </summary>
+    [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+    internal struct MLDsaAlgorithm : IEquatable<MLDsaAlgorithm>
+    {
+        /// <summary>
+        ///   Gets the underlying string representation of the algorithm name.
+        /// </summary>
+        /// <value>
+        ///   The underlying string representation of the algorithm name.
+        /// </value>
+        public string Name { get; }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="MLDsaAlgorithm" /> structure with a custom name.
+        /// </summary>
+        /// <param name="name">
+        ///   The name of the algorithm.
+        /// </param>
+        public MLDsaAlgorithm(string name)
+        {
+            Name = name;
+        }
+
+        // TODO: Our algorithm names generally match CNG.  If they don't in this case, consider changing the values.
+
+        /// <summary>
+        ///   Gets an ML-DSA algorithm identifier for the ML-DSA-44 algorithm.
+        /// </summary>
+        /// <value>
+        ///   An ML-DSA algorithm identifier for the ML-DSA-44 algorithm.
+        /// </value>
+        public static MLDsaAlgorithm MLDsa44 { get; } = new MLDsaAlgorithm("ML-DSA-44");
+
+        /// <summary>
+        ///   Gets an ML-DSA algorithm identifier for the ML-DSA-65 algorithm.
+        /// </summary>
+        /// <value>
+        ///   An ML-DSA algorithm identifier for the ML-DSA-65 algorithm.
+        /// </value>
+        public static MLDsaAlgorithm MLDsa65 { get; } = new MLDsaAlgorithm("ML-DSA-65");
+
+        /// <summary>
+        ///   Gets an ML-DSA algorithm identifier for the ML-DSA-87 algorithm.
+        /// </summary>
+        /// <value>
+        ///   An ML-DSA algorithm identifier for the ML-DSA-87 algorithm.
+        /// </value>
+        public static MLDsaAlgorithm MLDsa87 { get; } = new MLDsaAlgorithm("ML-DSA-87");
+
+        /// <summary>
+        ///   Indicates whether two <see cref="MLDsaAlgorithm"/> values are equal.
+        /// </summary>
+        /// <param name="other">
+        ///   The object to compare with the current instance.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if the <see cref="Name" /> property of <paramref name="other" /> is equal
+        ///   to that of the current instance;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        public bool Equals(MLDsaAlgorithm other)
+        {
+            return Name == other.Name;
+        }
+
+        /// <summary>
+        ///   Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">
+        ///   The object to compare with the current instance.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="obj" /> is a <see cref="MLDsaAlgorithm" /> value and
+        ///   its <see cref="Name" /> property is equal to that of the current instance;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        public override bool Equals(object? obj)
+        {
+            return obj is MLDsaAlgorithm other && Equals(other);
+        }
+
+        /// <summary>
+        ///   Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+
+        /// <summary>
+        ///   Determines whether two <see cref="MLDsaAlgorithm"/> specified values are equal.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns>
+        ///   <see langword="true" /> if both values have the same the <see cref="Name" /> value;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        public static bool operator ==(MLDsaAlgorithm left, MLDsaAlgorithm right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        ///   Determines whether two <see cref="MLDsaAlgorithm"/> specified values are not equal.
+        /// </summary>
+        /// <param name="left">The first instance to compare.</param>
+        /// <param name="right">The second instance to compare.</param>
+        ///   <see langword="true" /> if both values do not have the same the <see cref="Name" /> value;
+        ///   otherwise, <see langword="false" />.
+        public static bool operator !=(MLDsaAlgorithm left, MLDsaAlgorithm right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography
     ///   Represents a specific algorithm within the ML-DSA family.
     /// </summary>
     [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
-    internal class MLDsaAlgorithm
+    internal sealed class MLDsaAlgorithm
     {
         /// <summary>
         ///   Gets the underlying string representation of the algorithm name.

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography
     ///   Represents a specific algorithm within the ML-DSA family.
     /// </summary>
     [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
-    internal struct MLDsaAlgorithm : IEquatable<MLDsaAlgorithm>
+    internal class MLDsaAlgorithm
     {
         /// <summary>
         ///   Gets the underlying string representation of the algorithm name.
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography
         /// <param name="name">
         ///   The name of the algorithm.
         /// </param>
-        public MLDsaAlgorithm(string name)
+        private MLDsaAlgorithm(string name)
         {
             Name = name;
         }
@@ -55,72 +55,5 @@ namespace System.Security.Cryptography
         ///   An ML-DSA algorithm identifier for the ML-DSA-87 algorithm.
         /// </value>
         public static MLDsaAlgorithm MLDsa87 { get; } = new MLDsaAlgorithm("ML-DSA-87");
-
-        /// <summary>
-        ///   Indicates whether two <see cref="MLDsaAlgorithm"/> values are equal.
-        /// </summary>
-        /// <param name="other">
-        ///   The object to compare with the current instance.
-        /// </param>
-        /// <returns>
-        ///   <see langword="true" /> if the <see cref="Name" /> property of <paramref name="other" /> is equal
-        ///   to that of the current instance;
-        ///   otherwise, <see langword="false" />.
-        /// </returns>
-        public bool Equals(MLDsaAlgorithm other)
-        {
-            return Name == other.Name;
-        }
-
-        /// <summary>
-        ///   Determines whether the specified object is equal to the current object.
-        /// </summary>
-        /// <param name="obj">
-        ///   The object to compare with the current instance.
-        /// </param>
-        /// <returns>
-        ///   <see langword="true" /> if <paramref name="obj" /> is a <see cref="MLDsaAlgorithm" /> value and
-        ///   its <see cref="Name" /> property is equal to that of the current instance;
-        ///   otherwise, <see langword="false" />.
-        /// </returns>
-        public override bool Equals(object? obj)
-        {
-            return obj is MLDsaAlgorithm other && Equals(other);
-        }
-
-        /// <summary>
-        ///   Serves as the default hash function.
-        /// </summary>
-        /// <returns>A hash code for the current object.</returns>
-        public override int GetHashCode()
-        {
-            return Name.GetHashCode();
-        }
-
-        /// <summary>
-        ///   Determines whether two <see cref="MLDsaAlgorithm"/> specified values are equal.
-        /// </summary>
-        /// <param name="left">The first value to compare.</param>
-        /// <param name="right">The second value to compare.</param>
-        /// <returns>
-        ///   <see langword="true" /> if both values have the same the <see cref="Name" /> value;
-        ///   otherwise, <see langword="false" />.
-        /// </returns>
-        public static bool operator ==(MLDsaAlgorithm left, MLDsaAlgorithm right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        ///   Determines whether two <see cref="MLDsaAlgorithm"/> specified values are not equal.
-        /// </summary>
-        /// <param name="left">The first instance to compare.</param>
-        /// <param name="right">The second instance to compare.</param>
-        ///   <see langword="true" /> if both values do not have the same the <see cref="Name" /> value;
-        ///   otherwise, <see langword="false" />.
-        public static bool operator !=(MLDsaAlgorithm left, MLDsaAlgorithm right)
-        {
-            return !left.Equals(right);
-        }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Security.Cryptography
+{
+    internal sealed partial class MLDsaImplementation : MLDsa
+    {
+        internal static partial bool SupportsAny() => false;
+
+        // The instance override methods are unreachable, as the constructor will always throw.
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa GenerateKey(MLDsaAlgorithm algorithm) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportPublicKey(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportSecretKey(ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportSeed(ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Security.Cryptography
+{
+    internal sealed partial class MLDsaImplementation : MLDsa
+    {
+        internal static partial bool SupportsAny() => false;
+
+        // TODO: Define this in terms of Windows BCrypt.dll (ephemeral keys)
+
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa GenerateKey(MLDsaAlgorithm algorithm) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportPublicKey(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportSecretKey(ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial MLDsa ImportSeed(ParameterSetInfo info, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Security.Cryptography
+{
+    [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+    internal sealed partial class MLDsaImplementation : MLDsa
+    {
+        private MLDsaImplementation(MLDsaAlgorithm algorithm)
+            : base(algorithm)
+        {
+            MLDsa.ThrowIfNotSupported();
+        }
+
+        internal static partial bool SupportsAny();
+
+        internal static partial MLDsa GenerateKey(MLDsaAlgorithm algorithm);
+        internal static partial MLDsa ImportPublicKey(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source);
+        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source);
+        internal static partial MLDsa ImportSecretKey(ParameterSetInfo info, ReadOnlySpan<byte> source);
+        internal static partial MLDsa ImportSeed(ParameterSetInfo info, ReadOnlySpan<byte> source);
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
@@ -12,14 +12,14 @@ namespace System.Security.Cryptography
         private MLDsaImplementation(MLDsaAlgorithm algorithm)
             : base(algorithm)
         {
-            MLDsa.ThrowIfNotSupported();
+            ThrowIfNotSupported();
         }
 
         internal static partial bool SupportsAny();
 
         internal static partial MLDsa GenerateKey(MLDsaAlgorithm algorithm);
-        internal static partial MLDsa ImportPublicKey(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source);
-        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsa.ParameterSetInfo info, ReadOnlySpan<byte> source);
+        internal static partial MLDsa ImportPublicKey(ParameterSetInfo info, ReadOnlySpan<byte> source);
+        internal static partial MLDsa ImportPkcs8PrivateKeyValue(ParameterSetInfo info, ReadOnlySpan<byte> source);
         internal static partial MLDsa ImportSecretKey(ParameterSetInfo info, ReadOnlySpan<byte> source);
         internal static partial MLDsa ImportSeed(ParameterSetInfo info, ReadOnlySpan<byte> source);
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
@@ -97,6 +97,13 @@ namespace System.Security.Cryptography
         internal const string ECDsaWithSha3_384 = "2.16.840.1.101.3.4.3.11";
         internal const string ECDsaWithSha3_512 = "2.16.840.1.101.3.4.3.12";
 
+        internal const string MLDsa44 = "2.16.840.1.101.3.4.3.17";
+        internal const string MLDsa65 = "2.16.840.1.101.3.4.3.18";
+        internal const string MLDsa87 = "2.16.840.1.101.3.4.3.19";
+        internal const string MLDsa44PreHashSha512 = "2.16.840.1.101.3.4.3.32";
+        internal const string MLDsa65PreHashSha512 = "2.16.840.1.101.3.4.3.33";
+        internal const string MLDsa87PreHashSha512 = "2.16.840.1.101.3.4.3.34";
+
         internal const string Mgf1 = "1.2.840.113549.1.1.8";
         internal const string PSpecified = "1.2.840.113549.1.1.9";
 

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -123,6 +123,9 @@
   <data name="Argument_InvalidValue" xml:space="preserve">
     <value>Value was invalid.</value>
   </data>
+  <data name="Argument_SignatureContextTooLong255" xml:space="preserve">
+    <value>The specified signature context exceeds the maximum length of 255 bytes.</value>
+  </data>
   <data name="Argument_StreamNotReadable" xml:space="preserve">
     <value>Stream was not readable.</value>
   </data>
@@ -485,6 +488,9 @@
   </data>
   <data name="Cryptography_KeyTooSmall" xml:space="preserve">
     <value>The key is too small for the requested operation.</value>
+  </data>
+  <data name="Cryptography_KeyWrongSizeForAlgorithm" xml:space="preserve">
+    <value>The specified key is not the correct size for the indicated algorithm.</value>
   </data>
   <data name="Cryptography_MatchBlockSize" xml:space="preserve">
     <value>The specified plaintext size is not valid for the padding and block size.</value>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -19,6 +19,7 @@
     <UseOpenSsl Condition="'$(TargetPlatformIdentifier)' == 'unix'">true</UseOpenSsl>
     <UseOpenSslAead Condition="'$(UseOpenSsl)' == 'true' or '$(TargetPlatformIdentifier)' == 'osx'">true</UseOpenSslAead>
     <NeedOpenSslInitializer Condition="'$(UseOpenSslAead)' == 'true'">true</NeedOpenSslInitializer>
+    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DESIGNTIMEINTERFACES</DefineConstants>
   </PropertyGroup>
 
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' == ''" />
@@ -33,6 +34,8 @@
              Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeX509ChainHandle.cs"
              Link="Common\Microsoft\Win32\SafeHandles\SafeX509ChainHandle.cs" />
+    <Compile Include="$(CommonPath)System\Experimentals.cs"
+             Link="Common\System\Experimentals.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs"
              Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\IO\MemoryMappedFiles\MemoryMappedFileMemoryManager.cs"
@@ -314,6 +317,8 @@
              Link="Common\System\Security\Cryptography\Helpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeyBlobHelpers.cs"
              Link="Common\System\Security\Cryptography\KeyBlobHelpers.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\IImportExportShape.cs"
+             Link="Common\System\Security\Cryptography\IImportExportShape.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\IRuntimeAlgorithm.cs"
              Link="Common\System\Security\Cryptography\IRuntimeAlgorithm.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeyFormatHelper.cs"
@@ -322,6 +327,12 @@
              Link="Common\System\Security\Cryptography\KeyFormatHelper.Encrypted.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs"
              Link="Common\System\Security\Cryptography\KeySizeHelpers.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsa.cs"
+             Link="Common\System\Security\Cryptography\MLDsa.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaAlgorithm.cs"
+             Link="Common\System\Security\Cryptography\MLDsaAlgorithm.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.cs"
+             Link="Common\System\Security\Cryptography\MLDsaImplementation.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs"
              Link="Common\System\Security\Cryptography\Oids.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.Shared.cs"
@@ -701,6 +712,8 @@
              Link="Common\System\Sha1ForNonSecretPurposes.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs"
              Link="Common\System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\MLDsaImplementation.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\AesCcm.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\AesGcm.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\AesImplementation.NotSupported.cs" />
@@ -883,6 +896,8 @@
              Link="Common\System\Security\Cryptography\ECOpenSsl.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\ECOpenSsl.ImportExport.cs"
              Link="Common\System\Security\Cryptography\ECOpenSsl.ImportExport.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\MLDsaImplementation.NotSupported.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSAOpenSsl.cs"
              Link="Common\System\Security\Cryptography\RSAOpenSsl.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs"
@@ -1053,6 +1068,8 @@
              Link="Common\System\Security\Cryptography\ECDiffieHellmanDerivation.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaAndroid.cs"
              Link="Common\System\Security\Cryptography\ECDsaAndroid.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\MLDsaImplementation.NotSupported.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSAAndroid.cs"
              Link="Common\System\Security\Cryptography\RSAAndroid.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs"
@@ -1182,6 +1199,8 @@
              Link="Common\System\Security\Cryptography\ECDiffieHellmanSecurityTransforms.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaSecurityTransforms.cs"
              Link="Common\System\Security\Cryptography\ECDsaSecurityTransforms.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\MLDsaImplementation.NotSupported.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSASecurityTransforms.cs"
              Link="Common\System\Security\Cryptography\RSASecurityTransforms.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs"
@@ -1728,6 +1747,8 @@
              Link="Common\System\Security\Cryptography\ECDsaCng.ImportExport.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.SignVerify.cs"
              Link="Common\System\Security\Cryptography\ECDsaCng.SignVerify.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.Windows.cs"
+             Link="Common\System\Security\Cryptography\MLDsaImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.cs"
              Link="Common\System\Security\Cryptography\RSACng.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.EncryptDecrypt.cs"


### PR DESCRIPTION
This seeds a lot of untested boilerplate code as non-public types in System.Security.Cryptography.

When we start work on ML-DSA, we can take this, make MLDsa and MLDsaAlgorithm public, start to write tests, and wire up an implementation. We can also take this and clone+customize it for the other PQC algorithms.

It does not define all span-vs-array overloads for all spanified members, just one candidate per method group.

As the PQC experiment needs to make it further before we can commit to the shape, it is both starting without API Review, and pre-emptively applying the Experimental attribute.