### PR TITLE
Generate `.comment` section for ELF executables

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Diagnostics;
 using System.Buffers.Binary;
 using System.Numerics;
+using System.Reflection;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 using Internal.TypeSystem;
@@ -49,6 +50,7 @@ namespace ILCompiler.ObjectWriter
         private static readonly ObjectNodeSection ArmUnwindTableSection = new ObjectNodeSection(".ARM.extab", SectionType.ReadOnly);
         private static readonly ObjectNodeSection ArmAttributesSection = new ObjectNodeSection(".ARM.attributes", SectionType.ReadOnly);
         private static readonly ObjectNodeSection ArmTextThunkSection = new ObjectNodeSection(".text.thunks", SectionType.Executable);
+        private static readonly ObjectNodeSection CommentSection = new ObjectNodeSection(".comment", SectionType.ReadOnly);
 
         public ElfObjectWriter(NodeFactory factory, ObjectWritingOptions options)
             : base(factory, options)
@@ -93,6 +95,11 @@ namespace ILCompiler.ObjectWriter
             else if (section == ArmAttributesSection)
             {
                 type = SHT_ARM_ATTRIBUTES;
+            }
+            else if (section == CommentSection)
+            {
+                type = SHT_PROGBITS;
+                flags = SHF_MERGE | SHF_STRINGS;
             }
             else if (_machine == EM_ARM && section.Type == SectionType.UnwindData)
             {
@@ -567,6 +574,9 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void EmitSectionsAndLayout()
         {
+            SectionWriter commentSectionWriter = GetOrCreateSection(CommentSection);
+            commentSectionWriter.WriteUtf8String($".NET AOT {Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion}");
+
             if (_machine == EM_ARM)
             {
                 // Emit EABI attributes section


### PR DESCRIPTION
This is the standard way to emit compiler version info on ELF. No standard way for other formats.

Cc @dotnet/ilc-contrib 