### PR TITLE
[PERF] Enable Android CoreCLR and device startup testing

### DIFF
--- a/eng/pipelines/performance/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/performance/templates/build-perf-sample-apps.yml
@@ -1,41 +1,57 @@
 parameters:
   osGroup: ''
-  osSubgroup: ''
-  archType: ''
-  buildConfig: ''
-  runtimeFlavor: ''
-  helixQueues: ''
-  targetRid: ''
+  runtimeType: 'mono' # Currently only used for Android Hello World app
   nameSuffix: ''
-  platform: ''
-  shouldContinueOnError: ''
-  rootFolder: ''
-  includeRootFolder: ''
-  displayName: ''
-  artifactName: ''
-  archiveExtension: ''
-  archiveType: ''
-  tarCompression: ''
   hybridGlobalization: False
 
 steps:
 # Build Android sample app
   - ${{ if eq(parameters.osGroup, 'android') }}:
-    - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
-      displayName: Build HelloAndroid sample app
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/Bundle/bin/HelloAndroid.apk
-        includeRootFolder: true
-        displayName: Android Mono Artifacts
-        artifactName: AndroidMonoarm64
-        archiveExtension: '.tar.gz'
-        archiveType: tar
-        tarCompression: gz
-    - script: rm -r -f $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp
-      workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
-      displayName: clean bindir
+    - ${{ if eq(parameters.runtimeType, 'mono') }}:
+      - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=Mono
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
+        displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=Mono
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
+          artifactName:  AndroidMonoArm64BuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/Bundle/bin/HelloAndroid.apk
+          includeRootFolder: true
+          displayName: Android Sample App JIT Mono
+          artifactName: AndroidHelloWorldArm64Mono
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
+      - script: rm -r -f $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp
+        workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        displayName: clean bindir
+
+    - ${{ if eq(parameters.runtimeType, 'coreclr') }}:
+      - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=CoreCLR
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
+        displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
+          artifactName:  AndroidCoreCLRArm64BuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/Bundle/bin/HelloAndroid.apk
+          includeRootFolder: true
+          displayName: Android Sample App JIT CoreCLR
+          artifactName: AndroidHelloWorldArm64CoreCLR
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
+      - script: rm -r -f $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp
+        workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        displayName: clean bindir
 
   - ${{ if and(eq(parameters.osGroup, 'ios'), eq(parameters.nameSuffix, 'iOSMono')) }}:
     - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release AOT=True USE_LLVM=False DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=false HYBRID_GLOBALIZATION=${{ parameters.hybridGlobalization }}
@@ -48,7 +64,7 @@ steps:
       displayName: 'Publish binlog'
       inputs:
         pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName:  ${{ parameters.artifactName }}
+        artifactName:  iOSMonoArm64NoLLVMNoStripSymbolsBuildLog
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
         rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -70,7 +86,7 @@ steps:
       displayName: 'Publish binlog'
       inputs:
         pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName:  ${{ parameters.artifactName }}
+        artifactName:  iOSMonoArm64NoLLVMStripSymbolsBuildLog
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
         rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -92,7 +108,7 @@ steps:
       displayName: 'Publish binlog'
       inputs:
         pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName:  ${{ parameters.artifactName }}
+        artifactName:  iOSMonoArm64LLVMNoStripSymbolsBuildLog
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
         rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -114,7 +130,7 @@ steps:
       displayName: 'Publish binlog'
       inputs:
         pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName:  ${{ parameters.artifactName }}
+        artifactName: iOSMonoArm64LLVMStripSymbolsBuildLog
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
         rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -135,7 +151,7 @@ steps:
       displayName: 'Publish binlog'
       inputs:
         pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/msbuild.binlog
-        artifactName:  ${{ parameters.artifactName }}
+        artifactName: iOSNativeAOTArm64NoStripSymbolsBuildLog
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
         rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -157,7 +173,7 @@ steps:
       displayName: 'Publish binlog'
       inputs:
         pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/msbuild.binlog
