### PR TITLE
Remove unnecessary `GcInfoEncoder::DoNotTrackInPartiallyInterruptible`

### DIFF
--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -21,6 +21,7 @@ pr:
     # so that this build can block dependency auto-updates (this build is currently ignored)
     include:
     - src/coreclr/jit/*
+    - src/coreclr/gcinfo/*
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/coreclr/superpmi-replay.yml
+++ b/eng/pipelines/coreclr/superpmi-replay.yml
@@ -11,6 +11,7 @@ pr:
   paths:
     include:
     - src/coreclr/jit/*
+    - src/coreclr/gcinfo/*
     - src/coreclr/tools/superpmi/*
     exclude:
     - src/coreclr/inc/jiteeversionguid.h

--- a/src/coreclr/gcinfo/gcinfoencoder.cpp
+++ b/src/coreclr/gcinfo/gcinfoencoder.cpp
@@ -1397,6 +1397,10 @@ void GcInfoEncoder::Build()
 
                     liveState.WriteBit(slotIndex, becomesLive);
                 }
+                else
+                {
+                    assert(!"Saw untracked slot");
+                }
                 pCurrent++;
             }
         }

--- a/src/coreclr/gcinfo/gcinfoencoder.cpp
+++ b/src/coreclr/gcinfo/gcinfoencoder.cpp
@@ -909,97 +909,6 @@ void GcInfoEncoder::FinalizeSlotIds()
 #endif
 }
 
-#ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-
-// tells whether a slot cannot contain an object reference
-// at call instruction or right after returning
-bool GcInfoEncoder::DoNotTrackInPartiallyInterruptible(GcSlotDesc &slotDesc)
-{
-#if defined(TARGET_ARM)
-
-    _ASSERTE( m_SizeOfStackOutgoingAndScratchArea != (UINT32)-1 );
-    if(slotDesc.IsRegister())
-    {
-        int regNum = (int) slotDesc.Slot.RegisterNumber;
-        _ASSERTE(regNum >= 0 && regNum <= 14);
-        _ASSERTE(regNum != 13);  // sp
-
-        return ((regNum <= 3) || (regNum >= 12)) // R12 is volatile and SP/LR can't contain objects around calls
-            && regNum != 0                       // R0 can contain return value
-            ;
-    }
-    else if (!slotDesc.IsUntracked() && (slotDesc.Slot.Stack.Base == GC_SP_REL) &&
-        ((UINT32)slotDesc.Slot.Stack.SpOffset < m_SizeOfStackOutgoingAndScratchArea))
-    {
-        return TRUE;
-    }
-    else
-        return FALSE;
-
-#elif defined(TARGET_ARM64)
-
-    _ASSERTE(m_SizeOfStackOutgoingAndScratchArea != (UINT32)-1);
-    if (slotDesc.IsRegister())
-    {
-        int regNum = (int)slotDesc.Slot.RegisterNumber;
-        _ASSERTE(regNum >= 0 && regNum <= 30);
-        _ASSERTE(regNum != 18);
-
-        return (regNum <= 17 || regNum >= 29) // X0 through X17 are scratch, FP/LR can't be used for objects around calls
-            && regNum != 0                    // X0 can contain return value
-            && regNum != 1                    // X1 can contain return value
-            ;
-    }
-    else if (!slotDesc.IsUntracked() && (slotDesc.Slot.Stack.Base == GC_SP_REL) &&
-        ((UINT32)slotDesc.Slot.Stack.SpOffset < m_SizeOfStackOutgoingAndScratchArea))
-    {
-        return TRUE;
-    }
-    else
-        return FALSE;
-
-#elif defined(TARGET_AMD64)
-
-    _ASSERTE( m_SizeOfStackOutgoingAndScratchArea != (UINT32)-1 );
-    if(slotDesc.IsRegister())
-    {
-        int regNum = (int) slotDesc.Slot.RegisterNumber;
-        _ASSERTE(regNum >= 0 && regNum <= 16);
-        _ASSERTE(regNum != 4);  // rsp
-
-        UINT16 PreservedRegMask =
-            (1 << 3)  // rbx
-            | (1 << 5)  // rbp
-#ifndef UNIX_AMD64_ABI
-            | (1 << 6)  // rsi
-            | (1 << 7)  // rdi
-#endif // UNIX_AMD64_ABI
-            | (1 << 12)  // r12
-            | (1 << 13)  // r13
-            | (1 << 14)  // r14
-            | (1 << 15)  // r15
-            | (1 << 0)   // rax - may contain return value
-#ifdef UNIX_AMD64_ABI
-            | (1 << 2)   // rdx - may contain return value
-#endif
-            ;
-
-        return !(PreservedRegMask & (1 << regNum));
-    }
-    else if (!slotDesc.IsUntracked() && (slotDesc.Slot.Stack.Base == GC_SP_REL) &&
-        ((UINT32)slotDesc.Slot.Stack.SpOffset < m_SizeOfStackOutgoingAndScratchArea))
-    {
-        return TRUE;
-    }
-    else
-        return FALSE;
-
-#else
-    return FALSE;
-#endif
-}
-#endif // PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-
 void GcInfoEncoder::Build()
 {
 #ifdef _DEBUG
@@ -1389,18 +1298,11 @@ void GcInfoEncoder::Build()
             else
             {
                 UINT32 slotIndex = pCurrent->SlotId;
-                if(!DoNotTrackInPartiallyInterruptible(m_SlotTable[slotIndex]))
-                {
-                    BYTE becomesLive = pCurrent->BecomesLive;
-                    _ASSERTE((liveState.ReadBit(slotIndex) && !becomesLive)
-                            || (!liveState.ReadBit(slotIndex) && becomesLive));
+                BYTE becomesLive = pCurrent->BecomesLive;
+                _ASSERTE((liveState.ReadBit(slotIndex) && !becomesLive)
+                        || (!liveState.ReadBit(slotIndex) && becomesLive));
 
-                    liveState.WriteBit(slotIndex, becomesLive);
-                }
-                else
-                {
-                    assert(!"Saw untracked slot");
-                }
+                liveState.WriteBit(slotIndex, becomesLive);
                 pCurrent++;
             }
         }

--- a/src/coreclr/inc/gcinfoencoder.h
+++ b/src/coreclr/inc/gcinfoencoder.h
@@ -542,10 +542,6 @@ private:
     void SizeofSlotStateVarLengthVector(const BitArray& vector, UINT32 baseSkip, UINT32 baseRun, UINT32 * pSizeofSimple, UINT32 * pSizeofRLE, UINT32 * pSizeofRLENeg);
     UINT32 WriteSlotStateVarLengthVector(BitStreamWriter &writer, const BitArray& vector, UINT32 baseSkip, UINT32 baseRun);
 
-#ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-    bool DoNotTrackInPartiallyInterruptible(GcSlotDesc &slot);
-#endif // PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-
     // Assumes that "*ppTransitions" is has size "numTransitions", is sorted by CodeOffset then by SlotId,
     // and that "*ppEndTransitions" points one beyond the end of the array.  If "*ppTransitions" contains
     // any dead/live transitions pairs for the same CodeOffset and SlotID, removes those, by allocating a


### PR DESCRIPTION
The check as it was used always returned false (verified that with an assert on the first commit). Instead trust the user of the encoder on what registers to report and not report. This unblocks custom calling conventions like in #112406 and with runtime async.