### PR TITLE
[mono] Switch generic instance cache back to GHashTable; improve ginst hash function

### DIFF
--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -175,7 +175,8 @@ struct _MonoMemoryManager {
 	MonoAssemblyLoadContext **alcs;
 
 	// Generic-specific caches
-	dn_simdhash_ght_t *ginst_cache, *gmethod_cache, *gsignature_cache;
+	GHashTable *ginst_cache;
+	dn_simdhash_ght_t *gmethod_cache, *gsignature_cache;
 	MonoConcurrentHashTable *gclass_cache;
 
 	/* mirror caches of ones already on MonoImage. These ones contain generics */

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -238,7 +238,7 @@ memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
 	MonoMemoryManager *mm = memory_manager;
 	if (mm->gclass_cache)
 		mono_conc_hashtable_destroy (mm->gclass_cache);
-	free_simdhash (&mm->ginst_cache);
+	free_hash (&mm->ginst_cache);
 	free_simdhash (&mm->gmethod_cache);
 	free_simdhash (&mm->gsignature_cache);
 	free_hash (&mm->szarray_cache);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -3496,10 +3496,9 @@ mono_metadata_get_canonical_generic_inst (MonoGenericInst *candidate)
 	mono_loader_lock ();
 
 	if (!mm->ginst_cache)
-		mm->ginst_cache = dn_simdhash_ght_new_full (mono_metadata_generic_inst_hash, mono_metadata_generic_inst_equal, NULL, (GDestroyNotify)free_generic_inst, 0, NULL);
+		mm->ginst_cache = g_hash_table_new_full (mono_metadata_generic_inst_hash, mono_metadata_generic_inst_equal, NULL, (GDestroyNotify)free_generic_inst);
 
-	MonoGenericInst *ginst = NULL;
-	dn_simdhash_ght_try_get_value (mm->ginst_cache, candidate, (void **)&ginst);
+	MonoGenericInst *ginst = g_hash_table_lookup (mm->ginst_cache, candidate);
 	if (!ginst) {
 		int size = MONO_SIZEOF_GENERIC_INST + type_argc * sizeof (MonoType *);
 		ginst = (MonoGenericInst *)mono_mem_manager_alloc0 (mm, size);
@@ -3513,7 +3512,7 @@ mono_metadata_get_canonical_generic_inst (MonoGenericInst *candidate)
 		for (int i = 0; i < type_argc; ++i)
 			ginst->type_argv [i] = mono_metadata_type_dup (NULL, candidate->type_argv [i]);
 
-		dn_simdhash_ght_insert (mm->ginst_cache, ginst, ginst);
+		g_hash_table_insert (mm->ginst_cache, ginst, ginst);
 	}
 
 	mono_loader_unlock ();


### PR DESCRIPTION
This PR reverts the generic instance cache to use GHashTable and replaces the hash function for generic instances with a more robust hash function. The latter is mostly important for simdhash, but it should improve performance for GHashTable too.

This may address the increase in AOT compile times.