-        artifactName:  ${{ parameters.artifactName }}
+        artifactName: iOSNativeAOTArm64StripSymbolsBuildLog
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
         rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app

--- a/eng/pipelines/performance/templates/perf-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-build-jobs.yml
@@ -9,14 +9,15 @@ jobs:
       windows_x64: true
       windows_x86: true
       linux_musl_x64: true
-  
+      coreclrAndroid: true
+
   # build mono for AOT
   - template: /eng/pipelines/performance/templates/perf-mono-build-jobs.yml
     parameters:
       mono_x64: true
       monoAot_x64: true
       monoAndroid: true
-      
+
   # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
   - ${{ if false }}:
     # build PerfBDN app

--- a/eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
@@ -5,6 +5,7 @@ parameters:
     windows_x86: false
     linux_arm64: false
     windows_arm64: false
+    coreclrAndroid: false
 
 jobs:
   - ${{ if or(eq(parameters.linux_x64, true), eq(parameters.windows_x64, true), eq(parameters.windows_x86, true), eq(parameters.linux_musl_x64, true), eq(parameters.linux_arm64, true), eq(parameters.windows_arm64, true)) }}:
@@ -40,3 +41,21 @@ jobs:
               tarCompression: $(tarCompression)
               artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
               displayName: Build Assets
+
+  - ${{ if eq(parameters.coreclrAndroid, true) }}:
+    # build CoreCLR Android scenarios
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+        - android_arm64
+        jobParameters:
+          buildArgs: -s clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs -c $(_BuildConfig)
+          nameSuffix: AndroidCoreCLR
+          isOfficialBuild: false
+          postBuildSteps:
+            - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
+              parameters:
+                runtimeType: coreclr

--- a/eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml
@@ -20,13 +20,6 @@ jobs:
           postBuildSteps:
             - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
               parameters:
-                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-                includeRootFolder: true
-                displayName: iOS Mono Artifacts
-                artifactName: iOSMonoarm64
-                archiveExtension: '.tar.gz'
-                archiveType: tar
-                tarCompression: gz
                 hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
   - ${{ if eq(parameters.nativeAot, true) }}:
@@ -45,11 +38,4 @@ jobs:
           postBuildSteps:
             - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
               parameters:
-                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-                includeRootFolder: true
-                displayName: iOS NativeAOT Artifacts
-                artifactName: iOSNativeAOTarm64
-                archiveExtension: '.tar.gz'
-                archiveType: tar
-                tarCompression: gz
                 hybridGlobalization: ${{ parameters.hybridGlobalization }}

--- a/eng/pipelines/performance/templates/perf-mono-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-mono-build-jobs.yml
@@ -6,7 +6,7 @@ parameters:
     monoAndroid: false
     monoAndroidPacks: false
 
-jobs:              
+jobs:
   - ${{ if eq(parameters.monoAot_x64, true) }}:
     # build mono for AOT
     - template: /eng/pipelines/common/platform-matrix.yml
@@ -30,7 +30,7 @@ jobs:
                 archiveExtension: '.tar.gz'
                 archiveType: tar
                 tarCompression: gz
-                
+
   - ${{ if eq(parameters.mono_x64, true) }}:
     # build mono
     - template: /eng/pipelines/common/platform-matrix.yml
@@ -78,7 +78,7 @@ jobs:
               tarCompression: $(tarCompression)
               artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_mono
               displayName: Build Assets
-              
+
   - ${{ if eq(parameters.monoAot_arm64, true) }}:
     # build monoAot_arm64
     - template: /eng/pipelines/common/platform-matrix.yml
@@ -103,7 +103,7 @@ jobs:
                 archiveExtension: '.tar.gz'
                 archiveType: tar
                 tarCompression: gz
-                
+
   - ${{ if eq(parameters.monoAndroid, true) }}:
     # build mono Android scenarios
     - template: /eng/pipelines/common/platform-matrix.yml
@@ -120,14 +120,8 @@ jobs:
           postBuildSteps:
             - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
               parameters:
