### PR TITLE
Bring up runtime-diagnostics pipeline

### DIFF
--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -36,6 +36,7 @@ parameters:
   templatePath: 'templates'
   templateContext: ''
   disableComponentGovernance: ''
+  liveRuntimeDir: ''
 
 jobs:
 - template: /eng/common/${{ parameters.templatePath }}/job/job.yml
@@ -86,10 +87,7 @@ jobs:
       - _TestArgs: '-test'
       - _Cross: ''
 
-      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-        - _buildScript: $(Build.SourcesDirectory)\diagnostics\build.cmd
-      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-        - _buildScript: $(Build.SourcesDirectory)/diagnostics/build.sh
+      - _buildScript: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
 
       - ${{ if and(eq(parameters.testOnly, 'true'), eq(parameters.buildOnly, 'true')) }}:
         'error, testOnly and buildOnly cannot be true at the same time': error
@@ -136,12 +134,7 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - template: /eng/pipelines/common/templates/disable-vsupdate-or-failfast.yml
 
-    - checkout: self
-      path: s
-      clean: true
-      fetchDepth: $(checkoutFetchDepth)
     - checkout: diagnostics
-      path: s/diagnostics
       clean: true
       fetchDepth: $(checkoutFetchDepth)
 
@@ -215,6 +208,9 @@ jobs:
           -ci
           -configuration ${{ parameters.buildConfig }}
           -architecture ${{ parameters.archType }}
+          -privatebuild
+          -useCdac
+          -liveRuntimeDir ${{ parameters.liveRuntimeDir }}
           $(_TestArgs)
           $(_Cross)
           $(_InternalInstallArgs)

