### PR TITLE
[release/8.0-staging] [QUIC] Update MsQuic library version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -221,7 +221,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>8.0.0-rtm.23523.2</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.3.5</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.8</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>8.0.0-alpha.1.23527.1</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>16.0.5-alpha.1.24362.2</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>


### PR DESCRIPTION
Backport of #113159 from main (10.0) to release/8.0-staging

Contributes to #113136

## Customer Impact

Security in-depth change in msquic library - found internally.

We are updating just msquic dependency to 2.4.8 (we have reship msquic binaries on Windows -- on Linux we rely on external package published by msquic team directly). No unique changes to .NET code.

Note: We have done similar update in 2024/3 - see commit https://github.com/dotnet/runtime/commit/1207c3268c5c70f7c2d2539ee667acc3a2c819bd.

## Regression

No

## Testing

CI run - System.Net.Quic tests ran and passed, see https://github.com/dotnet/runtime/pull/113206#issuecomment-2706079128

## Risk

Low. Update of msquic library that is backward compatible (msquic team guaratnees it).
Also, customers on Linux get this version automatically with updates from their package managers.