### PR TITLE
Opt labels out of automated issue cleanup

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -19,6 +19,8 @@ configuration:
       - isOpen
       - isNotLabeledWith:
           label: backlog-cleanup-candidate
+      - isNotLabeledWith:
+          label: area-codegen-coreclr
       actions:
       - addReply:
           reply: >-

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -21,6 +21,10 @@ configuration:
           label: backlog-cleanup-candidate
       - isNotLabeledWith:
           label: area-codegen-coreclr
+      - isNotLabeledWith:
+          label: area-iltools-coreclr
+      - isNotLabeledWith:
+          label: area-tools-ilverification
       actions:
       - addReply:
           reply: >-


### PR DESCRIPTION
@JulieLeeMSFT requested opting the area-codegen-coreclr, area-iltools-coreclr, and area-tools-ilverification areas out of automated issue cleanup, like what happened in [#31852](https://github.com/dotnet/runtime/issues/31852#event-15967825262).
