### PR TITLE
Add System.Net.ServerSentEvents to runtime shared framework

### DIFF
--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -222,6 +222,7 @@
       Microsoft.Extensions.Options.DataAnnotations;
       Microsoft.Extensions.Primitives;
       System.Diagnostics.EventLog;
+      System.Net.ServerSentEvents;
       System.Security.Cryptography.Xml;
       System.Threading.RateLimiting;
     </AspNetCoreAppLibrary>

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -96,6 +96,7 @@
       System.Net.Quic;
       System.Net.Requests;
       System.Net.Security;
+      System.Net.ServerSentEvents;
       System.Net.ServicePoint;
       System.Net.Sockets;
       System.Net.WebClient;
@@ -222,7 +223,6 @@
       Microsoft.Extensions.Options.DataAnnotations;
       Microsoft.Extensions.Primitives;
       System.Diagnostics.EventLog;
-      System.Net.ServerSentEvents;
       System.Security.Cryptography.Xml;
       System.Threading.RateLimiting;
     </AspNetCoreAppLibrary>

--- a/src/libraries/System.Net.ServerSentEvents/ref/System.Net.ServerSentEvents.csproj
+++ b/src/libraries/System.Net.ServerSentEvents/ref/System.Net.ServerSentEvents.csproj
@@ -17,4 +17,11 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Memory\ref\System.Memory.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Threading\ref\System.Threading.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\ref\System.Runtime.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/libraries/System.Net.ServerSentEvents/src/System.Net.ServerSentEvents.csproj
+++ b/src/libraries/System.Net.ServerSentEvents/src/System.Net.ServerSentEvents.csproj
@@ -34,4 +34,11 @@ System.Net.ServerSentEvents.SseParser</PackageDescription>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
 
+   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Reference Include="System.Memory" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This enables us to support SSE in minimal APIs for https://github.com/dotnet/aspnetcore/issues/56172.