### PR TITLE
[release/9.0-staging] Backport "Ship CoreCLR packages in servicing releases"

### DIFF
--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -19,11 +19,6 @@
     <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
 
-  <!-- CoreCLR nuget packages shouldn't be published during servicing. -->
-  <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">
-    <IsShipping>false</IsShipping>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageIndex Condition="'$(MSBuildProjectExtension)' == '.pkgproj'" Include="$(PackageIndexFile)" />
   </ItemGroup>

--- a/src/coreclr/.nuget/Directory.Build.targets
+++ b/src/coreclr/.nuget/Directory.Build.targets
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
-    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == '' and '$(PreReleaseVersionLabel)' != 'servicing'">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
     <StableVersion Condition="'$(IsShippingPackage)' != 'true' and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Backport #113020 to release/9.0-staging

## Customer Impact

- [ ] Customer reported
- [x] Found internally

An attempt to backport #111444 revealed that CoreCLR packages (like ILAsm/ILDasm) aren't published in servicing releases, meaning fixes to these packages aren't reaching customers. As identified in #112710 ([comment](https://github.com/dotnet/runtime/issues/112710#issuecomment-2691159959)), there are some non-CoreCLR packages that also aren't being shipped in servicing releases, but probably should be.

## Regression

- [ ] Yes
- [x] No

As far as I know, there was never a conscious decision to stop updating these packages in servicing releases.

## Testing

An [official build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2651662&view=results) of `release/9.0-staging` with CoreCLR packages enabled for shipping passed, and I verified in the package manifest that these packages were shipped. Some manual verification that these packages were shipped in the next servicing release would be prudent.

## Risk

Low. While this will change the versions of the packages available to customers, I suspect few customers were using these packages to begin with, considering it took us this long to notice this.