-                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-                includeRootFolder: true
-                displayName: Android Mono Artifacts
-                artifactName: AndroidMonoarm64
-                archiveExtension: '.tar.gz'
-                archiveType: tar
-                tarCompression: gz
-              
+                runtimeType: mono
+
   - ${{ if eq(parameters.monoAndroidPacks, true) }}:
     # build mono runtime packs
     - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/testing/performance/android_scenarios.proj
+++ b/eng/testing/performance/android_scenarios.proj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
   <PropertyGroup>
       <IncludeXHarnessCli>true</IncludeXHarnessCli>
-      <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21566.2</MicrosoftDotNetXHarnessCLIVersion>
-      <XharnessPath>%HELIX_CORRELATION_PAYLOAD%\microsoft.dotnet.xharness.cli\$(MicrosoftDotNetXHarnessCLIVersion)\tools\net6.0\any\Microsoft.DotNet.XHarness.CLI.dll</XharnessPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <Python>python3</Python>
@@ -35,19 +33,25 @@
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <!-- <HelixWorkItem Include="SOD - Android Benchmarks.Droid APK Size"> # Disabled due to not working and needing consistent normal android results. https://github.com/dotnet/performance/issues/4729
+    <HelixWorkItem Include="Device Startup - Android HelloWorld">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_WORKITEM_ROOT%\HelloAndroid.apk .;$(Python) pre.py --apk-name HelloAndroid.apk</PreCommands>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\HelloAndroid.apk --package-name net.dot.HelloAndroid --scenario-name &quot;%(Identity)&quot;</Command>
+      <PostCommands>$(Python) post.py</PostCommands>
+    </HelixWorkItem>
+    <!-- <HelixWorkItem Include="SOD - Android Benchmarks.Droid APK Size" Condition="'$(RuntimeType)' == 'Mono'"> # Disabled due to not working and needing consistent normal android results. https://github.com/dotnet/performance/issues/4729
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <PreCommands>cd $(ScenarioDirectory)bdnandroid;copy %HELIX_WORKITEM_ROOT%\MonoBenchmarksDroid.apk .;$(Python) pre.py -1-apk-name MonoBenchmarksDroid.apk</PreCommands>
         <Command>$(Python) test.py sod -1-scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Android Benchmarks.Droid Extracted Size">
+    <HelixWorkItem Include="SOD - Android Benchmarks.Droid Extracted Size" Condition="'$(RuntimeType)' == 'Mono'">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <PreCommands>cd $(ScenarioDirectory)bdnandroid;copy %HELIX_WORKITEM_ROOT%\MonoBenchmarksDroid.apk .;$(Python) pre.py -1-unzip -1-apk-name MonoBenchmarksDroid.apk</PreCommands>
         <Command>$(Python) test.py sod -1-scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="Mobile Benchmark - Android Benchmarks.Droid Benchmark Run">
+    <HelixWorkItem Include="Mobile Benchmark - Android Benchmarks.Droid Benchmark Run" Condition="'$(RuntimeType)' == 'Mono'">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <PreCommands>echo on;set XHARNESSPATH=$(XharnessPath);cd $(ScenarioDirectory)bdnandroid;copy %HELIX_WORKITEM_ROOT%\MonoBenchmarksDroid.apk .;$(Python) pre.py -1-restart-device -1-apk-name MonoBenchmarksDroid.apk</PreCommands>
         <Command>$(Python) test.py androidinstrumentation -1-package-path .\pub\MonoBenchmarksDroid.apk -1-package-name com.microsoft.maui.benchmarks -1-instrumentation-name com.microsoft.maui.MainInstrumentation -1-scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>


### PR DESCRIPTION
Added runs to build the Sample Android app with runtime flavor CoreCLR, added back in the device startup jobs for android, and completed some cleanup both to make things more concise and to make the flow work with our current system.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2650816&view=results
Associated performance PR: https://github.com/dotnet/performance/pull/4738