### PR TITLE
[cDAC] fix condition to only link in native unwinders on Windows x64

### DIFF
--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -34,10 +34,10 @@
   <ItemGroup>
     <!-- TODO: Link libraries on non-windows platforms. -->
     <!-- https://github.com/dotnet/runtime/issues/112416 -->
-    <DirectPInvoke Include="unwinder_cdac_amd64" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'"/>
-    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_amd64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'" />
-    <DirectPInvoke Include="unwinder_cdac_arm64" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'"/>
-    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_arm64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'" />
+    <DirectPInvoke Include="unwinder_cdac_amd64" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'"/>
+    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_amd64.lib" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'" />
+    <DirectPInvoke Include="unwinder_cdac_arm64" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'"/>
+    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_arm64.lib" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -34,9 +34,9 @@
   <ItemGroup>
     <!-- TODO: Link libraries on non-windows platforms. -->
     <!-- https://github.com/dotnet/runtime/issues/112416 -->
-    <DirectPInvoke Include="unwinder_cdac_amd64" />
+    <DirectPInvoke Include="unwinder_cdac_amd64" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'"/>
     <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_amd64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'" />
-    <DirectPInvoke Include="unwinder_cdac_arm64" />
+    <DirectPInvoke Include="unwinder_cdac_arm64" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'"/>
     <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_arm64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'" />
   </ItemGroup>
 

--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -34,10 +34,10 @@
   <ItemGroup>
     <!-- TODO: Link libraries on non-windows platforms. -->
     <!-- https://github.com/dotnet/runtime/issues/112416 -->
-    <DirectPInvoke Include="unwinder_cdac_amd64" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'"/>
-    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_amd64.lib" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'" />
-    <DirectPInvoke Include="unwinder_cdac_arm64" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'"/>
-    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_arm64.lib" Condition="'$(TargetsWindows)' == 'true' and $(TargetArchitecture) == 'x64'" />
+    <DirectPInvoke Include="unwinder_cdac_amd64" Condition="'$(TargetsWindows)' == 'true' and '$(TargetArchitecture)' == 'x64'"/>
+    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_amd64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(TargetArchitecture)' == 'x64'" />
+    <DirectPInvoke Include="unwinder_cdac_arm64" Condition="'$(TargetsWindows)' == 'true' and '$(TargetArchitecture)' == 'x64'"/>
+    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_arm64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(TargetArchitecture)' == 'x64'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -35,9 +35,9 @@
     <!-- TODO: Link libraries on non-windows platforms. -->
     <!-- https://github.com/dotnet/runtime/issues/112416 -->
     <DirectPInvoke Include="unwinder_cdac_amd64" />
-    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_amd64.lib" Condition="'$(TargetsWindows)' == 'true'" />
+    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_amd64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'" />
     <DirectPInvoke Include="unwinder_cdac_arm64" />
-    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_arm64.lib" Condition="'$(TargetsWindows)' == 'true'" />
+    <NativeLibrary Include="$(CoreCLRArtifactsPath)cdaclibs\unwinder_cdac_arm64.lib" Condition="'$(TargetsWindows)' == 'true' and '$(Platform)' == 'x64'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#111759 broke Windows non-x64 builds by trying to link native unwinders which didn't exist.

Adds conditional to only link unwinders on Windows x64