### PR TITLE
Fix TensorPrimitives.MultiplyAddEstimate for integers

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
@@ -128,7 +128,7 @@ namespace System.Numerics.Tensors
                 {
                     return Vector128.MultiplyAddEstimate(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
                 }
-                else
+                else if (typeof(T) == typeof(float))
                 {
                     Debug.Assert(typeof(T) == typeof(float));
                     return Vector128.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
@@ -149,9 +149,9 @@ namespace System.Numerics.Tensors
                 {
                     if (typeof(T) == typeof(double)) return AdvSimd.Arm64.FusedMultiplyAdd(z.AsDouble(), x.AsDouble(), y.AsDouble()).As<double, T>();
                 }
+#endif
 
                 return (x * y) + z;
-#endif
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -162,7 +162,7 @@ namespace System.Numerics.Tensors
                 {
                     return Vector256.MultiplyAddEstimate(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
                 }
-                else
+                else if (typeof(T) == typeof(float))
                 {
                     Debug.Assert(typeof(T) == typeof(float));
                     return Vector256.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
@@ -173,9 +173,9 @@ namespace System.Numerics.Tensors
                     if (typeof(T) == typeof(float)) return Fma.MultiplyAdd(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Fma.MultiplyAdd(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
                 }
+#endif
 
                 return (x * y) + z;
-#endif
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -186,7 +186,7 @@ namespace System.Numerics.Tensors
                 {
                     return Vector512.MultiplyAddEstimate(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
                 }
-                else
+                else if (typeof(T) == typeof(float))
                 {
                     Debug.Assert(typeof(T) == typeof(float));
                     return Vector512.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
@@ -197,9 +197,9 @@ namespace System.Numerics.Tensors
                     if (typeof(T) == typeof(float)) return Avx512F.FusedMultiplyAdd(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Avx512F.FusedMultiplyAdd(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
                 }
+#endif
 
                 return (x * y) + z;
-#endif
             }
         }
     }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
@@ -130,7 +130,6 @@ namespace System.Numerics.Tensors
                 }
                 else if (typeof(T) == typeof(float))
                 {
-                    Debug.Assert(typeof(T) == typeof(float));
                     return Vector128.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
                 }
 #else
@@ -164,7 +163,6 @@ namespace System.Numerics.Tensors
                 }
                 else if (typeof(T) == typeof(float))
                 {
-                    Debug.Assert(typeof(T) == typeof(float));
                     return Vector256.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
                 }
 #else
@@ -188,7 +186,6 @@ namespace System.Numerics.Tensors
                 }
                 else if (typeof(T) == typeof(float))
                 {
-                    Debug.Assert(typeof(T) == typeof(float));
                     return Vector512.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
                 }
 #else

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -501,7 +501,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanDestinationFunctionsToTest))]
-        public void SpanDestinationFunctions_ThrowsForOverlapppingInputsWithOutputs(SpanDestinationDelegate tensorPrimitivesMethod, Func<T, T> expectedMethod, T? tolerance = null)
+        public void SpanDestinationFunctions_ThrowsForOverlappingInputsWithOutputs(SpanDestinationDelegate tensorPrimitivesMethod, Func<T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -639,7 +639,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_ThrowsForOverlapppingInputsWithOutputs(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
+        public void SpanSpanDestination_ThrowsForOverlappingInputsWithOutputs(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -751,7 +751,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanScalarDestinationFunctionsToTest))]
-        public void SpanScalarDestination_ThrowsForOverlapppingInputsWithOutputs(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
+        public void SpanScalarDestination_ThrowsForOverlappingInputsWithOutputs(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -851,7 +851,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(ScalarSpanFloatDestinationFunctionsToTest))]
-        public void SpanScalarFloatDestination_ThrowsForOverlapppingInputsWithOutputs(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
+        public void SpanScalarFloatDestination_ThrowsForOverlappingInputsWithOutputs(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -949,7 +949,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanIntDestinationFunctionsToTest))]
-        public void SpanIntDestination_ThrowsForOverlapppingInputsWithOutputs(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod, T? tolerance = null)
+        public void SpanIntDestination_ThrowsForOverlappingInputsWithOutputs(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -1091,7 +1091,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanSpanDestination_ThrowsForOverlapppingInputsWithOutputs(SpanSpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
+        public void SpanSpanSpanDestination_ThrowsForOverlappingInputsWithOutputs(SpanSpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -1206,7 +1206,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanScalarDestinationFunctionsToTest))]
-        public void SpanSpanScalarDestination_ThrowsForOverlapppingInputsWithOutputs(SpanSpanScalarDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
+        public void SpanSpanScalarDestination_ThrowsForOverlappingInputsWithOutputs(SpanSpanScalarDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -1320,7 +1320,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanScalarSpanDestinationFunctionsToTest))]
-        public void SpanScalarSpanDestination_ThrowsForOverlapppingInputsWithOutputs(SpanScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
+        public void SpanScalarSpanDestination_ThrowsForOverlappingInputsWithOutputs(SpanScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -1474,7 +1474,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanDestinationDestinationFunctionsToTest))]
-        public void SpanDestinationDestinationFunctions_ThrowsForOverlapppingInputsWithOutputs(SpanDestinationDestinationDelegate tensorPrimitivesMethod, Func<T, (T, T)> _)
+        public void SpanDestinationDestinationFunctions_ThrowsForOverlappingInputsWithOutputs(SpanDestinationDestinationDelegate tensorPrimitivesMethod, Func<T, (T, T)> _)
         {
             T[] array = new T[10];
             Assert.Throws<ArgumentException>(() => tensorPrimitivesMethod(array.AsSpan(1, 2), array.AsSpan(0, 2), array.AsSpan(4, 2)));
@@ -1747,7 +1747,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanDestinationFunctionsToTest))]
-        public void SpanDestinationFunctions_ThrowsForOverlapppingInputsWithOutputs(SpanDestinationDelegate tensorPrimitivesMethod, Func<T, T> _)
+        public void SpanDestinationFunctions_ThrowsForOverlappingInputsWithOutputs(SpanDestinationDelegate tensorPrimitivesMethod, Func<T, T> _)
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), array.AsSpan(0, 2)));
@@ -1833,7 +1833,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_ThrowsForOverlapppingInputsWithOutputs(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanSpanDestination_ThrowsForOverlappingInputsWithOutputs(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), array.AsSpan(5, 2), array.AsSpan(0, 2)));
@@ -1915,7 +1915,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanScalarDestinationFunctionsToTest))]
-        public void SpanScalarDestination_ThrowsForOverlapppingInputWithOutputs(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanScalarDestination_ThrowsForOverlappingInputWithOutputs(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> _)
         {
             T[] array = new T[10];
             T y = NextRandom();
@@ -2053,7 +2053,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanSpanDestination_ThrowsForOverlapppingInputsWithOutputs(SpanSpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
+        public void SpanSpanSpanDestination_ThrowsForOverlappingInputsWithOutputs(SpanSpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T, T> expectedMethod, T? tolerance = null)
         {
             _ = expectedMethod;
             _ = tolerance;
@@ -2132,7 +2132,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(ShiftRotateDestinationFunctionsToTest))]
-        public void ShiftRotateDestination_ThrowsForOverlapppingInputWithOutputs(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> _)
+        public void ShiftRotateDestination_ThrowsForOverlappingInputWithOutputs(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> _)
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), default, array.AsSpan(0, 2)));
@@ -2227,7 +2227,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void CopySign_ThrowsForOverlapppingInputsWithOutputs()
+        public void CopySign_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
 
