### PR TITLE
Ship CoreCLR packages in servicing releases

### DIFF
--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -14,11 +14,6 @@
     <PackagePlatform>AnyCPU</PackagePlatform>
   </PropertyGroup>
 
-  <!-- CoreCLR nuget packages shouldn't be published during servicing. -->
-  <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">
-    <IsShipping>false</IsShipping>
-  </PropertyGroup>
-
   <PropertyGroup>
     <!-- build the transport package which includes product and symbols in addition to standard packages
     This is a legacy setting as we tend to use symbol packages for symbol indexing and we don't use

--- a/src/coreclr/.nuget/Directory.Build.targets
+++ b/src/coreclr/.nuget/Directory.Build.targets
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
-    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == '' and '$(PreReleaseVersionLabel)' != 'servicing'">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
     <StableVersion Condition="'$(IsShippingPackage)' != 'true' and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Unblock shippable CoreCLR packages from being published in servicing releases. This will need to be backported to servicing branches. Here's an [official build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2651662&view=results) of `release/9.0-staging` with these changes. Fixes #112710.