### PR TITLE
Fix build breaks

### DIFF
--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -266,7 +266,6 @@ EXTERN_C CODE_LOCATION RhpInterfaceDispatchAVLocation8;
 EXTERN_C CODE_LOCATION RhpInterfaceDispatchAVLocation16;
 EXTERN_C CODE_LOCATION RhpInterfaceDispatchAVLocation32;
 EXTERN_C CODE_LOCATION RhpInterfaceDispatchAVLocation64;
-EXTERN_C CODE_LOCATION RhpVTableOffsetDispatchAVLocation;
 
 static bool InInterfaceDispatchHelper(uintptr_t faultingIP)
 {
@@ -281,7 +280,6 @@ static bool InInterfaceDispatchHelper(uintptr_t faultingIP)
         (uintptr_t)&RhpInterfaceDispatchAVLocation16,
         (uintptr_t)&RhpInterfaceDispatchAVLocation32,
         (uintptr_t)&RhpInterfaceDispatchAVLocation64,
-        (uintptr_t)&RhpVTableOffsetDispatchAVLocation,
     };
 
     // compare the IP against the list of known possible AV locations in the interface dispatch helpers

--- a/src/coreclr/nativeaot/Runtime/amd64/CachedInterfaceDispatchAot.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/CachedInterfaceDispatchAot.S
@@ -8,14 +8,6 @@
 // trick to avoid PLT relocation at runtime which corrupts registers
 #define REL_C_FUNC(name) C_FUNC(name)@gotpcrel
 
-// Stub dispatch routine for dispatch to a vtable slot
-LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
-        int 3
-        // UNIXTODO: Implement this function
-    ALTERNATE_ENTRY RhpVTableOffsetDispatchAVLocation
-        int 3
-LEAF_END RhpVTableOffsetDispatch, _TEXT
-
 // Cache miss case, call the runtime to resolve the target and update the cache.
 // Use universal transition helper to allow an exception to flow out of resolution
 LEAF_ENTRY RhpInterfaceDispatchSlow, _TEXT

--- a/src/coreclr/nativeaot/Runtime/amd64/CachedInterfaceDispatchAot.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/CachedInterfaceDispatchAot.asm
@@ -9,24 +9,6 @@ EXTERN RhpUniversalTransition_DebugStepTailCall : PROC
 EXTERN RhpCidResolve : PROC
 EXTERN RhpUniversalTransition_DebugStepTailCall : PROC
 
-
-;; Stub dispatch routine for dispatch to a vtable slot
-LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
-        ;; r11 currently contains the indirection cell address.
-        ;; load rax to point to the vtable offset (which is stored in the m_pCache field).
-        mov     rax, [r11 + OFFSETOF__InterfaceDispatchCell__m_pCache]
-
-        ;; Load the MethodTable from the object instance in rcx, and add it to the vtable offset
-        ;; to get the address in the vtable of what we want to dereference
-    ALTERNATE_ENTRY RhpVTableOffsetDispatchAVLocation
-        add     rax, [rcx]
-
-        ;; Load the target address of the vtable into rax
-        mov     rax, [rax]
-
-        TAILJMP_RAX
-LEAF_END RhpVTableOffsetDispatch, _TEXT
-
 ;; Cache miss case, call the runtime to resolve the target and update the cache.
 ;; Use universal transition helper to allow an exception to flow out of resolution
 LEAF_ENTRY RhpInterfaceDispatchSlow, _TEXT

--- a/src/coreclr/nativeaot/Runtime/arm64/CachedInterfaceDispatchAot.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/CachedInterfaceDispatchAot.S
@@ -10,26 +10,6 @@
     .extern RhpUniversalTransition_DebugStepTailCall
 
 //
