### PR TITLE
JIT: Avoid unnecessary write backs during physical promotion

### DIFF
--- a/src/coreclr/jit/bitsetasshortlong.h
+++ b/src/coreclr/jit/bitsetasshortlong.h
@@ -45,6 +45,7 @@ private:
     static bool               TryAddElemDLong(Env env, BitSetShortLongRep& bs, unsigned i);
     static void               RemoveElemDLong(Env env, BitSetShortLongRep& bs, unsigned i);
     static void               ClearDLong(Env env, BitSetShortLongRep& bs);
+    static void               FillDLong(Env env, BitSetShortLongRep& bs);
     static BitSetShortLongRep MakeUninitArrayBits(Env env);
     static BitSetShortLongRep MakeEmptyArrayBits(Env env);
     static BitSetShortLongRep MakeFullArrayBits(Env env);
@@ -133,6 +134,19 @@ public:
         {
             assert(bs != UninitVal());
             ClearDLong(env, bs);
+        }
+    }
+
+    static void FillD(Env env, BitSetShortLongRep& bs)
+    {
+        if (IsShort(env))
+        {
+            bs = (BitSetShortLongRep)size_t(-1);
+        }
+        else
+        {
+            assert(bs != UninitVal());
+            FillDLong(env, bs);
         }
     }
 
@@ -862,6 +876,20 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
     for (unsigned i = 0; i < len; i++)
     {
         bs[i] = 0;
+    }
+}
+
+template <typename Env, typename BitSetTraits>
+void BitSetOps</*BitSetType*/ BitSetShortLongRep,
+               /*Brand*/ BSShortLong,
+               /*Env*/ Env,
+               /*BitSetTraits*/ BitSetTraits>::FillDLong(Env env, BitSetShortLongRep& bs)
+{
+    assert(!IsShort(env));
+    unsigned len = BitSetTraits::GetArrSize(env);
+    for (unsigned i = 0; i < len; i++)
+    {
+        bs[i] = size_t(-1);
     }
 }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2514,6 +2514,29 @@ struct LoopSideEffects
     void AddModifiedElemType(Compiler* comp, CORINFO_CLASS_HANDLE structHnd);
 };
 
+// Data structure that keeps track of local definitions inside loops.
+class LoopDefinitions
+{
+    typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, bool> LocalDefinitionsMap;
+
+    FlowGraphNaturalLoops* m_loops;
+    // For every loop, we track all definitions exclusive to that loop.
+    // Definitions in descendant loops are not kept in their ancestor's maps.
+    LocalDefinitionsMap** m_maps;
+    // Blocks whose IR we have visited to find local definitions in.
+    BitVec m_visitedBlocks;
+
+    LocalDefinitionsMap* GetOrCreateMap(FlowGraphNaturalLoop* loop);
+
+    template <typename TFunc>
+    bool VisitLoopNestMaps(FlowGraphNaturalLoop* loop, TFunc& func);
+public:
+    LoopDefinitions(FlowGraphNaturalLoops* loops);
+
+    template <typename TFunc>
+    void VisitDefinedLocalNums(FlowGraphNaturalLoop* loop, TFunc func);
+};
+
 //  The following holds information about instr offsets in terms of generated code.
 
 enum class IPmappingDscKind

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -496,7 +496,7 @@ private:
                 if ((entry.FromReplacement != nullptr) && (entry.Type == TYP_REF))
                 {
                     Replacement* rep = entry.FromReplacement;
-                    if (rep->NeedsWriteBack)
+                    if (m_replacer->NeedsWriteBack(*rep))
                     {
                         statements->AddStatement(
                             Promotion::CreateWriteBack(m_compiler, m_src->AsLclVarCommon()->GetLclNum(), *rep));
@@ -784,7 +784,7 @@ private:
         if (entry.FromReplacement != nullptr)
         {
             // Check if the remainder is going to handle it.
-            if ((remainderStrategy.Type == RemainderStrategy::FullBlock) && !entry.FromReplacement->NeedsWriteBack &&
+            if ((remainderStrategy.Type == RemainderStrategy::FullBlock) && !m_replacer->NeedsWriteBack(*entry.FromReplacement) &&
                 (entry.ToReplacement == nullptr))
             {
 #ifdef DEBUG
@@ -1320,7 +1320,7 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                 JITDUMP("*** Block operation partially overlaps with start replacement of destination V%02u (%s)\n",
                         dstFirstRep->LclNum, dstFirstRep->Description);
 
-                if (dstFirstRep->NeedsWriteBack)
+                if (NeedsWriteBack(*dstFirstRep))
                 {
                     // The value of the replacement will be partially assembled from its old value and this struct
                     // operation.
@@ -1344,7 +1344,7 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                     JITDUMP("*** Block operation partially overlaps with end replacement of destination V%02u (%s)\n",
                             dstLastRep->LclNum, dstLastRep->Description);
 
-                    if (dstLastRep->NeedsWriteBack)
+                    if (NeedsWriteBack(*dstLastRep))
                     {
                         result.AddStatement(Promotion::CreateWriteBack(m_compiler, dstLcl->GetLclNum(), *dstLastRep));
                         ClearNeedsWriteBack(*dstLastRep);
@@ -1368,7 +1368,7 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                 JITDUMP("*** Block operation partially overlaps with start replacement of source V%02u (%s)\n",
                         srcFirstRep->LclNum, srcFirstRep->Description);
 
-                if (srcFirstRep->NeedsWriteBack)
+                if (NeedsWriteBack(*srcFirstRep))
                 {
                     result.AddStatement(Promotion::CreateWriteBack(m_compiler, srcLcl->GetLclNum(), *srcFirstRep));
                     ClearNeedsWriteBack(*srcFirstRep);
@@ -1385,7 +1385,7 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                     JITDUMP("*** Block operation partially overlaps with end replacement of source V%02u (%s)\n",
                             srcLastRep->LclNum, srcLastRep->Description);
 
-                    if (srcLastRep->NeedsWriteBack)
+                    if (NeedsWriteBack(*srcLastRep))
                     {
                         result.AddStatement(Promotion::CreateWriteBack(m_compiler, srcLcl->GetLclNum(), *srcLastRep));
                         ClearNeedsWriteBack(*srcLastRep);
@@ -1627,7 +1627,7 @@ void ReplaceVisitor::CopyBetweenFields(GenTree*                    store,
             assert(srcLcl != nullptr);
             statements->AddStatement(Promotion::CreateReadBack(m_compiler, srcLcl->GetLclNum(), *srcRep));
             ClearNeedsReadBack(*srcRep);
-            assert(!srcRep->NeedsWriteBack);
+            assert(!NeedsWriteBack(*srcRep));
         }
 
         if ((dstRep < dstEndRep) && (srcRep < srcEndRep))


### PR DESCRIPTION
Physical promotion sometimes needs to insert writebacks to restore the struct local from a promoted replacement field. This is required if the field is more up to date and we end up in a situation where we need to represent something using the struct local.

Before this change the handling of this was quite simplistic. We assumed that the replacement was more up to date than the struct local at the beginning of every basic block.
This PR instead adds flow sensitive tracking to propagate this information across basic blocks. We now only consider the replacement local to be more up to date than the struct local if it was actually written in any of the predecessors.

This fixes some regressions I saw in #112740 