### PR TITLE
Fix R2R files doublemap on UNIX

### DIFF
--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -195,7 +195,7 @@ private:
     PTR_PEImageLayout CreateLoadedLayout(bool throwOnFailure);
 
     // Create the flat layout
-    PTR_PEImageLayout CreateFlatLayout();
+    PTR_PEImageLayout CreateFlatLayout(BOOL bIsLoadedLayoutSuitable);
 
     void   SetLayout(DWORD dwLayout, PTR_PEImageLayout pLayout);
 #endif


### PR DESCRIPTION
Runtime creates both layouts for each dll: FlatLayout and LoadedLayout. Non-R2R smaps does not has difference after secondary LoadedLayout, but for R2R secondary LoadedLayout leads to additional smap containing Shared_Clean memory. 

This patch changes first FlatLayout creation to LoadedLayout eliminating this additional smap.

Smaps before this patch:
```
7f100d490000-7f100d491000 r--p 00000000 103:01 26091497                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_478cfe2/hello/readline.ni.dll
7f100d4a0000-7f100d4a1000 r-xp 00000000 103:01 26091497                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_478cfe2/hello/readline.ni.dll
7f100d4c1000-7f100d4c2000 rw-p 00001000 103:01 26091497                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_478cfe2/hello/readline.ni.dll
7f100d4e1000-7f100d4e2000 r--p 00001000 103:01 26091497                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_478cfe2/hello/readline.ni.dll
7f108807d000-7f108807f000 r--s 00000000 103:01 26091497                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_478cfe2/hello/readline.ni.dll
```
Smaps with this patch:
```
7fc50ff40000-7fc50ff41000 r--p 00000000 103:01 27937953                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_PR_74c544a/hello/readline.ni.dll
7fc50ff50000-7fc50ff51000 r-xp 00000000 103:01 27937953                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_PR_74c544a/hello/readline.ni.dll
7fc50ff71000-7fc50ff72000 rw-p 00001000 103:01 27937953                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_PR_74c544a/hello/readline.ni.dll
7fc50ff91000-7fc50ff92000 r--p 00001000 103:01 27937953                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_PR_74c544a/hello/readline.ni.dll
```

<details> <summary> Additional smap </summary>

```
7f108807d000-7f108807f000 r--s 00000000 103:01 26091497                  /home/runtime/installed_x64/clean_478cfe2/main_releaseO0_478cfe2/hello/readline.ni.dll
Size:                  8 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                   8 kB
Pss:                   3 kB
Shared_Clean:          8 kB
Shared_Dirty:          0 kB
Private_Clean:         0 kB
Private_Dirty:         0 kB
Referenced:            8 kB
Anonymous:             0 kB
LazyFree:              0 kB
AnonHugePages:         0 kB
ShmemPmdMapped:        0 kB
FilePmdMapped:        0 kB
Shared_Hugetlb:        0 kB
Private_Hugetlb:       0 kB
Swap:                  0 kB
SwapPss:               0 kB
Locked:                0 kB
THPeligible:        0
VmFlags: rd mr me ms sd
```
</details>

Question about this problem: https://github.com/dotnet/runtime/issues/112901
cc @gbalykov 