### PR TITLE
Perform additional checks in `PEHeaders`.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaders.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaders.cs
@@ -100,7 +100,7 @@ namespace System.Reflection.PortableExecutable
                 const Characteristics ImageOnlyCharacteristics = Characteristics.RelocsStripped | Characteristics.ExecutableImage;
                 // Because COFF files do not have a magic number, perform some additional checks to catch outright invalid files.
                 if (_coffHeader.SizeOfOptionalHeader != 0
-                    || _coffHeader.PointerToSymbolTable >= size
+                    || _coffHeader.PointerToSymbolTable >= actualSize
                     || (_coffHeader.Characteristics & ImageOnlyCharacteristics) != 0)
                 {
                     throw new BadImageFormatException(SR.UnknownFileFormat);
@@ -112,7 +112,7 @@ namespace System.Reflection.PortableExecutable
                 _peHeader = new PEHeader(ref reader);
             }
 
-            _sectionHeaders = ReadSectionHeaders(ref reader, size, isCoffOnly);
+            _sectionHeaders = ReadSectionHeaders(ref reader, actualSize, isCoffOnly);
 
             if (!isCoffOnly)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaders.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaders.cs
@@ -90,6 +90,12 @@ namespace System.Reflection.PortableExecutable
 
             SkipDosHeader(ref reader, out bool isCoffOnly);
 
+            if (isCoffOnly && isLoadedImage)
+            {
+                // Only images can be loaded.
+                throw new BadImageFormatException(SR.InvalidPESignature);
+            }
+
             _coffHeaderStartOffset = reader.Offset;
             _coffHeader = new CoffHeader(ref reader);
 
@@ -392,16 +398,8 @@ namespace System.Reflection.PortableExecutable
                     return;
                 }
 
-                if (_isLoadedImage)
-                {
-                    start = SectionHeaders[cormeta].VirtualAddress;
-                    size = SectionHeaders[cormeta].VirtualSize;
-                }
-                else
-                {
-                    start = SectionHeaders[cormeta].PointerToRawData;
-                    size = SectionHeaders[cormeta].SizeOfRawData;
-                }
+                start = SectionHeaders[cormeta].PointerToRawData;
+                size = SectionHeaders[cormeta].SizeOfRawData;
             }
             else if (_corHeader == null)
             {

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEHeadersTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEHeadersTests.cs
@@ -51,6 +51,13 @@ namespace System.Reflection.PortableExecutable.Tests
         }
 
         [Fact]
+        public void Ctor_InvalidFile()
+        {
+            using var stream = new MemoryStream(Misc.KeyPair);
+            Assert.Throws<BadImageFormatException>(() => new PEHeaders(stream));
+        }
+
+        [Fact]
         public void FromEmptyStream()
         {
             Assert.Throws<BadImageFormatException>(() => new PEHeaders(new MemoryStream()));

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEHeadersTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEHeadersTests.cs
@@ -68,6 +68,13 @@ namespace System.Reflection.PortableExecutable.Tests
         }
 
         [Fact]
+        public void Ctor_CoffFileLoadedImage()
+        {
+            byte[] file = new byte[CoffHeader.Size];
+            Assert.Throws<BadImageFormatException>(() => new PEHeaders(new MemoryStream(file), file.Length, isLoadedImage: true));
+        }
+
+        [Fact]
         public void FromEmptyStream()
         {
             Assert.Throws<BadImageFormatException>(() => new PEHeaders(new MemoryStream()));

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -869,15 +869,5 @@ namespace System.Reflection.PortableExecutable.Tests
                 }
             }
         }
-
-        [Fact]
-        public void HasMetadataShouldReturnFalseWhenPrefetchingMetadataOfImageWithoutMetadata()
-        {
-            using (var fileStream = new MemoryStream(Misc.KeyPair))
-            using (var peReader = new PEReader(fileStream, PEStreamOptions.PrefetchMetadata | PEStreamOptions.LeaveOpen))
-            {
-                Assert.False(peReader.HasMetadata);
-            }
-        }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -820,10 +820,7 @@ namespace System.Reflection.PortableExecutable.Tests
             Assert.Throws<ObjectDisposedException>(() => reader.ReadDebugDirectory());
             Assert.Throws<ObjectDisposedException>(() => reader.ReadCodeViewDebugDirectoryData(ddCodeView));
             Assert.Throws<ObjectDisposedException>(() => reader.ReadEmbeddedPortablePdbDebugDirectoryData(ddEmbedded));
-
-            MetadataReaderProvider __;
-            string ___;
-            Assert.Throws<ObjectDisposedException>(() => reader.TryOpenAssociatedPortablePdb(@"x", _ => null, out __, out ___));
+            Assert.Throws<ObjectDisposedException>(() => reader.TryOpenAssociatedPortablePdb(@"x", _ => null, out _, out _));
 
             // ok to use providers after PEReader disposed:
             var pdbReader = pdbProvider.GetMetadataReader();


### PR DESCRIPTION
Fixes #48419.
Supersedes #112830 for now.

See also https://github.com/dotnet/runtime/issues/112830#issuecomment-2677632672.

This PR updates the constructor of `PEHeaders` to perform some additional checks to detect files with an obviously invalid structure. Specifically:

* `CoffHeader.SizeOfOptionalHeader` is checked to be zero in object files.
* The size of the file is checked to fit as many as `CoffHeader.NumberOfSections` sections, in both object and image files.
* COFF files are rejected if `isLoadedImage` is set to `true`.