### PR TITLE
[android] Make Android app on coreclr use host-runtime contract and provide external assembly probe

### DIFF
--- a/src/mono/msbuild/android/build/AndroidBuild.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.targets
@@ -37,9 +37,16 @@
       <AndroidBundleDir Condition="'$(AndroidBundleDir)' == ''">$([MSBuild]::NormalizeDirectory('$(OutDir)', 'Bundle'))</AndroidBundleDir>
 
       <BundleDir>$(AndroidBundleDir)</BundleDir>
-      <RuntimeHeaders>$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'include', 'mono-2.0'))</RuntimeHeaders>
-      <RuntimeHeaders Condition="'$(UseMonoRuntime)' == 'false' and '$(UseNativeAOTRuntime)' != 'true'">$(CoreClrProjectRoot)hosts\inc</RuntimeHeaders>
     </PropertyGroup>
+
+    <ItemGroup>
+      <RuntimeHeaders Include="$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'include', 'mono-2.0'))"
+                      Condition="'$(UseMonoRuntime)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'"/>
+      <RuntimeHeaders Include="$(CoreClrProjectRoot)hosts\inc"
+                      Condition="'$(UseMonoRuntime)' == 'false' and '$(UseNativeAOTRuntime)' != 'true'" />
+      <RuntimeHeaders Include="$(SharedNativeRoot)"
+                      Condition="'$(UseMonoRuntime)' == 'false' and '$(UseNativeAOTRuntime)' != 'true'" />
+    </ItemGroup>
 
     <ItemGroup Condition="'$(UseMonoRuntime)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'">
       <RuntimeComponents Condition="'$(UseAllRuntimeComponents)' == 'true'" Include="@(_MonoRuntimeAvailableComponents)" />
@@ -246,7 +253,7 @@
         ForceInterpreter="$(MonoForceInterpreter)"
         IsLibraryMode="$(_IsLibraryMode)"
         MainLibraryFileName="$(MainLibraryFileName)"
-        MonoRuntimeHeaders="$(RuntimeHeaders)"
+        RuntimeHeaders="@(RuntimeHeaders)"
         NativeDependencies="@(_NativeDependencies)"
         OutputDir="$(AndroidBundleDir)"
         ProjectName="$(AppName)"

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -54,10 +54,14 @@
       <AppleBundleDir Condition="'$(AppleBundleDir)' == ''">$([MSBuild]::NormalizeDirectory('$(OutDir)', 'Bundle'))</AppleBundleDir>
 
       <BundleDir>$(AppleBundleDir)</BundleDir>
-      <RuntimeHeaders Condition="'$(UseMonoRuntime)' != 'false' and '$(UseNativeAOTRuntime)' != 'true'">$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'include', 'mono-2.0'))</RuntimeHeaders>
       <_AotModuleTablePath>$(AppleBundleDir)\modules.m</_AotModuleTablePath>
       <AppName Condition="'$(AppName)' == ''">$(AssemblyName)</AppName>
     </PropertyGroup>
+
+    <ItemGroup>
+      <RuntimeHeaders Include="$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'include', 'mono-2.0'))"
+                      Condition="'$(UseMonoRuntime)' != 'false' and '$(UseNativeAOTRuntime)' != 'true'" />
+    </ItemGroup>
 
     <ItemGroup Condition="'$(AppleAppBuilderRuntime)' == 'MonoVM'">
       <RuntimeComponents Condition="'$(UseAllRuntimeComponents)' == 'true'" Include="@(_MonoRuntimeAvailableComponents)"/>
@@ -298,7 +302,7 @@
       <LinkerArg Remove="@(_LinkerFlagsToDrop)" />
       <ExtraAppLinkerArgs Include="@(LinkerArg)" />
     </ItemGroup>
- 
+
     <PropertyGroup>
       <AppleAppBuilderRuntime Condition="'$(AppleAppBuilderRuntime)' == '' and '$(UseNativeAOTRuntime)' == 'true'">NativeAOT</AppleAppBuilderRuntime>
       <AppleAppBuilderRuntime Condition="'$(AppleAppBuilderRuntime)' == '' and '$(UseMonoRuntime)' == 'false'">CoreCLR</AppleAppBuilderRuntime>
