### PR TITLE
[mono] Switch simdhash to prime bucket counts; increase load factor

### DIFF
--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -204,9 +204,7 @@ bundled_resources_get (const char *id)
 	char key_buffer[1024];
 	key_from_id(id, key_buffer, sizeof(key_buffer));
 
-	MonoBundledResource *result = NULL;
-	dn_simdhash_ght_try_get_value (bundled_resources, key_buffer, (void **)&result);
-	return result;
+	return (MonoBundledResource *)dn_simdhash_ght_get_value_or_default (bundled_resources, key_buffer);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1252,7 +1252,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 	mono_mem_manager_lock (mm);
 	if (!mm->gmethod_cache)
 		mm->gmethod_cache = dn_simdhash_ght_new_full (inflated_method_hash, inflated_method_equal, NULL, (GDestroyNotify)free_inflated_method, 0, NULL);
-	dn_simdhash_ght_try_get_value (mm->gmethod_cache, iresult, (void **)&cached);
+	cached = dn_simdhash_ght_get_value_or_default (mm->gmethod_cache, iresult);
 	mono_mem_manager_unlock (mm);
 
 	if (cached) {
@@ -1358,8 +1358,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 
 	// check cache
 	mono_mem_manager_lock (mm);
-	cached = NULL;
-	dn_simdhash_ght_try_get_value (mm->gmethod_cache, iresult, (void **)&cached);
+	cached = dn_simdhash_ght_get_value_or_default (mm->gmethod_cache, iresult);
 	if (!cached) {
 		dn_simdhash_ght_insert (mm->gmethod_cache, iresult, iresult);
 		iresult->owner = mm;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -3359,7 +3359,7 @@ mono_metadata_get_inflated_signature (MonoMethodSignature *sig, MonoGenericConte
 		mm->gsignature_cache = dn_simdhash_ght_new_full (inflated_signature_hash, inflated_signature_equal, NULL, (GDestroyNotify)free_inflated_signature, 256, NULL);
 
 	// FIXME: The lookup is done on the newly allocated sig so it always fails
-	dn_simdhash_ght_try_get_value (mm->gsignature_cache, &helper, (gpointer *)&res);
+	res = dn_simdhash_ght_get_value_or_default (mm->gsignature_cache, &helper);
 	if (!res) {
 		res = mono_mem_manager_alloc0 (mm, sizeof (MonoInflatedMethodSignature));
 		// FIXME: sig is an inflated signature not owned by the mem manager

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2736,7 +2736,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 				default: return FALSE;
 			}
 		}
-	} 
+	}
 
 	return FALSE;
 }
@@ -10036,8 +10036,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 
 		// FIXME Publishing of seq points seems to be racy with tiereing. We can have both tiered and untiered method
 		// running at the same time. We could therefore get the optimized imethod seq points for the unoptimized method.
-		gpointer seq_points = NULL;
-		dn_simdhash_ght_try_get_value (jit_mm->seq_points, imethod->method, (void **)&seq_points);
+		gpointer seq_points = dn_simdhash_ght_get_value_or_default (jit_mm->seq_points, imethod->method);
 		if (!seq_points || seq_points != imethod->jinfo->seq_points)
 			dn_simdhash_ght_replace (jit_mm->seq_points, imethod->method, imethod->jinfo->seq_points);
 	}

--- a/src/mono/mono/mini/seq-points.c
+++ b/src/mono/mono/mini/seq-points.c
@@ -272,12 +272,12 @@ mono_get_seq_points (MonoMethod *method)
 	// FIXME:
 	jit_mm = get_default_jit_mm ();
 	jit_mm_lock (jit_mm);
-	dn_simdhash_ght_try_get_value (jit_mm->seq_points, method, (void **)&seq_points);
+	seq_points = dn_simdhash_ght_get_value_or_default (jit_mm->seq_points, method);
 	if (!seq_points && method->is_inflated) {
 		/* generic sharing + aot */
-		dn_simdhash_ght_try_get_value (jit_mm->seq_points, declaring_generic_method, (void **)&seq_points);
+		seq_points = dn_simdhash_ght_get_value_or_default (jit_mm->seq_points, declaring_generic_method);
 		if (!seq_points)
-			dn_simdhash_ght_try_get_value (jit_mm->seq_points, shared_method, (void **)&seq_points);
+			seq_points = dn_simdhash_ght_get_value_or_default (jit_mm->seq_points, shared_method);
 	}
 	jit_mm_unlock (jit_mm);
 

