### PR TITLE
Combine cast => negate => compare on ARM64

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -4775,8 +4775,44 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
                                 emit->emitIns_R_R_I(ins, cmpSize, op1->GetRegNum(), shiftOp1->GetRegNum(),
                                                     shiftOp2->AsIntConCommon()->IntegralValue(),
                                                     ShiftOpToInsOpts(oper));
+                                break;
                             }
-                            break;
+                            case GT_CAST:
+                            {
+                                GenTreeCast* cast = op2->gtGetOp1()->AsCast();
+
+                                GenIntCastDesc desc(cast);
+
+                                // These casts should not lead to an overflow check.
+                                assert(desc.CheckKind() == GenIntCastDesc::CHECK_NONE);
+
+                                insOpts extOpts = INS_OPTS_NONE;
+                                switch (desc.ExtendKind())
+                                {
+                                    case GenIntCastDesc::ZERO_EXTEND_SMALL_INT:
+                                        extOpts = (desc.ExtendSrcSize() == 1) ? INS_OPTS_UXTB : INS_OPTS_UXTH;
+                                        break;
+                                    case GenIntCastDesc::SIGN_EXTEND_SMALL_INT:
+                                        extOpts = (desc.ExtendSrcSize() == 1) ? INS_OPTS_SXTB : INS_OPTS_SXTH;
+                                        break;
+                                    case GenIntCastDesc::ZERO_EXTEND_INT:
+                                        extOpts = INS_OPTS_UXTW;
+                                        break;
+                                    case GenIntCastDesc::SIGN_EXTEND_INT:
+                                        extOpts = INS_OPTS_SXTW;
+                                        break;
+                                    case GenIntCastDesc::COPY:
+                                        extOpts = INS_OPTS_NONE; // Perform cast implicitly.
+                                        break;
+                                    default:
+                                        // Other casts should not lead here as they will not pass the
+                                        // IsContainableUnaryOrBinaryOp check.
+                                        unreached();
+                                }
+
+                                emit->emitIns_R_R(ins, cmpSize, op1->GetRegNum(), cast->CastOp()->GetRegNum(), extOpts);
+                                break;
+                            }
 
                             default:
                                 unreached();

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -4695,13 +4695,13 @@ void emitter::emitIns_R_R(instruction     ins,
         case INS_str:
         case INS_strb:
         case INS_strh:
-        case INS_cmn:
         case INS_tst:
             assert(insOptsNone(opt));
             emitIns_R_R_I(ins, attr, reg1, reg2, 0, INS_OPTS_NONE);
             return;
 
         case INS_cmp:
+        case INS_cmn:
             emitIns_R_R_I(ins, attr, reg1, reg2, 0, opt);
             return;
 

--- a/src/tests/JIT/opt/InstructionCombining/Cmn.cs
+++ b/src/tests/JIT/opt/InstructionCombining/Cmn.cs
@@ -50,6 +50,31 @@ namespace TestCompareNegative
                 fail = true;
             }
 
+            if (!CmnExtendedB(1, 0xff))
+            {
+                fail = true;
+            }
+            if (!CmnExtendedH(1, 0xffff))
+            {
+                fail = true;
+            }
+            if (!CmnExtendedS(1, 0xffffffff))
+            {
+                fail = true;
+            }
+            if (!CmnExtendedUB(-1, 0x101))
+            {
+                fail = true;
+            }
+            if (!CmnExtendedUH(-1, 0x10001))
+            {
+                fail = true;
+            }
+            if (!CmnExtendedUS(-1, 0x100000001))
+            {
+                fail = true;
+            }
+
             if (fail)
             {
                 return 101;
@@ -133,6 +158,48 @@ namespace TestCompareNegative
                 return true;
             }
             return false;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool CmnExtendedB(int a, int b)
+        {
+            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, SXTB
+            return (a == -(sbyte)b);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool CmnExtendedH(int a, int b)
+        {
+            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, SXTH
+            return (a == -(short)b);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool CmnExtendedS(long a, long b)
+        {
+            //ARM64-FULL-LINE: cmn {{x[0-9]+}}, {{w[0-9]+}}, SXTW
+            return (a == -(long)(int)b);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool CmnExtendedUB(int a, int b)
+        {
+            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, UXTB
+            return (a == -(byte)b);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool CmnExtendedUH(int a, int b)
+        {
+            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, UXTH
+            return (a == -(ushort)b);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool CmnExtendedUS(long a, long b)
+        {
+            //ARM64-FULL-LINE: cmn {{x[0-9]+}}, {{w[0-9]+}}, UXTW
+            return (a == -(uint)b);
         }
     }
 }


### PR DESCRIPTION
For example `a == -(sbyte)b`,
```
sxtb w0, w0
neg w0, w0
cmp w1, w0
```
becomes
```
cmn w1, w0, SXTB
```

Contributes towards #68028