--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -1,0 +1,265 @@
+parameters:
+  buildConfig: ''
+  name: ''
+  buildArgs: ''
+  archType: ''
+  hostedOs: ''
+  osGroup: ''
+  osSubgroup: ''
+  container: ''
+  crossBuild: false
+  variables: []
+  targetRid: ''
+  timeoutInMinutes: ''
+  dependsOn: []
+  # The following parameter is used to specify dependencies on other global build for the same platform.
+  # We provide this mechanism to allow for global builds to depend on other global builds and use the multiplexing
+  # that platform-matrix.yml enables.
+  # Each item can have the following properties:
+  # - name: The suffix of the job name to depend on.
+  # - buildConfig: The configuration of the job to depend on.
+  dependsOnGlobalBuilds: []
+  pool: ''
+  platform: ''
+  condition: true
+  useContinueOnErrorDuringBuild: false
+  shouldContinueOnError: false
+  isOfficialBuild: false
+  runtimeFlavor: 'coreclr'
+  runtimeVariant: ''
+  helixQueues: ''
+  enablePublishTestResults: false
+  testResultsFormat: ''
+  postBuildSteps: []
+  extraVariablesTemplates: []
+  preBuildSteps: []
+  templatePath: 'templates'
+  templateContext: ''
+  disableComponentGovernance: ''
+
+jobs:
+- template: /eng/common/${{ parameters.templatePath }}/job/job.yml
+  parameters:
+    name: ${{ coalesce(parameters.name, parameters.osGroup) }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
+    pool: ${{ parameters.pool }}
+    container: ${{ parameters.container }}
+    condition: and(succeeded(), ${{ parameters.condition }})
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    enablePublishTestResults: ${{ parameters.enablePublishTestResults }}
+    testResultsFormat: ${{ parameters.testResultsFormat }}
+
+    ${{ if ne(parameters.templateContext, '') }}:
+      templateContext: ${{ parameters.templateContext }}
+
+    artifacts:
+      publish:
+        logs:
+          ${{ if notin(parameters.osGroup, 'browser', 'wasi') }}:
+            name: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.name }}
+          ${{ if in(parameters.osGroup, 'browser', 'wasi') }}:
+            name: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.archType }}_${{ parameters.hostedOs }}_${{ parameters.buildConfig }}_${{ parameters.name }}
+
+    # Component governance does not work on musl machines
+    ${{ if eq(parameters.osSubGroup, '_musl') }}:
+      disableComponentGovernance: true
+    ${{ else }}:
+      disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
+
+    workspace:
+      clean: all
+
+    ${{ if or(ne(parameters.dependsOn,''), ne(parameters.dependsOnGlobalBuilds,'')) }}:
+      dependsOn:
+      - ${{ each build in parameters.dependsOn }}:
+        - ${{ build }}
+      - ${{ each globalBuild in parameters.dependsOnGlobalBuilds }}:
+        - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, coalesce(globalBuild.buildConfig, parameters.buildConfig), globalBuild.name) }}
+
+    variables:
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - group: DotNet-HelixApi-Access
+          - group: AzureDevOps-Artifact-Feeds-Pats
+      
+      - _PhaseName: ${{ coalesce(parameters.name, parameters.osGroup) }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
+      - _Pipeline_StreamDumpDir: $(Build.SourcesDirectory)/artifacts/tmp/${{ parameters.buildConfig }}/streams
+
+      - _TestArgs: '-test'
+      - _Cross: ''
+
+      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+        - _buildScript: $(Build.SourcesDirectory)\diagnostics\build.cmd
+      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+        - _buildScript: $(Build.SourcesDirectory)/diagnostics/build.sh
+
+      - ${{ if and(eq(parameters.testOnly, 'true'), eq(parameters.buildOnly, 'true')) }}:
+        'error, testOnly and buildOnly cannot be true at the same time': error
+
+      - ${{ if eq(parameters.testOnly, 'true') }}:
+        - _TestArgs: '-test -skipnative'
+
+      - ${{ if or(eq(parameters.buildOnly, 'true'), eq(parameters.isCodeQLRun, 'true')) }}:
+        - _TestArgs: ''
+
+      # For testing msrc's and service releases. The RuntimeSourceVersion is either "default" or the service release version to test
+      - _InternalInstallArgs: ''
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.isCodeQLRun, 'false')) }}:
+        - _InternalInstallArgs:
+            -dotnetruntimeversion '$(DotnetRuntimeVersion)'
+            -dotnetruntimedownloadversion '$(DotnetRuntimeDownloadVersion)'
+            -runtimesourcefeed '$(RuntimeFeedUrl)'
+            -runtimesourcefeedkey '$(RuntimeFeedBase64SasToken)'
+
+      - ${{ each variableTemplate in parameters.extraVariablesTemplates }}:
+        - template: ${{ variableTemplate.template }}
+          parameters:
+            osGroup: ${{ parameters.osGroup }}
+            osSubgroup: ${{ parameters.osSubgroup }}
+            archType: ${{ parameters.archType }}
+            buildConfig: ${{ parameters.buildConfig }}
+            runtimeFlavor: ${{ parameters.runtimeFlavor }}
+            runtimeVariant: ${{ parameters.runtimeVariant }}
+            helixQueues: ${{ parameters.helixQueues }}
+            targetRid: ${{ parameters.targetRid }}
+            name: ${{ parameters.name }}
+            platform: ${{ parameters.platform }}
+            shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+            ${{ if ne(variableTemplate.forwardedParameters, '') }}:
+              ${{ each parameter in variableTemplate.forwardedParameters }}:
+                ${{ parameter }}: ${{ parameters[parameter] }}
+            ${{ if ne(variableTemplate.parameters, '') }}:
+              ${{ insert }}: ${{ variableTemplate.parameters }}
+
+      - ${{ each variable in parameters.variables }}:
+        - ${{ variable }}
+
+    steps:
+    - ${{ if eq(parameters.osGroup, 'windows') }}:
+      - template: /eng/pipelines/common/templates/disable-vsupdate-or-failfast.yml
+
+    - checkout: self
+      path: s
+      clean: true
+      fetchDepth: $(checkoutFetchDepth)
+    - checkout: diagnostics
+      path: s/diagnostics
+      clean: true
+      fetchDepth: $(checkoutFetchDepth)
+
+    - ${{ if and(eq(parameters.isOfficialBuild, true), notin(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator')) }}:
+      - template: /eng/pipelines/common/restore-internal-tools.yml
+
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.hostedOs, 'windows')) }}:
+        - task: Bash@3
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - ${{ else }}:
+        - task: PowerShell@2
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        # Run the NuGetAuthenticate task after the internal feeds are added to the nuget.config
+        # This ensures that creds are set appropriately for all feeds in the config, and that the
+        # credential provider is installed.
+        - task: NuGetAuthenticate@1
+
+    - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
+      - script: $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh ${{ parameters.osGroup }}
+        displayName: Install Build Dependencies
+
+      - script: |
+          du -sh $(Build.SourcesDirectory)/*
+          df -h
+        displayName: Disk Usage before Build
+
+    - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:
+      # Update machine certs
+      - task: PowerShell@2
+        displayName: Update machine certs
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/pipelines/mono/update-machine-certs.ps1
+
+    - ${{ if ne(parameters.preBuildSteps,'') }}:
+      - ${{ each preBuildStep in parameters.preBuildSteps }}:
+        - ${{ if ne(preBuildStep.template, '') }}:
+          - template: ${{ preBuildStep.template }}
+            parameters:
+              osGroup: ${{ parameters.osGroup }}
+              osSubgroup: ${{ parameters.osSubgroup }}
+              archType: ${{ parameters.archType }}
+              buildConfig: ${{ parameters.buildConfig }}
+              runtimeFlavor: ${{ parameters.runtimeFlavor }}
+              runtimeVariant: ${{ parameters.runtimeVariant }}
+              helixQueues: ${{ parameters.helixQueues }}
+              targetRid: ${{ parameters.targetRid }}
+              name: ${{ parameters.name }}
+              platform: ${{ parameters.platform }}
+              shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+              ${{ if ne(preBuildStep.forwardedParameters, '') }}:
+                ${{ each parameter in preBuildStep.forwardedParameters }}:
+                  ${{ parameter }}: ${{ parameters[parameter] }}
+              ${{ if ne(preBuildStep.parameters, '') }}:
+                ${{ insert }}: ${{ preBuildStep.parameters }}
+        - ${{ else }}:
+          - ${{ preBuildStep }}
+
+    # Build
+    - script: $(_buildScript)
+          -ci
+          -configuration ${{ parameters.buildConfig }}
+          -architecture ${{ parameters.archType }}
+          $(_TestArgs)
+          $(_Cross)
+          $(_InternalInstallArgs)
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+      ${{ if eq(parameters.testOnly, 'true') }}:
+        displayName: Test
+      ${{ elseif eq(parameters.buildOnly, 'true') }}:
+        displayName: Build
+      ${{ else }}:
+        displayName: Build / Test
+      condition: succeeded()
+
+    - ${{ if in(parameters.osGroup, 'osx', 'ios', 'tvos', 'android') }}:
+      - script: |
+          du -sh $(Build.SourcesDirectory)/*
+          df -h
+        displayName: Disk Usage after Build
+        condition: always()
+
+      # If intended to send extra steps after regular build add them here.
+    - ${{ if ne(parameters.postBuildSteps,'') }}:
+      - ${{ each postBuildStep in parameters.postBuildSteps }}:
+        - ${{ if ne(postBuildStep.template, '') }}:
+          - template: ${{ postBuildStep.template }}
+            parameters:
+              osGroup: ${{ parameters.osGroup }}
+              osSubgroup: ${{ parameters.osSubgroup }}
+              archType: ${{ parameters.archType }}
+              buildConfig: ${{ parameters.buildConfig }}
+              runtimeFlavor: ${{ parameters.runtimeFlavor }}
+              runtimeVariant: ${{ parameters.runtimeVariant }}
+              helixQueues: ${{ parameters.helixQueues }}
+              targetRid: ${{ parameters.targetRid }}
+              name: ${{ parameters.name }}
+              platform: ${{ parameters.platform }}
+              shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+              ${{ if ne(postBuildStep.forwardedParameters, '') }}:
+                ${{ each parameter in postBuildStep.forwardedParameters }}:
+                  ${{ parameter }}: ${{ parameters[parameter] }}
+              ${{ if ne(postBuildStep.parameters, '') }}:
+                ${{ insert }}: ${{ postBuildStep.parameters }}
+        - ${{ else }}:
+          - ${{ postBuildStep }}
+
+      - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.osGroup, 'windows')) }}:
+        - powershell: ./eng/collect_vsinfo.ps1 -ArchiveRunName postbuild_log
+          displayName: Collect vslogs on exit
+          condition: always()

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -70,3 +70,16 @@ extends:
                   artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr$(archiveExtension)
                   unpackFolder: $(Build.SourcesDirectory)/artifacts/runtime
                   displayName: 'Runtime Build Artifacts'
+            postBuildSteps:
+            - task: PublishTestResults@2
+              inputs:
+                testResultsFormat: xUnit
+                testResultsFiles: '**/*.xml'
+                searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+                testRunTitle: 'Tests $(_PhaseName)'
+                failTaskOnFailedTests: true
+                publishRunAttachments: true
+                mergeTestResults: true
+                buildConfiguration: $(_BuildConfig)
+              continueOnError: true
+              condition: always()

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -4,9 +4,9 @@ resources:
   repositories:
     - repository: diagnostics
       type: github