@@ -324,7 +328,7 @@
       InvariantGlobalization="$(InvariantGlobalization)"
       IsLibraryMode="$(_IsLibraryMode)"
       MainLibraryFileName="$(MainLibraryFileName)"
-      MonoRuntimeHeaders="$(RuntimeHeaders)"
+      MonoRuntimeHeaders="@(RuntimeHeaders)"
       NativeMainSource="$(NativeMainSource)"
       NativeDependencies="@(NativeDependencies)"
       Optimized="$(Optimized)"

--- a/src/mono/msbuild/common/LibraryBuilder.targets
+++ b/src/mono/msbuild/common/LibraryBuilder.targets
@@ -1,7 +1,7 @@
 <Project>
   <UsingTask TaskName="EmitBundleSourceFiles"
              AssemblyFile="$(MonoTargetsTasksAssemblyPath)" />
-  <UsingTask TaskName="LibraryBuilderTask" 
+  <UsingTask TaskName="LibraryBuilderTask"
              AssemblyFile="$(LibraryBuilderTasksAssemblyPath)" />
 
   <Target Name="_BuildNativeLibrary"
@@ -33,7 +33,7 @@
       ExtraLinkerArguments="@(_ExtraLinkerArgs)"
       ExtraSources="@(_ExtraLibrarySources)"
       IsSharedLibrary="$(_IsSharedLibrary)"
-      MonoRuntimeHeaders="$(RuntimeHeaders)"
+      MonoRuntimeHeaders="@(RuntimeHeaders)"
       Name="$(AssemblyName)"
       OutputDirectory="$(BundleDir)"
       RuntimeIdentifier="$(RuntimeIdentifier)"

