### PR TITLE
[release/9.0-staging] Use invariant culture when formatting transfer capture in regex source generator (#113081)

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -2549,7 +2549,7 @@ namespace System.Text.RegularExpressions.Generator
                 }
                 else
                 {
-                    writer.WriteLine($"base.TransferCapture({capnum}, {uncapnum}, {startingPos}, pos);");
+                    writer.WriteLine($"base.TransferCapture({capnum.ToString(CultureInfo.InvariantCulture)}, {uncapnum}, {startingPos}, pos);");
                 }
 
                 if (isAtomic || !childBacktracks)


### PR DESCRIPTION
Backport of #113081 to release/9.0-staging

/cc @stephentoub

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Using the regex source generator with certain patterns (any containing a "balancing group") will cause the containing project to fail to build when compiling on a system where the culture uses something other than '-' as a negative sign. ~10% of cultures in CultureInfo.GetCultures fit this category. For example, if you try to compile this:
```csharp
using System.Text.RegularExpressions;

Example.M().IsMatch("test");

partial class Example
{
    [GeneratedRegex(@"(?<open>)(?<-open>)")]
    public static partial Regex M();
}
```
on a system in Sweden, it is likely to fail to build.

## Regression

- [ ] Yes
- [x] No

## Testing

Updated the test suite to run source generator tests in such a culture.

## Risk

Low. It's changing how a single number is rendered, using the invariant culture rather than the current culture. The new code will succeed in all the places the old code did, and where the old code failed, it would fail to compile.