### PR TITLE
Allow R2R for images provided via external_assembly_probe

### DIFF
--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -19,21 +19,18 @@ extern "C"
 }
 #endif
 
-namespace
+static bool AllowR2RForImage(PEImage* pOwner)
 {
-    bool AllowR2RForImage(PEImage* pOwner)
-    {
-        // Allow R2R for files
-        if (pOwner->IsFile())
-            return true;
+    // Allow R2R for files
+    if (pOwner->IsFile())
+        return true;
 
-        // Allow R2R for externally provided images
-        INT64 size;
-        if (pOwner->GetExternalData(&size) != NULL && size > 0)
-            return true;
+    // Allow R2R for externally provided images
+    INT64 size;
+    if (pOwner->GetExternalData(&size) != NULL && size > 0)
+        return true;
 
-        return false;
-    }
+    return false;
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -87,13 +87,11 @@ PEImageLayout* PEImageLayout::LoadConverted(PEImage* pOwner, bool disableMapping
         pFlat = (FlatImageLayout*)pOwner->GetFlatLayout();
         pFlat->AddRef();
     }
-    else
+    else if (AllowR2RForImage(pOwner))
     {
-        INT64 dataSize;
-        if (pOwner->IsFile() || pOwner->GetExternalData(&dataSize) != NULL)
-        {
-            pFlat = new FlatImageLayout(pOwner);
-        }
+        // We only expect to be converting images that aren't already opened in the R2R composite case
+        pFlat = new FlatImageLayout(pOwner);
+        _ASSERTE(pFlat->HasReadyToRunHeader());
     }
 
     if (pFlat == NULL || !pFlat->CheckILOnlyFormat())

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -19,6 +19,23 @@ extern "C"
 }
 #endif
 
+namespace
+{
+    bool AllowR2RForImage(PEImage* pOwner)
+    {
+        // Allow R2R for files
+        if (pOwner->IsFile())
+            return true;
+
+        // Allow R2R for externally provided images
+        INT64 size;
+        if (pOwner->GetExternalData(&size) != NULL && size > 0)
+            return true;
+
+        return false;
+    }
+}
+
 #ifndef DACCESS_COMPILE
 PEImageLayout* PEImageLayout::CreateFromByteArray(PEImage* pOwner, const BYTE* array, COUNT_T size)
 {
@@ -70,9 +87,13 @@ PEImageLayout* PEImageLayout::LoadConverted(PEImage* pOwner, bool disableMapping
         pFlat = (FlatImageLayout*)pOwner->GetFlatLayout();
         pFlat->AddRef();
     }
-    else if (pOwner->IsFile())
+    else
     {
-        pFlat = new FlatImageLayout(pOwner);
+        INT64 dataSize;
+        if (pOwner->IsFile() || pOwner->GetExternalData(&dataSize) != NULL)
+        {
+            pFlat = new FlatImageLayout(pOwner);
+        }
     }
 
     if (pFlat == NULL || !pFlat->CheckILOnlyFormat())
@@ -88,9 +109,8 @@ PEImageLayout* PEImageLayout::LoadConverted(PEImage* pOwner, bool disableMapping
     _ASSERTE(!pOwner->IsFile() || !pFlat->HasReadyToRunHeader() || disableMapping);
 #endif
 
-    // ignore R2R if the image is not a file.
-    if ((pFlat->HasReadyToRunHeader() && pOwner->IsFile()) ||
-        pFlat->HasWriteableSections())
+    if ((pFlat->HasReadyToRunHeader() && AllowR2RForImage(pOwner))
+        || pFlat->HasWriteableSections())
     {
         return new ConvertedImageLayout(pFlat, disableMapping);
     }
@@ -462,7 +482,7 @@ ConvertedImageLayout::ConvertedImageLayout(FlatImageLayout* source, bool disable
 
     IfFailThrow(Init(loadedImage));
 
-    if (m_pOwner->IsFile() && IsNativeMachineFormat())
+    if (AllowR2RForImage(m_pOwner) && IsNativeMachineFormat())
     {
         // Do base relocation and exception hookup, if necessary.
         // otherwise R2R will be disabled for this image.


### PR DESCRIPTION
Allow R2R for images provided via `external_assembly_probe` This re-uses the existing mechanism from single-file with R2R, where we load the image by copying it. This is obviously inefficient, but allows a first version of functioning R2R. 

I tried running the `AndroidSampleApp` (regular, R2R, and R2R composite) for the startup scenario in dotnet/performance, but the results for each run had so much variation in my setup (Windows, x64 emulator) that I don't think there was anything to take from it.