### PR TITLE
[android][tests] Do not package unused CoreCLR libs when building test apks

### DIFF
--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -448,7 +448,20 @@ public partial class ApkBuilder
         }
         else
         {
-            dynamicLibs.AddRange(Directory.GetFiles(AppDir, "*.so").Where(file => Path.GetFileName(file) != "libmonodroid.so"));
+            var excludedLibs = new HashSet<string> { "libmonodroid.so" };
+            if (IsCoreCLR)
+            {
+                // exclude standalone GC libs
+                excludedLibs.Add("libclrgc.so");
+                excludedLibs.Add("libclrgcexp.so");
+                if (StripDebugSymbols)
+                {
+                    // exclude debugger support libs
+                    excludedLibs.Add("libmscordbi.so");
+                    excludedLibs.Add("libmscordaccore.so");
+                }
+            }
+            dynamicLibs.AddRange(Directory.GetFiles(AppDir, "*.so").Where(file => !excludedLibs.Contains(Path.GetFileName(file))));
         }
 
         // add all *.so files to lib/%abi%/


### PR DESCRIPTION
As a short-term solution, this PR filters out unused CoreCLR libraries from .apks, which reduces the size of internally built Android apps (both for samples and tests).

As a long-term solution, we can:
- Identify and prevent packaging libraries which will never be used on Android
- Add the exclusion logic in the Android SDK
- Implement a component-model similar to: https://github.com/dotnet/runtime/blob/main/docs/design/mono/components.md

---
Contributes to: https://github.com/dotnet/runtime/issues/111954