### PR TITLE
[SGen/Tarjan] Handle edge case with node heaviness changing due to deduplication

### DIFF
--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -819,10 +819,12 @@ create_scc (ScanData *data)
 	g_assert (found);
 
 	// Clear the visited flag on nodes that were added with add_other_colors in the loop above
-	for (i = dyn_array_ptr_size (&color_merge_array); i < dyn_array_ptr_size (&color_data->other_colors); i++) {
-		ColorData *cd = (ColorData *)dyn_array_ptr_get (&color_data->other_colors, i);
-		g_assert (cd->visited);
-		cd->visited = FALSE;
+	if (!can_reduce_color) {
+		for (i = dyn_array_ptr_size (&color_merge_array); i < dyn_array_ptr_size (&color_data->other_colors); i++) {
+			ColorData *cd = (ColorData *)dyn_array_ptr_get (&color_data->other_colors, i);
+			g_assert (cd->visited);
+			cd->visited = FALSE;
+		}
 	}
 
 #if DUMP_GRAPH

--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -525,10 +525,15 @@ find_in_cache (int *insert_index)
 
 // Populate other_colors for a give color (other_colors represent the xrefs for this color)
 static void
-add_other_colors (ColorData *color, DynPtrArray *other_colors)
+add_other_colors (ColorData *color, DynPtrArray *other_colors, gboolean check_visited)
 {
 	for (int i = 0; i < dyn_array_ptr_size (other_colors); ++i) {
 		ColorData *points_to = (ColorData *)dyn_array_ptr_get (other_colors, i);
+		if (check_visited) {
+			if (points_to->visited)
+				continue;
+			points_to->visited = TRUE;
+		}
 		dyn_array_ptr_add (&color->other_colors, points_to);
 		// Inform targets
 		points_to->incoming_colors = MIN (points_to->incoming_colors + 1, INCOMING_COLORS_MAX);
@@ -552,7 +557,7 @@ new_color (gboolean has_bridges)
 	cd = alloc_color_data ();
 	cd->api_index = -1;
 
-	add_other_colors (cd, &color_merge_array);
+	add_other_colors (cd, &color_merge_array, FALSE);
 
 	/* if cacheSlot >= 0, it means we prepared a given slot to receive the new color */
 	if (cacheSlot >= 0)
@@ -791,12 +796,18 @@ create_scc (ScanData *data)
 			dyn_array_ptr_add (&color_data->bridges, other->obj);
 		}
 
-		// Maybe we should make sure we are not adding duplicates here. It is not really a problem
-		// since we will get rid of duplicates before submitting the SCCs to the client in gather_xrefs
-		if (color_data) {
-			add_other_colors (color_data, &other->xrefs);
-		} else {
-			g_assert (dyn_array_ptr_size (&other->xrefs) == 0);
+		if (dyn_array_ptr_size (&other->xrefs) > 0) {
+			g_assert (color_data != NULL);
+			g_assert (can_reduce_color == FALSE);
+			// We need to eliminate duplicates early otherwise the heaviness property
+			// can change in gather_xrefs and it breaks down the loop that reports the
+			// xrefs to the client.
+			//
+			// We reuse the visited flag to mark the objects that are already part of
+			// the color_data array. The array was created above with the new_color call
+			// and xrefs were populated from color_merge_array, which is already
+			// deduplicated and every entry is marked as visited.
+			add_other_colors (color_data, &other->xrefs, TRUE);
 		}
 		dyn_array_ptr_uninit (&other->xrefs);
 
@@ -806,6 +817,13 @@ create_scc (ScanData *data)
 		}
 	}
 	g_assert (found);
+
+	// Clear the visited flag on nodes that were added with add_other_colors in the loop above
+	for (i = dyn_array_ptr_size (&color_merge_array); i < dyn_array_ptr_size (&color_data->other_colors); i++) {
+		ColorData *cd = (ColorData *)dyn_array_ptr_get (&color_data->other_colors, i);
+		g_assert (cd->visited);
+		cd->visited = FALSE;
+	}
 
 #if DUMP_GRAPH
     if (color_data) {
@@ -1116,6 +1134,7 @@ processing_build_callback_data (int generation)
 			gather_xrefs (cd);
 			reset_xrefs (cd);
 			dyn_array_ptr_set_all (&cd->other_colors, &color_merge_array);
+			g_assert (color_visible_to_client (cd));
 			xref_count += dyn_array_ptr_size (&cd->other_colors);
 		}
 	}

