### PR TITLE
[10.0/preview-2] JIT: disable array stack allocation

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -673,7 +673,7 @@ RELEASE_CONFIG_INTEGER(JitObjectStackAllocationRefClass, "JitObjectStackAllocati
 RELEASE_CONFIG_INTEGER(JitObjectStackAllocationBoxedValueClass, "JitObjectStackAllocationBoxedValueClass", 1)
 RELEASE_CONFIG_INTEGER(JitObjectStackAllocationConditionalEscape, "JitObjectStackAllocationConditionalEscape", 1)
 CONFIG_STRING(JitObjectStackAllocationConditionalEscapeRange, "JitObjectStackAllocationConditionalEscapeRange")
-RELEASE_CONFIG_INTEGER(JitObjectStackAllocationArray, "JitObjectStackAllocationArray", 1)
+RELEASE_CONFIG_INTEGER(JitObjectStackAllocationArray, "JitObjectStackAllocationArray", 0)
 RELEASE_CONFIG_INTEGER(JitObjectStackAllocationSize, "JitObjectStackAllocationSize", 528)
 
 RELEASE_CONFIG_INTEGER(JitEECallTimingInfo, "JitEECallTimingInfo", 0)

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
@@ -156,16 +156,16 @@ namespace ObjectStackAllocation
             // Stack allocation of boxed structs is now enabled
             CallTestAndVerifyAllocation(BoxSimpleStructAndAddFields, 12, expectedAllocationKind);
 
-            // Fixed-sized stack array cases
-            CallTestAndVerifyAllocation(AllocateArrayWithNonGCElements, 84, expectedAllocationKind);
-            CallTestAndVerifyAllocation(AllocateArrayWithGCElements, 84, expectedAllocationKind);
-            CallTestAndVerifyAllocation(AllocateArrayT<int>, 84, expectedAllocationKind);
-            CallTestAndVerifyAllocation(AllocateArrayT<string>, 84, expectedAllocationKind);
-
             // The remaining tests currently never allocate on the stack
             if (expectedAllocationKind == AllocationKind.Stack) {
                 expectedAllocationKind = AllocationKind.Heap;
             }
+
+            // Fixed-sized stack array cases (allocate in 10p2 because we've disabled array stack allocation)
+            CallTestAndVerifyAllocation(AllocateArrayWithNonGCElements, 84, expectedAllocationKind);
+            CallTestAndVerifyAllocation(AllocateArrayWithGCElements, 84, expectedAllocationKind);
+            CallTestAndVerifyAllocation(AllocateArrayT<int>, 84, expectedAllocationKind);
+            CallTestAndVerifyAllocation(AllocateArrayT<string>, 84, expectedAllocationKind);
 
             // This test calls CORINFO_HELP_ISINSTANCEOFCLASS
             CallTestAndVerifyAllocation(AllocateSimpleClassAndCheckTypeHelper, 1, expectedAllocationKind);


### PR DESCRIPTION
Preview 2 is missing an important fix for stack-allocated arrays of GC types: #112711. This can lead to unexpected crashes in jitted code.

Disable array stack allocation to work around this.