### PR TITLE
JIT: Mark certain intrinsics as non-escaping

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -1669,6 +1669,13 @@ void HelperCallProperties::init()
                 isPure     = true;
                 break;
 
+            case CORINFO_HELP_MEMCPY:
+            case CORINFO_HELP_MEMZERO:
+            case CORINFO_HELP_MEMSET:
+            case CORINFO_HELP_NATIVE_MEMSET:
+                isNoEscape = true;
+                break;
+
             case CORINFO_HELP_LDELEMA_REF:
                 isPure = true;
                 break;


### PR DESCRIPTION
The goal is to support things like
```cs
BitConverter.GetBytes(val).AsSpan(0, 3).CopyTo(dst);
```
where we want to save n-bytes of a primitive into a span, today we can either use either ^ (allocates) or come up with something ugly/unsafe.

But looks like there more work to do in JIT to enable that. Currently, JIT gives up on saving the temp array into Span.