### PR TITLE
Assert pointer relocs are aligned

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
@@ -32,6 +32,7 @@ namespace ILCompiler.DependencyAnalysis
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
 
             var builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialAlignment(factory.Target.PointerSize);
             builder.AddSymbol(this);
             foreach (FrozenObjectNode node in factory.MetadataManager.GetFrozenObjects())
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
@@ -450,18 +450,21 @@ namespace ILCompiler.ObjectWriter
 #if DEBUG
                     // Pointer relocs should be aligned at pointer boundaries within the image.
                     // Processing misaligned relocs (especially relocs that straddle page boundaries) can be
-                    // expensive on Windows.
-                    bool hasPointerRelocs = false;
-                    foreach (Relocation reloc in nodeContents.Relocs)
+                    // expensive on Windows. But: we can't guarantee this on x86.
+                    if (_nodeFactory.Target.Architecture != TargetArchitecture.X86)
                     {
-                        if ((reloc.RelocType is RelocType.IMAGE_REL_BASED_DIR64 && _nodeFactory.Target.PointerSize == 8) ||
-                            (reloc.RelocType is RelocType.IMAGE_REL_BASED_HIGHLOW && _nodeFactory.Target.PointerSize == 4))
+                        bool hasPointerRelocs = false;
+                        foreach (Relocation reloc in nodeContents.Relocs)
                         {
-                            hasPointerRelocs = true;
-                            Debug.Assert(reloc.Offset % _nodeFactory.Target.PointerSize == 0);
+                            if ((reloc.RelocType is RelocType.IMAGE_REL_BASED_DIR64 && _nodeFactory.Target.PointerSize == 8) ||
+                                (reloc.RelocType is RelocType.IMAGE_REL_BASED_HIGHLOW && _nodeFactory.Target.PointerSize == 4))
+                            {
+                                hasPointerRelocs = true;
+                                Debug.Assert(reloc.Offset % _nodeFactory.Target.PointerSize == 0);
+                            }
                         }
+                        Debug.Assert(!hasPointerRelocs || (nodeContents.Alignment % _nodeFactory.Target.PointerSize) == 0);
                     }
-                    Debug.Assert(!hasPointerRelocs || (nodeContents.Alignment % _nodeFactory.Target.PointerSize) == 0);
 #endif
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
@@ -446,6 +446,23 @@ namespace ILCompiler.ObjectWriter
                         sectionWriter.Position,
                         nodeContents.Data,
                         nodeContents.Relocs));
+
+#if DEBUG
+                    // Pointer relocs should be aligned at pointer boundaries within the image.
+                    // Processing misaligned relocs (especially relocs that straddle page boundaries) can be
+                    // expensive on Windows.
+                    bool hasPointerRelocs = false;
+                    foreach (Relocation reloc in nodeContents.Relocs)
+                    {
+                        if ((reloc.RelocType is RelocType.IMAGE_REL_BASED_DIR64 && _nodeFactory.Target.PointerSize == 8) ||
+                            (reloc.RelocType is RelocType.IMAGE_REL_BASED_HIGHLOW && _nodeFactory.Target.PointerSize == 4))
+                        {
+                            hasPointerRelocs = true;
+                            Debug.Assert(reloc.Offset % _nodeFactory.Target.PointerSize == 0);
+                        }
+                    }
+                    Debug.Assert(!hasPointerRelocs || (nodeContents.Alignment % _nodeFactory.Target.PointerSize) == 0);
+#endif
                 }
 
                 // Emit unwinding frames and LSDA


### PR DESCRIPTION
This is a prerequisite for disabling data dehydration on Windows by default. Straddling pointers are not a big deal with dehydration, but straddling a page boundary with a reloc on Windows is a (perf) problem.

Cc @dotnet/ilc-contrib 
