### PR TITLE
[Android] Use lowered runtime flavor in Android sample app MakeFile

### DIFF
--- a/src/mono/sample/Android/Makefile
+++ b/src/mono/sample/Android/Makefile
@@ -6,7 +6,7 @@ AOT=false
 AOT_WITH_LIBRARY_FILES=false
 INTERP=false
 DEPLOY_AND_RUN?=true
-RUNTIME_FLAVOR?=Mono
+RUNTIME_FLAVOR?=mono
 R2R?=false
 R2R_COMPOSITE?=false
 
@@ -22,18 +22,23 @@ REPO_DIR=$(realpath $(TOP))
 TASKS_DIR=$(REPO_DIR)/src/tasks
 DOTNET=$(REPO_DIR)/dotnet.sh
 BUILD_SCRIPT=$(REPO_DIR)/build.sh
+RUNTIME_FLAVOR_LOWER := $(shell echo $(RUNTIME_FLAVOR) | tr '[:upper:]' '[:lower:]')
 
 all: appbuilder runtimepack run
 
 appbuilder:
 	$(DOTNET) build -c $(BUILD_CONFIG) $(TASKS_DIR)/AndroidAppBuilder/AndroidAppBuilder.csproj
 
-ifeq ($(RUNTIME_FLAVOR),Mono)
+ifeq ($(RUNTIME_FLAVOR_LOWER),mono)
 runtimepack:
 	$(BUILD_SCRIPT) mono+libs -os android -arch $(TARGET_ARCH) -c $(BUILD_CONFIG) -bl
-else
+else ifeq ($(RUNTIME_FLAVOR_LOWER),coreclr)
 runtimepack:
 	$(BUILD_SCRIPT) clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs -os android -arch $(TARGET_ARCH) -c $(BUILD_CONFIG) -bl
+else
+runtimepack:
+	@echo "Invalid RUNTIME_FLAVOR: $(RUNTIME_FLAVOR)"
+	@exit 1
 endif
 
 run: appbuilder


### PR DESCRIPTION
Use lowered runtime flavor in Android sample app MakeFile and abort for unrecognized `RUNTIME_FLAVOR`.

The previous behavior only accepted "Mono" as a `RUNTIME_FLAVOR` for building the `runtimepack`. This could cause unwanted behavior where passing `RUNTIME_FLAVOR=mono` would lead to building CoreCLR packs instead.