### PR TITLE
SPMI: Add fallback for `notifyInstructionSetUsage`

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -811,9 +811,21 @@ bool MethodContext::repNotifyInstructionSetUsage(CORINFO_InstructionSet isa, boo
     DD key{};
     key.A = (DWORD)isa;
     key.B = supported ? 1 : 0;
-    DWORD value = LookupByKeyOrMiss(NotifyInstructionSetUsage, key, ": key %u-%u", key.A, key.B);
-    DEBUG_REP(dmpNotifyInstructionSetUsage(key, value));
-    return value != 0;
+
+    if (NotifyInstructionSetUsage != nullptr)
+    {
+        int index = NotifyInstructionSetUsage->GetIndex(key);
+        if (index != -1)
+        {
+            DWORD value = NotifyInstructionSetUsage->GetItem(index);
+            DEBUG_REP(dmpNotifyInstructionSetUsage(key, value));
+            return value != 0;
+        }
+    }
+
+    // Fall back to most likely implementation instead of missing, since ISA
+    // usage changes are quite common on normal JIT changes.
+    return supported;
 }
 
 void MethodContext::recGetMethodAttribs(CORINFO_METHOD_HANDLE methodHandle, DWORD attribs)


### PR DESCRIPTION
I noticed that `notifyInstructionSetUsage` misses are pretty common, particularly because we query for instruction sets for some very basic instructions (e.g. `GT_RSZ`/`GT_RSH`). So changes that introduce new kinds of nodes now seem to be much more likely to miss.

The best solution would probably be to add another set of ISAs that is passed to the JIT so that `notifyInstructionSetUsage` can be purely a "result" type of JIT-EE call, but this change at least gets us back to what we had before with an improvement to when we actually know the answer.

As an example, I started getting lots of misses on win-x64 for #112740 after I merged the previous change. That turns out to be because that PR produces `GT_RSZ` which ends reporting `BMI2` usage, and that now results in a miss.

cc @dotnet/jit-contrib 