### PR TITLE
JIT: Skip validation of debug info mappings in optimized codegen

### DIFF
--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
@@ -10,12 +10,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
-    <!-- These expectedly interfere with debug info -->
-    <CLRTestEnvironmentVariable Include="DOTNET_JitNoForwardSub" Value="1" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableHeadTailMerge" Value="0" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableCrossBlockLocalAssertionProp" Value="0" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableOptRepeat" Value="0" />
-
     <ProjectReference Include="tests_d.ilproj" Aliases="tests_d" />
     <ProjectReference Include="tests_r.ilproj" Aliases="tests_r" />
     <ProjectReference Include="attribute.csproj" />

--- a/src/tests/JIT/Directed/debugging/debuginfo/tests.il
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tests.il
@@ -43,7 +43,7 @@
   {
     .custom instance void [attribute]ExpectedILMappings::.ctor() = {
       property int32[] Debug = int32[2]( 0 6 )
-      property int32[] Opts = int32[2]( 0 6 )
+      property int32[] Opts = int32[0]( )
     }
     .maxstack  8
     IL_0000:  call       int32 DebugInfoMethods::NeverInlined()
@@ -59,7 +59,7 @@
   {
     .custom instance void [attribute]ExpectedILMappings::.ctor() = {
       property int32[] Debug = int32[2]( 0 6 )
-      property int32[] Opts = int32[2]( 0 0xE )
+      property int32[] Opts = int32[0]( )
     }
     .maxstack  2
     .locals init (int32 V_0)
@@ -99,7 +99,7 @@
       // as this is used for the managed-ret-val feature, but the debugger filters out these mappings and does not
       // report them in the ETW event. We should probably change this, those mappings should be useful in any case.
       property int32[] Debug = int32[10]( 0x0 0x6 0xe 0x12 0x1a 0x1c 0x24 0x28 0x2c 0x34 ) 
-      property int32[] Opts = int32[6]( 0x0 0x6 0xe 0x12 0x1c 0x2c )
+      property int32[] Opts = int32[0]( )
     }
     .maxstack  2
     .locals init (int32 V_0)


### PR DESCRIPTION
The test of time has shown that this test just ends up being another place to modify, and it has never caught anything useful. At the same time it is currently disabling several JIT optimizations to pass, but those optimizations can only be disabled with checked JIT builds, so the test ends up failing in release.

Fix #104451