### PR TITLE
[release/8.0-staging] Back port logical equivalent of #102838

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedDirectoryStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedDirectoryStoreProvider.cs
@@ -46,6 +46,8 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     _storeDirectoryInfo.Refresh();
                     DirectoryInfo info = _storeDirectoryInfo;
+                    ret = _nativeCollection;
+                    elapsed = _recheckStopwatch.Elapsed;
 
                     if (ret == null ||
                         _forceRefresh ||

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
@@ -93,6 +93,9 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 lock (s_recheckStopwatch)
                 {
+                    ret = s_nativeCollections;
+                    elapsed = s_recheckStopwatch.Elapsed;
+
                     if (ret == null ||
                         elapsed > s_assumeInvalidInterval ||
                         LastWriteTimesHaveChanged())


### PR DESCRIPTION
This is a logical back port of #102838. The store providers went through a significant refactoring in .NET 9, so the changes would not back port cleanly to .NET 8.

/cc @bartonjs 

## Customer Impact

Reported by a customer in #113227 asking to apply the same fix in #102838. When the OpenSSL system and directory stores needed to be refreshed, a lock is taken. However, when the thread acquired the lock, the information about needing to refresh the store is stored in a local. This would lead to all threads that wait on the lock performing a store refresh because the locals were not updated after the lock was acquired.

The fix is to re-assign the locals with up-to-date information after the lock is taken.

## Regression

No.

## Testing

Existing tests ensure no functional changes are introduced. 

## Risk

Low. A similar fix was made for .NET 9. The change is isolated and simple to reason about.