### PR TITLE
Establish runtime-diagnostics pipeline

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -1,0 +1,34 @@
+trigger: none
+
+schedules:
+  - cron: "0 10 * * *" # run at 10:00 (UTC) which is 2:00 (PST).
+    displayName: Runtime Diagnostics scheduled run
+    branches:
+      include:
+      - main
+    always: true
+
+resources:
+  repositories:
+    - repository: diagnostics
+      type: github
+      name: dotnet/diagnostics
+      endpoint: public
+
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
+schedules:
+- cron: "30 2 * * *"
+  displayName: Every night at 2:30AM
+  branches:
+    include:
+    - main
+  always: true
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    - stage: Build
+      jobs:


### PR DESCRIPTION
The idea behind this pipeline is to pull in dotnet/diagnostics in order to supply live runtimes to diagnostics test runs. Although it will run on a schedule, the primary reason to have this is for PR validation when making changes we know could impact the diagnostics repo.

Note that this change is bare bones in order to establish the pipeline in AzDo.