### PR TITLE
Coalesce ifdef blocks

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
@@ -26,10 +26,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
             Interop.Runtime.CancelPromise(holder.GCHandle);
 #else
-
-#if FEATURE_WASM_MANAGED_THREADS
             lock (holder.ProxyContext)
-#endif
             {
                 if (promise.IsCompleted || holder.IsDisposed || holder.ProxyContext._isDisposed)
                 {


### PR DESCRIPTION
The `#ifdef` being tested is already known to be true because we're in the `#else` block of the previous test of `!FEATURE_WASM_MANAGED_THREADS` which is the same thing we were testing.
Noted in [this comment](https://github.com/dotnet/runtime/pull/113046#discussion_r1983726305)
