### PR TITLE
Fix encoding missed overridden properties

### DIFF
--- a/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -91,6 +91,7 @@ System.Text.CodePagesEncodingProvider</PackageDescription>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -88,10 +88,13 @@ System.Text.CodePagesEncodingProvider</PackageDescription>
     <Reference Include="System.Threading" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
-    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -581,7 +581,7 @@ namespace System.Text
         {
             get
             {
-                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                (ushort FamilyCodePage, byte _) item = EncodingTable.GetCodePageItem(CodePage);
                 return item.FamilyCodePage;
             }
         }
@@ -590,7 +590,7 @@ namespace System.Text
         {
             get
             {
-                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                (ushort _, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
                 return (item.CodePageFlags & EncodingTable.MIMECONTF_BROWSER) != 0;
             }
         }
@@ -599,7 +599,7 @@ namespace System.Text
         {
             get
             {
-                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                (ushort _, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
                 return (item.CodePageFlags & EncodingTable.MIMECONTF_SAVABLE_BROWSER) != 0;
             }
         }
@@ -608,7 +608,7 @@ namespace System.Text
         {
             get
             {
-                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                (ushort _, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
                 return (item.CodePageFlags & EncodingTable.MIMECONTF_MAILNEWS) != 0;
             }
         }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -617,8 +617,8 @@ namespace System.Text
         {
             get
             {
-                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
-                return (item.CodePageFlags & EncodingTable.MIMECONTF_SAVABLE_MAILNEWS) != 0;
+                (ushort _, byte codePageFlags) = EncodingTable.GetCodePageItem(CodePage);
+                return (codePageFlags & EncodingTable.MIMECONTF_SAVABLE_MAILNEWS) != 0;
             }
         }
     }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -576,5 +576,50 @@ namespace System.Text
                 50225 => "iso-2022-kr",
                 _ => WebName,
             };
+
+        public override int WindowsCodePage
+        {
+            get
+            {
+                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                return item.FamilyCodePage;
+            }
+        }
+
+        public override bool IsBrowserDisplay
+        {
+            get
+            {
+                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                return (item.CodePageFlags & EncodingTable.MIMECONTF_BROWSER) != 0;
+            }
+        }
+
+        public override bool IsBrowserSave
+        {
+            get
+            {
+                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                return (item.CodePageFlags & EncodingTable.MIMECONTF_SAVABLE_BROWSER) != 0;
+            }
+        }
+
+        public override bool IsMailNewsDisplay
+        {
+            get
+            {
+                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                return (item.CodePageFlags & EncodingTable.MIMECONTF_MAILNEWS) != 0;
+            }
+        }
+
+        public override bool IsMailNewsSave
+        {
+            get
+            {
+                (ushort FamilyCodePage, byte CodePageFlags) item = EncodingTable.GetCodePageItem(CodePage);
+                return (item.CodePageFlags & EncodingTable.MIMECONTF_SAVABLE_MAILNEWS) != 0;
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingTable.Data.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingTable.Data.cs
@@ -1271,6 +1271,285 @@ namespace System.Text
             57011, // x-iscii-pa
         ];
 
+        internal const byte MIMECONTF_MAILNEWS = 0x01;
+        internal const byte MIMECONTF_BROWSER = 0x2;
+        internal const byte MIMECONTF_SAVABLE_MAILNEWS = 0x4;
+        internal const byte MIMECONTF_SAVABLE_BROWSER = 0x08;
+
+        // Map codepage number to MIME flags. Uses MappedCodePages to get the index of the codepage
+        private static ReadOnlySpan<byte> MappedFlags =>
+        [
+            0, // 37     IBM EBCDIC (US-Canada)
+            0, // 437    OEM United States
+            0, // 500    IBM EBCDIC (International)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER, // 708    Arabic (ASMO 708)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER, // 720    Arabic (DOS)
+            0, // 737    Greek (DOS)
+            0, // 775    Baltic (DOS)
+            0, // 850    Western European (DOS)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER, // 852    Central European (DOS)
+            0, // 855    OEM Cyrillic
+            0, // 857    Turkish (DOS)
+            0, // 858    OEM Multilingual Latin I
+            0, // 860    Portuguese (DOS)
+            0, // 861    Icelandic (DOS)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER, // 862    Hebrew (DOS)
+            0, // 863    French Canadian (DOS)
+            0, // 864    Arabic (864)
+            0, // 865    Nordic (DOS)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER, // 866    Cyrillic (DOS)
+            0, // 869    Greek, Modern (DOS)
+            0, // 870    IBM EBCDIC (Multilingual Latin-2)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 874    Thai (Windows)
+            0, // 875    IBM EBCDIC (Greek Modern)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 932    Japanese (Shift-JIS)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 936    Chinese Simplified (GB2312)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 949    Korean
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 950    Chinese Traditional (Big5)
+            0, // 1026   IBM EBCDIC (Turkish Latin-5)
+            0, // 1047   IBM Latin-1
+            0, // 1140   IBM EBCDIC (US-Canada-Euro)
+            0, // 1141   IBM EBCDIC (Germany-Euro)
+            0, // 1142   IBM EBCDIC (Denmark-Norway-Euro)
+            0, // 1143   IBM EBCDIC (Finland-Sweden-Euro)
+            0, // 1144   IBM EBCDIC (Italy-Euro)
+            0, // 1145   IBM EBCDIC (Spain-Euro)
+            0, // 1146   IBM EBCDIC (UK-Euro)
+            0, // 1147   IBM EBCDIC (France-Euro)
+            0, // 1148   IBM EBCDIC (International-Euro)
+            0, // 1149   IBM EBCDIC (Icelandic-Euro)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1250   Central European (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1251   Cyrillic (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1252   Western European (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1253   Greek (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1254   Turkish (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1255   Hebrew (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1256   Arabic (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1257   Baltic (Windows)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 1258   Vietnamese (Windows)
+            0, // 1361   Korean (Johab)
+            0, // 10000  Western European (Mac)
+            0, // 10001  Japanese (Mac)
+            0, // 10002  Chinese Traditional (Mac)
+            0, // 10003  Korean (Mac)
+            0, // 10004  Arabic (Mac)
+            0, // 10005  Hebrew (Mac)
+            0, // 10006  Greek (Mac)
+            0, // 10007  Cyrillic (Mac)
+            0, // 10008  Chinese Simplified (Mac)
+            0, // 10010  Romanian (Mac)
+            0, // 10017  Ukrainian (Mac)
+            0, // 10021  Thai (Mac)
+            0, // 10029  Central European (Mac)
+            0, // 10079  Icelandic (Mac)
+            0, // 10081  Turkish (Mac)
+            0, // 10082  Croatian (Mac)
+            0, // 20000  Chinese Traditional (CNS)
+            0, // 20001  TCA Taiwan
+            0, // 20002  Chinese Traditional (Eten)
+            0, // 20003  IBM5550 Taiwan
+            0, // 20004  TeleText Taiwan
+            0, // 20005  Wang Taiwan
+            0, // 20105  Western European (IA5)
+            0, // 20106  German (IA5)
+            0, // 20107  Swedish (IA5)
+            0, // 20108  Norwegian (IA5)
+            0, // 20261  T.61
+            0, // 20269  ISO-6937
+            0, // 20273  IBM EBCDIC (Germany)
+            0, // 20277  IBM EBCDIC (Denmark-Norway)
+            0, // 20278  IBM EBCDIC (Finland-Sweden)
+            0, // 20280  IBM EBCDIC (Italy)
+            0, // 20284  IBM EBCDIC (Spain)
+            0, // 20285  IBM EBCDIC (UK)
+            0, // 20290  IBM EBCDIC (Japanese katakana)
+            0, // 20297  IBM EBCDIC (France)
+            0, // 20420  IBM EBCDIC (Arabic)
+            0, // 20423  IBM EBCDIC (Greek)
+            0, // 20424  IBM EBCDIC (Hebrew)
+            0, // 20833  IBM EBCDIC (Korean Extended)
+            0, // 20838  IBM EBCDIC (Thai)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 20866  Cyrillic (KOI8-R)
+            0, // 20871  IBM EBCDIC (Icelandic)
+            0, // 20880  IBM EBCDIC (Cyrillic Russian)
+            0, // 20905  IBM EBCDIC (Turkish)
+            0, // 20924  IBM Latin-1
+            0, // 20932  Japanese (JIS 0208-1990 and 0212-1990)
+            0, // 20936  Chinese Simplified (GB2312-80)
+            0, // 20949  Korean Wansung
+            0, // 21025  IBM EBCDIC (Cyrillic Serbian-Bulgarian)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 21866  Cyrillic (KOI8-U)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28592  Central European (ISO)
+            MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28593  Latin 3 (ISO)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28594  Baltic (ISO)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28595  Cyrillic (ISO)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28596  Arabic (ISO)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28597  Greek (ISO)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER, // 28598  Hebrew (ISO-Visual)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28599  Turkish (ISO)
+            MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28603  Estonian (ISO)
+            MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 28605  Latin 9 (ISO)
+            0, // 29001  Europa
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 38598  Hebrew (ISO-Logical)
+            MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 50220  Japanese (JIS)
+            MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 50221  Japanese (JIS-Allow 1 byte Kana)
+            0, // 50222  Japanese (JIS-Allow 1 byte Kana - SO/SI)
+            MIMECONTF_MAILNEWS, // 50225  Korean (ISO)
+            0, // 50227  Chinese Simplified (ISO-2022)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 51932  Japanese (EUC)
+            0, // 51936  Chinese Simplified (EUC)
+            MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 51949  Korean (EUC)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 52936  Chinese Simplified (HZ)
+            MIMECONTF_BROWSER | MIMECONTF_SAVABLE_BROWSER | MIMECONTF_MAILNEWS | MIMECONTF_SAVABLE_MAILNEWS, // 54936  Chinese Simplified (GB18030)
+            0, // 57002  ISCII Devanagari
+            0, // 57003  ISCII Bengali
+            0, // 57004  ISCII Tamil
+            0, // 57005  ISCII Telugu
+            0, // 57006  ISCII Assamese
+            0, // 57007  ISCII Oriya
+            0, // 57008  ISCII Kannada
+            0, // 57009  ISCII Malayalam
+            0, // 57010  ISCII Gujarati
+            0, // 57011  ISCII Punjabi
+        ];
+
+        // Map codepage number to family codepage. Uses MappedCodePages to get the index of the codepage
+        private static ReadOnlySpan<ushort> MappedFamilyCodePage =>
+        [
+            1252, // 37     IBM EBCDIC (US-Canada)
+            1252, // 437    OEM United States
+            1252, // 500    IBM EBCDIC (International)
+            1256, // 708    Arabic (ASMO 708)
+            1256, // 720    Arabic (DOS)
+            1253, // 737    Greek (DOS)
+            1257, // 775    Baltic (DOS)
+            1252, // 850    Western European (DOS)
+            1250, // 852    Central European (DOS)
+            1252, // 855    OEM Cyrillic
+            1254, // 857    Turkish (DOS)
+            1252, // 858    OEM Multilingual Latin I
+            1252, // 860    Portuguese (DOS)
+            1252, // 861    Icelandic (DOS)
+            1255, // 862    Hebrew (DOS)
+            1252, // 863    French Canadian (DOS)
+            1256, // 864    Arabic (864)
+            1252, // 865    Nordic (DOS)
+            1251, // 866    Cyrillic (DOS)
+            1253, // 869    Greek, Modern (DOS)
+            1250, // 870    IBM EBCDIC (Multilingual Latin-2)
+            874, // 874    Thai (Windows)
+            1253, // 875    IBM EBCDIC (Greek Modern)
+            932, // 932    Japanese (Shift-JIS)
+            936, // 936    Chinese Simplified (GB2312)
+            949, // 949    Korean
+            950, // 950    Chinese Traditional (Big5)
+            1254, // 1026   IBM EBCDIC (Turkish Latin-5)
+            1252, // 1047   IBM Latin-1
+            1252, // 1140   IBM EBCDIC (US-Canada-Euro)
+            1252, // 1141   IBM EBCDIC (Germany-Euro)
+            1252, // 1142   IBM EBCDIC (Denmark-Norway-Euro)
+            1252, // 1143   IBM EBCDIC (Finland-Sweden-Euro)
+            1252, // 1144   IBM EBCDIC (Italy-Euro)
+            1252, // 1145   IBM EBCDIC (Spain-Euro)
+            1252, // 1146   IBM EBCDIC (UK-Euro)
+            1252, // 1147   IBM EBCDIC (France-Euro)
+            1252, // 1148   IBM EBCDIC (International-Euro)
+            1252, // 1149   IBM EBCDIC (Icelandic-Euro)
+            1250, // 1250   Central European (Windows)
+            1251, // 1251   Cyrillic (Windows)
+            1252, // 1252   Western European (Windows)
+            1253, // 1253   Greek (Windows)
+            1254, // 1254   Turkish (Windows)
+            1255, // 1255   Hebrew (Windows)
+            1256, // 1256   Arabic (Windows)
+            1257, // 1257   Baltic (Windows)
+            1258, // 1258   Vietnamese (Windows)
+            949, // 1361   Korean (Johab)
+            1252, // 10000  Western European (Mac)
+            932, // 10001  Japanese (Mac)
+            950, // 10002  Chinese Traditional (Mac)
+            949, // 10003  Korean (Mac)
+            1256, // 10004  Arabic (Mac)
+            1255, // 10005  Hebrew (Mac)
+            1253, // 10006  Greek (Mac)
+            1251, // 10007  Cyrillic (Mac)
+            936, // 10008  Chinese Simplified (Mac)
+            1250, // 10010  Romanian (Mac)
+            1251, // 10017  Ukrainian (Mac)
+            874, // 10021  Thai (Mac)
+            1250, // 10029  Central European (Mac)
+            1252, // 10079  Icelandic (Mac)
+            1254, // 10081  Turkish (Mac)
+            1250, // 10082  Croatian (Mac)
+            950, // 20000  Chinese Traditional (CNS)
+            950, // 20001  TCA Taiwan
+            950, // 20002  Chinese Traditional (Eten)
+            950, // 20003  IBM5550 Taiwan
+            950, // 20004  TeleText Taiwan
+            950, // 20005  Wang Taiwan
+            1252, // 20105  Western European (IA5)
+            1252, // 20106  German (IA5)
+            1252, // 20107  Swedish (IA5)
+            1252, // 20108  Norwegian (IA5)
+            1252, // 20261  T.61
+            1252, // 20269  ISO-6937
+            1252, // 20273  IBM EBCDIC (Germany)
+            1252, // 20277  IBM EBCDIC (Denmark-Norway)
+            1252, // 20278  IBM EBCDIC (Finland-Sweden)
+            1252, // 20280  IBM EBCDIC (Italy)
+            1252, // 20284  IBM EBCDIC (Spain)
+            1252, // 20285  IBM EBCDIC (UK)
+            932, // 20290  IBM EBCDIC (Japanese katakana)
+            1252, // 20297  IBM EBCDIC (France)
+            1256, // 20420  IBM EBCDIC (Arabic)
+            1253, // 20423  IBM EBCDIC (Greek)
+            1255, // 20424  IBM EBCDIC (Hebrew)
+            949, // 20833  IBM EBCDIC (Korean Extended)
+            874, // 20838  IBM EBCDIC (Thai)
+            1251, // 20866  Cyrillic (KOI8-R)
+            1252, // 20871  IBM EBCDIC (Icelandic)
+            1251, // 20880  IBM EBCDIC (Cyrillic Russian)
+            1254, // 20905  IBM EBCDIC (Turkish)
+            1252, // 20924  IBM Latin-1
+            932, // 20932  Japanese (JIS 0208-1990 and 0212-1990)
+            936, // 20936  Chinese Simplified (GB2312-80)
+            949, // 20949  Korean Wansung
+            1251, // 21025  IBM EBCDIC (Cyrillic Serbian-Bulgarian)
+            1251, // 21866  Cyrillic (KOI8-U)
+            1250, // 28592  Central European (ISO)
+            1254, // 28593  Latin 3 (ISO)
+            1257, // 28594  Baltic (ISO)
+            1251, // 28595  Cyrillic (ISO)
+            1256, // 28596  Arabic (ISO)
+            1253, // 28597  Greek (ISO)
+            1255, // 28598  Hebrew (ISO-Visual)
+            1254, // 28599  Turkish (ISO)
+            1257, // 28603  Estonian (ISO)
+            1252, // 28605  Latin 9 (ISO)
+            1252, // 29001  Europa
+            1255, // 38598  Hebrew (ISO-Logical)
+            932, // 50220  Japanese (JIS)
+            932, // 50221  Japanese (JIS-Allow 1 byte Kana)
+            932, // 50222  Japanese (JIS-Allow 1 byte Kana - SO/SI)
+            949, // 50225  Korean (ISO)
+            936, // 50227  Chinese Simplified (ISO-2022)
+            932, // 51932  Japanese (EUC)
+            936, // 51936  Chinese Simplified (EUC)
+            949, // 51949  Korean (EUC)
+            936, // 52936  Chinese Simplified (HZ)
+            936, // 54936  Chinese Simplified (GB18030)
+            57002, // 57002  ISCII Devanagari
+            57003, // 57003  ISCII Bengali
+            57004, // 57004  ISCII Tamil
+            57005, // 57005  ISCII Telugu
+            57006, // 57006  ISCII Assamese
+            57007, // 57007  ISCII Oriya
+            57008, // 57008  ISCII Kannada
+            57009, // 57009  ISCII Malayalam
+            57010, // 57010  ISCII Gujarati
+            57011, // 57011  ISCII Punjabi
+        ];
+
         // s_webNames is a concatenation of the default encoding names
         // for each code page. It is used in retrieving the value for
         // System.Text.Encoding.WebName given System.Text.Encoding.CodePage.

--- a/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -392,6 +392,154 @@ namespace System.Text.Tests
             yield return new object[] { 57011, "x-iscii-pa", "x-iscii-pa" };
         }
 
+        // CodePage, WindowsCodePage, IsBrowserDisplay, IsBrowserSave, IsMailNewsDisplay, IsMailNewsSave
+        public static IEnumerable<object[]> CodePageMappingToWindowsCodePageAndFlags()
+        {
+            yield return new object[] {37, 1252, false, false, false, false};
+            yield return new object[] {437, 1252, false, false, false, false};
+            yield return new object[] {500, 1252, false, false, false, false};
+            yield return new object[] {708, 1256, true, true, false, false};
+            yield return new object[] {720, 1256, true, true, false, false};
+            yield return new object[] {737, 1253, false, false, false, false};
+            yield return new object[] {775, 1257, false, false, false, false};
+            yield return new object[] {850, 1252, false, false, false, false};
+            yield return new object[] {852, 1250, true, true, false, false};
+            yield return new object[] {855, 1252, false, false, false, false};
+            yield return new object[] {857, 1254, false, false, false, false};
+            yield return new object[] {858, 1252, false, false, false, false};
+            yield return new object[] {860, 1252, false, false, false, false};
+            yield return new object[] {861, 1252, false, false, false, false};
+            yield return new object[] {862, 1255, true, true, false, false};
+            yield return new object[] {863, 1252, false, false, false, false};
+            yield return new object[] {864, 1256, false, false, false, false};
+            yield return new object[] {865, 1252, false, false, false, false};
+            yield return new object[] {866, 1251, true, true, false, false};
+            yield return new object[] {869, 1253, false, false, false, false};
+            yield return new object[] {870, 1250, false, false, false, false};
+            yield return new object[] {874, 874, true, true, true, true};
+            yield return new object[] {875, 1253, false, false, false, false};
+            yield return new object[] {932, 932, true, true, true, true};
+            yield return new object[] {936, 936, true, true, true, true};
+            yield return new object[] {949, 949, true, true, true, true};
+            yield return new object[] {950, 950, true, true, true, true};
+            yield return new object[] {1026, 1254, false, false, false, false};
+            yield return new object[] {1047, 1252, false, false, false, false};
+            yield return new object[] {1140, 1252, false, false, false, false};
+            yield return new object[] {1141, 1252, false, false, false, false};
+            yield return new object[] {1142, 1252, false, false, false, false};
+            yield return new object[] {1143, 1252, false, false, false, false};
+            yield return new object[] {1144, 1252, false, false, false, false};
+            yield return new object[] {1145, 1252, false, false, false, false};
+            yield return new object[] {1146, 1252, false, false, false, false};
+            yield return new object[] {1147, 1252, false, false, false, false};
+            yield return new object[] {1148, 1252, false, false, false, false};
+            yield return new object[] {1149, 1252, false, false, false, false};
+            yield return new object[] {1200, 1200, false, true, false, false};
+            yield return new object[] {1201, 1200, false, false, false, false};
+            yield return new object[] {1250, 1250, true, true, true, true};
+            yield return new object[] {1251, 1251, true, true, true, true};
+            yield return new object[] {1252, 1252, true, true, true, true};
+            yield return new object[] {1253, 1253, true, true, true, true};
+            yield return new object[] {1254, 1254, true, true, true, true};
+            yield return new object[] {1255, 1255, true, true, true, true};
+            yield return new object[] {1256, 1256, true, true, true, true};
+            yield return new object[] {1257, 1257, true, true, true, true};
+            yield return new object[] {1258, 1258, true, true, true, true};
+            yield return new object[] {1361, 949, false, false, false, false};
+            yield return new object[] {10000, 1252, false, false, false, false};
+            yield return new object[] {10001, 932, false, false, false, false};
+            yield return new object[] {10002, 950, false, false, false, false};
+            yield return new object[] {10003, 949, false, false, false, false};
+            yield return new object[] {10004, 1256, false, false, false, false};
+            yield return new object[] {10005, 1255, false, false, false, false};
+            yield return new object[] {10006, 1253, false, false, false, false};
+            yield return new object[] {10007, 1251, false, false, false, false};
+            yield return new object[] {10008, 936, false, false, false, false};
+            yield return new object[] {10010, 1250, false, false, false, false};
+            yield return new object[] {10017, 1251, false, false, false, false};
+            yield return new object[] {10021, 874, false, false, false, false};
+            yield return new object[] {10029, 1250, false, false, false, false};
+            yield return new object[] {10079, 1252, false, false, false, false};
+            yield return new object[] {10081, 1254, false, false, false, false};
+            yield return new object[] {10082, 1250, false, false, false, false};
+            yield return new object[] {12000, 1200, false, false, false, false};
+            yield return new object[] {12001, 1200, false, false, false, false};
+            yield return new object[] {20000, 950, false, false, false, false};
+            yield return new object[] {20001, 950, false, false, false, false};
+            yield return new object[] {20002, 950, false, false, false, false};
+            yield return new object[] {20003, 950, false, false, false, false};
+            yield return new object[] {20004, 950, false, false, false, false};
+            yield return new object[] {20005, 950, false, false, false, false};
+            yield return new object[] {20105, 1252, false, false, false, false};
+            yield return new object[] {20106, 1252, false, false, false, false};
+            yield return new object[] {20107, 1252, false, false, false, false};
+            yield return new object[] {20108, 1252, false, false, false, false};
+            yield return new object[] {20127, 1252, false, false, true, true};
+            yield return new object[] {20261, 1252, false, false, false, false};
+            yield return new object[] {20269, 1252, false, false, false, false};
+            yield return new object[] {20273, 1252, false, false, false, false};
+            yield return new object[] {20277, 1252, false, false, false, false};
+            yield return new object[] {20278, 1252, false, false, false, false};
+            yield return new object[] {20280, 1252, false, false, false, false};
+            yield return new object[] {20284, 1252, false, false, false, false};
+            yield return new object[] {20285, 1252, false, false, false, false};
+            yield return new object[] {20290, 932, false, false, false, false};
+            yield return new object[] {20297, 1252, false, false, false, false};
+            yield return new object[] {20420, 1256, false, false, false, false};
+            yield return new object[] {20423, 1253, false, false, false, false};
+            yield return new object[] {20424, 1255, false, false, false, false};
+            yield return new object[] {20833, 949, false, false, false, false};
+            yield return new object[] {20838, 874, false, false, false, false};
+            yield return new object[] {20866, 1251, true, true, true, true};
+            yield return new object[] {20871, 1252, false, false, false, false};
+            yield return new object[] {20880, 1251, false, false, false, false};
+            yield return new object[] {20905, 1254, false, false, false, false};
+            yield return new object[] {20924, 1252, false, false, false, false};
+            yield return new object[] {20932, 932, false, false, false, false};
+            yield return new object[] {20936, 936, false, false, false, false};
+            yield return new object[] {20949, 949, false, false, false, false};
+            yield return new object[] {21025, 1251, false, false, false, false};
+            yield return new object[] {21866, 1251, true, true, true, true};
+            yield return new object[] {28591, 1252, true, true, true, true};
+            yield return new object[] {28592, 1250, true, true, true, true};
+            yield return new object[] {28593, 1254, false, false, true, true};
+            yield return new object[] {28594, 1257, true, true, true, true};
+            yield return new object[] {28595, 1251, true, true, true, true};
+            yield return new object[] {28596, 1256, true, true, true, true};
+            yield return new object[] {28597, 1253, true, true, true, true};
+            yield return new object[] {28598, 1255, true, true, false, false};
+            yield return new object[] {28599, 1254, true, true, true, true};
+            yield return new object[] {28603, 1257, false, false, true, true};
+            yield return new object[] {28605, 1252, false, true, true, true};
+            yield return new object[] {29001, 1252, false, false, false, false};
+            yield return new object[] {38598, 1255, true, true, true, true};
+            yield return new object[] {50220, 932, false, false, true, true};
+            yield return new object[] {50221, 932, false, true, true, true};
+            yield return new object[] {50222, 932, false, false, false, false};
+            yield return new object[] {50225, 949, false, false, true, false};
+            yield return new object[] {50227, 936, false, false, false, false};
+            yield return new object[] {51932, 932, true, true, true, true};
+            yield return new object[] {51936, 936, false, false, false, false};
+            yield return new object[] {51949, 949, false, false, true, true};
+            yield return new object[] {52936, 936, true, true, true, true};
+            yield return new object[] {54936, 936, true, true, true, true};
+            yield return new object[] {57002, 57002, false, false, false, false};
+            yield return new object[] {57003, 57003, false, false, false, false};
+            yield return new object[] {57004, 57004, false, false, false, false};
+            yield return new object[] {57005, 57005, false, false, false, false};
+            yield return new object[] {57006, 57006, false, false, false, false};
+            yield return new object[] {57007, 57007, false, false, false, false};
+            yield return new object[] {57008, 57008, false, false, false, false};
+            yield return new object[] {57009, 57009, false, false, false, false};
+            yield return new object[] {57010, 57010, false, false, false, false};
+            yield return new object[] {57011, 57011, false, false, false, false};
+#if NETFRAMEWORK
+            // UTF-7 is not supported in .NET Core, so we don't have a code page for it.
+            yield return new object[] {65000, 1200, false, false, true, true};
+#endif // NETFRAMEWORK
+            yield return new object[] {65001, 1200, true, true, true, true};
+        }
+
         public static IEnumerable<object[]> SpecificCodepageEncodings()
         {
             // Layout is codepage encoding, bytes, and matching unicode string.
@@ -520,6 +668,7 @@ namespace System.Text.Tests
 
             TestRegister1252();
             TestMultiBytesEncodingsSupportSurrogate();
+            TestWindowsCodePageAndFlagsThroughEncoding();
         }
 
         private static void ValidateDefaultEncodings()
@@ -626,6 +775,23 @@ namespace System.Text.Tests
         }
 
         [Theory]
