### PR TITLE
[release/8.0][browser][http] mute JS exceptions about network errors + HEAD verb

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -229,6 +229,99 @@ namespace System.Net.Http.Functional.Tests
         }
 
 #if NETCOREAPP
+        public static IEnumerable<object[]> HttpMethods => new object[][]
+        {
+            new [] { HttpMethod.Get },
+            new [] { HttpMethod.Head },
+            new [] { HttpMethod.Post },
+            new [] { HttpMethod.Put },
+            new [] { HttpMethod.Delete },
+            new [] { HttpMethod.Options },
+            new [] { HttpMethod.Patch },
+        };
+
+        public static IEnumerable<object[]> HttpMethodsAndAbort => new object[][]
+        {
+            new object[] { HttpMethod.Get, "abortBeforeHeaders" },
+            new object[] { HttpMethod.Head , "abortBeforeHeaders"},
+            new object[] { HttpMethod.Post , "abortBeforeHeaders"},
+            new object[] { HttpMethod.Put , "abortBeforeHeaders"},
+            new object[] { HttpMethod.Delete , "abortBeforeHeaders"},
+            new object[] { HttpMethod.Options , "abortBeforeHeaders"},
+            new object[] { HttpMethod.Patch , "abortBeforeHeaders"},
+
+            new object[] { HttpMethod.Get, "abortAfterHeaders" },
+            new object[] { HttpMethod.Post , "abortAfterHeaders"},
+            new object[] { HttpMethod.Put , "abortAfterHeaders"},
+            new object[] { HttpMethod.Delete , "abortAfterHeaders"},
+            new object[] { HttpMethod.Options , "abortAfterHeaders"},
+            new object[] { HttpMethod.Patch , "abortAfterHeaders"},
+
+            new object[] { HttpMethod.Get, "abortDuringBody" },
+            new object[] { HttpMethod.Post , "abortDuringBody"},
+            new object[] { HttpMethod.Put , "abortDuringBody"},
+            new object[] { HttpMethod.Delete , "abortDuringBody"},
+            new object[] { HttpMethod.Options , "abortDuringBody"},
+            new object[] { HttpMethod.Patch , "abortDuringBody"},
+
+       };
+
+        [MemberData(nameof(HttpMethods))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
+        public async Task BrowserHttpHandler_StreamingResponse(HttpMethod method)
+        {
+            var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
+
+            var req = new HttpRequestMessage(method, Configuration.Http.RemoteHttp11Server.BaseUri + "echo.ashx");
+            req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
+
+            if(method == HttpMethod.Post)
+            {
+                req.Content = new StringContent("hello world");
+            }
+
+            using (HttpClient client = CreateHttpClientForRemoteServer(Configuration.Http.RemoteHttp11Server))
+            // we need to switch off Response buffering of default ResponseContentRead option
+            using (HttpResponseMessage response = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
+            {
+                using var content = response.Content;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(typeof(StreamContent), content.GetType());
+                Assert.NotEqual(0, content.Headers.ContentLength);
+                if (method != HttpMethod.Head)
+                {
+                    var data = await content.ReadAsByteArrayAsync();
+                    Assert.NotEqual(0, data.Length);
+                }
+            }
+        }
+
+        [MemberData(nameof(HttpMethodsAndAbort))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
+        public async Task BrowserHttpHandler_StreamingResponseAbort(HttpMethod method, string abort)
+        {
+            var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
+
+            var req = new HttpRequestMessage(method, Configuration.Http.RemoteHttp11Server.BaseUri + "echo.ashx?" + abort + "=true");
+            req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
+
+            if (method == HttpMethod.Post || method == HttpMethod.Put || method == HttpMethod.Patch)
+            {
+                req.Content = new StringContent("hello world");
+            }
+
+            HttpClient client = CreateHttpClientForRemoteServer(Configuration.Http.RemoteHttp11Server);
+            if (abort == "abortDuringBody")
+            {
+                using var res = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
+                await Assert.ThrowsAsync<HttpRequestException>(() => res.Content.ReadAsByteArrayAsync());
+            }
+            else
+            {
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead));
+            }
+        }
+
         [OuterLoop]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public async Task BrowserHttpHandler_Streaming()

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoHandler.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace NetCoreServer
 {
@@ -20,23 +22,80 @@ namespace NetCoreServer
                 return;
             }
 
-            // Add original request method verb as a custom response header.
-            context.Response.Headers["X-HttpRequest-Method"] = context.Request.Method;
+
+            var qs = context.Request.QueryString.HasValue ? context.Request.QueryString.Value : "";
+            var delay = 0;
+            if (qs.Contains("delay1sec"))
+            {
+                delay = 1000;
+            }
+            else if (qs.Contains("delay10sec"))
+            {
+                delay = 10000;
+            }
+
+            if (qs.Contains("abortBeforeHeaders"))
+            {
+                context.Abort();
+                return;
+            }
+
+            if (delay > 0)
+            {
+                context.Features.Get<IHttpResponseBodyFeature>().DisableBuffering();
+            }
 
             // Echo back JSON encoded payload.
             RequestInformation info = await RequestInformation.CreateAsync(context.Request);
             string echoJson = info.SerializeToJson();
+            byte[] bytes = Encoding.UTF8.GetBytes(echoJson);
+
+            // Add original request method verb as a custom response header.
+            context.Response.Headers["X-HttpRequest-Method"] = context.Request.Method;
 
             // Compute MD5 hash so that clients can verify the received data.
             using (MD5 md5 = MD5.Create())
             {
-                byte[] bytes = Encoding.UTF8.GetBytes(echoJson);
                 byte[] hash = md5.ComputeHash(bytes);
                 string encodedHash = Convert.ToBase64String(hash);
 
                 context.Response.Headers["Content-MD5"] = encodedHash;
                 context.Response.ContentType = "application/json";
                 context.Response.ContentLength = bytes.Length;
+            }
+
+            await context.Response.StartAsync(CancellationToken.None);
+
+            if (qs.Contains("abortAfterHeaders"))
+            {
+                await Task.Delay(10);
+                context.Abort();
+                return;
+            }
+
+            if(context.Request.Method == "HEAD")
+            {
+                return;
+            }
+
+            if (delay > 0 || qs.Contains("abortDuringBody"))
+            {
+                await context.Response.Body.WriteAsync(bytes, 0, 10);
+                await context.Response.Body.FlushAsync();
+                if (qs.Contains("abortDuringBody"))
+                {
+                    await context.Response.Body.FlushAsync();
+                    await Task.Delay(10);
+                    context.Abort();
+                    return;
+                }
+
+                await Task.Delay(delay);
+                await context.Response.Body.WriteAsync(bytes, 10, bytes.Length-10);
+                await context.Response.Body.FlushAsync();
+            }
+            else
+            {
                 await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
             }
         }


### PR DESCRIPTION
Backport of #113014 to release/8.0 with modifications for Net8

## Customer Impact
1) In browser HTTP client we subscribe for rejected promises in order to suppress unhandled rejection of `AbortError` when we issue the abort. The current handler also handles other network errors and aborts the whole program, which is not what it should do. Instead the network error should be propagated to managed HTTP client code.

2) in Firefox when the verb is HEAD, the body is null. We should not fail because of that.

- [x] Customer reported
- [ ] Found internally

Contributes to https://github.com/dotnet/runtime/issues/112172
Fixes https://github.com/dotnet/runtime/issues/111992

## Regression

- [x] Yes
- [ ] No

## Testing

Automated tests.

## Risk

**Low**

Both issues are only triggered when user enabled streaming responses. That's opt-in feature in Net8.
