### PR TITLE
Do not cache method parameters for collectible methods

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -71,7 +71,7 @@ namespace System.Dynamic.Utils
             if (!pic.TryGetValue(method, out ParameterInfo[]? pis))
             {
                 pis = method.GetParameters();
-                if (method.DeclaringType?.IsCollectible == false)
+                if (!method.IsCollectible)
                 {
                     pic[method] = pis;
                 }


### PR DESCRIPTION
When using a method from a generic class from a non-collectible assembly with a generic parameter from a collectible assembly in a LINQ expression, the collectible assembly may be prevented from unloading. This is due to the method parameters being cached in a dictionary with the method info.

Fix #112518