### PR TITLE
JIT: Avoid rotating/splitting loop bodies during 3-opt layout

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -600,6 +600,12 @@ private:
     // Convenience flag for phases that need to track edge visitation
     bool m_visited;
 
+    // Convenience flag for phases that need to cache loop back edges
+    bool m_isLoopBackEdge;
+
+    // Convenience flag for phases that need to cache loop exit edges
+    bool m_isLoopExitEdge;
+
     // True if likelihood has been set
     INDEBUG(bool m_likelihoodSet);
 
@@ -611,6 +617,8 @@ public:
         , m_likelihood(0)
         , m_dupCount(0)
         , m_visited(false)
+        , m_isLoopBackEdge(false)
+        , m_isLoopExitEdge(false)
 #ifdef DEBUG
         , m_likelihoodSet(false)
 #endif // DEBUG
@@ -711,6 +719,26 @@ public:
     {
         assert(visited());
         m_visited = false;
+    }
+
+    bool isLoopBackEdge() const
+    {
+        return m_isLoopBackEdge;
+    }
+
+    void markLoopBackEdge()
+    {
+        m_isLoopBackEdge = true;
+    }
+
+    bool isLoopExitEdge() const
+    {
+        return m_isLoopExitEdge;
+    }
+
+    void markLoopExitEdge()
+    {
+        m_isLoopExitEdge = true;
     }
 };
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5263,6 +5263,13 @@ void Compiler::ThreeOptLayout::CompactHotJumps()
             edge = unlikelyEdge;
         }
 
+        // Don't interleave loop and non-loop blocks.
+        // We will leave it to 3-opt to determine if breaking up loop bodies is profitable.
+        if (compiler->m_loops->IsLoopExitEdge(edge))
+        {
+            continue;
+        }
+
         BasicBlock* const target = edge->getDestinationBlock();
         const unsigned    srcPos = i;
         const unsigned    dstPos = target->bbPreorderNum;
@@ -5295,7 +5302,7 @@ void Compiler::ThreeOptLayout::CompactHotJumps()
             for (unsigned pos = dstPos - 1; pos != srcPos; pos--)
             {
                 BasicBlock* const blockToMove = blockOrder[pos];
-                blockOrder[pos + offset]      = blockOrder[pos];
+                blockOrder[pos + offset]      = blockToMove;
                 blockToMove->bbPreorderNum += offset;
             }
 
@@ -5320,7 +5327,7 @@ void Compiler::ThreeOptLayout::CompactHotJumps()
             for (unsigned pos = srcPos - 1; pos >= dstPos; pos--)
             {
                 BasicBlock* const blockToMove = blockOrder[pos];
-                blockOrder[pos + 1]           = blockOrder[pos];
+                blockOrder[pos + 1]           = blockToMove;
                 blockToMove->bbPreorderNum++;
             }
 


