### PR TITLE
Link peer's X509 stack handle to parent SSL safe handle

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -123,7 +123,14 @@ internal static partial class Interop
         internal static partial IntPtr SslGetCertificate(IntPtr ssl);
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerCertChain")]
-        internal static partial SafeSharedX509StackHandle SslGetPeerCertChain(SafeSslHandle ssl);
+        internal static partial SafeSharedX509StackHandle SslGetPeerCertChain_private(SafeSslHandle ssl);
+
+        internal static SafeSharedX509StackHandle SslGetPeerCertChain(SafeSslHandle ssl)
+        {
+            return SafeInteriorHandle.OpenInteriorHandle(
+                SslGetPeerCertChain_private,
+                ssl);
+        }
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerFinished")]
         internal static partial int SslGetPeerFinished(SafeSslHandle ssl, IntPtr buf, int count);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -123,7 +123,7 @@ internal static partial class Interop
         internal static partial IntPtr SslGetCertificate(IntPtr ssl);
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerCertChain")]
-        internal static partial SafeSharedX509StackHandle SslGetPeerCertChain_private(SafeSslHandle ssl);
+        private static partial SafeSharedX509StackHandle SslGetPeerCertChain_private(SafeSslHandle ssl);
 
         internal static SafeSharedX509StackHandle SslGetPeerCertChain(SafeSslHandle ssl)
         {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -102,5 +102,57 @@ namespace System.Net.Security.Tests
                 await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => client.ReadAsync(readBuffer, cts.Token).AsTask());
             }
         }
+
+        [Fact]
+        [OuterLoop("Computationally expensive")]
+        public async Task Dispose_ParallelWithHandshake_ThrowsODE()
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.CancelAfter(TestConfiguration.PassingTestTimeout);
+
+            await Parallel.ForEachAsync(System.Linq.Enumerable.Range(0, 10000), cts.Token, async (i, token) =>
+            {
+                (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+                using (client)
+                using (server)
+                using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
+                using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
+                {
+                    SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions()
+                    {
+                        TargetHost = Guid.NewGuid().ToString("N"),
+                        RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
+                    };
+
+                    SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions()
+                    {
+                        ServerCertificate = serverCertificate,
+                    };
+
+                    var clientTask = Task.Run(() => client.AuthenticateAsClientAsync(clientOptions, cts.Token));
+                    var serverTask = Task.Run(() => server.AuthenticateAsServerAsync(serverOptions, cts.Token));
+
+                    // Dispose the instances while the handshake is in progress.
+                    client.Dispose();
+                    server.Dispose();
+
+                    await ValidateExceptionAsync(clientTask);
+                    await ValidateExceptionAsync(serverTask);
+                }
+            });
+
+            static async Task ValidateExceptionAsync(Task task)
+            {
+                try
+                {
+                    await task;
+                }
+                // either we disposed the stream, or the other side does and we get unexpected EOF
+                catch (Exception ex) when (ex is ObjectDisposedException or IOException)
+                {
+                    return;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #109689.

Fixes rare data race between handshake and SslStream.Dispose() where we would try to access already freed STACKOF(X509) and crash.

I also reviewed other interop usages to make sure there are no similar bugs lurking elsewhere on SslStream codebase.

Tested locally by inserting artificial delays at relevant places.