### PR TITLE
Remove use of --no-lock with Homebrew.

### DIFF
--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -26,5 +26,5 @@ To build the runtime repo, you will also need to install the following dependenc
 You can install them separately, or you can alternatively opt to install *[Homebrew](https://brew.sh/)* and use the `Brewfile` provided by the repo, which takes care of everything for you. If you go by this route, once you have *Homebrew* up and running on your machine, run the following command from the root of the repo to download and install all the necessary dependencies at once:
 
 ```bash
-brew bundle --no-lock --file eng/Brewfile
+brew bundle --file eng/Brewfile
 ```

--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -26,5 +26,5 @@ To build the runtime repo, you will also need to install the following dependenc
 You can install them separately, or you can alternatively opt to install *[Homebrew](https://brew.sh/)* and use the `Brewfile` provided by the repo, which takes care of everything for you. If you go by this route, once you have *Homebrew* up and running on your machine, run the following command from the root of the repo to download and install all the necessary dependencies at once:
 
 ```bash
-brew bundle --file eng/Brewfile
+./eng/common/native/install-dependencies.sh
 ```

--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -23,7 +23,7 @@ To build the runtime repo, you will also need to install the following dependenc
 - `python3`
 - `ninja` (This one is optional. It is an alternative tool to `make` for building native code)
 
-You can install them separately, or you can alternatively opt to install *[Homebrew](https://brew.sh/)* and use the `Brewfile` provided by the repo, which takes care of everything for you. If you go by this route, once you have *Homebrew* up and running on your machine, run the following command from the root of the repo to download and install all the necessary dependencies at once:
+You can install them separately, or you can alternatively opt to install *[Homebrew](https://brew.sh/)* and use the `install-dependencies.sh` script provided by the repo, which takes care of everything for you. If you go by this route, once you have *Homebrew* up and running on your machine, run the following command from the root of the repo to download and install all the necessary dependencies at once:
 
 ```bash
 ./eng/common/native/install-dependencies.sh

--- a/eng/Brewfile
+++ b/eng/Brewfile
@@ -1,5 +1,0 @@
-brew "cmake"
-brew "icu4c"
-brew "openssl@3"
-brew "pkg-config"
-brew "python3"

--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -44,7 +44,7 @@ case "$os" in
         export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
         # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
         # brew update --preinstall
-        brew bundle --no-upgrade --no-lock --file=- <<EOF
+        brew bundle --no-upgrade --file=- <<EOF
 brew "cmake"
 brew "icu4c"
 brew "openssl@3"


### PR DESCRIPTION
Homebrew removed lock file generation in https://github.com/Homebrew/homebrew-bundle/pull/1509, and left `--no-lock` as a no-op. It was removed entirely in https://github.com/Homebrew/homebrew-bundle/commit/98d8ad7ddcca7e7b700cd496207d51fa042c0b00, which causes errors when passing this option.

Associated arcade PR: https://github.com/dotnet/arcade/pull/15608

Closes #113276