### PR TITLE
Make IsApplePlatform() public

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -242,8 +242,12 @@ namespace System
             false;
 #endif
 
-        internal static bool IsApplePlatform() =>
-#if TARGET_OSX || TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+        /// <summary>
+        /// Indicates whether the current application is running on Apple platforms, including macOS, iOS, tvOS, watchOS, and Mac Catalyst.
+        /// </summary>
+        [NonVersionable]
+        public static bool IsApplePlatform() =>
+#if TARGET_OSX || TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS || TARGET_WATCHOS
             true;
 #else
             false;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4913,6 +4913,7 @@ namespace System
         public static bool IsMacCatalystVersionAtLeast(int major, int minor = 0, int build = 0) { throw null; }
         public static bool IsMacOS() { throw null; }
         public static bool IsMacOSVersionAtLeast(int major, int minor = 0, int build = 0) { throw null; }
+        public static bool IsApplePlatform() { throw null; }
         public static bool IsOSPlatform(string platform) { throw null; }
         public static bool IsOSPlatformVersionAtLeast(string platform, int major, int minor = 0, int build = 0, int revision = 0) { throw null; }
         public static bool IsTvOS() { throw null; }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
@@ -23,6 +23,15 @@ namespace System.Tests
             "Wasi",
         };
 
+        private static readonly HashSet<string> AllApplePlatformNames = new()
+        {
+            "macOS",
+            "MacCatalyst",
+            "iOS",
+            "tvOS",
+            "watchOS",
+        };
+
         [Theory]
         [InlineData(PlatformID.Other, "1.0.0.0")]
         [InlineData(PlatformID.MacOSX, "1.2")]
@@ -187,6 +196,15 @@ namespace System.Tests
             }
 
             Assert.True(currentOSCheck());
+
+            if (AllApplePlatformNames.Contains(currentOSName))
+            {
+                Assert.Equal(true, OperatingSystem.IsApplePlatform());
+            }
+            else 
+            {
+                Assert.Equal(false, OperatingSystem.IsApplePlatform());
+            }
 
             Dictionary<string, bool> allResults = new()
             {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
@@ -199,11 +199,11 @@ namespace System.Tests
 
             if (AllApplePlatformNames.Contains(currentOSName))
             {
-                Assert.Equal(true, OperatingSystem.IsApplePlatform());
+                Assert.True(OperatingSystem.IsApplePlatform());
             }
             else 
             {
-                Assert.Equal(false, OperatingSystem.IsApplePlatform());
+                Assert.False(OperatingSystem.IsApplePlatform());
             }
 
             Dictionary<string, bool> allResults = new()


### PR DESCRIPTION
Make `OperatingSystem.IsApplePlatform()` public, which indicates whether the current application is running on Apple platforms, including macOS, iOS, tvOS, watchOS, and Mac Catalyst.

Closes #113262 