### PR TITLE
Remove ValidationContext.MemberType

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -170,27 +170,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </value>
         public IDictionary<object, object?> Items => _items;
 
-        internal Type? MemberType
-        {
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "The ctors are marked with RequiresUnreferencedCode.")]
-            get
-            {
-                Type? propertyType = _propertyType;
-
-                if (propertyType is null && MemberName != null)
-                {
-                    _propertyType = propertyType = ValidationAttributeStore.Instance.GetPropertyType(this);
-                }
-
-                return propertyType;
-            }
-
-            set => _propertyType = value;
-        }
-
-        private Type? _propertyType;
-
         #endregion
 
         #region Methods

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -522,7 +522,6 @@ namespace System.ComponentModel.DataAnnotations
             {
                 var context = CreateValidationContext(instance, validationContext);
                 context.MemberName = property.Name;
-                context.MemberType = property.PropertyType;
 
                 if (_store.GetPropertyValidationAttributes(context).Any())
                 {


### PR DESCRIPTION
This property is unused, and is only ever set. It has an UnconditionalSuppressMessage suppression, which makes it hard to tell if there is a trimming issue here or not.

Since this code isn't used, it is better to just remove it to make the trim analysis of this class easier.