### PR TITLE
Better ARM intrinsics implementation for dn_simdhash

### DIFF
--- a/src/native/containers/dn-simdhash-arch.h
+++ b/src/native/containers/dn-simdhash-arch.h
@@ -120,7 +120,7 @@ find_first_matching_suffix_simd (
 	// See https://community.arm.com/arm-community-blogs/b/servers-and-cloud-computing-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
 	uint16x8_t match_vector16 = vreinterpretq_u16_u8(vceqq_u8(needle.vec, haystack.vec));
 	uint8x8_t match_bits = vshrn_n_u16(match_vector16, 4);
-	uint64_t match_bits_scalar = vget_lane_u64(match_bits, 0);
+	uint64_t match_bits_scalar = vget_lane_u64(vreinterpret_u64_u8(match_bits), 0);
 	return ctzll(match_bits_scalar) >> 2;
 #else
 	dn_simdhash_assert(!"Scalar fallback should be in use here");

--- a/src/native/containers/dn-simdhash-arch.h
+++ b/src/native/containers/dn-simdhash-arch.h
@@ -21,7 +21,7 @@
 #include <wasm_simd128.h>
 #elif defined(_M_AMD64) || defined(_M_X64) || (_M_IX86_FP == 2) || defined(__SSE2__)
 #include <emmintrin.h>
-#elif defined(__ARM_NEON)
+#elif defined(__ARM_ARCH_ISA_A64)
 #include <arm_neon.h>
 #elif defined(__wasm)
 #define DN_SIMDHASH_USE_SCALAR_FALLBACK 1
@@ -116,7 +116,7 @@ find_first_matching_suffix_simd (
 	return ctz(wasm_i8x16_bitmask(wasm_i8x16_eq(needle.vec, haystack.vec)));
 #elif defined(_M_AMD64) || defined(_M_X64) || (_M_IX86_FP == 2) || defined(__SSE2__)
 	return ctz(_mm_movemask_epi8(_mm_cmpeq_epi8(needle.m128, haystack.m128)));
-#elif defined(__ARM_NEON)
+#elif defined(__ARM_ARCH_ISA_A64)
 	// See https://community.arm.com/arm-community-blogs/b/servers-and-cloud-computing-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
 	uint16x8_t match_vector16 = vreinterpretq_u16_u8(vceqq_u8(needle.vec, haystack.vec));
 	uint8x8_t match_bits = vshrn_n_u16(match_vector16, 4);

--- a/src/native/containers/dn-simdhash-arch.h
+++ b/src/native/containers/dn-simdhash-arch.h
@@ -10,14 +10,14 @@
 #include "dn-simdhash.h"
 
 #if defined(_M_AMD64) || defined(_M_X64) || (_M_IX86_FP == 2) || defined(__SSE2__)
-#define SIMDHASH_USE_SSE2 1
+#define DN_SIMDHASH_USE_SSE2 1
 #endif
 
 #if defined(__clang__) || defined (__GNUC__) // use vector intrinsics
 
 #if defined(__wasm_simd128__)
 #include <wasm_simd128.h>
-#elif SIMDHASH_USE_SSE2
+#elif DN_SIMDHASH_USE_SSE2
 #include <emmintrin.h>
 #elif defined(__ARM_ARCH_ISA_A64)
 #include <arm_neon.h>
@@ -40,7 +40,7 @@
 typedef uint8_t dn_u8x16 __attribute__ ((vector_size (DN_SIMDHASH_VECTOR_WIDTH), aligned(DN_SIMDHASH_VECTOR_WIDTH)));
 typedef union {
 	_Alignas(DN_SIMDHASH_VECTOR_WIDTH) dn_u8x16 vec;
-#if SIMDHASH_USE_SSE2
+#if DN_SIMDHASH_USE_SSE2
 	_Alignas(DN_SIMDHASH_VECTOR_WIDTH) __m128i m128;
 #endif
 	_Alignas(DN_SIMDHASH_VECTOR_WIDTH) uint8_t values[DN_SIMDHASH_VECTOR_WIDTH];
@@ -121,7 +121,7 @@ find_first_matching_suffix_simd (
     return 32;
 #elif defined(__wasm_simd128__)
 	return ctz(wasm_i8x16_bitmask(wasm_i8x16_eq(needle.vec, haystack.vec)));
-#elif SIMDHASH_USE_SSE2
+#elif DN_SIMDHASH_USE_SSE2
 	return ctz(_mm_movemask_epi8(_mm_cmpeq_epi8(needle.m128, haystack.m128)));
 #elif defined(__ARM_ARCH_ISA_A64)
 	// See https://community.arm.com/arm-community-blogs/b/servers-and-cloud-computing-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
@@ -134,7 +134,7 @@ find_first_matching_suffix_simd (
 #endif
 }
 
-#elif SIMDHASH_USE_SSE2
+#elif DN_SIMDHASH_USE_SSE2
 // neither clang or gcc, but we have SSE2 available, so assume this is MSVC on x86 or x86-64
 // msvc neon intrinsics don't seem to expose a 128-bit wide vector so there's no neon in here
 #include <intrin.h> // for _BitScanForward

--- a/src/native/containers/dn-simdhash-specialization.h
+++ b/src/native/containers/dn-simdhash-specialization.h
@@ -182,7 +182,7 @@ DN_SIMDHASH_SCAN_BUCKET_INTERNAL (DN_SIMDHASH_T_PTR hash, bucket_t *restrict buc
 	#define bucket_suffixes (bucket->suffixes)
 #elif !defined(DN_SIMDHASH_USE_SCALAR_FALLBACK)
 	// Perform an eager load of the vector if SIMD is in use, even though we do
-	//  byte loads to extract lanes on non-wasm platforms. It's faster on x64 for
+	//  byte loads to extract lanes on some platforms. It's faster on x64 for
 	//  a reason I can't identify, and it significantly improves wasm codegen
 	dn_simdhash_suffixes bucket_suffixes = bucket->suffixes;
 #else
@@ -190,7 +190,9 @@ DN_SIMDHASH_SCAN_BUCKET_INTERNAL (DN_SIMDHASH_T_PTR hash, bucket_t *restrict buc
 	//  no good reason.
 	#define bucket_suffixes (bucket->suffixes)
 #endif
+
 	uint8_t count = dn_simdhash_extract_lane(bucket_suffixes, DN_SIMDHASH_COUNT_SLOT),
+	// Loading this late at the point of the if with DN_UNLIKELY doesn't seem to improve codegen or perf
 		overflow_count = dn_simdhash_extract_lane(bucket_suffixes, DN_SIMDHASH_CASCADED_SLOT);
 	// We could early-out here when count==0, but it doesn't appear to meaningfully improve
 	//  search performance to do so, and might actually worsen it
@@ -200,18 +202,20 @@ DN_SIMDHASH_SCAN_BUCKET_INTERNAL (DN_SIMDHASH_T_PTR hash, bucket_t *restrict buc
 	uint32_t index = find_first_matching_suffix_simd(search_vector, bucket_suffixes);
 #endif
 #undef bucket_suffixes
-	for (; index < count; index++) {
-		// FIXME: Could be profitable to manually hoist the data load outside of the loop,
-		//  if not out of SCAN_BUCKET_INTERNAL entirely. Clang appears to do LICM on it.
-		// It's better to index bucket->keys each iteration inside the loop than to precompute
-		//  a pointer outside and bump the pointer, because in many cases the bucket will be
-		//  empty, and in many other cases it will have one match. Putting the index inside the
-		//  loop means that for empty/no-match buckets we don't do the index calculation at all.
-		if (DN_SIMDHASH_KEY_EQUALS(DN_SIMDHASH_GET_DATA(hash), needle, bucket->keys[index]))
-			return index;
+
+	if (DN_LIKELY(index < count)) {
+		DN_SIMDHASH_KEY_T *key = &bucket->keys[index];
+		do {
+			// FIXME: Could be profitable to manually hoist the data load outside of the loop,
+			//  if not out of SCAN_BUCKET_INTERNAL entirely. Clang appears to do LICM on it.
+			if (DN_SIMDHASH_KEY_EQUALS(DN_SIMDHASH_GET_DATA(hash), needle, *key))
+				return index;
+			key++;
+			index++;
+		} while (index < count);
 	}
 
-	if (overflow_count)
+	if (DN_UNLIKELY(overflow_count))
 		return DN_SIMDHASH_SCAN_BUCKET_OVERFLOWED;
 	else
 		return DN_SIMDHASH_SCAN_BUCKET_NO_OVERFLOW;


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/113074
Speculative better implementation of dn_simdhash search for ARM NEON. I've examined the generated assembly and it looks right, but I don't have a way to test this locally right now so I'm testing it on CI.
This by necessity restricts NEON support to ARM64 (ARM32's vector registers are too narrow and not all the intrinsics I need exist on it). On ARM32 we should use scalar fallback.