### PR TITLE
Add trim to FileInfo (issue #70524)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -20,6 +20,7 @@ namespace System.IO
 
         internal FileInfo(string originalPath, string? fullPath = null, string? fileName = null, bool isNormalized = false)
         {
+            originalPath = originalPath.Trim();
             OriginalPath = originalPath;
 
             fullPath ??= originalPath;

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/Directory.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/Directory.cs
@@ -53,6 +53,13 @@ namespace System.IO.Tests
             var directory = Directory(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory", "File"));
             Assert.Equal(new string(Path.DirectorySeparatorChar, 2) + Path.Combine("Machine", "Directory"), directory);
         }
+
+        [Fact]
+        public void LeadingSpacesTrimmed()
+        {
+            var directory = Directory(Path.Combine(" leading-space", "trailing-space "));
+            Assert.Equal(Path.Combine("leading-space", "trailing-space"), directory);
+        }
     }
 
     public class FileInfo_DirectoryName : FileInfo_Directory

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/Name.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/Name.cs
@@ -33,5 +33,12 @@ namespace System.IO.Tests
             var info = new FileInfo(Path.DirectorySeparatorChar + Path.Combine("Directory", "File"));
             Assert.Equal("File", info.Name);
         }
+
+        [Fact]
+        public void TrimmedName()
+        {
+            var info = new FileInfo(Path.Combine(" leading-space", "trailing-space "));
+            Assert.Equal("trailing-space", info.Name);
+        }
     }
 }


### PR DESCRIPTION

While debugging strange behavior I came across this issue today and had a few head scratching moments until I found that a 
`new FileInfo(path).Name` returns a file name with a trailing space. I did not expect this behavior.

In a full file path, I think there is no risk in trimming it.
Of course it's a different story for directory paths.

I found this Issue (#70524) which I think fully captures this behavior and the discussion validates that it's a problem that deserves a fix.