### PR TITLE
Fix exception propagation from managed to native on Unix

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -8616,7 +8616,7 @@ extern "C" bool QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollideCla
 #ifdef HOST_UNIX
                 // Don't allow propagating exceptions from managed to native code except for the case when it is called by the
                 // CallDescrWorkerInternal.
-                || IsCallDescrWorkerInternalReturnAddress(GetControlPC(pThis->m_crawl.GetRegisterSet())) 
+                || !IsCallDescrWorkerInternalReturnAddress(GetControlPC(pThis->m_crawl.GetRegisterSet()))
 #endif
                )
             {

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -8612,7 +8612,13 @@ extern "C" bool QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollideCla
             // DebuggerU2MCatchHandlerFrame with CatchesAllExceptions() returning true).
             // If not, the exception is unhandled.
             if ((pFrame == FRAME_TOP) ||
-                (IsTopmostDebuggerU2MCatchHandlerFrame(pFrame) && !((DebuggerU2MCatchHandlerFrame*)pFrame)->CatchesAllExceptions()))
+                (IsTopmostDebuggerU2MCatchHandlerFrame(pFrame) && !((DebuggerU2MCatchHandlerFrame*)pFrame)->CatchesAllExceptions())
+#ifdef HOST_UNIX
+                // Don't allow propagating exceptions from managed to native code except for the case when it is called by the
+                // CallDescrWorkerInternal.
+                || IsCallDescrWorkerInternalReturnAddress(GetControlPC(pThis->m_crawl.GetRegisterSet())) 
+#endif
+               )
             {
                 if (pTopExInfo->m_passNumber == 1)
                 {


### PR DESCRIPTION
The new exception handling on Unix doesn't prevent propagation of exceptions from managed to external native code like the old one did. Instead of reporting an unhandled exception, it rethrows the PAL_SEHException that later ends up being reported as C++ unhandled exception.

This change fixes that behavior by enabling exception propagation from managed to native code only for the case when the native caller is CallDescrWorkerInternal.

Close #112497 