-      name: dotnet/diagnostics
+      name: steveisok/diagnostics
       endpoint: public
-      ref: refs/heads/stpfiste/live-runtime-option
+      ref: refs/heads/live-runtime-option
 
 variables:
   - template: /eng/pipelines/common/variables.yml
@@ -37,9 +37,13 @@ extends:
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             timeoutInMinutes: 360
             postBuildSteps:
+            - powershell: |
+                $versionDir = Get-ChildItem -Directory -Path "$(Build.SourcesDirectory)\artifacts\bin\testhost\net*\shared\Microsoft.NETCore.App" | Select-Object -ExpandProperty FullName
+                Write-Host "##vso[task.setvariable variable=versionDir]$versionDir"
+              displayName: 'Set Path to Shared Framework Artifacts'
             - template: /eng/pipelines/common/upload-artifact-step.yml
               parameters:
-                rootFolder: $(Build.SourcesDirectory)/artifacts/bin/testhost/net*/shared/Microsoft.NETCore.App/**/
+                rootFolder: $(versionDir)
                 includeRootFolder: false
                 archiveType: $(archiveType)
                 archiveExtension: $(archiveExtension)
@@ -58,7 +62,8 @@ extends:
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360
-            dependsOn: build_windows_x64_release_AllSubsets_CoreCLR
+            dependsOn: 
+            - build_windows_x64_release_AllSubsets_CoreCLR
             preBuildSteps:
               - template: /eng/pipelines/common/download-artifact-step.yml
                 parameters:

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -32,7 +32,7 @@ extends:
           platforms:
           - windows_x64
           jobParameters:
