### PR TITLE
RBO: "X < Y" means "X + 1 <= Y"

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7685,6 +7685,7 @@ public:
     bool          optRelopTryInferWithOneEqualOperand(const VNFuncApp&      domApp,
                                                       const VNFuncApp&      treeApp,
                                                       RelopImplicationInfo* rii);
+    bool optRelopTryInferWithTreePlusOne(const VNFuncApp& domApp, const VNFuncApp& treeApp, RelopImplicationInfo* rii);
 
     /**************************************************************************
      *               Value/Assertion propagation

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -660,11 +660,13 @@ bool Compiler::optRelopTryInferWithTreePlusOne(const VNFuncApp&      domApp,
         return false;
     }
 
+    // clang-format off
     static const RelopImplicationRule implicationRules[] = {
         // domRelop, inferFromTrue, inferFromFalse, treeRelop, reverse
-        {U(GE), false, true, U(LE), true},
-        {U(LE), true, false, U(LE), true},
+        {  U(GE),    false,         true,           U(LE),     true  },
+        {  U(LT),    true,          false,          U(LE),     true  },
     };
+    // clang-format on
 
     for (const RelopImplicationRule& rule : implicationRules)
     {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/112953 

```cs
public static ReadOnlySpan<char> Test(ReadOnlySpan<char> span, int offset)
{
    if ((uint)offset < (uint)span.Length)
        return span.Slice(offset + 1);
    return span;
}
```
Codegen diff:
```diff
; Method Program:Test(System.ReadOnlySpan`1[ushort],int):System.ReadOnlySpan`1[ushort] (FullOpts)
-      sub      rsp, 40
       mov      rax, bword ptr [rdx]
       mov      edx, dword ptr [rdx+0x08]
       cmp      r8d, edx
       jb       SHORT G_M39302_IG04
       mov      bword ptr [rcx], rax
       mov      dword ptr [rcx+0x08], edx
       jmp      SHORT G_M39302_IG05
G_M39302_IG04:
       inc      r8d
-      cmp      r8d, edx
-      ja       SHORT G_M39302_IG07
       mov      r10d, r8d
       lea      rax, bword ptr [rax+2*r10]
       sub      edx, r8d
       mov      bword ptr [rcx], rax
       mov      dword ptr [rcx+0x08], edx
G_M39302_IG05:
       mov      rax, rcx
-      add      rsp, 40
       ret      
-G_M39302_IG07:
-      call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
-      int3     
-; Total bytes of code: 62
+; Total bytes of code: 42
```