### PR TITLE
[release/8.0-staging] Use invariant culture when formatting transfer capture in regex source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -2419,7 +2419,7 @@ namespace System.Text.RegularExpressions.Generator
                 }
                 else
                 {
-                    writer.WriteLine($"base.TransferCapture({capnum}, {uncapnum}, {startingPos}, pos);");
+                    writer.WriteLine($"base.TransferCapture({capnum.ToString(CultureInfo.InvariantCulture)}, {uncapnum}, {startingPos}, pos);");
                 }
 
                 if (isAtomic || !childBacktracks)

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -134,6 +134,12 @@ namespace System.Text.RegularExpressions.Tests
             return results[0];
         }
 
+        private static readonly CultureInfo s_cultureWithMinusNegativeSign = new CultureInfo("")
+        {
+            // To validate that generation still succeeds even when something other than '-' is used.
+            NumberFormat = new NumberFormatInfo() { NegativeSign = $"{(char)0x2212}" }
+        };
+
         internal static async Task<Regex[]> SourceGenRegexAsync(
             (string pattern, CultureInfo? culture, RegexOptions? options, TimeSpan? matchTimeout)[] regexes, CancellationToken cancellationToken = default)
         {
@@ -212,13 +218,24 @@ namespace System.Text.RegularExpressions.Tests
             comp = comp.ReplaceSyntaxTree(comp.SyntaxTrees.First(), CSharpSyntaxTree.ParseText(SourceText.From(code.ToString(), Encoding.UTF8), s_previewParseOptions));
 
             // Run the generator
-            GeneratorDriverRunResult generatorResults = s_generatorDriver.RunGenerators(comp!, cancellationToken).GetRunResult();
-            ImmutableArray<Diagnostic> generatorDiagnostics = generatorResults.Diagnostics.RemoveAll(d => d.Severity <= DiagnosticSeverity.Hidden);
-            if (generatorDiagnostics.Length != 0)
+            CultureInfo origCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = s_cultureWithMinusNegativeSign;
+            GeneratorDriverRunResult generatorResults;
+            ImmutableArray<Diagnostic> generatorDiagnostics;
+            try
             {
-                throw new ArgumentException(
-                    string.Join(Environment.NewLine, generatorResults.GeneratedTrees.Select(t => NumberLines(t.ToString()))) + Environment.NewLine +
-                    string.Join(Environment.NewLine, generatorDiagnostics));
+                generatorResults = s_generatorDriver.RunGenerators(comp!, cancellationToken).GetRunResult();
+                generatorDiagnostics = generatorResults.Diagnostics.RemoveAll(d => d.Severity <= DiagnosticSeverity.Hidden);
+                if (generatorDiagnostics.Length != 0)
+                {
+                    throw new ArgumentException(
+                        string.Join(Environment.NewLine, generatorResults.GeneratedTrees.Select(t => NumberLines(t.ToString()))) + Environment.NewLine +
+                        string.Join(Environment.NewLine, generatorDiagnostics));
+                }
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = origCulture;
             }
 
             // Compile the assembly to a stream


### PR DESCRIPTION
Backport of #113081 to release/8.0-staging

/cc @stephentoub

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Using the regex source generator with certain patterns (any containing a "balancing group") will cause the containing project to fail to build when compiling on a system where the culture uses something other than '-' as a negative sign. ~10% of cultures in CultureInfo.GetCultures fit this category. For example, if you try to compile this:
```csharp
using System.Text.RegularExpressions;

Example.M().IsMatch("test");

partial class Example
{
    [GeneratedRegex(@"(?<open>)(?<-open>)")]
    public static partial Regex M();
}
```
on a system in Sweden, it is likely to fail to build.

## Regression

- [ ] Yes
- [x] No

## Testing

Updated the test suite to run source generator tests in such a culture.

## Risk

Low. It's changing how a single number is rendered, using the invariant culture rather than the current culture. The new code will succeed in all the places the old code did, and where the old code failed, it would fail to compile.