### PR TITLE
[mono] Fix detecting [DisableRuntimeMarshalling] in MarshalingPInvokeScanner.

### DIFF
--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -106,8 +106,8 @@ namespace MonoTargetsTasks
 
         private bool IsDisableRuntimeMarshallingAttribute (MetadataReader mdtReader, StringHandle ns, StringHandle name)
         {
-            return mdtReader.GetString(ns) == "System.Runtime.CompilerServices" &&
-                   mdtReader.GetString(name) == "DisableRuntimeMarshallingAttribute";
+            return mdtReader.StringComparer.Equals(ns, "System.Runtime.CompilerServices") &&
+                   mdtReader.StringComparer.Equals(name, "DisableRuntimeMarshallingAttribute");
         }
 
         private bool IsAssemblyIncompatible(string assyPath, MinimalMarshalingTypeCompatibilityProvider mmtcp)

--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -104,7 +104,7 @@ namespace MonoTargetsTasks
             }
         }
 
-        private bool IsDisableRuntimeMarshallingAttribute (MetadataReader mdtReader, StringHandle ns, StringHandle name)
+        private static bool IsDisableRuntimeMarshallingAttribute(MetadataReader mdtReader, StringHandle ns, StringHandle name)
         {
             return mdtReader.StringComparer.Equals(ns, "System.Runtime.CompilerServices") &&
                    mdtReader.StringComparer.Equals(name, "DisableRuntimeMarshallingAttribute");
@@ -133,7 +133,7 @@ namespace MonoTargetsTasks
                     if (IsDisableRuntimeMarshallingAttribute(mdtReader, td.Namespace, td.Name))
                         return false;
                 }
-                else if(attr.Constructor.Kind == HandleKind.MemberReference)
+                else if (attr.Constructor.Kind == HandleKind.MemberReference)
                 {
                     MemberReferenceHandle mrh = (MemberReferenceHandle)attr.Constructor;
                     MemberReference mr = mdtReader.GetMemberReference(mrh);

--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -104,6 +104,12 @@ namespace MonoTargetsTasks
             }
         }
 
+        private bool IsDisableRuntimeMarshallingAttribute (MetadataReader mdtReader, StringHandle ns, StringHandle name)
+        {
+            return mdtReader.GetString(ns) == "System.Runtime.CompilerServices" &&
+                   mdtReader.GetString(name) == "DisableRuntimeMarshallingAttribute";
+        }
+
         private bool IsAssemblyIncompatible(string assyPath, MinimalMarshalingTypeCompatibilityProvider mmtcp)
         {
             using FileStream file = new FileStream(assyPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -124,9 +130,19 @@ namespace MonoTargetsTasks
                     TypeDefinitionHandle tdh = md.GetDeclaringType();
                     TypeDefinition td = mdtReader.GetTypeDefinition(tdh);
 
-                    if (mdtReader.GetString(td.Namespace) == "System.Runtime.CompilerServices" &&
-                        mdtReader.GetString(td.Name) == "DisableRuntimeMarshallingAttribute")
+                    if (IsDisableRuntimeMarshallingAttribute(mdtReader, td.Namespace, td.Name))
                         return false;
+                }
+                else if(attr.Constructor.Kind == HandleKind.MemberReference)
+                {
+                    MemberReferenceHandle mrh = (MemberReferenceHandle)attr.Constructor;
+                    MemberReference mr = mdtReader.GetMemberReference(mrh);
+                    if (mr.Parent.Kind == HandleKind.TypeReference) {
+                        TypeReference tr = mdtReader.GetTypeReference((TypeReferenceHandle)mr.Parent);
+
+                        if (IsDisableRuntimeMarshallingAttribute(mdtReader, tr.Namespace, tr.Name))
+                            return false;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fix detecting the [DisableRuntimeMarshalling] attribute in
MarshalingPInvokeScanner for assemblies that reference the attribute from
another assembly (i.e. any assembly except System.Runtime.dll).

Fixes https://github.com/dotnet/runtime/issues/112980.