### PR TITLE
JIT: Fix Lowering::LowerRange

### DIFF
--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -53,28 +53,7 @@ private:
     {
         LowerRange(range.FirstNode(), range.LastNode());
     }
-    void LowerRange(GenTree* firstNode, GenTree* lastNode)
-    {
-        assert(lastNode != nullptr);
-
-        // Lower nodes until we get to the node after the last node expected to
-        // be lowered. This is the most robust way to do this since LowerNode
-        // can both remove nodes or replace a node by a new range of nodes.
-        // Note that stopNode can be null if lastNode was truly the last node
-        // of the block, which is ok.
-        GenTree* stopNode = lastNode->gtNext;
-
-        for (GenTree* cur = firstNode; cur != stopNode;)
-        {
-            cur = LowerNode(cur);
-
-            if ((stopNode != nullptr) && (cur == nullptr))
-            {
-                assert(!"Ran out of nodes before getting to stop node");
-                break;
-            }
-        }
-    }
+    void LowerRange(GenTree* firstNode, GenTree* lastNode);
 
     // ContainCheckRange handles new code that is introduced by or after Lowering,
     // and that is known to be already in Lowered form.
@@ -640,6 +619,7 @@ private:
     unsigned              vtableCallTemp;       // local variable we use as a temp for vtable calls
     mutable SideEffectSet m_scratchSideEffects; // SideEffectSet used for IsSafeToContainMem and isRMWIndirCandidate
     BasicBlock*           m_block;
+    GenTree*              m_stopNodeSentinel = nullptr;
 
 #ifdef FEATURE_FIXED_OUT_ARGS
     unsigned m_outgoingArgSpaceSize = 0;

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -51,15 +51,23 @@ private:
     // LowerRange handles new code that is introduced by or after Lowering.
     void LowerRange(LIR::ReadOnlyRange& range)
     {
-        for (GenTree* newNode : range)
-        {
-            LowerNode(newNode);
-        }
+        LowerRange(range.FirstNode(), range.LastNode());
     }
     void LowerRange(GenTree* firstNode, GenTree* lastNode)
     {
-        LIR::ReadOnlyRange range(firstNode, lastNode);
-        LowerRange(range);
+        GenTree* cur = firstNode;
+
+        while (true)
+        {
+            GenTree* next = LowerNode(cur);
+            if (cur == lastNode)
+            {
+                break;
+            }
+
+            cur = next;
+            assert(cur != nullptr);
+        }
     }
 
     // ContainCheckRange handles new code that is introduced by or after Lowering,

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -67,6 +67,12 @@ private:
         for (GenTree* cur = firstNode; cur != stopNode;)
         {
             cur = LowerNode(cur);
+
+            if ((stopNode != nullptr) && (cur == nullptr))
+            {
+                assert(!"Ran out of nodes before getting to stop node");
+                break;
+            }
         }
     }
 

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -55,18 +55,18 @@ private:
     }
     void LowerRange(GenTree* firstNode, GenTree* lastNode)
     {
-        GenTree* cur = firstNode;
+        assert(lastNode != nullptr);
 
-        while (true)
+        // Lower nodes until we get to the node after the last node expected to
+        // be lowered. This is the most robust way to do this since LowerNode
+        // can both remove nodes or replace a node by a new range of nodes.
+        // Note that stopNode can be null if lastNode was truly the last node
+        // of the block, which is ok.
+        GenTree* stopNode = lastNode->gtNext;
+
+        for (GenTree* cur = firstNode; cur != stopNode;)
         {
-            GenTree* next = LowerNode(cur);
-            if (cur == lastNode)
-            {
-                break;
-            }
-
-            cur = next;
-            assert(cur != nullptr);
+            cur = LowerNode(cur);
         }
     }
 


### PR DESCRIPTION
For example, this would break when `LowerNode` ended up deciding to remove the current node.

To make this fully robust we now insert a sentinel node and stop when we get to it. Using `lastNode->gtNext` as the sentinel node would seemingly be possible, but we have code that removes the user of the node being lowered, which would not work in that scenario: 
https://github.com/dotnet/runtime/blob/78142b0e78681a3be581040c7b988bc91d5a8169/src/coreclr/jit/lowerxarch.cpp#L1506-L1514.