### PR TITLE
[mono] Fix for issue 109410

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -6806,6 +6806,8 @@ mono_object_handle_isinst (MonoObjectHandle obj, MonoClass *klass, MonoError *er
 {
 	error_init (error);
 
+	g_assert (klass);
+
 	if (!m_class_is_inited (klass))
 		mono_class_init_internal (klass);
 

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -953,6 +953,7 @@ class_type_info (MonoMemoryManager *mem_manager, MonoClass *klass, MonoRgctxInfo
 		/*First slot is the cache itself, the second the vtable.*/
 		gpointer **cache_data = (gpointer **)mono_mem_manager_alloc0 (mem_manager, sizeof (gpointer) * 2);
 		cache_data [1] = (gpointer *)klass;
+		mono_memory_barrier ();
 		return cache_data;
 	}
 	case MONO_RGCTX_INFO_ARRAY_ELEMENT_SIZE:

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -953,7 +953,6 @@ class_type_info (MonoMemoryManager *mem_manager, MonoClass *klass, MonoRgctxInfo
 		/*First slot is the cache itself, the second the vtable.*/
 		gpointer **cache_data = (gpointer **)mono_mem_manager_alloc0 (mem_manager, sizeof (gpointer) * 2);
 		cache_data [1] = (gpointer *)klass;
-		mono_memory_barrier ();
 		return cache_data;
 	}
 	case MONO_RGCTX_INFO_ARRAY_ELEMENT_SIZE:

--- a/src/mono/mono/mini/type-checking.c
+++ b/src/mono/mono/mini/type-checking.c
@@ -36,9 +36,6 @@ emit_cached_check_args (MonoCompile *cfg, MonoInst *obj, MonoClass *klass, int c
 		/* klass - it's the second element of the cache entry*/
 		EMIT_NEW_LOAD_MEMBASE (cfg, args [1], OP_LOAD_MEMBASE, alloc_preg (cfg), cache_ins->dreg, TARGET_SIZEOF_VOID_P);
 
-		/* klass nullcheck */
-		MONO_EMIT_EXPLICIT_NULL_CHECK (cfg, args [1]->dreg);
-
 		args [2] = cache_ins; /* cache */
 	} else {
 		int idx;

--- a/src/mono/mono/mini/type-checking.c
+++ b/src/mono/mono/mini/type-checking.c
@@ -36,10 +36,14 @@ emit_cached_check_args (MonoCompile *cfg, MonoInst *obj, MonoClass *klass, int c
 		/* klass - it's the second element of the cache entry*/
 		EMIT_NEW_LOAD_MEMBASE (cfg, args [1], OP_LOAD_MEMBASE, alloc_preg (cfg), cache_ins->dreg, TARGET_SIZEOF_VOID_P);
 
+		/* klass nullcheck */
+		MONO_EMIT_EXPLICIT_NULL_CHECK (cfg, args [1]->dreg);
+
 		args [2] = cache_ins; /* cache */
 	} else {
 		int idx;
 
+		g_assert (klass);
 		EMIT_NEW_CLASSCONST (cfg, args [1], klass); /* klass */
 
 		idx = get_castclass_cache_idx (cfg); /* inline cache*/


### PR DESCRIPTION
Issue #109410 appears to be a case where klass is 0 when we perform an isinst operation, but the cache and obj are nonzero and look like valid addresses. klass is either a compile-time (well, jit-time) constant or being fetched out of the cache (it looks like it can be either depending on some sort of rgctx condition).

This PR adds null checks in two places along with a memory barrier in the location where we believe an uninitialized cache is being published to other threads.