### PR TITLE
Include xmmintrin.h early on x86 as well

### DIFF
--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -73,7 +73,7 @@
 
 #include <olectl.h>
 
-#ifdef HOST_AMD64
+#if defined(HOST_AMD64) || defined(HOST_X86)
 #include <xmmintrin.h>
 #endif
 

--- a/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathNative.cpp
+++ b/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathNative.cpp
@@ -10,7 +10,7 @@ extern "C" DLL_EXPORT int STDMETHODCALLTYPE GetZero()
 
 #ifdef EXE
 
-extern "C" int __cdecl main(int argc,  char **argv)
+int __cdecl main(int argc,  char **argv)
 {
     return 0;
 }


### PR DESCRIPTION
We're hitting problems with our `debugreturn.h` machinery on x86 with Clang 20. Include xmmintrin.h early on that platform as well to work around it.

Related: https://github.com/dotnet/runtime/pull/113248