### PR DESCRIPTION
Part of #107749. My recent comparison of 3-opt to an external TSP optimizer ([comment](https://github.com/dotnet/runtime/issues/107749#issuecomment-2683530746)) revealed the former's tendency to leave loop bodies broken up if hot jump compaction decided to create fallthrough along one of the loop's exit paths. The initial layout should probably keep loop bodies compact on principle, and rely on 3-opt's profitability heuristics to decide when to break them up. As a motivating example, consider the following layout from `benchmarks.run_pgo`:
```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight     IBC [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1     1106 [000..001)-> BB42(0.0607),BB37(0.939)  ( cond )                     i LIR IBC
BB37 [0081]  1       BB01                  0.94  1039 [000..???)-> BB02(1)                 (always)                     LIR IBC internal
BB10 [0015]  1       BB09                  7.05  7796 [000..001)-> BB12(1)                 (always)                     i LIR IBC bwd
BB12 [0017]  2       BB08,BB10            11.46 12670 [000..001)-> BB02(0.939),BB42(0.0607)  ( cond )                     i LIR IBC bwd bwd-src
BB02 [0012]  2       BB12,BB37            11.70 12940 [000..001)-> BB05(0.678),BB03(0.322) ( cond )                     i LIR IBC bwd bwd-target
BB05 [0022]  1       BB02                  7.93  8770 [000..001)-> BB06(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB06 [0038]  1       BB05                  7.93  8770 [000..001)-> BB07(1)                 (always)                     i LIR IBC bwd
BB07 [0023]  2       BB04,BB06            11.70 12940 [000..001)-> BB09(0.623),BB08(0.377) ( cond )                     i LIR IBC bwd
BB09 [0014]  1       BB07                  7.29  8066 [000..001)-> BB11(0.0335),BB10(0.967)  ( cond )                     i LIR IBC bwd
BB11 [0016]  1       BB09                  0.24   270 [000..001)-> BB14(1)                 (always)                     i LIR IBC
BB16 [0002]  1       BB14                  0.24   270 [01B..021)-> BB18(1)                 (always)                     i LIR IBC
BB18 [0004]  2       BB16,BB17             0.70   774 [029..02F)-> BB25(0.00775),BB19(0.992)   ( cond )                     i LIR IBC bwd
BB19 [0005]  1       BB18                  0.69   768 [02F..030)-> BB22(0.678),BB20(0.322) ( cond )                     i LIR IBC bwd bwd-src
BB22 [0042]  1       BB19                  0.47   520 [02F..030)-> BB23(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB23 [0058]  1       BB22                  0.47   520 [02F..030)-> BB24(1)                 (always)                     i LIR IBC bwd
BB24 [0043]  2       BB21,BB23             0.69   768 [02F..044)-> BB17(0.656),BB25(0.344) ( cond )                     i LIR IBC bwd bwd-src
BB17 [0003]  1       BB24                  0.46   504 [021..029)-> BB18(1)                 (always)                     i LIR IBC bwd bwd-target
BB20 [0041]  1       BB19                  0.22   248 [02F..030)-> BB21(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB21 [0050]  1       BB20                  0.22   248 [02F..030)-> BB24(1)                 (always)                     i LIR IBC bwd
BB25 [0006]  2       BB18,BB24             0.24   270 [044..04A)-> BB27(1)                 (always)                     i LIR IBC
BB27 [0008]  2       BB25,BB26             0.57   634 [052..05A)-> BB38(0),BB28(1)         ( cond )                     i LIR IBC bwd
BB28 [0009]  1       BB27                  0.57   634 [05A..05B)-> BB31(0.678),BB29(0.322) ( cond )                     i LIR IBC bwd bwd-src
BB31 [0062]  1       BB28                  0.39   430 [05A..05B)-> BB33(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB33 [0078]  1       BB31                  0.39   430 [05A..05B)-> BB34(1)                 (always)                     i LIR IBC bwd
BB34 [0063]  2       BB30,BB33             0.57   634 [05A..06F)-> BB26(0.574),BB38(0.426) ( cond )                     i LIR IBC bwd bwd-src
BB26 [0007]  1       BB34                  0.33   364 [04A..052)-> BB27(1)                 (always)                     i LIR IBC bwd bwd-target
BB29 [0061]  1       BB28                  0.18   204 [05A..05B)-> BB30(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB30 [0070]  1       BB29                  0.18   204 [05A..05B)-> BB34(1)                 (always)                     i LIR IBC bwd
BB42 [0086]  2       BB01,BB12             0.76   836 [000..001)-> BB14(1)                 (always)                     i LIR IBC
BB14 [0019]  2       BB11,BB42             1.00  1106 [000..012)-> BB16(0.244),BB15(0.756) ( cond )                     i LIR IBC
BB15 [0001]  1       BB14                  0.76   836 [012..01B)-> BB38(1)                 (always)                     i LIR IBC
BB38 [0082]  3       BB15,BB27,BB34        1.00  1106 [06F..070)                           (return)                     i LIR IBC
BB03 [0021]  1       BB02                  3.77  4170 [000..001)-> BB04(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB04 [0030]  1       BB03                  3.77  4170 [000..001)-> BB07(1)                 (always)                     i LIR IBC bwd
BB08 [0013]  1       BB07                  4.41  4874 [000..001)-> BB12(1)                 (always)                     i LIR IBC bwd
BB41 [0085]  6       BB03,BB05,BB20,BB22,BB29,BB31   0        0 [05A..05B)                           (throw )                     i LIR IBC rare gcsafe bwd
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Notice how the placement of `[BB03, BB08]` at the end of the method creates a bimodal distribution of code density. With this PR, this is fixed:
```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight     IBC [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1     1106 [000..001)-> BB42(0.0607),BB37(0.939)  ( cond )                     i LIR IBC
BB37 [0081]  1       BB01                  0.94  1039 [000..???)-> BB02(1)                 (always)                     LIR IBC internal
BB05 [0022]  1       BB02                  7.93  8770 [000..001)-> BB06(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB06 [0038]  1       BB05                  7.93  8770 [000..001)-> BB07(1)                 (always)                     i LIR IBC bwd
BB07 [0023]  2       BB04,BB06            11.70 12940 [000..001)-> BB09(0.623),BB08(0.377) ( cond )                     i LIR IBC bwd
BB09 [0014]  1       BB07                  7.29  8066 [000..001)-> BB11(0.0335),BB10(0.967)  ( cond )                     i LIR IBC bwd
BB10 [0015]  1       BB09                  7.05  7796 [000..001)-> BB12(1)                 (always)                     i LIR IBC bwd
BB12 [0017]  2       BB08,BB10            11.46 12670 [000..001)-> BB02(0.939),BB42(0.0607)  ( cond )                     i LIR IBC bwd bwd-src
BB02 [0012]  2       BB12,BB37            11.70 12940 [000..001)-> BB05(0.678),BB03(0.322) ( cond )                     i LIR IBC bwd bwd-target
BB03 [0021]  1       BB02                  3.77  4170 [000..001)-> BB04(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB04 [0030]  1       BB03                  3.77  4170 [000..001)-> BB07(1)                 (always)                     i LIR IBC bwd
BB08 [0013]  1       BB07                  4.41  4874 [000..001)-> BB12(1)                 (always)                     i LIR IBC bwd
BB11 [0016]  1       BB09                  0.24   270 [000..001)-> BB14(1)                 (always)                     i LIR IBC
BB42 [0086]  2       BB01,BB12             0.76   836 [000..001)-> BB14(1)                 (always)                     i LIR IBC
BB14 [0019]  2       BB11,BB42             1.00  1106 [000..012)-> BB16(0.244),BB15(0.756) ( cond )                     i LIR IBC
BB15 [0001]  1       BB14                  0.76   836 [012..01B)-> BB38(1)                 (always)                     i LIR IBC
BB38 [0082]  3       BB15,BB27,BB34        1.00  1106 [06F..070)                           (return)                     i LIR IBC
BB16 [0002]  1       BB14                  0.24   270 [01B..021)-> BB18(1)                 (always)                     i LIR IBC
BB18 [0004]  2       BB16,BB17             0.70   774 [029..02F)-> BB25(0.00775),BB19(0.992)   ( cond )                     i LIR IBC bwd
BB19 [0005]  1       BB18                  0.69   768 [02F..030)-> BB22(0.678),BB20(0.322) ( cond )                     i LIR IBC bwd bwd-src
BB22 [0042]  1       BB19                  0.47   520 [02F..030)-> BB23(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB23 [0058]  1       BB22                  0.47   520 [02F..030)-> BB24(1)                 (always)                     i LIR IBC bwd
BB24 [0043]  2       BB21,BB23             0.69   768 [02F..044)-> BB17(0.656),BB25(0.344) ( cond )                     i LIR IBC bwd bwd-src
BB17 [0003]  1       BB24                  0.46   504 [021..029)-> BB18(1)                 (always)                     i LIR IBC bwd bwd-target
BB20 [0041]  1       BB19                  0.22   248 [02F..030)-> BB21(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB21 [0050]  1       BB20                  0.22   248 [02F..030)-> BB24(1)                 (always)                     i LIR IBC bwd
BB25 [0006]  2       BB18,BB24             0.24   270 [044..04A)-> BB27(1)                 (always)                     i LIR IBC
BB27 [0008]  2       BB25,BB26             0.57   634 [052..05A)-> BB38(0),BB28(1)         ( cond )                     i LIR IBC bwd
BB28 [0009]  1       BB27                  0.57   634 [05A..05B)-> BB31(0.678),BB29(0.322) ( cond )                     i LIR IBC bwd bwd-src
BB31 [0062]  1       BB28                  0.39   430 [05A..05B)-> BB33(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB33 [0078]  1       BB31                  0.39   430 [05A..05B)-> BB34(1)                 (always)                     i LIR IBC bwd
BB34 [0063]  2       BB30,BB33             0.57   634 [05A..06F)-> BB26(0.574),BB38(0.426) ( cond )                     i LIR IBC bwd bwd-src
BB26 [0007]  1       BB34                  0.33   364 [04A..052)-> BB27(1)                 (always)                     i LIR IBC bwd bwd-target
BB29 [0061]  1       BB28                  0.18   204 [05A..05B)-> BB30(1),BB41(0)         ( cond )                     i LIR IBC bwd
BB30 [0070]  1       BB29                  0.18   204 [05A..05B)-> BB34(1)                 (always)                     i LIR IBC bwd
BB41 [0085]  6       BB03,BB05,BB20,BB22,BB29,BB31   0        0 [05A..05B)                           (throw )                     i LIR IBC rare gcsafe bwd
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```