### PR TITLE
Remove unused HexConverter from System.Runtime.Numerics

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -31,8 +31,6 @@
              Link="CoreLib\System\Collections\Generic\ValueListBuilder.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="CoreLib\System\Text\ValueStringBuilder.cs" />
-    <Compile Include="$(CommonPath)System\HexConverter.cs"
-             Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Number.Formatting.Common.cs"
              Link="Common\System\Number.Formatting.Common.cs" />
     <Compile Include="$(CommonPath)System\Number.NumberBuffer.cs"


### PR DESCRIPTION
Due to the changes in #95543, which updated the code to use `Convert.FromHexString` introduced in #86556, the `HexConverter` class is no longer being used.