### PR TITLE
Add test for external assembly probe mechanism

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.hpp
+++ b/src/coreclr/hosts/corerun/corerun.hpp
@@ -134,6 +134,33 @@ namespace pal
         return INVALID_FILE_ATTRIBUTES != ::GetFileAttributesW(file_path.c_str());
     }
 
+    inline bool try_map_file_readonly(const char* path, void** mapped, int64_t* size)
+    {
+        HANDLE file = ::CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (file == INVALID_HANDLE_VALUE)
+            return false;
+
+        HANDLE file_mapping = ::CreateFileMappingA(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
+        if (file_mapping  == nullptr)
+        {
+            ::CloseHandle(file);
+            return false;
+        }
+
+        void* mapped_local = ::MapViewOfFile(file_mapping, FILE_MAP_READ, 0, 0, 0);
+        if (mapped_local == nullptr)
+        {
+            ::CloseHandle(file);
+            return false;
+        }
+
+        *size = ::GetFileSize(file, nullptr);
+        *mapped = mapped_local;
+        ::CloseHandle(file_mapping);
+        ::CloseHandle(file);
+        return true;
+    }
+
     // Forward declaration
     void ensure_trailing_delimiter(pal::string_t& dir);
 
@@ -300,7 +327,9 @@ public:
 #else // !TARGET_WINDOWS
 #include <dirent.h>
 #include <dlfcn.h>
+#include <fcntl.h>
 #include <limits.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -309,7 +338,6 @@ public:
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #else // !__APPLE__
-#include <fcntl.h>
 #include <ctype.h>
 #endif // !__APPLE__
 
@@ -431,6 +459,33 @@ namespace pal
             return false;
         }
 
+        return true;
+    }
+
+    inline bool try_map_file_readonly(const char* path, void** mapped, int64_t* size)
+    {
+        int fd = open(path, O_RDONLY);
+        if (fd == -1)
+            return false;
+
+        struct stat buf;
+        if (fstat(fd, &buf) == -1)
+        {
+            close(fd);
+            return false;
+        }
+
+        int64_t size_local = buf.st_size;
+        void* mapped_local = mmap(NULL, size_local, PROT_READ, MAP_PRIVATE, fd, 0);
+        if (mapped == MAP_FAILED)
+        {
+            close(fd);
+            return false;
+        }
+
+        *mapped = mapped_local;
+        *size = size_local;
+        close(fd);
         return true;
     }
 

--- a/src/coreclr/hosts/corerun/corerun.hpp
+++ b/src/coreclr/hosts/corerun/corerun.hpp
@@ -151,6 +151,7 @@ namespace pal
         if (mapped_local == nullptr)
         {
             ::CloseHandle(file);
+            ::CloseHandle(file_mapping);
             return false;
         }
 

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -456,6 +456,8 @@ ConvertedImageLayout::ConvertedImageLayout(FlatImageLayout* source, bool disable
     LOG((LF_LOADER, LL_INFO100, "PEImage: Opening manually mapped stream\n"));
 
 #ifdef TARGET_WINDOWS
+    // LoadImageByMappingParts assumes the source has a file mapping handle created/managed by the runtime.
+    // This is not the case for non-file images (for example, external data). Only try to load by mapping for files.
     if (!disableMapping && m_pOwner->IsFile())
     {
         loadedImage = source->LoadImageByMappingParts(this->m_imageParts);

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -456,7 +456,7 @@ ConvertedImageLayout::ConvertedImageLayout(FlatImageLayout* source, bool disable
     LOG((LF_LOADER, LL_INFO100, "PEImage: Opening manually mapped stream\n"));
 
 #ifdef TARGET_WINDOWS
-    if (!disableMapping)
+    if (!disableMapping && m_pOwner->IsFile())
     {
         loadedImage = source->LoadImageByMappingParts(this->m_imageParts);
         if (loadedImage == NULL)

--- a/src/tests/Loader/ExternalAssemblyProbe/ExternalAssemblyProbe.cs
+++ b/src/tests/Loader/ExternalAssemblyProbe/ExternalAssemblyProbe.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+public unsafe class ExternalAssemblyProbe
+{
+    [Fact]
+    public static void ExternalAppAssemblies()
+    {
+        // In order to get to this point, the runtime must have been able to find the app assemblies
+        // Check that the TPA is indeed empty - that is, the runtime is not relying on that property.
+        string tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.True(string.IsNullOrEmpty(tpa), "TRUSTED_PLATFORM_ASSEMBLIES should be empty");
+    }
+}

--- a/src/tests/Loader/ExternalAssemblyProbe/ExternalAssemblyProbe.csproj
+++ b/src/tests/Loader/ExternalAssemblyProbe/ExternalAssemblyProbe.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+    <!-- External assembly probe via host-runtime contract is not implemented.
+         The test uses probing to start at all, so it needs to be disabled in the project, not via an attribute -->
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ExternalAssemblyProbe.cs" />
+
+    <CLRTestEnvironmentVariable Include="APP_ASSEMBLIES" Value="EXTERNAL" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Only try to convert to a loaded layout by file mapping for images that are files
- Add test that uses corerun with external assembly probe

Contributes to https://github.com/dotnet/runtime/issues/112706