-// Stub dispatch routine for dispatch to a vtable slot
-//
-    LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
-        // x11 contains the interface dispatch cell address.
-        // load x12 to point to the vtable offset (which is stored in the m_pCache field).
-        ldr     x12, [x11, #OFFSETOF__InterfaceDispatchCell__m_pCache]
-
-        // Load the MethodTable from the object instance in x0, and add it to the vtable offset
-        // to get the address in the vtable of what we want to dereference
-    ALTERNATE_ENTRY RhpVTableOffsetDispatchAVLocation
-        ldr     x13, [x0]
-        add     x12, x12, x13
-
-        // Load the target address of the vtable into x12
-        ldr     x12, [x12]
-
-        br      x12
-    LEAF_END RhpVTableOffsetDispatch, _TEXT
-
-//
 // Cache miss case, call the runtime to resolve the target and update the cache.
 // Use universal transition helper to allow an exception to flow out of resolution.
 //

--- a/src/coreclr/nativeaot/Runtime/arm64/CachedInterfaceDispatchAot.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/CachedInterfaceDispatchAot.asm
@@ -11,26 +11,6 @@
     EXTERN RhpUniversalTransition_DebugStepTailCall
 
 ;;
-;; Stub dispatch routine for dispatch to a vtable slot
-;;
-    LEAF_ENTRY RhpVTableOffsetDispatch
-        ;; x11 contains the interface dispatch cell address.
-        ;; load x12 to point to the vtable offset (which is stored in the m_pCache field).
-        ldr     x12, [x11, #OFFSETOF__InterfaceDispatchCell__m_pCache]
-
-        ;; Load the MethodTable from the object instance in x0, and add it to the vtable offset
-        ;; to get the address in the vtable of what we want to dereference
-    ALTERNATE_ENTRY RhpVTableOffsetDispatchAVLocation
-        ldr     x13, [x0]
-        add     x12, x12, x13
-
-        ;; Load the target address of the vtable into x12
-        ldr     x12, [x12]
-
-        br      x12
-    LEAF_END RhpVTableOffsetDispatch
-
-;;
 ;; Cache miss case, call the runtime to resolve the target and update the cache.
 ;; Use universal transition helper to allow an exception to flow out of resolution.
 ;;

--- a/src/coreclr/nativeaot/Runtime/portable.cpp
+++ b/src/coreclr/nativeaot/Runtime/portable.cpp
@@ -323,12 +323,6 @@ FCIMPL0(void, RhpInterfaceDispatch64)
 }
 FCIMPLEND
 
-FCIMPL0(void, RhpVTableOffsetDispatch)
-{
-    ASSERT_UNCONDITIONALLY("NYI");
-}
-FCIMPLEND
-
 // @TODO Implement UniversalTransition
 EXTERN_C void * ReturnFromUniversalTransition;
 void * ReturnFromUniversalTransition;

--- a/src/coreclr/runtime/CachedInterfaceDispatch.cpp
+++ b/src/coreclr/runtime/CachedInterfaceDispatch.cpp
@@ -241,12 +241,14 @@ static uint32_t CacheSizeToIndex(uint32_t cCacheEntries)
 // address of the interface dispatch stub associated with this size of cache is returned.
 static uintptr_t AllocateCache(uint32_t cCacheEntries, InterfaceDispatchCache * pExistingCache, const DispatchCellInfo *pNewCellInfo, void ** ppStub)
 {
+#ifndef FEATURE_NATIVEAOT
     if (pNewCellInfo->CellType == DispatchCellType::VTableOffset)
     {
         *ppStub = (void *)&RhpVTableOffsetDispatch;
         ASSERT(!InterfaceDispatchCell::IsCache(pNewCellInfo->GetVTableOffset()));
         return pNewCellInfo->GetVTableOffset();
     }
+#endif
 
     ASSERT((cCacheEntries >= 1) && (cCacheEntries <= CID_MAX_CACHE_SIZE));
     ASSERT((pExistingCache == NULL) || (pExistingCache->m_cEntries < cCacheEntries));

--- a/src/coreclr/runtime/arm/StubDispatch.S
+++ b/src/coreclr/runtime/arm/StubDispatch.S
@@ -77,30 +77,6 @@ DEFINE_INTERFACE_DISPATCH_STUB 16
 DEFINE_INTERFACE_DISPATCH_STUB 32
 DEFINE_INTERFACE_DISPATCH_STUB 64
 
-// Stub dispatch routine for dispatch to a vtable slot
-LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
-        // On input we have the indirection cell data structure in r12. But we need more scratch registers and
-        // we may A/V on a null this. Both of these suggest we need a real prolog and epilog.
-        PROLOG_PUSH {r1}
-
-        // r12 currently holds the indirection cell address. We need to update it to point to the vtable
-        // offset instead.
-        ldr         r12, [r12, #OFFSETOF__InterfaceDispatchCell__m_pCache]
-
-        // Load the MethodTable from the object instance in r0.
-        ALTERNATE_ENTRY RhpVTableOffsetDispatchAVLocation
-        ldr         r1, [r0]
-
-        // add the vtable offset to the MethodTable pointer
-        add         r12, r1, r12
-
-        // Load the target address of the vtable into r12
-        ldr         r12, [r12]
-
-        EPILOG_POP  {r1}
-        EPILOG_BRANCH_REG r12
-LEAF_END RhpVTableOffsetDispatch, _TEXT
-
 // Initial dispatch on an interface when we don't have a cache yet.
 LEAF_ENTRY RhpInitialInterfaceDispatch, _TEXT
         // Just tail call to the cache miss helper.

--- a/src/coreclr/runtime/i386/StubDispatch.asm
+++ b/src/coreclr/runtime/i386/StubDispatch.asm
@@ -95,22 +95,6 @@ RhpInterfaceDispatchSlow proc
         jmp         _RhpUniversalTransition_DebugStepTailCall@0
 RhpInterfaceDispatchSlow endp
 
-;; Stub dispatch routine for dispatch to a vtable slot
-_RhpVTableOffsetDispatch@0 proc public
-        ;; eax currently contains the indirection cell address. We need to update it to point to the vtable offset (which is in the m_pCache field)
-        mov     eax, [eax + OFFSETOF__InterfaceDispatchCell__m_pCache]
-
-        ;; add the vtable offset to the MethodTable pointer
-        add     eax, [ecx]
-
-        ;; Load the target address of the vtable into eax
-        mov     eax, [eax]
-
-        ;; tail-jump to the target
-        jmp     eax
-_RhpVTableOffsetDispatch@0 endp
-
-
 ;; Initial dispatch on an interface when we don't have a cache yet.
 FASTCALL_FUNC RhpInitialDynamicInterfaceDispatch, 0
 ALTERNATE_ENTRY _RhpInitialInterfaceDispatch

--- a/src/coreclr/runtime/loongarch64/StubDispatch.S
+++ b/src/coreclr/runtime/loongarch64/StubDispatch.S
@@ -83,26 +83,6 @@
     LEAF_END RhpInitialInterfaceDispatch, _TEXT
 
 //
-// Stub dispatch routine for dispatch to a vtable slot
-//
-    LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
-        // t2 contains the interface dispatch cell address.
-        // load t3 to point to the vtable offset (which is stored in the m_pCache field).
-        ld.d  $t3, $t2, OFFSETOF__InterfaceDispatchCell__m_pCache
-
-        // Load the MethodTable from the object instance in a0, and add it to the vtable offset
-        // to get the address in the vtable of what we want to dereference
-    ALTERNATE_ENTRY RhpVTableOffsetDispatchAVLocation
-        ld.d  $t4, $a0, 0
-        add.d  $t3, $t3, $t4
-
-        // Load the target address of the vtable into t3
-        ld.d  $t3, $t3, 0
-
-        jirl  $r0, $t3, 0
-    LEAF_END RhpVTableOffsetDispatch, _TEXT
-
-//
 // Cache miss case, call the runtime to resolve the target and update the cache.
 // Use universal transition helper to allow an exception to flow out of resolution.
 //

--- a/src/coreclr/runtime/riscv64/StubDispatch.S
+++ b/src/coreclr/runtime/riscv64/StubDispatch.S
@@ -82,25 +82,6 @@
     LEAF_END RhpInitialInterfaceDispatch, _TEXT
 
     //
-    // Stub dispatch routine for dispatch to a vtable slot
-    //
-    LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
-        // t2 contains the interface dispatch cell address.
-        // Load t3 to point to the vtable offset (which is stored in the m_pCache field).
-        ld  t3, OFFSETOF__InterfaceDispatchCell__m_pCache(t2)
-
-        // Load the MethodTable from the object instance in a0, and add it to the vtable offset
-        // to get the address in the vtable of what we want to dereference
-        ld    t4, 0(a0)
-        add   t3, t3, t4
-
-        // Load the target address of the vtable into t3
-        ld    t3, 0(t3)
-
-        jr  t3
-    LEAF_END RhpVTableOffsetDispatch, _TEXT
-
-    //
     // Cache miss case, call the runtime to resolve the target and update the cache.
     // Use universal transition helper to allow an exception to flow out of resolution.
     //


### PR DESCRIPTION
Fixes build breaks on less mainstream platforms caused by #111771.

Samples:

Windows x86:

```
Runtime.WorkstationGC.lib(EHHelpers.cpp.obj)(0,0): error LNK2001: unresolved external symbol _RhpVTableOffsetDispatchAVLocation [D:\a\_work\1\s\src\tests\baseservices\compilerservices\FixedAddressValueType\FixedAddressValueType.csproj]
```

Riscv:

```
ld.lld : error : undefined symbol: RhpVTableOffsetDispatchAVLocation [/runtime/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj] [/runtime/src/tests/build.proj]
```