-            buildArgs: -s clr+libs+host+packs -c $(_BuildConfig)
+            buildArgs: -s clr+libs+tools.cdacreader+host+packs -c $(_BuildConfig)
             nameSuffix: AllSubsets_CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             timeoutInMinutes: 360

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -1,13 +1,5 @@
 trigger: none
 
-schedules:
-  - cron: "0 10 * * *" # run at 10:00 (UTC) which is 2:00 (PST).
-    displayName: Runtime Diagnostics scheduled run
-    branches:
-      include:
-      - main
-    always: true
-
 resources:
   repositories:
     - repository: diagnostics

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -53,7 +53,6 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/diagnostics/runtime-diag-job.yml
           buildConfig: release
-          runtimeFlavor: mono
           platforms:
           - windows_x64
           jobParameters:

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -4,9 +4,8 @@ resources:
   repositories:
     - repository: diagnostics
       type: github
-      name: steveisok/diagnostics
+      name: dotnet/diagnostics
       endpoint: public
-      ref: refs/heads/live-runtime-option
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -6,6 +6,7 @@ resources:
       type: github
       name: dotnet/diagnostics
       endpoint: public
+      ref: refs/heads/stpfiste/live-runtime-option
 
 variables:
   - template: /eng/pipelines/common/variables.yml