--- a/src/mono/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/sample/Android/AndroidSampleApp.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <RuntimeComponents Condition="'$(RuntimeFlavor)' == 'Mono' and '$(DiagnosticPorts)' != ''" Include="diagnostics_tracing" />
+    <RuntimeHeaders Include="$(SharedNativeRoot)" Condition="'$(RuntimeFlavor)' != 'Mono'"/>
   </ItemGroup>
 
   <Import Project="$(MonoProjectRoot)\msbuild\android\build\AndroidBuild.props" />

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Utilities;
 public class AndroidAppBuilderTask : Task
 {
     [Required]
-    public string[] RuntimeHeaders { get; set; } = Array.Empty<string>()!;
+    public string[] RuntimeHeaders { get; set; } = [];
 
     /// <summary>
     /// Target directory with *dll and other content to be AOT'd and/or bundled

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Utilities;
 public class AndroidAppBuilderTask : Task
 {
     [Required]
-    public string MonoRuntimeHeaders { get; set; } = ""!;
+    public string[] RuntimeHeaders { get; set; } = Array.Empty<string>()!;
 
     /// <summary>
     /// Target directory with *dll and other content to be AOT'd and/or bundled
@@ -141,7 +141,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.NativeDependencies = NativeDependencies;
         apkBuilder.ExtraLinkerArguments = ExtraLinkerArguments;
         apkBuilder.RuntimeFlavor = RuntimeFlavor;
-        (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(RuntimeIdentifier, MainLibraryFileName, MonoRuntimeHeaders);
+        (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(RuntimeIdentifier, MainLibraryFileName, RuntimeHeaders);
 
         return true;
     }

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -64,7 +64,7 @@ public partial class ApkBuilder
     public (string apk, string packageId) BuildApk(
         string runtimeIdentifier,
         string mainLibraryFileName,
-        string runtimeHeaders)
+        string[] runtimeHeaders)
     {
         if (!Enum.TryParse(RuntimeFlavor, true, out parsedRuntimeFlavor))
         {
@@ -324,9 +324,10 @@ public partial class ApkBuilder
         string aotSources = assemblerFiles.ToString();
         string monodroidSource = IsCoreCLR ?
             "monodroid-coreclr.c" : (IsLibraryMode) ? "monodroid-librarymode.c" : "monodroid.c";
+        string runtimeInclude = string.Join(" ", runtimeHeaders.Select(h => $"\"{NormalizePathToUnix(h)}\""));
 
         string cmakeLists = Utils.GetEmbeddedResource("CMakeLists-android.txt")
-            .Replace("%RuntimeInclude%", NormalizePathToUnix(runtimeHeaders))
+            .Replace("%RuntimeInclude%", runtimeInclude)
             .Replace("%NativeLibrariesToLink%", NormalizePathToUnix(nativeLibraries))
             .Replace("%MONODROID_SOURCE%", monodroidSource)
             .Replace("%AotSources%", NormalizePathToUnix(aotSources))

--- a/src/tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
+++ b/src/tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
@@ -21,7 +21,7 @@ add_library(
 
 %Defines%
 
-include_directories("%RuntimeInclude%")
+include_directories(%RuntimeInclude%)
 
 target_link_libraries(
     monodroid

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
@@ -41,7 +41,7 @@ static const char* g_executable_path = NULL;
 static unsigned int g_coreclr_domainId = 0;
 static void* g_coreclr_handle = NULL;
 
-#define MAX_MAPPED_COUNT 50 // Arbitrarily 'large enough' number
+#define MAX_MAPPED_COUNT 256 // Arbitrarily 'large enough' number
 static void* g_mapped_files[MAX_MAPPED_COUNT];
 static size_t g_mapped_file_sizes[MAX_MAPPED_COUNT];
 static unsigned int g_mapped_files_count = 0;

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -47,7 +47,7 @@ public class AppleAppBuilderTask : Task
     /// <summary>
     /// Path to Mono public headers (*.h)
     /// </summary>
-    public string[] MonoRuntimeHeaders { get; set; } = Array.Empty<string>();
+    public string[] MonoRuntimeHeaders { get; set; } = [];
 
     /// <summary>
     /// This library will be used as an entry point (e.g. TestRunner.dll). Can

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -47,7 +47,7 @@ public class AppleAppBuilderTask : Task
     /// <summary>
     /// Path to Mono public headers (*.h)
     /// </summary>
-    public string MonoRuntimeHeaders { get; set; } = ""!;
+    public string[] MonoRuntimeHeaders { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// This library will be used as an entry point (e.g. TestRunner.dll). Can
@@ -201,7 +201,7 @@ public class AppleAppBuilderTask : Task
 
         if (targetRuntime == TargetRuntime.NativeAOT || targetRuntime == TargetRuntime.CoreCLR)
         {
-            if (!string.IsNullOrEmpty(MonoRuntimeHeaders))
+            if (MonoRuntimeHeaders.Length != 0)
                 throw new ArgumentException($"Property \"{nameof(MonoRuntimeHeaders)}\" is not supported with {Runtime} runtime and will be ignored.");
 
             if (!string.IsNullOrEmpty(MainLibraryFileName) && targetRuntime == TargetRuntime.NativeAOT)
@@ -224,7 +224,7 @@ public class AppleAppBuilderTask : Task
         }
         else
         {
-            if (string.IsNullOrEmpty(MonoRuntimeHeaders))
+            if (MonoRuntimeHeaders.Length == 0)
                 throw new ArgumentException($"The \"{nameof(AppleAppBuilderTask)}\" task was not given a value for the required parameter \"{nameof(MonoRuntimeHeaders)}\" when using Mono runtime.");
         }
     }

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists-librarymode.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists-librarymode.txt.template
@@ -20,7 +20,7 @@ add_executable(
 %Defines%
 
 if(NOT %UseNativeAOTRuntime%)
-    include_directories("%MonoInclude%")
+    include_directories(%MonoInclude%)
 endif()
 
 set_target_properties(%ProjectName% PROPERTIES

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -28,8 +28,8 @@ endif()
 
 %Defines%
 
-if(NOT "%MonoInclude%" STREQUAL "")
-    include_directories("%MonoInclude%")
+if(%HasMonoIncludes%)
+    include_directories(%MonoInclude%)
 endif()
 
 set_target_properties(%ProjectName% %AotTargetsList% PROPERTIES

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -177,7 +177,7 @@ internal sealed class Xcode
         IEnumerable<string> excludes,
         string workspace,
         string binDir,
-        string monoInclude,
+        string[] monoInclude,
         bool preferDylibs,
         bool useConsoleUiTemplate,
         bool forceAOT,
@@ -250,7 +250,7 @@ internal sealed class Xcode
         IEnumerable<string> excludes,
         string workspace,
         string binDir,
-        string monoInclude,
+        string[] monoInclude,
         bool preferDylibs,
         bool useConsoleUiTemplate,
         bool forceAOT,
@@ -347,7 +347,8 @@ internal sealed class Xcode
             .Replace("%ProjectName%", projectName)
             .Replace("%AppResources%", appResources)
             .Replace("%MainSource%", nativeMainSource)
-            .Replace("%MonoInclude%", monoInclude)
+            .Replace("%HasMonoIncludes%", monoInclude.Length > 0 ? "TRUE" : "FALSE")
+            .Replace("%MonoInclude%", string.Join(" ", monoInclude.Select(h => $"\"{h}\"")))
             .Replace("%HardenedRuntime%", hardenedRuntime ? "TRUE" : "FALSE");
 
         string toLink = "";

--- a/src/tasks/Common/Builders/AppBuilderTask.cs
+++ b/src/tasks/Common/Builders/AppBuilderTask.cs
@@ -30,7 +30,7 @@ public class AppBuilderTask : Task
     /// Path to Mono public headers (*.h)
     /// </summary>
     [Required]
-    public string[] MonoRuntimeHeaders { get; set; } = Array.Empty<string>();
+    public string[] MonoRuntimeHeaders { get; set; } = [];
 
     /// <summary>
     /// Path to store build artifacts

--- a/src/tasks/Common/Builders/AppBuilderTask.cs
+++ b/src/tasks/Common/Builders/AppBuilderTask.cs
@@ -30,7 +30,7 @@ public class AppBuilderTask : Task
     /// Path to Mono public headers (*.h)
     /// </summary>
     [Required]
-    public string MonoRuntimeHeaders { get; set; } = ""!;
+    public string[] MonoRuntimeHeaders { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// Path to store build artifacts

--- a/src/tasks/LibraryBuilder/LibraryBuilder.cs
+++ b/src/tasks/LibraryBuilder/LibraryBuilder.cs
@@ -344,7 +344,7 @@ public class LibraryBuilderTask : AppBuilderTask
         buildOptions.CompilerArguments.Add("-D HOST_ANDROID=1");
         buildOptions.CompilerArguments.Add("-fPIC");
         buildOptions.CompilerArguments.Add(IsSharedLibrary ? $"-shared -o {libraryName}" : $"-o {libraryName}");
-        buildOptions.IncludePaths.Add(MonoRuntimeHeaders);
+        buildOptions.IncludePaths.AddRange(MonoRuntimeHeaders);
         buildOptions.LinkerArguments.Add($"--soname={libraryName}");
 
         // Google requires all the native libraries to be aligned to 16 bytes (for 16k memory page size)
@@ -386,7 +386,7 @@ public class LibraryBuilderTask : AppBuilderTask
         buildOptions.CompilerArguments.Add(IsSharedLibrary ? $"-dynamiclib -o {libraryName}" : $"-o {libraryName}");
         buildOptions.CompilerArguments.Add("-D HOST_APPLE_MOBILE=1");
         buildOptions.CompilerArguments.Add("-D FORCE_AOT=1");
-        buildOptions.IncludePaths.Add(MonoRuntimeHeaders);
+        buildOptions.IncludePaths.AddRange(MonoRuntimeHeaders);
         buildOptions.NativeLibraryPaths.AddRange(libs);
         buildOptions.Sources.AddRange(sources);
         buildOptions.Sources.Add("preloaded-assemblies.c");

--- a/src/tasks/LibraryBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/LibraryBuilder/Templates/CMakeLists.txt.template
@@ -15,7 +15,7 @@ set(DOTNET_EXTRA_SOURCES
     preloaded-assemblies.c
 %ExtraSources%)
 
-include_directories("%MonoInclude%")
+include_directories(%MonoInclude%)
 
 add_library(
     aot_library STATIC

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -265,7 +265,7 @@
         AppDir="$(BuildDir)"
         DiagnosticPorts="$(DiagnosticPorts)"
         ForceInterpreter="$(MonoInterp)"
-        MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)/native/include/mono-2.0"
+        RuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)/native/include/mono-2.0"
         OutputDir="$(AppDir)"
         ProjectName="$(Category)"
         RuntimeComponents="@(RuntimeComponents)"


### PR DESCRIPTION
- Update app builder targets / tasks to allow specifying multiple runtime header directories
- Make Android app on coreclr use `host_runtime_contract::external_assembly_probe`