### PR TITLE
[browser] Add application environment to boot config

### DIFF
--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -326,7 +326,7 @@ async function loadBootConfig (module: DotnetModuleInternal): Promise<void> {
 
     // Prefer user-defined application environment
     if (loaderHelpers.config.applicationEnvironment) {
-        loadedConfig.applicationEnvironment = undefined;
+        loadedConfig.applicationEnvironment = loaderHelpers.config.applicationEnvironment;
     }
 
     deep_merge_config(loaderHelpers.config, loadedConfig);

--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -343,7 +343,7 @@ async function readBootConfigResponse (loadConfigResponse: Response): Promise<Mo
     const config = loaderHelpers.config;
     const loadedConfig: MonoConfig = await loadConfigResponse.json();
 
-    if (!config.applicationEnvironment) {
+    if (!config.applicationEnvironment && !loadedConfig.applicationEnvironment) {
         loadedConfig.applicationEnvironment = loadConfigResponse.headers.get("Blazor-Environment") || loadConfigResponse.headers.get("DotNet-Environment") || undefined;
     }
 

--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -324,6 +324,11 @@ async function loadBootConfig (module: DotnetModuleInternal): Promise<void> {
         }
     }
 
+    // Prefer user-defined application environment
+    if (loaderHelpers.config.applicationEnvironment) {
+        loadedConfig.applicationEnvironment = undefined;
+    }
+
     deep_merge_config(loaderHelpers.config, loadedConfig);
 
     if (!loaderHelpers.config.applicationEnvironment) {

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -325,6 +325,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GenerateBuildWasmBootJson" DependsOnTargets="$(GenerateBuildWasmBootJsonDependsOn)">
     <PropertyGroup>
       <_WasmBuildBootJsonPath>$(IntermediateOutputPath)$(_WasmBootConfigFileName)</_WasmBuildBootJsonPath>
+      <_WasmBuildApplicationEnvironmentName>$(WasmApplicationEnvironmentName)</_WasmBuildApplicationEnvironmentName>
+      <_WasmBuildApplicationEnvironmentName Condition="'$(_WasmBuildApplicationEnvironmentName)' == ''">Development</_WasmBuildApplicationEnvironmentName>
     </PropertyGroup>
 
     <ItemGroup>
@@ -359,6 +361,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GenerateWasmBootJson
       AssemblyPath="@(IntermediateAssembly)"
+      ApplicationEnvironment="$(_WasmBuildApplicationEnvironmentName)"
       Resources="@(WasmStaticWebAsset);@(_WasmJsModuleCandidatesForBuild)"
       Endpoints="@(_WasmResolvedEndpoints)"
       DebugBuild="true"
@@ -617,6 +620,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="GeneratePublishWasmBootJson" DependsOnTargets="$(GeneratePublishWasmBootJsonDependsOn)">
+    <PropertyGroup>
+      <_WasmPublishApplicationEnvironmentName>$(WasmApplicationEnvironmentName)</_WasmPublishApplicationEnvironmentName>
+    </PropertyGroup>
     <ItemGroup>
       <_WasmPublishAsset
         Include="@(StaticWebAsset)"
@@ -649,6 +655,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GenerateWasmBootJson
       AssemblyPath="@(IntermediateAssembly)"
+      ApplicationEnvironment="$(_WasmPublishApplicationEnvironmentName)"
       Resources="@(_WasmPublishAsset);@(_WasmJsModuleCandidatesForPublish)"
       Endpoints="@(_WasmResolvedEndpointsForPublish)"
       DebugBuild="false"

--- a/src/mono/wasm/Wasm.Build.Tests/AppSettingsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/AppSettingsTests.cs
@@ -35,7 +35,7 @@ public class AppSettingsTests : WasmTemplateTestsBase
         PublishProject(
             info, 
             config,
-            new (ExtraMSBuildArgs: $"-p:WasmApplicationEnvironmentName={msBuildApplicationEnvironment}")
+            new PublishOptions(ExtraMSBuildArgs: $"-p:WasmApplicationEnvironmentName={msBuildApplicationEnvironment}")
         );
         BrowserRunOptions options = new(
             config,

--- a/src/mono/wasm/Wasm.Build.Tests/AppSettingsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/AppSettingsTests.cs
@@ -42,7 +42,7 @@ public class AppSettingsTests : WasmTemplateTestsBase
 
     [Theory]
     [MemberData(nameof(LoadAppSettingsBasedOnApplicationEnvironmentData))]
-    public async Task LoadAppSettingsBasedOnApplicationEnvironment(bool publish, string msBuildApplicationEnvironment, string queryApplicationEnvironment, string expectedApplicationEnvironment)
+    public async Task LoadAppSettingsBasedOnApplicationEnvironment(bool publish, string? msBuildApplicationEnvironment, string? queryApplicationEnvironment, string expectedApplicationEnvironment)
     {
         Configuration config = Configuration.Debug;
         ProjectInfo info = CopyTestAsset(config, aot: false, TestAsset.WasmBasicTestApp, "AppSettingsTest");

--- a/src/mono/wasm/Wasm.Build.Tests/AppSettingsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/AppSettingsTests.cs
@@ -21,32 +21,49 @@ public class AppSettingsTests : WasmTemplateTestsBase
     {
     }
 
+    public static IEnumerable<object?[]> LoadAppSettingsBasedOnApplicationEnvironmentData()
+    {
+        // Defaults
+        yield return new object?[] { false, null, null, "Development" };
+        yield return new object?[] { true, null, null, "Production" };
+
+        // Override defaults from MSBuild
+        yield return new object?[] { false, "Production", null, "Production" };
+        yield return new object?[] { true, "Development", null, "Development" };
+
+        // Override defaults from JavaScript
+        yield return new object?[] { false, null, "Production", "Production" };
+        yield return new object?[] { true, null, "Development", "Development" };
+
+        // Override MSBuild from JavaScript
+        yield return new object?[] { false, "FromMSBuild", "Production", "Production" };
+        yield return new object?[] { true, "FromMSBuild", "Development", "Development" };
+    }
+
     [Theory]
-    [InlineData("Development", null)]
-    [InlineData("Production", null)]
-    [InlineData(null, "Development")]
-    [InlineData(null, "Production")]
-    [InlineData("Production", "Development")]
-    [InlineData("Development", "Production")]
-    public async Task LoadAppSettingsBasedOnApplicationEnvironment(string msBuildApplicationEnvironment, string queryApplicationEnvironment)
+    [MemberData(nameof(LoadAppSettingsBasedOnApplicationEnvironmentData))]
+    public async Task LoadAppSettingsBasedOnApplicationEnvironment(bool publish, string msBuildApplicationEnvironment, string queryApplicationEnvironment, string expectedApplicationEnvironment)
     {
         Configuration config = Configuration.Debug;
         ProjectInfo info = CopyTestAsset(config, aot: false, TestAsset.WasmBasicTestApp, "AppSettingsTest");
-        PublishProject(
-            info, 
-            config,
-            new PublishOptions(ExtraMSBuildArgs: $"-p:WasmApplicationEnvironmentName={msBuildApplicationEnvironment}")
-        );
-        BrowserRunOptions options = new(
+        string extraMSBuildArgs = msBuildApplicationEnvironment != null ? $"-p:WasmApplicationEnvironmentName={msBuildApplicationEnvironment}" : string.Empty;
+
+        if (publish)
+            PublishProject(info, config, new PublishOptions(ExtraMSBuildArgs: extraMSBuildArgs));
+        else
+            BuildProject(info, config, new BuildOptions(ExtraMSBuildArgs: extraMSBuildArgs));
+        
+        BrowserRunOptions runOptions = new(
             config,
             TestScenario: "AppSettingsTest",
             BrowserQueryString: new NameValueCollection { { "applicationEnvironment", queryApplicationEnvironment } }
         );
-        RunResult result = await RunForPublishWithWebServer(options);
+        RunResult result = publish
+            ? await RunForPublishWithWebServer(runOptions)
+            : await RunForBuildWithDotnetRun(runOptions);
 
-        string effectiveApplicationEnvironment = queryApplicationEnvironment ?? msBuildApplicationEnvironment;
         Assert.Contains(result.TestOutput, m => m.Contains("'/appsettings.json' exists 'True'"));
-        Assert.Contains(result.TestOutput, m => m.Contains($"'/appsettings.Development.json' exists '{effectiveApplicationEnvironment == "Development"}'"));
-        Assert.Contains(result.TestOutput, m => m.Contains($"'/appsettings.Production.json' exists '{effectiveApplicationEnvironment == "Production"}'"));
+        Assert.Contains(result.TestOutput, m => m.Contains($"'/appsettings.Development.json' exists '{expectedApplicationEnvironment == "Development"}'"));
+        Assert.Contains(result.TestOutput, m => m.Contains($"'/appsettings.Production.json' exists '{expectedApplicationEnvironment == "Production"}'"));
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -107,14 +107,14 @@ public class WasmTemplateTestsBase : BuildTestBase
         bool aot,
         TestAsset asset,
         string idPrefix,
-        bool appendUnicodeToPath = true,
+        bool? appendUnicodeToPath = null,
         bool runAnalyzers = true,
         string extraProperties = "",
         string extraItems = "",
         string insertAtEnd = "")
     {
         (string projectName, string logPath, string nugetDir) =
-            InitProjectLocation(idPrefix, config, aot, appendUnicodeToPath, avoidAotLongPathIssue: s_isWindows && aot);
+            InitProjectLocation(idPrefix, config, aot, appendUnicodeToPath ?? s_buildEnv.IsRunningOnCI, avoidAotLongPathIssue: s_isWindows && aot);
         Utils.DirectoryCopy(Path.Combine(BuildEnvironment.TestAssetsPath, asset.Name), Path.Combine(_projectDir));
         if (!string.IsNullOrEmpty(asset.RunnableProjectSubPath))
         {

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -60,7 +60,7 @@ public class WasmTemplateTestsBase : BuildTestBase
         Configuration config,
         bool aot,
         string idPrefix = "wbt",
-        bool appendUnicodeToPath = true,
+        bool? appendUnicodeToPath = null,
         string extraArgs = "",
         bool runAnalyzers = true,
         bool addFrameworkArg = false,
@@ -69,7 +69,7 @@ public class WasmTemplateTestsBase : BuildTestBase
         string insertAtEnd = "")
     {
         (string projectName, string logPath, string nugetDir) =
-            InitProjectLocation(idPrefix, config, aot, appendUnicodeToPath);
+            InitProjectLocation(idPrefix, config, aot, appendUnicodeToPath ?? s_buildEnv.IsRunningOnCI);
 
         if (addFrameworkArg)
             extraArgs += $" -f {DefaultTargetFramework}";

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -44,7 +44,10 @@ switch (testCase) {
         }
         break;
     case "AppSettingsTest":
-        dotnet.withApplicationEnvironment(params.get("applicationEnvironment"));
+        const applicationEnvironment = params.get("applicationEnvironment");
+        if (applicationEnvironment) {
+            dotnet.withApplicationEnvironment(applicationEnvironment);
+        }
         break;
     case "LazyLoadingTest":
         dotnet.withDiagnosticTracing(true);

--- a/src/mono/wasm/testassets/WasmBasicTestApp/README.md
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/README.md
@@ -8,7 +8,7 @@ It typically suits scenario where you need more than a plain template app. If th
 The app reads `test` query parameter and uses it to switch between test cases. Entrypoint is `main.js`.
 There is common unit, then switch based on test case for modifying app startup, then app starts and executes next switch based on test case for actually running code.
 
-Some test cases passes additional parameters to differentiate behavior, see `src/mono/wasm/Wasm.Build.Tests/TestAppScenarios`.
+Some test cases passes additional parameters to differentiate behavior, see `src/mono/wasm/Wasm.Build.Tests`.
 
 ### Running out side of WBT
 

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
@@ -24,6 +24,8 @@ public class BootJsonData
 
     public string mainAssemblyName { get; set; }
 
+    public string applicationEnvironment { get; set; }
+
     /// <summary>
     /// Gets the set of resources needed to boot the application. This includes the transitive
     /// closure of .NET assemblies (including the entrypoint assembly), the dotnet.wasm file,

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
@@ -24,6 +24,7 @@ public class BootJsonData
 
     public string mainAssemblyName { get; set; }
 
+    [DataMember(EmitDefaultValue = false)]
     public string applicationEnvironment { get; set; }
 
     /// <summary>

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -109,9 +109,13 @@ public class GenerateWasmBootJson : Task
         var result = new BootJsonData
         {
             resources = new ResourcesData(),
-            startupMemoryCache = helper.ParseOptionalBool(StartupMemoryCache),
-            applicationEnvironment = ApplicationEnvironment
+            startupMemoryCache = helper.ParseOptionalBool(StartupMemoryCache)
         };
+
+        if (IsTargeting100OrLater())
+        {
+            result.applicationEnvironment = ApplicationEnvironment;
+        }
 
         if (IsTargeting80OrLater())
         {
@@ -492,12 +496,16 @@ public class GenerateWasmBootJson : Task
     private Version? parsedTargetFrameworkVersion;
     private static readonly Version version80 = new Version(8, 0);
     private static readonly Version version90 = new Version(9, 0);
+    private static readonly Version version100 = new Version(10, 0);
 
     private bool IsTargeting80OrLater()
         => IsTargetingVersionOrLater(version80);
 
     private bool IsTargeting90OrLater()
         => IsTargetingVersionOrLater(version90);
+
+    private bool IsTargeting100OrLater()
+        => IsTargetingVersionOrLater(version100);
 
     private bool IsTargetingVersionOrLater(Version version)
     {

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -84,6 +84,8 @@ public class GenerateWasmBootJson : Task
 
     public bool FingerprintAssets { get; set; }
 
+    public string ApplicationEnvironment { get; set; }
+
     public override bool Execute()
     {
         var entryAssemblyName = AssemblyName.GetAssemblyName(AssemblyPath).Name;
@@ -108,6 +110,7 @@ public class GenerateWasmBootJson : Task
         {
             resources = new ResourcesData(),
             startupMemoryCache = helper.ParseOptionalBool(StartupMemoryCache),
+            applicationEnvironment = ApplicationEnvironment
         };
 
         if (IsTargeting80OrLater())


### PR DESCRIPTION
- Add MSBuild property to define application environment.
- Prefer value defined by JavaScript API over the value in boot config. 
- Unrelated: Use unicode character in Wasm.Build.Tests path only on CI by default, because it complicates copy-pasting paths from terminal locally

Contributes to https://github.com/dotnet/aspnetcore/issues/59456