--- a/src/native/containers/dn-simdhash-ght-compatible.c
+++ b/src/native/containers/dn-simdhash-ght-compatible.c
@@ -16,27 +16,6 @@ typedef struct dn_simdhash_ght_data {
 	dn_simdhash_ght_destroy_func value_destroy_func;
 } dn_simdhash_ght_data;
 
-static inline uint32_t
-dn_simdhash_ght_hash (dn_simdhash_ght_data data, void * key)
-{
-	dn_simdhash_ght_hash_func hash_func = data.hash_func;
-	if (hash_func)
-		return (uint32_t)hash_func(key);
-	else
-		// FIXME: Seed
-		return MurmurHash3_32_ptr(key, 0);
-}
-
-static inline int32_t
-dn_simdhash_ght_equals (dn_simdhash_ght_data data, void * lhs, void * rhs)
-{
-	dn_simdhash_ght_equal_func equal_func = data.key_equal_func;
-	if (equal_func)
-		return equal_func(lhs, rhs);
-	else
-		return lhs == rhs;
-}
-
 static inline void
 dn_simdhash_ght_removed (dn_simdhash_ght_data data, void * key, void * value)
 {
@@ -68,18 +47,38 @@ dn_simdhash_ght_replaced (dn_simdhash_ght_data data, void * old_key, void * new_
 #define DN_SIMDHASH_KEY_T void *
 #define DN_SIMDHASH_VALUE_T void *
 #define DN_SIMDHASH_INSTANCE_DATA_T dn_simdhash_ght_data
-#define DN_SIMDHASH_KEY_HASHER dn_simdhash_ght_hash
-#define DN_SIMDHASH_KEY_EQUALS dn_simdhash_ght_equals
+
+#define DN_SIMDHASH_SCAN_DATA_T dn_simdhash_ght_equal_func
+#define DN_SIMDHASH_GET_SCAN_DATA(data) data.key_equal_func
+
+#define DN_SIMDHASH_KEY_HASHER(data, key) (uint32_t)data.hash_func(key)
+#define DN_SIMDHASH_KEY_EQUALS(scan_data, lhs, rhs) scan_data(lhs, rhs)
+
 #define DN_SIMDHASH_ON_REMOVE dn_simdhash_ght_removed
 #define DN_SIMDHASH_ON_REPLACE dn_simdhash_ght_replaced
+// perfect cache alignment. 128-byte buckets for 64-bit pointers, 64-byte buckets for 32-bit pointers
 #if SIZEOF_VOID_P == 8
-#define DN_SIMDHASH_BUCKET_CAPACITY 11
+#define DN_SIMDHASH_BUCKET_CAPACITY 14
 #else
 #define DN_SIMDHASH_BUCKET_CAPACITY 12
 #endif
 #define DN_SIMDHASH_NO_DEFAULT_NEW 1
 
 #include "dn-simdhash-specialization.h"
+
+static unsigned int
+dn_simdhash_ght_default_hash (const void * key)
+{
+    // You might think we should avalanche the key bits but in my testing, it doesn't help.
+    // Right now the default hash function is rarely used anyway
+    return (unsigned int)(size_t)key;
+}
+
+static int32_t
+dn_simdhash_ght_default_comparer (const void * a, const void * b)
+{
+	return a == b;
+}
 
 dn_simdhash_ght_t *
 dn_simdhash_ght_new (
@@ -88,6 +87,13 @@ dn_simdhash_ght_new (
 )
 {
 	dn_simdhash_ght_t *hash = dn_simdhash_new_internal(&DN_SIMDHASH_T_META, DN_SIMDHASH_T_VTABLE, capacity, allocator);
+	// Most users of dn_simdhash_ght are passing a custom comparer, and always doing an indirect call ends up being faster
+	//  than conditionally doing a fast inline check when there's no comparer set. Somewhat counter-intuitive, but true
+	//  on both x64 and arm64. Probably due to the smaller code size and reduced branch predictor pressure.
+	if (!hash_func)
+		hash_func = dn_simdhash_ght_default_hash;
+	if (!key_equal_func)
+		key_equal_func = dn_simdhash_ght_default_comparer;
 	dn_simdhash_instance_data(dn_simdhash_ght_data, hash).hash_func = hash_func;
 	dn_simdhash_instance_data(dn_simdhash_ght_data, hash).key_equal_func = key_equal_func;
 	return hash;
@@ -101,6 +107,10 @@ dn_simdhash_ght_new_full (
 )
 {
 	dn_simdhash_ght_t *hash = dn_simdhash_new_internal(&DN_SIMDHASH_T_META, DN_SIMDHASH_T_VTABLE, capacity, allocator);
+	if (!hash_func)
+		hash_func = dn_simdhash_ght_default_hash;
+	if (!key_equal_func)
+		key_equal_func = dn_simdhash_ght_default_comparer;
 	dn_simdhash_instance_data(dn_simdhash_ght_data, hash).hash_func = hash_func;
 	dn_simdhash_instance_data(dn_simdhash_ght_data, hash).key_equal_func = key_equal_func;
 	dn_simdhash_instance_data(dn_simdhash_ght_data, hash).key_destroy_func = key_destroy_func;
@@ -144,4 +154,18 @@ dn_simdhash_ght_insert_replace (
 			assert(0);
 			return;
 	}
+}
+
+void *
+dn_simdhash_ght_get_value_or_default (
+	dn_simdhash_ght_t *hash, void * key
+)
+{
+	check_self(hash);
+	uint32_t key_hash = DN_SIMDHASH_KEY_HASHER(DN_SIMDHASH_GET_DATA(hash), key);
+	DN_SIMDHASH_VALUE_T *value_ptr = DN_SIMDHASH_FIND_VALUE_INTERNAL(hash, key, key_hash);
+	if (value_ptr)
+		return *value_ptr;
+	else
+		return NULL;
 }

--- a/src/native/containers/dn-simdhash-ght-compatible.h
+++ b/src/native/containers/dn-simdhash-ght-compatible.h
@@ -28,6 +28,12 @@ dn_simdhash_ght_insert_replace (
 	int32_t overwrite_key
 );
 
+// faster and simpler to use than dn_simdhash_ght_try_get_value, use it wisely
+void *
+dn_simdhash_ght_get_value_or_default (
+	dn_simdhash_ght_t *hash, void * key
+);
+
 // compatibility shims for the g_hash_table_ versions in glib.h
 #define dn_simdhash_ght_insert(h,k,v)  dn_simdhash_ght_insert_replace ((h),(k),(v),FALSE)
 #define dn_simdhash_ght_replace(h,k,v) dn_simdhash_ght_insert_replace ((h),(k),(v),TRUE)

--- a/src/native/containers/dn-simdhash-ptr-ptr.c
+++ b/src/native/containers/dn-simdhash-ptr-ptr.c
@@ -11,10 +11,11 @@
 #define DN_SIMDHASH_T dn_simdhash_ptr_ptr
 #define DN_SIMDHASH_KEY_T void *
 #define DN_SIMDHASH_VALUE_T void *
-#define DN_SIMDHASH_KEY_HASHER(hash, key) (MurmurHash3_32_ptr(key, 0))
-#define DN_SIMDHASH_KEY_EQUALS(hash, lhs, rhs) (lhs == rhs)
+#define DN_SIMDHASH_KEY_HASHER(data, key) (MurmurHash3_32_ptr(key, 0))
+#define DN_SIMDHASH_KEY_EQUALS(data, lhs, rhs) (lhs == rhs)
+// perfect cache alignment. 128-byte buckets for 64-bit pointers, 64-byte buckets for 32-bit pointers
 #if SIZEOF_VOID_P == 8
-#define DN_SIMDHASH_BUCKET_CAPACITY 11
+#define DN_SIMDHASH_BUCKET_CAPACITY 14
 #else
 #define DN_SIMDHASH_BUCKET_CAPACITY 12
 #endif

--- a/src/native/containers/dn-simdhash-ptrpair-ptr.c
+++ b/src/native/containers/dn-simdhash-ptrpair-ptr.c
@@ -26,8 +26,8 @@ dn_ptrpair_t_equals (dn_ptrpair_t lhs, dn_ptrpair_t rhs)
 #define DN_SIMDHASH_T dn_simdhash_ptrpair_ptr
 #define DN_SIMDHASH_KEY_T dn_ptrpair_t
 #define DN_SIMDHASH_VALUE_T void *
-#define DN_SIMDHASH_KEY_HASHER(hash, key) dn_ptrpair_t_hash(key)
-#define DN_SIMDHASH_KEY_EQUALS(hash, lhs, rhs) dn_ptrpair_t_equals(lhs, rhs)
+#define DN_SIMDHASH_KEY_HASHER(data, key) dn_ptrpair_t_hash(key)
+#define DN_SIMDHASH_KEY_EQUALS(data, lhs, rhs) dn_ptrpair_t_equals(lhs, rhs)
 #if SIZEOF_VOID_P == 8
 // 192 bytes holds 12 16-byte blocks, so 11 keys and one suffix table
 #define DN_SIMDHASH_BUCKET_CAPACITY 11

--- a/src/native/containers/dn-simdhash-string-ptr.c
+++ b/src/native/containers/dn-simdhash-string-ptr.c
@@ -35,8 +35,8 @@ dn_simdhash_str_hash (dn_simdhash_str_key v1)
 #define DN_SIMDHASH_T dn_simdhash_string_ptr
 #define DN_SIMDHASH_KEY_T dn_simdhash_str_key
 #define DN_SIMDHASH_VALUE_T void *
-#define DN_SIMDHASH_KEY_HASHER(hash, key) dn_simdhash_str_hash(key)
-#define DN_SIMDHASH_KEY_EQUALS(hash, lhs, rhs) dn_simdhash_str_equal(lhs, rhs)
+#define DN_SIMDHASH_KEY_HASHER(data, key) dn_simdhash_str_hash(key)
+#define DN_SIMDHASH_KEY_EQUALS(data, lhs, rhs) dn_simdhash_str_equal(lhs, rhs)
 #define DN_SIMDHASH_ACCESSOR_SUFFIX _raw
 
 // perfect cache alignment. 32-bit ptrs: 8-byte keys. 64-bit: 16-byte keys.

--- a/src/native/containers/dn-simdhash-u32-ptr.c
+++ b/src/native/containers/dn-simdhash-u32-ptr.c
@@ -7,7 +7,7 @@
 #define DN_SIMDHASH_T dn_simdhash_u32_ptr
 #define DN_SIMDHASH_KEY_T uint32_t
 #define DN_SIMDHASH_VALUE_T void *
-#define DN_SIMDHASH_KEY_HASHER(hash, key) murmur3_fmix32(key)
-#define DN_SIMDHASH_KEY_EQUALS(hash, lhs, rhs) (lhs == rhs)
+#define DN_SIMDHASH_KEY_HASHER(data, key) murmur3_fmix32(key)
+#define DN_SIMDHASH_KEY_EQUALS(data, lhs, rhs) (lhs == rhs)
 
 #include "dn-simdhash-specialization.h"

--- a/src/native/containers/dn-simdhash-utils.h
+++ b/src/native/containers/dn-simdhash-utils.h
@@ -176,6 +176,35 @@ MurmurHash3_32_streaming (const uint8_t *key, uint32_t seed)
 	return h1;
 }
 
+static inline uint32_t
+MurmurHash3_32 (const uint8_t *key, uint32_t key_length, uint32_t seed)
+{
+	uint32_t h1 = seed;
+
+	while (key_length >= sizeof(uint32_t)) {
+		uint32_t block = *(uint32_t *)key;
+		MURMUR3_HASH_BLOCK(block);
+		key += sizeof(uint32_t);
+		key_length -= sizeof(uint32_t);
+	}
+
+	if (key_length) {
+		uint32_t last_block = 0;
+		// This is incorrect but easier to write
+		while (key_length > 0) {
+			last_block |= *key;
+			last_block <<= 8;
+			key++;
+		}
+		MURMUR3_HASH_BLOCK(last_block);
+	}
+
+	// finalize. note this is not the same as 32_streaming
+	h1 ^= key_length;
+	h1 = murmur3_fmix32(h1);
+	return h1;
+}
+
 // end of reformulated murmur3-32
 
 void

--- a/src/native/containers/simdhash-benchmark/Makefile
+++ b/src/native/containers/simdhash-benchmark/Makefile
@@ -5,7 +5,7 @@ benchmark_deps := $(wildcard ./*.c) $(wildcard ./*.h)
 # I don't know why this is necessary
 nodejs_path := $(shell which node)
 
-benchmark_sources := ../dn-simdhash.c ../dn-vector.c ./benchmark.c ../dn-simdhash-u32-ptr.c ../dn-simdhash-string-ptr.c ./ghashtable.c ./all-measurements.c
+benchmark_sources := ../dn-simdhash.c ../dn-vector.c ./benchmark.c ../dn-simdhash-u32-ptr.c ../dn-simdhash-string-ptr.c ../dn-simdhash-ght-compatible.c ./ghashtable.c ./all-measurements.c
 common_options := -g -O3 -DNO_CONFIG_H -lm -DNDEBUG
 ifeq ($(SIMD), 0)
 	wasm_options := -mbulk-memory
@@ -15,12 +15,10 @@ endif
 
 benchmark-native: $(dn_deps) $(benchmark_deps)
 	clang $(benchmark_sources) $(common_options) -DSIZEOF_VOID_P=8
+	objdump -S -d --no-show-raw-insn ./a.out > ./a.dis
 
 benchmark-wasm: $(dn_deps) $(benchmark_deps)
 	~/Projects/emscripten/emcc $(benchmark_sources) $(common_options) $(wasm_options) -DSIZEOF_VOID_P=4
-
-disassemble-benchmark: benchmark-native benchmark-wasm
-	objdump -d ./a.out > ./a.dis
 	~/wabt/bin/wasm2wat ./a.out.wasm > ./a.wat
 
 run-native: benchmark-native
@@ -29,5 +27,5 @@ run-native: benchmark-native
 run-wasm: benchmark-wasm
 	$(nodejs_path) ./a.out.js $(FILTER)
 
-default_target: disassemble-benchmark
+default_target: benchmark-native
 


### PR DESCRIPTION
Supercedes (contains) #113241.

The current version of dn_simdhash_ght_compatible has especially bad performance on arm64 vs x64, so I took some steps to redesign it and address some codegen deficiencies. This has the added benefit of making it a bit faster on x64 as well.

There weren't benchmarks for ght_compatible in the benchmark suite originally, so I added a couple. (I was benchmarking end-to-end originally, which makes it harder to compare across platforms.)

The F14 research and my initial research into vectorized hashing both showed that power-of-two bucket counts delivered optimal performance, but later on when doing the Dictionary vectorization work I determined that power-of-two counts have vastly inferior collision resistance compared to prime bucket counts. GHashTable and SCG.Dictionary both use spaced primes for bucket counts, so this PR attempts to do the same for dn_simdhash.

The best-case performance (for an optimal hash) gets a little worse but when I benchmarked power-of-two counts with a synthetic bad hash function the perf regression was over 100x, versus ~2x for prime bucket counts.

I also improved the search suffix selection to match the better one I came up with from the vectorized dictionary research, and added some benchmarks for the bad hash function scenario.

Selected benchmark measurements from x64:

| scenario | simdhash u32_ptr | simdhash_ght | ghashtable |
|----------|------------------|--------------|------------|
| find missing keys | 18.574ns | 20.505ns | 62.659ns |
| find random keys | 22.574ns | 26.241ns | 47.767ns |
| find sequential keys | n/a | 42.262ns | 38.103ns |
| find missing key with bad hash | n/a | 3.465ns | 0.972ns | 
| find random key with bad hash | n/a | 2.383ns | 1.021ns |

I did measurements on ampere arm64 as well and verified that it's okay there.