@@ -2490,7 +2490,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(ScalarSpanDestinationFunctionsToTest))]
-        public void ScalarSpanDestination_ThrowsForOverlapppingInputsWithOutputs(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
+        public void ScalarSpanDestination_ThrowsForOverlappingInputsWithOutputs(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(default, array.AsSpan(4, 2), array.AsSpan(3, 2)));

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -236,7 +236,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Abs_ThrowsForOverlapppingInputsWithOutputs()
+        public void Abs_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Abs(array.AsSpan(1, 5), array.AsSpan(0, 5)));
@@ -307,7 +307,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Add_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void Add_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Add(array.AsSpan(1, 2), array.AsSpan(5, 2), array.AsSpan(0, 2)));
@@ -366,7 +366,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Add_TensorScalar_ThrowsForOverlapppingInputsWithOutputs()
+        public void Add_TensorScalar_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Add(array.AsSpan(1, 2), default(T), array.AsSpan(0, 2)));
@@ -442,7 +442,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void AddMultiply_ThreeTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void AddMultiply_ThreeTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => AddMultiply(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(7, 2), array.AsSpan(0, 2)));
@@ -520,7 +520,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void AddMultiply_TensorTensorScalar_ThrowsForOverlapppingInputsWithOutputs()
+        public void AddMultiply_TensorTensorScalar_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => AddMultiply(array.AsSpan(1, 2), array.AsSpan(4, 2), default(T), array.AsSpan(0, 2)));
@@ -596,7 +596,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void AddMultiply_TensorScalarTensor_ThrowsForOverlapppingInputsWithOutputs()
+        public void AddMultiply_TensorScalarTensor_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => AddMultiply(array.AsSpan(1, 2), default(T), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -704,7 +704,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Cosh_ThrowsForOverlapppingInputsWithOutputs()
+        public void Cosh_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 
@@ -876,7 +876,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Divide_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void Divide_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Divide(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -935,7 +935,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Divide_TensorScalar_ThrowsForOverlapppingInputsWithOutputs()
+        public void Divide_TensorScalar_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Divide(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -1066,7 +1066,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Exp_ThrowsForOverlapppingInputsWithOutputs()
+        public void Exp_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 
@@ -1410,7 +1410,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Log_ThrowsForOverlapppingInputsWithOutputs()
+        public void Log_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 
@@ -1495,7 +1495,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Log2_ThrowsForOverlapppingInputsWithOutputs()
+        public void Log2_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 
@@ -1682,7 +1682,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Max_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void Max_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Max(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -1869,7 +1869,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void MaxMagnitude_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void MaxMagnitude_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => MaxMagnitude(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -2056,7 +2056,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Min_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void Min_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Min(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -2241,7 +2241,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void MinMagnitude_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void MinMagnitude_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => MinMagnitude(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -2315,7 +2315,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Multiply_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void Multiply_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Multiply(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -2374,7 +2374,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Multiply_TensorScalar_ThrowsForOverlapppingInputsWithOutputs()
+        public void Multiply_TensorScalar_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Multiply(array.AsSpan(1, 2), default(T), array.AsSpan(0, 2)));
@@ -2450,7 +2450,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void MultiplyAdd_ThreeTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void MultiplyAdd_ThreeTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => MultiplyAdd(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(7, 2), array.AsSpan(0, 2)));
@@ -2513,7 +2513,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void MultiplyAdd_TensorTensorScalar_ThrowsForOverlapppingInputsWithOutputs()
+        public void MultiplyAdd_TensorTensorScalar_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => MultiplyAdd(array.AsSpan(1, 2), array.AsSpan(4, 2), default(T), array.AsSpan(0, 2)));
@@ -2574,7 +2574,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void MultiplyAdd_TensorScalarTensor_ThrowsForOverlapppingInputsWithOutputs()
+        public void MultiplyAdd_TensorScalarTensor_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => MultiplyAdd(array.AsSpan(1, 2), default(T), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -2632,7 +2632,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Negate_ThrowsForOverlapppingInputsWithOutputs()
+        public void Negate_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Negate(array.AsSpan(1, 2), array.AsSpan(0, 2)));
@@ -2827,7 +2827,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Sigmoid_ThrowsForOverlapppingInputsWithOutputs()
+        public void Sigmoid_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 
@@ -2935,7 +2935,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Sinh_ThrowsForOverlapppingInputsWithOutputs()
+        public void Sinh_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 
@@ -3019,7 +3019,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void SoftMax_ThrowsForOverlapppingInputsWithOutputs()
+        public void SoftMax_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 
@@ -3093,7 +3093,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Subtract_TwoTensors_ThrowsForOverlapppingInputsWithOutputs()
+        public void Subtract_TwoTensors_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Subtract(array.AsSpan(1, 2), array.AsSpan(4, 2), array.AsSpan(0, 2)));
@@ -3152,7 +3152,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Subtract_TensorScalar_ThrowsForOverlapppingInputsWithOutputs()
+        public void Subtract_TensorScalar_ThrowsForOverlappingInputsWithOutputs()
         {
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => Subtract(array.AsSpan(1, 2), default(T), array.AsSpan(0, 2)));
@@ -3317,7 +3317,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public void Tanh_ThrowsForOverlapppingInputsWithOutputs()
+        public void Tanh_ThrowsForOverlappingInputsWithOutputs()
         {
             if (!IsFloatingPoint) return;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/112989
Introduced in https://github.com/dotnet/runtime/pull/102181