### PR TITLE
Fixup null annotations from ClaimsPrincipal

### DIFF
--- a/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
+++ b/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
@@ -90,7 +90,7 @@ namespace System.Security.Claims
         public ClaimsPrincipal(System.Security.Principal.IIdentity identity) { }
         public ClaimsPrincipal(System.Security.Principal.IPrincipal principal) { }
         public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get { throw null; } }
-        public static System.Func<System.Security.Claims.ClaimsPrincipal> ClaimsPrincipalSelector { get { throw null; } set { } }
+        public static System.Func<System.Security.Claims.ClaimsPrincipal?>? ClaimsPrincipalSelector { get { throw null; } set { } }
         public static System.Security.Claims.ClaimsPrincipal? Current { get { throw null; } }
         protected virtual byte[]? CustomSerializationData { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.ClaimsIdentity> Identities { get { throw null; } }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -28,7 +28,7 @@ namespace System.Security.Claims
         private readonly byte[]? _userSerializationData;
 
         private static Func<IEnumerable<ClaimsIdentity>, ClaimsIdentity?> s_identitySelector = SelectPrimaryIdentity;
-        private static Func<ClaimsPrincipal> s_principalSelector = ClaimsPrincipalSelector;
+        private static Func<ClaimsPrincipal?>? s_principalSelector;
 
         private static ClaimsPrincipal? SelectClaimsPrincipal()
         {
@@ -74,26 +74,14 @@ namespace System.Security.Claims
 
         public static Func<IEnumerable<ClaimsIdentity>, ClaimsIdentity?> PrimaryIdentitySelector
         {
-            get
-            {
-                return s_identitySelector;
-            }
-            set
-            {
-                s_identitySelector = value;
-            }
+            get => s_identitySelector;
+            set => s_identitySelector = value;
         }
 
-        public static Func<ClaimsPrincipal> ClaimsPrincipalSelector
+        public static Func<ClaimsPrincipal?>? ClaimsPrincipalSelector
         {
-            get
-            {
-                return s_principalSelector;
-            }
-            set
-            {
-                s_principalSelector = value;
-            }
+            get => s_principalSelector;
+            set => s_principalSelector = value;
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Claims/tests/ClaimsPrincipalTests.cs
+++ b/src/libraries/System.Security.Claims/tests/ClaimsPrincipalTests.cs
@@ -242,6 +242,26 @@ namespace System.Security.Claims
             }).Dispose();
         }
 
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void ClaimsPrincipalSelector_DefaultNull()
+        {
+            RemoteExecutor.Invoke(static () =>
+            {
+                Assert.Null(ClaimsPrincipal.ClaimsPrincipalSelector);
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void ClaimsPrincipalSelector_Roundtrip()
+        {
+            RemoteExecutor.Invoke(static () =>
+            {
+                ClaimsPrincipal selected = new();
+                ClaimsPrincipal.ClaimsPrincipalSelector = () => selected;
+                Assert.Same(selected, ClaimsPrincipal.ClaimsPrincipalSelector());
+            }).Dispose();
+        }
+
         private class NonClaimsPrincipal : IPrincipal
         {
             public IIdentity Identity { get; set; }


### PR DESCRIPTION
The code around `s_claimsPrincipalSelector` was a little confusing, so this cleans it up, and changes some nullable annotations.

1. `ClaimsPrincipalSelector` can return a null `Func`. The field initializer was _probably_ meant to be `SelectClaimsPrincipal`, not `ClaimsPrincipalSelector`. However, [it's like this in .NET Framework](https://referencesource.microsoft.com/#mscorlib/system/security/claims/ClaimsPrincipal.cs,79), so we'll leave it functionally the same for compat.
2. As such, the `ref` has been adjusted so that `ClaimsPrincipalSelector` can be null, as well as the `Func` itself allowing its return value to be null. The selector is allows to say "I don't know, null" for `Current`, so the Func should be allowed to return null.

Fixes #111031