### PR TITLE
[infra] Add runtime-llvm to build analysis

### DIFF
--- a/eng/build-analysis-configuration.json
+++ b/eng/build-analysis-configuration.json
@@ -11,6 +11,10 @@
        {
          "PipelineId": 154,
          "PipelineName": "runtime-extra-platforms"
+       },
+       {
+         "PipelineId": 157,
+         "PipelineName": "runtime-llvm"
        }
     ]
 }


### PR DESCRIPTION
Adding `runtime-llvm` to Build Analysis config to get proper tracking of CI failures.