### PR TITLE
[RISC-V] Eliminate unecessary add instruction in array indirection

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5616,7 +5616,10 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
     }
 
     // dest = dest + elemOffs
-    GetEmitter()->emitIns_R_R_I(INS_addi, attr, node->GetRegNum(), node->GetRegNum(), node->gtElemOffset);
+    if (node->gtElemOffset != 0)
+    {
+        GetEmitter()->emitIns_R_R_I(INS_addi, attr, node->GetRegNum(), node->GetRegNum(), node->gtElemOffset);
+    }
 
     gcInfo.gcMarkRegSetNpt(base->gtGetRegMask());
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -15,6 +15,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 */
 
+#include "gentreeopsdef.h"
 #include "jitpch.h"
 #ifdef _MSC_VER
 #pragma hdrstop
@@ -690,6 +691,19 @@ GenTree* Lowering::LowerNode(GenTree* node)
             }
         }
         break;
+
+#if defined(TARGET_RISCV64)
+        case GT_INDEX_ADDR:
+        {
+            GenTree* nextNode = nullptr;
+            if (TryLowerIndirAfterIndexAddr(node->AsIndexAddr(), &nextNode))
+            {
+                assert(nextNode != nullptr);
+                return nextNode;
+            }
+        }
+        break;
+#endif
 
 #if defined(FEATURE_HW_INTRINSICS) && defined(TARGET_XARCH)
         case GT_BSWAP:

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -126,6 +126,9 @@ private:
     void TryCompressConstVecData(GenTreeStoreInd* node);
 #endif // TARGET_XARCH
 #endif // FEATURE_HW_INTRINSICS
+#ifdef TARGET_RISCV64
+    bool TryLowerIndirAfterIndexAddr(GenTreeIndexAddr* indexAddr, GenTree** nextNode);
+#endif // TARGET_RISCV64
 
 #ifdef DEBUG
     static void CheckCallArg(GenTree* arg);


### PR DESCRIPTION
Introduced `TryLowerIndirAfterIndexAddr` to try and move offset value from a GT_INDEX_ADDR node to the following GT_INDIR node to eliminate unecessary add instruction.

For example, currently, the following C# code:

```cs
[MethodImpl(MethodImplOptions.NoInlining)]
private static int MemoryAccess(int[] a, int b)
{
	return a[b];
}
```

Generates the following assembly:
```asm
slli           a2, a1, 2
add            a0, a0, a2
addi           a0, a0, 16  # <- this can be eliminated by moving offset to the load instruction below
lw             a0, 0(a0)
sw             a0, -16(fp)
nop
lw             a0, -16(fp)
```

After adding `TryLowerIndirAfterIndexAddr`, the generated assembly becomes:
```asm
slli           a2, a1, 2
add            a0, a0, a2
lw             a0, 16(a0)
sw             a0, -16(fp)
nop
lw             a0, -16(fp)
```

Part of #84834, cc @dotnet/samsung