### PR TITLE
[android] Make native debugging test apps a little easier

### DIFF
--- a/src/mono/msbuild/android/build/AndroidBuild.InTree.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.InTree.targets
@@ -23,16 +23,6 @@
     <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
-  <!-- Android Studio only shows debug symbols when they end with .so as opposed to .dbg. Rename so they can be associated with the libs -->
-  <Target Name="_PrepDebuggingSymbols" 
-          Condition="'$(StripDebugSymbols)' != 'true'"
-          AfterTargets="_InitializeCommonProperties">
-    <ItemGroup>
-      <_SymbolFiles Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)*.so.dbg" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_SymbolFiles)" DestinationFiles="@(_SymbolFiles->'%(RootDir)%(Directory)%(Filename).so')" />
-  </Target>
-
   <!-- Override the ResolveReadyToRunCompilers target to use the in-build crossgen2.
        This needs to be imported after SDK targets, so any project requiring this should set AfterMicrosoftNETSdkTargets -->
   <Target Name="ResolveReadyToRunCompilers" Condition="'$(PublishReadyToRun)' == true" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">

--- a/src/mono/msbuild/android/build/AndroidBuild.InTree.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.InTree.targets
@@ -23,6 +23,16 @@
     <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
+  <!-- Android Studio only shows debug symbols when they end with .so as opposed to .dbg. Rename so they can be associated with the libs -->
+  <Target Name="_PrepDebuggingSymbols" 
+          Condition="'$(StripDebugSymbols)' != 'true'"
+          AfterTargets="_InitializeCommonProperties">
+    <ItemGroup>
+      <_SymbolFiles Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)*.so.dbg" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_SymbolFiles)" DestinationFiles="@(_SymbolFiles->'%(RootDir)%(Directory)%(Filename).so')" />
+  </Target>
+
   <!-- Override the ResolveReadyToRunCompilers target to use the in-build crossgen2.
        This needs to be imported after SDK targets, so any project requiring this should set AfterMicrosoftNETSdkTargets -->
   <Target Name="ResolveReadyToRunCompilers" Condition="'$(PublishReadyToRun)' == true" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">

--- a/src/mono/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/sample/Android/AndroidSampleApp.csproj
@@ -9,7 +9,7 @@
     <TrimMode>Link</TrimMode>
     <ForceAOT Condition="'$(ForceAOT)' == ''">false</ForceAOT>
     <RunAOTCompilation Condition="'$(RunAOTCompilation)' == ''">$(ForceAOT)</RunAOTCompilation>
-    <StripDebugSymbols Condition="'$(Configuration)' == 'Release'">True</StripDebugSymbols>
+    <StripDebugSymbols Condition="'$(StripDebugSymbols)' == '' and '$(Configuration)' == 'Release'">true</StripDebugSymbols>
     <AppName>HelloAndroid</AppName>
     <MainLibraryFileName>$(AssemblyName).dll</MainLibraryFileName>
     <EnableDefaultAssembliesToBundle>true</EnableDefaultAssembliesToBundle>

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -493,6 +493,20 @@ public partial class ApkBuilder
             // NOTE: we can run android-strip tool from NDK to shrink native binaries here even more.
 
             File.Copy(dynamicLib, Path.Combine(OutputDir, destRelative), true);
+
+            if (!StripDebugSymbols)
+            {
+                // symbol files need to end in .so.so so they'll show up in android studio
+                string debugLib = dynamicLib + ".dbg";
+                string destDebugLib = destRelative + ".so";
+
+                if (File.Exists(debugLib))
+                {
+                    File.Copy(debugLib, Path.Combine(OutputDir, destDebugLib), true);
+                    Utils.RunProcess(logger, androidSdkHelper.AaptPath, $"add {apkFile} {NormalizePathToUnix(destDebugLib)}", workingDir: OutputDir);
+                }
+            }
+
             Utils.RunProcess(logger, androidSdkHelper.AaptPath, $"add {apkFile} {NormalizePathToUnix(destRelative)}", workingDir: OutputDir);
         }
         Utils.RunProcess(logger, androidSdkHelper.AaptPath, $"add {apkFile} classes.dex", workingDir: OutputDir);


### PR DESCRIPTION
This change adds block in the AndroidAppBuilder where it'll copy .dbg files into the apk lib/arch folder and rename the extension to .so. When you build the test, you can open the apk in Android Studio and you won't have to hunt very far to manually associate the symbol libraries.

To native debug the runtime in android studio, all runtime native lib symbols need to end in .so as opposed to .dbg. We have yet to find a way for Android Studio to automatically pick this up and so you have to manually associate libs to symbol libs in the UI. The UI filters based on .so and that is the reason for the rename.

