### PR TITLE
[RISC-V] Eliminate unnecessary add instruction in array indirection

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1119,6 +1119,11 @@ bool CodeGen::genCreateAddrMode(GenTree*  addr,
             [reg1 + reg2]
             [reg1 + reg2 * natural-scale]
 
+        The following indirections are valid address modes on riscv64:
+
+            [reg]
+            [reg  + icon]
+
      */
 
     /* All indirect address modes require the address to be an addition */
@@ -1225,6 +1230,7 @@ AGAIN:
 
                     goto AGAIN;
 
+#ifndef TARGET_RISCV64
                 // TODO-ARM-CQ: For now we don't try to create a scaled index.
                 case GT_MUL:
                     if (op1->gtOverflow())
@@ -1249,6 +1255,7 @@ AGAIN:
                     }
                     break;
                 }
+#endif // !TARGET_RISCV64
 
                 default:
                     break;
@@ -1269,7 +1276,7 @@ AGAIN:
 
     switch (op1->gtOper)
     {
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH) || defined(TARGET_RISCV64)
         // TODO-ARM-CQ: For now we don't try to create a scaled index.
         case GT_ADD:
 
@@ -1291,8 +1298,9 @@ AGAIN:
                 }
             }
             break;
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH || TARGET_RISCV64
 
+#ifndef TARGET_RISCV64
         case GT_MUL:
 
             if (op1->gtOverflow())
@@ -1334,6 +1342,7 @@ AGAIN:
             }
             break;
         }
+#endif // !TARGET_RISCV64
 
         case GT_COMMA:
 
@@ -1347,7 +1356,7 @@ AGAIN:
     noway_assert(op2);
     switch (op2->gtOper)
     {
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH) || defined(TARGET_RISCV64)
         // TODO-ARM64-CQ, TODO-ARM-CQ: For now we only handle MUL and LSH because
         // arm doesn't support both scale and offset at the same. Offset is handled
         // at the emitter as a peephole optimization.
@@ -1370,8 +1379,9 @@ AGAIN:
                 }
             }
             break;
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH || TARGET_RISCV64
 
+#ifndef TARGET_RISCV64
         case GT_MUL:
 
             if (op2->gtOverflow())
@@ -1409,6 +1419,7 @@ AGAIN:
             }
             break;
         }
+#endif // !TARGET_RISCV64
 
         case GT_COMMA:
 
@@ -1428,6 +1439,9 @@ AGAIN:
 #endif
 
 FOUND_AM:
+#ifdef TARGET_RISCV64
+    assert(mul == 0 || mul == 1);
+#endif
 
     if (rv2)
     {

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1230,7 +1230,6 @@ AGAIN:
 
                     goto AGAIN;
 
-#ifndef TARGET_RISCV64
                 // TODO-ARM-CQ: For now we don't try to create a scaled index.
                 case GT_MUL:
                     if (op1->gtOverflow())
@@ -1255,7 +1254,6 @@ AGAIN:
                     }
                     break;
                 }
-#endif // !TARGET_RISCV64
 
                 default:
                     break;
@@ -1300,7 +1298,6 @@ AGAIN:
             break;
 #endif // TARGET_XARCH || TARGET_RISCV64
 
-#ifndef TARGET_RISCV64
         case GT_MUL:
 
             if (op1->gtOverflow())
@@ -1342,7 +1339,6 @@ AGAIN:
             }
             break;
         }
-#endif // !TARGET_RISCV64
 
         case GT_COMMA:
 
@@ -1381,7 +1377,6 @@ AGAIN:
             break;
 #endif // TARGET_XARCH || TARGET_RISCV64
 
-#ifndef TARGET_RISCV64
         case GT_MUL:
 
             if (op2->gtOverflow())
@@ -1419,7 +1414,6 @@ AGAIN:
             }
             break;
         }
-#endif // !TARGET_RISCV64
 
         case GT_COMMA:
 


### PR DESCRIPTION
RISC-V supports the following addressing mode: `[reg]` & `[reg + imm]`.

`genCreateAddrMode` already supports constant determination, however, it's currently only enabled for XARCH.

Additionally, I disabled scale extraction for RISC-V.

Before patch:
```asm
slli           a1, a1, 2
addi           a1, a1, 16
add            t6, a0, a1
lw             a0, 0(t6)
```

After patch applied:
```asm
slli           a1, a1, 2
add            a2, a0, a1
lw             a0, 16(a2)
```

See related discussion here: https://github.com/dotnet/runtime/pull/112917

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung