### PR TITLE
Allow `MakeGenericType`/`MakeArrayType` of arbitrary types

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -50,10 +50,6 @@
 
   <ItemGroup Condition="'$(TestNativeAot)' == 'true'">
     <RdXmlFile Include="$(MSBuildThisFileDirectory)default.rd.xml" />
-
-    <!-- xunit calls MakeGenericType to check if something is IEquatable -->
-    <IlcArg Include="--feature:System.Reflection.IsTypeConstructionEagerlyValidated=false" />
-
     <TrimmerRootAssembly Include="TestUtilities" />
   </ItemGroup>
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -53,7 +53,8 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         // Invoke and field access support.
         //==============================================================================================
-        public abstract MethodBaseInvoker TryGetMethodInvoker(RuntimeTypeHandle declaringTypeHandle, QMethodDefinition methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
+        public abstract void ValidateGenericMethodConstraints(MethodInfo method);
+        public abstract MethodBaseInvoker TryGetMethodInvokerNoConstraintCheck(RuntimeTypeHandle declaringTypeHandle, QMethodDefinition methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
         public abstract FieldAccessor TryGetFieldAccessor(MetadataReader reader, RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle, FieldHandle fieldHandle);
 
         //==============================================================================================
@@ -108,7 +109,7 @@ namespace Internal.Reflection.Core.Execution
             {
                 genericMethodTypeArgumentHandles[i] = genericMethodTypeArguments[i].TypeHandle;
             }
-            MethodBaseInvoker methodInvoker = TryGetMethodInvoker(typeDefinitionHandle, methodHandle, genericMethodTypeArgumentHandles);
+            MethodBaseInvoker methodInvoker = TryGetMethodInvokerNoConstraintCheck(typeDefinitionHandle, methodHandle, genericMethodTypeArgumentHandles);
             if (methodInvoker == null)
                 exception = ReflectionCoreExecution.ExecutionEnvironment.CreateNonInvokabilityException(exceptionPertainant);
             return methodInvoker;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -144,7 +144,9 @@ namespace System.Reflection.Runtime.MethodInfos
             if (typeArguments.Length != GenericTypeParameters.Length)
                 throw new ArgumentException(SR.Format(SR.Argument_NotEnoughGenArguments, typeArguments.Length, GenericTypeParameters.Length));
             RuntimeMethodInfo methodInfo = (RuntimeMethodInfo)RuntimeConstructedGenericMethodInfo.GetRuntimeConstructedGenericMethodInfo(this, genericTypeArguments);
-            MethodBaseInvoker _ = methodInfo.MethodInvoker; // For compatibility with other Make* apis, trigger any missing metadata exceptions now rather than later.
+
+            ReflectionCoreExecution.ExecutionEnvironment.ValidateGenericMethodConstraints(methodInfo);
+
             return methodInfo;
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -404,14 +404,14 @@ namespace System.Reflection.Runtime.TypeInfos
             // Do not implement this as a call to MakeArrayType(1) - they are not interchangeable. MakeArrayType() returns a
             // vector type ("SZArray") while MakeArrayType(1) returns a multidim array of rank 1. These are distinct types
             // in the ECMA model and in CLR Reflection.
-            return this.GetArrayTypeWithTypeHandle().ToType();
+            return this.GetArrayType().ToType();
         }
 
         public Type MakeArrayType(int rank)
         {
             if (rank <= 0)
                 throw new IndexOutOfRangeException();
-            return this.GetMultiDimArrayTypeWithTypeHandle(rank).ToType();
+            return this.GetMultiDimArrayType(rank).ToType();
         }
 
         public Type MakePointerType()
@@ -475,7 +475,7 @@ namespace System.Reflection.Runtime.TypeInfos
                     throw new TypeLoadException(SR.CannotUseByRefLikeTypeInInstantiation);
             }
 
-            return this.GetConstructedGenericTypeWithTypeHandle(runtimeTypeArguments!).ToType();
+            return this.GetConstructedGenericType(runtimeTypeArguments!).ToType();
         }
 
         public Type DeclaringType

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -322,14 +322,7 @@ namespace System.Runtime.CompilerServices
                 throw new NotSupportedException(SR.NotSupported_ByRefLike);
             }
 