@@ -38,7 +39,7 @@ extends:
             postBuildSteps:
             - template: /eng/pipelines/common/upload-artifact-step.yml
               parameters:
-                rootFolder: $(Build.SourcesDirectory)/artifacts/bin
+                rootFolder: $(Build.SourcesDirectory)/artifacts/bin/testhost/net*/shared/Microsoft.NETCore.App/**/
                 includeRootFolder: false
                 archiveType: $(archiveType)
                 archiveExtension: $(archiveExtension)
@@ -55,4 +56,13 @@ extends:
           jobParameters:
             name: Windows
             isOfficialBuild: ${{ variables.isOfficialBuild }}
+            liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360
+            dependsOn: build_windows_x64_release_AllSubsets_CoreCLR
+            preBuildSteps:
+              - template: /eng/pipelines/common/download-artifact-step.yml
+                parameters:
+                  artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
+                  artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr$(archiveExtension)
+                  unpackFolder: $(Build.SourcesDirectory)/artifacts/runtime
+                  displayName: 'Runtime Build Artifacts'

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -9,8 +9,6 @@ resources:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
-  - name: diagJobTemplate
-    value: /eng/common/templates/job/job.yml
 
 schedules:
 - cron: "30 2 * * *"
@@ -37,21 +35,24 @@ extends:
             nameSuffix: AllSubsets_CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             timeoutInMinutes: 360
-      - template: /eng/pipelines/build.yml@diagnostics
+            postBuildSteps:
+            - template: /eng/pipelines/common/upload-artifact-step.yml
+              parameters:
+                rootFolder: $(Build.SourcesDirectory)/artifacts/bin
+                includeRootFolder: false
+                archiveType: $(archiveType)
+                archiveExtension: $(archiveExtension)
+                tarCompression: $(tarCompression)
+                artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
+                displayName: Build Assets            
+      - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: ${{ variables.diagJobTemplate }}
-          name: Windows
-          osGroup: Windows_NT
-          buildConfigs:
-          - configuration: Debug
-            architecture: x64
-          - configuration: Release
-            architecture: x64
-            artifactUploadPath: bin
-          - configuration: Release
-            architecture: x86
-            artifactUploadPath: bin/Windows_NT.x86.Release
-          - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            - configuration: Release
-              architecture: arm64
-              artifactUploadPath: bin/Windows_NT.arm64.Release
+          jobTemplate: /eng/pipelines/diagnostics/runtime-diag-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - windows_x64
+          jobParameters:
+            name: Windows
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 360

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -32,3 +32,32 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms:
+          - windows_x64
+          jobParameters:
+            buildArgs: -s clr+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: AllSubsets_CoreCLR
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 360
+      - template: /eng/pipelines/build.yml@diagnostics
+        parameters:
+          jobTemplate: /eng/common/templates/job/job.yml@diagnostics
+          name: Windows
+          osGroup: Windows_NT
+          buildConfigs:
+          - configuration: Debug
+            architecture: x64
+          - configuration: Release
+            architecture: x64
+            artifactUploadPath: bin
+          - configuration: Release
+            architecture: x86
+            artifactUploadPath: bin/Windows_NT.x86.Release
+          - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            - configuration: Release
+              architecture: arm64
+              artifactUploadPath: bin/Windows_NT.arm64.Release


### PR DESCRIPTION
The goal of this change is to allow any runtime PR that may impact diagnostics to manually trigger a pipeline that runs the runtime->diagnostics build / test.

The yml is probably a bit duplicative, but the intent is to keep it simple.