+        [MemberData(nameof(CodePageMappingToWindowsCodePageAndFlags))]
+        public static void TestWindowsCodePageAndFlags(int codePage, int windowsCodePage, bool isBrowserDisplay, bool isBrowserSave, bool isMailNewsDisplay, bool isMailNewsSave)
+        {
+            Encoding encoding = CodePagesEncodingProvider.Instance.GetEncoding(codePage);
+            if (encoding is null) // Not supported encoded like utf cases
+            {
+                return;
+            }
+
+            Assert.Equal(windowsCodePage, encoding.WindowsCodePage);
+            Assert.Equal(isBrowserDisplay, encoding.IsBrowserDisplay);
+            Assert.Equal(isBrowserSave, encoding.IsBrowserSave);
+            Assert.Equal(isMailNewsDisplay, encoding.IsMailNewsDisplay);
+            Assert.Equal(isMailNewsSave, encoding.IsMailNewsSave);
+        }
+
+        [Theory]
         [MemberData(nameof(CodePageInfo))]
         public static void TestEncodingDisplayNames(int codePage, string webName, string queryString)
         {
@@ -638,6 +804,29 @@ namespace System.Text.Tests
             // Names can't be empty, and must be printable characters.
             Assert.False(string.IsNullOrWhiteSpace(name));
             Assert.All(name, c => Assert.True(c >= ' ' && c < '~' + 1, "Name: " + name + " contains character: " + c));
+        }
+
+        [Fact]
+        public static void TestWindowsCodePageAndFlagsThroughEncoding()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            foreach (var objects in CodePageMappingToWindowsCodePageAndFlags())
+            {
+                int codePage = (int)objects[0];
+                int windowsCodePage = (int)objects[1];
+                bool isBrowserDisplay = (bool)objects[2];
+                bool isBrowserSave = (bool)objects[3];
+                bool isMailNewsDisplay = (bool)objects[4];
+                bool isMailNewsSave = (bool)objects[5];
+
+                Encoding encoding = Encoding.GetEncoding(codePage);
+                Assert.Equal(windowsCodePage, encoding.WindowsCodePage);
+                Assert.Equal(isBrowserDisplay, encoding.IsBrowserDisplay);
+                Assert.Equal(isBrowserSave, encoding.IsBrowserSave);
+                Assert.Equal(isMailNewsDisplay, encoding.IsMailNewsDisplay);
+                Assert.Equal(isMailNewsSave, encoding.IsMailNewsSave);
+            }
         }
 
         private static void TestMultiBytesEncodingsSupportSurrogate()

--- a/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -806,8 +806,7 @@ namespace System.Text.Tests
             Assert.All(name, c => Assert.True(c >= ' ' && c < '~' + 1, "Name: " + name + " contains character: " + c));
         }
 
-        [Fact]
-        public static void TestWindowsCodePageAndFlagsThroughEncoding()
+        private static void TestWindowsCodePageAndFlagsThroughEncoding()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/113059

When we introduced the codepage encodings library, we missed supporting the encoding properties `WindowsCodePage`, `IsBrowserDisplay`, `IsBrowserSave`, `IsMailNewsDisplay`, and `IsMailNewsSave`. The current behavior is these properties will throw `NotSupportedException`. 
Some users hit this issue when migrating from .NET Framework to .NET. 