-            Debug.Assert(MethodTable.Of<object>()->NumVtableSlots > 0);
-            if (mt->NumVtableSlots == 0)
-            {
-                // This is a type without a vtable or GCDesc. We must not allow creating an instance of it
-                throw ReflectionCoreExecution.ExecutionEnvironment.CreateMissingMetadataException(type);
-            }
-            // Paranoid check: not-meant-for-GC-heap types should be reliably identifiable by empty vtable.
-            Debug.Assert(!mt->ContainsGCPointers || RuntimeImports.RhGetGCDescSize(mt) != 0);
+            RuntimeAugments.EnsureMethodTableSafeToAllocate(mt);
 
             if (mt->IsNullable)
             {
@@ -364,13 +357,7 @@ namespace System.Runtime.CompilerServices
             if (mt->ElementType == EETypeElementType.Void || mt->IsGenericTypeDefinition || mt->IsByRef || mt->IsPointer || mt->IsFunctionPointer)
                 throw new ArgumentException(SR.Arg_TypeNotSupported);
 
-            if (mt->NumVtableSlots == 0)
-            {
-                // This is a type without a vtable or GCDesc. We must not allow creating an instance of it
-                throw ReflectionCoreExecution.ExecutionEnvironment.CreateMissingMetadataException(Type.GetTypeFromHandle(type));
-            }
-            // Paranoid check: not-meant-for-GC-heap types should be reliably identifiable by empty vtable.
-            Debug.Assert(!mt->ContainsGCPointers || RuntimeImports.RhGetGCDescSize(mt) != 0);
+            RuntimeAugments.EnsureMethodTableSafeToAllocate(mt);
 
             if (!mt->IsValueType)
             {

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -218,14 +218,14 @@ namespace Internal.Reflection.Execution
             return TypeLoaderEnvironment.Instance.TryGetConstructedGenericTypeForComponents(genericTypeDefinitionHandle, genericTypeArgumentHandles, out runtimeTypeHandle);
         }
 
-        public sealed override MethodBaseInvoker TryGetMethodInvoker(RuntimeTypeHandle declaringTypeHandle, QMethodDefinition methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles)
+        public sealed override void ValidateGenericMethodConstraints(MethodInfo method)
+        {
+            ConstraintValidator.EnsureSatisfiesClassConstraints(method);
+        }
+
+        public sealed override MethodBaseInvoker TryGetMethodInvokerNoConstraintCheck(RuntimeTypeHandle declaringTypeHandle, QMethodDefinition methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles)
         {
             MethodBase methodInfo = ExecutionDomain.GetMethod(declaringTypeHandle, methodHandle, genericMethodTypeArgumentHandles);
-
-            // Validate constraints first. This is potentially useless work if the method already exists, but it prevents bad
-            // inputs to reach the type loader (we don't have support to e.g. represent pointer types within the type loader)
-            if (genericMethodTypeArgumentHandles != null && genericMethodTypeArgumentHandles.Length > 0)
-                ConstraintValidator.EnsureSatisfiesClassConstraints((MethodInfo)methodInfo);
 
             MethodSignatureComparer methodSignatureComparer = new MethodSignatureComparer(methodHandle);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -49,15 +49,14 @@ namespace ILCompiler.DependencyAnalysis
             Section hashTableSection = writer.NewSection();
             hashTableSection.Place(typeMapHashTable);
 
-            foreach (var type in factory.MetadataManager.GetTypesWithConstructedEETypes())
+            foreach (var type in factory.MetadataManager.GetTypesWithEETypes())
             {
                 if (!type.IsArray)
                     continue;
 
                 var arrayType = (ArrayType)type;
 
-                // Look at the constructed type symbol. If a constructed type wasn't emitted, then the array map entry isn't valid for use
-                IEETypeNode arrayTypeSymbol = factory.ConstructedTypeSymbol(arrayType);
+                IEETypeNode arrayTypeSymbol = factory.NecessaryTypeSymbol(arrayType);
 
                 Vertex vertex = writer.GetUnsignedConstant(_externalReferences.GetIndex(arrayTypeSymbol));
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericTypesHashtableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericTypesHashtableNode.cs
@@ -45,14 +45,7 @@ namespace ILCompiler.DependencyAnalysis
             Section nativeSection = nativeWriter.NewSection();
             nativeSection.Place(hashtable);
 
-            // We go over constructed EETypes only. The places that need to consult this hashtable at runtime
-            // all need constructed EETypes. Placing unconstructed EETypes into this hashtable could make us
-            // accidentally satisfy e.g. MakeGenericType for something that was only used in a cast. Those
-            // should throw MissingRuntimeArtifact instead.
-            //
-            // We already make sure "necessary" EETypes that could potentially be loaded at runtime through
-            // the dynamic type loader get upgraded to constructed EETypes at AOT compile time.
-            foreach (var type in factory.MetadataManager.GetTypesWithConstructedEETypes())
+            foreach (var type in factory.MetadataManager.GetTypesWithEETypes())
             {
                 // If this is an instantiated non-canonical generic type, add it to the generic instantiations hashtable
                 if (!type.HasInstantiation || type.IsGenericDefinition || type.IsCanonicalSubtype(CanonicalFormKind.Any))

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -565,9 +565,6 @@
     <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_hostOS)' != 'windows'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
     <IlcReference Include="$(TargetingPackPath)/*.dll" />
 
-    <!-- xunit calls MakeGenericType to check if something is IEquatable -->
-    <IlcArg Condition="'$(EagerlyValidateTypeConstruction)' != 'false'" Include="--feature:System.Reflection.IsTypeConstructionEagerlyValidated=false" />
-
     <!-- Bump the generic cycle tolerance. There's at least one test with a cycle that is reachable at runtime to depth 6 -->
     <IlcArg Include="--maxgenericcycle:7" />
 

--- a/src/tests/nativeaot/Directory.Build.props
+++ b/src/tests/nativeaot/Directory.Build.props
@@ -3,10 +3,6 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- NativeAOT tests don't need this xunit Assert compat quirk.
-         The tests explicitly test customer scenarios with eager type construction checks present. -->
-    <EagerlyValidateTypeConstruction>false</EagerlyValidateTypeConstruction>
-
     <!-- We expect trimming to be fully enabled in these tests -->
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
   </PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -806,6 +806,18 @@ internal static class ReflectionTest
             public override int GetHashCode() => 500;
         }
 
+        class NeverAllocatedButUsedInGenericMethod<T>
+        {
+        }
+
+        class Atom;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Type GetNeverAllocatedButUsedInGenericMethod() => typeof(NeverAllocatedButUsedInGenericMethod<>);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static object GenericMethod<T>() => null;
+
         public static void Run()
         {
             Console.WriteLine(nameof(TestGetUninitializedObject));
@@ -819,6 +831,31 @@ internal static class ReflectionTest
             // Check that the vtable of a type passed to GetUninitializedObject is intact.
             var obj2 = RuntimeHelpers.GetUninitializedObject(typeof(AlsoNeverAllocated));
             if (obj2.GetHashCode() != 500)
+                throw new Exception();
+
+            // Do what's needed so that we force an unconstructed MT for NeverAllocatedButUsedInGenericMethod<Atom> into the program
+            // 1. Statically call the method
+            // 2. Make the method visible target of reflection
+            // This will force the compiler to place the method generic dictionary into a hashtable addressable using the instantiation.
+            GenericMethod<NeverAllocatedButUsedInGenericMethod<Atom>>();
+            typeof(TestGetUninitializedObject).GetMethod(nameof(GenericMethod));
+
+            Type t1 = GetNeverAllocatedButUsedInGenericMethod().MakeGenericType(typeof(Atom));
+            _ = t1.TypeHandle; // Type handle is only suitable for casting but we can get it
+
+            bool thrown = true;
+            try
+            {
+                // Needs to throw, the MT is only a necessary MT, not constructed MT
+                RuntimeHelpers.GetUninitializedObject(t1);
+                thrown = false;
+            }
+            catch (NotSupportedException e)
+            {
+                if (!e.Message.Contains("ReflectionTest+TestGetUninitializedObject+NeverAllocatedButUsedInGenericMethod`1[ReflectionTest+TestGetUninitializedObject+Atom]"))
+                    throw new Exception();
+            }
+            if (!thrown)
                 throw new Exception();
         }
     }
@@ -1933,17 +1970,24 @@ internal static class ReflectionTest
     class TypeConstructionTest
     {
         struct Atom { }
+        struct ArrayElementUsedInGenericDictionary { }
 
         class Gen<T> { }
 
         static Type s_atom = typeof(Atom);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Type GetArrayElementUsedInGenericDictionary() => typeof(ArrayElementUsedInGenericDictionary);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static object GenericMethod<T>() => null;
 
         public static void Run()
         {
             string message1 = "";
             try
             {
-                typeof(Gen<>).MakeGenericType(s_atom);
+                _ = typeof(Gen<>).MakeGenericType(s_atom).TypeHandle;
             }
             catch (Exception ex)
             {
@@ -1955,7 +1999,7 @@ internal static class ReflectionTest
             string message2 = "";
             try
             {
-                s_atom.MakeArrayType();
+                _ = s_atom.MakeArrayType().TypeHandle;
             }
             catch (Exception ex)
             {
@@ -1974,6 +2018,24 @@ internal static class ReflectionTest
                 message3 = ex.Message;
             }
             if (!message3.Contains("ReflectionTest+TypeConstructionTest+Atom[]"))
+                throw new Exception();
+
+            // Do what's needed so that we force an unconstructed MT for ArrayElementUsedInGenericDictionary[] into the program
+            // 1. Statically call the method
+            // 2. Make the method visible target of reflection
+            // This will force the compiler to place the method generic dictionary into a hashtable addressable using the instantiation.
+            GenericMethod<ArrayElementUsedInGenericDictionary[]>();
+            typeof(TestGetUninitializedObject).GetMethod(nameof(GenericMethod));
+            string message4 = "";
+            try
+            {
+                Array.CreateInstance(GetArrayElementUsedInGenericDictionary(), 10);
+            }
+            catch (Exception ex)
+            {
+                message4 = ex.Message;
+            }
+            if (!message4.Contains("ReflectionTest+TypeConstructionTest+ArrayElementUsedInGenericDictionary[]"))
                 throw new Exception();
         }
     }
@@ -2183,7 +2245,7 @@ internal static class ReflectionTest
             bool exists = false;
             try
             {
-                typeof(GenericClass<>).MakeGenericType(GetAtom3());
+                _ = typeof(GenericClass<>).MakeGenericType(GetAtom3()).TypeHandle;
                 exists = true;
             }
             catch


### PR DESCRIPTION
When we worked on .NET Native, we didn't have static analysis but at least wanted to have some predictability in how dynamic code fails with AOT. We decided we want `MakeGenericType` & co. to be the thing that fails instead of subsequent operations that try to obtain a type handle (one needs a type handle to do "interesting" reflection operations).

As we refined the model and introduced static analysis, we decided it's fine if trim/AOT unsafe code can get at things that are in "undefined" state [^1] (named types that might not have type handles, MethodInfos that don't have parameter names, etc.). The static analysis warning is always at the problematic operation and what happens next can be anything.

But `MakeGenericType` failing early sometimes got in the way. For example xUnit uses `MakeGenericType` to create a new interface at runtime and check `IsAssignableFrom` with it. We don't actually need a usable type handle for this. We had an opt-out switch that we only enabled for testing to get xUnit working. But that also means we were not testing the shipping configuration whenever xUnit was involved.

This PR makes it so `MakeGeneric`/`MakeArray` can actually succeed even if we don't have the code/data structures for the type. Trying to do "interesting" reflection with it is going to throw the good old MissingMetadata-like exception - the difference is just in the timing.

I'm also changing things to allow obtaining `TypeHandle` on generic types even if they're in the "necessary" form only. This will only bring us to parity with what already happens for non-generic types. We already have blocks in places to make sure such `TypeHandle` cannot be used for much more than casting (e.g. `GetUninitializedObject` has a preexisting block for this).

Cc @dotnet/ilc-contrib 

[^1]: We say we're fine with undefined behavior for trim-unsafe code, but that does not include GC holes.