--- a/src/mono/mono/tests/sgen-bridge-pathologies.cs
+++ b/src/mono/mono/tests/sgen-bridge-pathologies.cs
@@ -18,11 +18,6 @@ public class NonBridge
 	public object Link;
 }
 
-public class NonBridge2 : NonBridge
-{
-	public object Link2;
-}
-
 class Driver {
 	const int OBJ_COUNT = 200 * 1000;
 	const int LINK_COUNT = 2;
@@ -238,35 +233,6 @@ class Driver {
 		asyncStreamWriter.Link2 = asyncStateMachineBox;
 	}
 
-	/*
-	 * Simulates a graph where a heavy node has its fanout components
-	 * represented by cycles with back-references to the heavy node and
-	 * references to the same bridge objects.
-	 * This enters a pathological path in the SCC contraction where the
-	 * links to the bridge objects need to be correctly deduplicated. The
-	 * deduplication causes the heavy node to no longer be heavy.
-	 */
-	static void FauxHeavyNodeWithCycles ()
-	{
-		Bridge fanout = new Bridge ();
-
-		// Need enough edges for the node to be considered heavy by bridgeless_color_is_heavy
-		NonBridge[] fauxHeavyNode = new NonBridge [100];
-		for (int i = 0; i < fauxHeavyNode.Length; i++) {
-			NonBridge2 cycle = new NonBridge2 ();
-			cycle.Link = fanout;
-			cycle.Link2 = fauxHeavyNode;
-			fauxHeavyNode[i] = cycle;
-		}
-
-		// Need at least HEAVY_REFS_MIN + 1 fan-in nodes
-		Bridge[] faninNodes = new Bridge [3];
-		for (int i = 0; i < faninNodes.Length; i++) {
-			faninNodes[i] = new Bridge ();
-			faninNodes[i].Links.Add (fauxHeavyNode);
-		}
-	}
-
 	static void RunTest (ThreadStart setup)
 	{
 		var t = new Thread (setup);
@@ -291,8 +257,6 @@ class Driver {
 		RunTest (SetupDeadList);
 		RunTest (SetupSelfLinks);
 		RunTest (Spider);
-		RunTest (NestedCycles);
-		RunTest (FauxHeavyNodeWithCycles);
 
 		for (int i = 0; i < 0; ++i) {
 			GC.Collect ();

--- a/src/mono/mono/tests/sgen-bridge-pathologies.cs
+++ b/src/mono/mono/tests/sgen-bridge-pathologies.cs
@@ -207,32 +207,6 @@ class Driver {
 		c.Links.Add (last_level);
 	}
 
-	/*
-	 * Simulates a graph with two nested cycles that is produces by
-	 * the async state machine when `async Task M()` method gets its
-	 * continuation rooted by an Action held by RunnableImplementor
-	 * (ie. the task continuation is hooked through the SynchronizationContext
-	 * implentation and rooted only by Android bridge objects).
-	 */
-	static void NestedCycles ()
-	{ 
-		Bridge runnableImplementor = new Bridge ();
-		Bridge byteArrayOutputStream = new Bridge ();
-		NonBridge2 action = new NonBridge2 ();
-		NonBridge displayClass = new NonBridge ();
-		NonBridge2 asyncStateMachineBox = new NonBridge2 ();
-		NonBridge2 asyncStreamWriter = new NonBridge2 ();
-
-		runnableImplementor.Links.Add(action);
-		action.Link = displayClass;
-		action.Link2 = asyncStateMachineBox;
-		displayClass.Link = action;
-		asyncStateMachineBox.Link = asyncStreamWriter;
-		asyncStateMachineBox.Link2 = action;
-		asyncStreamWriter.Link = byteArrayOutputStream;
-		asyncStreamWriter.Link2 = asyncStateMachineBox;
-	}
-
 	static void RunTest (ThreadStart setup)
 	{
 		var t = new Thread (setup);

--- a/src/tests/GC/Features/Bridge/Bridge.cs
+++ b/src/tests/GC/Features/Bridge/Bridge.cs
@@ -279,6 +279,35 @@ public class BridgeTest
         asyncStreamWriter.Link2 = asyncStateMachineBox;
     }
 
+	// Simulates a graph where a heavy node has its fanout components
+	// represented by cycles with back-references to the heavy node and
+	// references to the same bridge objects.
+	// This enters a pathological path in the SCC contraction where the
+	// links to the bridge objects need to be correctly deduplicated. The
+	// deduplication causes the heavy node to no longer be heavy.
+	static void FauxHeavyNodeWithCycles()
+	{
+		Bridge fanout = new Bridge();
+
+		// Need enough edges for the node to be considered heavy by bridgeless_color_is_heavy
+		NonBridge[] fauxHeavyNode = new NonBridge[100];
+		for (int i = 0; i < fauxHeavyNode.Length; i++)
+        {
+			NonBridge2 cycle = new NonBridge2();
+			cycle.Link = fanout;
+			cycle.Link2 = fauxHeavyNode;
+			fauxHeavyNode[i] = cycle;
+		}
+
+		// Need at least HEAVY_REFS_MIN + 1 fan-in nodes
+		Bridge[] faninNodes = new Bridge[3];
+		for (int i = 0; i < faninNodes.Length; i++)
+        {
+			faninNodes[i] = new Bridge();
+			faninNodes[i].Links.Add(fauxHeavyNode);
+		}
+	}
+
     static void RunGraphTest(Action test)
     {
         Console.WriteLine("Start test {0}", test.Method.Name);
@@ -386,6 +415,7 @@ public class BridgeTest
         RunGraphTest(SetupDeadList);
         RunGraphTest(SetupSelfLinks);
         RunGraphTest(NestedCycles);
+        RunGraphTest(FauxHeavyNodeWithCycles);
 //        RunGraphTest(Spider); // Crashes
         return 100;
     }


### PR DESCRIPTION
This code path can introduce duplicates into the `color->other_colors` array:
https://github.com/dotnet/runtime/blob/b658cd25af266afbde9f83f77d13519de9f533f0/src/mono/mono/metadata/sgen-tarjan-bridge.c#L795-L798

Then we get to the code that counts `xref_count`:
https://github.com/dotnet/runtime/blob/b658cd25af266afbde9f83f77d13519de9f533f0/src/mono/mono/metadata/sgen-tarjan-bridge.c#L1101-L1114

It uses the `color_visible_to_client` helper method which in turn calls `bridgeless_color_is_heavy`:
https://github.com/dotnet/runtime/blob/b658cd25af266afbde9f83f77d13519de9f533f0/src/mono/mono/metadata/sgen-tarjan-bridge.c#L131-L139

The `fanout` metric is computed from the count of `other_colors` which contain duplicates. Once the references are gathered with `gather_xrefs` they get deduplicated. This can change the number of fanout nodes just enough that it no longer satisfies the "heavy" property. We still increase the `xref_count` but in the second loop that iterates over the same data it will get skipped and result in a mismatch:
https://github.com/dotnet/runtime/blob/b658cd25af266afbde9f83f77d13519de9f533f0/src/mono/mono/metadata/sgen-tarjan-bridge.c#L1126-L1130 

Repro: https://github.com/user-attachments/files/19044193/Archive.zip

Fixes #106410