### PR TITLE
Escape analysis readme

### DIFF
--- a/docs/design/coreclr/jit/DeabstractionAndConditionalEscapeAnalysis.md
+++ b/docs/design/coreclr/jit/DeabstractionAndConditionalEscapeAnalysis.md
@@ -118,14 +118,14 @@ Based on this PGO data, the JIT first translates the above into something like t
     IEnumerator<int> tt = null;
     if (o.GetType().Equals(typeof(int[])))
     {
-        a = (int[]) o;
+        var a = (int[]) o;
         tt = a.GetEnumerator();
     }
     else
     {
         tt = o.GetEnumerator();
     }
-    e = tt;
+    var e = tt;
     // -------------- End GDV "diamond"
 
     try
@@ -134,7 +134,7 @@ Based on this PGO data, the JIT first translates the above into something like t
         bool b0 = false;
         if (e.GetType().Equals(typeof(SZGenericArrayEnumerator<int>)))
         {
-            ea = (SZGenericArrayEnumerator<int>) e;
+            var ea = (SZGenericArrayEnumerator<int>) e;
             b0 = ea.MoveNext();
         }
         else
@@ -334,21 +334,21 @@ The eventual set of surviving allocations are then transformed to be new struct-
     IEnumerable<int> t = null;
     if (o.Type == O)
     {
-        ac = new E();
+        var ac = new E();
         t = ac;
     }
     else
     {
         t = o.GetEnumerator();
     }
-    e = t;
+    var e = t;
 
     if (e.Type == E)
     {
         // inlined e.MoveNext
-        ea = (E) e;
+        var ea = (E) e;
         // enumerator ref may be copied to other locals
-        tt = ea;
+        var tt = ea;
         tt.field--;
     }
     else

--- a/docs/design/coreclr/jit/DeabstractionAndConditionalEscapeAnalysis.md
+++ b/docs/design/coreclr/jit/DeabstractionAndConditionalEscapeAnalysis.md
@@ -5,7 +5,7 @@ There are interesting, important, and optimizable patterns where objects of seve
 For example, consider the abstract enumeration supported by `IEnumerable<T>`. Here an enumerable `o` of some type (say `O`) can produce an enumerator `e` of some type (say `E`) that then operates on `o`. The typical pattern is:
 ```C#
 O o = ...
-foreach(T t in o) { ... t }
+foreach (T t in o) { ... t }
 ```
 Under the covers, this requires creation of (or access to) a ref class or boxed value class `e` (Footnote 1).
 
@@ -118,12 +118,12 @@ Based on this PGO data, the JIT first translates the above into something like t
     IEnumerator<int> tt = null;
     if (o.GetType().Equals(typeof(int[])))
     {
-        auto a = (int[]) o;
+        a = (int[]) o;
         tt = a.GetEnumerator();
     }
     else
     {
-        tt = o.GetEnumerator;
+        tt = o.GetEnumerator();
     }
     e = tt;
     // -------------- End GDV "diamond"
@@ -134,7 +134,7 @@ Based on this PGO data, the JIT first translates the above into something like t
         bool b0 = false;
         if (e.GetType().Equals(typeof(SZGenericArrayEnumerator<int>)))
         {
-            auto ea = (SZGenericArrayEnumerator<int>) e;
+            ea = (SZGenericArrayEnumerator<int>) e;
             b0 = ea.MoveNext();
         }
         else


### PR DESCRIPTION
Found two usages of the C++ keyword `auto while reading this very interesting document.

Since several local variables didn't use `var` nor explicit type, I went with just removing `auto`.
In a second commit I've added `var` to local variables without a type - let me know if that should just be reverted.