### PR TITLE
Disable FEATURE_RX_THUNKS on Windows

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -81,6 +81,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <SdkNativeLibrary Include="user32.lib" />
       <SdkNativeLibrary Include="version.lib" />
       <SdkNativeLibrary Include="ws2_32.lib" />
+      <SdkNativeLibrary Include="WindowsApp.lib" />
     </ItemGroup>
 
     <ItemGroup>
@@ -104,6 +105,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Condition="'$(_targetArchitecture)' == 'x86'" Include="/safeseh" />
       <!-- Do not warn if someone declares UnmanagedCallersOnly with an entrypoint of 'DllGetClassObject' and similar -->
       <LinkerArg Include="/IGNORE:4104" />
+      <!-- section 'XYZ' is missing specification in section layout file; will be put after all specified section -->
+      <LinkerArg Include="/IGNORE:4290" />
+      <LinkerArg Include="/SECTIONLAYOUT:@$(MSBuildThisFileDirectory)sectionlayout.txt" />
       <!-- Opt into CETCOMPAT by default. -->
       <LinkerArg Condition="'$(CETCompat)' != 'false' and '$(_targetArchitecture)' == 'x64'" Include="/CETCOMPAT" />
       <!-- Allow user to opt out. -->

--- a/src/coreclr/nativeaot/BuildIntegration/sectionlayout.txt
+++ b/src/coreclr/nativeaot/BuildIntegration/sectionlayout.txt
@@ -1,0 +1,54 @@
+;;
+;; section layout file
+;;
+
+;;
+;; The first thunks section should be 64K aligned because it can get
+;; mapped multiple  times in memory, and mapping works on allocation
+;; granularity boundaries (we don't want to map more than what we need)
+;;
+;; The easiest way to do so is by having the thunks section at the 
+;; first 64K aligned virtual address in the binary. We provide this section
+;; layout file to the linker to tell it how to layout the thunks sections
+;; that we care about.
+;;
+;; The PE spec says images cannot have gaps between sections (other 
+;; than what is required by the section alignment value in the header),
+;; therefore we need a couple of padding data sections (otherwise the
+;; OS will not load the image).
+;;
+
+.pad0
+.pad1
+.pad2
+.pad3
+.pad4
+.pad5
+.pad6
+.pad7
+.pad8
+.pad9
+.pad10
+.pad11
+.pad12
+.pad13
+.pad14
+.tks0 10000
+.tkd0 11000             
+.tks1 12000
+.tkd1 13000
+.tks2 14000
+.tkd2 15000
+.tks3 16000
+.tkd3 17000
+.tks4 18000
+.tkd4 19000
+.tks5 1A000
+.tkd5 1B000
+.tks6 1C000
+.tkd6 1D000
+.tks7 1E000
+.tkd7 1F000
+
+;; All other sections: handled automatically by linker. No need to
+;; explicitly list them

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -6,7 +6,7 @@ project(Runtime)
 # Include auto-generated files on include path
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if (CLR_CMAKE_TARGET_APPLE)
+if (CLR_CMAKE_TARGET_APPLE OR CLR_CMAKE_TARGET_WIN32)
   list(APPEND RUNTIME_SOURCES_ARCH_ASM
     ${ARCH_SOURCES_DIR}/ThunkPoolThunks.${ASM_SUFFIX}
   )

--- a/src/coreclr/nativeaot/Runtime/i386/ThunkPoolThunks.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/ThunkPoolThunks.asm
@@ -1,0 +1,301 @@
+;; Licensed to the .NET Foundation under one or more agreements.
+;; The .NET Foundation licenses this file to you under the MIT license.
+
+        .586
+        .model  flat
+        option  casemap:none
+        .code
+
+LEAF_ENTRY macro Name, Section
+    Section segment para 'CODE'
+    align   16
+    public  Name
+    Name    proc
+endm
+
+NAMED_LEAF_ENTRY macro Name, Section, SectionAlias
+    Section segment para alias(SectionAlias) 'CODE'
+    align   16
+    public  Name
+    Name    proc
+endm
+
+LEAF_END macro Name, Section
+    Name    endp
+    Section ends
+endm
+
+NAMED_READONLY_DATA_SECTION macro Section, SectionAlias
+    Section segment alias(SectionAlias) read 'DATA'
+    align   16
+    DQ 0
+    Section ends
+endm
+
+NAMED_READWRITE_DATA_SECTION macro Section, SectionAlias
+    Section segment alias(SectionAlias) read write 'DATA'
+    align   16
+    DQ 0
+    Section ends
+endm
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  STUBS & DATA SECTIONS  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+THUNK_CODESIZE                      equ 0Ch     ;; 5-byte lea, 6-byte jmp, 1 byte of nops
+THUNK_DATASIZE                      equ 08h     ;; 2 dwords
+
+THUNK_POOL_NUM_THUNKS_PER_PAGE      equ 0155h   ;; 341 thunks per page
+
+PAGE_SIZE                           equ 01000h  ;; 4K
+POINTER_SIZE                        equ 04h
+
+
+LOAD_DATA_ADDRESS macro groupIndex, index, thunkPool
+        ;; set eax to beginning of data page : eax <- [thunkPool] + PAGE_SIZE
+        ;; fix offset of the data            : eax <- eax + (THUNK_DATASIZE * current thunk's index)
+        lea     eax, [thunkPool + PAGE_SIZE + (groupIndex * THUNK_DATASIZE * 10 + THUNK_DATASIZE * index)]
+endm
+
+JUMP_TO_COMMON macro groupIndex, index, thunkPool
+        ;; jump to the location pointed at by the last qword in the data page
+        jmp     dword ptr [thunkPool + PAGE_SIZE + PAGE_SIZE - POINTER_SIZE]
+endm
+
+TenThunks macro groupIndex, thunkPool
+        ;; Each thunk will load the address of its corresponding data (from the page that immediately follows)
+        ;; and call a common stub. The address of the common stub is setup by the caller (first qword
+        ;; in the thunks data section, hence the +8's below) depending on the 'kind' of thunks needed (interop,
+        ;; fat function pointers, etc...)
+
+        ;; Each data block used by a thunk consists of two qword values:
+        ;;      - Context: some value given to the thunk as context (passed in r10). Example for fat-fptrs: context = generic dictionary
+        ;;      - Target : target code that the thunk eventually jumps to.
+
+        LOAD_DATA_ADDRESS groupIndex,0,thunkPool
+        JUMP_TO_COMMON    groupIndex,0,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,1,thunkPool
+        JUMP_TO_COMMON    groupIndex,1,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,2,thunkPool
+        JUMP_TO_COMMON    groupIndex,2,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,3,thunkPool
+        JUMP_TO_COMMON    groupIndex,3,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,4,thunkPool
+        JUMP_TO_COMMON    groupIndex,4,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,5,thunkPool
+        JUMP_TO_COMMON    groupIndex,5,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,6,thunkPool
+        JUMP_TO_COMMON    groupIndex,6,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,7,thunkPool
+        JUMP_TO_COMMON    groupIndex,7,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,8,thunkPool
+        JUMP_TO_COMMON    groupIndex,8,thunkPool
+
+        LOAD_DATA_ADDRESS groupIndex,9,thunkPool
+        JUMP_TO_COMMON    groupIndex,9,thunkPool
+endm
+
+THUNKS_PAGE_BLOCK macro thunkPool
+        TenThunks 0,thunkPool
+        TenThunks 1,thunkPool
+        TenThunks 2,thunkPool
+        TenThunks 3,thunkPool
+        TenThunks 4,thunkPool
+        TenThunks 5,thunkPool
+        TenThunks 6,thunkPool
+        TenThunks 7,thunkPool
+        TenThunks 8,thunkPool
+        TenThunks 9,thunkPool
+        TenThunks 10,thunkPool
+        TenThunks 11,thunkPool
+        TenThunks 12,thunkPool
+        TenThunks 13,thunkPool
+        TenThunks 14,thunkPool
+        TenThunks 15,thunkPool
+        TenThunks 16,thunkPool
+        TenThunks 17,thunkPool
+        TenThunks 18,thunkPool
+        TenThunks 19,thunkPool
+        TenThunks 20,thunkPool
+        TenThunks 21,thunkPool
+        TenThunks 22,thunkPool
+        TenThunks 23,thunkPool
+        TenThunks 24,thunkPool
+        TenThunks 25,thunkPool
+        TenThunks 26,thunkPool
+        TenThunks 27,thunkPool
+        TenThunks 28,thunkPool
+        TenThunks 29,thunkPool
+        TenThunks 30,thunkPool
+        TenThunks 31,thunkPool
+        TenThunks 32,thunkPool
+        TenThunks 33,thunkPool
+        LOAD_DATA_ADDRESS 34,0,thunkPool
+        JUMP_TO_COMMON    34,0,thunkPool
+endm
+
+;;
+;; The first thunks section should be 64K aligned because it can get
+;; mapped multiple  times in memory, and mapping works on allocation
+;; granularity boundaries (we don't want to map more than what we need)
+;;
+;; The easiest way to do so is by having the thunks section at the
+;; first 64K aligned virtual address in the binary. We provide a section
+;; layout file to the linker to tell it how to layout the thunks sections
+;; that we care about. (ndp\rh\src\runtime\DLLs\app\mrt100_app_sectionlayout.txt)
+;;
+;; The PE spec says images cannot have gaps between sections (other
+;; than what is required by the section alignment value in the header),
+;; therefore we need a couple of padding data sections (otherwise the
+;; OS will not load the image).
+;;
+
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment0, ".pad0"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment1, ".pad1"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment2, ".pad2"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment3, ".pad3"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment4, ".pad4"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment5, ".pad5"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment6, ".pad6"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment7, ".pad7"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment8, ".pad8"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment9, ".pad9"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment10, ".pad10"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment11, ".pad11"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment12, ".pad12"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment13, ".pad13"
+NAMED_READONLY_DATA_SECTION PaddingFor64KAlignment14, ".pad14"
+
+;;
+;; Thunk Stubs
+;; NOTE: Keep number of blocks in sync with macro/constant named 'NUM_THUNK_BLOCKS' in:
+;;      - ndp\FxCore\src\System.Private.CoreLib\System\Runtime\InteropServices\ThunkPool.cs
+;;      - ndp\rh\src\tools\rhbind\zapimage.h
+;;
+NAMED_LEAF_ENTRY ThunkPool, TKS0, ".tks0"
+    THUNKS_PAGE_BLOCK ThunkPool
+LEAF_END ThunkPool, TKS0
+
+NAMED_READWRITE_DATA_SECTION ThunkData0, ".tkd0"
+
+NAMED_LEAF_ENTRY ThunkPool1, TKS1, ".tks1"
+    THUNKS_PAGE_BLOCK ThunkPool1
+LEAF_END ThunkPool1, TKS1
+
+NAMED_READWRITE_DATA_SECTION ThunkData1, ".tkd1"
+
+NAMED_LEAF_ENTRY ThunkPool2, TKS2, ".tks2"
+    THUNKS_PAGE_BLOCK ThunkPool2
+LEAF_END ThunkPool2, TKS2
+
+NAMED_READWRITE_DATA_SECTION ThunkData2, ".tkd2"
+
+NAMED_LEAF_ENTRY ThunkPool3, TKS3, ".tks3"
+    THUNKS_PAGE_BLOCK ThunkPool3
+LEAF_END ThunkPool3, TKS3
+
+NAMED_READWRITE_DATA_SECTION ThunkData3, ".tkd3"
+
+NAMED_LEAF_ENTRY ThunkPool4, TKS4, ".tks4"
+    THUNKS_PAGE_BLOCK ThunkPool4
+LEAF_END ThunkPool4, TKS4
+
+NAMED_READWRITE_DATA_SECTION ThunkData4, ".tkd4"
+
+NAMED_LEAF_ENTRY ThunkPool5, TKS5, ".tks5"
+    THUNKS_PAGE_BLOCK ThunkPool5
+LEAF_END ThunkPool5, TKS5
+
+NAMED_READWRITE_DATA_SECTION ThunkData5, ".tkd5"
+
+NAMED_LEAF_ENTRY ThunkPool6, TKS6, ".tks6"
+    THUNKS_PAGE_BLOCK ThunkPool6
+LEAF_END ThunkPool6, TKS6
+
+NAMED_READWRITE_DATA_SECTION ThunkData6, ".tkd6"
+
+NAMED_LEAF_ENTRY ThunkPool7, TKS7, ".tks7"
+    THUNKS_PAGE_BLOCK ThunkPool7
+LEAF_END ThunkPool7, TKS7
+
+NAMED_READWRITE_DATA_SECTION ThunkData7, ".tkd7"
+
+;;
+;; IntPtr RhpGetThunksBase()
+;;
+LEAF_ENTRY RhpGetThunksBase, _TEXT
+        ;; Return the address of the first thunk pool to the caller (this is really the base address)
+        lea     eax, [ThunkPool]
+        ret
+LEAF_END RhpGetThunksBase, _TEXT
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; General Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;
+;; int RhpGetNumThunksPerBlock()
+;;
+LEAF_ENTRY RhpGetNumThunksPerBlock, _TEXT
+        mov     eax, THUNK_POOL_NUM_THUNKS_PER_PAGE
+        ret
+LEAF_END RhpGetNumThunksPerBlock, _TEXT
+
+;;
+;; int RhpGetThunkSize()
+;;
+LEAF_ENTRY RhpGetThunkSize, _TEXT
+        mov     eax, THUNK_CODESIZE
+        ret
+LEAF_END RhpGetThunkSize, _TEXT
+
+;;
+;; int RhpGetNumThunkBlocksPerMapping()
+;;
+LEAF_ENTRY RhpGetNumThunkBlocksPerMapping, _TEXT
+        mov     eax, 8
+        ret
+LEAF_END RhpGetNumThunkBlocksPerMapping, _TEXT
+
+;;
+;; int RhpGetThunkBlockSize
+;;
+LEAF_ENTRY RhpGetThunkBlockSize, _TEXT
+        mov     eax, PAGE_SIZE * 2
+        ret
+LEAF_END RhpGetThunkBlockSize, _TEXT
+
+;;
+;; IntPtr RhpGetThunkDataBlockAddress(IntPtr thunkStubAddress)
+;;
+LEAF_ENTRY RhpGetThunkDataBlockAddress, _TEXT
+        mov     eax, ecx
+        mov     ecx, PAGE_SIZE - 1
+        not     ecx
+        and     eax, ecx
+        add     eax, PAGE_SIZE
+        ret
+LEAF_END RhpGetThunkDataBlockAddress, _TEXT
+
+;;
+;; IntPtr RhpGetThunkStubsBlockAddress(IntPtr thunkDataAddress)
+;;
+LEAF_ENTRY RhpGetThunkStubsBlockAddress, _TEXT
+        mov     eax, ecx
+        mov     ecx, PAGE_SIZE - 1
+        not     ecx
+        and     eax, ecx
+        sub     eax, PAGE_SIZE
+        ret
+LEAF_END RhpGetThunkStubsBlockAddress, _TEXT
+
+
+end

--- a/src/coreclr/tools/aot/ILCompiler/reproNative/reproNative.vcxproj
+++ b/src/coreclr/tools/aot/ILCompiler/reproNative/reproNative.vcxproj
@@ -45,7 +45,7 @@
     <CoreClrSourceRoot>..\..\..\..\</CoreClrSourceRoot>
     <NativeAotSourceRoot>$(CoreClrSourceRoot)nativeaot\</NativeAotSourceRoot>
     <ArtifactsRoot>$(CoreClrSourceRoot)..\..\artifacts\</ArtifactsRoot>
-    <Win32SDKLibs>advapi32.lib;bcrypt.lib;crypt32.lib;iphlpapi.lib;kernel32.lib;mswsock.lib;ncrypt.lib;normaliz.lib;ntdll.lib;ole32.lib;oleaut32.lib;secur32.lib;user32.lib;version.lib;ws2_32.lib</Win32SDKLibs>
+    <Win32SDKLibs>advapi32.lib;bcrypt.lib;crypt32.lib;iphlpapi.lib;kernel32.lib;mswsock.lib;ncrypt.lib;normaliz.lib;ntdll.lib;ole32.lib;oleaut32.lib;secur32.lib;user32.lib;version.lib;ws2_32.lib;WindowsApp.lib</Win32SDKLibs>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -191,6 +191,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\x64\Debug\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.x64.Debug\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Debug\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Debug\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Debug\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Debug\aotsdk\Runtime.VxsortDisabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Debug\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Debug\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -209,6 +210,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\Arm64\Debug\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.Arm64.Debug\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Debug\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Debug\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Debug\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Debug\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Debug\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -228,6 +230,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\x86\Debug\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.x86.Debug\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Debug\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Debug\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Debug\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Debug\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Debug\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Checked|x64'">
@@ -248,6 +251,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\x64\Checked\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.x64.Checked\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Checked\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Checked\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Checked\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Checked\aotsdk\Runtime.VxsortDisabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Checked\aotsdk\standalonegc-disabled.lib;;$(ArtifactsRoot)bin\coreclr\windows.x64.Checked\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Checked|ARM64'">
@@ -268,6 +272,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\Arm64\Checked\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.Arm64.Checked\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Checked\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Checked\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Checked\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Checked\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Checked\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Checked|Win32'">
@@ -289,6 +294,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\x86\Checked\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.x86.Checked\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Checked\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Checked\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Checked\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Checked\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Checked\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -309,6 +315,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\x64\Release\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.x64.Release\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Release\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Release\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Release\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Release\aotsdk\Runtime.VxsortDisabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Release\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x64.Release\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -329,6 +336,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\Arm64\Release\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.Arm64.Release\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Release\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Release\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Release\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Release\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.Arm64.Release\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -350,6 +358,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>$(ArtifactsRoot)bin\repro\x86\Release\repro.obj;$(Win32SDKLibs);%(AdditionalDependencies);$(ArtifactsRoot)bin\coreclr\windows.x86.Release\aotsdk\Runtime.WorkstationGC.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Release\aotsdk\System.Globalization.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Release\aotsdk\System.IO.Compression.Native.Aot.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Release\aotsdk\eventpipe-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Release\aotsdk\standalonegc-disabled.lib;$(ArtifactsRoot)bin\coreclr\windows.x86.Release\aotsdk\aotminipal.lib</AdditionalDependencies>
+      <AdditionalOptions>/SECTIONLAYOUT:@$(NativeAotSourceRoot)BuildIntegration\sectionlayout.txt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Would fix #113114.

Opening as a draft, just want to see what the CI says.

I already know this has problems with CFG. `SetProcessValidCallTargets` works fine first time we call it for the thunks block that is still within the image. But second time we call it when a remapping actually happens, it fails and the thunks are not marked as valid call targets.

Cc @filipnavara (I'm including your x86 fix for testing but this could easily be a separate pull request once this is validated - so that you get the credit... and the blame).

Cc @dotnet/ilc-contrib 